### PR TITLE
feat[io]: Handle IOEngineConfig(port=0) auto-bind and expose listen port

### DIFF
--- a/src/io/rdma/backend_impl.hpp
+++ b/src/io/rdma/backend_impl.hpp
@@ -24,6 +24,7 @@
 #include <infiniband/verbs.h>
 
 #include <atomic>
+#include <cstdint>
 #include <mutex>
 #include <optional>
 #include <shared_mutex>
@@ -153,6 +154,11 @@ class ControlPlaneServer {
                      NotifManager*);
   ~ControlPlaneServer();
 
+  std::optional<uint16_t> GetListenPort() const {
+    if (!ctx) return std::nullopt;
+    return static_cast<uint16_t>(ctx->GetPort());
+  }
+
   // Remote engine meta management
   void RegisterRemoteEngine(const EngineDesc&);
   void DeregisterRemoteEngine(const EngineDesc&);
@@ -227,6 +233,11 @@ class RdmaBackend : public Backend {
  public:
   RdmaBackend(EngineKey, const IOEngineConfig&, const RdmaBackendConfig&);
   ~RdmaBackend();
+
+  std::optional<uint16_t> GetListenPort() const {
+    if (!server) return std::nullopt;
+    return server->GetListenPort();
+  }
 
   void RegisterRemoteEngine(const EngineDesc&);
   void DeregisterRemoteEngine(const EngineDesc&);

--- a/tests/python/io/test_engine.py
+++ b/tests/python/io/test_engine.py
@@ -111,6 +111,22 @@ def test_engine_desc():
     assert desc == unpacked_desc
 
 
+def test_engine_desc_port_zero_auto_bind():
+    config = IOEngineConfig(
+        host="127.0.0.1",
+        port=0,
+    )
+    engine = IOEngine(key="engine_port0", config=config)
+    engine.create_backend(BackendType.RDMA)
+
+    desc = engine.get_engine_desc()
+    assert desc.port > 0
+
+    packed_desc = desc.pack()
+    unpacked_desc = EngineDesc.unpack(packed_desc)
+    assert desc == unpacked_desc
+
+
 def test_mem_desc():
     config = IOEngineConfig(
         host="127.0.0.1",


### PR DESCRIPTION
* When `IOEngineConfig.port == 0`, update `EngineDesc.port` and `IOEngineConfig.port` after RDMA backend binds.
* Add `test_engine_desc_port_zero_auto_bind` to assert desc.port > 0 and pack/unpack consistency.