### PR TITLE
Enhancement of mori ep unit test

### DIFF
--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -28,18 +28,17 @@ import torch.distributed as dist
 
 class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
     def __init__(self, config):
-        super().__init__(config)
+        super().__init__(config, use_max_token_num=True)
 
     def gen_test_data(self):
-        return super().gen_test_data(use_max_token_num=True)
+        return super().gen_test_data()
 
     def run_once(self, op, test_data, check_result):
         (
-            all_rank_num_token,
-            all_rank_indices,
-            all_rank_input,
-            all_rank_weights,
-            all_rank_scales,
+            input,
+            indices,
+            weights,
+            scales,
         ) = test_data
 
         start_event = torch.cuda.Event(enable_timing=True)
@@ -54,11 +53,11 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
             dispatch_indices,
             dispatch_recv_num_token,
         ) = op.dispatch(
-            all_rank_input[self.config.rank],
-            all_rank_weights[self.config.rank],
+            input,
+            weights,
             # None,
-            all_rank_scales[self.config.rank],
-            all_rank_indices[self.config.rank],
+            scales,
+            indices,
             block_num=80,
             warp_per_block=16,
         )
@@ -68,20 +67,25 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
 
         if check_result:
             self.check_dispatch_result(
-                op,
                 test_data,
                 dispatch_output,
                 dispatch_weights,
                 dispatch_scales,
                 dispatch_indices,
                 dispatch_recv_num_token,
+                op.get_dispatch_src_token_pos(),
             )
 
         total_recv_num_token = dispatch_recv_num_token[0].item()
 
         combine_input = op.get_registered_combine_input_buffer(self.config.data_type)
-        combine_input[:total_recv_num_token, :].copy_(
-            dispatch_output[:total_recv_num_token, :]
+        self.moe_sum(
+            dispatch_recv_num_token,
+            dispatch_output,
+            dispatch_weights,
+            dispatch_indices,
+            dispatch_scales,
+            output=combine_input[:total_recv_num_token],
         )
 
         self.sync()
@@ -99,11 +103,11 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
         comb_duration = start_event.elapsed_time(end_event)
 
         if check_result:
-            self.check_combine_result(op, test_data, combine_output)
+            self.check_combine_result(test_data, combine_output)
         op.reset()
         self.sync()
 
-        element_size = all_rank_input[self.config.rank].element_size()
+        element_size = input.element_size()
         total_bytes = total_recv_num_token * self.config.hidden_dim * element_size
         disp_bandwidth = total_bytes / (1000**3) / (disp_duration / (10**3))
         comb_bandwidth = total_bytes / (1000**3) / (comb_duration / (10**3))
@@ -204,11 +208,11 @@ def _bench_dispatch_combine(
         block_num=80,
         use_external_inp_buf=False,
     )
-    benchmark = EpDispatchCombineBenchmark(config)
 
     with TorchDistContext(rank=rank, world_size=world_size, master_port=port):
         mori.shmem.shmem_torch_process_group_init("default")
         op = mori.ops.EpDispatchCombineOp(config)
+        benchmark = EpDispatchCombineBenchmark(config)
         benchmark.run(op)
         # benchmark.output()
         # mori.shmem.shmem_finalize()

--- a/tests/python/ops/test_dispatch_combine.py
+++ b/tests/python/ops/test_dispatch_combine.py
@@ -21,230 +21,383 @@
 # SOFTWARE.
 import pytest
 import mori
-from tests.python.utils import TorchDistProcessManager
+from tests.python.utils import TorchDistProcessManager, ExceptionWrapper
 import torch
 import torch.distributed as dist
+from tqdm import tqdm
 
 
 class EpDispatchCombineTestCase:
-    def __init__(self, config):
+    def __init__(self, config, use_max_token_num=False):
         self.config = config
         self.device = torch.device("cuda", self.config.rank)
         self.rng = torch.Generator(device=self.device)
-        self.rng.manual_seed(123)
+        self.rng.manual_seed(123 + self.config.rank)
+        self.check_dispatch = False
+
+        if use_max_token_num:
+            num_token = self.config.max_num_inp_token_per_rank
+        else:
+            num_token = torch.randint(
+                1, self.config.max_num_inp_token_per_rank + 1, (1,)
+            ).item()
+
+        # Initialize all rank tokens
+        self.num_token = num_token
+        self.all_rank_num_token = [None] * self.config.world_size
+        torch.distributed.all_gather_object(self.all_rank_num_token, num_token)
+
+        # Initialize all rank indices, weights, input and scales
+        (
+            self.all_rank_input,
+            self.all_rank_indices,
+            self.all_rank_weights,
+            self.all_rank_scales,
+        ) = ([], [], [], [])
+        scale_dtype = (
+            torch.float8_e4m3fnuz if self.config.scale_type_size == 1 else torch.float32
+        )
+        for rank_num_token in self.all_rank_num_token:
+            self.all_rank_input.append(
+                torch.empty(
+                    rank_num_token,
+                    self.config.hidden_dim,
+                    dtype=self.config.data_type,
+                    device=self.device,
+                )
+            )
+            self.all_rank_indices.append(
+                torch.empty(
+                    rank_num_token,
+                    self.config.num_experts_per_token,
+                    dtype=torch.int32,
+                    device=self.device,
+                )
+            )
+            self.all_rank_weights.append(
+                torch.empty(
+                    rank_num_token,
+                    self.config.num_experts_per_token,
+                    dtype=torch.float32,
+                    device=self.device,
+                )
+            )
+            self.all_rank_scales.append(
+                torch.empty(
+                    rank_num_token,
+                    self.config.scale_dim,
+                    dtype=scale_dtype,
+                    device=self.device,
+                )
+            )
 
     def sync(self):
         torch.cuda.synchronize()
         dist.barrier()
 
-    def gen_test_data(self, use_max_token_num=False):
-        if use_max_token_num:
-            num_token = torch.tensor(
-                [
-                    self.config.max_num_inp_token_per_rank
-                    for i in range(self.config.world_size)
-                ]
-            ).to(self.device)
-        else:
-            num_token = torch.randint(
-                0,
-                self.config.max_num_inp_token_per_rank + 1,
-                [self.config.world_size],
+    def quantize_input(self, input):
+        # Quantize input with scale_dim
+        input = input.view(input.size(0), self.config.scale_dim, -1)
+        scales = input.abs().amax(dim=-1, keepdim=True).to(torch.float32)
+        scales.clamp_(min=1e-12)
+        input = (input / scales).to(torch.float8_e4m3fnuz).view(self.num_token, -1)
+        return input, scales.squeeze(-1)
+
+    def dequantize_input(self, input, scales, dtype):
+        # Quantize input with scale_dim
+        if scales.dtype == torch.float8_e4m3fnuz:
+            scales = scales.to(torch.float32)
+        reshaped_input = input.view(input.size(0), self.config.scale_dim, -1).to(
+            torch.float32
+        )
+        dequant_input = (
+            (reshaped_input * scales.unsqueeze(-1)).to(dtype).view(*input.shape)
+        )
+        return dequant_input
+
+    def gen_test_data(self):
+        # gen indices
+        indices = torch.empty(
+            self.num_token,
+            self.config.num_experts_per_token,
+            dtype=torch.int64,
+            # device=self.device,
+        )
+        for i in range(self.num_token):
+            perm = torch.randperm(
+                self.config.num_experts_per_rank * self.config.world_size,
                 generator=self.rng,
                 device=self.device,
             )
-
-        # gen indices
-        all_rank_indices = []
-        for r in range(self.config.world_size):
-            indices = torch.empty(
-                num_token[r],
-                self.config.num_experts_per_token,
-                dtype=torch.int64,
-                # device=self.device,
-            )
-            for i in range(num_token[r]):
-                perm = torch.randperm(
-                    self.config.num_experts_per_rank * self.config.world_size,
-                    generator=self.rng,
-                    device=self.device,
-                )
-                indices[i] = perm[: self.config.num_experts_per_token]
-            all_rank_indices.append(indices.to(torch.int32).to(self.device))
+            indices[i] = perm[: self.config.num_experts_per_token]
+        indices = indices.to(torch.int32).to(self.device)
 
         # gen weights
-        all_rank_weights = [
-            torch.rand(
-                num_token[r],
-                self.config.num_experts_per_token,
-                dtype=torch.float32,
-                generator=self.rng,
-                device=self.device,
-            )
-            for r in range(self.config.world_size)
-        ]
-
-        # gen scales
-        all_rank_scales = [
-            torch.rand(
-                num_token[r],
-                self.config.scale_dim,
-                dtype=torch.float32,
-                generator=self.rng,
-                device=self.device,
-            )
-            for r in range(self.config.world_size)
-        ]
-        if self.config.scale_type_size == 1:
-            all_rank_scales = [t.to(torch.float8_e4m3fnuz) for t in all_rank_scales]
+        weights = torch.rand(
+            self.num_token,
+            self.config.num_experts_per_token,
+            dtype=torch.float32,
+            generator=self.rng,
+            device=self.device,
+        )
 
         # gen input & output
         # some functions such as randn and cat are not implemented for fp8
-        all_rank_input = []
-        for r in range(self.config.world_size):
-            all_rank_input.append(
-                torch.randn(
-                    num_token[r],
-                    self.config.hidden_dim,
-                    dtype=torch.float32,
-                    generator=self.rng,
-                    device=self.device,
-                ).to(self.config.data_type)
-            )
+        input = torch.randn(
+            self.num_token,
+            self.config.hidden_dim,
+            dtype=torch.float32,
+            generator=self.rng,
+            device=self.device,
+        )
+
+        if self.config.data_type == torch.float8_e4m3fnuz and self.config.scale_dim > 0:
+            input, scales = self.quantize_input(input)
+            if self.config.scale_type_size == 1:
+                scales = scales.to(torch.float8_e4m3fnuz)
+        else:
+            input = input.to(self.config.data_type)
+            scales = None
 
         return (
-            num_token,
-            all_rank_indices,
-            all_rank_input,
-            all_rank_weights,
-            all_rank_scales,
+            input,
+            indices,
+            weights,
+            scales,
         )
 
     def check_dispatch_result(
         self,
-        op,
         test_data,
         dispatch_output,
         dispatch_weights,
         dispatch_scales,
         dispatch_indices,
         dispatch_recv_num_token,
+        src_token_pos,
     ):
-        self.sync()
         (
-            all_rank_num_token,
-            all_rank_indices,
-            all_rank_input,
-            all_rank_weights,
-            all_rank_scales,
+            input,
+            indices,
+            weights,
+            scales,
         ) = test_data
-        src_token_pos = op.get_dispatch_src_token_pos()
+
+        dist.all_gather(self.all_rank_input, input)
+        dist.all_gather(self.all_rank_indices, indices)
+        if dispatch_weights is not None:
+            dist.all_gather(self.all_rank_weights, weights)
+        if dispatch_scales is not None:
+            dist.all_gather(self.all_rank_scales, scales)
 
         for i, pos in enumerate(src_token_pos):
             src_rank = int(pos) // self.config.max_num_inp_token_per_rank
             src_id = int(pos) % self.config.max_num_inp_token_per_rank
-            assert torch.equal(all_rank_input[src_rank][src_id], dispatch_output[i])
+            assert torch.equal(
+                self.all_rank_input[src_rank][src_id], dispatch_output[i]
+            )
             if dispatch_weights is not None:
                 assert torch.equal(
-                    all_rank_weights[src_rank][src_id], dispatch_weights[i]
+                    self.all_rank_weights[src_rank][src_id], dispatch_weights[i]
                 )
             if dispatch_scales is not None:
                 assert torch.equal(
-                    all_rank_scales[src_rank][src_id], dispatch_scales[i]
+                    self.all_rank_scales[src_rank][src_id], dispatch_scales[i]
                 )
-            assert torch.equal(all_rank_indices[src_rank][src_id], dispatch_indices[i])
+            assert torch.equal(
+                self.all_rank_indices[src_rank][src_id], dispatch_indices[i]
+            )
         assert len(torch.unique(src_token_pos)) == len(src_token_pos)
         assert len(src_token_pos) == dispatch_recv_num_token[0]
 
     def check_combine_result(
-        self, op, test_data, combine_output, combine_output_weight=None
+        self, test_data, combine_output, combine_output_weight, round
     ):
-        self.sync()
-        all_rank_num_token = test_data[0]
-        all_rank_indices = test_data[1]
-        all_rank_input = test_data[2]
-        all_rank_weights = test_data[3]
+        (
+            input,
+            indices,
+            weights,
+            scales,
+        ) = test_data
 
-        for i in range(all_rank_num_token[self.config.rank]):
-            pes = [
-                (idx // self.config.num_experts_per_rank)
-                for idx in all_rank_indices[self.config.rank][i].cpu().tolist()
-            ]
-            unique_pes = len(set(pes))
+        def _get_expected(input, indices, weights, scales, combine_weights):
+            if input.dtype == torch.float8_e4m3fnuz:
+                assert scales is not None
+                input = self.dequantize_input(input, scales, dtype=torch.float32)
 
-            got, expected = combine_output[i], (
-                all_rank_input[self.config.rank][i].to(torch.float32) * unique_pes
-            ).to(self.config.data_type)
-
-            result_match = torch.allclose(
-                got.float(), expected.float(), atol=1e-2, rtol=1e-2
+            expected_output = input * torch.sum(weights, dim=1, keepdim=True)
+            expected_output = expected_output.to(torch.bfloat16)
+            pes = indices // self.config.num_experts_per_rank
+            unique_pes = torch.tensor(
+                [torch.unique(x).numel() for x in pes],
+                device=self.device,
+                dtype=indices.dtype,
             )
-            if not result_match and self.config.rank == 0:
-                print(f"Result mismatch for token {i}:")
-                print(
-                    f"  indices[{i}]: {all_rank_indices[self.config.rank][i].cpu().tolist()}"
+            expected_weight = weights * unique_pes.unsqueeze(1)
+            return expected_output, expected_weight
+
+        expected_output, expected_weight = _get_expected(
+            input, indices, weights, scales, combine_output_weight
+        )
+
+        combine_output = combine_output
+        combine_output_weight = combine_output_weight
+
+        result_match = torch.allclose(
+            combine_output, expected_output, atol=1e-2, rtol=1e-2
+        )
+        weight_match = (
+            torch.allclose(combine_output_weight, expected_weight, atol=1e-5, rtol=1e-5)
+            if combine_output_weight is not None
+            else True
+        )
+
+        if result_match and weight_match:
+            return
+
+        for i in range(self.num_token):
+            result_match = torch.allclose(
+                combine_output[i], expected_output[i], atol=1e-2, rtol=1e-2
+            )
+            if not result_match:
+                error_msg = (
+                    f"{round}-th Combine result mismatch for token {i}:\n"
+                    f"  indices[{i}]: {indices[i].cpu().tolist()}\n"
+                    f"  got: {combine_output[i]}\n"
+                    f"  expected : {expected_output[i]}\n"
                 )
-                print(f"  pes: {pes}")
-                print(f"  unique_pes: {unique_pes}")
-                print(f"  got: {got}")
-                print(f"  expected : {expected}")
+                raise ValueError(error_msg)
 
             if combine_output_weight is not None:
-                got_weight, expected_weight = (
-                    combine_output_weight[i],
-                    all_rank_weights[self.config.rank][i] * unique_pes,
-                )
                 weight_match = torch.allclose(
-                    got_weight, expected_weight, atol=1e-5, rtol=1e-5
+                    combine_output_weight[i], expected_weight[i], atol=1e-5, rtol=1e-5
                 )
-                if not weight_match and self.config.rank == 0:
-                    print(f"Weight mismatch for token {i}:")
-                    print(
-                        f"  indices[{i}]: {all_rank_indices[self.config.rank][i].cpu().tolist()}"
+                if not weight_match:
+                    error_msg = (
+                        f"{round}-th Combine weight mismatch for token {i}:\n"
+                        f"  indices[{i}]: {indices[i].cpu().tolist()}\n"
+                        f"  got_weight: {combine_output_weight[i]}\n"
+                        f"  expected_weight: {expected_weight[i]}\n"
                     )
-                    print(f"  pes: {pes}")
-                    print(f"  unique_pes: {unique_pes}")
-                    print(f"  got_weight: {got_weight}")
-                    print(
-                        f"  expected_weight (weights[{i}] * {unique_pes}): {expected_weight}"
+                    raise ValueError(error_msg)
+
+    def run_mori(self, test_dataset, op):
+        outputs = []
+        if self.config.rank == 0:
+            total_num_token = sum(self.all_rank_num_token)
+            test_dataset = tqdm(
+                test_dataset,
+                desc="Running MORI dispatch/combine (#tokens={})".format(
+                    total_num_token
+                ),
+            )
+        for test_data in test_dataset:
+            (
+                input,
+                indices,
+                weights,
+                scales,
+            ) = test_data
+
+            (
+                dispatch_output,
+                dispatch_weights,
+                dispatch_scales,
+                dispatch_indices,
+                dispatch_recv_num_token,
+            ) = op.dispatch(
+                input,
+                weights,
+                scales,
+                indices,
+            )
+
+            if self.check_dispatch:
+                dispatch_result = (
+                    dispatch_output.clone(),
+                    dispatch_weights.clone(),
+                    dispatch_scales.clone() if dispatch_scales is not None else None,
+                    dispatch_indices.clone(),
+                    dispatch_recv_num_token.clone(),
+                    op.src_token_pos.clone(),
+                )
+            else:
+                dispatch_result = None
+
+            num_recv_token = dispatch_recv_num_token.item()
+            if num_recv_token == 0:
+                weighted_output = torch.empty_like(dispatch_output)
+            else:
+                dispatch_output = dispatch_output[:num_recv_token]
+                dispatch_weights = dispatch_weights[:num_recv_token]
+                dispatch_indices = dispatch_indices[:num_recv_token]
+                if dispatch_scales is not None:
+                    dispatch_scales = dispatch_scales[:num_recv_token]
+
+                mask = (
+                    self.config.num_experts_per_rank * self.config.rank
+                    <= dispatch_indices
+                ) & (
+                    dispatch_indices
+                    < self.config.num_experts_per_rank * (self.config.rank + 1)
+                )
+                mask = mask.to(self.device)
+                if dispatch_output.dtype == torch.float8_e4m3fnuz:
+                    dispatch_output = self.dequantize_input(
+                        dispatch_output, dispatch_scales, dtype=torch.float32
                     )
+                masked_weights = (mask * dispatch_weights).sum(dim=-1)
+                weighted_output = dispatch_output * masked_weights.unsqueeze(1)
 
-    def run_test_once(self, op, test_data):
-        (
-            all_rank_num_token,
-            all_rank_indices,
-            all_rank_input,
-            all_rank_weights,
-            all_rank_scales,
-        ) = test_data
-        (
-            dispatch_output,
-            dispatch_weights,
-            dispatch_scales,
-            dispatch_indices,
-            dispatch_recv_num_token,
-        ) = op.dispatch(
-            all_rank_input[self.config.rank],
-            all_rank_weights[self.config.rank],
-            all_rank_scales[self.config.rank],
-            all_rank_indices[self.config.rank],
-        )
-        self.sync()
-        self.check_dispatch_result(
-            op,
-            test_data,
-            dispatch_output,
-            dispatch_weights,
-            dispatch_scales,
-            dispatch_indices,
-            dispatch_recv_num_token,
-        )
+            weighted_output = weighted_output.to(torch.float32)
+            combine_output, combine_output_weights = op.combine(
+                weighted_output, dispatch_weights, dispatch_indices
+            )
 
-        combine_output, combine_output_weight = op.combine(
-            dispatch_output, dispatch_weights, dispatch_indices, call_reset=False
-        )
-        self.sync()
-        self.check_combine_result(op, test_data, combine_output, combine_output_weight)
+            combine_result = (
+                combine_output[: self.num_token].clone().to(torch.bfloat16),
+                combine_output_weights[: self.num_token].clone(),
+            )
+            outputs.append((dispatch_result, combine_result))
+
+        return outputs
+
+    def run_test(self, op, test_dataset):
+        # Run mori dispathc/combine for all test data
+        mori_results = self.run_mori(test_dataset, op)
+
+        # Check mori results
+        test_data_and_results = zip(test_dataset, mori_results)
+        if self.config.rank == 0:
+            test_data_and_results = tqdm(test_data_and_results, desc="Checking Result")
+
+        for i, (test_data, mori_result) in enumerate(test_data_and_results):
+            self.check_result(test_data, mori_result, i)
+
+    def check_result(self, test_data, mori_result, round):
+        dispatch_result, combine_result = mori_result
+        # Check dispatch output
+        if dispatch_result is not None:
+            (
+                dispatch_output,
+                dispatch_weights,
+                dispatch_scales,
+                dispatch_indices,
+                dispatch_recv_num_token,
+                src_token_pos,
+            ) = dispatch_result
+            self.check_dispatch_result(
+                test_data,
+                dispatch_output,
+                dispatch_weights,
+                dispatch_scales,
+                dispatch_indices,
+                dispatch_recv_num_token,
+                src_token_pos,
+            )
+        # Check combine output
+        combine_output, combine_weights = combine_result
+        self.check_combine_result(test_data, combine_output, combine_weights, round)
 
 
 @pytest.fixture(scope="session")
@@ -270,6 +423,7 @@ def _test_dispatch_combine(
     max_num_inp_token_per_rank,
     num_experts_per_rank,
     num_experts_per_token,
+    num_reps,
 ):
     config = mori.ops.EpDispatchCombineConfig(
         data_type=data_type,
@@ -287,8 +441,8 @@ def _test_dispatch_combine(
     )
     op = mori.ops.EpDispatchCombineOp(config)
     test_case = EpDispatchCombineTestCase(config)
-    test_data = test_case.gen_test_data()
-    test_case.run_test_once(op, test_data)
+    test_data = [test_case.gen_test_data() for _ in range(num_reps)]
+    test_case.run_test(op, test_data)
 
 
 # TODO: create a sub process group so that we can test worlds size < 8
@@ -297,9 +451,10 @@ def _test_dispatch_combine(
 @pytest.mark.parametrize("hidden_dim", (7168, 4096))
 @pytest.mark.parametrize("scale_dim", (0, 32))
 @pytest.mark.parametrize("scale_type_size", (1, 4))
-@pytest.mark.parametrize("max_num_inp_token_per_rank", (1, 128))
+@pytest.mark.parametrize("max_num_inp_token_per_rank", (1, 128, 2048))
 @pytest.mark.parametrize("num_experts_per_rank", (32,))
 @pytest.mark.parametrize("num_experts_per_token", (8,))
+@pytest.mark.parametrize("num_reps", (1,))
 def test_dispatch_combine(
     torch_dist_process_manager,
     world_size,
@@ -310,7 +465,19 @@ def test_dispatch_combine(
     max_num_inp_token_per_rank,
     num_experts_per_rank,
     num_experts_per_token,
+    num_reps,
 ):
+    if (data_type == torch.float8_e4m3fnuz) != (scale_dim > 0):
+        pytest.skip("skip fp8 with scale_dim == 0")
+
+    # Drain result queue if any result remains in the queue.
+    result_queue = torch_dist_process_manager.result_queue
+    while not result_queue.empty():
+        try:
+            result_queue.get_nowait()
+        except Exception:
+            break
+
     for i in range(world_size):
         torch_dist_process_manager.task_queue.put(
             (
@@ -324,18 +491,18 @@ def test_dispatch_combine(
                     max_num_inp_token_per_rank,
                     num_experts_per_rank,
                     num_experts_per_token,
+                    num_reps,
                 ],
             )
         )
 
-    results = []
     for i in range(world_size):
         (
             rank,
             result,
         ) = torch_dist_process_manager.result_queue.get()
-        results.append(result)
 
-    for result in results:
         if result is not None:
-            pytest.assume(False, result)
+            assert isinstance(result, ExceptionWrapper)
+            torch_dist_process_manager.on_error = True
+            result.reraise()


### PR DESCRIPTION
This is a work by a team from Moreh Inc.
## Motivation
Currently, Mori EP unit test (i.e. `test_dispatch_combine.py`) does not sufficiently cover real cases.
#### Problem 1. Each test case performed dispatch/combine only once.
 - In practice, depending on the model, dispatch/combine is executed multiple times corresponding to the number of layers.
   - e.g. In DeepSeek-R1, dispatch/combine is performed 58 times per step.
- When dispatch/combine is executed multiple times, there may be cases where the results are incorrect, but currently this is not being checked.
#### Problem 2. There is  synchronization across devices before checking the results.
- In practice, for performance reasons, explicit synchronization is not performed after dispatch and combine. 
- Most issues with the output values occur due to device-to-device timing differences.
  - Since the unit test is synchronizing across devices after dispatch/combine, it cannot detect the timing issue.
## Technical Details
Updated the unit tests to more closely resemble real use cases:
 - Introduced the `num_reps` parameter to allow each test case to perform dispatch/combine multiple times.
 - Removed explicitly synchronize across devices after dispatch/combine.
    - Instead, results are stored in a list during execution.
    - verification is performed after all dispatch/combine operations are complete.
> [!Note] 
> Currently, there is an issue in Mori EP where results are incorrect if `num_reps` is greater than 1. I will create a PR to fix this.

Fixed an issue where the test would hang if an error occurred on some ranks:
- Previously, the parent process waited for results from all processes, but if an error occurred on some ranks, other ranks continued executing dispatch/combine and never sent a test result to the result queue.
  - As a result, the parent process would wait indefinitely for responses that never arrive, causing the test to hang.
- Changed the behavior so that if an error occurs in any process, the error is raised immediately without waiting for the result queue.
## Test Plan
```
pytest -s -v tests/python/ops/test_dispatch_combine.py
```
## Test Result
```
=================================================================================================================================================== test session starts ====================================================================================================================================================
platform linux -- Python 3.12.11, pytest-8.4.2, pluggy-1.6.0 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /app/mori
plugins: assume-2.4.3, anyio-4.10.0, asyncio-1.1.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 48 items

test_dispatch_combine.py::test_dispatch_combine[1-8-32-1-1-0-7168-data_type0-8] Multiprocessing start method set to spawn
SKIPPED (skip fp8 with scale_dim == 0)
test_dispatch_combine.py::test_dispatch_combine[1-8-32-1-1-0-7168-data_type1-8] rank 0 RDMA devices: mlx5_0, mlx5_1, mlx5_2, mlx5_3, mlx5_4
rank 7 rankInNode 7 select device [0] mlx5_0
rank 2 rankInNode 2 select device [3] mlx5_3
rank 4 rankInNode 4 select device [1] mlx5_1
rank 3 rankInNode 3 select device [4] mlx5_4
rank 0 rankInNode 0 select device [0] mlx5_0
rank 1 rankInNode 1 select device [2] mlx5_2
rank 6 rankInNode 6 select device [3] mlx5_3
rank 5 rankInNode 5 select device [3] mlx5_3
Running MORI dispatch/combine (#tokens=8): 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 32.81it/s]
Checking Result: 1it [00:00, 20.22it/s]
PASSED
test_dispatch_combine.py::test_dispatch_combine[1-8-32-1-1-0-4096-data_type0-8] SKIPPED (skip fp8 with scale_dim == 0)
Running MORI dispatch/combine (#tokens=8): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 3024.01it/s]
Checking Result: 1it [00:00, 1384.72it/s]
PASSED
Running MORI dispatch/combine (#tokens=8): 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 94.81it/s]
Checking Result: 1it [00:00, 1506.03it/s]
PASSED
test_dispatch_combine.py::test_dispatch_combine[1-8-32-1-1-32-7168-data_type1-8] SKIPPED (skip fp8 with scale_dim == 0)
Running MORI dispatch/combine (#tokens=8): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 2435.72it/s]
Checking Result: 1it [00:00, 1615.68it/s]
PASSED
... (skip) ...
test_dispatch_combine.py::test_dispatch_combine[1-8-32-2048-4-32-7168-data_type1-8] SKIPPED (skip fp8 with scale_dim == 0)
Running MORI dispatch/combine (#tokens=9202): 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 13.28it/s]
Checking Result: 1it [00:00, 18.28it/s]
PASSED
test_dispatch_combine.py::test_dispatch_combine[1-8-32-2048-4-32-4096-data_type1-8] SKIPPED (skip fp8 with scale_dim == 0)

============================================================================================================================================= 24 passed, 24 skipped in 16.69s ==============================================================================================================================================
```
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.