### PR TITLE
Add elastic EP for dispatch/combine flows

### DIFF
--- a/include/mori/utils/hip_helper.hpp
+++ b/include/mori/utils/hip_helper.hpp
@@ -48,16 +48,28 @@ inline int GetCurDeviceMaxThreads() {
   return GetMaxThreads(device);
 }
 
-inline int GetDeviceWallClockFreqMhz(int device) {
+inline int GetMaxThreads(int device) {
+  hipDeviceProp_t prop;
+  HIP_RUNTIME_CHECK(hipGetDeviceProperties(&prop, device));
+  return prop.maxThreadsPerMultiProcessor;
+}
+
+inline int GetCurDeviceMaxThreads() {
+  int device = 0;
+  HIP_RUNTIME_CHECK(hipGetDevice(&device));
+  return GetMaxThreads(device);
+}
+
+inline int GetDeviceWallClockFreqKHz(int device) {
   int rate;
   HIP_RUNTIME_CHECK(hipDeviceGetAttribute(&rate, hipDeviceAttributeWallClockRate, device));
   return rate;
 }
 
-inline int GetCurDeviceWallClockFreqMhz() {
+inline int GetCurDeviceWallClockFreqKHz() {
   int device = 0;
   HIP_RUNTIME_CHECK(hipGetDevice(&device));
-  return GetDeviceWallClockFreqMhz(device);
+  return GetDeviceWallClockFreqKHz(device);
 }
 
 }  // namespace mori

--- a/include/mori/utils/hip_helper.hpp
+++ b/include/mori/utils/hip_helper.hpp
@@ -48,18 +48,6 @@ inline int GetCurDeviceMaxThreads() {
   return GetMaxThreads(device);
 }
 
-inline int GetMaxThreads(int device) {
-  hipDeviceProp_t prop;
-  HIP_RUNTIME_CHECK(hipGetDeviceProperties(&prop, device));
-  return prop.maxThreadsPerMultiProcessor;
-}
-
-inline int GetCurDeviceMaxThreads() {
-  int device = 0;
-  HIP_RUNTIME_CHECK(hipGetDevice(&device));
-  return GetMaxThreads(device);
-}
-
 inline int GetDeviceWallClockFreqKHz(int device) {
   int rate;
   HIP_RUNTIME_CHECK(hipDeviceGetAttribute(&rate, hipDeviceAttributeWallClockRate, device));

--- a/python/mori/kernel_profiler/__init__.py
+++ b/python/mori/kernel_profiler/__init__.py
@@ -146,7 +146,7 @@ def export_to_perfetto(
     sanitize_orphans=True,
 ):
     if not gpu_freq_ghz:
-        gpu_freq_ghz = mori_cpp.get_cur_device_wall_clock_freq_mhz() / 1e6
+        gpu_freq_ghz = mori_cpp.get_cur_device_wall_clock_freq_khz() / 1e6
 
     if slot_map is None:
         slot_map = _discover_all_slots()

--- a/python/mori/ops/dispatch_combine.py
+++ b/python/mori/ops/dispatch_combine.py
@@ -204,6 +204,8 @@ class EpDispatchCombineOp:
         block_num: int = -1,
         rdma_block_num: int = -1,
         warp_per_block: int = -1,
+        active_ranks=None,
+        timeout_us=None,
     ):
         """Dispatch tokens to experts based on top-k indices.
 
@@ -225,6 +227,8 @@ class EpDispatchCombineOp:
             self.auto_block_num if self.auto_block_num else block_num,
             self.auto_rdma_block_num if self.auto_rdma_block_num else rdma_block_num,
             self.auto_warp_per_block if self.auto_warp_per_block else warp_per_block,
+            active_ranks,
+            timeout_us,
         )
 
     def dispatch_send(
@@ -235,6 +239,8 @@ class EpDispatchCombineOp:
         indices: torch.Tensor,
         block_num: int = -1,
         warp_per_block: int = -1,
+        active_ranks=None,
+        timeout_us=None,
     ):
         return self.dispatch(
             input,
@@ -243,18 +249,24 @@ class EpDispatchCombineOp:
             indices,
             self.auto_block_num if self.auto_block_num else block_num,
             self.auto_warp_per_block if self.auto_warp_per_block else warp_per_block,
+            active_ranks=active_ranks,
+            timeout_us=timeout_us,
         )
 
     def dispatch_recv(
         self,
         block_num: int = -1,
         warp_per_block: int = -1,
+        active_ranks=None,
+        timeout_us=None,
     ):
         return self._dispatch_recv_func(
             self._handle,
             self.config.kernel_type.value,
             self.auto_block_num if self.auto_block_num else block_num,
             self.auto_warp_per_block if self.auto_warp_per_block else warp_per_block,
+            active_ranks,
+            timeout_us,
         )
 
     def combine(
@@ -267,6 +279,8 @@ class EpDispatchCombineOp:
         warp_per_block: int = -1,
         use_external_inp_buf: int = -1,
         call_reset: bool = False,
+        active_ranks=None,
+        timeout_us=None,
     ):
         """Combine tokens from experts back to original positions.
 
@@ -291,6 +305,8 @@ class EpDispatchCombineOp:
             self.auto_rdma_block_num if self.auto_rdma_block_num else rdma_block_num,
             self.auto_warp_per_block if self.auto_warp_per_block else warp_per_block,
             use_external_inp_buf,
+            active_ranks,
+            timeout_us,
         )
         if call_reset:
             self._reset_func(self._handle)
@@ -303,6 +319,8 @@ class EpDispatchCombineOp:
         indices: torch.Tensor,
         block_num: int = -1,
         warp_per_block: int = -1,
+        active_ranks=None,
+        timeout_us=None,
     ):
         return self.combine(
             input,
@@ -310,18 +328,24 @@ class EpDispatchCombineOp:
             indices,
             self.auto_block_num if self.auto_block_num else block_num,
             self.auto_warp_per_block if self.auto_warp_per_block else warp_per_block,
+            active_ranks=active_ranks,
+            timeout_us=timeout_us,
         )
 
     def combine_recv(
         self,
         block_num: int = -1,
         warp_per_block: int = -1,
+        active_ranks=None,
+        timeout_us=None,
     ):
         return self._combine_recv_func(
             self._handle,
             self.config.kernel_type.value,
             self.auto_block_num if self.auto_block_num else block_num,
             self.auto_warp_per_block if self.auto_warp_per_block else warp_per_block,
+            active_ranks,
+            timeout_us,
         )
 
     def dispatch_standard_moe(

--- a/src/ops/dispatch_combine/dispatch_combine.cpp
+++ b/src/ops/dispatch_combine/dispatch_combine.cpp
@@ -21,11 +21,12 @@
 // SOFTWARE.
 #include "mori/ops/dispatch_combine/dispatch_combine.hpp"
 
-#include <algorithm>
 #include <hip/hip_bfloat16.h>
 #include <hip/hip_fp8.h>
 #include <hip/hip_runtime.h>
 #include <hip/hip_runtime_api.h>
+
+#include <algorithm>
 
 #include "mori/core/core.hpp"
 #include "mori/shmem/shmem.hpp"
@@ -65,6 +66,7 @@ EpDispatchCombineHandle::EpDispatchCombineHandle(EpDispatchCombineConfig config_
   this->maxThreads = std::min(GetCurDeviceMaxThreads(), 1024);
   MORI_OPS_INFO("Device capability: multiProcessorCount=%d, maxThreads=%d",
                 static_cast<int>(this->multiProcessorCount), static_cast<int>(this->maxThreads));
+  this->wallClockRateKHz = GetCurDeviceWallClockFreqKHz();
 }
 
 EpDispatchCombineHandle::~EpDispatchCombineHandle() {

--- a/src/ops/dispatch_combine/low_latency_async.cpp
+++ b/src/ops/dispatch_combine/low_latency_async.cpp
@@ -61,15 +61,9 @@ __global__ void EpDispatchLowLatencyAsyncSend(EpDispatchCombineArgs<T> args) {
       condition = destPe == (args.tokenIndices[srcTokId * config.numExpertPerToken + laneId] /
                              config.numExpertPerRank);
     }
-    if (__any(condition)) {
+    if (__any(condition) || !core::IsRankActive(args.activeRanks, destPe)) {
       // Indicate that this token is already sent to the destination PE by setting an overflow
-      // token index
-      if (laneId == 0)
-        args.dispDestTokIdMap[i] = config.worldSize * config.MaxNumTokensToSendPerRank();
-      continue;
-    }
-
-    if (!core::IsRankActive(args.activeRanks, destPe)) {
+      // token index, or the destination PE is inactive
       if (laneId == 0)
         args.dispDestTokIdMap[i] = config.worldSize * config.MaxNumTokensToSendPerRank();
       continue;

--- a/src/ops/dispatch_combine/low_latency_async.cpp
+++ b/src/ops/dispatch_combine/low_latency_async.cpp
@@ -25,6 +25,7 @@
 #include <hip/hip_fp8.h>
 #include <hip/hip_runtime.h>
 #include <hip/hip_runtime_api.h>
+
 #include <type_traits>
 
 #include "mori/core/core.hpp"
@@ -68,6 +69,12 @@ __global__ void EpDispatchLowLatencyAsyncSend(EpDispatchCombineArgs<T> args) {
       continue;
     }
 
+    if (!core::IsRankActive(args.activeRanks, destPe)) {
+      if (laneId == 0)
+        args.dispDestTokIdMap[i] = config.worldSize * config.MaxNumTokensToSendPerRank();
+      continue;
+    }
+
     if (laneId == 0) {
       // decide token id in dest pe
       destTokId = atomicAdd(args.destPeTokenCounter + destPe, 1);
@@ -102,6 +109,7 @@ __global__ void EpDispatchLowLatencyAsyncSend(EpDispatchCombineArgs<T> args) {
 
   uint64_t* recvTokenNums = args.recvTokenNumMemObj->template GetAs<uint64_t*>();
   for (int destPe = blockId; destPe < npes; destPe += blockNum) {
+    if (!core::IsRankActive(args.activeRanks, destPe)) continue;
     for (int qpId = warpId; qpId < config.numQpPerPe; qpId += warpNum) {
       if (laneId == 0) shmem::ShmemUint32WaitUntilEquals(args.dispatchGridBarrier, globalWarpNum);
       int tokenNum = core::AtomicLoadRelaxed(args.destPeTokenCounter + destPe);
@@ -134,21 +142,24 @@ __global__ void EpDispatchLowLatencyAsyncRecv(EpDispatchCombineArgs<T> args) {
 
   int blocksPerPe = blockNum / npes;
   int destPe = blockId / blocksPerPe;
+  const bool peerActive = core::IsRankActive(args.activeRanks, destPe);
 
   // TODO(ditian12): index value is wrong when signal completion at send phase, hence we signal at
   // recv phase as a workaround at the cost of extra latency, we should still investigate the reason
   if ((blockId % blocksPerPe) == 0) {
     for (int qpId = warpId; qpId < config.numQpPerPe; qpId += warpNum) {
       if (laneId == 0) {
-        shmem::ShmemQuietThread(destPe, qpId);
-        int tokenNum = core::AtomicLoadRelaxed(args.destPeTokenCounter + destPe);
-        // TODO(ditian12): send atomic op right after quiet lead to hang issue, need to investigate
-        // shmem::ShmemAtomicTypeNonFetchThread<uint64_t>(
-        //     args.recvTokenNumMemObj, (myPe * config.numQpPerPe + qpId) * sizeof(uint64_t),
-        //     static_cast<uint64_t>(tokenNum + 1), core::AMO_ADD, destPe, qpId);
-        shmem::ShmemPutUint64ImmNbiThread(args.recvTokenNumMemObj,
-                                          (myPe * config.numQpPerPe + qpId) * sizeof(uint64_t),
-                                          static_cast<uint64_t>(tokenNum + 1), destPe, qpId);
+        if (peerActive) {
+          shmem::ShmemQuietThread(destPe, qpId);
+          int tokenNum = core::AtomicLoadRelaxed(args.destPeTokenCounter + destPe);
+          // TODO(ditian12): send atomic op right after quiet lead to hang issue, need to
+          // investigate shmem::ShmemAtomicTypeNonFetchThread<uint64_t>(
+          //     args.recvTokenNumMemObj, (myPe * config.numQpPerPe + qpId) * sizeof(uint64_t),
+          //     static_cast<uint64_t>(tokenNum + 1), core::AMO_ADD, destPe, qpId);
+          shmem::ShmemPutUint64ImmNbiThread(args.recvTokenNumMemObj,
+                                            (myPe * config.numQpPerPe + qpId) * sizeof(uint64_t),
+                                            static_cast<uint64_t>(tokenNum + 1), destPe, qpId);
+        }
       }
     }
   }
@@ -156,9 +167,14 @@ __global__ void EpDispatchLowLatencyAsyncRecv(EpDispatchCombineArgs<T> args) {
   uint64_t* recvTokenNums = args.recvTokenNumMemObj->template GetAs<uint64_t*>();
   uint64_t recvTokenNum = 0;
   if (laneId < config.numQpPerPe) {
-    recvTokenNum = shmem::ShmemUint64WaitUntilGreaterThan(
-                       recvTokenNums + destPe * config.numQpPerPe + laneId, 0) -
-                   1;
+    if (peerActive) {
+      uint64_t got = core::WaitUntilGreaterThanOrTimeoutSystem(
+          recvTokenNums + destPe * config.numQpPerPe + laneId, uint64_t{0}, args.timeoutTicks,
+          args.activeRanks, destPe);
+      recvTokenNum = (got > 0) ? (got - 1) : 0;
+    } else {
+      recvTokenNum = 0;
+    }
   }
   recvTokenNum = __shfl(recvTokenNum, 0);
 
@@ -245,10 +261,9 @@ __global__ void EpCombineLowLatencyAsyncSend(EpDispatchCombineArgs<T> args) {
           reinterpret_cast<TokT*>(stagingPtr + stagingTokId * tokHiddenBytes),
           args.inpTokenBuf + tokenId * config.hiddenDim, config.hiddenDim, laneId);
     } else {
-      core::WarpCopy<uint8_t, 4>(stagingPtr + stagingTokId * tokHiddenBytes,
-                                 reinterpret_cast<uint8_t*>(args.inpTokenBuf) +
-                                     tokenId * tokHiddenBytes,
-                                 tokHiddenBytes);
+      core::WarpCopy<uint8_t, 4>(
+          stagingPtr + stagingTokId * tokHiddenBytes,
+          reinterpret_cast<uint8_t*>(args.inpTokenBuf) + tokenId * tokHiddenBytes, tokHiddenBytes);
     }
   }
   if (laneId == 0) {
@@ -257,6 +272,7 @@ __global__ void EpCombineLowLatencyAsyncSend(EpDispatchCombineArgs<T> args) {
 
   uint64_t* recvTokenNums = args.recvTokenNumMemObj->template GetAs<uint64_t*>();
   for (int destPe = blockId; destPe < npes; destPe += blockNum) {
+    if (!core::IsRankActive(args.activeRanks, destPe)) continue;
     for (int qpId = warpId; qpId < config.numQpPerPe; qpId += warpNum) {
       int tokenNum = 0;
       if (laneId == 0) {
@@ -293,6 +309,7 @@ __global__ void EpCombineLowLatencyAsyncRecv(EpDispatchCombineArgs<T> args) {
                 "Fp8 direct cast combine currently only supports bf16 input");
 
   for (int destPe = blockId; destPe < npes; destPe += blockNum) {
+    if (!core::IsRankActive(args.activeRanks, destPe)) continue;
     for (int qpId = warpId; qpId < config.numQpPerPe; qpId += warpNum) {
       if (laneId == 0) {
         shmem::ShmemQuietThread(destPe, qpId);
@@ -308,11 +325,15 @@ __global__ void EpCombineLowLatencyAsyncRecv(EpDispatchCombineArgs<T> args) {
   }
 
   for (int destPe = laneId; destPe < npes; destPe += warpSize) {
+    if (!core::IsRankActive(args.activeRanks, destPe)) continue;
     uint64_t barrierFlag = args.crossDeviceBarrierFlag[0];
-    for (int i = 0; i < config.numQpPerPe; i++)
-      shmem::ShmemUint64WaitUntilEquals(args.crossDeviceBarrierMemObj->template GetAs<uint64_t*>() +
-                                            destPe * config.numQpPerPe + i,
-                                        barrierFlag);
+    for (int i = 0; i < config.numQpPerPe; i++) {
+      uint64_t* addr = args.crossDeviceBarrierMemObj->template GetAs<uint64_t*>() +
+                       destPe * config.numQpPerPe + i;
+      const bool ok = core::WaitUntilEqualsOrTimeoutSystem(addr, barrierFlag, args.timeoutTicks,
+                                                           args.activeRanks, destPe);
+      if (!ok) core::AtomicStoreRelaxedSystem(addr, barrierFlag);
+    }
   }
 
   extern __shared__ char sharedMem[];
@@ -335,22 +356,21 @@ __global__ void EpCombineLowLatencyAsyncRecv(EpDispatchCombineArgs<T> args) {
         index_t destTokId = args.dispDestTokIdMap[tokenId * config.numExpertPerToken + j];
         index_t destPe = destTokId / config.MaxNumTokensToSendPerRank();
 
-        TokT* stagingPtr =
-            (destPe != myPe) ? args.shmemCombineInpTokMemObj->template GetAs<TokT*>()
-                             : args.shmemStagingTokMemObj->template GetAs<TokT*>();
-        if (destPe < npes) {
+        TokT* stagingPtr = (destPe != myPe) ? args.shmemCombineInpTokMemObj->template GetAs<TokT*>()
+                                            : args.shmemStagingTokMemObj->template GetAs<TokT*>();
+        if ((destPe < npes) && core::IsRankActive(args.activeRanks, destPe)) {
           srcPtrs[j] = stagingPtr + destTokId * config.hiddenDim + hiddenDimOffset;
         } else {
           srcPtrs[j] = nullptr;
         }
       }
 
-      T* outPtr = args.shmemCombineOutTokMemObj->template GetAs<T*>() +
-                  tokenId * config.hiddenDim + hiddenDimOffset;
+      T* outPtr = args.shmemCombineOutTokMemObj->template GetAs<T*>() + tokenId * config.hiddenDim +
+                  hiddenDimOffset;
       if constexpr (UseFp8DirectCast) {
-        core::WarpAccumCombineInternalFp8ToBf16(
-            outPtr, reinterpret_cast<const TokT* const*>(srcPtrs), config.numExpertPerToken, laneId,
-            hiddenDimSize);
+        core::WarpAccumCombineInternalFp8ToBf16(outPtr,
+                                                reinterpret_cast<const TokT* const*>(srcPtrs),
+                                                config.numExpertPerToken, laneId, hiddenDimSize);
       } else {
         core::WarpAccum<T, 4>(outPtr, srcPtrs, nullptr, config.numExpertPerToken, hiddenDimSize);
       }
@@ -391,29 +411,27 @@ __global__ void EpCombineLowLatencyAsyncRecv(EpDispatchCombineArgs<T> args) {
 #endif
 
 // Macro to instantiate async kernels for all data types
-#define INSTANTIATE_ASYNC_KERNEL(KernelName)                                                \
-  template __global__ void KernelName<hip_bfloat16>(EpDispatchCombineArgs<hip_bfloat16>    \
-                                                         args);                              \
-  MORI_FP8_FNUZ(template __global__ void KernelName<__hip_fp8_e4m3_fnuz>(                   \
-                    EpDispatchCombineArgs<__hip_fp8_e4m3_fnuz> args);)                      \
-  MORI_FP8_OCP(template __global__ void KernelName<__hip_fp8_e4m3>(                         \
-                   EpDispatchCombineArgs<__hip_fp8_e4m3> args);)                            \
-  template __global__ void KernelName<mori_fp4x2_e2m1>(EpDispatchCombineArgs<mori_fp4x2_e2m1> \
-                                                            args);                           \
+#define INSTANTIATE_ASYNC_KERNEL(KernelName)                                                   \
+  template __global__ void KernelName<hip_bfloat16>(EpDispatchCombineArgs<hip_bfloat16> args); \
+  MORI_FP8_FNUZ(template __global__ void KernelName<__hip_fp8_e4m3_fnuz>(                      \
+                    EpDispatchCombineArgs<__hip_fp8_e4m3_fnuz> args);)                         \
+  MORI_FP8_OCP(template __global__ void KernelName<__hip_fp8_e4m3>(                            \
+                   EpDispatchCombineArgs<__hip_fp8_e4m3> args);)                               \
+  template __global__ void KernelName<mori_fp4x2_e2m1>(                                        \
+      EpDispatchCombineArgs<mori_fp4x2_e2m1> args);                                            \
   template __global__ void KernelName<float>(EpDispatchCombineArgs<float> args);
 
 // Macro to instantiate async combine kernels (includes optional bf16->fp8 direct-cast path)
-#define INSTANTIATE_ASYNC_COMBINE_KERNEL(KernelName)                                        \
-  template __global__ void KernelName<hip_bfloat16>(EpDispatchCombineArgs<hip_bfloat16>    \
-                                                         args);                              \
-  MORI_FP8_ANY(template __global__ void KernelName<hip_bfloat16, true>(                     \
-                   EpDispatchCombineArgs<hip_bfloat16> args);)                              \
-  MORI_FP8_FNUZ(template __global__ void KernelName<__hip_fp8_e4m3_fnuz>(                   \
-                    EpDispatchCombineArgs<__hip_fp8_e4m3_fnuz> args);)                      \
-  MORI_FP8_OCP(template __global__ void KernelName<__hip_fp8_e4m3>(                         \
-                   EpDispatchCombineArgs<__hip_fp8_e4m3> args);)                            \
-  template __global__ void KernelName<mori_fp4x2_e2m1>(EpDispatchCombineArgs<mori_fp4x2_e2m1> \
-                                                            args);                           \
+#define INSTANTIATE_ASYNC_COMBINE_KERNEL(KernelName)                                           \
+  template __global__ void KernelName<hip_bfloat16>(EpDispatchCombineArgs<hip_bfloat16> args); \
+  MORI_FP8_ANY(template __global__ void KernelName<hip_bfloat16, true>(                        \
+                   EpDispatchCombineArgs<hip_bfloat16> args);)                                 \
+  MORI_FP8_FNUZ(template __global__ void KernelName<__hip_fp8_e4m3_fnuz>(                      \
+                    EpDispatchCombineArgs<__hip_fp8_e4m3_fnuz> args);)                         \
+  MORI_FP8_OCP(template __global__ void KernelName<__hip_fp8_e4m3>(                            \
+                   EpDispatchCombineArgs<__hip_fp8_e4m3> args);)                               \
+  template __global__ void KernelName<mori_fp4x2_e2m1>(                                        \
+      EpDispatchCombineArgs<mori_fp4x2_e2m1> args);                                            \
   template __global__ void KernelName<float>(EpDispatchCombineArgs<float> args);
 
 INSTANTIATE_ASYNC_KERNEL(EpDispatchLowLatencyAsyncSend)


### PR DESCRIPTION
## Motivation

This PR adds elastic EP behavior to `dispatch_combine` so jobs can continue making progress when some rank/node become unresponsive, instead of hanging on cross-rank synchronization.
The goal is to improve robustness for internode MoE dispatch/combine under partial-failure scenarios while keeping the existing behavior unchanged when elastic mode is not enabled.

## Technical Details

- Added optional elastic EP state (`active_ranks`) and timeout (`timeout_us`) plumbing from Python API -> pybind -> C++ handle -> device kernels.
- Introduced device-side elastic utilities in `device_primitives` (rank active checks, rank deactivation, wait-with-timeout helpers) and applied them across internode/intranode/low-latency dispatch+combine synchronization points.
- Updated `EpDispatchCombineHandle` to store elastic state and wall-clock rate, and converted timeout from microseconds to device wall-clock ticks.
- Renamed wall-clock helper API from MHz naming to KHz naming for correctness/clarity:
  - `get_cur_device_wall_clock_freq_mhz` -> `get_cur_device_wall_clock_freq_khz`
  - corresponding C++ helper rename in HIP utils and Python kernel profiler usage.
- Extended Python `EpDispatchCombineOp` interfaces (`dispatch*` / `combine*`) with optional `active_ranks` and `timeout_us` parameters.
- Added/expanded tests and example coverage for elastic behavior:
  - New elastic EP test path in `tests/python/ops/test_dispatch_combine.py` (`test_dispatch_combine_elastic_ep`)
  - Updated internode example test to support dropout simulation (`drop_rank`) and timeout-based inactive rank handling.

## Test Plan

- Unit/integration:
  - `tests/python/ops/test_dispatch_combine.py::test_dispatch_combine`
  - `tests/python/ops/test_dispatch_combine.py::test_dispatch_combine_elastic_ep`
- Example/internode validation:
  - `examples/ops/dispatch_combine/test_dispatch_combine_internode.py` with:
    - normal mode (`drop_rank=-1`)
    - dropout simulation (`drop_rank=<rank_id>`, `timeout_us=<value>`)

## Test Result

- Unit tests passed
