### PR TITLE
docs: add missing libpci-dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MORI stands for Modular RDMA Interface
 - pytorch:rocm >= 6.4.0
 - Linux packages
     
-    ```apt-get install -y git cython3 ibverbs-utils openmpi-bin libopenmpi-dev cmake libdw1```
+    ```apt-get install -y git cython3 ibverbs-utils openmpi-bin libopenmpi-dev libpci-dev cmake libdw1```
 
 Or build docker image with:
 ```
@@ -32,3 +32,4 @@ pytest tests/python/ops/
 # Benchmark performance
 python3 tests/python/ops/bench_dispatch_combine.py 
 ```
+


### PR DESCRIPTION
## Motivation
Add missing libpci-dev dependency in README.md, reference from docker file: https://github.com/ROCm/mori/blob/88a38d475e970367ab6b686912e32eb3841e21c2/docker/Dockerfile.dev#L10
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Fix build issue: 
```
/app/users/xisun/mori-poc/src/application/topology/pci.cpp:18:10: fatal error: 'pci/pci.h' file not found
         18 | #include <pci/pci.h>
            |          ^~~~~~~~~~~
```
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
