### PR TITLE
Feature: add expert map support for shared experts & EPLB

### DIFF
--- a/examples/ops/dispatch_combine/test_dispatch_combine.cpp
+++ b/examples/ops/dispatch_combine/test_dispatch_combine.cpp
@@ -179,10 +179,10 @@ class EpDispatchCombineTestCase {
     RandomInitializeToken();
     if (IsNoDataRank(handle.config)) {
       handle.PrepareInference(GetHipDataType<T>(), nullptr, outTokBuf, weightsBuf, scalesBuf,
-                              nullptr, 0);
+                              nullptr, nullptr, 0);
     } else {
       handle.PrepareInference(GetHipDataType<T>(), inpTokBuf, outTokBuf, weightsBuf, scalesBuf,
-                              tokenIndices, numToken);
+                              tokenIndices, nullptr, numToken);
     }
     // PrintDispatch();
     // PrintDispatchStats();
@@ -465,7 +465,7 @@ class EpDispatchCombineTestCase {
     EpDispatchCombineConfig& config = handle.config;
     if (IsNoDataRank(handle.config)) {
       handle.PrepareInference(GetHipDataType<T>(), inpTokBuf, outTokBuf, weightsBuf, scalesBuf,
-                              nullptr, 0);
+                              nullptr, nullptr, 0);
     }
     // HIP_RUNTIME_CHECK(hipMemcpy(inpTokBuf, outTokBuf,
     //                             config.MaxNumTokensToRecvPerRank() * config.hiddenDim *

--- a/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
+++ b/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
@@ -42,6 +42,7 @@ class EpDispatchCombineTestCase:
         max_tokens,
         kernel_type,
         dtype=torch.bfloat16,
+        with_expert_map=False,
     ):
         self.rank = rank
         self.gpu_per_node = gpu_per_node
@@ -64,6 +65,7 @@ class EpDispatchCombineTestCase:
             gpu_per_node=self.gpu_per_node,
             rdma_block_num=64,
         )
+        self.with_expert_map = with_expert_map
 
     def setup(self):
         local_rank = self.rank % self.gpu_per_node
@@ -214,15 +216,21 @@ class EpDispatchCombineTestCase:
                 ).to(self.config.data_type)
             )
 
+        total_num_expert = self.config.num_experts_per_rank * self.config.world_size
+        expert_map = torch.randperm(
+            total_num_expert, generator=self.rng, device=self.device
+        ).to(torch.int32)
+
         return (
             num_token,
             all_rank_indices,
             all_rank_input,
             all_rank_weights,
             all_rank_scales,
+            expert_map if self.with_expert_map else None,
         )
 
-    def count_token_num(self, all_rank_indices):
+    def count_token_num(self, all_rank_indices, expert_map):
         # Per-rank counts
         rank_counts = torch.zeros(
             self.config.world_size, dtype=torch.int32, device=self.device
@@ -238,9 +246,11 @@ class EpDispatchCombineTestCase:
             src_node = src_rank // self.config.gpu_per_node
 
             # Map expert IDs to rank IDs
-            token_ranks = (
-                indices // self.config.num_experts_per_rank
-            )  # [num_tokens, num_experts_per_token]
+            if expert_map is not None:
+                indices = [expert_map[ids] for ids in indices]
+            else:
+                indices = [ids for ids in indices]
+            token_ranks = [ids // self.config.num_experts_per_rank for ids in indices]
 
             # Deduplicate rank IDs per token
             unique_ranks_per_token = [torch.unique(row) for row in token_ranks]
@@ -265,10 +275,10 @@ class EpDispatchCombineTestCase:
                         rank_counts_remote_send[src_rank] += 1
 
         if self.config.rank == 0:
-            print("Rank counts (deduplicated):", rank_counts)
-            # print("Rank counts local nodes:", rank_counts - rank_counts_remote_recv)
-            # print("Rank counts from other nodes:", rank_counts_remote_recv)
-            # print("Rank counts to other nodes:", rank_counts_remote_send)
+            print(self.config.rank, "Rank counts (deduplicated):", rank_counts)
+        # print("Rank counts local nodes:", rank_counts - rank_counts_remote_recv)
+        # print("Rank counts from other nodes:", rank_counts_remote_recv)
+        # print("Rank counts to other nodes:", rank_counts_remote_send)
         return rank_counts, rank_counts_remote_recv, rank_counts_remote_send
 
     def run_test_once(self, op, test_data, error_round, round):
@@ -278,6 +288,7 @@ class EpDispatchCombineTestCase:
             all_rank_input,
             all_rank_weights,
             all_rank_scales,
+            expert_map,
         ) = test_data
         dist.barrier()
 
@@ -293,13 +304,14 @@ class EpDispatchCombineTestCase:
             # None,
             all_rank_scales[self.rank],
             all_rank_indices[self.rank],
+            index_to_exp_id=expert_map,
             block_num=self.config.block_num,
             warp_per_block=16,
         )
         torch.cuda.synchronize()
         dist.barrier()
 
-        rank_counts, _, _ = self.count_token_num(all_rank_indices)
+        rank_counts, _, _ = self.count_token_num(all_rank_indices, expert_map)
 
         src_token_pos = op.get_dispatch_src_token_pos().tolist()
         max_num_token_to_send_per_rank = self.config.max_num_inp_token_per_rank
@@ -307,10 +319,10 @@ class EpDispatchCombineTestCase:
 
         # Check recv token num
         print(f"rank {self.rank} recv {recv_token_num} tokens")
-        token_num_pass = rank_counts[self.rank] == recv_token_num
+        token_num_pass = rank_counts[self.config.rank] == recv_token_num
         if not token_num_pass:
             print(
-                f"rank {self.rank} expected token num {rank_counts[self.rank]} got {recv_token_num}"
+                f"rank {self.rank} expected token num {rank_counts[self.config.rank]} got {recv_token_num}"
             )
             assert False
 
@@ -353,9 +365,11 @@ class EpDispatchCombineTestCase:
         dist.barrier()
 
         for i in range(all_rank_num_token[self.rank]):
+            indices = all_rank_indices[self.config.rank][i].cpu()
+            if expert_map is not None:
+                indices = expert_map[indices]
             pes = [
-                (idx // self.config.num_experts_per_rank)
-                for idx in all_rank_indices[self.rank][i].cpu().tolist()
+                (idx // self.config.num_experts_per_rank) for idx in indices.tolist()
             ]
             unique_pes = len(set(pes))
             unique_innode_pes = len(
@@ -449,6 +463,7 @@ class EpDispatchCombineTestCase:
             all_rank_input,
             all_rank_weights,
             all_rank_scales,
+            expert_map,
         ) = test_data
 
         start_event = torch.cuda.Event(enable_timing=True)
@@ -468,6 +483,7 @@ class EpDispatchCombineTestCase:
             all_rank_weights[self.rank],
             all_rank_scales[self.rank],
             all_rank_indices[self.rank],
+            index_to_exp_id=expert_map,
             block_num=self.config.block_num,
             warp_per_block=16,
         )
@@ -695,6 +711,7 @@ def test_dispatch_combine(
         kernel_type,
         torch.bfloat16,
         # torch.float8_e4m3fnuz,
+        with_expert_map=False,
     )
     test_case.setup()
     if is_bench:

--- a/python/mori/ops/dispatch_combine.py
+++ b/python/mori/ops/dispatch_combine.py
@@ -107,6 +107,7 @@ class EpDispatchCombineOp:
         weights: torch.Tensor,
         scales: torch.Tensor,
         indices: torch.Tensor,
+        index_to_exp_id: torch.Tensor = None,
         block_num: int = -1,
         warp_per_block: int = -1,
     ):
@@ -117,6 +118,7 @@ class EpDispatchCombineOp:
             weights,
             scales,
             indices,
+            index_to_exp_id,
             block_num,
             warp_per_block,
         )

--- a/src/ops/dispatch_combine/internode.hpp
+++ b/src/ops/dispatch_combine/internode.hpp
@@ -24,6 +24,7 @@
 #include "mori/core/core.hpp"
 #include "mori/ops/dispatch_combine/dispatch_combine.hpp"
 #include "mori/shmem/shmem.hpp"
+#include "src/ops/dispatch_combine/intranode.hpp"
 
 namespace mori {
 namespace moe {
@@ -91,7 +92,8 @@ __global__ void EpDispatchInterNodeKernel(EpDispatchCombineArgs<T> args) {
     for (int tokenId = globalSubWarpId; tokenId < args.curRankNumToken;
          tokenId += globalSubWarpNum) {
       const int expertOffset = tokenId * numExpertPerToken + laneInSubWarp;
-      index_t destExpert = args.tokenIndices[expertOffset];
+      // index_t destExpert = args.tokenIndices[expertOffset];
+      index_t destExpert = GetExpertIndex(args, expertOffset);
       index_t destPe = destExpert / config.numExpertPerRank;
 
       unsigned long long subWarpMask = ((1ULL << numExpertPerToken) - 1ULL)

--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -31,7 +31,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
         super().__init__(config)
 
     def gen_test_data(self):
-        return super().gen_test_data(use_max_token_num=True)
+        return super().gen_test_data(use_max_token_num=True, with_expert_map=False)
 
     def run_once(self, op, test_data, check_result):
         (
@@ -40,6 +40,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
             all_rank_input,
             all_rank_weights,
             all_rank_scales,
+            _,
         ) = test_data
 
         start_event = torch.cuda.Event(enable_timing=True)
@@ -92,7 +93,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
             None,
             dispatch_indices,
             block_num=80,
-            warp_per_block=16,
+            warp_per_block=4,
         )
         end_event.record()
         self.sync()
@@ -182,7 +183,7 @@ def _bench_dispatch_combine(
     world_size,
     port,
     max_num_inp_token_per_rank=128,
-    data_type=torch.float8_e4m3fnuz,
+    data_type=torch.bfloat16,
     hidden_dim=7168,
     scale_dim=0,
     scale_type_size=0,

--- a/tests/python/ops/test_dispatch_combine.py
+++ b/tests/python/ops/test_dispatch_combine.py
@@ -37,7 +37,7 @@ class EpDispatchCombineTestCase:
         torch.cuda.synchronize()
         dist.barrier()
 
-    def gen_test_data(self, use_max_token_num=False):
+    def gen_test_data(self, use_max_token_num=False, with_expert_map=False):
         if use_max_token_num:
             num_token = torch.tensor(
                 [
@@ -112,12 +112,17 @@ class EpDispatchCombineTestCase:
                 ).to(self.config.data_type)
             )
 
+        total_num_expert = self.config.num_experts_per_rank * self.config.world_size
+        expert_map = torch.randperm(total_num_expert).to(torch.int32).to(self.device)
+        # expert_map = torch.arange(total_num_expert).to(torch.int32).to(self.device)
+
         return (
             num_token,
             all_rank_indices,
             all_rank_input,
             all_rank_weights,
             all_rank_scales,
+            expert_map if with_expert_map else None,
         )
 
     def check_dispatch_result(
@@ -137,6 +142,7 @@ class EpDispatchCombineTestCase:
             all_rank_input,
             all_rank_weights,
             all_rank_scales,
+            expert_map,
         ) = test_data
         src_token_pos = op.get_dispatch_src_token_pos()
 
@@ -160,15 +166,21 @@ class EpDispatchCombineTestCase:
         self, op, test_data, combine_output, combine_output_weight=None
     ):
         self.sync()
-        all_rank_num_token = test_data[0]
-        all_rank_indices = test_data[1]
-        all_rank_input = test_data[2]
-        all_rank_weights = test_data[3]
+        (
+            all_rank_num_token,
+            all_rank_indices,
+            all_rank_input,
+            all_rank_weights,
+            all_rank_scales,
+            expert_map,
+        ) = test_data
 
         for i in range(all_rank_num_token[self.config.rank]):
+            indices = all_rank_indices[self.config.rank][i].cpu()
+            if expert_map is not None:
+                indices = expert_map[indices]
             pes = [
-                (idx // self.config.num_experts_per_rank)
-                for idx in all_rank_indices[self.config.rank][i].cpu().tolist()
+                (idx // self.config.num_experts_per_rank) for idx in indices.tolist()
             ]
             unique_pes = len(set(pes))
 
@@ -181,9 +193,7 @@ class EpDispatchCombineTestCase:
             )
             if not result_match and self.config.rank == 0:
                 print(f"Result mismatch for token {i}:")
-                print(
-                    f"  indices[{i}]: {all_rank_indices[self.config.rank][i].cpu().tolist()}"
-                )
+                print(f"  indices[{i}]: {indices}")
                 print(f"  pes: {pes}")
                 print(f"  unique_pes: {unique_pes}")
                 print(f"  got: {got}")
@@ -199,9 +209,7 @@ class EpDispatchCombineTestCase:
                 )
                 if not weight_match and self.config.rank == 0:
                     print(f"Weight mismatch for token {i}:")
-                    print(
-                        f"  indices[{i}]: {all_rank_indices[self.config.rank][i].cpu().tolist()}"
-                    )
+                    print(f"  indices[{i}]: {indices}")
                     print(f"  pes: {pes}")
                     print(f"  unique_pes: {unique_pes}")
                     print(f"  got_weight: {got_weight}")
@@ -216,6 +224,7 @@ class EpDispatchCombineTestCase:
             all_rank_input,
             all_rank_weights,
             all_rank_scales,
+            expert_map,
         ) = test_data
         (
             dispatch_output,
@@ -228,6 +237,7 @@ class EpDispatchCombineTestCase:
             all_rank_weights[self.config.rank],
             all_rank_scales[self.config.rank],
             all_rank_indices[self.config.rank],
+            index_to_exp_id=expert_map,
         )
         self.sync()
         self.check_dispatch_result(
@@ -270,6 +280,7 @@ def _test_dispatch_combine(
     max_num_inp_token_per_rank,
     num_experts_per_rank,
     num_experts_per_token,
+    with_expert_map,
 ):
     config = mori.ops.EpDispatchCombineConfig(
         data_type=data_type,
@@ -287,7 +298,7 @@ def _test_dispatch_combine(
     )
     op = mori.ops.EpDispatchCombineOp(config)
     test_case = EpDispatchCombineTestCase(config)
-    test_data = test_case.gen_test_data()
+    test_data = test_case.gen_test_data(with_expert_map=with_expert_map)
     test_case.run_test_once(op, test_data)
 
 
@@ -300,6 +311,7 @@ def _test_dispatch_combine(
 @pytest.mark.parametrize("max_num_inp_token_per_rank", (1, 128))
 @pytest.mark.parametrize("num_experts_per_rank", (32,))
 @pytest.mark.parametrize("num_experts_per_token", (8,))
+@pytest.mark.parametrize("with_expert_map", (True, False))
 def test_dispatch_combine(
     torch_dist_process_manager,
     world_size,
@@ -310,6 +322,7 @@ def test_dispatch_combine(
     max_num_inp_token_per_rank,
     num_experts_per_rank,
     num_experts_per_token,
+    with_expert_map,
 ):
     for i in range(world_size):
         torch_dist_process_manager.task_queue.put(
@@ -324,6 +337,7 @@ def test_dispatch_combine(
                     max_num_inp_token_per_rank,
                     num_experts_per_rank,
                     num_experts_per_token,
+                    with_expert_map,
                 ],
             )
         )

--- a/tests/python/ops/test_dispatch_combine.py
+++ b/tests/python/ops/test_dispatch_combine.py
@@ -114,7 +114,6 @@ class EpDispatchCombineTestCase:
 
         total_num_expert = self.config.num_experts_per_rank * self.config.world_size
         expert_map = torch.randperm(total_num_expert).to(torch.int32).to(self.device)
-        # expert_map = torch.arange(total_num_expert).to(torch.int32).to(self.device)
 
         return (
             num_token,


### PR DESCRIPTION
## Motivation

TODO

## Technical Details
To map expert index, caller should pass a tensor of shape [total_num_expert] to dispatch. No changes need to be made to combine.
```
        total_num_expert = self.config.num_experts_per_rank * self.config.world_size
        expert_map = torch.randperm(total_num_expert).to(torch.int32).to(self.device)
        op.dispatch(
                all_rank_input[self.config.rank],
                all_rank_weights[self.config.rank],
                all_rank_scales[self.config.rank],
                all_rank_indices[self.config.rank],
                index_to_exp_id=expert_map,
        )
```

## Test Plan

TODO