### PR TITLE
[feat]: allreduce eager interface

### DIFF
--- a/build_allreduce.sh
+++ b/build_allreduce.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# Mori AllReduce fast build script
+
+set -e # exit on error
+
+# color definitions
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}=====================================${NC}"
+echo -e "${GREEN}Mori AllReduce build script${NC}"
+echo -e "${GREEN}=====================================${NC}"
+echo ""
+
+# check dependencies
+echo -e "${YELLOW}[1/6] check dependencies...${NC}"
+
+# check MPI
+if ! command -v mpirun &>/dev/null; then
+  echo -e "${RED}error: MPI not found!${NC}"
+  echo "install: sudo apt-get install libopenmpi-dev"
+  exit 1
+fi
+echo "  ✓ MPI: $(mpirun --version | head -1)"
+
+# check HIP
+if ! command -v hipcc &>/dev/null; then
+  echo -e "${RED}error: HIP not found!${NC}"
+  echo "install ROCm: https://rocm.docs.amd.com/"
+  exit 1
+fi
+echo "  ✓ HIP: $(hipcc --version | grep -i hip | head -1)"
+
+# check CMake
+if ! command -v cmake &>/dev/null; then
+  echo -e "${RED}error: CMake not found!${NC}"
+  echo "install: sudo apt-get install cmake"
+  exit 1
+fi
+echo "  ✓ CMake: $(cmake --version | head -1)"
+
+echo ""
+
+# create and enter build directory
+echo -e "${YELLOW}[2/6] create build directory...${NC}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+if [ -d "build" ]; then
+  echo "  build directory already exists"
+  read -p "  clean old build? (y/N): " -n 1 -r
+  echo
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    echo "  cleaning..."
+    rm -rf build
+    mkdir build
+  fi
+else
+  mkdir build
+fi
+
+cd build
+echo "  ✓ working directory: $(pwd)"
+echo ""
+
+# configure CMake
+echo -e "${YELLOW}[3/6] configure CMake...${NC}"
+cmake .. \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DUSE_ROCM=ON \
+  -DBUILD_COLLECTIVE=ON \
+  -DBUILD_EXAMPLES=ON \
+  -DBUILD_TESTS=ON
+
+if [ $? -ne 0 ]; then
+  echo -e "${RED}CMake configuration failed!${NC}"
+  exit 1
+fi
+echo "  ✓ CMake configuration successful"
+echo ""
+
+# compile
+echo -e "${YELLOW}[4/6] compiling...${NC}"
+NPROC=$(nproc)
+echo "  using ${NPROC} cores to compile"
+
+cmake --build . -j ${NPROC}
+
+if [ $? -ne 0 ]; then
+  echo -e "${RED}compilation failed!${NC}"
+  exit 1
+fi
+echo "  ✓ compilation successful"
+echo ""
+
+# verify compilation result
+echo -e "${YELLOW}[5/6] verify compilation result...${NC}"
+
+# check library
+if [ -f "src/collective/libmori_collective.so" ]; then
+  echo "  ✓ libmori_collective.so generated successfully"
+  ls -lh src/collective/libmori_collective.so | awk '{print "    size:", $5}'
+else
+  echo -e "${RED}  ✗ libmori_collective.so not found${NC}"
+  exit 1
+fi
+
+# check example program
+if [ -f "examples/allreduce_example" ]; then
+  echo "  ✓ allreduce_example generated successfully"
+else
+  echo -e "${RED}  ✗ allreduce_example not found${NC}"
+  exit 1
+fi
+
+echo ""
+
+# done
+echo -e "${GREEN}=====================================${NC}"
+echo -e "${GREEN}compilation done!${NC}"
+echo -e "${GREEN}=====================================${NC}"
+echo ""
+
+# run instructions
+echo -e "${YELLOW}[6/6] run instructions:${NC}"
+echo ""
+echo "single node 2 GPU test:"
+echo "  cd $(pwd)"
+echo "  mpirun -np 2 ./examples/allreduce_example"
+echo ""
+echo "single node 4 GPU test:"
+echo "  mpirun -np 4 ./examples/allreduce_example"
+echo ""
+echo "specify GPUs:"
+echo "  export HIP_VISIBLE_DEVICES=0,1"
+echo "  mpirun -np 2 ./examples/allreduce_example"
+echo ""
+echo "view more documents:"
+echo "  cat $(dirname $SCRIPT_DIR)/docs/ALLREDUCE_BUILD_GUIDE.md"
+echo ""
+
+# ask whether to run immediately
+read -p "run test immediately? (using 8 GPUs) (y/N): " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+  echo ""
+  echo -e "${GREEN}running test...${NC}"
+  echo ""
+  mpirun --allow-run-as-root -np 8 ./examples/allreduce_example
+fi

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Find MPI package (required by allreduce_example)
+find_package(MPI REQUIRED)
+
 add_executable(dist_write dist_rdma_ops/dist_write.cpp utils/args_parser.cpp)
 target_include_directories(dist_write
                            PRIVATE ${CMAKE_SOURCE_DIR}/examples/utils)
@@ -20,6 +23,11 @@ target_link_libraries(put_thread_allgather mori_shmem hip::host hip::device)
 
 add_executable(all_reduce collective/all_reduce.cpp)
 target_link_libraries(all_reduce mori_collective hip::host hip::device)
+
+# Custom allreduce example (using MPI)
+add_executable(allreduce_example collective/allreduce_example.cpp)
+target_link_libraries(allreduce_example mori_collective MPI::MPI_CXX hip::host hip::device)
+target_include_directories(allreduce_example PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
 add_executable(all_gather collective/all_gather.cpp)
 target_link_libraries(all_gather mori_shmem hip::host hip::device)

--- a/examples/collective/allreduce_example.cpp
+++ b/examples/collective/allreduce_example.cpp
@@ -1,0 +1,207 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// Example: Using IntraNodeAllReduceExecutor with MPI
+//
+// This example demonstrates AllReduce using MPI for IPC handle exchange
+
+#include "mori/collective/all_reduce/intra_node_executor.hpp"
+#include <hip/hip_runtime.h>
+#include <mpi.h>
+#include <vector>
+#include <iostream>
+#include <memory>
+
+// Helper function to initialize data
+void initializeData(float* data, size_t count, int rank) {
+  for (size_t i = 0; i < count; i++) {
+    data[i] = static_cast<float>(rank + 1);
+  }
+}
+
+// Helper function to verify results
+bool verifyResults(const float* data, size_t count, int num_ranks) {
+  float expected = 0.0f;
+  for (int r = 0; r < num_ranks; r++) {
+    expected += static_cast<float>(r + 1);
+  }
+  
+  bool success = true;
+  for (size_t i = 0; i < count; i++) {
+    if (std::abs(data[i] - expected) > 1e-5) {
+      std::cerr << "Mismatch at index " << i 
+                << ": expected " << expected 
+                << ", got " << data[i] << std::endl;
+      success = false;
+      break;
+    }
+  }
+  return success;
+}
+
+int main(int argc, char** argv) {
+  // ===== init MPI =====
+  MPI_Init(&argc, &argv);
+  
+  int rank, num_ranks;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &num_ranks);
+  
+  const size_t count = 1024 * 1024;  // Number of elements
+  
+  if (rank == 0) {
+    std::cout << "==================================" << std::endl;
+    std::cout << "IntraNode AllReduce Example (MPI)" << std::endl;
+    std::cout << "==================================" << std::endl;
+    std::cout << "Num Ranks: " << num_ranks << std::endl;
+    std::cout << "Count: " << count << std::endl;
+    std::cout << "Data Type: float" << std::endl;
+    std::cout << std::endl;
+  }
+  
+  try {
+    // set device
+    hipSetDevice(rank);
+    
+    // ===== step 1: initialize executor (using polymorphism with smart pointer) =====
+    if (rank == 0) {
+      std::cout << "[Step 1] initialize executor..." << std::endl;
+    }
+    
+    // Use base class smart pointer to hold derived class object (polymorphism)
+    std::unique_ptr<mori::collective::AllReduceExecutor<float>> executor(
+        new mori::collective::IntraNodeAllReduceExecutor<float>(
+            num_ranks,           // number of GPUs
+            rank,                // current rank
+            MPI_COMM_WORLD       // MPI communicator
+        )
+    );
+    
+    MPI_Barrier(MPI_COMM_WORLD);
+    if (rank == 0) {
+      std::cout << "  ✓ initialization completed (IPC handles exchanged via MPI)" << std::endl;
+      std::cout << std::endl;
+    }
+    
+    // allocate device memory
+    float* d_data;
+    hipMalloc(&d_data, count * sizeof(float));
+    
+    // initialize input data
+    std::vector<float> h_data(count);
+    initializeData(h_data.data(), count, rank);
+    hipMemcpy(d_data, h_data.data(), count * sizeof(float), hipMemcpyHostToDevice);
+    
+    // create stream
+    hipStream_t stream;
+    hipStreamCreate(&stream);
+    
+    // ===== step 2: execute AllReduce (can be called multiple times) =====
+    if (rank == 0) {
+      std::cout << "[Step 2] execute AllReduce..." << std::endl;
+    }
+    
+    // first call
+    int result = executor->Execute(
+        d_data,      // input
+        d_data,      // output (in-place)
+        count,       // number of elements
+        stream       // HIP stream
+    );
+    
+    if (result != 0) {
+      std::cerr << "  Rank " << rank << ": ✗ AllReduce execution failed, error code: " << result << std::endl;
+      MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+    
+    hipStreamSynchronize(stream);
+    
+    // verify results
+    hipMemcpy(h_data.data(), d_data, count * sizeof(float), hipMemcpyDeviceToHost);
+    bool success = verifyResults(h_data.data(), count, num_ranks);
+    
+    int global_success;
+    MPI_Allreduce(&success, &global_success, 1, MPI_INT, MPI_LAND, MPI_COMM_WORLD);
+    
+    if (rank == 0) {
+      if (global_success) {
+        std::cout << "  ✓ first AllReduce completed, results verified" << std::endl;
+        std::cout << std::endl;
+      } else {
+        std::cout << "  ✗ results verification failed" << std::endl;
+        MPI_Abort(MPI_COMM_WORLD, 1);
+      }
+    }
+    
+    // ===== step 3: multiple calls demonstration =====
+    if (rank == 0) {
+      std::cout << "[Step 3] multiple calls demonstration..." << std::endl;
+    }
+    
+    for (int iter = 0; iter < 5; iter++) {
+      // reinitialize data
+      initializeData(h_data.data(), count, rank);
+      hipMemcpy(d_data, h_data.data(), count * sizeof(float), hipMemcpyHostToDevice);
+      
+      // execute AllReduce (completely same call)
+      result = executor->Execute(d_data, d_data, count, stream);
+      hipStreamSynchronize(stream);
+      
+      if (result != 0) {
+        std::cerr << "  Rank " << rank << ": ✗ call " << iter + 1 << " failed" << std::endl;
+        MPI_Abort(MPI_COMM_WORLD, 1);
+      }
+      
+      if (rank == 0) {
+        std::cout << "  ✓ call " << iter + 1 << " succeeded" << std::endl;
+      }
+    }
+    
+    MPI_Barrier(MPI_COMM_WORLD);
+    if (rank == 0) {
+      std::cout << std::endl;
+      std::cout << "==================================" << std::endl;
+      std::cout << "✓ all tests passed!" << std::endl;
+      std::cout << "==================================" << std::endl;
+    }
+    
+    // clean up
+    hipFree(d_data);
+    hipStreamDestroy(stream);
+    
+    MPI_Finalize();
+    return 0;
+    
+  } catch (const std::exception& e) {
+    std::cerr << "Rank " << rank << ": ✗ Exception: " << e.what() << std::endl;
+    MPI_Abort(MPI_COMM_WORLD, 1);
+    return 1;
+  }
+}
+
+/*
+ * how to run:
+ * 
+ * run (8 processes):
+ * mpirun --allow-run-as-root -np 8 ./allreduce_example
+ * 
+ * run (4 processes):
+ * mpirun --allow-run-as-root -np 4 ./allreduce_example
+ * 
+ * usage:
+ * 
+ * 1. initialize (once, using polymorphism with smart pointer):
+ *    std::unique_ptr<AllReduceExecutor<float>> executor(
+ *        new IntraNodeAllReduceExecutor<float>(num_ranks, rank, MPI_COMM_WORLD));
+ *    
+ * 2. use (multiple times):
+ *    executor->Execute(d_input, d_output, count, stream);
+ *    
+ * key points:
+ * - uses template-based polymorphism with smart pointer for automatic memory management
+ * - data type is specified via template parameter (e.g., float, half)
+ * - no need for dtype_size parameter anymore
+ * - no need for manual delete - unique_ptr handles cleanup automatically
+ * - IPC handles are exchanged automatically via MPI_Allgather
+ * - each process runs on an independent GPU (via hipSetDevice(rank))
+ * - supports 2/4/6/8 processes (GPUs)
+ */

--- a/examples/collective/allreduce_example.cpp
+++ b/examples/collective/allreduce_example.cpp
@@ -118,9 +118,10 @@ int main(int argc, char** argv) {
     // verify results
     hipMemcpy(h_data.data(), d_data, count * sizeof(float), hipMemcpyDeviceToHost);
     bool success = verifyResults(h_data.data(), count, num_ranks);
+    int success_int = success ? 1 : 0;
     
     int global_success;
-    MPI_Allreduce(&success, &global_success, 1, MPI_INT, MPI_LAND, MPI_COMM_WORLD);
+    MPI_Allreduce(&success_int, &global_success, 1, MPI_INT, MPI_LAND, MPI_COMM_WORLD);
     
     if (rank == 0) {
       if (global_success) {

--- a/include/mori/collective/all_reduce/intra_node_executor.hpp
+++ b/include/mori/collective/all_reduce/intra_node_executor.hpp
@@ -1,0 +1,202 @@
+#pragma once
+
+#include "mori/collective/all_reduce/allreduce_config.hpp"
+#include "mori/collective/all_reduce/allreduce_executor.hpp"
+#include "mori/collective/all_reduce/intra_node_impl.cuh"
+#include <memory>
+#include <mpi.h>
+
+namespace mori {
+namespace collective {
+
+/**
+ * IntraNodeAllReduceExecutor - intra node AllReduce high level wrapper
+ * 
+ * usage:
+ * 1. one initialization: AllReduceExecutor<T>* executor = new IntraNodeAllReduceExecutor<T>(num_ranks, rank, mpi_comm);
+ * 2. multiple calls: executor->Execute(d_input, d_output, count, stream);
+ * 
+ * internally call private interfaces (initializeSignals, initializeIPC, cleanupIPC)
+ * to call member functions of intra_node_ to implement high level wrapper
+ */
+template <typename T>
+class IntraNodeAllReduceExecutor : public AllReduceExecutor<T> {
+public:
+  /**
+   * constructor - initialize executor
+   * 
+   * @param num_ranks number of GPUs (must be 2, 4, 6, 8)
+   * @param rank rank of current GPU (0 to num_ranks-1)
+   * @param mpi_comm MPI communicator (for IPC handle exchange)
+   * @param max_size maximum buffer size (default 64MB)
+   * @param config AllReduce configuration (optional)
+   */
+  IntraNodeAllReduceExecutor(
+      int num_ranks,
+      int rank,
+      MPI_Comm mpi_comm,
+      size_t max_size = 8192 * 1024 * 8,
+      const AllReduceConfig& config = AllReduceConfig()
+  );
+
+  ~IntraNodeAllReduceExecutor() override;
+
+  /**
+   * execute AllReduce operation
+   * 
+   * @param input input data pointer (device memory)
+   * @param output output data pointer (device memory, can be same as input)
+   * @param count number of elements
+   * @param stream HIP stream (asynchronous execution)
+   * @return 0 on success, error code otherwise
+   */
+  int Execute(T* input, T* output, size_t count, hipStream_t stream) override;
+
+private:
+  std::unique_ptr<IntraNode> intra_node_;  // core implementation
+  AllReduceConfig config_;                  // configuration
+  MPI_Comm mpi_comm_;                       // MPI communicator
+  bool initialized_;                        // initialization flag
+
+  // ===== private interfaces =====
+  
+  /**
+   * initialize signal buffer
+   * call intra_node_->allocate_buffers()
+   */
+  void initializeSignals();
+
+  /**
+   * initialize IPC communication
+   * 1. get local IPC handle: intra_node_->get_meta_buffer_ipc_handle()
+   * 2. use MPI_Allgather to collect IPC handles from all ranks
+   * 3. call intra_node_->init_custom_ar() to create kernel entity
+   * 4. get local pre-registered buffer IPC handle: intra_node_->get_buffer_ipc_handle()
+   * 5. use MPI_Allgather to collect IPC handles from all ranks
+   * 6. register pre-registered buffer (similar to aiter's self.register_buffer(self.buffer))
+   */
+  void initializeIPC();
+
+  /**
+   * clean up IPC resources
+   * call intra_node_->dispose()
+   */
+  void cleanupIPC();
+};
+
+// ===== Template Implementation =====
+
+template <typename T>
+IntraNodeAllReduceExecutor<T>::IntraNodeAllReduceExecutor(
+    int num_ranks,
+    int rank,
+    MPI_Comm mpi_comm,
+    size_t max_size,
+    const AllReduceConfig& config)
+    : config_(config),
+      mpi_comm_(mpi_comm),
+      initialized_(false) {
+  
+  // create IntraNode instance
+  intra_node_ = std::make_unique<IntraNode>(num_ranks, rank, max_size, true);
+  
+  try {
+    // call private interfaces in order to initialize
+    initializeSignals();
+    initializeIPC();
+    initialized_ = true;
+  } catch (const std::exception& e) {
+    cleanupIPC();
+    throw;
+  }
+}
+
+template <typename T>
+IntraNodeAllReduceExecutor<T>::~IntraNodeAllReduceExecutor() {
+  cleanupIPC();
+}
+
+template <typename T>
+int IntraNodeAllReduceExecutor<T>::Execute(T* input, T* output, size_t count, 
+                                            hipStream_t stream) {
+  if (!initialized_ || !intra_node_) {
+    return -1;  // Not initialized
+  }
+  
+  try {
+    // call all_reduce method of intra_node_
+    // registered=false: Eager mode, will copy to pre-registered buffer first
+    // TODO: graph mode will be supported later
+    bool use_new = true;
+    bool registered = false;  // default use eager mode
+    intra_node_->all_reduce<T>(stream, input, output, count, use_new, registered);
+    return 0;
+  } catch (const std::exception& e) {
+    // TODO: add error logging
+    return -2;  // Execution failed
+  }
+}
+
+// ===== private interfaces implementation =====
+
+template <typename T>
+void IntraNodeAllReduceExecutor<T>::initializeSignals() {
+  // call allocate_buffers() of intra_node_ to allocate signal buffer
+  intra_node_->allocate_buffers();
+}
+
+template <typename T>
+void IntraNodeAllReduceExecutor<T>::initializeIPC() {
+  int num_ranks = intra_node_->get_num_ranks();
+  int rank = intra_node_->get_rank();
+  
+  // 1. get IPC handle of local meta buffer
+  hipIpcMemHandle_t my_meta_handle = intra_node_->get_meta_buffer_ipc_handle();
+  int64_t my_meta_offset = 0;  // meta buffer starts from the beginning
+  
+  // 2. use MPI_Allgather to collect IPC handles of meta buffer from all ranks
+  std::vector<hipIpcMemHandle_t> all_meta_handles(num_ranks);
+  std::vector<int64_t> all_meta_offsets(num_ranks);
+  
+  MPI_Allgather(&my_meta_handle, sizeof(hipIpcMemHandle_t), MPI_BYTE,
+                all_meta_handles.data(), sizeof(hipIpcMemHandle_t), MPI_BYTE,
+                mpi_comm_);
+  
+  MPI_Allgather(&my_meta_offset, 1, MPI_INT64_T,
+                all_meta_offsets.data(), 1, MPI_INT64_T,
+                mpi_comm_);
+  
+  // 3. call init_custom_ar() of intra_node_ to create kernel entity
+  intra_node_->init_custom_ar(all_meta_handles, all_meta_offsets);
+  
+  // 4. get IPC handle of local pre-registered buffer
+  hipIpcMemHandle_t my_buffer_handle = intra_node_->get_buffer_ipc_handle();
+  int64_t my_buffer_offset = 0;  // buffer starts from the beginning
+  
+  // 5. use MPI_Allgather to collect IPC handles of buffer from all ranks
+  std::vector<hipIpcMemHandle_t> all_buffer_handles(num_ranks);
+  std::vector<int64_t> all_buffer_offsets(num_ranks);
+  
+  MPI_Allgather(&my_buffer_handle, sizeof(hipIpcMemHandle_t), MPI_BYTE,
+                all_buffer_handles.data(), sizeof(hipIpcMemHandle_t), MPI_BYTE,
+                mpi_comm_);
+  
+  MPI_Allgather(&my_buffer_offset, 1, MPI_INT64_T,
+                all_buffer_offsets.data(), 1, MPI_INT64_T,
+                mpi_comm_);
+  
+  // 6. register pre-registered buffer (similar to aiter's self.register_buffer(self.buffer))
+  intra_node_->register_pre_allocated_buffer(all_buffer_handles, all_buffer_offsets);
+}
+
+template <typename T>
+void IntraNodeAllReduceExecutor<T>::cleanupIPC() {
+  if (intra_node_) {
+    // call dispose() of intra_node_ to clean up resources
+    intra_node_->dispose();
+  }
+}
+
+} // namespace collective
+} // namespace mori
+

--- a/include/mori/collective/all_reduce/intra_node_impl.cuh
+++ b/include/mori/collective/all_reduce/intra_node_impl.cuh
@@ -78,22 +78,6 @@ public:
     }
   }
 
-  /*
-  // allreduce interface, auto select dtype
-  void all_reduce(hipStream_t stream, void* input, void* output, 
-                  size_t count, size_t dtype_size, bool use_new = true, bool registered = false) {
-    if (dtype_size == 2) {
-      all_reduce<half>(stream, reinterpret_cast<half*>(input),
-                      reinterpret_cast<half*>(output), count, use_new, registered);
-    } else if (dtype_size == 4) {
-      all_reduce<float>(stream, reinterpret_cast<float*>(input),
-                       reinterpret_cast<float*>(output), count, use_new, registered);
-    } else {
-      throw std::runtime_error("Unsupported dtype_size: " + std::to_string(dtype_size));
-    }
-  }
-  */
-
   // release all device buffers
   void dispose() {
     kernel_entity_.reset();

--- a/include/mori/collective/all_reduce/intra_node_impl.cuh
+++ b/include/mori/collective/all_reduce/intra_node_impl.cuh
@@ -1,0 +1,239 @@
+#pragma once
+
+#include "kernel/kernel_entity.cuh"
+#include <memory>
+#include <vector>
+
+/**
+ * IntraNode - single node communication operator class implementation
+ * */
+class IntraNode {
+public:
+  IntraNode(int num_ranks, int rank, size_t max_size = 8192 * 1024 * 8, bool fully_connected = true)
+    : num_ranks_(num_ranks),
+      rank_(rank),
+      max_size_(max_size),
+      fully_connected_(fully_connected),
+      meta_buffer_(nullptr),
+      rank_data_buffer_(nullptr),
+      pre_registered_buffer_(nullptr),
+      kernel_entity_(nullptr) {
+    
+    if (num_ranks_ < 2 || num_ranks_ > 8) {
+      throw std::runtime_error("IntraNode only supports 2-8 ranks");
+    }
+    if (num_ranks_ % 2 != 0) {
+      throw std::runtime_error("IntraNode requires even number of ranks");
+    }
+    if (rank_ < 0 || rank_ >= num_ranks_) {
+      throw std::runtime_error("Invalid rank: " + std::to_string(rank_));
+    }
+  }
+
+  ~IntraNode() {
+    dispose();
+  }
+  
+  // initialize kernel entity
+  void init_custom_ar(const std::vector<hipIpcMemHandle_t>& handles,
+                     const std::vector<int64_t>& offsets) {
+    if (handles.size() != static_cast<size_t>(num_ranks_) ||
+        offsets.size() != static_cast<size_t>(num_ranks_)) {
+      throw std::runtime_error("handles and offsets size must match num_ranks");
+    }
+    kernel_entity_ = std::make_unique<CommKernelEntity>(
+      reinterpret_cast<Signal*>(meta_buffer_),
+      rank_data_buffer_,
+      8 * 1024 * 1024,  // rank_data_size
+      handles.data(),
+      offsets,
+      rank_,
+      fully_connected_
+    );
+  }
+
+  // launch kernel for allreduce
+  template <typename T>
+  void all_reduce(hipStream_t stream, T* input, T* output, int size, 
+                  bool use_new = true, bool registered = false) {
+    if (!kernel_entity_) {
+      throw std::runtime_error("kernel_entity not initialized, call init_custom_ar first");
+    }
+    
+    if (registered) {
+      // CUDA Graph mode
+      kernel_entity_->dispatchAllReduce<T>(stream, input, output, size, use_new);
+    } else {
+      // Eager mode
+      auto input_size = size * sizeof(T);
+      if (input_size > max_size_) {
+        throw std::runtime_error("input size exceeds max_size");
+      }
+      
+      HIP_CALL(hipMemcpyAsync(pre_registered_buffer_, input, input_size,
+                              hipMemcpyDeviceToDevice, stream));
+      kernel_entity_->dispatchAllReduce<T>(stream, 
+                                          reinterpret_cast<T*>(pre_registered_buffer_),
+                                          output, size, use_new);
+    }
+  }
+
+  /*
+  // allreduce interface, auto select dtype
+  void all_reduce(hipStream_t stream, void* input, void* output, 
+                  size_t count, size_t dtype_size, bool use_new = true, bool registered = false) {
+    if (dtype_size == 2) {
+      all_reduce<half>(stream, reinterpret_cast<half*>(input),
+                      reinterpret_cast<half*>(output), count, use_new, registered);
+    } else if (dtype_size == 4) {
+      all_reduce<float>(stream, reinterpret_cast<float*>(input),
+                       reinterpret_cast<float*>(output), count, use_new, registered);
+    } else {
+      throw std::runtime_error("Unsupported dtype_size: " + std::to_string(dtype_size));
+    }
+  }
+  */
+
+  // release all device buffers
+  void dispose() {
+    kernel_entity_.reset();
+    
+    if (meta_buffer_) {
+      HIP_CALL(hipFree(meta_buffer_));
+      meta_buffer_ = nullptr;
+    }
+    
+    if (rank_data_buffer_) {
+      HIP_CALL(hipFree(rank_data_buffer_));
+      rank_data_buffer_ = nullptr;
+    }
+    
+    if (pre_registered_buffer_) {
+      HIP_CALL(hipFree(pre_registered_buffer_));
+      pre_registered_buffer_ = nullptr;
+    }
+  }
+
+  // return Signal size
+  static size_t meta_size() { 
+    return sizeof(Signal); 
+  }
+
+  // register buffer, used for eager mode
+  // IPC handles can not bind with dynamic addresses or changable addresses
+  // so buffer were pre-alllocated
+  // d2d copy input data to buffer
+  // replaced by register_pre_allocated_buffer, but maybe needed for future use
+  /*
+  void register_buffer(void* buffer,
+                      const std::vector<hipIpcMemHandle_t>& handles,
+                      const std::vector<int64_t>& offsets) {
+    if (!kernel_entity_) {
+      throw std::runtime_error("kernel_entity not initialized");
+    }
+    kernel_entity_->register_buffer(buffer, handles, offsets);
+  }
+  */
+
+  // register pre-allocated buffer, used for eager mode
+  // bind IPC handles with pre-allocated buffer
+  void register_pre_allocated_buffer(const std::vector<hipIpcMemHandle_t>& handles,
+                                     const std::vector<int64_t>& offsets) {
+    if (!kernel_entity_) {
+      throw std::runtime_error("kernel_entity not initialized");
+    }
+    kernel_entity_->register_buffer(pre_registered_buffer_, handles, offsets);
+  }
+
+  // get IPC handle of pre-registered buffer
+  hipIpcMemHandle_t get_buffer_ipc_handle() const {
+    if (!pre_registered_buffer_) {
+      throw std::runtime_error("pre_registered_buffer not allocated");
+    }
+    
+    hipIpcMemHandle_t handle;
+    HIP_CALL(hipIpcGetMemHandle(&handle, pre_registered_buffer_));
+    return handle;
+  }
+
+  // get IPC meta of graph buffer
+  std::pair<std::vector<uint8_t>, std::vector<int64_t>> get_graph_buffer_ipc_meta() {
+    if (!kernel_entity_) {
+      throw std::runtime_error("kernel_entity not initialized");
+    }
+    
+    auto [handles_bytes, offsets] = kernel_entity_->get_graph_buffer_ipc_meta();
+    return {handles_bytes, offsets};
+  }
+
+  // register graph buffers, used for CUDA Graph mode
+  void register_graph_buffers(const std::vector<std::vector<hipIpcMemHandle_t>>& handles,
+                             const std::vector<std::vector<int64_t>>& offsets) {
+    if (!kernel_entity_) {
+      throw std::runtime_error("kernel_entity not initialized");
+    }
+    kernel_entity_->register_graph_buffers(handles, offsets);
+  }
+
+  // support function, can be called by executor
+  
+  // allocate meta buffer, rank data buffer and pre-registered buffer
+  void allocate_buffers() {
+    // 1. allocate meta buffer (for signal sync and temp buffer)
+    size_t meta_total_size = sizeof(Signal) + max_size_;
+    void* buffer;
+    
+    hipStreamCaptureMode mode = hipStreamCaptureModeRelaxed;
+    hipStream_t stream = 0;
+    
+    HIP_CALL(hipThreadExchangeStreamCaptureMode(&mode));
+    HIP_CALL(hipExtMallocWithFlags(&buffer, meta_total_size, hipDeviceMallocUncached));
+    HIP_CALL(hipMemsetAsync(buffer, 0, meta_total_size, stream));
+    HIP_CALL(hipStreamSynchronize(stream));
+    HIP_CALL(hipThreadExchangeStreamCaptureMode(&mode));
+    
+    meta_buffer_ = buffer;
+    
+    // 2. allocate rank data buffer (for RankData array)
+    size_t rank_data_size = 8 * 1024 * 1024;
+    HIP_CALL(hipMalloc(&rank_data_buffer_, rank_data_size));
+    
+    // 3. allocate pre-registered buffer (for eager mode data storage)
+    HIP_CALL(hipMalloc(&pre_registered_buffer_, max_size_));
+  }
+
+  // 获取本地 meta buffer 的 IPC handle
+  hipIpcMemHandle_t get_meta_buffer_ipc_handle() const {
+    if (!meta_buffer_) {
+      throw std::runtime_error("meta_buffer not allocated");
+    }
+    
+    hipIpcMemHandle_t handle;
+    HIP_CALL(hipIpcGetMemHandle(&handle, meta_buffer_));
+    return handle;
+  }
+
+  // get member variables, can be accessed by executor
+  int get_rank() const { return rank_; }
+  int get_num_ranks() const { return num_ranks_; }
+  void* get_meta_buffer() const { return meta_buffer_; }
+  void* get_rank_data_buffer() const { return rank_data_buffer_; }
+
+  // get pre-registered buffer, can be accessed by executor
+  void* get_pre_registered_buffer() const { return pre_registered_buffer_; }
+
+private:
+  int num_ranks_;
+  int rank_;
+  size_t max_size_;
+  bool fully_connected_;
+  
+  // device memory
+  void* meta_buffer_;              // Signal metadata + temp buffer
+  void* rank_data_buffer_;         // Rank data storage
+  void* pre_registered_buffer_;    // Pre-registered buffer for eager mode
+  
+  // Kernel entity, as a member variable
+  std::unique_ptr<CommKernelEntity> kernel_entity_;
+};
+

--- a/include/mori/collective/all_reduce/kernel/kernel_entity.cuh
+++ b/include/mori/collective/all_reduce/kernel/kernel_entity.cuh
@@ -251,7 +251,7 @@ private:
   char* open_ipc_handle(const hipIpcMemHandle_t* ipc_handle) {
     // Convert hipIpcMemHandle_t to IPC_KEY for use as map key
     auto [it, new_handle] =
-      ipc_handles_.insert({*((IPC_KEY*)&ipc_handle), nullptr});
+      ipc_handles_.insert({*((const IPC_KEY*)ipc_handle), nullptr});
     // insert success
     if (new_handle) {
       char* ipc_ptr;

--- a/include/mori/collective/all_reduce/kernel/kernel_entity.cuh
+++ b/include/mori/collective/all_reduce/kernel/kernel_entity.cuh
@@ -1,0 +1,297 @@
+#pragma once
+#include "kernel_impl.cuh"
+
+#define HIP_CALL(call)                                                       \
+    do                                                                       \
+    {                                                                        \
+        hipError_t err = call;                                               \
+        if(err != hipSuccess)                                                \
+        {                                                                    \
+            printf("\n[AITER] %s:%d fail to call %s ---> [HIP error](%s)\n", \
+                   __FILE__,                                                 \
+                   __LINE__,                                                 \
+                   #call,                                                    \
+                   hipGetErrorString(err));                                  \
+            exit(0);                                                         \
+        }                                                                    \
+    } while(0)
+
+/*
+ * same as custom_all_reduce.cuh
+ * class CustomAllreduce
+ * */
+
+// IPC handle key type (same as aiter)
+using IPC_KEY = std::array<uint8_t, sizeof(hipIpcMemHandle_t)>;
+static_assert(sizeof(IPC_KEY) == sizeof(hipIpcMemHandle_t));
+static_assert(alignof(IPC_KEY) == alignof(hipIpcMemHandle_t));
+
+class CommKernelEntity {
+public:
+  int rank_;
+  int world_size_;
+  bool full_nvlink_;
+
+  // below are device pointers
+  RankSignals sg_;
+  Signal* self_sg_;
+  std::unordered_map<void*, RankData*> buffers_;
+
+  // stores the registered device pointers from all ranks
+  RankData* d_rank_data_base_;
+  RankData* d_rank_data_end_;
+
+  // used for hipgraph on, in capture stage, save input addresses for bind IPC handles
+  std::vector<void*> graph_unreg_buffers_;
+  // a map from IPC handles to opened IPC pointers
+  std::map<IPC_KEY, char*> ipc_handles_;
+
+  CommKernelEntity(Signal* meta, void* rank_data, size_t rank_data_sz,
+                   const hipIpcMemHandle_t* handles,
+                   const std::vector<int64_t> &offsets, int rank,
+                   bool fully_connected = true) :
+    rank_(rank),
+    world_size_(offsets.size()),
+    full_nvlink_(fully_connected),
+    self_sg_(meta),
+    d_rank_data_base_(reinterpret_cast<RankData*>(rank_data)),
+    d_rank_data_end_(d_rank_data_base_ + rank_data_sz / sizeof(RankData)) {
+    for (int i = 0; i < world_size_; ++i) {
+      Signal* rank_sg;
+      if (i != rank_) {
+        char* handle = open_ipc_handle(&handles[i]);
+        handle += offsets[i];
+        rank_sg = (Signal*)handle;
+      }
+      else {
+        rank_sg = self_sg_;
+      }
+      sg_.signals[i] = rank_sg;
+    }
+    printf("rank %d, CommKernelEntity constructed, meta ipc bind finished\n", rank_);
+  }
+
+  // register buffer with IPC handles from all ranks
+  void register_buffer(void* self_ptr, 
+                       const std::vector<hipIpcMemHandle_t>& handles,
+                       const std::vector<int64_t>& offsets) {
+    check_rank_data_capacity();
+    RankData data;
+    for (int i = 0; i < world_size_; i++) {
+      if (i != rank_) {
+        char* handle = open_ipc_handle(&handles[i]);
+        handle += offsets[i];
+        data.ptrs[i] = handle;
+      }
+      else {
+        data.ptrs[i] = self_ptr;
+      }
+    }
+    auto d_data = d_rank_data_base_++;
+    HIP_CALL(hipMemcpy(d_data, &data, sizeof(RankData), hipMemcpyHostToDevice));
+    buffers_[self_ptr] = d_data;
+  }
+
+  // get graph buffer IPC meta (returns handles as bytes and offsets)
+  std::pair<std::vector<uint8_t>, std::vector<int64_t>> get_graph_buffer_ipc_meta() {
+    printf("rank %d, get_graph_buffer_ipc_meta called\n", rank_);
+    auto num_buffers = graph_unreg_buffers_.size();
+    auto handle_sz = sizeof(hipIpcMemHandle_t);
+    std::vector<uint8_t> handles(handle_sz * num_buffers, 0);
+    std::vector<int64_t> offsets(num_buffers);
+    
+    for (size_t i = 0; i < num_buffers; i++) {
+      auto ptr = graph_unreg_buffers_[i];
+      void* base_ptr;
+      
+      // Get base address of allocation
+      if (hipPointerGetAttribute(&base_ptr,
+                                HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR,
+                                (hipDeviceptr_t)ptr) != hipSuccess) {
+        throw std::runtime_error("failed to get pointer attr");
+      }
+      
+      // Get IPC handle for base address
+      HIP_CALL(hipIpcGetMemHandle(
+          (hipIpcMemHandle_t*)&handles[i * handle_sz], base_ptr));
+      
+      // Calculate offset from base
+      offsets[i] = ((char*)ptr) - ((char*)base_ptr);
+    }
+    
+    return std::make_pair(handles, offsets);
+    printf("rank %d, get_graph_buffer_ipc_meta finished\n", rank_);
+  }
+
+  // register graph buffers captured during CUDA graph recording
+  void register_graph_buffers(
+      const std::vector<std::vector<hipIpcMemHandle_t>>& handles,
+      const std::vector<std::vector<int64_t>>& offsets) {
+    printf("rank %d, register_graph_buffers called, handles size: %zu, offsets size: %zu\n", rank_, handles.size(), offsets.size());
+    auto num_buffers = graph_unreg_buffers_.size();
+    check_rank_data_capacity(num_buffers);
+    
+    std::vector<RankData> rank_data(num_buffers);
+    for (int i = 0; i < num_buffers; i++) {
+      auto self_ptr = graph_unreg_buffers_[i];
+      auto& rd = rank_data[i];
+      for (int j = 0; j < world_size_; j++) {
+        if (j != rank_) {
+          char* handle = open_ipc_handle(&handles[j][i]);
+          handle += offsets[j][i];
+          rd.ptrs[j] = handle;
+        }
+        else {
+          rd.ptrs[j] = self_ptr;
+        }
+      }
+    }
+    HIP_CALL(hipMemcpy(d_rank_data_base_, rank_data.data(),
+                       sizeof(RankData) * num_buffers,
+                       hipMemcpyHostToDevice));
+    d_rank_data_base_ += num_buffers;
+    graph_unreg_buffers_.clear();
+    printf("rank %d, register_graph_buffers finished\n", rank_);
+  }
+
+  // main allreduce dispatch function
+  // TODO: add dispatch logic about naive kernel
+  template <typename T>
+  void dispatchAllReduce(hipStream_t stream, T* input, T* output, int size, bool use_new = true) {
+    RankData* ptrs = get_buffer_RD(stream, input);
+    
+    auto d = packed_t<T>::P::size;
+    if (size % d != 0) {
+      throw std::runtime_error(
+          "custom allreduce currently requires input length to be multiple of " +
+          std::to_string(d));
+    }
+    if (kMaxBlocks > 80) {
+      throw std::runtime_error("max supported block limit is 80");
+    }
+    
+    auto bytes = size * sizeof(T);
+    size /= d;
+    
+    int blocks = 16;
+    int threads = 512;
+    bool call_1stage = false;
+    bool call_2stage = false;
+    
+    if (world_size_ == 2) {
+      call_1stage = true;
+    }
+    else if (full_nvlink_) {
+      if ((world_size_ <= 4 && bytes < 160 * 1024) || 
+          (world_size_ <= 8 && bytes < 80 * 1024)) {
+        call_1stage = true;
+      }
+      else {
+        call_2stage = true;
+      }
+    }
+    
+    if (call_1stage) {
+      blocks = std::min(kMaxBlocks, (size + (threads / world_size_) - 1) / (threads / world_size_));
+    }
+    else if (call_2stage) {
+      blocks = std::min(kMaxBlocks, (size / world_size_ + (threads / world_size_) - 1) / (threads / world_size_));
+    }
+    
+#define KL(ngpus, name) \
+    name<T, ngpus><<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_, size);
+
+#define dispatch(ngpus, name) \
+    do { \
+      if (bytes % 128 == 0 && world_size_ != 6) { \
+        KL(ngpus, name) \
+      } \
+      else { \
+        KL(ngpus, name##_naive) \
+      } \
+    } while(0)
+
+#define REDUCE_CASE(ngpus) \
+    case ngpus: { \
+      if (call_1stage) { \
+        dispatch(ngpus, cross_device_reduce_1stage); \
+      } \
+      else if (call_2stage) { \
+        dispatch(ngpus, cross_device_reduce_2stage); \
+      } \
+      break; \
+    }
+    
+    switch (world_size_) {
+      REDUCE_CASE(2)
+      REDUCE_CASE(4)
+      REDUCE_CASE(6)
+      REDUCE_CASE(8)
+    default:
+      throw std::runtime_error(
+          "custom allreduce only supports num gpus in (2,4,6,8). Actual num gpus = " +
+          std::to_string(world_size_));
+    }
+    
+#undef REDUCE_CASE
+#undef dispatch
+#undef KL
+  }
+
+  ~CommKernelEntity() {
+    for (auto& [handle, ptr] : ipc_handles_) {
+      if (ptr) {
+        HIP_CALL(hipIpcCloseMemHandle(ptr));
+      }
+    }
+  }
+
+private:
+
+  char* open_ipc_handle(const hipIpcMemHandle_t* ipc_handle) {
+    // Convert hipIpcMemHandle_t to IPC_KEY for use as map key
+    auto [it, new_handle] =
+      ipc_handles_.insert({*((IPC_KEY*)&ipc_handle), nullptr});
+    // insert success
+    if (new_handle) {
+      char* ipc_ptr;
+      HIP_CALL(hipIpcOpenMemHandle((void**)&ipc_ptr,
+                                   *((const hipIpcMemHandle_t *)ipc_handle),
+                                   hipIpcMemLazyEnablePeerAccess));
+      it->second = ipc_ptr;
+    }
+    return it->second;
+  }
+
+  void check_rank_data_capacity(size_t num = 1) {
+    if (d_rank_data_base_ + num > d_rank_data_end_) {
+      throw std::runtime_error(
+          "Rank data buffer is overflow by " +
+          std::to_string(d_rank_data_base_ + num - d_rank_data_end_));
+    }
+  }
+
+  RankData* get_buffer_RD(hipStream_t stream, void* input) {
+    RankData* ptrs;
+    auto it = buffers_.find(input);
+    if (it != buffers_.end()) {
+      ptrs = it->second;
+    }
+    else {
+      hipStreamCaptureStatus status;
+      HIP_CALL(hipStreamIsCapturing(stream, &status));
+      if (status == hipStreamCaptureStatusActive) {
+        ptrs = d_rank_data_base_ + graph_unreg_buffers_.size();
+        graph_unreg_buffers_.push_back(input);
+      }
+      else {
+        throw std::runtime_error(
+            "buffer address " +
+            std::to_string(reinterpret_cast<uint64_t>(input)) +
+            " is not registered!");
+      }
+    }
+    return ptrs;
+  }
+};
+

--- a/include/mori/collective/all_reduce/kernel/kernel_impl.cuh
+++ b/include/mori/collective/all_reduce/kernel/kernel_impl.cuh
@@ -1,0 +1,288 @@
+#pragma once
+/*
+ * impl kernel function
+ * both global function and device function
+ * included by kernel_entity.cuh
+ * */
+#include <iostream>
+#include <limits>
+#include <map>
+#include <unordered_map>
+#include <vector>
+#include "vec_type.cuh"
+
+constexpr int kMaxBlocks = 80;
+
+struct Signal {
+  alignas(128) uint32_t start[kMaxBlocks][8];
+  alignas(128) uint32_t end[kMaxBlocks][8];
+  alignas(128) uint32_t _flag[kMaxBlocks];
+};
+
+// data pointer array
+struct __align__(16) RankData {
+  const void* ptrs[8];
+};
+
+// Signal pointer array
+struct __align__(16) RankSignals {
+  Signal* signals[8];
+};
+
+template <int ngpus>
+DINLINE void start_sync(const RankSignals &sg, Signal* self_sg, int rank) {
+  uint32_t flag = self_sg->_flag[blockIdx.x] + 1;
+
+  if (threadIdx.x < ngpus) {
+    // cross device store
+    __scoped_atomic_store_n(
+        &sg.signals[threadIdx.x]->start[blockIdx.x][rank], // dst addr
+        flag,                                              // src data
+        __ATOMIC_RELAXED,                                  // atomic level
+        __MEMORY_SCOPE_SYSTEM                              // memory scope
+    );
+
+    // local device load
+    // wait other ranks cross device store finish
+    while (
+        __scoped_atomic_load_n(&self_sg->start[blockIdx.x][threadIdx.x], __ATOMIC_RELAXED, __MEMORY_SCOPE_DEVICE) < flag
+    );
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x == 0) {
+    self_sg->_flag[blockIdx.x] = flag;
+  }
+}
+
+template <int ngpus, bool final_sync = false>
+DINLINE void end_sync(const RankSignals &sg, Signal* self_sg, int rank) {
+  __syncthreads();
+
+  uint32_t flag = self_sg->_flag[blockIdx.x] + 1;
+  if (threadIdx.x < ngpus) {
+    __scoped_atomic_store_n(
+        &sg.signals[threadIdx.x]->end[blockIdx.x][rank],
+        flag,
+        final_sync ? __ATOMIC_RELAXED : __ATOMIC_RELEASE,
+        __MEMORY_SCOPE_SYSTEM
+    );
+    while (
+        __scoped_atomic_load_n(
+          &self_sg->end[blockIdx.x][threadIdx.x],
+          final_sync ? __ATOMIC_RELAXED : __ATOMIC_ACQUIRE,
+          __MEMORY_SCOPE_DEVICE
+        ) < flag
+    );
+  }
+
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    self_sg->_flag[blockIdx.x] = flag;
+  }
+}
+
+// get temp buffer for 2-stage allreduce
+template <typename P>
+DINLINE P* get_tmp_buf(Signal* sg) {
+  return (P*)(((Signal*)sg) + 1);
+}
+
+// 1-stage allreduce kernel (naive version)
+template <typename T, int ngpus>
+__global__ void __launch_bounds__(512, 1) 
+cross_device_reduce_1stage_naive(
+    RankData* _dp, 
+    RankSignals sg,
+    Signal* self_sg,
+    T* __restrict__ result, 
+    int rank, 
+    int size
+) {
+  using P = typename packed_t<T>::P;
+  using A = typename packed_t<T>::A;
+  
+  auto dp = *_dp;
+  start_sync<ngpus>(sg, self_sg, rank);
+  
+  // do the actual reduction
+  for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < size;
+       idx += gridDim.x * blockDim.x) {
+    ((P*)result)[idx] = packed_reduce<P, ngpus, A>((const P**)&dp.ptrs[0], idx);
+  }
+  
+  end_sync<ngpus, true>(sg, self_sg, rank);
+}
+
+// 2-stage allreduce kernel (naive version)
+template <typename T, int ngpus>
+__global__ void __launch_bounds__(512, 1)
+cross_device_reduce_2stage_naive(
+    RankData* _dp,
+    RankSignals sg,
+    Signal* self_sg,
+    T* __restrict__ result,
+    int rank,
+    int size
+) {
+  int tid = blockIdx.x * blockDim.x + threadIdx.x;
+  int stride = gridDim.x * blockDim.x;
+  using P = typename packed_t<T>::P;
+  using A = typename packed_t<T>::A;
+  
+  int part = size / ngpus;
+  int start = rank * part;
+  int end = rank == ngpus - 1 ? size : start + part;
+  int largest_part = part + size % ngpus;
+  
+  const P* ptrs[ngpus];
+  P* tmps[ngpus];
+#pragma unroll
+  for (int i = 0; i < ngpus; i++) {
+    int target = (rank + i) % ngpus;
+    ptrs[i] = (const P*)_dp->ptrs[target];
+    tmps[i] = get_tmp_buf<P>(sg.signals[target]);
+  }
+  auto tmp_out = tmps[0];
+  
+  start_sync<ngpus>(sg, self_sg, rank);
+  
+  // stage 1: reduce scatter
+  for (int idx = start + tid; idx < end; idx += stride) {
+    tmp_out[idx - start] = packed_reduce<P, ngpus, A>(ptrs, idx);
+  }
+  
+  end_sync<ngpus>(sg, self_sg, rank);
+  
+  // stage 2: allgather
+  for (int idx = tid; idx < largest_part; idx += stride) {
+#pragma unroll
+    for (int i = 0; i < ngpus; i++) {
+      int gather_from_rank = ((rank + i) % ngpus);
+      if (gather_from_rank == ngpus - 1 || idx < part) {
+        int dst_idx = gather_from_rank * part + idx;
+        ((P*)result)[dst_idx] = tmps[i][idx];
+      }
+    }
+  }
+}
+
+// 1-stage allreduce kernel (optimized version)
+#define THREAD_NUM 512
+
+template <typename T, int ngpus>
+__global__ void __launch_bounds__(512, 1)
+cross_device_reduce_1stage(
+    RankData* _dp,
+    RankSignals sg,
+    Signal* self_sg,
+    T* __restrict__ result,
+    int rank,
+    int size
+) {
+  using P = typename packed_t<T>::P;
+  using A = typename packed_t<T>::A;
+  constexpr int pack_size = packed_t<T>::P::size;
+  constexpr int tnum_gpu = THREAD_NUM / ngpus;
+  __shared__ T tmp_smem[tnum_gpu * ngpus * pack_size];
+  
+  auto dp = *_dp;
+  int warp_id = threadIdx.x / tnum_gpu;
+  int lane_id = threadIdx.x % tnum_gpu;
+  
+  start_sync<ngpus>(sg, self_sg, rank);
+  
+  // do the actual reduction
+  for (int idx = blockIdx.x * tnum_gpu + lane_id; idx < size;
+       idx += gridDim.x * tnum_gpu) {
+    *(reinterpret_cast<P*>(&tmp_smem[0]) + threadIdx.x) = 
+        ((const P**)&dp.ptrs[0])[warp_id][idx];
+    __syncthreads();
+    
+    if (warp_id == 0) {
+      A add_reg = upcast_v<typename P::type, pack_size>(
+          *(reinterpret_cast<P*>(&tmp_smem[0]) + threadIdx.x));
+      
+      constexpr int smem_gpu_loop_stride = tnum_gpu * pack_size;
+#pragma unroll
+      for (int i = 1; i < ngpus; ++i) {
+        P tmp = *(reinterpret_cast<P*>(&tmp_smem[smem_gpu_loop_stride * i]) + threadIdx.x);
+        packed_assign_add(add_reg, upcast_v<typename P::type, pack_size>(tmp));
+      }
+      
+      ((P*)result)[idx] = downcast_v<typename P::type, pack_size>(add_reg);
+    }
+    __syncthreads();
+  }
+}
+
+// 2-stage allreduce kernel (optimized version)
+template <typename T, int ngpus>
+__global__ void __launch_bounds__(512, 1)
+cross_device_reduce_2stage(
+    RankData* _dp,
+    RankSignals sg,
+    Signal* self_sg,
+    T* __restrict__ result,
+    int rank,
+    int size
+) {
+  constexpr int pack_size = packed_t<T>::P::size;
+  constexpr int tnum_gpu = THREAD_NUM / ngpus;
+  using P = typename packed_t<T>::P;
+  using A = typename packed_t<T>::A;
+  __shared__ T tmp_smem[tnum_gpu * ngpus * pack_size];
+  
+  int warp_id = threadIdx.x / tnum_gpu;
+  int lane_id = threadIdx.x % tnum_gpu;
+  int tid = blockIdx.x * tnum_gpu + lane_id;
+  int stride = gridDim.x * tnum_gpu;
+  
+  int part = size / ngpus;
+  int start = rank * part;
+  int end = rank == ngpus - 1 ? size : start + part;
+  int largest_part = part + size % ngpus;
+  
+  const P* ptrs[ngpus];
+  P* tmps[ngpus];
+#pragma unroll
+  for (int i = 0; i < ngpus; i++) {
+    int target = (rank + i) % ngpus;
+    ptrs[i] = (const P*)_dp->ptrs[target];
+    tmps[i] = get_tmp_buf<P>(sg.signals[target]);
+  }
+  auto tmp_out = tmps[0];
+  
+  start_sync<ngpus>(sg, self_sg, rank);
+  
+  // stage 1: reduce scatter
+  for (int idx = start + tid; idx < end; idx += stride) {
+    *(reinterpret_cast<P*>(&tmp_smem[0]) + threadIdx.x) = ptrs[warp_id][idx];
+    __syncthreads();
+    
+    if (warp_id == 0) {
+      A add_reg = upcast_v<typename P::type, pack_size>(
+          *(reinterpret_cast<P*>(&tmp_smem[0]) + threadIdx.x));
+      
+      constexpr int smem_gpu_loop_stride = tnum_gpu * pack_size;
+#pragma unroll
+      for (int i = 1; i < ngpus; ++i) {
+        P tmp = *(reinterpret_cast<P*>(&tmp_smem[i * smem_gpu_loop_stride]) + threadIdx.x);
+        packed_assign_add(add_reg, upcast_v<typename P::type, pack_size>(tmp));
+      }
+      
+      tmp_out[idx - start] = downcast_v<typename P::type, pack_size>(add_reg);
+    }
+    __syncthreads();
+  }
+  
+  end_sync<ngpus>(sg, self_sg, rank);
+  
+  // stage 2: allgather
+  for (int idx = tid; idx < largest_part; idx += stride) {
+    int dst_idx = (warp_id + rank) % ngpus * part + idx;
+    ((P*)result)[dst_idx] = tmps[warp_id][idx];
+  }
+}
+

--- a/include/mori/collective/all_reduce/kernel/vec_type.cuh
+++ b/include/mori/collective/all_reduce/kernel/vec_type.cuh
@@ -1,0 +1,125 @@
+#pragma once
+
+#include <iostream>
+#include <hip/hip_runtime.h>
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
+
+template <typename T, int sz>
+struct __align__(alignof(T) * sz) array_t {
+  T data[sz];
+  using type = T;
+  static constexpr int size = sz;
+};
+
+template <typename T>
+struct packed_t {
+  using P = array_t<T, 16 / sizeof(T)>;
+  using A = array_t<float, 16 / sizeof(T)>;
+};
+
+#define DINLINE __device__ __forceinline__
+
+// scalar upcast
+template <typename T>
+DINLINE float upcast_s(T val) {
+  return static_cast<float>(val);
+}
+
+template <>
+DINLINE float upcast_s<half>(half val) {
+  return __half2float(val);
+}
+
+template <>
+DINLINE float upcast_s<__hip_bfloat16>(__hip_bfloat16 val) {
+  return __bfloat162float(val);
+}
+
+// scalar downcast
+template <typename T>
+DINLINE T downcast_s(float val) {
+  return static_cast<T>(val);
+}
+
+template <>
+DINLINE half downcast_s(float val) {
+  return __float2half(val);
+}
+
+template <>
+DINLINE __hip_bfloat16 downcast_s(float val) {
+  return __float2bfloat16(val);
+}
+
+// scalar add (a value changed)
+template <typename T>
+DINLINE T &assign_add(T &a, T b) {
+  return a += b;
+}
+
+template <>
+DINLINE half &assign_add(half &a, half b) {
+  a = __hadd(a, b);
+  return a;
+}
+
+template <>
+DINLINE __hip_bfloat16 &assign_add(__hip_bfloat16 &a, __hip_bfloat16 b) {
+  a = __hadd(a, b);
+  return a;
+}
+
+// pack add (a value changed)
+template <typename T, int N>
+DINLINE array_t<T, N> &packed_assign_add(array_t<T, N> &a, array_t<T, N> b) {
+#pragma unroll
+  for (int i = 0; i < N; ++i) {
+    assign_add<T>(a.data[i], b.data[i]);
+  }
+  return a;
+}
+
+// pack upcast
+template <typename T, int N>
+DINLINE array_t<float, N> upcast_v(array_t<T, N> val) {
+  if constexpr (std::is_same<T, float>::value) {
+    return val;
+  }
+  else {
+    array_t<float, N> out;
+#pragma unroll
+    for (int i = 0; i < N; ++i) {
+      out.data[i] = upcast_s<T>(val.data[i]);
+    }
+    return out;
+  }
+}
+
+// pack downcast
+template <typename T, int N>
+DINLINE array_t<T, N> downcast_v(array_t<float, N> val) {
+  if constexpr(std::is_same<T, float>::value) {
+    return val;
+  }
+  else {
+    array_t<T, N> out;
+#pragma unroll
+    for (int i = 0; i < N; ++i) {
+      out.data[i] = downcast_s<T>(val.data[i]);
+    }
+    return out;
+  }
+}
+
+template <typename P, int ngpus, typename A>
+DINLINE P packed_reduce(const P* ptrs[], int idx) {
+  A tmp = upcast_v(ptrs[0][idx]);
+#pragma unroll
+  for (int i = 1; i < ngpus; ++i)
+  {
+    packed_assign_add(tmp, upcast_v(ptrs[i][idx]));
+  }
+  return downcast_v<typename P::type, P::size>(tmp);
+}
+

--- a/src/collective/CMakeLists.txt
+++ b/src/collective/CMakeLists.txt
@@ -1,9 +1,36 @@
 find_package(MPI REQUIRED)
 
-add_library(
-  mori_collective SHARED
-  allreduce/allreduce_manager.cpp topology_detector.cpp
-  allreduce/ring_1d_executor.cpp allreduce/one_shot_executor.cpp)
+# Source files list
+set(COLLECTIVE_SOURCES
+  allreduce/allreduce_manager.cpp
+  topology_detector.cpp
+  allreduce/ring_1d_executor.cpp
+  # intra_node_executor is header-only template class
+)
+
+add_library(mori_collective SHARED ${COLLECTIVE_SOURCES})
+
+# HIP compile options (extracted from aiter, PyTorch dependencies removed)
+if(USE_ROCM)
+  target_compile_definitions(mori_collective PRIVATE
+    __HIP_PLATFORM_AMD__=1
+    USE_ROCM=1
+    HIPBLAS_V2
+    __HIP_PLATFORM_HCC__=1
+  )
+
+  # HIP-specific compile options
+  target_compile_options(mori_collective PRIVATE
+    $<$<COMPILE_LANGUAGE:HIP>:
+      --offload-arch=native
+      -fgpu-flush-denormals-to-zero
+      -fno-offload-uniform-block
+      -mllvm --amdgpu-kernarg-preload-count=16
+      -fno-gpu-rdc
+      -Wno-unused-result
+    >
+  )
+endif()
 
 target_link_libraries(
   mori_collective
@@ -11,3 +38,4 @@ target_link_libraries(
   PRIVATE hip::host hip::device)
 
 target_include_directories(mori_collective PUBLIC ${CMAKE_SOURCE_DIR}/include)
+


### PR DESCRIPTION
## Motivation

move aiter allreduce to mori

## Technical Details

use RAII to manage class lifecycle.
use MPI instead of torch.distributed to implement handle broadcasting.
only eager mode was implemented, not support hipgraph on

## Test Plan

see examples/collective/allreduce_example.cpp

## Test Result

Accuracy test passed. No performance test conducted yet.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
