### PR TITLE
Optim: MORI-IO eliminate repeated session construction via cache

### DIFF
--- a/src/io/rdma/backend_impl.hpp
+++ b/src/io/rdma/backend_impl.hpp
@@ -243,6 +243,31 @@ class RdmaBackend : public Backend {
 
  private:
   void CreateSession(const MemoryDesc& local, const MemoryDesc& remote, RdmaBackendSession& sess);
+  // Session cache helpers
+  struct SessionCacheKey {
+    EngineKey remoteEngineKey;  // use remote memory's engine key
+    MemoryUniqueId localMemId;
+    MemoryUniqueId remoteMemId;
+    bool operator==(const SessionCacheKey& o) const {
+      return remoteEngineKey == o.remoteEngineKey && localMemId == o.localMemId &&
+             remoteMemId == o.remoteMemId;
+    }
+  };
+  struct SessionCacheKeyHash {
+    std::size_t operator()(const SessionCacheKey& k) const noexcept {
+      auto hash_combine = [](std::size_t& seed, std::size_t v) {
+        // 64-bit variant of boost::hash_combine / splitmix64 inspired
+        seed ^= v + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2);
+      };
+      std::size_t seed = 0;
+      hash_combine(seed, std::hash<std::string>()(k.remoteEngineKey));
+      hash_combine(seed, std::hash<uint64_t>()(k.localMemId));
+      hash_combine(seed, std::hash<uint64_t>()(k.remoteMemId));
+      return seed;
+    }
+  };
+  RdmaBackendSession* GetOrCreateSessionCached(const MemoryDesc& local, const MemoryDesc& remote);
+  void InvalidateSessionsForMemory(MemoryUniqueId id);
 
  private:
   EngineKey myEngKey;
@@ -251,6 +276,10 @@ class RdmaBackend : public Backend {
   std::unique_ptr<NotifManager> notif{nullptr};
   std::unique_ptr<ControlPlaneServer> server{nullptr};
   std::unique_ptr<Executor> executor{nullptr};
+  // session cache
+  std::unordered_map<SessionCacheKey, std::unique_ptr<RdmaBackendSession>, SessionCacheKeyHash>
+      sessionCache;
+  std::mutex sessionCacheMu;
 };
 
 }  // namespace io


### PR DESCRIPTION
## Motivation

Every `ReadWrite` / `BatchReadWrite` call previously rebuilt a transient `RdmaBackendSession`, repeating:
- Endpoint existence checks (`CountEndpoint` + possible `BuildRdmaConn`)
- Local/remote MR lookup and (re)registration
- Construction of the session wrapper object

In the non-session usage pattern this dominated latency for small and mid-sized transfers, yielding very poor effective bandwidth.

## Technical Details

**This patch adds:**

* session cache keyed by (remoteEngineKey, localMemId, remoteMemId)
* lazy creation outside lock, then insertion
* invalidation on DeregisterMemory to prevent stale reuse
* stronger hash_combine-based mixer for composite key
* ReadWrite + BatchReadWrite now reuse cached session objects

**Performance Impact**  
Representative benchmark (non-session mode, `--transfer-batch-size 128`, 2 nodes):

Latency (us) and bandwidth (GB/s) improvements (selected points):
- 8–64 B: Min latency drops from ~12.8 ms to ~0.338 ms (≈38× reduction)  
- 4 KB: Min latency from ~12.88 ms → 0.345 ms; BW 0.04 → 1.52 GB/s  
- 64 KB: BW 0.67 → 22.94 GB/s  
- 1 MB: BW 10.68 → 44.70 GB/s  

## Test Plan

1. Run benchmark without session mode (`--enable-sess` omitted) on at least 2 nodes:  
```
torchrun --nnodes=2 --node_rank=0 --nproc_per_node=1 \
  --master_addr=10.194.132.229 --master_port=1234 \
  tests/python/io/benchmark.py --host=10.194.132.229 \
  --transfer-batch-size 128 --all
```
2. Compare before/after tables; verify bandwidth scaling and latency collapse for small sizes.  
3. Run existing unit tests to ensure no functional regressions.

## Test Result

**Detailed Results (Before)**  
```
+--------------------------------------------------------------------------------------------------------+
|                                            Initiator Rank 0                                            |
+-------------+-----------+----------------+---------------+---------------+--------------+--------------+
| MsgSize (B) | BatchSize | TotalSize (MB) | Max BW (GB/s) | Avg Bw (GB/s) | Min Lat (us) | Avg Lat (us) |
+-------------+-----------+----------------+---------------+---------------+--------------+--------------+
|      8      |    128    |      0.00      |      0.00     |      0.00     |   12849.09   |   15244.48   |
|      16     |    128    |      0.00      |      0.00     |      0.00     |   12853.86   |   12903.93   |
|      32     |    128    |      0.00      |      0.00     |      0.00     |   12852.19   |   12901.13   |
|      64     |    128    |      0.01      |      0.00     |      0.00     |   12843.13   |   12918.05   |
|     128     |    128    |      0.02      |      0.00     |      0.00     |   12891.77   |   12933.63   |
|     256     |    128    |      0.03      |      0.00     |      0.00     |   12842.89   |   12884.41   |
|     512     |    128    |      0.07      |      0.01     |      0.01     |   12840.75   |   12941.77   |
|     1024    |    128    |      0.13      |      0.01     |      0.01     |   12888.43   |   12913.93   |
|     2048    |    128    |      0.26      |      0.02     |      0.02     |   12883.42   |   12991.62   |
|     4096    |    128    |      0.52      |      0.04     |      0.04     |   12881.04   |   13102.54   |
|     8192    |    128    |      1.05      |      0.08     |      0.07     |   12537.00   |   15228.33   |
|    16384    |    128    |      2.10      |      0.17     |      0.17     |   12566.80   |   12602.03   |
|    32768    |    128    |      4.19      |      0.33     |      0.33     |   12539.63   |   12631.07   |
|    65536    |    128    |      8.39      |      0.67     |      0.67     |   12564.18   |   12606.47   |
|    131072   |    128    |     16.78      |      1.34     |      1.33     |   12526.99   |   12584.95   |
|    262144   |    128    |     33.55      |      2.68     |      2.65     |   12521.51   |   12641.80   |
|    524288   |    128    |     67.11      |      5.36     |      5.33     |   12530.80   |   12589.74   |
|   1048576   |    128    |     134.22     |     10.68     |     10.64     |   12567.76   |   12612.66   |
+-------------+-----------+----------------+---------------+---------------+--------------+--------------+
```

**Detailed Results (After)**  
```
+--------------------------------------------------------------------------------------------------------+
|                                            Initiator Rank 0                                            |
+-------------+-----------+----------------+---------------+---------------+--------------+--------------+
| MsgSize (B) | BatchSize | TotalSize (MB) | Max BW (GB/s) | Avg Bw (GB/s) | Min Lat (us) | Avg Lat (us) |
+-------------+-----------+----------------+---------------+---------------+--------------+--------------+
|      8      |    128    |      0.00      |      0.00     |      0.00     |    338.08    |    343.67    |
|      16     |    128    |      0.00      |      0.01     |      0.01     |    336.65    |    342.49    |
|      32     |    128    |      0.00      |      0.01     |      0.01     |    338.32    |    343.15    |
|      64     |    128    |      0.01      |      0.02     |      0.02     |    339.51    |    344.09    |
|     128     |    128    |      0.02      |      0.05     |      0.05     |    338.32    |    343.77    |
|     256     |    128    |      0.03      |      0.10     |      0.10     |    339.27    |    343.79    |
|     512     |    128    |      0.07      |      0.19     |      0.19     |    338.08    |    350.27    |
|     1024    |    128    |      0.13      |      0.39     |      0.38     |    340.22    |    347.18    |
|     2048    |    128    |      0.26      |      0.77     |      0.75     |    342.13    |    349.48    |
|     4096    |    128    |      0.52      |      1.52     |      1.50     |    345.23    |    348.79    |
|     8192    |    128    |      1.05      |      3.03     |      2.95     |    346.42    |    355.52    |
|    16384    |    128    |      2.10      |      5.81     |      5.75     |    360.73    |    364.65    |
|    32768    |    128    |      4.19      |     11.49     |     11.33     |    365.02    |    370.34    |
|    65536    |    128    |      8.39      |     22.94     |     22.51     |    365.73    |    372.70    |
|    131072   |    128    |     16.78      |     42.67     |     42.60     |    393.15    |    393.80    |
|    262144   |    128    |     33.55      |     43.87     |     43.84     |    764.85    |    765.31    |
|    524288   |    128    |     67.11      |     44.43     |     44.42     |   1510.38    |   1510.91    |
|   1048576   |    128    |     134.22     |     44.70     |     44.69     |   3002.64    |   3003.07    |
+-------------+-----------+----------------+---------------+---------------+--------------+--------------+
```

**Unit Tests**
```
=========================================================================== test session starts ===========================================================================platform linux -- Python 3.12.10, pytest-7.3.2, pluggy-1.6.0
rootdir: /niko/mori
plugins: rerunfailures-14.0, cpp-2.3.0, xdist-3.3.1, hypothesis-5.35.1, xdoctest-1.1.0, flakefinder-1.1.0, assume-2.4.3
collected 68 items                                                                                                                                                        

tests/python/io/test_engine.py ..[2025-09-17 04:36:13.549] [info] worker 0 enter main loop, running on core 0
..................................................................                                                                 [100%]

=========================================================================== 68 passed in 13.68s ===========================================================================
```
