### PR TITLE
use setuptools-scm to set package version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ cd mori && docker build -t rocm/mori:dev -f docker/Dockerfile.dev .
 
 ### Install with Python
 ```
-cd mori && git submodule update --init --recursive && pip3 install .
+cd mori && pip install -r requirements-build.txt && git submodule update --init --recursive && pip3 install .
 ```
 
 ### Test dispatch / combine

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,3 @@
+cmake>=3.26
+setuptools>=77.0.3
+setuptools-scm>=8

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ import shutil
 from setuptools import Command, Extension, find_packages, setup
 from setuptools.command.build import build as _build
 from setuptools.command.build_ext import build_ext
+from setuptools_scm import get_version
 
 
 def _get_torch_cmake_prefix_path() -> str:
@@ -73,7 +74,7 @@ extensions = [
 
 setup(
     name="mori",
-    version="0.0.0",
+    use_scm_version=True,
     description="Modular RDMA Interface",
     packages=find_packages(where="python"),
     package_dir={"": "python"},
@@ -82,6 +83,7 @@ setup(
         "build_ext": CMakeBuild,
         "build": CustomBuild,
     },
+    setup_requires=["setuptools_scm"],
     install_requires=["torch", "pytest-assume"],
     python_requires=">=3.10",
     ext_modules=extensions,


### PR DESCRIPTION
mori-0.1.dev136+g30f8d4d21
By using [setuptools-scm](https://pypi.org/project/setuptools-scm/), we can get versioning information directly from git.

Example of version string for a dev build: mori-0.1.dev136+g30f8d4d21 (136 commits after last tag, commit sha: g30f8d4d21)

Note that for builds of tags the version string is set to the tag, falling back to current behaviour.