### PR TITLE
Refactor: MORI-IO add support for multi-session batch transfers

### DIFF
--- a/examples/io/example.py
+++ b/examples/io/example.py
@@ -77,13 +77,13 @@ def batch_read_write_example(initiator, target, size, batch_size):
     # Perform batch p2p transfer from initiator to target
     transfer_uid = initiator.allocate_transfer_uid()
     transfer_status = initiator.batch_read(
-        initiator_mem,
-        local_offsets,
-        target_mem,
-        remote_offsets,
-        sizes,
-        transfer_uid,
-    )
+        [initiator_mem],
+        [local_offsets],
+        [target_mem],
+        [remote_offsets],
+        [sizes],
+        [transfer_uid],
+    )[0]
 
     while transfer_status.InProgress():
         pass

--- a/include/mori/io/common.hpp
+++ b/include/mori/io/common.hpp
@@ -129,6 +129,10 @@ struct TransferStatus {
 };
 
 using SizeVec = std::vector<size_t>;
+using MemDescVec = std::vector<MemoryDesc>;
+using BatchSizeVec = std::vector<SizeVec>;
+using TransferUniqueIdVec = std::vector<TransferUniqueId>;
+using TransferStatusPtrVec = std::vector<TransferStatus*>;
 
 }  // namespace io
 }  // namespace mori

--- a/include/mori/io/engine.hpp
+++ b/include/mori/io/engine.hpp
@@ -93,12 +93,13 @@ class IOEngine {
   void Write(const MemoryDesc& localSrc, size_t localOffset, const MemoryDesc& remoteDest,
              size_t remoteOffset, size_t size, TransferStatus* status, TransferUniqueId id);
 
-  void BatchRead(const MemoryDesc& localDest, const SizeVec& localOffsets,
-                 const MemoryDesc& remoteSrc, const SizeVec& remoteOffsets, const SizeVec& sizes,
-                 TransferStatus* status, TransferUniqueId id);
-  void BatchWrite(const MemoryDesc& localSrc, const SizeVec& localOffsets,
-                  const MemoryDesc& remoteDest, const SizeVec& remoteOffsets, const SizeVec& sizes,
-                  TransferStatus* status, TransferUniqueId id);
+  void BatchRead(const MemDescVec& localDest, const BatchSizeVec& localOffsets,
+                 const MemDescVec& remoteSrc, const BatchSizeVec& remoteOffsets,
+                 const BatchSizeVec& sizes, TransferStatusPtrVec& status, TransferUniqueIdVec& ids);
+  void BatchWrite(const MemDescVec& localSrc, const BatchSizeVec& localOffsets,
+                  const MemDescVec& remoteDest, const BatchSizeVec& remoteOffsets,
+                  const BatchSizeVec& sizes, TransferStatusPtrVec& status,
+                  TransferUniqueIdVec& ids);
   // Take the transfer status of an inbound op
   bool PopInboundTransferStatus(EngineKey remote, TransferUniqueId id, TransferStatus* status);
 

--- a/python/mori/io/engine.py
+++ b/python/mori/io/engine.py
@@ -160,7 +160,7 @@ class IOEngine:
         sizes,
         transfer_uid,
     ):
-        transfer_status = mori_cpp.TransferStatus()
+        transfer_status = [mori_cpp.TransferStatus() for _ in range(len(sizes))]
         func(
             local_dest_mem_desc,
             local_offsets,

--- a/src/io/engine.cpp
+++ b/src/io/engine.cpp
@@ -213,8 +213,8 @@ void IOEngine::BatchRead(const MemDescVec& localDest, const BatchSizeVec& localO
     backend->BatchRead(localDest[i], localOffsets[i], remoteSrc[i], remoteOffsets[i], sizes[i],
                        status[i], ids[i]);
     if (status[i]->Failed()) {
-      MORI_IO_ERROR("Engine batch read error {} message {}", status->CodeUint32(),
-                    status->Message());
+      MORI_IO_ERROR("Engine batch read error {} message {}", status[i]->CodeUint32(),
+                    status[i]->Message());
     }
   }
 }
@@ -237,9 +237,9 @@ void IOEngine::BatchWrite(const MemDescVec& localSrc, const BatchSizeVec& localO
     SELECT_BACKEND_AND_RETURN_IF_NONE(localSrc[i], remoteDest[i], status[i], backend);
     backend->BatchWrite(localSrc[i], localOffsets[i], remoteDest[i], remoteOffsets[i], sizes[i],
                         status[i], ids[i]);
-    if (status->Failed()) {
-      MORI_IO_ERROR("Engine batch write error {} message {}", status->CodeUint32(),
-                    status->Message());
+    if (status[i]->Failed()) {
+      MORI_IO_ERROR("Engine batch write error {} message {}", status[i]->CodeUint32(),
+                    status[i]->Message());
     }
   }
 }

--- a/tests/python/io/benchmark.py
+++ b/tests/python/io/benchmark.py
@@ -361,15 +361,15 @@ class MoriIoBenchmark:
                     else self.engine.batch_write
                 )
                 args = (
-                    self.mem,
-                    offsets,
-                    self.target_mem,
-                    offsets,
-                    sizes,
-                    transfer_uid,
+                    [self.mem],
+                    [offsets],
+                    [self.target_mem],
+                    [offsets],
+                    [sizes],
+                    [transfer_uid],
                 )
             st = time.time()
-            transfer_status = func(*args)
+            transfer_status = func(*args)[0]
             transfer_status.Wait()
             duration = time.time() - st
             assert transfer_status.Succeeded()

--- a/tests/python/io/stress_test.py
+++ b/tests/python/io/stress_test.py
@@ -427,7 +427,14 @@ class MoriIoStress:
             st = func(offsets_src, offsets_dst, sizes, uid)
         else:
             func = self.engine.batch_read if is_read else self.engine.batch_write
-            st = func(self.mem, offsets_src, self.target_mem, offsets_dst, sizes, uid)
+            st = func(
+                [self.mem],
+                [offsets_src],
+                [self.target_mem],
+                [offsets_dst],
+                [sizes],
+                [uid],
+            )[0]
 
         while st.InProgress():
             time.sleep(0.00005)

--- a/tests/python/io/test_engine.py
+++ b/tests/python/io/test_engine.py
@@ -252,8 +252,13 @@ def test_rdma_backend_ops(
             transfer_uid = initiator.allocate_transfer_uid()
             func = initiator.batch_read if op_type == "read" else initiator.batch_write
             transfer_status = func(
-                initiator_mem, offsets, target_mem, offsets, sizes, transfer_uid
-            )
+                [initiator_mem],
+                [offsets],
+                [target_mem],
+                [offsets],
+                [sizes],
+                [transfer_uid],
+            )[0]
         uid_status_list.append((transfer_uid, transfer_status))
     else:
         for i in range(batch_size):
@@ -334,8 +339,8 @@ def test_no_backend():
 
     transfer_uid = initiator.allocate_transfer_uid()
     transfer_status = initiator.batch_read(
-        initiator_mem, offsets, target_mem, offsets, sizes, transfer_uid
-    )
+        [initiator_mem], [offsets], [target_mem], [offsets], [sizes], [transfer_uid]
+    )[0]
 
     assert transfer_status.Failed()
     assert transfer_status.Code() == StatusCode.ERR_BAD_STATE


### PR DESCRIPTION
## Motivation

The current batch API is limited to read/write operations within a single transfer session (one source, one destination). To improve performance and reduce API call overhead, this PR extends the API to support batching multiple, independent transfers in a single call.

## API Change

The `BatchRead` and `BatchWrite` functions are overloaded to accept vectors of transfer parameters. This allows each entry in the batch to have its own source/destination memory descriptors, status pointers, and transfer IDs.

**Old API (Single Session)**
```cpp
  void IOEngine::BatchRead(const MemoryDesc& localDest, const SizeVec& localOffsets,
                 const MemoryDesc& remoteSrc, const SizeVec& remoteOffsets, const SizeVec& sizes,
                 TransferStatus* status, TransferUniqueId id);
  void IOEngine::BatchWrite(const MemoryDesc& localSrc, const SizeVec& localOffsets,
                  const MemoryDesc& remoteDest, const SizeVec& remoteOffsets, const SizeVec& sizes,
                  TransferStatus* status, TransferUniqueId id);
```

**New API (Multi-Session)**
```cpp
  void IOEngine::BatchRead(const MemDescVec& localDest, const BatchSizeVec& localOffsets,
                 const MemDescVec& remoteSrc, const BatchSizeVec& remoteOffsets,
                 const BatchSizeVec& sizes, TransferStatusPtrVec& status, TransferUniqueIdVec& ids);
  void IOEngine::BatchWrite(const MemDescVec& localSrc, const BatchSizeVec& localOffsets,
                  const MemDescVec& remoteDest, const BatchSizeVec& remoteOffsets,
                  const BatchSizeVec& sizes, TransferStatusPtrVec& status,
                  TransferUniqueIdVec& ids);
```
