### PR TITLE
Feat: add multi-qp support for EPV1 kernel

### DIFF
--- a/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
+++ b/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
@@ -44,6 +44,7 @@ class EpDispatchCombineTestCase:
         world_size,
         max_tokens,
         kernel_type,
+        num_qp,
         dtype=torch.bfloat16,
     ):
         self.rank = rank
@@ -59,12 +60,13 @@ class EpDispatchCombineTestCase:
             max_num_inp_token_per_rank=max_tokens,
             num_experts_per_rank=16,
             num_experts_per_token=8,
-            warp_num_per_block=16,
-            block_num=32,
+            warp_num_per_block=8,
+            block_num=64,
             max_token_type_size=2,
             kernel_type=kernel_type_map[kernel_type],
             gpu_per_node=self.gpu_per_node,
-            rdma_block_num=16,
+            rdma_block_num=32,
+            num_qp_per_pe=num_qp,
         )
 
     def setup(self):
@@ -292,7 +294,7 @@ class EpDispatchCombineTestCase:
             all_rank_scales[self.rank],
             all_rank_indices[self.rank],
             block_num=self.config.block_num,
-            warp_per_block=16,
+            # warp_per_block=16,
         )
         torch.cuda.synchronize()
 
@@ -341,7 +343,7 @@ class EpDispatchCombineTestCase:
             dispatch_weights,
             all_rank_indices[self.rank],
             block_num=self.config.block_num,
-            warp_per_block=16,
+            # warp_per_block=16,
         )
         torch.cuda.synchronize()
         for i in range(all_rank_num_token[self.rank]):
@@ -459,14 +461,14 @@ class EpDispatchCombineTestCase:
                 all_rank_scales[self.rank],
                 all_rank_indices[self.rank],
                 block_num=self.config.block_num,
-                warp_per_block=16,
+                # warp_per_block=16,
             )
             _, _ = op.combine(
                 dispatch_output,
                 dispatch_weights,
                 all_rank_indices[self.rank],
                 block_num=self.config.block_num,
-                warp_per_block=16,
+                # warp_per_block=16,
             )
             torch.cuda.synchronize()
             time.sleep(0.0001)
@@ -495,14 +497,14 @@ class EpDispatchCombineTestCase:
                 all_rank_scales[self.rank],
                 all_rank_indices[self.rank],
                 block_num=self.config.block_num,
-                warp_per_block=16,
+                # warp_per_block=16,
             )
             _, _ = op.combine(
                 dispatch_output,
                 dispatch_weights,
                 all_rank_indices[self.rank],
                 block_num=self.config.block_num,
-                warp_per_block=16,
+                # warp_per_block=16,
             )
         torch.cuda.synchronize()
 
@@ -538,7 +540,7 @@ class EpDispatchCombineTestCase:
                 all_rank_scales[self.rank],
                 all_rank_indices[self.rank],
                 block_num=self.config.block_num,
-                warp_per_block=16,
+                # warp_per_block=16,
             )
             torch.cuda.synchronize()
             total_recv_num_token = dispatch_recv_num_token[0].item()
@@ -548,7 +550,7 @@ class EpDispatchCombineTestCase:
                 # None,
                 all_rank_indices[self.rank],
                 block_num=self.config.block_num,
-                warp_per_block=16,
+                # warp_per_block=16,
             )
             torch.cuda.synchronize()
 
@@ -575,7 +577,7 @@ class EpDispatchCombineTestCase:
                 all_rank_scales[self.rank],
                 all_rank_indices[self.rank],
                 block_num=self.config.block_num,
-                warp_per_block=16,
+                # warp_per_block=16,
             )
             events[2 * i + 1].record()
             combine_output, _ = op.combine(
@@ -583,7 +585,7 @@ class EpDispatchCombineTestCase:
                 dispatch_weights,
                 all_rank_indices[self.rank],
                 block_num=self.config.block_num,
-                warp_per_block=16,
+                # warp_per_block=16,
             )
             events[2 * i + 2].record()
         torch.cuda.synchronize()
@@ -816,7 +818,7 @@ class EpDispatchCombineTestCase:
 
 
 def test_dispatch_combine(
-    local_rank, num_node, gpu_per_node, max_tokens, kernel_type, cmd="test"
+    local_rank, num_node, gpu_per_node, max_tokens, kernel_type, num_qp, cmd="test"
 ):
     world_size = num_node * gpu_per_node
     node_rank = int(os.environ["RANK"])
@@ -828,6 +830,7 @@ def test_dispatch_combine(
         world_size,
         max_tokens,
         kernel_type,
+        num_qp,
         torch.bfloat16,
         # torch.float8_e4m3fnuz,
     )
@@ -865,6 +868,12 @@ parser.add_argument(
     help="Type of kernel to test",
     choices=["v0", "v1", "v1_ll"],
 )
+parser.add_argument(
+    "--num-qp",
+    type=int,
+    default=1,
+    help="Number of qp per processing endpoint",
+)
 args_cli = parser.parse_args()
 
 if __name__ == "__main__":
@@ -880,6 +889,7 @@ if __name__ == "__main__":
             gpu_per_node,
             args_cli.max_tokens,
             args_cli.kernel_type,
+            args_cli.num_qp,
             args_cli.cmd,
         ),
         nprocs=gpu_per_node,

--- a/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
+++ b/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
@@ -294,7 +294,6 @@ class EpDispatchCombineTestCase:
             all_rank_scales[self.rank],
             all_rank_indices[self.rank],
             block_num=self.config.block_num,
-            # warp_per_block=16,
         )
         torch.cuda.synchronize()
 
@@ -343,7 +342,6 @@ class EpDispatchCombineTestCase:
             dispatch_weights,
             all_rank_indices[self.rank],
             block_num=self.config.block_num,
-            # warp_per_block=16,
         )
         torch.cuda.synchronize()
         for i in range(all_rank_num_token[self.rank]):
@@ -461,14 +459,12 @@ class EpDispatchCombineTestCase:
                 all_rank_scales[self.rank],
                 all_rank_indices[self.rank],
                 block_num=self.config.block_num,
-                # warp_per_block=16,
             )
             _, _ = op.combine(
                 dispatch_output,
                 dispatch_weights,
                 all_rank_indices[self.rank],
                 block_num=self.config.block_num,
-                # warp_per_block=16,
             )
             torch.cuda.synchronize()
             time.sleep(0.0001)
@@ -497,14 +493,12 @@ class EpDispatchCombineTestCase:
                 all_rank_scales[self.rank],
                 all_rank_indices[self.rank],
                 block_num=self.config.block_num,
-                # warp_per_block=16,
             )
             _, _ = op.combine(
                 dispatch_output,
                 dispatch_weights,
                 all_rank_indices[self.rank],
                 block_num=self.config.block_num,
-                # warp_per_block=16,
             )
         torch.cuda.synchronize()
 
@@ -540,7 +534,6 @@ class EpDispatchCombineTestCase:
                 all_rank_scales[self.rank],
                 all_rank_indices[self.rank],
                 block_num=self.config.block_num,
-                # warp_per_block=16,
             )
             torch.cuda.synchronize()
             total_recv_num_token = dispatch_recv_num_token[0].item()
@@ -550,7 +543,6 @@ class EpDispatchCombineTestCase:
                 # None,
                 all_rank_indices[self.rank],
                 block_num=self.config.block_num,
-                # warp_per_block=16,
             )
             torch.cuda.synchronize()
 
@@ -577,7 +569,6 @@ class EpDispatchCombineTestCase:
                 all_rank_scales[self.rank],
                 all_rank_indices[self.rank],
                 block_num=self.config.block_num,
-                # warp_per_block=16,
             )
             events[2 * i + 1].record()
             combine_output, _ = op.combine(
@@ -585,7 +576,6 @@ class EpDispatchCombineTestCase:
                 dispatch_weights,
                 all_rank_indices[self.rank],
                 block_num=self.config.block_num,
-                # warp_per_block=16,
             )
             events[2 * i + 2].record()
         torch.cuda.synchronize()

--- a/include/mori/ops/dispatch_combine/dispatch_combine.hpp
+++ b/include/mori/ops/dispatch_combine/dispatch_combine.hpp
@@ -86,8 +86,10 @@ struct EpDispatchCombineConfig {
   // If true, use external buffer which incurs extra copy overhead; otherwise, the kernel assumes
   // the provided buffer is shmemInpTokMemObj
   bool useExternalInpBuffer{true};
+  KernelType kernelType{KernelType::IntraNode};
   int gpuPerNode{8};
   int rdmaBlockNum{1};
+  int numQpPerPe{1};
 
   inline __host__ __device__ int MaxNumTokensToSendPerRank() const { return maxNumInpTokenPerRank; }
 
@@ -222,7 +224,7 @@ class EpDispatchCombineHandle {
   index_t* dispDestTokIdMap{nullptr};
   index_t* totalRecvTokenNum{nullptr};
   mori::application::SymmMemObjPtr crossDeviceBarrierMemObj;
-  uint32_t* crossDeviceBarrierFlag{nullptr};
+  uint64_t* crossDeviceBarrierFlag{nullptr};
 
   // Inter-node v1 kernel parameters
   // Signal the completion of inter-node token transfer
@@ -281,7 +283,7 @@ struct EpDispatchCombineArgs {
   index_t* dispDestTokIdMap{nullptr};
   index_t* totalRecvTokenNum{nullptr};
   mori::application::SymmMemObjPtr crossDeviceBarrierMemObj;
-  uint32_t* crossDeviceBarrierFlag{nullptr};
+  uint64_t* crossDeviceBarrierFlag{nullptr};
   mori::application::SymmMemObjPtr interNodeChunkFlagMemObj;
   index_t* destNodeTokenCounter{nullptr};
   mori::application::SymmMemObjPtr nodeRecvTokenNumMemObj;

--- a/include/mori/shmem/shmem_api.hpp
+++ b/include/mori/shmem/shmem_api.hpp
@@ -48,6 +48,8 @@ enum ShmemTeamType {
   TEAM_NODE = 2,
 };
 
+int ShmemNumQpPerPe();
+
 // TODO: finish team pe api
 // int ShmemTeamMyPe(ShmemTeamType);
 // int ShmemTeamNPes(ShmemTeamType);

--- a/python/mori/ops/dispatch_combine.py
+++ b/python/mori/ops/dispatch_combine.py
@@ -49,6 +49,7 @@ class EpDispatchCombineConfig:
     kernel_type: EpDispatchCombineKernelType = EpDispatchCombineKernelType.IntraNode
     gpu_per_node: int = 8
     rdma_block_num: int = 0
+    num_qp_per_pe: int = 1
 
 
 def _cpp_dispatch_combine_factory(entity_name):
@@ -74,8 +75,10 @@ class EpDispatchCombineOp:
                 warp_num_per_block=config.warp_num_per_block,
                 block_num=config.block_num,
                 use_external_inp_buf=config.use_external_inp_buf,
+                kernel_type=config.kernel_type,
                 gpu_per_node=config.gpu_per_node,
                 rdma_block_num=config.rdma_block_num,
+                num_qp_per_pe=config.num_qp_per_pe,
             )
         )
 

--- a/python/mori/shmem/api.py
+++ b/python/mori/shmem/api.py
@@ -36,3 +36,7 @@ def shmem_mype():
 
 def shmem_npes():
     return mori_cpp.shmem_npes()
+
+
+def shmem_num_qp_per_pe():
+    return mori_cpp.shmem_num_qp_per_pe()

--- a/src/ops/dispatch_combine/internode.hpp
+++ b/src/ops/dispatch_combine/internode.hpp
@@ -30,10 +30,10 @@ namespace moe {
 
 #define MAX_GPUS_PER_NODE 8
 
-#define DEBUG 0
+#define MORI_INTERNODE_V0_DEBUG 0
 
 __device__ void SyncIfDebugEnabled(const char* msg) {
-#if DEBUG == 1
+#if MORI_INTERNODE_V0_DEBUG == 1
   __syncthreads();
   if ((threadIdx.x == 0) && (blockIdx.x == 0)) {
     shmem::ShmemQuietThread();
@@ -352,7 +352,7 @@ inline __device__ void CrossDeviceBarrierInterNodeKernel(EpDispatchCombineArgs<T
       args.crossDeviceBarrierMemObj->template GetAs<volatile uint64_t*>();
   if (thdId < args.config.worldSize) {
     uint64_t currentVal = core::AtomicLoadRelaxedSystem(localBarrierPtr + thdId);
-#if DEBUG == 1
+#if MORI_INTERNODE_V0_DEBUG == 1
     printf("Thread %d: localBarrierPtr[%d] = %lu, expected = %lu\n", thdId, thdId, currentVal,
            (uint64_t)(crossDeviceBarrierFlag * numQps));
 #endif

--- a/src/ops/dispatch_combine/internode_v1.cpp
+++ b/src/ops/dispatch_combine/internode_v1.cpp
@@ -264,11 +264,12 @@ inline __device__ void DispatchInterNodeSend(EpDispatchCombineArgs<T>& args) {
         if (laneId == 0) {
           index_t tokenNum = std::min(tokenId + warpSize, endTokenIdx) - tokenId;
           size_t stagingTokOffset = tokenId * xferBytes;
+          int qpId = (tokenId / warpSize);
           shmem::ShmemPutMemNbiSignalThread(args.shmemDispatchInpTokMemObj, remoteIdx * xferBytes,
                                             args.shmemStagingTokMemObj, stagingTokOffset,
                                             tokenNum * xferBytes, args.interNodeChunkFlagMemObj,
                                             (myNode * maxChunkNum + flagSlotId) * sizeof(uint64_t),
-                                            tokenNum + 1, core::atomicType::AMO_SET, proxyPe);
+                                            tokenNum + 1, core::atomicType::AMO_SET, proxyPe, qpId);
         }
         if (shouldSend) args.interNodeDispSendMap[nNodes * tokenId + i] = destTokId;
       }

--- a/src/ops/dispatch_combine/internode_v1.cpp
+++ b/src/ops/dispatch_combine/internode_v1.cpp
@@ -230,11 +230,12 @@ inline __device__ void DispatchInterNodeSend(EpDispatchCombineArgs<T>& args) {
           size_t remoteIdx = (myNode * config.MaxNumTokensToRecvPerRank() + destTokId);
           if (count > 0) {
             size_t stagingTokOffset = tokenId * xferBytes;
+            int qpId = (tokenId / warpSize) % config.numQpPerPe;
             shmem::ShmemPutMemNbiSignalThread(
                 args.shmemDispatchInpTokMemObj, remoteIdx * xferBytes, args.shmemStagingTokMemObj,
                 stagingTokOffset, count * xferBytes, args.interNodeChunkFlagMemObj,
                 (myNode * maxChunkNum + flagSlotId) * sizeof(uint64_t), flag,
-                core::atomicType::AMO_SET, proxyPe);
+                core::atomicType::AMO_SET, proxyPe, qpId);
           }
           args.interNodeDispSendMap[nNodes * tokenId + i] = destTokId;
         }
@@ -264,7 +265,7 @@ inline __device__ void DispatchInterNodeSend(EpDispatchCombineArgs<T>& args) {
         if (laneId == 0) {
           index_t tokenNum = std::min(tokenId + warpSize, endTokenIdx) - tokenId;
           size_t stagingTokOffset = tokenId * xferBytes;
-          int qpId = (tokenId / warpSize);
+          int qpId = (tokenId / warpSize) % config.numQpPerPe;
           shmem::ShmemPutMemNbiSignalThread(args.shmemDispatchInpTokMemObj, remoteIdx * xferBytes,
                                             args.shmemStagingTokMemObj, stagingTokOffset,
                                             tokenNum * xferBytes, args.interNodeChunkFlagMemObj,
@@ -295,7 +296,7 @@ template <typename T>
 inline __device__ void DispatchInterNodeRecv(EpDispatchCombineArgs<T>& args) {
   DEF_COMMON_VARS;
 
-  constexpr int numRecvBlock = 4;
+  constexpr int numRecvBlock = 8;
   int maxChunkNum = core::CeilDiv(config.maxNumInpTokenPerRank, warpSize);
 
   uint64_t* chunkFlag = args.interNodeChunkFlagMemObj->template GetAs<uint64_t*>();
@@ -495,7 +496,7 @@ inline __device__ void CombineSync(EpDispatchCombineArgs<T>& args) {
   }
 
   // After all warps copy done, set barrier flag
-  uint32_t barrierFlag = 0;
+  uint64_t barrierFlag = 0;
   int finishedWarp = 0;
   if (laneId == 0) {
     finishedWarp = atomicAdd(args.combineGridBarrier, 1);
@@ -507,13 +508,13 @@ inline __device__ void CombineSync(EpDispatchCombineArgs<T>& args) {
     if (laneId < config.gpuPerNode) {
       int destPe = myNode * config.gpuPerNode + laneId;
       core::AtomicStoreRelaxedSystem(
-          args.crossDeviceBarrierMemObj->template GetAs<uint32_t*>(destPe) + args.config.rank,
+          args.crossDeviceBarrierMemObj->template GetAs<uint64_t*>(destPe) + args.config.rank,
           barrierFlag);
     }
     if (laneId == 0) args.combineGridBarrier[0] = 0;
   }
   // Wait other pes to set flag
-  uint32_t* localBarrierPtr = args.crossDeviceBarrierMemObj->template GetAs<uint32_t*>();
+  uint64_t* localBarrierPtr = args.crossDeviceBarrierMemObj->template GetAs<uint64_t*>();
   if (laneId < config.gpuPerNode) {
     int destPe = myNode * config.gpuPerNode + laneId;
     while (core::AtomicLoadRelaxedSystem(localBarrierPtr + destPe) != barrierFlag) {
@@ -569,7 +570,7 @@ template <typename T>
 inline __device__ void CombineInterNode(EpDispatchCombineArgs<T>& args) {
   DEF_COMMON_VARS;
 
-  constexpr int numRecvBlock = 4;
+  constexpr int numRecvBlock = 8;
   int maxChunkNum = core::CeilDiv(config.maxNumInpTokenPerRank, warpSize);
 
   uint64_t* chunkFlag = args.interNodeChunkFlagMemObj->template GetAs<uint64_t*>();
@@ -626,16 +627,17 @@ inline __device__ void CombineInterNode(EpDispatchCombineArgs<T>& args) {
       args.interNodeChunkFlagMemObj->template GetAs<uint64_t*>()[node * maxChunkNum + k] = 0;
       args.interNodeChunkFlagCombine[node * maxChunkNum + k] = 0;
       int proxyPe = node * config.gpuPerNode + (config.rank % config.gpuPerNode);
+      int qpId = k % config.numQpPerPe;
       shmem::ShmemPutTypeNbiWarp<uint8_t>(
           args.shmemStagingTokMemObj,
           ((myNode + nNodes) * config.MaxNumTokensToRecvPerRank() + startTokenIdx) * combXferBytes,
           args.shmemStagingTokMemObj,
           (node * config.MaxNumTokensToRecvPerRank() + startTokenIdx) * combXferBytes,
-          thisChunkTokenNum * combXferBytes, proxyPe);
+          thisChunkTokenNum * combXferBytes, proxyPe, qpId);
     }
   }
   int finishedWarp = 0;
-  uint32_t barrierFlag = 0;
+  uint64_t barrierFlag = 0;
   if (laneId == 0) {
     finishedWarp = atomicAdd(args.interNodeBlocksBarrier, 1);
     barrierFlag = core::AtomicLoadRelaxed(args.crossDeviceBarrierFlag);
@@ -646,16 +648,22 @@ inline __device__ void CombineInterNode(EpDispatchCombineArgs<T>& args) {
     if ((laneId < nNodes) &&
         (laneId != myNode)) {  // avoid setting myNode, it will be set in intra node branch
       int proxyPe = laneId * config.gpuPerNode + (config.rank % config.gpuPerNode);
-      shmem::ShmemPutUint32ImmNbiThread(args.crossDeviceBarrierMemObj,
-                                        args.config.rank * sizeof(uint32_t), barrierFlag, proxyPe);
+      for (int i = 0; i < config.numQpPerPe; i++) {
+        shmem::ShmemAtomicTypeNonFetchThread<uint64_t>(args.crossDeviceBarrierMemObj,
+                                                       args.config.rank * sizeof(uint64_t), 1,
+                                                       core::AMO_ADD, proxyPe, i);
+      }
+      // shmem::ShmemPutUint64ImmNbiThread(args.crossDeviceBarrierMemObj,
+      // args.config.rank * sizeof(uint64_t), barrierFlag, proxyPe);
     }
     if (laneId == 0) args.interNodeBlocksBarrier[0] = 0;
 
     // Wait other nodes
-    uint32_t* localBarrierPtr = args.crossDeviceBarrierMemObj->template GetAs<uint32_t*>();
-    if (laneId < nNodes) {
+    uint64_t* localBarrierPtr = args.crossDeviceBarrierMemObj->template GetAs<uint64_t*>();
+    if ((laneId < nNodes) && (laneId != myNode)) {
       int proxyPe = laneId * config.gpuPerNode + (config.rank % config.gpuPerNode);
-      while (core::AtomicLoadRelaxedSystem(localBarrierPtr + proxyPe) != barrierFlag) {
+      while (core::AtomicLoadRelaxedSystem(localBarrierPtr + proxyPe) !=
+             (barrierFlag * config.numQpPerPe)) {
       }
     }
   }

--- a/src/pybind/mori.cpp
+++ b/src/pybind/mori.cpp
@@ -229,6 +229,8 @@ int64_t ShmemMyPe() { return mori::shmem::ShmemMyPe(); }
 
 int64_t ShmemNPes() { return mori::shmem::ShmemNPes(); }
 
+int64_t ShmemNumQpPerPe() { return mori::shmem::ShmemNumQpPerPe(); }
+
 }  // namespace
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -247,14 +249,16 @@ void RegisterMoriOps(py::module_& m) {
       .export_values();
 
   pybind11::class_<mori::moe::EpDispatchCombineConfig>(m, "EpDispatchCombineConfig")
-      .def(pybind11::init<int, int, int, int, int, int, int, int, int, int, int, bool, int, int>(),
+      .def(pybind11::init<int, int, int, int, int, int, int, int, int, int, int, bool,
+                          moe::KernelType, int, int, int>(),
            py::arg("rank") = 0, py::arg("world_size") = 0, py::arg("hidden_dim") = 0,
            py::arg("scale_dim") = 0, py::arg("scale_type_size") = 0,
            py::arg("max_token_type_size") = 0, py::arg("max_num_inp_token_per_rank") = 0,
            py::arg("num_experts_per_rank") = 0, py::arg("num_experts_per_token") = 0,
            py::arg("warp_num_per_block") = 0, py::arg("block_num") = 0,
-           py::arg("use_external_inp_buf") = true, py::arg("gpu_per_node") = 8,
-           py::arg("rdma_block_num") = 0)
+           py::arg("use_external_inp_buf") = true,
+           py::arg("kernel_type") = moe::KernelType::IntraNode, py::arg("gpu_per_node") = 8,
+           py::arg("rdma_block_num") = 0, py::arg("num_qp_per_pe") = 1)
       .def_readwrite("rank", &mori::moe::EpDispatchCombineConfig::rank)
       .def_readwrite("world_size", &mori::moe::EpDispatchCombineConfig::worldSize)
       .def_readwrite("hidden_dim", &mori::moe::EpDispatchCombineConfig::hiddenDim)
@@ -268,8 +272,10 @@ void RegisterMoriOps(py::module_& m) {
                      &mori::moe::EpDispatchCombineConfig::numExpertPerToken)
       .def_readwrite("warp_num_per_block", &mori::moe::EpDispatchCombineConfig::warpNumPerBlock)
       .def_readwrite("block_num", &mori::moe::EpDispatchCombineConfig::blockNum)
+      .def_readwrite("kernel_type", &mori::moe::EpDispatchCombineConfig::kernelType)
       .def_readwrite("gpu_per_node", &mori::moe::EpDispatchCombineConfig::gpuPerNode)
-      .def_readwrite("rdma_block_num", &mori::moe::EpDispatchCombineConfig::rdmaBlockNum);
+      .def_readwrite("rdma_block_num", &mori::moe::EpDispatchCombineConfig::rdmaBlockNum)
+      .def_readwrite("num_qp_per_pe", &mori::moe::EpDispatchCombineConfig::numQpPerPe);
 
   DeclareEpDispatchCombineHandle(m);
 }
@@ -279,6 +285,7 @@ void RegisterMoriShmem(py::module_& m) {
   m.def("shmem_finalize", &ShmemFinalize);
   m.def("shmem_mype", &ShmemMyPe);
   m.def("shmem_npes", &ShmemNPes);
+  m.def("shmem_num_qp_per_pe", &ShmemNumQpPerPe);
 }
 
 void RegisterMoriIo(pybind11::module_& m) {

--- a/src/shmem/init.cpp
+++ b/src/shmem/init.cpp
@@ -150,6 +150,11 @@ int ShmemNPes() {
   return states->bootStates->worldSize;
 }
 
+int ShmemNumQpPerPe() {
+  ShmemStates* states = ShmemStatesSingleton::GetInstance();
+  return states->rdmaStates->commContext->GetNumQpPerPe();
+}
+
 // int ShmemTeamMyPe(ShmemTeamType);
 // int ShmemTeamNPes(ShmemTeamType);
 


### PR DESCRIPTION
Dual-port NIC need more than 1 qp to saturate bandwidth.

- Minor perf degradation is observed on CX7 single-port NIC
- #warps should be limited to 8 to avoid "HSA_INVALID_ISA" core, to achieve on par perf, we double # blocks to compensate the decrease of #warps.

