### PR TITLE
Fix: gfx950 compilation error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,8 @@ if(USE_ROCM)
 
   if(DEFINED GPU_TARGETS)
     list(GET GPU_TARGETS 0 GPU_ARCH)
-    message(STATUS "GPU ARCH: ${GPU_ARCH}")
+    message(STATUS "GPU_TARGETS: ${GPU_TARGETS}")
+    # TODO: should iterate all archs
     if(GPU_ARCH MATCHES "^gfx8")
       add_definitions(-D__GFX8__=1)
     elseif(GPU_ARCH MATCHES "^gfx9")

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ cd mori && docker build -t rocm/mori:dev -f docker/Dockerfile.dev .
 
 ### Install with Python
 ```
+# NOTE: for venv build, add --no-build-isolation at the end
 cd mori && pip install -r requirements-build.txt && git submodule update --init --recursive && pip3 install .
 ```
 

--- a/include/mori/ops/dispatch_combine/dispatch_combine.hpp
+++ b/include/mori/ops/dispatch_combine/dispatch_combine.hpp
@@ -29,6 +29,7 @@
 #include <variant>
 
 #include "mori/application/application.hpp"
+#include "mori/utils/data_types.hpp"
 
 namespace mori {
 namespace moe {
@@ -293,8 +294,12 @@ struct EpDispatchCombineArgs {
 };
 
 using EpDispatchCombineArgsVariant =
-    std::variant<EpDispatchCombineArgs<float>, EpDispatchCombineArgs<hip_bfloat16>,
-                 EpDispatchCombineArgs<__hip_fp8_e4m3_fnuz> >;
+    std::variant<EpDispatchCombineArgs<float>, EpDispatchCombineArgs<hip_bfloat16>
+#ifdef MORI_FP8_TYPE_FNUZ_ENABLED
+                 ,
+                 EpDispatchCombineArgs<__hip_fp8_e4m3_fnuz>
+#endif
+                 >;
 
 template <typename T>
 EpDispatchCombineArgs<T> GetEpDispatchCombineArgs(const EpDispatchCombineHandle& handle) {
@@ -354,7 +359,9 @@ inline EpDispatchCombineArgsVariant GetEpDispatchCombineArgsByInputType(
     case HIP_R_16BF:
       return GetEpDispatchCombineArgs<hip_bfloat16>(handle);
     case HIP_R_8F_E4M3_FNUZ:
+#ifdef MORI_FP8_TYPE_FNUZ_ENABLED
       return GetEpDispatchCombineArgs<__hip_fp8_e4m3_fnuz>(handle);
+#endif
     default:
       std::ostringstream oss;
       oss << "Unsupported inputType " << HipDataTypeToString(handle.inputType)

--- a/include/mori/ops/dispatch_combine/dispatch_combine.hpp
+++ b/include/mori/ops/dispatch_combine/dispatch_combine.hpp
@@ -49,6 +49,8 @@ inline const char* HipDataTypeToString(hipDataType dtype) {
       return "HIP_R_32F";
     case HIP_R_16BF:
       return "HIP_R_16BF";
+    case HIP_R_8F_E4M3:
+      return "HIP_R_8F_E4M3";
     case HIP_R_8F_E4M3_FNUZ:
       return "HIP_R_8F_E4M3_FNUZ";
     default:
@@ -62,6 +64,8 @@ inline size_t GetHipDataTypeSize(hipDataType dtype) {
       return sizeof(float);
     case HIP_R_16BF:
       return sizeof(hip_bfloat16);
+    case HIP_R_8F_E4M3:
+      return sizeof(__hip_fp8_e4m3);
     case HIP_R_8F_E4M3_FNUZ:
       return sizeof(__hip_fp8_e4m3_fnuz);
     default:
@@ -299,6 +303,10 @@ using EpDispatchCombineArgsVariant =
                  ,
                  EpDispatchCombineArgs<__hip_fp8_e4m3_fnuz>
 #endif
+#ifdef MORI_FP8_TYPE_OCP_ENABLED
+                 ,
+                 EpDispatchCombineArgs<__hip_fp8_e4m3>
+#endif
                  >;
 
 template <typename T>
@@ -358,6 +366,10 @@ inline EpDispatchCombineArgsVariant GetEpDispatchCombineArgsByInputType(
       return GetEpDispatchCombineArgs<float>(handle);
     case HIP_R_16BF:
       return GetEpDispatchCombineArgs<hip_bfloat16>(handle);
+    case HIP_R_8F_E4M3:
+#ifdef MORI_FP8_TYPE_OCP_ENABLED
+      return GetEpDispatchCombineArgs<__hip_fp8_e4m3>(handle);
+#endif
     case HIP_R_8F_E4M3_FNUZ:
 #ifdef MORI_FP8_TYPE_FNUZ_ENABLED
       return GetEpDispatchCombineArgs<__hip_fp8_e4m3_fnuz>(handle);

--- a/include/mori/ops/dispatch_combine/dispatch_combine.hpp
+++ b/include/mori/ops/dispatch_combine/dispatch_combine.hpp
@@ -366,12 +366,12 @@ inline EpDispatchCombineArgsVariant GetEpDispatchCombineArgsByInputType(
       return GetEpDispatchCombineArgs<float>(handle);
     case HIP_R_16BF:
       return GetEpDispatchCombineArgs<hip_bfloat16>(handle);
-    case HIP_R_8F_E4M3:
 #ifdef MORI_FP8_TYPE_OCP_ENABLED
+    case HIP_R_8F_E4M3:
       return GetEpDispatchCombineArgs<__hip_fp8_e4m3>(handle);
 #endif
-    case HIP_R_8F_E4M3_FNUZ:
 #ifdef MORI_FP8_TYPE_FNUZ_ENABLED
+    case HIP_R_8F_E4M3_FNUZ:
       return GetEpDispatchCombineArgs<__hip_fp8_e4m3_fnuz>(handle);
 #endif
     default:

--- a/include/mori/utils/data_types.hpp
+++ b/include/mori/utils/data_types.hpp
@@ -1,0 +1,9 @@
+#include <hip/hip_fp8.h>
+
+#if defined(HIP_FP8_TYPE_FNUZ) && HIP_FP8_TYPE_FNUZ == 1
+#define MORI_FP8_TYPE_FNUZ_ENABLED
+#endif
+
+#if defined(HIP_FP8_TYPE_OCP) && HIP_FP8_TYPE_OCP == 1
+#define MORI_FP8_TYPE_OCP_ENABLED
+#endif

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def _get_torch_cmake_prefix_path() -> str:
     return torch.utils.cmake_prefix_path
 
 
-_supported_arch_list = ["gfx942"]
+_supported_arch_list = ["gfx942", "gfx950"]
 
 
 def _get_gpu_archs() -> str:

--- a/src/ops/dispatch_combine/internode_v1.cpp
+++ b/src/ops/dispatch_combine/internode_v1.cpp
@@ -745,21 +745,27 @@ __global__ void EpCombineInterNodeV1Kernel(EpDispatchCombineArgs<T> args) {
 /* ---------------------------------------------------------------------------------------------- */
 template __global__ void EpDispatchInterNodeV1Kernel<hip_bfloat16>(
     EpDispatchCombineArgs<hip_bfloat16> args);
+#ifdef MORI_FP8_TYPE_FNUZ_ENABLED
 template __global__ void EpDispatchInterNodeV1Kernel<__hip_fp8_e4m3_fnuz>(
     EpDispatchCombineArgs<__hip_fp8_e4m3_fnuz> args);
+#endif
 template __global__ void EpDispatchInterNodeV1Kernel<float>(EpDispatchCombineArgs<float> args);
 
 template __global__ void EpDispatchInterNodeV1KernelLowLatency<hip_bfloat16>(
     EpDispatchCombineArgs<hip_bfloat16> args);
+#ifdef MORI_FP8_TYPE_FNUZ_ENABLED
 template __global__ void EpDispatchInterNodeV1KernelLowLatency<__hip_fp8_e4m3_fnuz>(
     EpDispatchCombineArgs<__hip_fp8_e4m3_fnuz> args);
+#endif
 template __global__ void EpDispatchInterNodeV1KernelLowLatency<float>(
     EpDispatchCombineArgs<float> args);
 
 template __global__ void EpCombineInterNodeV1Kernel<hip_bfloat16>(
     EpDispatchCombineArgs<hip_bfloat16> args);
+#ifdef MORI_FP8_TYPE_FNUZ_ENABLED
 template __global__ void EpCombineInterNodeV1Kernel<__hip_fp8_e4m3_fnuz>(
     EpDispatchCombineArgs<__hip_fp8_e4m3_fnuz> args);
+#endif
 template __global__ void EpCombineInterNodeV1Kernel<float>(EpDispatchCombineArgs<float> args);
 
 }  // namespace moe

--- a/src/ops/dispatch_combine/internode_v1.cpp
+++ b/src/ops/dispatch_combine/internode_v1.cpp
@@ -749,6 +749,10 @@ template __global__ void EpDispatchInterNodeV1Kernel<hip_bfloat16>(
 template __global__ void EpDispatchInterNodeV1Kernel<__hip_fp8_e4m3_fnuz>(
     EpDispatchCombineArgs<__hip_fp8_e4m3_fnuz> args);
 #endif
+#ifdef MORI_FP8_TYPE_OCP_ENABLED
+template __global__ void EpDispatchInterNodeV1Kernel<__hip_fp8_e4m3>(
+    EpDispatchCombineArgs<__hip_fp8_e4m3> args);
+#endif
 template __global__ void EpDispatchInterNodeV1Kernel<float>(EpDispatchCombineArgs<float> args);
 
 template __global__ void EpDispatchInterNodeV1KernelLowLatency<hip_bfloat16>(
@@ -756,6 +760,10 @@ template __global__ void EpDispatchInterNodeV1KernelLowLatency<hip_bfloat16>(
 #ifdef MORI_FP8_TYPE_FNUZ_ENABLED
 template __global__ void EpDispatchInterNodeV1KernelLowLatency<__hip_fp8_e4m3_fnuz>(
     EpDispatchCombineArgs<__hip_fp8_e4m3_fnuz> args);
+#endif
+#ifdef MORI_FP8_TYPE_OCP_ENABLED
+template __global__ void EpDispatchInterNodeV1KernelLowLatency<__hip_fp8_e4m3>(
+    EpDispatchCombineArgs<__hip_fp8_e4m3> args);
 #endif
 template __global__ void EpDispatchInterNodeV1KernelLowLatency<float>(
     EpDispatchCombineArgs<float> args);
@@ -765,6 +773,10 @@ template __global__ void EpCombineInterNodeV1Kernel<hip_bfloat16>(
 #ifdef MORI_FP8_TYPE_FNUZ_ENABLED
 template __global__ void EpCombineInterNodeV1Kernel<__hip_fp8_e4m3_fnuz>(
     EpDispatchCombineArgs<__hip_fp8_e4m3_fnuz> args);
+#endif
+#ifdef MORI_FP8_TYPE_OCP_ENABLED
+template __global__ void EpCombineInterNodeV1Kernel<__hip_fp8_e4m3>(
+    EpDispatchCombineArgs<__hip_fp8_e4m3> args);
 #endif
 template __global__ void EpCombineInterNodeV1Kernel<float>(EpDispatchCombineArgs<float> args);
 

--- a/src/pybind/torch_utils.hpp
+++ b/src/pybind/torch_utils.hpp
@@ -42,6 +42,8 @@ inline torch::Dtype GetTorchDataType() {
     return torch::kUInt64;
   } else if constexpr (std::is_same_v<T, hip_bfloat16>) {
     return torch::kBFloat16;
+  } else if constexpr (std::is_same_v<T, __hip_fp8_e4m3>) {
+    return torch::kFloat8_e4m3fn;
   } else if constexpr (std::is_same_v<T, __hip_fp8_e4m3_fnuz>) {
     return torch::kFloat8_e4m3fnuz;
   } else {
@@ -55,6 +57,8 @@ inline hipDataType ScalarTypeToHipDataType(at::ScalarType scalarType) {
       return HIP_R_32F;
     case at::kBFloat16:
       return HIP_R_16BF;
+    case at::kFloat8_e4m3fn:
+      return HIP_R_8F_E4M3;
     case at::kFloat8_e4m3fnuz:
       return HIP_R_8F_E4M3_FNUZ;
     default:

--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -277,7 +277,6 @@ def _bench_dispatch_combine(
     port,
     max_num_inp_token_per_rank=128,
     data_type=torch.bfloat16,
-    # data_type=torch.float8_e4m3fnuz,
     hidden_dim=7168,
     scale_dim=0,
     scale_type_size=0,
@@ -311,16 +310,22 @@ def _bench_dispatch_combine(
         # mori.shmem.shmem_finalize()
 
 
-def bench_dispatch_combine(max_num_inp_token_per_rank=4096):
+def bench_dispatch_combine(max_num_inp_token_per_rank=4096, dtype=torch.bfloat16):
     world_size = 8
     port = get_free_port()
     torch.multiprocessing.spawn(
         _bench_dispatch_combine,
-        args=(world_size, port, max_num_inp_token_per_rank),
+        args=(world_size, port, max_num_inp_token_per_rank, dtype),
         nprocs=world_size,
         join=True,
     )
 
+
+_DATA_TYPE_MAP = {
+    "bf16": torch.bfloat16,
+    "fp8_e4m3_fnuz": torch.float8_e4m3fnuz,
+    "fp8_e4m3": torch.float8_e4m3fn,
+}
 
 if __name__ == "__main__":
     import argparse
@@ -332,9 +337,17 @@ if __name__ == "__main__":
         default=4096,
         help="Maximum number of input tokens per rank (default: 4096)",
     )
-
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default="bf16",
+        choices=["bf16", "fp8_e4m3_fnuz", "fp8_e4m3"],
+        help="Data type of dispatch / combine",
+    )
     args = parser.parse_args()
 
     print(f"Running benchmark with max_tokens_per_rank: {args.max_tokens}")
     print("-" * 60)
-    bench_dispatch_combine(max_num_inp_token_per_rank=args.max_tokens)
+    bench_dispatch_combine(
+        max_num_inp_token_per_rank=args.max_tokens, dtype=_DATA_TYPE_MAP[args.dtype]
+    )

--- a/tests/python/ops/test_dispatch_combine.py
+++ b/tests/python/ops/test_dispatch_combine.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 import pytest
 import mori
-from tests.python.utils import TorchDistProcessManager
+from tests.python.utils import TorchDistProcessManager, data_type_supported
 import torch
 import torch.distributed as dist
 
@@ -293,7 +293,26 @@ def _test_dispatch_combine(
 
 # TODO: create a sub process group so that we can test worlds size < 8
 @pytest.mark.parametrize("world_size", (8,))
-@pytest.mark.parametrize("data_type", (torch.float8_e4m3fnuz, torch.bfloat16))
+@pytest.mark.parametrize(
+    "data_type",
+    (
+        torch.bfloat16,
+        pytest.param(
+            torch.float8_e4m3fnuz,
+            marks=pytest.mark.skipif(
+                not data_type_supported(torch.float8_e4m3fnuz),
+                reason="Skip float8_e4m3fnuz, it is not supported",
+            ),
+        ),
+        pytest.param(
+            torch.float8_e4m3fn,
+            marks=pytest.mark.skipif(
+                not data_type_supported(torch.float8_e4m3fn),
+                reason="Skip float8_e4m3fn, it is not supported",
+            ),
+        ),
+    ),
+)
 @pytest.mark.parametrize("hidden_dim", (7168, 4096))
 @pytest.mark.parametrize("scale_dim", (0, 32))
 @pytest.mark.parametrize("scale_type_size", (1, 4))

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -61,6 +61,16 @@ def get_free_port():
         return s.getsockname()[1]
 
 
+def data_type_supported(dtype):
+    arch = torch.cuda.get_device_capability(0)
+    arch_int = int("".join(map(str, arch)))
+    if dtype is torch.float8_e4m3fnuz:
+        return arch_int == 94
+    if dtype is torch.float8_e4m3fn:
+        return arch_int >= 95
+    return True
+
+
 class TorchDistContext:
     def __init__(
         self,


### PR DESCRIPTION
- add float8_e4m3_fnuz / float8_e4m3 detection to avoid compilation error on arch >= gfx950