### PR TITLE
Fix: none dispatch weights when local token number is 0

### DIFF
--- a/src/ops/dispatch_combine/intranode.hpp
+++ b/src/ops/dispatch_combine/intranode.hpp
@@ -54,6 +54,8 @@ inline __device__ void CrossDeviceBarrierIntraNodeKernel(EpDispatchCombineArgs<T
         crossDeviceBarrierFlag);
   }
 
+  if (globalThdId == 0) atomicAdd(args.crossDeviceBarrierFlag, 1);
+
   uint32_t* localBarrierPtr = args.crossDeviceBarrierMemObj->template GetAs<uint32_t*>();
   if (thdId < args.config.worldSize) {
     while (core::AtomicLoadRelaxedSystem(localBarrierPtr + thdId) != crossDeviceBarrierFlag) {
@@ -273,11 +275,6 @@ __global__ void EpCombineIntraNodeKernel(EpDispatchCombineArgs<T> args) {
                                 srcWeightsPtr, nullptr, config.numExpertPerToken,
                                 config.numExpertPerToken);
     }
-  }
-
-  if (globalThdId == 0) {
-    __hip_atomic_fetch_add(args.crossDeviceBarrierFlag, 1, __ATOMIC_RELEASE,
-                           __HIP_MEMORY_SCOPE_SYSTEM);
   }
 }
 

--- a/src/pybind/mori.cpp
+++ b/src/pybind/mori.cpp
@@ -74,7 +74,7 @@ LaunchDispatch(mori::moe::EpDispatchCombineHandle& handle, int kernelType,
                        {handle.config.MaxNumTokensToRecv(), handle.config.hiddenDim},
                        torch::TensorOptions().dtype(input.scalar_type()).device(torch::kCUDA));
 
-  std::optional<torch::Tensor> outWeights = torch::from_blob(
+  torch::Tensor outWeights = torch::from_blob(
       handle.shmemDispatchOutWeightsMemObj->Get(),
       {handle.config.MaxNumTokensToRecv(), handle.config.numExpertPerToken},
       torch::TensorOptions().dtype(mori::GetTorchDataType<float>()).device(torch::kCUDA));

--- a/src/pybind/mori.cpp
+++ b/src/pybind/mori.cpp
@@ -80,7 +80,7 @@ LaunchDispatch(mori::moe::EpDispatchCombineHandle& handle, int kernelType,
       torch::TensorOptions().dtype(mori::GetTorchDataType<float>()).device(torch::kCUDA));
 
   std::optional<torch::Tensor> outScales{std::nullopt};
-  if (handle.config.scaleDim > 0) {
+  if (scales.has_value() && handle.config.scaleDim > 0) {
     outScales =
         torch::from_blob(handle.shmemOutScalesMemObj->Get(),
                          {handle.config.MaxNumTokensToRecv(), handle.config.scaleDim},

--- a/src/pybind/mori.cpp
+++ b/src/pybind/mori.cpp
@@ -74,16 +74,13 @@ LaunchDispatch(mori::moe::EpDispatchCombineHandle& handle, int kernelType,
                        {handle.config.MaxNumTokensToRecv(), handle.config.hiddenDim},
                        torch::TensorOptions().dtype(input.scalar_type()).device(torch::kCUDA));
 
-  std::optional<torch::Tensor> outWeights{std::nullopt};
-  if (weightPtr) {
-    outWeights = torch::from_blob(
-        handle.shmemDispatchOutWeightsMemObj->Get(),
-        {handle.config.MaxNumTokensToRecv(), handle.config.numExpertPerToken},
-        torch::TensorOptions().dtype(mori::GetTorchDataType<float>()).device(torch::kCUDA));
-  }
+  std::optional<torch::Tensor> outWeights = torch::from_blob(
+      handle.shmemDispatchOutWeightsMemObj->Get(),
+      {handle.config.MaxNumTokensToRecv(), handle.config.numExpertPerToken},
+      torch::TensorOptions().dtype(mori::GetTorchDataType<float>()).device(torch::kCUDA));
 
   std::optional<torch::Tensor> outScales{std::nullopt};
-  if (scales.has_value() && handle.config.scaleDim > 0) {
+  if (handle.config.scaleDim > 0) {
     outScales =
         torch::from_blob(handle.shmemOutScalesMemObj->Get(),
                          {handle.config.MaxNumTokensToRecv(), handle.config.scaleDim},

--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -31,7 +31,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
         super().__init__(config)
 
     def gen_test_data(self):
-        return super().gen_test_data(use_max_token_num=True)
+        return super().gen_test_data(use_max_token_num=False)
 
     def run_once(self, op, test_data, check_result):
         (
@@ -108,7 +108,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
         ll_mode_scale = (
             self.config.max_num_inp_token_per_rank
             * self.config.num_experts_per_token
-            / total_recv_num_token
+            / (total_recv_num_token+0.01)
         )
         disp_bandwidth = total_bytes / (1000**3) / (disp_duration / (10**3))
         comb_bandwidth = total_bytes / (1000**3) / (comb_duration / (10**3))
@@ -138,8 +138,9 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
         for i in range(iters):
             self.sync()
             disp_dur, comb_dur, disp_bw, comb_bw, total_bytes, ll_mode_scale = (
-                self.run_once(op, test_data_list[i], False)
+                self.run_once(op, test_data_list[i], True)
             )
+            continue
 
             disp_dur_list = [torch.zeros(1) for _ in range(self.config.world_size)]
             disp_bw_list = [torch.zeros(1) for _ in range(self.config.world_size)]
@@ -282,7 +283,7 @@ def _bench_dispatch_combine(
     scale_dim=0,
     scale_type_size=0,
     num_experts_per_rank=32,
-    num_experts_per_token=8,
+    num_experts_per_token=1,
 ):
     config = mori.ops.EpDispatchCombineConfig(
         data_type=data_type,

--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -31,7 +31,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
         super().__init__(config)
 
     def gen_test_data(self):
-        return super().gen_test_data(use_max_token_num=False)
+        return super().gen_test_data(use_max_token_num=True)
 
     def run_once(self, op, test_data, check_result):
         (
@@ -108,7 +108,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
         ll_mode_scale = (
             self.config.max_num_inp_token_per_rank
             * self.config.num_experts_per_token
-            / (total_recv_num_token+0.01)
+            / (total_recv_num_token + 0.01)
         )
         disp_bandwidth = total_bytes / (1000**3) / (disp_duration / (10**3))
         comb_bandwidth = total_bytes / (1000**3) / (comb_duration / (10**3))
@@ -138,9 +138,8 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
         for i in range(iters):
             self.sync()
             disp_dur, comb_dur, disp_bw, comb_bw, total_bytes, ll_mode_scale = (
-                self.run_once(op, test_data_list[i], True)
+                self.run_once(op, test_data_list[i], False)
             )
-            continue
 
             disp_dur_list = [torch.zeros(1) for _ in range(self.config.world_size)]
             disp_bw_list = [torch.zeros(1) for _ in range(self.config.world_size)]
@@ -283,7 +282,7 @@ def _bench_dispatch_combine(
     scale_dim=0,
     scale_type_size=0,
     num_experts_per_rank=32,
-    num_experts_per_token=1,
+    num_experts_per_token=8,
 ):
     config = mori.ops.EpDispatchCombineConfig(
         data_type=data_type,


### PR DESCRIPTION
- Move the atomic incremental of barrier flag to avoid skipping it when local token num = 0
- Always returns weight tensor even if local token num is 0, because zero local token doesn't mean this rank will not receive tokens from other ranks