### PR TITLE
Fix: fix output buffer overwrite issue in intranode EP.

### DIFF
--- a/examples/ops/dispatch_combine/test_dispatch_combine.cpp
+++ b/examples/ops/dispatch_combine/test_dispatch_combine.cpp
@@ -249,7 +249,8 @@ class EpDispatchCombineTestCase {
         index_t srcPe = srcTokId / config.maxNumInpTokenPerRank;
         index_t localSrcTokId = srcTokId - srcPe * config.maxNumInpTokenPerRank;
 
-        T* localTokBuf = handle.shmemOutTokMemObj->template GetAs<T*>() + i * config.hiddenDim;
+        T* localTokBuf =
+            handle.shmemDispatchOutTokMemObj->template GetAs<T*>() + i * config.hiddenDim;
         T* srcTokBuf = reinterpret_cast<T*>(globalInpTokBufCpu) + srcPe * inpTokEleNum +
                        localSrcTokId * config.hiddenDim;
 
@@ -291,7 +292,8 @@ class EpDispatchCombineTestCase {
         index_t srcTokDispatchId = peSortToTokenIdxMapsVec[srcPe][peSortedId];
         index_t srcTokId = srcTokDispatchId / config.numExpertPerToken;
 
-        T* localTokBuf = handle.shmemOutTokMemObj->template GetAs<T*>() + i * config.hiddenDim;
+        T* localTokBuf =
+            handle.shmemDispatchOutTokMemObj->template GetAs<T*>() + i * config.hiddenDim;
 
         T* srcTokBuf = reinterpret_cast<T*>(globalInpTokBufCpu) + srcPe * inpTokEleNum +
                        srcTokId * config.hiddenDim;
@@ -348,7 +350,7 @@ class EpDispatchCombineTestCase {
         float expected =
             float(T(float(reinterpret_cast<T*>(inpTokBufCpu)[tokenOffset + j]) * weightSum));
         // float got = float(handle.outTokenBuf[tokenOffset + j]);
-        float got = float(handle.shmemOutTokMemObj->template GetAs<T*>()[tokenOffset + j]);
+        float got = float(handle.shmemCombineOutTokMemObj->template GetAs<T*>()[tokenOffset + j]);
         assert(weightSum != 0);
         if (abs(got - expected) > runConfig.atol) {
           std::cout << "Wrong result at pos " << j << ": mype " << config.rank << " tokenId " << i
@@ -468,7 +470,7 @@ class EpDispatchCombineTestCase {
     // HIP_RUNTIME_CHECK(hipMemcpy(inpTokBuf, outTokBuf,
     //                             config.MaxNumTokensToRecvPerRank() * config.hiddenDim *
     //                             sizeof(T), hipMemcpyDeviceToDevice));
-    HIP_RUNTIME_CHECK(hipMemcpy(inpTokBuf, handle.shmemOutTokMemObj->template GetAs<T*>(),
+    HIP_RUNTIME_CHECK(hipMemcpy(inpTokBuf, handle.shmemDispatchOutTokMemObj->template GetAs<T*>(),
                                 config.MaxNumTokensToRecvPerRank() * config.hiddenDim * sizeof(T),
                                 hipMemcpyDeviceToDevice));
     HIP_RUNTIME_CHECK(

--- a/include/mori/ops/dispatch_combine/dispatch_combine.hpp
+++ b/include/mori/ops/dispatch_combine/dispatch_combine.hpp
@@ -171,12 +171,14 @@ class EpDispatchCombineHandle {
   // Registered buffers for tokens, shmemOutTokMemObj will be returned to user as output
   mori::application::SymmMemObjPtr shmemDispatchInpTokMemObj;
   mori::application::SymmMemObjPtr shmemCombineInpTokMemObj;
-  mori::application::SymmMemObjPtr shmemOutTokMemObj;
+  mori::application::SymmMemObjPtr shmemDispatchOutTokMemObj;
+  mori::application::SymmMemObjPtr shmemCombineOutTokMemObj;
   mori::application::SymmMemObjPtr shmemStagingTokMemObj;
 
   // Registered buffer used for weights, indices and scales
   mori::application::SymmMemObjPtr shmemInpWeightsMemObj;
-  mori::application::SymmMemObjPtr shmemOutWeightsMemObj;
+  mori::application::SymmMemObjPtr shmemDispatchOutWeightsMemObj;
+  mori::application::SymmMemObjPtr shmemCombineOutWeightsMemObj;
   mori::application::SymmMemObjPtr shmemInpScalesMemObj;
   mori::application::SymmMemObjPtr shmemOutScalesMemObj;
   mori::application::SymmMemObjPtr shmemInpIndicesMemObj;
@@ -231,10 +233,12 @@ struct EpDispatchCombineArgs {
   uint8_t* scalesBuf{nullptr};
   mori::application::SymmMemObjPtr shmemDispatchInpTokMemObj;
   mori::application::SymmMemObjPtr shmemCombineInpTokMemObj;
-  mori::application::SymmMemObjPtr shmemOutTokMemObj;
+  mori::application::SymmMemObjPtr shmemDispatchOutTokMemObj;
+  mori::application::SymmMemObjPtr shmemCombineOutTokMemObj;
   mori::application::SymmMemObjPtr shmemStagingTokMemObj;
   mori::application::SymmMemObjPtr shmemInpWeightsMemObj;
-  mori::application::SymmMemObjPtr shmemOutWeightsMemObj;
+  mori::application::SymmMemObjPtr shmemDispatchOutWeightsMemObj;
+  mori::application::SymmMemObjPtr shmemCombineOutWeightsMemObj;
   mori::application::SymmMemObjPtr shmemInpScalesMemObj;
   mori::application::SymmMemObjPtr shmemOutScalesMemObj;
   mori::application::SymmMemObjPtr shmemInpIndicesMemObj;
@@ -276,10 +280,12 @@ EpDispatchCombineArgs<T> GetEpDispatchCombineArgs(const EpDispatchCombineHandle&
   args.localPeTokenCounter = handle.localPeTokenCounter;
   args.shmemDispatchInpTokMemObj = handle.shmemDispatchInpTokMemObj;
   args.shmemCombineInpTokMemObj = handle.shmemCombineInpTokMemObj;
-  args.shmemOutTokMemObj = handle.shmemOutTokMemObj;
+  args.shmemDispatchOutTokMemObj = handle.shmemDispatchOutTokMemObj;
+  args.shmemCombineOutTokMemObj = handle.shmemCombineOutTokMemObj;
   args.shmemStagingTokMemObj = handle.shmemStagingTokMemObj;
   args.shmemInpWeightsMemObj = handle.shmemInpWeightsMemObj;
-  args.shmemOutWeightsMemObj = handle.shmemOutWeightsMemObj;
+  args.shmemDispatchOutWeightsMemObj = handle.shmemDispatchOutWeightsMemObj;
+  args.shmemCombineOutWeightsMemObj = handle.shmemCombineOutWeightsMemObj;
   args.shmemInpScalesMemObj = handle.shmemInpScalesMemObj;
   args.shmemOutScalesMemObj = handle.shmemOutScalesMemObj;
   args.shmemInpIndicesMemObj = handle.shmemInpIndicesMemObj;

--- a/src/ops/dispatch_combine/dispatch_combine.cpp
+++ b/src/ops/dispatch_combine/dispatch_combine.cpp
@@ -74,12 +74,16 @@ void EpDispatchCombineHandle::InitializeShmemBuf() {
       ShmemMallocAndReturnMemObjPtr(maxStagingTokSize, hipDeviceMallocUncached);
   shmemCombineInpTokMemObj =
       ShmemMallocAndReturnMemObjPtr(maxStagingTokSize, hipDeviceMallocUncached);
-  shmemOutTokMemObj = ShmemMallocAndReturnMemObjPtr(maxTokenSize, hipDeviceMallocUncached);
+  shmemDispatchOutTokMemObj = ShmemMallocAndReturnMemObjPtr(maxTokenSize, hipDeviceMallocUncached);
+  shmemCombineOutTokMemObj = ShmemMallocAndReturnMemObjPtr(maxTokenSize, hipDeviceMallocUncached);
   shmemStagingTokMemObj = ShmemMallocAndReturnMemObjPtr(maxStagingTokSize, hipDeviceMallocUncached);
 
   size_t maxWeightSize = config.MaxNumTokensToRecv() * config.numExpertPerToken * sizeof(float);
   shmemInpWeightsMemObj = ShmemMallocAndReturnMemObjPtr(maxWeightSize, hipDeviceMallocUncached);
-  shmemOutWeightsMemObj = ShmemMallocAndReturnMemObjPtr(maxWeightSize, hipDeviceMallocUncached);
+  shmemDispatchOutWeightsMemObj =
+      ShmemMallocAndReturnMemObjPtr(maxWeightSize, hipDeviceMallocUncached);
+  shmemCombineOutWeightsMemObj =
+      ShmemMallocAndReturnMemObjPtr(maxWeightSize, hipDeviceMallocUncached);
 
   if (config.scaleDim > 0 && config.scaleTypeSize > 0) {
     size_t maxScaleSize = config.MaxNumTokensToRecv() * config.scaleDim * config.scaleTypeSize;
@@ -95,10 +99,12 @@ void EpDispatchCombineHandle::InitializeShmemBuf() {
 void EpDispatchCombineHandle::FinalizeShmemBuf() {
   ShmemFree(shmemDispatchInpTokMemObj->localPtr);
   ShmemFree(shmemCombineInpTokMemObj->localPtr);
-  ShmemFree(shmemOutTokMemObj->localPtr);
+  ShmemFree(shmemDispatchOutTokMemObj->localPtr);
+  ShmemFree(shmemCombineOutTokMemObj->localPtr);
   ShmemFree(shmemStagingTokMemObj->localPtr);
   ShmemFree(shmemInpWeightsMemObj->localPtr);
-  ShmemFree(shmemOutWeightsMemObj->localPtr);
+  ShmemFree(shmemDispatchOutWeightsMemObj->localPtr);
+  ShmemFree(shmemCombineOutWeightsMemObj->localPtr);
   if (shmemInpScalesMemObj.IsValid()) ShmemFree(shmemInpScalesMemObj->localPtr);
   if (shmemOutScalesMemObj.IsValid()) ShmemFree(shmemOutScalesMemObj->localPtr);
   ShmemFree(shmemInpIndicesMemObj->localPtr);

--- a/src/pybind/mori.cpp
+++ b/src/pybind/mori.cpp
@@ -70,14 +70,14 @@ LaunchDispatch(mori::moe::EpDispatchCombineHandle& handle, int kernelType,
                         at::cuda::getCurrentHIPStream());
 
   torch::Tensor out =
-      torch::from_blob(handle.shmemOutTokMemObj->Get(),
+      torch::from_blob(handle.shmemDispatchOutTokMemObj->Get(),
                        {handle.config.MaxNumTokensToRecv(), handle.config.hiddenDim},
                        torch::TensorOptions().dtype(input.scalar_type()).device(torch::kCUDA));
 
   std::optional<torch::Tensor> outWeights{std::nullopt};
   if (weightPtr) {
     outWeights = torch::from_blob(
-        handle.shmemOutWeightsMemObj->Get(),
+        handle.shmemDispatchOutWeightsMemObj->Get(),
         {handle.config.MaxNumTokensToRecv(), handle.config.numExpertPerToken},
         torch::TensorOptions().dtype(mori::GetTorchDataType<float>()).device(torch::kCUDA));
   }
@@ -127,13 +127,13 @@ std::tuple<torch::Tensor, std::optional<torch::Tensor>> LaunchCombine(
 
   auto options = torch::TensorOptions().dtype(input.scalar_type()).device(torch::kCUDA);
   torch::Tensor out =
-      torch::from_blob(handle.shmemOutTokMemObj->Get(),
+      torch::from_blob(handle.shmemCombineOutTokMemObj->Get(),
                        {handle.config.maxNumInpTokenPerRank, handle.config.hiddenDim}, options);
 
   std::optional<torch::Tensor> outWeights{std::nullopt};
   if (weightsPtr) {
     outWeights =
-        torch::from_blob(handle.shmemOutWeightsMemObj->Get(),
+        torch::from_blob(handle.shmemCombineOutWeightsMemObj->Get(),
                          {handle.config.maxNumInpTokenPerRank, handle.config.numExpertPerToken},
                          torch::TensorOptions().dtype(weights->scalar_type()).device(torch::kCUDA));
   }


### PR DESCRIPTION
This is a work by a team from Moreh Inc.
## Motivation
Fixed the problem where the output occasionally becomes incorrect.

## Technical Details
### Issue
When running the intranode EP, the output occasionally becomes incorrect.
### Cause
This issue occurs because both the dispatch and combine phases share the same output buffers, 
`shmemOutTokMemObj` and `shmemOutWeightsMemObj`.
Since these buffers are reused across phases, they can be overwritten due to differences in execution timing between ranks.

In intranode EP, each dispatch/combine kernel behaviors are as follows:
- Dispatch (send phase): Sends data to the remote device’s `shmemOutTokMemObj` and `shmemOutWeightsMemObj`.
- Combine (send phase): Writes the combine output and output weights into its own`shmemOutTokMemObj` and `shmemOutWeightsMemObj`.
The Core Issue

Because the same buffers are reused for every dispatch/combine call, the combine result should be copied to the user buffer.
- Within a single rank, the sequence dispatch → memcpy → combine → memcpy is strictly ordered, so it’s safe.
- However, across ranks, there’s no guaranteed order between dispatch and combine phases except for the cross barrier used inside combine.

While one rank is performing the **combine recv phase**, another rank might already be executing the **dispatch send phase**.
- If there’s a delay between the combine call and the memcpy that follows it, another rank’s dispatch may overwrite the shared buffer in that gap.
- This situation makes output incorrect.
<img width="868" height="348" alt="image" src="https://github.com/user-attachments/assets/53cea465-9783-4757-b6ca-d5420fe2873e" />

### Fix
Split `shmemOutTokMemObj` and `shmemOutWeightsMemObj` into seperate objects for dispatch and combine

## Test Plan
1) Merge [moreh-dev:enhance_mori_ep_test](https://github.com/moreh-dev/mori/tree/enhance_mori_ep_test) and [moreh-dev:fix_ep_result_error](https://github.com/moreh-dev/mori/tree/fix_ep_result_error) branches
  - `moreh-dev:fix_ep_result_error` : fixed possible result value error in internode and intranode EP (https://github.com/ROCm/mori/pull/87)
  - `moreh-dev:enhance_mori_ep_test` : enhanced mori ep unit test. (https://github.com/ROCm/mori/pull/92)
2) Modify  `tests/python/ops/test_dispatch_combine.py` as below:
```
diff --git tests/python/ops/test_dispatch_combine.py tests/python/ops/test_dispatch_combine.py
index c515434..d9a4dd7 100644
--- tests/python/ops/test_dispatch_combine.py
+++ tests/python/ops/test_dispatch_combine.py
@@ -454,7 +454,7 @@ def _test_dispatch_combine(
 @pytest.mark.parametrize("max_num_inp_token_per_rank", (1, 128, 2048))
 @pytest.mark.parametrize("num_experts_per_rank", (32,))
 @pytest.mark.parametrize("num_experts_per_token", (8,))
-@pytest.mark.parametrize("num_reps", (1,))
+@pytest.mark.parametrize("num_reps", (8,))
 def test_dispatch_combine(
     torch_dist_process_manager,
     world_size,
```
3. Execute the test script
```
pytest -s -v tests/python/ops/test_dispatch_combine.py
```
## Test Result
Before modification: the test fails
```
E       ValueError: Caught ValueError in rank 0.
E       Original Traceback (most recent call last):
E         File "/app/mori/tests/python/utils.py", line 171, in _worker
E           result = func(rank, *args)
E                    ^^^^^^^^^^^^^^^^^
E         File "/app/mori/tests/python/ops/test_dispatch_combine.py", line 445, in _test_dispatch_combine
E           test_case.run_test(op, test_data)
E         File "/app/mori/tests/python/ops/test_dispatch_combine.py", line 375, in run_test
E           self.check_result(test_data, mori_result, i)
E         File "/app/mori/tests/python/ops/test_dispatch_combine.py", line 400, in check_result
E           self.check_combine_result(test_data, combine_output, combine_weights, round)
E         File "/app/mori/tests/python/ops/test_dispatch_combine.py", line 269, in check_combine_result
E           raise ValueError(error_msg)
E       ValueError: 0-th Combine result mismatch for token 0:
E         indices[0]: [104, 49, 208, 235, 114, 18, 28, 55]
E         got: tensor([ 9.3259e-15, -5.9292e-20, -1.2821e-22,  ...,  3.1641e-01,
E                3.7969e+00, -8.4375e-01], device='cuda:0', dtype=torch.bfloat16)
E         expected : tensor([ 1.9922,  0.9961, -1.2500,  ...,  0.3164,  3.7969, -0.8438],
E              device='cuda:0', dtype=torch.bfloat16)
```
After modification: all test passed
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
