### PR TITLE
Feat: JAX integration via XLA FFI custom calls (supersedes #173)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Mori ops API surface -- changes here affect both torch and XLA FFI shims.
+# Require review from the ops team when either shim or the shared handle is modified.
+/include/mori/ops/dispatch_combine/   @amd/mori-ops
+/src/pybind/pybind_ops.cpp            @amd/mori-ops
+/src/ffi/mori_xla_ffi_ops.cpp         @amd/mori-ops
+/src/ffi/mori_xla_ffi_handle_mgr.hpp  @amd/mori-ops
+/tests/python/test_shim_parity.py     @amd/mori-ops
+/tests/cpp/ffi/                        @amd/mori-ops

--- a/3rdparty/xla_ffi/VERSION
+++ b/3rdparty/xla_ffi/VERSION
@@ -1,0 +1,7 @@
+Vendored from rocm-xla/rocm-jaxlib-v0.9.0 branch
+Commit: ca6c4f848f (PR #37629: [ROCm] Propagate register spill info for autotuner filtering)
+
+Files:
+  xla/ffi/api/c_api.h   - C ABI structs (header-only, no external deps)
+  xla/ffi/api/api.h     - C++ handler macros (depends on c_api.h only)
+  xla/ffi/api/ffi.h     - C++ FFI implementation (depends on c_api.h + api.h)

--- a/3rdparty/xla_ffi/xla/ffi/api/api.h
+++ b/3rdparty/xla_ffi/xla/ffi/api/api.h
@@ -1,0 +1,2297 @@
+/* Copyright 2023 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_FFI_API_API_H_
+#define XLA_FFI_API_API_H_
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <complex>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <initializer_list>
+#include <iostream>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+// This is a header-only base C++ library that defines templates for decoding
+// XLA FFI call frames and invoking corresponding C++ functions. This must have
+// no dependencies outside of the C++ standard library.
+//
+// There are two extensions to this base library:
+//
+//   (1) xla/ffi/api/ffi.h for defining "external" FFI handlers loaded from
+//       dynamic libraries potentially built with different toolchains and/or
+//       a different XLA commit. It is a header-only library without any
+//       dependencies.
+//
+//   (2) xla/ffi/ffi.h for defining "internal" FFI handlers that must be
+//       statically linked into the binary and must be built from the same
+//       commit using the same toolchain, as it provides access to XLA
+//       implementation details (e.g. ServiceExecutableOptions) and C++ ABI
+//       across different libraries is hard.
+//
+// Extensions define template specializations for argument-decoding hooks
+// defined in this file.
+
+#include "xla/ffi/api/c_api.h"
+
+#ifdef __has_builtin
+#define XLA_FFI_HAS_BUILTIN(x) __has_builtin(x)
+#else
+#define XLA_FFI_HAS_BUILTIN(x) 0
+#endif
+
+#if __has_attribute(always_inline)
+#define XLA_FFI_ATTRIBUTE_ALWAYS_INLINE __attribute__((always_inline))
+#elif defined(_MSC_VER)
+#define XLA_FFI_ATTRIBUTE_ALWAYS_INLINE __forceinline
+#else
+#define XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+#endif
+
+#if __has_attribute(noinline)
+#define XLA_FFI_ATTRIBUTE_NEVER_INLINE __attribute__((noinline))
+#elif defined(_MSC_VER)
+#define XLA_FFI_ATTRIBUTE_NEVER_INLINE __declspec(noinline)
+#else
+#define XLA_FFI_ATTRIBUTE_NEVER_INLINE
+#endif
+
+#if XLA_FFI_HAS_BUILTIN(__builtin_expect)
+#define XLA_FFI_PREDICT_FALSE(x) (__builtin_expect(false || (x), false))
+#define XLA_FFI_PREDICT_TRUE(x) (__builtin_expect(false || (x), true))
+#else
+#define XLA_FFI_PREDICT_FALSE(x) (x)
+#define XLA_FFI_PREDICT_TRUE(x) (x)
+#endif
+
+//===----------------------------------------------------------------------===//
+// Builtin enum pretty printing
+//===----------------------------------------------------------------------===//
+
+inline std::ostream& operator<<(std::ostream& os,
+                                const XLA_FFI_DataType dtype) {
+  switch (dtype) {
+    case XLA_FFI_DataType_INVALID:
+      return os << "INVALID";
+    case XLA_FFI_DataType_PRED:
+      return os << "PRED";
+    case XLA_FFI_DataType_S1:
+      return os << "S1";
+    case XLA_FFI_DataType_S2:
+      return os << "S2";
+    case XLA_FFI_DataType_S4:
+      return os << "S4";
+    case XLA_FFI_DataType_S8:
+      return os << "S8";
+    case XLA_FFI_DataType_S16:
+      return os << "S16";
+    case XLA_FFI_DataType_S32:
+      return os << "S32";
+    case XLA_FFI_DataType_S64:
+      return os << "S64";
+    case XLA_FFI_DataType_U1:
+      return os << "U1";
+    case XLA_FFI_DataType_U2:
+      return os << "U2";
+    case XLA_FFI_DataType_U4:
+      return os << "U4";
+    case XLA_FFI_DataType_U8:
+      return os << "U8";
+    case XLA_FFI_DataType_U16:
+      return os << "U16";
+    case XLA_FFI_DataType_U32:
+      return os << "U32";
+    case XLA_FFI_DataType_U64:
+      return os << "U64";
+    case XLA_FFI_DataType_F16:
+      return os << "F16";
+    case XLA_FFI_DataType_F32:
+      return os << "F32";
+    case XLA_FFI_DataType_F64:
+      return os << "F64";
+    case XLA_FFI_DataType_BF16:
+      return os << "BF16";
+    case XLA_FFI_DataType_C64:
+      return os << "C64";
+    case XLA_FFI_DataType_C128:
+      return os << "C128";
+    case XLA_FFI_DataType_TOKEN:
+      return os << "TOKEN";
+    case XLA_FFI_DataType_F4E2M1FN:
+      return os << "F4E2M1FN";
+    case XLA_FFI_DataType_F8E5M2:
+      return os << "F8E5M2";
+    case XLA_FFI_DataType_F8E3M4:
+      return os << "F8E3M4";
+    case XLA_FFI_DataType_F8E4M3:
+      return os << "F8E4M3";
+    case XLA_FFI_DataType_F8E4M3FN:
+      return os << "F8E4M3FN";
+    case XLA_FFI_DataType_F8E4M3B11FNUZ:
+      return os << "F8E4M3B11FNUZ";
+    case XLA_FFI_DataType_F8E5M2FNUZ:
+      return os << "F8E5M2FNUZ";
+    case XLA_FFI_DataType_F8E4M3FNUZ:
+      return os << "F8E4M3FNUZ";
+    case XLA_FFI_DataType_F8E8M0FNU:
+      return os << "F8E8M0FNU";
+  }
+}
+
+inline std::ostream& operator<<(std::ostream& os, const XLA_FFI_AttrType type) {
+  switch (type) {
+    case XLA_FFI_AttrType_ARRAY:
+      return os << "array";
+    case XLA_FFI_AttrType_DICTIONARY:
+      return os << "dictionary";
+    case XLA_FFI_AttrType_SCALAR:
+      return os << "scalar";
+    case XLA_FFI_AttrType_STRING:
+      return os << "string";
+  }
+}
+
+inline std::ostream& operator<<(std::ostream& os,
+                                const XLA_FFI_ExecutionStage stage) {
+  switch (stage) {
+    case XLA_FFI_ExecutionStage_INSTANTIATE:
+      return os << "instantiate";
+    case XLA_FFI_ExecutionStage_PREPARE:
+      return os << "prepare";
+    case XLA_FFI_ExecutionStage_INITIALIZE:
+      return os << "initialize";
+    case XLA_FFI_ExecutionStage_EXECUTE:
+      return os << "execute";
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Builtin structs equality
+//===----------------------------------------------------------------------===//
+
+inline bool operator==(const XLA_FFI_TypeId& a, const XLA_FFI_TypeId& b) {
+  return a.type_id == b.type_id;
+}
+
+inline bool operator!=(const XLA_FFI_TypeId& a, const XLA_FFI_TypeId& b) {
+  return !(a == b);
+}
+
+inline bool operator==(const XLA_FFI_Api_Version& a,
+                       const XLA_FFI_Api_Version& b) {
+  return a.major_version == b.major_version &&
+         a.minor_version == b.minor_version;
+}
+
+inline bool operator!=(const XLA_FFI_Api_Version& a,
+                       const XLA_FFI_Api_Version& b) {
+  return !(a == b);
+}
+
+inline bool operator==(const XLA_FFI_Metadata& a, const XLA_FFI_Metadata& b) {
+  return a.api_version == b.api_version && a.traits == b.traits &&
+         a.state_type_id == b.state_type_id;
+}
+
+inline bool operator!=(const XLA_FFI_Metadata& a, const XLA_FFI_Metadata& b) {
+  return !(a == b);
+}
+
+inline bool operator==(const XLA_FFI_Handler_Bundle& a,
+                       const XLA_FFI_Handler_Bundle& b) {
+  return a.instantiate == b.instantiate && a.prepare == b.prepare &&
+         a.initialize == b.initialize && a.execute == b.execute;
+}
+
+inline bool operator!=(const XLA_FFI_Handler_Bundle& a,
+                       const XLA_FFI_Handler_Bundle& b) {
+  return !(a == b);
+}
+
+namespace xla::ffi {
+
+enum class ExecutionStage : uint8_t {
+  kInstantiate = XLA_FFI_ExecutionStage_INSTANTIATE,
+  kPrepare = XLA_FFI_ExecutionStage_PREPARE,
+  kInitialize = XLA_FFI_ExecutionStage_INITIALIZE,
+  kExecute = XLA_FFI_ExecutionStage_EXECUTE,
+};
+
+enum class Traits : uint32_t {
+  // Indicates that the handler is compatible with command buffers. In the
+  // XLA:GPU CUDA backend, we rely on graph capture to trace the execution of a
+  // FFI handler and record it as a command buffer (CUDA graph). For a FFI
+  // handler to be compatible with CUDA graphs, it has to satisfy certain
+  // constraints as documented in
+  // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#prohibited-and-unhandled-operations.
+  //
+  // Broadly speaking, a handler that satisfies the following conditions should
+  // be compatible with command buffers:
+  //   1. it only launches kernels that must be captured in command buffers on
+  //      the device (e.g. it does *not* do autotuning). This is because
+  //      everything it launches will be captured in the command buffer;
+  //   2. the FFI handler only uses device allocations passed in as buffer
+  //      arguments (e.g. it does *not* do any runtime device memory
+  //      allocations);
+  //   3. the FFI handler may not query the execution status of the stream.
+  kCmdBufferCompatible = XLA_FFI_HANDLER_TRAITS_COMMAND_BUFFER_COMPATIBLE,
+};
+
+// Forward declare template defined below.
+template <ExecutionStage stage, typename... Ts>
+class Binding;
+
+// Forward declare template defined below.
+template <ExecutionStage stage, typename Fn, typename... Ts>
+class Handler;
+
+//===----------------------------------------------------------------------===//
+// XLA FFI virtual base for implementing FFI handlers
+//===----------------------------------------------------------------------===//
+
+class Ffi {
+ public:
+  // Creates an empty binding specification which allows to define FFI handler
+  // signature separately from implementation and rely on compile time type
+  // checking to verify that signature matches the provided implementation.
+  template <ExecutionStage stage = ExecutionStage::kExecute>
+  static Binding<stage> Bind();
+
+  // Creates an empty binding for the instantiate stage.
+  static Binding<ExecutionStage::kInstantiate> BindInstantiate();
+
+  // Creates an empty binding for the prepare stage.
+  static Binding<ExecutionStage::kPrepare> BindPrepare();
+
+  // Creates an empty binding for the initialize stage.
+  static Binding<ExecutionStage::kInitialize> BindInitialize();
+
+  // Automatic FFI binding that does binding specification inference from the
+  // `fn` type signature and binds `fn` to it. This enables a more concise FFI
+  // handler registration with fully automatic type inference at the cost of
+  // less readable error messages, template metaprogramming "magic" and a risk
+  // to accidentally change handler type without noticing it.
+  template <typename Fn, ExecutionStage stage = ExecutionStage::kExecute>
+  static auto BindTo(Fn fn, std::initializer_list<Traits> traits = {});
+
+  virtual ~Ffi() = default;
+  virtual XLA_FFI_Error* Call(XLA_FFI_CallFrame* call_frame) const = 0;
+
+  // Registers FFI handler bundle with an XLA runtime under the given name on a
+  // given platform.
+  static XLA_FFI_Error* RegisterStaticHandler(
+      const XLA_FFI_Api* api, std::string_view name, std::string_view platform,
+      XLA_FFI_Handler_Bundle bundle, XLA_FFI_Handler_Traits traits = 0);
+
+  // Registers FFI execute handler with an XLA runtime under the given name on a
+  // given platform.
+  static XLA_FFI_Error* RegisterStaticHandler(
+      const XLA_FFI_Api* api, std::string_view name, std::string_view platform,
+      XLA_FFI_Handler* execute, XLA_FFI_Handler_Traits traits = 0) {
+    return RegisterStaticHandler(
+        api, name, platform,
+        XLA_FFI_Handler_Bundle{nullptr, nullptr, nullptr, execute}, traits);
+  }
+
+  // Registers a custom type so that it can be used with State and UserData
+  // arguments to external FFI handlers. The `name` argument must be a unique
+  // identifier for the type, and duplicate registrations with the same name
+  // are not allowed. When successful, a unique ID will be returned by updating
+  // `type_id`.
+  static XLA_FFI_Error* RegisterTypeId(const XLA_FFI_Api* api,
+                                       std::string_view name,
+                                       XLA_FFI_TypeId* type_id,  // in-out
+                                       XLA_FFI_TypeInfo type_info);
+
+  static XLA_FFI_Error* RegisterTypeId(const XLA_FFI_Api* api,
+                                       std::string_view name,
+                                       XLA_FFI_TypeId* type_id,  // in-out
+                                       const XLA_FFI_TypeInfo* type_info);
+
+  // This is a helper template that allows to convert function pointers from
+  // the run time values to compile time values (template arguments) with
+  // automatic template arguments deduction.
+  //
+  // Example:
+  //
+  //   static Error Foo(int32_t arg) {... }
+  //
+  //   template<typename Callable>
+  //   void call(Callable callable) { callable(42); }
+  //
+  //   call(Foo);                  // `Foo` passed as a runtime value
+  //   call(Ffi::Wrapper<Foo>())   // `Foo` passed as a template argument
+  //
+  // In the first case compiler will not be able to inline `Foo` into the `call`
+  // body. However in the second case it can do that, because function pointer
+  // is a statically known value (template non-type argument).
+  template <auto fn>
+  struct Wrapper;
+
+  template <typename Ret, typename... Args, Ret (*fn)(Args...)>
+  struct Wrapper<fn> {
+    XLA_FFI_ATTRIBUTE_ALWAYS_INLINE Ret operator()(Args... args) const {
+      return fn(std::forward<Args>(args)...);
+    }
+  };
+
+ protected:
+  template <typename... Args>
+  static std::string StrCat(Args... args);
+
+  static XLA_FFI_Error* Sucess();
+
+  static XLA_FFI_Error* MakeError(const XLA_FFI_Api* api,
+                                  XLA_FFI_Error_Code errc, std::string message);
+
+  static XLA_FFI_Error* InvalidArgument(const XLA_FFI_Api* api,
+                                        std::string message);
+
+  static XLA_FFI_Error* FailedPrecondition(const XLA_FFI_Api* api,
+                                           std::string message);
+
+  static XLA_FFI_Error* CheckStructSize(const XLA_FFI_Api* api,
+                                        std::string_view struct_name,
+                                        size_t expected, size_t actual);
+
+  static XLA_FFI_Error* StructSizeIsGreaterOrEqual(const XLA_FFI_Api* api,
+                                                   std::string_view struct_name,
+                                                   size_t expected,
+                                                   size_t actual);
+};
+
+inline XLA_FFI_Error* Ffi::RegisterStaticHandler(
+    const XLA_FFI_Api* api, std::string_view name, std::string_view platform,
+    XLA_FFI_Handler_Bundle bundle, XLA_FFI_Handler_Traits traits) {
+  XLA_FFI_Handler_Register_Args args;
+  args.struct_size = XLA_FFI_Handler_Register_Args_STRUCT_SIZE;
+  args.extension_start = nullptr;
+  args.name = XLA_FFI_ByteSpan{name.data(), name.size()};
+  args.platform = XLA_FFI_ByteSpan{platform.data(), platform.size()};
+  args.bundle = bundle;
+  args.traits = traits;
+  return api->XLA_FFI_Handler_Register(&args);
+}
+
+inline XLA_FFI_Error* Ffi::RegisterTypeId(const XLA_FFI_Api* api,
+                                          std::string_view name,
+                                          XLA_FFI_TypeId* type_id,
+                                          XLA_FFI_TypeInfo type_info) {
+  return RegisterTypeId(api, name, type_id, &type_info);
+}
+
+inline XLA_FFI_Error* Ffi::RegisterTypeId(const XLA_FFI_Api* api,
+                                          std::string_view name,
+                                          XLA_FFI_TypeId* type_id,
+                                          const XLA_FFI_TypeInfo* type_info) {
+  assert(type_id && "type_id must not be null");
+  XLA_FFI_Type_Register_Args args;
+  args.struct_size = XLA_FFI_Type_Register_Args_STRUCT_SIZE;
+  args.extension_start = nullptr;
+  args.name = XLA_FFI_ByteSpan{name.data(), name.size()};
+  args.type_id = type_id;
+  args.type_info = type_info;
+  return api->XLA_FFI_Type_Register(&args);
+}
+
+template <typename... Args>
+std::string Ffi::StrCat(Args... args) {
+  std::stringstream ss;
+  (ss << ... << args);
+  return ss.str();
+}
+
+inline XLA_FFI_Error* Ffi::Sucess() { return nullptr; }
+
+inline XLA_FFI_Error* Ffi::MakeError(const XLA_FFI_Api* api,
+                                     XLA_FFI_Error_Code errc,
+                                     std::string message) {
+  XLA_FFI_Error_Create_Args args;
+  args.struct_size = XLA_FFI_Error_Create_Args_STRUCT_SIZE;
+  args.extension_start = nullptr;
+  args.errc = errc;
+  args.message = message.c_str();
+  return api->XLA_FFI_Error_Create(&args);
+}
+
+inline XLA_FFI_Error* Ffi::InvalidArgument(const XLA_FFI_Api* api,
+                                           std::string message) {
+  return MakeError(api, XLA_FFI_Error_Code_INVALID_ARGUMENT,
+                   std::move(message));
+}
+
+inline XLA_FFI_Error* Ffi::FailedPrecondition(const XLA_FFI_Api* api,
+                                              std::string message) {
+  return MakeError(api, XLA_FFI_Error_Code_FAILED_PRECONDITION,
+                   std::move(message));
+}
+
+inline XLA_FFI_Error* Ffi::CheckStructSize(const XLA_FFI_Api* api,
+                                           std::string_view struct_name,
+                                           size_t expected, size_t actual) {
+  if (XLA_FFI_PREDICT_FALSE(expected != actual)) {
+    return InvalidArgument(
+        api, StrCat("Unexpected ", struct_name, " size: expected ", expected,
+                    " got ", actual, ". Check installed software versions."));
+  }
+  return nullptr;
+}
+
+inline XLA_FFI_Error* Ffi::StructSizeIsGreaterOrEqual(
+    const XLA_FFI_Api* api, std::string_view struct_name, size_t expected,
+    size_t actual) {
+  if (XLA_FFI_PREDICT_FALSE(actual < expected)) {
+    return InvalidArgument(
+        api, StrCat("Unexpected ", struct_name, " size: expected at least ",
+                    expected, " got ", actual,
+                    ". Check installed software versions."));
+  }
+  return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
+// XLA_FFI_Error helpers
+//===----------------------------------------------------------------------===//
+
+namespace internal {
+
+inline void DestroyError(const XLA_FFI_Api* api, XLA_FFI_Error* error) {
+  XLA_FFI_Error_Destroy_Args args;
+  args.struct_size = XLA_FFI_Error_Destroy_Args_STRUCT_SIZE;
+  args.extension_start = nullptr;
+  args.error = error;
+  api->XLA_FFI_Error_Destroy(&args);
+}
+
+inline const char* GetErrorMessage(const XLA_FFI_Api* api,
+                                   XLA_FFI_Error* error) {
+  XLA_FFI_Error_GetMessage_Args args;
+  args.struct_size = XLA_FFI_Error_GetMessage_Args_STRUCT_SIZE;
+  args.extension_start = nullptr;
+  args.error = error;
+  api->XLA_FFI_Error_GetMessage(&args);
+  return args.message;
+}
+
+}  // namespace internal
+
+//===----------------------------------------------------------------------===//
+// Type tags for distinguishing handler argument types
+//===----------------------------------------------------------------------===//
+
+// Dictionary gives type-safe run time access to all attributes. Concrete
+// implementation is provided by the `ffi.h` header.
+class Dictionary;
+
+// Context gives run time access to the execution context. Concrete
+// implementation is provided by the `ffi.h` header.
+class Context;
+
+namespace internal {
+
+// WARNING: A lot of template metaprogramming on top of C++ variadic templates
+// parameter packs. We need this to be able to pattern match FFI handler
+// signature at compile time.
+
+// A type tag for decoding argument.
+template <typename T>
+struct ArgTag {};
+
+// A type tag for decoding optional argument.
+template <typename T>
+struct OptionalArgTag {};
+
+// A type tag to forward all remaining args as `RemainingArgs`.
+struct RemainingArgsTag {};
+
+// A type tag to distinguish parameters tied to results in the `Binding`
+// variadic template. In XLA FFI we use destination passing style APIs and don't
+// return anything from the handler, but instead pass a destination where the
+// handler should write the result.
+template <typename T>
+struct RetTag {};
+
+// A type tag for decoding optional result.
+template <typename T>
+struct OptionalRetTag {};
+
+// A type tag to forward all remaining results as `RemainingRets`.
+struct RemainingRetsTag {};
+
+// A type tag to distinguish parameters tied to the attributes in the
+// `Binding` variadic template.
+template <typename T>
+struct AttrTag {};
+
+// A type tag to forward all attributes as `Dictionary` (and optionally decode
+// it into a custom struct).
+template <typename T>
+struct AttrsTag {};
+
+// A type tag to distinguish parameter extracted from an execution context.
+template <typename T>
+struct CtxTag {};
+
+//----------------------------------------------------------------------------//
+// A template for counting tagged arguments in the Ts pack.
+//----------------------------------------------------------------------------//
+
+template <template <typename> typename Tag, typename... Ts>
+struct NumTagged;
+
+template <template <typename> typename Tag>
+struct NumTagged<Tag> {
+  static constexpr int64_t value = 0;
+};
+
+template <template <typename> typename Tag, typename T, typename... Ts>
+struct NumTagged<Tag, Tag<T>, Ts...> {
+  static constexpr int64_t value = 1 + NumTagged<Tag, Ts...>::value;
+};
+
+template <template <typename> typename Tag, typename T, typename... Ts>
+struct NumTagged<Tag, T, Ts...> {
+  static constexpr int64_t value = 0 + NumTagged<Tag, Ts...>::value;
+};
+
+//----------------------------------------------------------------------------//
+
+template <typename T>
+struct IsOptionalArgTag : std::false_type {};
+template <typename T>
+struct IsOptionalArgTag<OptionalArgTag<T>> : std::true_type {};
+
+template <typename T>
+struct IsOptionalRetTag : std::false_type {};
+template <typename T>
+struct IsOptionalRetTag<OptionalRetTag<T>> : std::true_type {};
+
+// Checks if parameter pack has an optional argument.
+template <typename... Ts>
+using HasOptionalArgTag = std::disjunction<IsOptionalArgTag<Ts>...>;
+
+// Checks if parameter pack has remaining arguments.
+template <typename... Ts>
+using HasRemainingArgsTag =
+    std::disjunction<std::is_same<RemainingArgsTag, Ts>...>;
+
+// Checks if parameter pack has an optional result.
+template <typename... Ts>
+using HasOptionalRetTag = std::disjunction<IsOptionalRetTag<Ts>...>;
+
+// Checks if parameter pack has remaining results.
+template <typename... Ts>
+using HasRemainingRetsTag =
+    std::disjunction<std::is_same<RemainingRetsTag, Ts>...>;
+
+//----------------------------------------------------------------------------//
+
+template <typename T>
+constexpr XLA_FFI_DataType NativeTypeToCApiDataType() {
+  if constexpr (std::is_same_v<T, char>) {
+    return XLA_FFI_DataType_U8;
+  } else if constexpr (std::is_same_v<T, bool>) {
+    return XLA_FFI_DataType_PRED;
+  } else if constexpr (std::is_same_v<T, int8_t>) {
+    return XLA_FFI_DataType_S8;
+  } else if constexpr (std::is_same_v<T, int16_t>) {
+    return XLA_FFI_DataType_S16;
+  } else if constexpr (std::is_same_v<T, int32_t>) {
+    return XLA_FFI_DataType_S32;
+  } else if constexpr (std::is_same_v<T, int64_t>) {
+    return XLA_FFI_DataType_S64;
+  } else if constexpr (std::is_same_v<T, uint8_t>) {
+    return XLA_FFI_DataType_U8;
+  } else if constexpr (std::is_same_v<T, uint16_t>) {
+    return XLA_FFI_DataType_U16;
+  } else if constexpr (std::is_same_v<T, uint32_t>) {
+    return XLA_FFI_DataType_U32;
+  } else if constexpr (std::is_same_v<T, uint64_t>) {
+    return XLA_FFI_DataType_U64;
+  } else if constexpr (std::is_same_v<T, float>) {
+    return XLA_FFI_DataType_F32;
+  } else if constexpr (std::is_same_v<T, double>) {
+    return XLA_FFI_DataType_F64;
+  } else if constexpr (std::is_same_v<T, std::complex<float>>) {
+    return XLA_FFI_DataType_C64;
+  } else {
+    static_assert(std::is_same_v<T, std::complex<double>>,
+                  "unsupported FFI data type");
+    return XLA_FFI_DataType_C128;
+  }
+}
+
+}  // namespace internal
+
+//===----------------------------------------------------------------------===//
+// Binding variadic template defines FFI handler signature
+//===----------------------------------------------------------------------===//
+
+template <ExecutionStage stage, typename... Ts>
+class Binding {
+ public:
+  template <typename T>
+  Binding<stage, Ts..., internal::ArgTag<T>> Arg() && {
+    static_assert(!internal::HasOptionalArgTag<Ts...>::value,
+                  "argument can't be passed after optional argument");
+    static_assert(!internal::HasRemainingArgsTag<Ts...>::value,
+                  "argument can't be passed after remaining arguments");
+    return {std::move(*this)};
+  }
+
+  template <typename T>
+  Binding<stage, Ts..., internal::RetTag<T>> Ret() && {
+    static_assert(!internal::HasOptionalRetTag<Ts...>::value,
+                  "result can't be passed after optional result");
+    static_assert(!internal::HasRemainingRetsTag<Ts...>::value,
+                  "result can't be passed after remaining results");
+    return {std::move(*this)};
+  }
+
+  template <typename T>
+  Binding<stage, Ts..., internal::OptionalArgTag<T>> OptionalArg() && {
+    static_assert(
+        !internal::HasRemainingArgsTag<Ts...>::value,
+        "optional argument can't be passed after remaining arguments");
+    return {std::move(*this)};
+  }
+
+  template <typename T>
+  Binding<stage, Ts..., internal::OptionalRetTag<T>> OptionalRet() && {
+    static_assert(!internal::HasRemainingRetsTag<Ts...>::value,
+                  "optional result can't be passed after remaining results");
+    return {std::move(*this)};
+  }
+
+  Binding<stage, Ts..., internal::RemainingArgsTag> RemainingArgs() && {
+    static_assert(!internal::HasRemainingArgsTag<Ts...>::value,
+                  "remaining arguments can be passed just once");
+    return {std::move(*this)};
+  }
+
+  Binding<stage, Ts..., internal::RemainingRetsTag> RemainingRets() && {
+    static_assert(!internal::HasRemainingRetsTag<Ts...>::value,
+                  "remaining results can be passed just once");
+    return {std::move(*this)};
+  }
+
+  template <typename T>
+  Binding<stage, Ts..., internal::CtxTag<T>> Ctx() && {
+    return {std::move(*this)};
+  }
+
+  Binding<stage, Ts..., internal::CtxTag<Context>> Ctx() && {
+    return {std::move(*this)};
+  }
+
+  template <typename T>
+  Binding<stage, Ts..., internal::AttrTag<T>> Attr(std::string attr) && {
+    static_assert(internal::NumTagged<internal::AttrsTag, Ts...>::value == 0,
+                  "dictionary attributes can't be mixed with regular ones");
+    attrs_.push_back(std::move(attr));
+    return {std::move(*this)};
+  }
+
+  template <typename T = Dictionary>
+  Binding<stage, Ts..., internal::AttrsTag<T>> Attrs() && {
+    static_assert(internal::NumTagged<internal::AttrTag, Ts...>::value == 0,
+                  "dictionary attributes can't be mixed with regular ones");
+    return {std::move(*this)};
+  }
+
+  template <typename Fn>
+  std::unique_ptr<Handler<stage, Fn, Ts...>> To(
+      Fn fn, std::initializer_list<Traits> traits = {}) {
+    return std::unique_ptr<Handler<stage, Fn, Ts...>>(
+        new Handler<stage, Fn, Ts...>(std::move(fn), traits, attrs_));
+  }
+
+ private:
+  template <ExecutionStage, typename...>
+  friend class Binding;
+  friend class Ffi;
+
+  explicit Binding() {
+    static_assert(sizeof...(Ts) == 0, "arguments must be empty");
+  }
+
+  template <typename... TTs>
+  Binding(Binding<stage, TTs...>&& other)  // NOLINT
+      : attrs_(std::move(other.attrs_)) {}
+
+  Binding(Binding&) = delete;
+
+  std::vector<std::string> attrs_;  // names of bound attributes
+};
+
+template <ExecutionStage stage>
+Binding<stage> Ffi::Bind() {
+  return xla::ffi::Binding<stage>();
+}
+
+inline Binding<ExecutionStage::kInstantiate> Ffi::BindInstantiate() {
+  return Bind<ExecutionStage::kInstantiate>();
+}
+
+inline Binding<ExecutionStage::kPrepare> Ffi::BindPrepare() {
+  return Bind<ExecutionStage::kPrepare>();
+}
+
+inline Binding<ExecutionStage::kInitialize> Ffi::BindInitialize() {
+  return Bind<ExecutionStage::kInitialize>();
+}
+
+//===----------------------------------------------------------------------===//
+// Template metaprogramming to automatically infer Binding from invocable
+// object.
+//===----------------------------------------------------------------------===//
+
+// A little bit of metaprogramming that automatically infers the binding schema
+// from an invocable type signature.
+
+// XLA FFI binding for an argument.
+//
+// Example: binding for the `MyType` argument
+//
+//   template <>
+//   struct ArgBinding<MyType> {
+//     using Arg = MyType;
+//   };
+//
+template <typename T>
+struct ArgBinding {
+  using Arg = void;
+};
+
+// XLA FFI binding for a returned result.
+//
+// Example: binding for the `MyType` result
+//
+//   template <>
+//   struct RetBinding<MyType> {
+//     using Ret = MyType;
+//   };
+//
+template <typename T>
+struct RetBinding {
+  using Ret = void;
+};
+
+// XLA FFI binding for a named attribute.
+//
+// Example: binding for the `MyType` attribute
+//
+//   template <>
+//   struct AttrBinding<MyAttr> {
+//     using Attr = MyAttr;
+//     static constexpr std::string_view name() { return "my_attr"; }
+//   };
+//
+template <typename T>
+struct AttrBinding {
+  using Attr = void;
+};
+
+// XLA FFI binding for dictionary attributes: automatic parsing of all
+// attributes into user defined struct.
+template <typename T>
+struct AttrsBinding {
+  using Attrs = void;
+};
+
+// XLA FFI binding for values passed via context.
+//
+// Example: binding for the `gpuStream_t` platform stream
+//
+//   template <>
+//   struct CtxBinding<gpuStream_t> {
+//     using Ctx = PlatformStream<gpuStream_t>;
+//   };
+//
+template <typename T>
+struct CtxBinding {
+  using Ctx = void;
+};
+
+namespace internal {
+
+template <typename Param>
+inline constexpr bool is_arg_binding_v =
+    !std::is_void_v<typename ArgBinding<Param>::Arg>;
+
+template <typename Param>
+inline constexpr bool is_ret_binding_v =
+    !std::is_void_v<typename RetBinding<Param>::Ret>;
+
+template <typename Param>
+inline constexpr bool is_attr_binding_v =
+    !std::is_void_v<typename AttrBinding<Param>::Attr>;
+
+template <typename Param>
+inline constexpr bool is_attrs_binding_v =
+    !std::is_void_v<typename AttrsBinding<Param>::Attrs>;
+
+template <typename Param>
+inline constexpr bool is_ctx_binding_v =
+    !std::is_void_v<typename CtxBinding<Param>::Ctx>;
+
+// A helper template to bind `Params` to `Fn` one by one.
+template <typename Fn, typename... Params>
+struct BindOne;
+
+// A specialization that binds one parameter.
+template <typename Fn, typename Param, typename... Params>
+struct BindOne<Fn, Param, Params...> {
+  // Binds single parameter and then continues with remaining parameters using
+  // recursive template instantiation.
+  template <typename InFlightBinding>
+  static auto To(Fn fn, InFlightBinding binding,
+                 std::initializer_list<Traits> traits) {
+    if constexpr (is_arg_binding_v<Param>) {
+      // Bind parameter as an FFI handler argument.
+      return BindOne<Fn, Params...>::To(
+          std::move(fn),
+          std::move(binding).template Arg<typename ArgBinding<Param>::Arg>(),
+          traits);
+
+    } else if constexpr (is_ret_binding_v<Param>) {
+      // Bind parameter as an FFI handler result.
+      return BindOne<Fn, Params...>::To(
+          std::move(fn),
+          std::move(binding).template Ret<typename RetBinding<Param>::Ret>(),
+          traits);
+
+    } else if constexpr (is_attr_binding_v<Param>) {
+      // Bind parameter as a named FFI handler attribute.
+      return BindOne<Fn, Params...>::To(
+          std::move(fn),
+          std::move(binding).template Attr<typename AttrBinding<Param>::Attr>(
+              std::string(AttrBinding<Param>::name())),
+          traits);
+
+    } else if constexpr (is_attrs_binding_v<Param>) {
+      // Bind parameter as attributes dictionary.
+      return BindOne<Fn, Params...>::To(
+          std::move(fn),
+          std::move(binding)
+              .template Attrs<typename AttrsBinding<Param>::Attrs>(),
+          traits);
+
+    } else if constexpr (is_ctx_binding_v<Param>) {
+      // Bind parameter as an FFI handler context.
+      return BindOne<Fn, Params...>::To(
+          std::move(fn),
+          std::move(binding).template Ctx<typename CtxBinding<Param>::Ctx>(),
+          traits);
+
+    } else {
+      // Parameter is not recognized as one of the types that can be bound to
+      // FFI handler.
+      static_assert(sizeof(Param) == 0,
+                    "parameter is not supported for binding");
+    }
+  }
+};
+
+// A specialization that binds `Fn` after consuming all parameters.
+template <typename Fn>
+struct BindOne<Fn> {
+  template <typename InFlightBinding>
+  static auto To(Fn fn, InFlightBinding binding,
+                 std::initializer_list<Traits> traits) {
+    return binding.To(std::move(fn), traits);
+  }
+};
+
+template <ExecutionStage stage, typename Fn>
+struct Bind;
+
+// Binding specialization for function pointers (and captureless lambdas that
+// can be casted to function pointers).
+template <ExecutionStage stage, typename ResultType, typename... Params>
+struct Bind<stage, ResultType (*)(Params...)> {
+  using Fn = ResultType (*)(Params...);
+
+  static auto To(Fn fn, std::initializer_list<Traits> traits) {
+    return BindOne<Fn, Params...>::To(std::move(fn), Ffi::Bind<stage>(),
+                                      traits);
+  }
+};
+
+// Binding specialization for callables (lambdas with captures).
+template <ExecutionStage stage, typename ResultType, typename Fn,
+          typename... Params>
+struct Bind<stage, ResultType (Fn::*)(Params...) const> {
+  static auto To(Fn fn, std::initializer_list<Traits> traits) {
+    return BindOne<Fn, Params...>::To(std::move(fn), Ffi::Bind<stage>(),
+                                      traits);
+  }
+};
+
+}  // namespace internal
+
+template <typename Fn, ExecutionStage stage>
+auto Ffi::BindTo(Fn fn, std::initializer_list<Traits> traits) {
+  if constexpr (std::is_pointer_v<Fn>) {
+    return internal::Bind<stage, Fn>::To(fn, traits);
+  } else {
+    return internal::Bind<stage, decltype(&Fn::operator())>::To(std::move(fn),
+                                                                traits);
+  }
+}
+
+// A container for defining parameters corresponding to results.
+template <typename T>
+class Result {
+ public:
+  Result(T value) : value_(value) {}  // NOLINT
+  T& operator*() { return value_; }
+  T* operator->() { return &value_; }
+
+ private:
+  T value_;
+};
+
+// A container for defining parameters corresponding to attributes with an
+// attribute name available as compile time value.
+template <typename T, char const* attr_name>
+class Attr {
+ public:
+  Attr(T value) : value_(value) {}  // NOLINT
+  T& operator*() { return value_; }
+  T* operator->() { return &value_; }
+
+ private:
+  T value_;
+};
+
+//===----------------------------------------------------------------------===//
+// Attributes bindings
+//===----------------------------------------------------------------------===//
+
+// Default attribute binding for `Attr` parameters.
+template <typename T, const char* attr_name>
+struct AttrBinding<Attr<T, attr_name>> {
+  using Attr = T;
+  static constexpr std::string_view name() { return attr_name; }
+};
+
+// Default attributes binding for `Dictionary` parameters.
+template <>
+struct AttrsBinding<Dictionary> {
+  using Attrs = Dictionary;
+};
+
+//===----------------------------------------------------------------------===//
+// Arguments decoding implementation
+//===----------------------------------------------------------------------===//
+
+// XLA FFI arguments decoding must be defined by specializing this template.
+//
+// Example: decoding for the `MyType` arguments
+//
+//   template <>
+//   struct ArgDecoding<MyType> {
+//     static bool Isa(XLA_FFI_ArgType type, void* arg);
+//     static std::optional<MyType> Decode(XLA_FFI_ArgType type, void* arg);
+//   };
+//
+// If argument can't be decoded it should return the empty optional.
+template <typename T>
+struct ArgDecoding;
+
+//===----------------------------------------------------------------------===//
+// Results decoding implementation
+//===----------------------------------------------------------------------===//
+
+// XLA FFI results decoding must be defined by specializing this template.
+//
+// Example: decoding for the `MyType` results
+//
+//   template <>
+//   struct RetDecoding<MyType> {
+//     static bool Isa(XLA_FFI_RetType type, void* ret);
+//     static std::optional<MyType> Decode(XLA_FFI_RetType type, void* ret);
+//   };
+//
+// If argument can't be decoded it should return the empty optional.
+template <typename T>
+struct RetDecoding;
+
+//===----------------------------------------------------------------------===//
+// Attributes decoding implementation
+//===----------------------------------------------------------------------===//
+
+// XLA FFI attribute decoding must be defined by specializing this template.
+//
+// Example: decoding for the `MyType` attributes
+//
+//   template <>
+//   struct AttrDecoding<MyType> {
+//     using Type = <handler argument type for attribute type MyType>
+//     static bool Isa(XLA_FFI_AttrType type, void* attr);
+//     static std::optional<MyType> Decode(XLA_FFI_AttrType type, void* attr,
+//                                         DiagnosticEngine&);
+//   }
+//
+template <typename T>
+struct AttrDecoding;
+
+//===----------------------------------------------------------------------===//
+// Context decoding implementation
+//===----------------------------------------------------------------------===//
+
+// XLA FFI execution context decoding must be defined by specializing this
+// template.
+//
+// Example: decoding for the `MyType` context
+//
+//   template <>
+//   struct CtxDecoding<MyType> {
+//    using Type = <handler argument type for context type MyType>;
+//    static std::optional<Type> Decode(const XLA_FFI_Api* api,
+//                                      XLA_FFI_ExecutionContext* ctx);
+//   }
+//
+template <typename T>
+struct CtxDecoding;
+
+//===----------------------------------------------------------------------===//
+// Result encoding implementation
+//===----------------------------------------------------------------------===//
+
+// XLA FFI result encoding (conversion from a returned status-like type to FFI
+// error type) must be defined by specializing this template.
+//
+// Example: encoding `absl::Status` result
+//
+//   template<ExecutionStage stage>
+//   struct ResultEncoding<stage, absl::Status> {
+//     XLA_FFI_Error* Encode(const XLA_FFI_Api* api,
+//                           XLA_FFI_ExecutionContext* ctx,
+//                           absl::Status status) {...}
+//   };
+//
+// Result encoding is execution stage specific, for example at instantiation
+// stage FFI handler can return an FFI handler state, while at execution stage
+// we only support returning a status-like type.
+//
+// Asynchronous FFI handlers can return encoded result as an `XLA_FFI_Future*`
+// or as an `std::variant` of `XLA_FFI_Error*` and `XLA_FFI_Future*`, where an
+// error can be used to return synchronous errors (i.e., invalid arguments), and
+// a future can be used to return asynchronous completion. See example of such
+// encoding in result encoding for `Future`.
+//
+// Example: encoding `xla::ffi::Future` result
+//
+//   template<ExecutionStage stage>
+//   struct ResultEncoding<state, xla::ffi::Future> {
+//     std::variant<XLA_FFI_Error*, XLA_FFI_Future*> Encode(
+//       const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx,
+//       xla::ffi::Future future) {...}
+//   };
+//
+template <ExecutionStage stage, typename T>
+struct ResultEncoding;
+
+//===----------------------------------------------------------------------===//
+// Diagnostics
+//===----------------------------------------------------------------------===//
+
+class DiagnosticEngine;
+
+// RAII wrapper around constructed, but but not yet emitted diagnostic. In
+// flight diagnostic gives an opportunity to build a diagnostic before reporting
+// it to the engine, similar to the builder pattern.
+class InFlightDiagnostic {
+ public:
+  explicit InFlightDiagnostic(DiagnosticEngine* engine, std::string s)
+      : engine_(engine) {
+    stream_ << s;
+  }
+  InFlightDiagnostic(const InFlightDiagnostic&) = delete;
+  InFlightDiagnostic& operator=(const InFlightDiagnostic&) = delete;
+
+  ~InFlightDiagnostic();
+
+  template <typename Arg>
+  InFlightDiagnostic& operator<<(Arg&& arg) {
+    stream_ << std::forward<Arg>(arg);
+    return *this;
+  }
+
+  template <typename T>
+  operator std::optional<T>() const {  // NOLINT
+    return std::nullopt;
+  }
+
+ private:
+  DiagnosticEngine* engine_;
+  std::stringstream stream_;
+};
+
+class DiagnosticEngine {
+ public:
+  DiagnosticEngine() = default;
+  DiagnosticEngine(const DiagnosticEngine&) = delete;
+  DiagnosticEngine& operator=(const DiagnosticEngine&) = delete;
+
+  InFlightDiagnostic Emit(std::string message) {
+    return InFlightDiagnostic(this, std::move(message));
+  }
+
+  std::string Result() const { return acc_; }
+
+ private:
+  friend class InFlightDiagnostic;
+
+  void append(std::string s) { acc_.append(std::move(s)); }
+
+  std::string acc_;
+};
+
+inline InFlightDiagnostic::~InFlightDiagnostic() {
+  engine_->append(stream_.str());
+}
+
+//===----------------------------------------------------------------------===//
+// Decoding arguments and attributes
+//===----------------------------------------------------------------------===//
+
+namespace internal {
+
+// When decoding input data we need to keep track of how many arguments and
+// attributes we decoded so far to compute call frame offsets.
+struct DecodingOffsets {
+  int64_t args = 0;
+  int64_t rets = 0;
+  int64_t attrs = 0;
+};
+
+struct DecodingContext {
+  XLA_FFI_CallFrame* call_frame;
+
+  const std::string* attrs_names;  // not owned
+  const std::size_t* attrs_idx;    // not owned
+};
+
+template <typename T>
+struct Decode;
+
+template <typename T>
+struct Decode<ArgTag<T>> {
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<T> call(DecodingOffsets& offsets, DecodingContext& ctx,
+                               DiagnosticEngine& diagnostic) {
+    int64_t idx = offsets.args++;
+    return ArgDecoding<T>::Decode(ctx.call_frame->args.types[idx],
+                                  ctx.call_frame->args.args[idx], diagnostic);
+  }
+};
+
+template <typename T>
+struct Decode<OptionalArgTag<T>> {
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<std::optional<T>> call(DecodingOffsets& offsets,
+                                              DecodingContext& ctx,
+                                              DiagnosticEngine& diagnostic) {
+    if (XLA_FFI_PREDICT_FALSE(offsets.args >= ctx.call_frame->args.size)) {
+      return std::optional<T>(std::nullopt);
+    }
+    return Decode<ArgTag<T>>::call(offsets, ctx, diagnostic);
+  }
+};
+
+template <typename T>
+struct Decode<RetTag<T>> {
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<Result<T>> call(DecodingOffsets& offsets,
+                                       DecodingContext& ctx,
+                                       DiagnosticEngine& diagnostic) {
+    int64_t idx = offsets.rets++;
+    return RetDecoding<T>::Decode(ctx.call_frame->rets.types[idx],
+                                  ctx.call_frame->rets.rets[idx], diagnostic);
+  }
+};
+
+template <typename T>
+struct Decode<OptionalRetTag<T>> {
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<std::optional<Result<T>>> call(
+      DecodingOffsets& offsets, DecodingContext& ctx,
+      DiagnosticEngine& diagnostic) {
+    if (XLA_FFI_PREDICT_FALSE(offsets.rets >= ctx.call_frame->rets.size)) {
+      return std::optional<Result<T>>(std::nullopt);
+    }
+    return Decode<RetTag<T>>::call(offsets, ctx, diagnostic);
+  }
+};
+
+template <typename T>
+struct Decode<AttrTag<T>> {
+  using R = typename AttrDecoding<T>::Type;
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<R> call(DecodingOffsets& offsets, DecodingContext& ctx,
+                               DiagnosticEngine& diagnostic) {
+    // Find decoded attribute corresponding to the given attribute index.
+    int64_t i = offsets.attrs++;
+
+    // Get mapping from the attribute to its index in the sorted array.
+    size_t idx = ctx.attrs_idx[i];
+
+    // Load attribute from call frame using index into the sorted array.
+    XLA_FFI_AttrType attr_type = ctx.call_frame->attrs.types[idx];
+    XLA_FFI_ByteSpan* attr_name = ctx.call_frame->attrs.names[idx];
+    void* attr = ctx.call_frame->attrs.attrs[idx];
+
+    // We use a handwritten string comparison function because calling builtin
+    // string compare function adds a function call overhead on a hot path, and
+    // we expect all attribute names to be short and equal.
+    auto eq = [](XLA_FFI_ByteSpan* a, std::string_view b) {
+      if (XLA_FFI_PREDICT_FALSE(a->len != b.size())) {
+        return false;
+      }
+      for (size_t i = 0; i < a->len; ++i) {
+        if (XLA_FFI_PREDICT_FALSE(a->ptr[i] != b.data()[i])) {
+          return false;
+        }
+      }
+      return true;
+    };
+
+    // TODO(ezhulenev): Currently we require that attributes passed to the FFI
+    // handler must match attributes referenced in a binding, however
+    // we could safely ignore extra attributes. Relax this if needed.
+    if (XLA_FFI_PREDICT_FALSE(!eq(attr_name, ctx.attrs_names[i]))) {
+      return diagnostic.Emit("Attribute name mismatch: ")
+             << std::string_view{attr_name->ptr, attr_name->len} << " vs "
+             << ctx.attrs_names[i];
+    }
+
+    return AttrDecoding<T>::Decode(attr_type, attr, diagnostic);
+  }
+};
+
+template <typename T>
+struct Decode<CtxTag<T>> {
+  using R = typename CtxDecoding<T>::Type;
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<R> call(DecodingOffsets& offsets, DecodingContext& ctx,
+                               DiagnosticEngine& diagnostic) {
+    return CtxDecoding<T>::Decode(ctx.call_frame->api, ctx.call_frame->ctx,
+                                  diagnostic);
+  }
+};
+
+}  // namespace internal
+
+//===----------------------------------------------------------------------===//
+// Type-safe wrapper for accessing a variable number of arguments.
+//===----------------------------------------------------------------------===//
+
+namespace internal {
+
+class RemainingArgsBase {
+ public:
+  RemainingArgsBase(const XLA_FFI_Args* args, size_t offset)
+      : args_(args), offset_(offset) {
+    assert(offset <= args_->size && "illegal remaining args offset");
+  }
+
+  template <typename T>
+  bool isa(size_t index) const {
+    size_t idx = offset() + index;
+    assert(idx < args_->size && "illegal remaining args index");
+    return ArgDecoding<T>::Isa(args_->types[idx], args_->args[idx]);
+  }
+
+  size_t size() const { return args_->size - offset_; }
+  bool empty() const { return size() == 0; }
+
+ protected:
+  const XLA_FFI_Args* args() const { return args_; }
+  size_t offset() const { return offset_; }
+
+ private:
+  const XLA_FFI_Args* args_;
+  size_t offset_;
+};
+
+}  // namespace internal
+
+//===----------------------------------------------------------------------===//
+// Type-safe wrapper for accessing a variable number of results.
+//===----------------------------------------------------------------------===//
+
+namespace internal {
+
+class RemainingRetsBase {
+ public:
+  RemainingRetsBase(const XLA_FFI_Rets* rets, size_t offset)
+      : rets_(rets), offset_(offset) {
+    assert(offset <= rets_->size && "illegal remaining rets offset");
+  }
+
+  template <typename T>
+  bool isa(size_t index) const {
+    size_t idx = offset_ + index;
+    assert(idx < rets_->size && "illegal remaining rets index");
+    return RetDecoding<T>::Isa(rets_->types[idx], rets_->rets[idx]);
+  }
+
+  size_t size() const { return rets_->size - offset_; }
+  bool empty() const { return size() == 0; }
+
+ protected:
+  const XLA_FFI_Rets* rets() const { return rets_; }
+  size_t offset() const { return offset_; }
+
+ private:
+  const XLA_FFI_Rets* rets_;  // not owned
+  size_t offset_;
+};
+
+}  // namespace internal
+
+//===----------------------------------------------------------------------===//
+// Type-safe wrapper for accessing dictionary attributes.
+//===----------------------------------------------------------------------===//
+
+namespace internal {
+
+// Forward declare dictionary attribute decoding defined below.
+template <typename T, typename... Ts>
+struct DecodeDictionaryAttr;
+
+class DictionaryBase {
+ public:
+  explicit DictionaryBase(const XLA_FFI_Attrs* attrs) : attrs_(attrs) {}
+
+  // Iterator for iterating over dictionary attribute names.
+  class Iterator {
+   public:
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type = ptrdiff_t;
+    using value_type = std::string_view;
+
+    bool operator==(const Iterator& it) const { return idx_ == it.idx_; }
+    bool operator!=(const Iterator& it) const { return idx_ != it.idx_; }
+
+    std::string_view operator*() const {
+      return std::string_view{attrs_->names[idx_]->ptr,
+                              attrs_->names[idx_]->len};
+    }
+
+    Iterator& operator++() {
+      ++idx_;
+      return *this;
+    }
+
+   private:
+    friend class DictionaryBase;
+    Iterator(const XLA_FFI_Attrs* attrs, size_t idx)
+        : attrs_(attrs), idx_(idx) {}
+
+    const XLA_FFI_Attrs* attrs_;
+    size_t idx_ = 0;
+  };
+
+  size_t size() const { return attrs_->size; }
+
+  bool contains(std::string_view name) const { return Find(name).has_value(); }
+
+  Iterator begin() const { return Iterator(attrs_, 0); }
+  Iterator end() const { return Iterator(attrs_, size()); }
+
+  template <typename T>
+  bool contains(std::string_view name) const {
+    std::optional<size_t> idx = Find(name);
+    if (XLA_FFI_PREDICT_FALSE(!idx.has_value())) {
+      return false;
+    }
+
+    XLA_FFI_AttrType attr_type = attrs_->types[*idx];
+    void* attr = attrs_->attrs[*idx];
+    return AttrDecoding<T>::Isa(attr_type, attr);
+  }
+
+  template <typename T>
+  bool isa(const Iterator& it) const {
+    XLA_FFI_AttrType attr_type = attrs_->types[it.idx_];
+    void* attr = attrs_->attrs[it.idx_];
+    return AttrDecoding<T>::Isa(attr_type, attr);
+  }
+
+ protected:
+  template <typename T, typename... Ts>
+  friend struct DecodeDictionaryAttr;
+
+  template <typename T>
+  std::optional<size_t> get(const Iterator& it,
+                            DiagnosticEngine& diagnostic) const {
+    XLA_FFI_AttrType attr_type = attrs_->types[it.idx_];
+    void* attr = attrs_->attrs[it.idx_];
+    return AttrDecoding<T>::Decode(attr_type, attr, diagnostic);
+  }
+
+  template <typename T>
+  std::optional<T> get(std::string_view name,
+                       DiagnosticEngine& diagnostic) const {
+    std::optional<size_t> idx = Find(name);
+    if (XLA_FFI_PREDICT_FALSE(!idx.has_value())) {
+      return diagnostic.Emit("Unexpected attribute: ") << name;
+    }
+
+    XLA_FFI_AttrType attr_type = attrs_->types[*idx];
+    void* attr = attrs_->attrs[*idx];
+    return AttrDecoding<T>::Decode(attr_type, attr, diagnostic);
+  }
+
+ private:
+  std::optional<size_t> Find(std::string_view name) const {
+    XLA_FFI_ByteSpan** begin = attrs_->names;
+    XLA_FFI_ByteSpan** end = begin + attrs_->size;
+
+    auto eq = [](XLA_FFI_ByteSpan* a, std::string_view b) {
+      return std::string_view{a->ptr, a->len} == b;
+    };
+
+    auto lt = [](XLA_FFI_ByteSpan* a, std::string_view b) {
+      return std::string_view{a->ptr, a->len} < b;
+    };
+
+    // Lower bound can be `end` if the attribute is not found, or the first
+    // attribute not ordered before the `name`.
+    auto lower_bound = std::lower_bound(begin, end, name, lt);
+    return lower_bound == end || !eq(*lower_bound, name)
+               ? std::nullopt
+               : std::make_optional(std::distance(begin, lower_bound));
+  }
+
+  const XLA_FFI_Attrs* attrs_;
+};
+
+}  // namespace internal
+
+//===----------------------------------------------------------------------===//
+// Decoding for aggregate attributes (decoding dictionaries into structs).
+//===----------------------------------------------------------------------===//
+
+// Decode `AttrsTag` into a type `T` relying on struct decoding defined below.
+template <typename T>
+struct internal::Decode<internal::AttrsTag<T>> {
+  static std::optional<T> call(DecodingOffsets& offsets, DecodingContext& ctx,
+                               DiagnosticEngine& diagnostic) {
+    return AttrDecoding<T>::Decode(XLA_FFI_AttrType_DICTIONARY,
+                                   &ctx.call_frame->attrs, diagnostic);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Type-safe wrapper for accessing context.
+//===----------------------------------------------------------------------===//
+
+namespace internal {
+
+class ContextBase {
+ public:
+  ContextBase(const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx)
+      : api_(api), ctx_(ctx) {}
+
+  const XLA_FFI_Api* api() const { return api_; }
+  XLA_FFI_ExecutionContext* ctx() const { return ctx_; }
+
+ protected:
+  template <typename T>
+  std::optional<typename CtxDecoding<T>::Type> get(
+      DiagnosticEngine& diagnostic) const {
+    return CtxDecoding<T>::Decode(api_, ctx_, diagnostic);
+  }
+
+ private:
+  const XLA_FFI_Api* api_;
+  XLA_FFI_ExecutionContext* ctx_;
+};
+
+}  // namespace internal
+
+//===----------------------------------------------------------------------===//
+// Template metaprogramming for decoding handler signature
+//===----------------------------------------------------------------------===//
+
+// Forward declare classes for decoding variadic number of arguments and
+// results. They are defined in `ffi.h` headers (internal and external), to be
+// able to use slightly different implementations for internal and external
+// FFI (`absl::StatusOr` vs `ffi::ErrorOr`).
+class RemainingArgs;
+class RemainingRets;
+
+namespace internal {
+// A helper struct to extract the type of the handler argument.
+template <typename T>
+struct FnArgType;
+
+template <typename T>
+struct FnArgType<internal::ArgTag<T>> {
+  using Type = T;
+};
+
+template <typename T>
+struct FnArgType<internal::OptionalArgTag<T>> {
+  using Type = std::optional<T>;
+};
+
+template <>
+struct FnArgType<internal::RemainingArgsTag> {
+  using Type = RemainingArgs;
+};
+
+template <typename T>
+struct FnArgType<internal::RetTag<T>> {
+  using Type = Result<T>;
+};
+
+template <typename T>
+struct FnArgType<internal::OptionalRetTag<T>> {
+  using Type = std::optional<Result<T>>;
+};
+
+template <>
+struct FnArgType<internal::RemainingRetsTag> {
+  using Type = RemainingRets;
+};
+
+template <typename T>
+struct FnArgType<internal::AttrTag<T>> {
+  using Type = typename AttrDecoding<T>::Type;
+};
+
+template <typename T>
+struct FnArgType<internal::AttrsTag<T>> {
+  using Type = T;
+};
+
+template <typename T>
+struct FnArgType<internal::CtxTag<T>> {
+  using Type = typename CtxDecoding<T>::Type;
+};
+
+// A template to detect result encodings that are state constructors. We use
+// this to report back the TypeId of the state as a part of the metadata.
+template <typename ResultEnconding, typename = void>
+struct IsStateConstructor : std::false_type {};
+
+// Check if the ResultEncoding has a static `state_type_id()` method returning
+// the XLA_FFI_TypeId.
+template <typename ResultEncoding>
+struct IsStateConstructor<
+    ResultEncoding,
+    std::enable_if_t<std::is_same_v<XLA_FFI_TypeId,
+                                    decltype(ResultEncoding::state_type_id())>>>
+    : std::true_type {};
+
+template <typename ResultEncoding>
+static constexpr bool is_state_constructor_v =  // NOLINT
+    IsStateConstructor<ResultEncoding>::value;
+
+}  // namespace internal
+
+//===----------------------------------------------------------------------===//
+// Handler decodes FFI call frame and invokes `Fn` with decoded arguments
+//===----------------------------------------------------------------------===//
+
+template <ExecutionStage stage, typename Fn, typename... Ts>
+class Handler : public Ffi {
+  static constexpr int64_t kSize = sizeof...(Ts);
+
+  static constexpr int64_t kNumArgs =
+      internal::NumTagged<internal::ArgTag, Ts...>::value;
+
+  static constexpr int64_t kNumOptionalArgs =
+      internal::NumTagged<internal::OptionalArgTag, Ts...>::value;
+
+  static constexpr int64_t kNumRets =
+      internal::NumTagged<internal::RetTag, Ts...>::value;
+
+  static constexpr int64_t kNumOptionalRets =
+      internal::NumTagged<internal::OptionalRetTag, Ts...>::value;
+
+  static constexpr int64_t kNumAttrs =
+      internal::NumTagged<internal::AttrTag, Ts...>::value;
+
+  static constexpr int64_t kNumDictAttrs =
+      internal::NumTagged<internal::AttrsTag, Ts...>::value;
+
+  static_assert(kNumAttrs == 0 || kNumDictAttrs == 0,
+                "dictionary attributes can't be mixed with regular ones");
+
+  template <typename T>
+  using FnArgType = typename internal::FnArgType<T>::Type;
+
+  static_assert(std::is_invocable_v<Fn, FnArgType<Ts>...>,
+                "FFI binding signature is not compatible with a function type");
+
+  using ResultType = std::invoke_result_t<Fn, FnArgType<Ts>...>;
+
+ public:
+  // We deliberately opt-out from the cognitive complexity check, as this
+  // function is on a hot path, any any attempt to split it leads to measurable
+  // regressions in microbenchmarks. It is a straight line block of mostly
+  // constexpr conditionals, that gets optimized to a much smaller code size in
+  // all template instantiations.
+  //
+  // NOLINTNEXTLINE(readability-function-cognitive-complexity)
+  XLA_FFI_Error* Call(XLA_FFI_CallFrame* call_frame) const override {
+    // Sanity checking call frame struct size.
+    if (XLA_FFI_Error* err = CheckStructSize(
+            call_frame->api, "XLA_FFI_CallFrame", XLA_FFI_CallFrame_STRUCT_SIZE,
+            call_frame->struct_size);
+        XLA_FFI_PREDICT_FALSE(err)) {
+      return err;
+    }
+
+    // If passed a call frame with the metadata extension, just return the
+    // metadata.
+    if (XLA_FFI_PREDICT_FALSE(call_frame->extension_start != nullptr &&
+                              call_frame->extension_start->type ==
+                                  XLA_FFI_Extension_Metadata)) {
+      return PopulateMetadata(call_frame->api,
+                              reinterpret_cast<XLA_FFI_Metadata_Extension*>(
+                                  call_frame->extension_start));
+    }
+
+    // Check that handler is called during correct execution stage.
+    if (XLA_FFI_PREDICT_FALSE(call_frame->stage !=
+                              static_cast<XLA_FFI_ExecutionStage>(stage))) {
+      return InvalidArgument(call_frame->api,
+                             StrCat("Wrong execution stage: expected `",
+                                    static_cast<XLA_FFI_ExecutionStage>(stage),
+                                    "` but got `", call_frame->stage, "`"));
+    }
+
+    // Check that the number of passed arguments matches the signature. Each
+    // individual argument decoding will check the actual type.
+    if constexpr (internal::HasRemainingArgsTag<Ts...>::value) {
+      if (XLA_FFI_PREDICT_FALSE(call_frame->args.size < kNumArgs)) {
+        return InvalidArgument(
+            call_frame->api,
+            StrCat("[", call_frame->stage, "] ",
+                   "Wrong number of arguments: expected at least ",
+                   kNumArgs - kNumOptionalArgs - 1, " but got ",
+                   call_frame->args.size));
+      }
+    } else if constexpr (internal::HasOptionalArgTag<Ts...>::value) {
+      if (XLA_FFI_PREDICT_FALSE(call_frame->args.size < kNumArgs)) {
+        return InvalidArgument(
+            call_frame->api,
+            StrCat("[", call_frame->stage, "] ",
+                   "Wrong number of arguments: expected at least ",
+                   kNumArgs - kNumOptionalArgs, " but got ",
+                   call_frame->args.size));
+      }
+    } else {
+      // It is safe to not theck the number of arguments if we don't plan to
+      // decode any of them, i.e. for prepare/initialize stages where the FFI
+      // handler might be interested only in the attributes or context.
+      if (XLA_FFI_PREDICT_FALSE(call_frame->args.size != kNumArgs &&
+                                kNumArgs > 0)) {
+        return InvalidArgument(
+            call_frame->api,
+            StrCat("[", call_frame->stage, "] ",
+                   "Wrong number of arguments: expected ", kNumArgs,
+                   " but got ", call_frame->args.size));
+      }
+    }
+
+    // Check that the number of results matches the signature. Each individual
+    // result decoding will check the actual type.
+    if constexpr (internal::HasRemainingRetsTag<Ts...>::value) {
+      if (XLA_FFI_PREDICT_FALSE(call_frame->rets.size < kNumRets)) {
+        return InvalidArgument(
+            call_frame->api,
+            StrCat("[", call_frame->stage, "] ",
+                   "Wrong number of results: expected at least ",
+                   kNumRets - kNumOptionalRets - 1, " but got ",
+                   call_frame->rets.size));
+      }
+    } else if constexpr (internal::HasOptionalRetTag<Ts...>::value) {
+      if (XLA_FFI_PREDICT_FALSE(call_frame->rets.size < kNumRets)) {
+        return InvalidArgument(
+            call_frame->api,
+            StrCat("[", call_frame->stage, "] ",
+                   "Wrong number of results: expected at least ",
+                   kNumRets - kNumOptionalRets, " but got ",
+                   call_frame->rets.size));
+      }
+    } else {
+      // It is safe to not theck the number of results if we don't plan to
+      // decode any of them, i.e. for prepare/initialize stages where the FFI
+      // handler might be interested only in the attributes or context.
+      if (XLA_FFI_PREDICT_FALSE(call_frame->rets.size != kNumRets &&
+                                kNumRets > 0)) {
+        return InvalidArgument(
+            call_frame->api,
+            StrCat("[", call_frame->stage, "] ",
+                   "Wrong number of results: expected ", kNumRets, " but got ",
+                   call_frame->rets.size));
+      }
+    }
+
+    // Check that the number of passed attributes matches the signature. Each
+    // individual attribute decoding will check the actual type.
+    //
+    // If we decode attributes into a dictionary (or a custom struct decoded
+    // from a dictionary), then there is no need to check the number of
+    // attributes, as the FFI handler (or a struct decoding) should be
+    // responsible for it.
+    //
+    // If the number of bound attributes is zero, then we also don't care about
+    // the number of attributes in the call frame. FFI handler can safely choose
+    // to ignore attributes in this case. We only need to check the number of
+    // attributes if we plan to decode them, as we build a mapping from the
+    // attribute name to its index in the call frame attributes.
+    if (XLA_FFI_PREDICT_FALSE(kNumDictAttrs == 0 && kNumAttrs > 0 &&
+                              call_frame->attrs.size != kNumAttrs)) {
+      std::stringstream msg;
+      msg << "[" << call_frame->stage << "] "
+          << "Wrong number of attributes: expected " << kNumAttrs << " but got "
+          << call_frame->attrs.size;
+      if (call_frame->attrs.size > 0) {
+        msg << " with name(s): ";
+        for (int64_t n = 0; n < call_frame->attrs.size - 1; ++n) {
+          msg << std::string_view(call_frame->attrs.names[n]->ptr,
+                                  call_frame->attrs.names[n]->len)
+              << ", ";
+        }
+        msg << std::string_view(
+            call_frame->attrs.names[call_frame->attrs.size - 1]->ptr,
+            call_frame->attrs.names[call_frame->attrs.size - 1]->len);
+      }
+      return InvalidArgument(call_frame->api, msg.str());
+    }
+
+    // Define index sequences to access custom call operands.
+    using Is = std::make_index_sequence<kSize>;
+
+    return Call(call_frame, Is{});
+  }
+
+ private:
+  XLA_FFI_Error* PopulateMetadata(const XLA_FFI_Api* api,
+                                  XLA_FFI_Metadata_Extension* extension) const {
+    if (XLA_FFI_Error* err =
+            StructSizeIsGreaterOrEqual(api, "XLA_FFI_Metadata_Extension",
+                                       XLA_FFI_Metadata_Extension_STRUCT_SIZE,
+                                       extension->extension_base.struct_size)) {
+      return err;
+    }
+
+    if (XLA_FFI_Error* err = StructSizeIsGreaterOrEqual(
+            api, "XLA_FFI_Metadata", XLA_FFI_Metadata_STRUCT_SIZE,
+            extension->metadata->struct_size)) {
+      return err;
+    }
+
+    // Set the API version to the version of the FFI headers used by a handler.
+    extension->metadata->api_version = XLA_FFI_Api_Version{
+        XLA_FFI_Api_Version_STRUCT_SIZE,
+        /*extension_start=*/nullptr,
+        XLA_FFI_API_MAJOR,
+        XLA_FFI_API_MINOR,
+    };
+
+    // Collect all traits and store them in the metadata.
+    XLA_FFI_Handler_Traits traits = 0;
+    for (const Traits& trait : traits_) {
+      traits |= static_cast<XLA_FFI_Handler_Traits>(trait);
+    }
+    extension->metadata->traits = traits;
+
+    // Check if the handler creates a new state object and if so, record its
+    // type id in the metadata.
+    using ResultEncoding = ResultEncoding<stage, ResultType>;
+    if constexpr (internal::is_state_constructor_v<ResultEncoding>) {
+      if (ResultEncoding::state_type_id() == XLA_FFI_UNKNOWN_TYPE_ID) {
+        return FailedPrecondition(api,
+                                  "Types used by FFI handlers must be "
+                                  "registered before the handler registration");
+      }
+      extension->metadata->state_type_id = ResultEncoding::state_type_id();
+    } else {
+      extension->metadata->state_type_id = XLA_FFI_UNKNOWN_TYPE_ID;
+    }
+
+    return Sucess();
+  }
+
+  template <size_t... Is>
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE XLA_FFI_Error* Call(
+      XLA_FFI_CallFrame* call_frame, std::index_sequence<Is...>) const {
+    // A helper structure to allow each decoder find the correct offset.
+    internal::DecodingOffsets offsets;
+
+    // Package all the data required for decoding ffi handler operands.
+    internal::DecodingContext ctx = {call_frame, attrs_.data(),
+                                     attrs_idx_.data()};
+
+    DiagnosticEngine diagnostic;
+
+    std::tuple<std::optional<FnArgType<Ts>>...> args = {
+        internal::Decode<Ts>::call(offsets, ctx, diagnostic)...};
+
+    if constexpr (sizeof...(Ts) > 0) {
+      // We intentionally use `&`, as it generates fewer branch instructions.
+      bool all_decoded = (std::get<Is>(args).has_value() & ...);
+      if (XLA_FFI_PREDICT_FALSE(!all_decoded)) {
+        return FailedDecodeError(
+            call_frame, {std::get<Is>(args).has_value()...}, diagnostic);
+      }
+    }
+
+    ResultType result = fn_(std::move(*std::get<Is>(args))...);
+    auto encoded = ResultEncoding<stage, ResultType>::Encode(
+        call_frame->api, call_frame->ctx, std::move(result));
+
+    // We do support three kinds of FFI result encodings:
+    //   (1) Synchronous handlers that return result encoded as XLA_FFI_Error*
+    //   (2) Asynchronous handlers that return result encoded as XLA_FFI_Future*
+    //   (3) Handlers that can return either (1) or (2)
+    static constexpr bool kIsEncodedError =
+        std::is_same_v<decltype(encoded), XLA_FFI_Error*>;
+    static constexpr bool kIsEncodedFuture =
+        std::is_same_v<decltype(encoded), XLA_FFI_Future*>;
+    static constexpr bool kIsEncodedErrorOrFuture =
+        std::is_same_v<decltype(encoded),
+                       std::variant<XLA_FFI_Error*, XLA_FFI_Future*>>;
+
+    static_assert(
+        kIsEncodedError || kIsEncodedFuture || kIsEncodedErrorOrFuture,
+        "Unsupported result encoding type");
+
+    if constexpr (kIsEncodedError) {
+      return encoded;
+    }
+
+    if constexpr (kIsEncodedFuture) {
+      call_frame->future = encoded;
+      assert(call_frame->future != nullptr);
+      return nullptr;
+    }
+
+    if constexpr (kIsEncodedErrorOrFuture) {
+      if (encoded.index() == 0) {
+        return std::get<0>(encoded);
+      }
+      call_frame->future = std::get<1>(encoded);
+      assert(call_frame->future != nullptr);
+      return nullptr;
+    }
+
+    std::abort();  // unreachable
+  }
+
+  XLA_FFI_Error* FailedDecodeError(const XLA_FFI_CallFrame* call_frame,
+                                   std::array<bool, kSize> decoded,
+                                   const DiagnosticEngine& diagnostic) const {
+    std::stringstream message;
+    message << "[" << call_frame->stage << "] "
+            << "Failed to decode all FFI handler operands (bad operands at: ";
+    for (size_t cnt = 0, idx = 0; idx < kSize; ++idx) {
+      if (!decoded[idx]) {
+        if (cnt++) {
+          message << ", ";
+        }
+        message << std::to_string(idx);
+      }
+    }
+    message << ")";
+    if (auto s = std::move(diagnostic).Result(); !s.empty()) {
+      message << "\nDiagnostics:\n" << s;
+    }
+    return InvalidArgument(call_frame->api, message.str());
+  }
+
+  template <ExecutionStage, typename...>
+  friend class Binding;
+
+  Handler(Fn fn, std::vector<Traits> traits, std::vector<std::string> attrs)
+      : fn_(std::move(fn)),
+        traits_(std::move(traits)),
+        attrs_(std::move(attrs)) {
+    // Sort attributes' names and remove duplicates. These unique attributes are
+    // what we'll be looking for in the call frame attributes.
+    std::vector<std::string> sorted = attrs_;
+    std::sort(sorted.begin(), sorted.end());
+    sorted.erase(
+        std::unique(sorted.begin(), sorted.end(), std::equal_to<std::string>()),
+        sorted.end());
+
+    // Find index of every attribute in the sorted attributes vector.
+    for (size_t i = 0; i < attrs_.size(); ++i) {
+      attrs_idx_.push_back(std::distance(
+          sorted.begin(),
+          std::find(sorted.begin(), sorted.end(), attrs_[i])));  // NOLINT
+    }
+  }
+
+  Fn fn_;
+  std::vector<Traits> traits_;
+
+  std::vector<std::string> attrs_;  // names of bound attributes
+
+  // A mapping from the attribute index (index into the `attrs_` member) to its
+  // index in the lexicographically sorted vector of attribute names. Call frame
+  // passes attributes sorted by name, and with this index we can find the
+  // attribute we are looking for using O(1) lookup, assuming if the call frame
+  // has exact same attributes as the binding. If not, this allows to do a more
+  // efficient binary search by skipping a part of the call frame attributes.
+  std::vector<size_t> attrs_idx_;
+};
+
+//===----------------------------------------------------------------------===//
+// Builtin attributes decoding
+//===----------------------------------------------------------------------===//
+
+#define XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(T, TYPE)                     \
+  template <>                                                              \
+  struct AttrDecoding<T> {                                                 \
+    using Type = T;                                                        \
+    XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static bool Isa(XLA_FFI_AttrType type, \
+                                                    void* attr) {          \
+      return type == XLA_FFI_AttrType_SCALAR &&                            \
+             reinterpret_cast<XLA_FFI_Scalar*>(attr)->dtype == TYPE;       \
+    }                                                                      \
+                                                                           \
+    XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<T> Decode(        \
+        XLA_FFI_AttrType type, void* attr, DiagnosticEngine& diagnostic) { \
+      if (XLA_FFI_PREDICT_FALSE(type != XLA_FFI_AttrType_SCALAR)) {        \
+        return diagnostic.Emit("Wrong attribute type: expected ")          \
+               << XLA_FFI_AttrType_SCALAR << " but got " << type;          \
+      }                                                                    \
+                                                                           \
+      auto* scalar = reinterpret_cast<XLA_FFI_Scalar*>(attr);              \
+      if (XLA_FFI_PREDICT_FALSE(scalar->dtype != TYPE)) {                  \
+        return diagnostic.Emit("Wrong scalar data type: expected ")        \
+               << TYPE << " but got " << scalar->dtype;                    \
+      }                                                                    \
+                                                                           \
+      return *reinterpret_cast<T*>(scalar->value);                         \
+    }                                                                      \
+  }
+
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(bool, XLA_FFI_DataType_PRED);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(int8_t, XLA_FFI_DataType_S8);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(int16_t, XLA_FFI_DataType_S16);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(int32_t, XLA_FFI_DataType_S32);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(int64_t, XLA_FFI_DataType_S64);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(uint8_t, XLA_FFI_DataType_U8);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(uint16_t, XLA_FFI_DataType_U16);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(uint32_t, XLA_FFI_DataType_U32);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(uint64_t, XLA_FFI_DataType_U64);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(float, XLA_FFI_DataType_F32);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(double, XLA_FFI_DataType_F64);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(std::complex<float>,
+                                      XLA_FFI_DataType_C64);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(std::complex<double>,
+                                      XLA_FFI_DataType_C128);
+
+#undef XLA_FFI_REGISTER_SCALAR_ATTR_DECODING
+
+// Decoding for an attribute of `std::variant<T0, T1, Ts...>` type.
+//
+// Returns the decoding result for a first type that matches the attribute type,
+// if no type matches, returns std::nullopt.
+template <typename T0, typename T1, typename... Ts>
+struct AttrDecoding<std::variant<T0, T1, Ts...>> {
+  using Type = std::variant<T0, T1, Ts...>;
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static bool Isa(XLA_FFI_AttrType type,
+                                                  void* attr) {
+    return AttrDecoding<T0>::Isa(type, attr) ||
+           AttrDecoding<T1>::Isa(type, attr) ||
+           (AttrDecoding<Ts>::Isa(type, attr) || ...);
+  };
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(
+      XLA_FFI_AttrType type, void* attr, DiagnosticEngine& diagnostic) {
+    return Decode<T0, T1, Ts...>(type, attr, diagnostic);
+  }
+
+ private:
+  template <typename U, typename... Us>
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(
+      XLA_FFI_AttrType type, void* attr, DiagnosticEngine& diagnostic) {
+    if (AttrDecoding<U>::Isa(type, attr)) {
+      if (auto decoded = AttrDecoding<U>::Decode(type, attr, diagnostic);
+          XLA_FFI_PREDICT_TRUE(decoded)) {
+        return std::move(*decoded);
+      }
+      return std::nullopt;
+    }
+
+    if constexpr (sizeof...(Us) > 0) {
+      return Decode<Us...>(type, attr, diagnostic);
+    }
+
+    return diagnostic.Emit(
+        "Wrong attribute type: it doesn't match any of the variant types");
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Automatic dictionary attributes to structs decoding.
+//===----------------------------------------------------------------------===//
+
+template <typename T>
+struct StructMember {
+  using Type = T;
+
+  explicit StructMember(std::string_view name) : name(name) {}
+  std::string_view name;
+};
+
+namespace internal {
+
+// Decodes dictionary attribute into the object of type `T` that must be
+// constructible from the `Ts` types.
+template <typename T, typename... Ts>
+struct DecodeDictionaryAttr {
+  static constexpr size_t kSize = sizeof...(Ts);
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<T> Decode(const XLA_FFI_Attrs* attrs,
+                                 std::array<std::string_view, kSize> names,
+                                 DiagnosticEngine& diagnostic) {
+    return Decode(attrs, names, std::make_index_sequence<kSize>{}, diagnostic);
+  }
+
+  template <size_t... Is>
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<T> Decode(
+      const XLA_FFI_Attrs* attrs, std::array<std::string_view, kSize> names,
+      std::index_sequence<Is...>, DiagnosticEngine& diagnostic) {
+    if (XLA_FFI_PREDICT_FALSE(kSize != attrs->size)) {
+      return diagnostic.Emit("Wrong number of attributes: expected ")
+             << kSize << " attributes but got " << attrs->size;
+    }
+
+    // TODO(ezhulenev): We rely on dictionary to lookup struct members by name
+    // at run time, however it can become really expensive. We should
+    // pre-compute mapping from `names` to index in the `XLA_FFI_Attrs`
+    // (attributes ordered by name) in a static variable, and rely on it
+    // to decode attributes with constant run time complexity.
+    //
+    // Consider using `static auto decoder = ...` below, and compute mapping in
+    // constructor. Add benchmarks first to know what to improve!
+    internal::DictionaryBase dict(attrs);
+
+    std::tuple<std::optional<Ts>...> members = {
+        dict.get<Ts>(names[Is], diagnostic)...};
+    bool all_decoded = (std::get<Is>(members).has_value() && ...);
+    if (XLA_FFI_PREDICT_FALSE(!all_decoded)) {
+      return std::nullopt;
+    }
+
+    return T{std::move(*std::get<Is>(members))...};
+  }
+};
+
+template <typename... Members>
+auto StructMemberNames(Members... m) {
+  return std::array<std::string_view, sizeof...(Members)>{m.name...};
+}
+
+template <typename T, typename... Members>
+auto DictionaryDecoder(Members... m) {
+  return DecodeDictionaryAttr<T, typename Members::Type...>();
+}
+
+}  // namespace internal
+
+// Example: register decoding for a user-defined struct
+//
+//   struct PairOfI64 { int64_t a; int64_t b; };
+//
+//   XLA_FFI_REGISTER_STRUCT_ATTR_DECODING(
+//     PairOfI64,
+//     StructMember<int64_t>("a"),
+//     StructMember<int64_t>("b"));
+//
+// Automatically registers attributes binding for a struct that allows automatic
+// binding specification inference from a callable signature.
+//
+#define XLA_FFI_REGISTER_STRUCT_ATTR_DECODING(T, ...)                         \
+  namespace xla::ffi {                                                        \
+  template <>                                                                 \
+  struct AttrsBinding<T> {                                                    \
+    using Attrs = T;                                                          \
+  };                                                                          \
+                                                                              \
+  template <>                                                                 \
+  struct AttrDecoding<T> {                                                    \
+    using Type = T;                                                           \
+    XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<T> Decode(           \
+        XLA_FFI_AttrType type, void* attr, DiagnosticEngine& diagnostic) {    \
+      if (XLA_FFI_PREDICT_FALSE(type != XLA_FFI_AttrType_DICTIONARY)) {       \
+        diagnostic.Emit("Wrong attribute type: expected ")                    \
+            << XLA_FFI_AttrType_DICTIONARY << " but got " << type;            \
+        return std::nullopt;                                                  \
+      }                                                                       \
+                                                                              \
+      auto decoder = ::xla::ffi::internal::DictionaryDecoder<T>(__VA_ARGS__); \
+      return decltype(decoder)::Decode(                                       \
+          reinterpret_cast<const XLA_FFI_Attrs*>(attr),                       \
+          internal::StructMemberNames(__VA_ARGS__), diagnostic);              \
+    }                                                                         \
+  };                                                                          \
+  } /* namespace xla::ffi */                                                  \
+  static_assert(std::is_class_v<::xla::ffi::AttrsBinding<T>>);                \
+  static_assert(std::is_class_v<::xla::ffi::AttrDecoding<T>>)
+
+// Registers decoding for a user-defined enum class type. Uses enums underlying
+// type to decode the attribute as a scalar value and cast it to the enum type.
+#define XLA_FFI_REGISTER_ENUM_ATTR_DECODING(T)                           \
+  namespace xla::ffi {                                                   \
+  template <>                                                            \
+  struct AttrDecoding<T> {                                               \
+    using Type = T;                                                      \
+    using U = std::underlying_type_t<Type>;                              \
+    static_assert(std::is_enum<Type>::value, "Expected enum class");     \
+                                                                         \
+    XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(   \
+        XLA_FFI_AttrType attr_type, void* attr,                          \
+        DiagnosticEngine& diagnostic) {                                  \
+      if (XLA_FFI_PREDICT_FALSE(attr_type != XLA_FFI_AttrType_SCALAR)) { \
+        return diagnostic.Emit("Wrong attribute type: expected ")        \
+               << XLA_FFI_AttrType_SCALAR << " but got " << attr_type;   \
+      }                                                                  \
+                                                                         \
+      auto* scalar = reinterpret_cast<XLA_FFI_Scalar*>(attr);            \
+      constexpr auto expected_dtype =                                    \
+          ::xla::ffi::internal::NativeTypeToCApiDataType<U>();           \
+      if (XLA_FFI_PREDICT_FALSE(scalar->dtype != expected_dtype)) {      \
+        return diagnostic.Emit("Wrong scalar data type: expected ")      \
+               << expected_dtype << " but got " << scalar->dtype;        \
+      }                                                                  \
+                                                                         \
+      auto underlying = *reinterpret_cast<U*>(scalar->value);            \
+      return static_cast<Type>(underlying);                              \
+    }                                                                    \
+  };                                                                     \
+  } /* namespace xla::ffi */                                             \
+  static_assert(std::is_class_v<::xla::ffi::AttrDecoding<T>>)
+
+//===----------------------------------------------------------------------===//
+// Helper macro for registering FFI implementations
+//===----------------------------------------------------------------------===//
+
+// In all macros below we use captureless lambda to function pointer conversion
+// to create a static XLA_FFI_Handler function pointer variable.
+
+// Use explicit binding specification and traits to create a handler.
+#define XLA_FFI_DEFINE_HANDLER_EXPLICIT_WITH_TRAITS(fn, impl, binding, traits) \
+  static constexpr XLA_FFI_Handler* fn = +[](XLA_FFI_CallFrame* call_frame) {  \
+    static auto* handler = binding.To(impl, traits).release();                 \
+    return handler->Call(call_frame);                                          \
+  }
+
+// Use explicit binding specification to create a handler.
+#define XLA_FFI_DEFINE_HANDLER_EXPLICIT(fn, impl, binding)                    \
+  static constexpr XLA_FFI_Handler* fn = +[](XLA_FFI_CallFrame* call_frame) { \
+    static auto* handler = binding.To(impl).release();                        \
+    return handler->Call(call_frame);                                         \
+  }
+
+// Automatically infer binding specification from the implementation.
+#define XLA_FFI_DEFINE_HANDLER_AUTO(fn, impl)                                 \
+  static constexpr XLA_FFI_Handler* fn = +[](XLA_FFI_CallFrame* call_frame) { \
+    static auto* handler = ::xla::ffi::Ffi::BindTo(impl).release();           \
+    return handler->Call(call_frame);                                         \
+  }
+
+#define XLA_FFI_DEFINE_HANDLER_X(x, fn, impl, binding, traits, FUNC, ...) FUNC
+
+// Define XLA FFI handler as a static function pointer variable, which allows
+// to define handlers in nested scopes without polluting the global namespace.
+//
+// This is a trick to define macro with optional parameters.
+// Source: https://stackoverflow.com/a/8814003
+#define XLA_FFI_DEFINE_HANDLER(fn, impl, ...)                               \
+  XLA_FFI_DEFINE_HANDLER_X(                                                 \
+      , fn, impl, ##__VA_ARGS__,                                            \
+      XLA_FFI_DEFINE_HANDLER_EXPLICIT_WITH_TRAITS(fn, impl, ##__VA_ARGS__), \
+      XLA_FFI_DEFINE_HANDLER_EXPLICIT(fn, impl, ##__VA_ARGS__),             \
+      XLA_FFI_DEFINE_HANDLER_AUTO(fn, impl))
+
+// TODO(ezhulenev): Add a callback so that end users can log registration error
+// to appropriate logging destination, e.g. LOG(FATAL) for duplicate internal
+// FFI handlers.
+#define XLA_FFI_REGISTER_HANDLER(API, NAME, PLATFORM, FUNC, ...)    \
+  XLA_FFI_REGISTER_HANDLER_(API, NAME, PLATFORM, FUNC, __COUNTER__, \
+                            ##__VA_ARGS__)
+#define XLA_FFI_REGISTER_HANDLER_(API, NAME, PLATFORM, FUNC, N, ...) \
+  XLA_FFI_REGISTER_HANDLER__(API, NAME, PLATFORM, FUNC, N, ##__VA_ARGS__)
+#define XLA_FFI_REGISTER_HANDLER__(API, NAME, PLATFORM, FUNC, N, ...)       \
+  [[maybe_unused]] static const XLA_FFI_Error*                              \
+      xla_ffi_static_handler_##N##_registered_ = [] {                       \
+        return ::xla::ffi::Ffi::RegisterStaticHandler(API, NAME, PLATFORM,  \
+                                                      FUNC, ##__VA_ARGS__); \
+      }()
+
+// Following two APIs are intended for users who want to export XLA FFI handler
+// from a shared library as a C function symbol.
+
+// Declares C function that returns FFI type id.
+#define XLA_FFI_DECLARE_TYPE_ID_SYMBOL(type_id_fn) \
+  extern "C" XLA_FFI_TypeId* type_id_fn()
+
+// Declares C function that returns FFI type info.
+#define XLA_FFI_DECLARE_TYPE_INFO_SYMBOL(type_info_fn) \
+  extern "C" const XLA_FFI_TypeInfo* type_info_fn()
+
+// Declares C function that implements FFI handler.
+#define XLA_FFI_DECLARE_HANDLER_SYMBOL(fn) \
+  extern "C" XLA_FFI_Error* fn(XLA_FFI_CallFrame* call_frame)
+
+// Defines C function that implements FFI handler.
+#define XLA_FFI_DEFINE_HANDLER_SYMBOL(fn, impl, ...)                           \
+  extern "C" XLA_FFI_Error* fn(XLA_FFI_CallFrame* call_frame) {                \
+    XLA_FFI_DEFINE_HANDLER(handler, impl, ##__VA_ARGS__);                      \
+    return (*handler)(call_frame);                                             \
+  }                                                                            \
+                                                                               \
+  static_assert(                                                               \
+      std::is_invocable_r_v<XLA_FFI_Error*, decltype(fn), XLA_FFI_CallFrame*>, \
+      "FFI handler must return XLA_FFI_Error* and accept XLA_FFI_CallFrame*")
+
+}  // namespace xla::ffi
+
+#endif  // XLA_FFI_API_API_H_

--- a/3rdparty/xla_ffi/xla/ffi/api/c_api.h
+++ b/3rdparty/xla_ffi/xla/ffi/api/c_api.h
@@ -1,0 +1,786 @@
+/* Copyright 2023 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_FFI_API_C_API_H_
+#define XLA_FFI_API_C_API_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+// XLA FFI C API follows PJRT API style for consistency. See `pjrt_c_api.h`.
+// More details on versioning strategy and example version checks:
+// https://github.com/tensorflow/community/blob/master/rfcs/20200612-stream-executor-c-api/C_API_versioning_strategy.md
+
+// Every struct passed across the C API boundary has its size as a member, and
+// we use it as a sanity check for API compatibility.
+#define XLA_FFI_STRUCT_SIZE(struct_type, last_field) \
+  (offsetof(struct_type, last_field) + sizeof(((struct_type*)0)->last_field))
+
+// Must update XLA_FFI_DEFINE_STRUCT_TRAITS with the new `last_field` after
+// adding a new member to a struct.
+#define XLA_FFI_DEFINE_STRUCT_TRAITS(sname, last_field) \
+  typedef struct sname sname;                           \
+  enum { sname##_STRUCT_SIZE = XLA_FFI_STRUCT_SIZE(sname, last_field) }
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct XLA_FFI_Api XLA_FFI_Api;                  // Forward declare
+typedef struct XLA_FFI_InternalApi XLA_FFI_InternalApi;  // Forward declare
+
+//===----------------------------------------------------------------------===//
+// Extensions
+//===----------------------------------------------------------------------===//
+
+typedef enum {
+  XLA_FFI_Extension_Metadata = 1,
+} XLA_FFI_Extension_Type;
+
+typedef struct XLA_FFI_Extension_Base {
+  size_t struct_size;
+  XLA_FFI_Extension_Type type;
+  struct XLA_FFI_Extension_Base* next;
+} XLA_FFI_Extension_Base;
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Extension_Base, next);
+
+//===----------------------------------------------------------------------===//
+// Version
+//===----------------------------------------------------------------------===//
+
+// XLA FFI provides a stable binary API for registering custom calls with
+// XLA runtime. XLA runtime guarantees that old API version are supported for
+// at least 12 months, after that point FFI library has to be recompiled with
+// latest XLA FFI headers to support new features. We don't plan to break ABI
+// compatibility, unless it's absolutely necessary to enable new features that
+// can't be implemented in a backward compatible way.
+//
+// The range of supported API versions is defined in `xla/ffi/ffi_api.cc`.
+
+// Incremented when an ABI-incompatible change is made to the interface.
+//
+// Major changes include:
+// * Deleting a method or argument
+// * Changing the type of an argument
+// * Rearranging fields in the XLA_FFI_Api or argument structs
+#define XLA_FFI_API_MAJOR 0
+
+// Incremented when the interface is updated in a way that is potentially
+// ABI-compatible with older versions, if supported by the caller and/or
+// implementation.
+//
+// Callers can implement forwards compatibility by using XLA_FFI_Api_Version to
+// check if the implementation is aware of newer interface additions.
+//
+// Implementations can implement backwards compatibility by using the
+// `struct_size` fields to detect how many struct fields the caller is aware of.
+//
+// Minor changes include:
+// * Adding a new field to the XLA_FFI_Api or argument structs
+// * Renaming a method or argument (doesn't affect ABI)
+#define XLA_FFI_API_MINOR 2
+
+struct XLA_FFI_Api_Version {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+  int major_version;  // out
+  int minor_version;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Api_Version, minor_version);
+
+//===----------------------------------------------------------------------===//
+// Error codes
+//===----------------------------------------------------------------------===//
+
+// XLA FFI error is a mechanism to communicate errors between XLA and XLA FFI
+// via a set of C APIs. This is somewhat similar to type-erased version of
+// absl::Status exposed via API with opaque pointers.
+//
+// Returning NULL error is equivalent to returning absl::OkStatus().
+//
+// Ownership of an XLA_FFI_Error is always transferred to the caller, and the
+// caller is responsible for destroying it:
+//
+// (1) If the error is returned from an XLA FFI handler, the XLA runtime will
+//     destroy it (XLA is the caller who calls into the handler implementation).
+//
+// (2) If the error is returned from an XLA FFI API call, the caller is
+//     responsible for destroying it.
+typedef struct XLA_FFI_Error XLA_FFI_Error;
+
+// Codes are based on https://abseil.io/docs/cpp/guides/status-codes
+typedef enum {
+  XLA_FFI_Error_Code_OK = 0,
+  XLA_FFI_Error_Code_CANCELLED = 1,
+  XLA_FFI_Error_Code_UNKNOWN = 2,
+  XLA_FFI_Error_Code_INVALID_ARGUMENT = 3,
+  XLA_FFI_Error_Code_DEADLINE_EXCEEDED = 4,
+  XLA_FFI_Error_Code_NOT_FOUND = 5,
+  XLA_FFI_Error_Code_ALREADY_EXISTS = 6,
+  XLA_FFI_Error_Code_PERMISSION_DENIED = 7,
+  XLA_FFI_Error_Code_RESOURCE_EXHAUSTED = 8,
+  XLA_FFI_Error_Code_FAILED_PRECONDITION = 9,
+  XLA_FFI_Error_Code_ABORTED = 10,
+  XLA_FFI_Error_Code_OUT_OF_RANGE = 11,
+  XLA_FFI_Error_Code_UNIMPLEMENTED = 12,
+  XLA_FFI_Error_Code_INTERNAL = 13,
+  XLA_FFI_Error_Code_UNAVAILABLE = 14,
+  XLA_FFI_Error_Code_DATA_LOSS = 15,
+  XLA_FFI_Error_Code_UNAUTHENTICATED = 16
+} XLA_FFI_Error_Code;
+
+//===----------------------------------------------------------------------===//
+// Error reporting APIs
+//===----------------------------------------------------------------------===//
+
+struct XLA_FFI_Error_Create_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+  const char* message;
+  XLA_FFI_Error_Code errc;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Error_Create_Args, errc);
+
+typedef XLA_FFI_Error* XLA_FFI_Error_Create(XLA_FFI_Error_Create_Args* args);
+
+struct XLA_FFI_Error_GetMessage_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+  XLA_FFI_Error* error;
+  const char* message;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Error_GetMessage_Args, message);
+
+typedef void XLA_FFI_Error_GetMessage(XLA_FFI_Error_GetMessage_Args* args);
+
+struct XLA_FFI_Error_Destroy_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+  XLA_FFI_Error* error;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Error_Destroy_Args, error);
+
+typedef void XLA_FFI_Error_Destroy(XLA_FFI_Error_Destroy_Args* args);
+
+//===----------------------------------------------------------------------===//
+// DataType
+//===----------------------------------------------------------------------===//
+
+// This enum corresponds to xla::PrimitiveType enum defined in `xla_data.proto`.
+// LINT.IfChange
+typedef enum {
+  XLA_FFI_DataType_INVALID = 0,
+  XLA_FFI_DataType_PRED = 1,
+  XLA_FFI_DataType_S1 = 30,
+  XLA_FFI_DataType_S2 = 26,
+  XLA_FFI_DataType_S4 = 21,
+  XLA_FFI_DataType_S8 = 2,
+  XLA_FFI_DataType_S16 = 3,
+  XLA_FFI_DataType_S32 = 4,
+  XLA_FFI_DataType_S64 = 5,
+  XLA_FFI_DataType_U1 = 31,
+  XLA_FFI_DataType_U2 = 27,
+  XLA_FFI_DataType_U4 = 22,
+  XLA_FFI_DataType_U8 = 6,
+  XLA_FFI_DataType_U16 = 7,
+  XLA_FFI_DataType_U32 = 8,
+  XLA_FFI_DataType_U64 = 9,
+  XLA_FFI_DataType_F16 = 10,
+  XLA_FFI_DataType_F32 = 11,
+  XLA_FFI_DataType_F64 = 12,
+  XLA_FFI_DataType_BF16 = 16,
+  XLA_FFI_DataType_C64 = 15,
+  XLA_FFI_DataType_C128 = 18,
+  XLA_FFI_DataType_TOKEN = 17,
+  XLA_FFI_DataType_F8E5M2 = 19,
+  XLA_FFI_DataType_F8E3M4 = 29,
+  XLA_FFI_DataType_F8E4M3 = 28,
+  XLA_FFI_DataType_F8E4M3FN = 20,
+  XLA_FFI_DataType_F8E4M3B11FNUZ = 23,
+  XLA_FFI_DataType_F8E5M2FNUZ = 24,
+  XLA_FFI_DataType_F8E4M3FNUZ = 25,
+  XLA_FFI_DataType_F4E2M1FN = 32,
+  XLA_FFI_DataType_F8E8M0FNU = 33,
+} XLA_FFI_DataType;
+// LINT.ThenChange(ffi_test.cc)
+
+//===----------------------------------------------------------------------===//
+// Builtin argument types
+//===----------------------------------------------------------------------===//
+
+struct XLA_FFI_Buffer {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_DataType dtype;
+  void* data;
+  int64_t rank;
+  int64_t* dims;  // length == rank
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Buffer, dims);
+
+typedef enum {
+  XLA_FFI_ArgType_BUFFER = 1,
+} XLA_FFI_ArgType;
+
+//===----------------------------------------------------------------------===//
+// Builtin result types
+//===----------------------------------------------------------------------===//
+
+typedef enum {
+  XLA_FFI_RetType_BUFFER = 1,
+} XLA_FFI_RetType;
+
+//===----------------------------------------------------------------------===//
+// Builtin attribute types
+//===----------------------------------------------------------------------===//
+
+typedef enum {
+  XLA_FFI_AttrType_ARRAY = 1,
+  XLA_FFI_AttrType_DICTIONARY = 2,
+  XLA_FFI_AttrType_SCALAR = 3,
+  XLA_FFI_AttrType_STRING = 4,
+} XLA_FFI_AttrType;
+
+//===----------------------------------------------------------------------===//
+// Execution context
+//===----------------------------------------------------------------------===//
+
+// Execution context provides access to per-invocation state.
+typedef struct XLA_FFI_ExecutionContext XLA_FFI_ExecutionContext;
+
+//===----------------------------------------------------------------------===//
+// Primitives
+//===----------------------------------------------------------------------===//
+
+// We use byte spans to pass strings to handlers because strings might not be
+// null terminated, and even if they are, looking for a null terminator can
+// become very expensive in tight loops.
+typedef struct XLA_FFI_ByteSpan {
+  const char* ptr;
+  size_t len;
+} XLA_FFI_ByteSpan;
+
+// A struct to pass a scalar value to FFI handler.
+typedef struct XLA_FFI_Scalar {
+  XLA_FFI_DataType dtype;
+  void* value;
+} XLA_FFI_Scalar;
+
+// A struct to pass a dense array to FFI handler.
+typedef struct XLA_FFI_Array {
+  XLA_FFI_DataType dtype;
+  size_t size;
+  void* data;
+} XLA_FFI_Array;
+
+//===----------------------------------------------------------------------===//
+// Type registry
+//===----------------------------------------------------------------------===//
+
+// TypeId uniquely identifies a user-defined type in a given XLA FFI instance.
+typedef struct XLA_FFI_TypeId {
+  int64_t type_id;
+} XLA_FFI_TypeId;
+
+// TypeInfo contains function pointers required by XLA runtime to manipulate
+// user-defined types. For example stateful handlers must tell XLA runtime how
+// to destroy their state when executable is being destroyed.
+typedef struct XLA_FFI_TypeInfo {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+  void (*deleter)(void* object);
+} XLA_FFI_TypeInfo;
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_TypeInfo, deleter);
+
+//===----------------------------------------------------------------------===//
+// Future
+//===----------------------------------------------------------------------===//
+
+// XLA FFI future is a mechanism to signal a result of asynchronous computation
+// (FFI handler) to the XLA runtime. It is similar to `std::future<void>` in C++
+// standard library, and implemented on top of `tsl::AsyncValue` in XLA runtime.
+//
+// XLA FFI users should use `Future` and `Promise` types defined in `xla::ffi`
+// namespace (see `ffi/api/ffi.h`), instead of using this API directly.
+typedef struct XLA_FFI_Future XLA_FFI_Future;
+
+struct XLA_FFI_Future_Create_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+  XLA_FFI_Future* future;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Future_Create_Args, extension_start);
+
+typedef XLA_FFI_Error* XLA_FFI_Future_Create(XLA_FFI_Future_Create_Args* args);
+
+struct XLA_FFI_Future_SetAvailable_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+  XLA_FFI_Future* future;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Future_SetAvailable_Args, future);
+
+typedef XLA_FFI_Error* XLA_FFI_Future_SetAvailable(
+    XLA_FFI_Future_SetAvailable_Args* args);
+
+struct XLA_FFI_Future_SetError_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+  XLA_FFI_Future* future;
+  XLA_FFI_Error* error;  // ownership is transferred to the XLA runtime
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Future_SetError_Args, error);
+
+typedef XLA_FFI_Error* XLA_FFI_Future_SetError(
+    XLA_FFI_Future_SetError_Args* args);
+
+//===----------------------------------------------------------------------===//
+// Call frame
+//===----------------------------------------------------------------------===//
+
+// XLA runtime has multiple execution stages and it is possible to run
+// different handlers for each stage:
+//
+// (1) Instantiate - called when FFI handler is instantiated as a part of XLA
+//     executable instantiation. Every call site will have its own "instance" of
+//     the FFI handler, and it is possible to attach an arbitrary user-defined
+//     state to the FFI handler instance, and get it back in other execution
+//     stages. Constructed state owned by the XLA runtime and destructed
+//     together with a parent executable.
+//
+// (2) Prepare - called before the execution to let FFI handlers to prepare
+//     for the execution and request resources from runtime, i.e. in XLA:GPU
+//     we use prepare stage to request collective cliques.
+//
+// (3) Initialize - called before the execution after acquiring all the
+//     resources requested in the prepare stage.
+//
+// (4) Execute - called when FFI handler is executed. Note that FFI handler
+//     can be called as a part of command buffer capture (CUDA graph capture
+//     on GPU backend) and argument buffers might contain uninitialized
+//     values in this case.
+//
+// XLA program (HLO module) compiled to an XLA executable that can be executed
+// on any device accessible to the process, and by extension FFI handlers are
+// not instantiated for any particular device, but for a process. FFI handlers
+// running at instantiation stage do not have access to the underlying device
+// (memory allocation, stream, etc.) and arguments, however they can access
+// execution context and attributes.
+//
+// It is undefined behavior to access argument buffers in prepare and initialize
+// stages as they might not be initialized yet. However it is safe to use memory
+// address as it is assigned ahead of time by buffer assignment.
+typedef enum {
+  XLA_FFI_ExecutionStage_INSTANTIATE = 0,
+  XLA_FFI_ExecutionStage_PREPARE = 1,
+  XLA_FFI_ExecutionStage_INITIALIZE = 2,
+  XLA_FFI_ExecutionStage_EXECUTE = 3,
+} XLA_FFI_ExecutionStage;
+
+struct XLA_FFI_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  int64_t size;
+  XLA_FFI_ArgType* types;  // length == size
+  void** args;             // length == size
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Args, args);
+
+struct XLA_FFI_Rets {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  int64_t size;
+  XLA_FFI_RetType* types;  // length == size
+  void** rets;             // length == size
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Rets, rets);
+
+// FFI handler attributes are always sorted by name, so that the handler can
+// rely on binary search to look up attributes by name.
+struct XLA_FFI_Attrs {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  int64_t size;
+  XLA_FFI_AttrType* types;   // length == size
+  XLA_FFI_ByteSpan** names;  // length == size
+  void** attrs;              // length == size
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Attrs, attrs);
+
+struct XLA_FFI_CallFrame {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  const XLA_FFI_Api* api;
+  XLA_FFI_ExecutionContext* ctx;
+  XLA_FFI_ExecutionStage stage;
+  XLA_FFI_Args args;
+  XLA_FFI_Rets rets;
+  XLA_FFI_Attrs attrs;
+
+  // XLA FFI handler implementation can use `future` to signal a result of
+  // asynchronous computation to the XLA runtime. XLA runtime will keep all
+  // arguments, results and attributes alive until `future` is completed.
+  XLA_FFI_Future* future;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_CallFrame, attrs);
+
+//===----------------------------------------------------------------------===//
+// FFI handler
+//===----------------------------------------------------------------------===//
+
+// External functions registered with XLA as FFI handlers.
+typedef XLA_FFI_Error* XLA_FFI_Handler(XLA_FFI_CallFrame* call_frame);
+
+// XLA FFI handlers for execution stages (see XLA_FFI_ExecutionStage).
+typedef struct XLA_FFI_Handler_Bundle {
+  XLA_FFI_Handler* instantiate;  // optional
+  XLA_FFI_Handler* prepare;      // optional
+  XLA_FFI_Handler* initialize;   // optional
+  XLA_FFI_Handler* execute;      // required
+} XLA_FFI_Handler_Bundle;
+
+enum XLA_FFI_Handler_TraitsBits {
+  // Calls to FFI handler are safe to trace into the command buffer. It means
+  // that calls to FFI handler always launch exactly the same device operations
+  // (can depend on attribute values) that can be captured and then replayed.
+  XLA_FFI_HANDLER_TRAITS_COMMAND_BUFFER_COMPATIBLE = 1u << 0,
+};
+
+typedef uint32_t XLA_FFI_Handler_Traits;
+
+struct XLA_FFI_Handler_Register_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ByteSpan name;
+  XLA_FFI_ByteSpan platform;
+  XLA_FFI_Handler_Bundle bundle;
+  XLA_FFI_Handler_Traits traits;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Handler_Register_Args, traits);
+
+typedef XLA_FFI_Error* XLA_FFI_Handler_Register(
+    XLA_FFI_Handler_Register_Args* args);
+
+//===----------------------------------------------------------------------===//
+// TypeId
+//===----------------------------------------------------------------------===//
+
+#define XLA_FFI_UNKNOWN_TYPE_ID XLA_FFI_TypeId{0}
+
+struct XLA_FFI_Type_Register_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ByteSpan name;
+  XLA_FFI_TypeId* type_id;  // in-out
+  const XLA_FFI_TypeInfo* type_info;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Type_Register_Args, type_id);
+
+// Registers user type `name` with XLA. If type id is `XLA_FFI_UNKNOWN_TYPE_ID`,
+// XLA will assign a unique type id and return it in `type_id` out argument,
+// otherwise XLA will verify that type id is unique and matches the type id of
+// the type registered with the same `name` earlier.
+typedef XLA_FFI_Error* XLA_FFI_Type_Register(XLA_FFI_Type_Register_Args* args);
+
+//===----------------------------------------------------------------------===//
+// ExecutionContext
+//===----------------------------------------------------------------------===//
+
+struct XLA_FFI_ExecutionContext_Get_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ExecutionContext* ctx;
+  XLA_FFI_TypeId* type_id;
+  void* data;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_ExecutionContext_Get_Args, data);
+
+// Returns an opaque data from the execution context for a given type id.
+typedef XLA_FFI_Error* XLA_FFI_ExecutionContext_Get(
+    XLA_FFI_ExecutionContext_Get_Args* args);
+
+//===----------------------------------------------------------------------===//
+// State
+//===----------------------------------------------------------------------===//
+
+struct XLA_FFI_State_Set_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ExecutionContext* ctx;
+  XLA_FFI_TypeId* type_id;
+  void* state;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_State_Set_Args, state);
+
+// Sets execution state to the `state` of type `type_id`. Returns an error if
+// state already set.
+typedef XLA_FFI_Error* XLA_FFI_State_Set(XLA_FFI_State_Set_Args* args);
+
+struct XLA_FFI_State_Get_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ExecutionContext* ctx;
+  XLA_FFI_TypeId* type_id;
+  void* state;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_State_Get_Args, state);
+
+// Gets execution state of type `type_id`. Returns an error if state is not set,
+// or set with a state of a different type.
+typedef XLA_FFI_Error* XLA_FFI_State_Get(XLA_FFI_State_Get_Args* args);
+
+//===----------------------------------------------------------------------===//
+// Stream
+//===----------------------------------------------------------------------===//
+
+struct XLA_FFI_Stream_Get_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ExecutionContext* ctx;
+  void* stream;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Stream_Get_Args, stream);
+
+// Returns an underling platform-specific stream via out argument, i.e. for CUDA
+// platform it returns `CUstream` (same as `cudaStream`).
+typedef XLA_FFI_Error* XLA_FFI_Stream_Get(XLA_FFI_Stream_Get_Args* args);
+
+//===----------------------------------------------------------------------===//
+// Device memory allocation
+//===----------------------------------------------------------------------===//
+
+struct XLA_FFI_DeviceMemory_Allocate_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ExecutionContext* ctx;
+  size_t size;
+  size_t alignment;
+  void* data;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_DeviceMemory_Allocate_Args, data);
+
+// Allocates a block of memory on the device bound to the execution context.
+typedef XLA_FFI_Error* XLA_FFI_DeviceMemory_Allocate(
+    XLA_FFI_DeviceMemory_Allocate_Args* args);
+
+struct XLA_FFI_DeviceMemory_Free_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ExecutionContext* ctx;
+  size_t size;
+  void* data;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_DeviceMemory_Free_Args, data);
+
+// Frees previously allocated device memory.
+typedef XLA_FFI_Error* XLA_FFI_DeviceMemory_Free(
+    XLA_FFI_DeviceMemory_Free_Args* args);
+
+//===----------------------------------------------------------------------===//
+// ThreadPool
+//===----------------------------------------------------------------------===//
+
+// A function pointer for a task to be scheduled on a thread pool. XLA runtime
+// will call this function with a user-defined `data` pointer on one of the
+// runtime-managed threads. For XLA:CPU backends the task will be invoked on
+// a thread pool that runs all compute tasks (Eigen thread pool).
+//
+// IMPORTANT: Users must not rely on any particular execution order or the
+// number of available threads. Tasks can be executed in the caller thread, or
+// in a thread pool with size `1`, and it is unsafe to assume that all scheduled
+// tasks can be executed in parallel.
+typedef void XLA_FFI_Task(void* data);
+
+struct XLA_FFI_ThreadPool_Schedule_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ExecutionContext* ctx;
+  XLA_FFI_Task* task;
+  void* data;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_ThreadPool_Schedule_Args, data);
+
+// Schedules a task to be executed on a thread pool managed by XLA runtime.
+// Returns an error if thread pool is not available.
+typedef XLA_FFI_Error* XLA_FFI_ThreadPool_Schedule(
+    XLA_FFI_ThreadPool_Schedule_Args* args);
+
+struct XLA_FFI_ThreadPool_NumThreads_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ExecutionContext* ctx;
+  int64_t* num_threads;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_ThreadPool_NumThreads_Args, num_threads);
+
+// Returns the number of threads in the thread pool managed by XLA runtime.
+typedef XLA_FFI_Error* XLA_FFI_ThreadPool_NumThreads(
+    XLA_FFI_ThreadPool_NumThreads_Args* args);
+
+//===----------------------------------------------------------------------===//
+// RunId
+//===----------------------------------------------------------------------===//
+
+// RunId is a unique identifier for a particular "logical execution" of an XLA
+// model.
+//
+// A logical execution might encompass multiple executions of one or more
+// HloModules. Runs that are part of the same logical execution can communicate
+// via collective ops, whereas runs that are part of different logical
+// executions are isolated.
+//
+// Corresponds to `::xla::RunId` (see `xla/executable_run_options.h`).
+
+struct XLA_FFI_RunId_Get_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ExecutionContext* ctx;
+  int64_t run_id;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_RunId_Get_Args, run_id);
+
+// Returns a unique identifier for the current logical execution.
+typedef XLA_FFI_Error* XLA_FFI_RunId_Get(XLA_FFI_RunId_Get_Args* args);
+
+//===----------------------------------------------------------------------===//
+// DeviceOrdinal
+//===----------------------------------------------------------------------===//
+
+struct XLA_FFI_DeviceOrdinal_Get_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ExecutionContext* ctx;
+  int32_t device_ordinal;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_DeviceOrdinal_Get_Args, device_ordinal);
+
+// Returns a unique identifier for the current logical execution.
+typedef XLA_FFI_Error* XLA_FFI_DeviceOrdinal_Get(
+    XLA_FFI_DeviceOrdinal_Get_Args* args);
+
+//===----------------------------------------------------------------------===//
+// Metadata extension
+//===----------------------------------------------------------------------===//
+
+// XLA FFI handler metadata allows the XLA runtime to query handler properties
+// during XLA compilation and execution. We use a metadata extension to verify
+// that XLA is compatible with the FFI version used to compile the handler.
+struct XLA_FFI_Metadata {
+  size_t struct_size;
+
+  XLA_FFI_Api_Version api_version;
+  XLA_FFI_Handler_Traits traits;
+
+  // For stateful handlers, the type id of the state type. Otherwise, the type
+  // id is `XLA_FFI_UNKNOWN_TYPE_ID`.
+  XLA_FFI_TypeId state_type_id;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Metadata, traits);
+
+struct XLA_FFI_Metadata_Extension {
+  XLA_FFI_Extension_Base extension_base;
+  XLA_FFI_Metadata* metadata;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Metadata_Extension, metadata);
+
+//===----------------------------------------------------------------------===//
+// API access
+//===----------------------------------------------------------------------===//
+
+#define _XLA_FFI_API_STRUCT_FIELD(fn_type) fn_type* fn_type
+
+struct XLA_FFI_Api {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_Api_Version api_version;
+  const XLA_FFI_InternalApi* internal_api;
+
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Error_Create);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Error_GetMessage);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Error_Destroy);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Handler_Register);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Stream_Get);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Type_Register);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_ExecutionContext_Get);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_State_Set);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_State_Get);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_DeviceMemory_Allocate);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_DeviceMemory_Free);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_ThreadPool_Schedule);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_ThreadPool_NumThreads);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Future_Create);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Future_SetAvailable);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Future_SetError);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_RunId_Get);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_DeviceOrdinal_Get);
+};
+
+#undef _XLA_FFI_API_STRUCT_FIELD
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Api, XLA_FFI_DeviceOrdinal_Get);
+
+const XLA_FFI_Api* XLA_FFI_GetApi();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // XLA_FFI_API_C_API_H_

--- a/3rdparty/xla_ffi/xla/ffi/api/ffi.h
+++ b/3rdparty/xla_ffi/xla/ffi/api/ffi.h
@@ -1,0 +1,1675 @@
+/* Copyright 2023 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_FFI_API_FFI_H_
+#define XLA_FFI_API_FFI_H_
+
+#include <string_view>
+#ifdef XLA_FFI_FFI_H_
+#error Two different XLA FFI implementations cannot be included together. \
+       See README.md for more details.
+#endif  // XLA_FFI_FFI_H_
+
+#include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <complex>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <mutex>  // NOLINT
+#include <numeric>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "xla/ffi/api/c_api.h"
+
+// IWYU pragma: begin_exports
+#include "xla/ffi/api/api.h"
+// IWYU pragma: end_exports
+
+namespace xla::ffi {
+
+// All user data types that are passed via the execution context or state must
+// be registered with the XLA FFI ahead of time to get unique type id.
+using TypeId = XLA_FFI_TypeId;      // NOLINT
+using TypeInfo = XLA_FFI_TypeInfo;  // NOLINT
+
+enum class DataType : uint8_t {
+  INVALID = XLA_FFI_DataType_INVALID,
+  PRED = XLA_FFI_DataType_PRED,
+  S1 = XLA_FFI_DataType_S1,
+  S2 = XLA_FFI_DataType_S2,
+  S4 = XLA_FFI_DataType_S4,
+  S8 = XLA_FFI_DataType_S8,
+  S16 = XLA_FFI_DataType_S16,
+  S32 = XLA_FFI_DataType_S32,
+  S64 = XLA_FFI_DataType_S64,
+  U1 = XLA_FFI_DataType_U1,
+  U2 = XLA_FFI_DataType_U2,
+  U4 = XLA_FFI_DataType_U4,
+  U8 = XLA_FFI_DataType_U8,
+  U16 = XLA_FFI_DataType_U16,
+  U32 = XLA_FFI_DataType_U32,
+  U64 = XLA_FFI_DataType_U64,
+  F16 = XLA_FFI_DataType_F16,
+  F32 = XLA_FFI_DataType_F32,
+  F64 = XLA_FFI_DataType_F64,
+  BF16 = XLA_FFI_DataType_BF16,
+  C64 = XLA_FFI_DataType_C64,
+  C128 = XLA_FFI_DataType_C128,
+  TOKEN = XLA_FFI_DataType_TOKEN,
+  F8E5M2 = XLA_FFI_DataType_F8E5M2,
+  F8E4M3 = XLA_FFI_DataType_F8E4M3,
+  F8E4M3FN = XLA_FFI_DataType_F8E4M3FN,
+  F8E4M3B11FNUZ = XLA_FFI_DataType_F8E4M3B11FNUZ,
+  F8E5M2FNUZ = XLA_FFI_DataType_F8E5M2FNUZ,
+  F8E4M3FNUZ = XLA_FFI_DataType_F8E4M3FNUZ,
+  F8E3M4 = XLA_FFI_DataType_F8E3M4,
+  F4E2M1FN = XLA_FFI_DataType_F4E2M1FN,
+  F8E8M0FNU = XLA_FFI_DataType_F8E8M0FNU,
+};
+
+// Create aliases in ::xla::ffi namespace for all DataTypes, for consistency
+// with xla that defines PrimitiveType enums in ::xla namespace.
+inline constexpr DataType PRED = DataType::PRED;
+inline constexpr DataType S1 = DataType::S1;
+inline constexpr DataType S2 = DataType::S2;
+inline constexpr DataType S4 = DataType::S4;
+inline constexpr DataType S8 = DataType::S8;
+inline constexpr DataType S16 = DataType::S16;
+inline constexpr DataType S32 = DataType::S32;
+inline constexpr DataType S64 = DataType::S64;
+inline constexpr DataType U1 = DataType::U1;
+inline constexpr DataType U2 = DataType::U2;
+inline constexpr DataType U4 = DataType::U4;
+inline constexpr DataType U8 = DataType::U8;
+inline constexpr DataType U16 = DataType::U16;
+inline constexpr DataType U32 = DataType::U32;
+inline constexpr DataType U64 = DataType::U64;
+inline constexpr DataType F16 = DataType::F16;
+inline constexpr DataType F32 = DataType::F32;
+inline constexpr DataType F64 = DataType::F64;
+inline constexpr DataType BF16 = DataType::BF16;
+inline constexpr DataType C64 = DataType::C64;
+inline constexpr DataType C128 = DataType::C128;
+inline constexpr DataType TOKEN = DataType::TOKEN;
+inline constexpr DataType F8E5M2 = DataType::F8E5M2;
+inline constexpr DataType F8E4M3 = DataType::F8E4M3;
+inline constexpr DataType F8E4M3FN = DataType::F8E4M3FN;
+inline constexpr DataType F8E4M3B11FNUZ = DataType::F8E4M3B11FNUZ;
+inline constexpr DataType F8E5M2FNUZ = DataType::F8E5M2FNUZ;
+inline constexpr DataType F8E4M3FNUZ = DataType::F8E4M3FNUZ;
+inline constexpr DataType F8E3M4 = DataType::F8E3M4;
+inline constexpr DataType F4E2M1FN = DataType::F4E2M1FN;
+inline constexpr DataType F8E8M0FNU = DataType::F8E8M0FNU;
+
+inline std::ostream& operator<<(std::ostream& os, const DataType dtype) {
+  return os << static_cast<XLA_FFI_DataType>(dtype);
+}
+
+constexpr size_t ByteWidth(DataType dtype) {
+  switch (dtype) {
+    case DataType::INVALID:
+    case DataType::TOKEN:
+      return 0;
+    case DataType::PRED:
+      return 1;
+    case DataType::S1:
+    case DataType::S2:
+    case DataType::S4:
+    case DataType::S8:
+    case DataType::U1:
+    case DataType::U2:
+    case DataType::U4:
+    case DataType::U8:
+    case DataType::F8E5M2:
+    case DataType::F8E4M3:
+    case DataType::F8E4M3FN:
+    case DataType::F8E4M3B11FNUZ:
+    case DataType::F8E5M2FNUZ:
+    case DataType::F8E4M3FNUZ:
+    case DataType::F8E3M4:
+    case DataType::F4E2M1FN:
+    case DataType::F8E8M0FNU:
+      return 1;
+    case DataType::S16:
+    case DataType::U16:
+    case DataType::F16:
+    case DataType::BF16:
+      return 2;
+    case DataType::S32:
+    case DataType::U32:
+    case DataType::F32:
+      return 4;
+    case DataType::S64:
+    case DataType::U64:
+    case DataType::F64:
+      return 8;
+    case DataType::C64:
+      return 8;
+    case DataType::C128:
+      return 16;
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Span is non-owning view into contiguous values of type `T`.
+//===----------------------------------------------------------------------===//
+
+// TODO(ezhulenev): Replace with `std::span` when C++20 is available.
+template <typename T>
+class Span {
+ public:
+  constexpr Span() : data_(nullptr), size_(0) {}
+
+  Span(T* data, size_t size) : data_(data), size_(size) {}
+  Span(const std::vector<std::remove_const_t<T>>& vec)  // NOLINT
+      : Span(vec.data(), vec.size()) {}
+
+  T& operator[](size_t index) const { return data_[index]; }
+
+  bool operator==(const Span<T>& other) const {
+    return size() == other.size() && std::equal(begin(), end(), other.begin());
+  }
+
+  T& front() const { return data_[0]; }
+  T& back() const { return data_[size_ - 1]; }
+  Span<T> first(size_t n) const { return Span<T>(data_, n); }
+  Span<T> last(size_t n) const { return Span<T>(data_ + size_ - n, n); }
+  size_t size() const { return size_; }
+
+  T* begin() const { return data_; }
+  T* end() const { return data_ + size_; }
+
+ private:
+  T* data_;
+  size_t size_;
+};
+
+//===----------------------------------------------------------------------===//
+// Error
+//===----------------------------------------------------------------------===//
+
+enum class ErrorCode : uint8_t {
+  kOk = XLA_FFI_Error_Code_OK,
+  kCancelled = XLA_FFI_Error_Code_CANCELLED,
+  kUnknown = XLA_FFI_Error_Code_UNKNOWN,
+  kInvalidArgument = XLA_FFI_Error_Code_INVALID_ARGUMENT,
+  kDeadlineExceeded = XLA_FFI_Error_Code_DEADLINE_EXCEEDED,
+  kNotFound = XLA_FFI_Error_Code_NOT_FOUND,
+  kAlreadyExists = XLA_FFI_Error_Code_ALREADY_EXISTS,
+  kPermissionDenied = XLA_FFI_Error_Code_PERMISSION_DENIED,
+  kResourceExhausted = XLA_FFI_Error_Code_RESOURCE_EXHAUSTED,
+  kFailedPrecondition = XLA_FFI_Error_Code_FAILED_PRECONDITION,
+  kAborted = XLA_FFI_Error_Code_ABORTED,
+  kOutOfRange = XLA_FFI_Error_Code_OUT_OF_RANGE,
+  kUnimplemented = XLA_FFI_Error_Code_UNIMPLEMENTED,
+  kInternal = XLA_FFI_Error_Code_INTERNAL,
+  kUnavailable = XLA_FFI_Error_Code_UNAVAILABLE,
+  kDataLoss = XLA_FFI_Error_Code_DATA_LOSS,
+  kUnauthenticated = XLA_FFI_Error_Code_UNAUTHENTICATED,
+};
+
+class Error {
+ public:
+  Error() = default;
+
+  Error(ErrorCode errc, std::string message)
+      : errc_(errc), message_(std::move(message)) {}
+
+  Error(XLA_FFI_Error_Code errc, std::string message)
+      : Error(static_cast<ErrorCode>(errc), std::move(message)) {}
+
+  bool success() const { return errc_ == ErrorCode::kOk; }
+  bool failure() const { return !success(); }
+
+  std::optional<ErrorCode> errc() const { return errc_; }
+  const std::string& message() const { return message_; }
+
+  static Error Success() { return Error(); }
+
+  static Error Internal(std::string message) {
+    return Error(ErrorCode::kInternal, std::move(message));
+  }
+
+  static Error InvalidArgument(std::string message) {
+    return Error(ErrorCode::kInvalidArgument, std::move(message));
+  }
+
+ private:
+  ErrorCode errc_ = ErrorCode::kOk;
+  std::string message_;
+};
+
+//===----------------------------------------------------------------------===//
+// Expected<T, E> and ErrorOr<T>
+//===----------------------------------------------------------------------===//
+
+// Forward declare.
+template <typename E>
+class Unexpected;
+
+// TODO(slebedev): Replace with `std::expected` when C++23 is available.
+template <typename T, typename E>
+class Expected {
+ public:
+  constexpr Expected(T value) : data_(std::move(value)) {}  // NOLINT
+  constexpr Expected(Unexpected<E> u);                      // NOLINT
+
+  constexpr operator bool() const {  // NOLINT
+    return has_value();
+  }
+
+  constexpr T& operator*() & { return value(); }
+  constexpr const T& operator*() const& { return value(); }
+  constexpr T&& operator*() && { return std::move(value()); }
+  constexpr const T& operator*() const&& { return std::move(value()); }
+
+  constexpr T* operator->() { return &value(); }
+  constexpr const T* operator->() const { return &value(); }
+
+  constexpr bool has_value() const { return std::holds_alternative<T>(data_); }
+  constexpr bool has_error() const { return std::holds_alternative<E>(data_); }
+
+  constexpr T& value() & { return std::get<T>(data_); }
+  constexpr const T& value() const& { return std::get<T>(data_); }
+  constexpr T&& value() && { return std::get<T>(std::move(data_)); }
+  constexpr const T& value() const&& { return std::get<T>(std::move(data_)); }
+
+  constexpr E& error() & { return std::get<E>(data_); }
+  constexpr const E& error() const& { return std::get<E>(data_); }
+  constexpr E&& error() && { return std::get<E>(std::move(data_)); }
+  constexpr const E&& error() const&& { return std::get<E>(std::move(data_)); }
+
+ private:
+  std::variant<T, E> data_;
+};
+
+template <typename E>
+class Unexpected {
+ public:
+  constexpr Unexpected(E error) : error_(std::move(error)) {}  // NOLINT
+
+ private:
+  template <typename, typename>
+  friend class Expected;
+
+  E error_;
+};
+
+Unexpected(const char*) -> Unexpected<std::string>;
+
+template <typename T, typename E>
+constexpr Expected<T, E>::Expected(Unexpected<E> u)
+    : data_(std::move(u.error_)) {}
+
+template <typename T>
+class ErrorOr : public Expected<T, Error> {
+ public:
+  using Expected<T, Error>::Expected;
+};
+
+//===----------------------------------------------------------------------===//
+// Future
+//===----------------------------------------------------------------------===//
+
+// A Promise and a Future are loosely based on `std::promise` and `std::future`,
+// with an API similar to `tsl::AsyncValue`. Implementation is based on a
+// simplified version of an AsyncValue with at most one waiter.
+
+// A promise to complete execution with a success or an error.
+class Promise;
+
+// A promise that completes when a specific number of count downs have occurred.
+class CountDownPromise;
+
+// A future that becomes available when a corresponding promise is completed.
+class Future {
+ public:
+  explicit Future(const Promise& promise);
+  explicit Future(const CountDownPromise& promise);
+
+  Future(Future&&) = default;
+  Future& operator=(Future&&) = default;
+
+  template <typename F>
+  void OnReady(F&& f);
+
+ private:
+  friend class Promise;
+
+  using Waiter = std::function<void(const std::optional<Error>& error)>;
+
+  enum class State : uint8_t { kPending, kAvailable, kError };
+
+  struct WaiterAndState {
+    static_assert(alignof(std::max_align_t) >= 8 && sizeof(Waiter*) == 8);
+
+    static constexpr uint64_t kStateMask = (1ull << 2) - 1;
+    static constexpr uint64_t kPointerMask = ~kStateMask;
+
+    WaiterAndState(Waiter* ptr, State state) {
+      value = (reinterpret_cast<uintptr_t>(ptr) & kPointerMask) |
+              (static_cast<uintptr_t>(state) & kStateMask);
+    }
+
+    WaiterAndState() : WaiterAndState(nullptr, State::kPending) {}
+
+    State state() const { return static_cast<State>(value & kStateMask); }
+
+    Waiter* waiter() const {
+      return reinterpret_cast<Waiter*>(value & kPointerMask);
+    }
+
+    uintptr_t value;
+  };
+
+  static_assert(std::atomic<WaiterAndState>::is_always_lock_free,
+                "WaiterAndState atomic must be lock-free");
+
+  struct Data {
+    std::atomic<WaiterAndState> waiter_and_state = WaiterAndState();
+    std::optional<Error> error;
+  };
+
+  std::shared_ptr<Data> data_;
+};
+
+class Promise {
+ public:
+  Promise() : data_(std::make_shared<Future::Data>()) {}
+
+  Promise(const Promise&) = default;
+  Promise& operator=(const Promise&) = default;
+
+  Promise(Promise&&) = default;
+  Promise& operator=(Promise&&) = default;
+
+  void SetAvailable();
+  void SetError(Error error);
+
+ private:
+  friend class Future;
+
+  void SetCompleted(Future::State state);
+
+  std::shared_ptr<Future::Data> data_;
+};
+
+// A simple implementation of `tsl::CountDownAsyncValueRef` that is compatible
+// with `ffi::Future`.
+class CountDownPromise {
+ public:
+  CountDownPromise() = default;
+
+  CountDownPromise(Promise promise, int64_t count)
+      : state_(std::make_shared<State>(std::move(promise), count)) {
+    assert(count > 0 && "Count must be positive");
+  }
+
+  explicit CountDownPromise(int64_t count)
+      : CountDownPromise(Promise(), count) {}
+
+  // Drops the count by `count` and returns true if the underlying promise
+  // became available.
+  bool CountDown(size_t count, const Error& error = Error::Success()) {
+    assert(state_->count.load() >= count && "Invalid count down value");
+
+    if (XLA_FFI_PREDICT_FALSE(!error.success())) {
+      std::lock_guard<std::mutex> lock(state_->mutex);  // NOLINT
+      state_->is_error.store(true, std::memory_order_release);
+      state_->error = error;
+    }
+
+    bool is_complete =
+        state_->count.fetch_sub(count, std::memory_order_acq_rel) == count;
+    if (XLA_FFI_PREDICT_FALSE(is_complete)) {
+      bool is_error = state_->is_error.load(std::memory_order_acquire);
+      if (XLA_FFI_PREDICT_FALSE(is_error)) {
+        auto take_error = [&] {
+          std::lock_guard<std::mutex> lock(state_->mutex);  // NOLINT
+          return state_->error;
+        };
+        state_->promise.SetError(take_error());
+      } else {
+        state_->promise.SetAvailable();
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  // Drops the count by `1` and returns true if the underlying promise became
+  // available.
+  bool CountDown(Error error = Error::Success()) { return CountDown(1, error); }
+
+ private:
+  friend class Future;
+
+  struct State {
+    State(Promise promise, int64_t count)
+        : promise(std::move(promise)), count(count), is_error(false) {}
+
+    Promise promise;
+    std::atomic<int64_t> count;
+    std::atomic<bool> is_error;
+
+    std::mutex mutex;  // NOLINT
+    Error error;
+  };
+
+  std::shared_ptr<State> state_;
+
+  const Promise& AsPromise() const { return state_->promise; }
+};
+
+inline Future::Future(const Promise& promise) : data_(promise.data_) {
+  assert(data_.use_count() == 2 &&
+         "Promise can be used to create at most one Future");
+}
+
+inline Future::Future(const CountDownPromise& promise)
+    : Future(promise.AsPromise()) {}
+
+template <typename F>
+void Future::OnReady(F&& f) {
+  static_assert(std::is_invocable_v<F, const std::optional<Error>&>,
+                "F must be compatible with Waiter signature");
+
+  WaiterAndState old_value =
+      data_->waiter_and_state.load(std::memory_order_acquire);
+
+  // If future is already completed, just run the waiter.
+  if (old_value.state() != State::kPending) {
+    f(data_->error);
+    return;
+  }
+
+  // Otherwise, add the waiter to the future.
+  auto* waiter = new Waiter(std::forward<F>(f));
+  auto new_value = WaiterAndState(waiter, State::kPending);
+
+  while (!data_->waiter_and_state.compare_exchange_weak(
+      old_value, new_value, std::memory_order_acq_rel,
+      std::memory_order_acquire)) {
+    // Another thread completed the future, just run the waiter.
+    if (old_value.state() != State::kPending) {
+      assert(old_value.waiter() == nullptr);
+      (*waiter)(data_->error);
+      delete waiter;
+      return;
+    }
+  }
+
+  // If CAS succeeded the future must be in the pending state.
+  assert(old_value.state() == State::kPending);
+}
+
+inline void Promise::SetAvailable() { SetCompleted(Future::State::kAvailable); }
+
+inline void Promise::SetError(Error error) {
+  assert(error.errc() != ErrorCode::kOk);
+  assert(data_->error == std::nullopt);
+  data_->error = std::move(error);
+
+  SetCompleted(Future::State::kError);
+}
+
+inline void Promise::SetCompleted(Future::State state) {
+  Future::WaiterAndState old_value = data_->waiter_and_state.exchange(
+      {nullptr, state}, std::memory_order_acq_rel);
+  assert(old_value.state() == Future::State::kPending);
+
+  if (Future::Waiter* waiter = old_value.waiter()) {
+    (*waiter)(data_->error);
+    delete waiter;
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Arguments
+//===----------------------------------------------------------------------===//
+
+// Dynamically-typed buffer.
+//
+// No checks are done at decoding time. Any dtype and rank combination is
+// accepted.
+class AnyBuffer {
+ public:
+  using Dimensions = Span<const int64_t>;
+
+  explicit AnyBuffer(const XLA_FFI_Buffer* buf) : buf_(buf) {
+    assert(buf != nullptr && "XLA_FFI_Buffer must be non-null");
+  }
+
+  DataType element_type() const { return DataType(buf_->dtype); }
+
+  Dimensions dimensions() const { return Dimensions(buf_->dims, buf_->rank); }
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE size_t size_bytes() const {
+    return ByteWidth(element_type()) * element_count();
+  }
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE size_t element_count() const {
+    Dimensions dims = dimensions();
+    return std::accumulate(dims.begin(), dims.end(), int64_t{1},
+                           std::multiplies<>());
+  }
+
+  void* untyped_data() const { return buf_->data; }
+
+  template <typename T>
+  T* typed_data() const {
+    assert(internal::NativeTypeToCApiDataType<T>() == buf_->dtype &&
+           "Template type must match the underlying buffer dtype");
+    return reinterpret_cast<T*>(buf_->data);
+  }
+
+  template <typename T>
+  T* reinterpret_data() const {
+    assert(sizeof(T) == ByteWidth(element_type()) &&
+           !(reinterpret_cast<std::uintptr_t>(buf_->data) % alignof(T)) &&
+           "Requested type must have the same byte width and alignment as the "
+           "underlying buffer type");
+    return reinterpret_cast<T*>(buf_->data);
+  }
+
+ private:
+  const XLA_FFI_Buffer* buf_;
+};
+
+namespace internal {
+
+// A workaround for the fact that a static_assertion can be evaluated
+// whether or not the template is instantiated
+template <DataType dtype>
+struct always_false : std::false_type {};
+
+template <DataType dtype>
+struct DataTypeToNative {
+  static_assert(always_false<dtype>::value, "unsupported data type");
+};
+
+#define XLA_FFI_REGISTER_DATATYPE_MAPPING(data_type_value, actual_type) \
+  template <>                                                           \
+  struct DataTypeToNative<data_type_value> {                            \
+    using type = actual_type;                                           \
+  };
+
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::PRED, bool);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::U8, uint8_t);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::U16, uint16_t);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::U32, uint32_t);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::U64, uint64_t);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::S8, int8_t);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::S16, int16_t);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::S32, int32_t);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::S64, int64_t);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::F16, uint16_t);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::F32, float);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::F64, double);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::BF16, uint16_t);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::C64, std::complex<float>);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::C128, std::complex<double>);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::TOKEN, void);
+
+#undef XLA_FFI_REGISTER_DATATYPE_MAPPING
+
+inline constexpr size_t kDynamicRank = std::numeric_limits<size_t>::max();
+
+}  // namespace internal
+
+constexpr DataType ToComplex(DataType dtype) {
+  switch (dtype) {
+    case DataType::F32:
+      return DataType::C64;
+    case DataType::F64:
+      return DataType::C128;
+    default:
+      return DataType::INVALID;
+  }
+}
+
+constexpr DataType ToReal(DataType dtype) {
+  switch (dtype) {
+    case DataType::C64:
+      return DataType::F32;
+    case DataType::C128:
+      return DataType::F64;
+    default:
+      return dtype;
+  }
+}
+
+constexpr DataType ToImag(DataType dtype) {
+  switch (dtype) {
+    case DataType::C64:
+      return DataType::F32;
+    case DataType::C128:
+      return DataType::F64;
+    default:
+      return dtype;
+  }
+}
+
+template <DataType dtype>
+using NativeType = typename internal::DataTypeToNative<dtype>::type;
+
+template <DataType dtype>
+constexpr bool IsComplexType() {
+  return std::is_same_v<NativeType<dtype>,
+                        std::complex<NativeType<ToReal(dtype)>>>;
+}
+
+static_assert(ToReal(DataType::C64) == DataType::F32);
+static_assert(ToReal(DataType::C128) == DataType::F64);
+static_assert(ToReal(DataType::F32) == DataType::F32);
+static_assert(ToComplex(DataType::F32) == DataType::C64);
+static_assert(ToComplex(DataType::F64) == DataType::C128);
+static_assert(ToComplex(DataType::S32) == DataType::INVALID);
+static_assert(ToComplex(ToReal(DataType::C64)) == DataType::C64);
+static_assert(ToComplex(ToImag(DataType::C128)) == DataType::C128);
+static_assert(IsComplexType<DataType::C64>());
+static_assert(IsComplexType<DataType::C128>());
+static_assert(!IsComplexType<DataType::F32>());
+
+// Buffer with a statically-known dtype and rank.
+//
+// The dtype and rank are checked at decoding time. If rank is not specified,
+// any rank is accepted.
+template <DataType dtype, size_t rank = internal::kDynamicRank>
+class Buffer {
+ public:
+  using Dimensions = AnyBuffer::Dimensions;
+
+  explicit Buffer(const XLA_FFI_Buffer* buf) : buf_(buf) {
+    assert(buf_ != nullptr && "XLA_FFI_Buffer must be non-null");
+  }
+
+  DataType element_type() const { return dtype; }
+
+  Dimensions dimensions() const {
+    return Dimensions(buf_->dims,
+                      rank == internal::kDynamicRank ? buf_->rank : rank);
+  }
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE size_t size_bytes() const {
+    return ByteWidth(dtype) * element_count();
+  }
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE size_t element_count() const {
+    Dimensions dims = dimensions();
+    return std::accumulate(dims.begin(), dims.end(), int64_t{1},
+                           std::multiplies<>());
+  }
+
+  void* untyped_data() const { return buf_->data; }
+
+  NativeType<dtype>* typed_data() const {
+    return reinterpret_cast<NativeType<dtype>*>(untyped_data());
+  }
+
+ private:
+  const XLA_FFI_Buffer* buf_;
+};
+
+// clang-format off
+template <DataType dtype> using BufferR0 = Buffer<dtype, 0>;
+template <DataType dtype> using BufferR1 = Buffer<dtype, 1>;
+template <DataType dtype> using BufferR2 = Buffer<dtype, 2>;
+template <DataType dtype> using BufferR3 = Buffer<dtype, 3>;
+template <DataType dtype> using BufferR4 = Buffer<dtype, 4>;
+// clang-format on
+
+using Token = BufferR0<DataType::TOKEN>;  // NOLINT
+
+namespace internal {
+
+template <DataType dtype, size_t rank>
+XLA_FFI_ATTRIBUTE_ALWAYS_INLINE bool IsaBuffer(XLA_FFI_Buffer* buf) {
+  return static_cast<DataType>(buf->dtype) == dtype &&
+         (rank == internal::kDynamicRank || buf->rank == rank);
+}
+
+template <DataType dtype, size_t rank>
+XLA_FFI_ATTRIBUTE_ALWAYS_INLINE std::optional<Buffer<dtype, rank>> DecodeBuffer(
+    XLA_FFI_Buffer* buf, DiagnosticEngine& diagnostic) {
+  if (auto buf_dtype = static_cast<DataType>(buf->dtype);
+      XLA_FFI_PREDICT_FALSE(buf_dtype != dtype)) {
+    return diagnostic.Emit("Wrong buffer dtype: expected ")
+           << dtype << " but got " << buf_dtype;
+  }
+
+  if constexpr (rank != internal::kDynamicRank) {
+    if (XLA_FFI_PREDICT_FALSE(buf->rank != rank)) {
+      return diagnostic.Emit("Wrong buffer rank: expected ")
+             << rank << " but got " << buf->rank;
+    }
+  }
+
+  return Buffer<dtype, rank>(buf);
+}
+
+}  // namespace internal
+
+template <DataType dtype, size_t rank = internal::kDynamicRank>
+using ResultBuffer = Result<Buffer<dtype, rank>>;
+
+// clang-format off
+template <DataType dtype> using ResultBufferR0 = ResultBuffer<dtype, 0>;
+template <DataType dtype> using ResultBufferR1 = ResultBuffer<dtype, 1>;
+template <DataType dtype> using ResultBufferR2 = ResultBuffer<dtype, 2>;
+template <DataType dtype> using ResultBufferR3 = ResultBuffer<dtype, 3>;
+template <DataType dtype> using ResultBufferR4 = ResultBuffer<dtype, 4>;
+// clang-format on
+
+//===----------------------------------------------------------------------===//
+// Arguments binding
+//===----------------------------------------------------------------------===//
+
+template <>
+struct ArgBinding<AnyBuffer> {
+  using Arg = AnyBuffer;
+};
+
+template <DataType dtype, size_t rank>
+struct ArgBinding<Buffer<dtype, rank>> {
+  using Arg = Buffer<dtype, rank>;
+};
+
+//===----------------------------------------------------------------------===//
+// Results binding
+//===----------------------------------------------------------------------===//
+
+template <>
+struct RetBinding<Result<AnyBuffer>> {
+  using Ret = AnyBuffer;
+};
+
+template <DataType dtype, size_t rank>
+struct RetBinding<Result<Buffer<dtype, rank>>> {
+  using Ret = Buffer<dtype, rank>;
+};
+
+//===----------------------------------------------------------------------===//
+// Arguments decoding
+//===----------------------------------------------------------------------===//
+
+inline std::ostream& operator<<(std::ostream& os, const XLA_FFI_ArgType type) {
+  switch (type) {
+    case XLA_FFI_ArgType_BUFFER:
+      return os << "buffer";
+  }
+}
+
+template <>
+struct ArgDecoding<AnyBuffer> {
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static bool Isa(XLA_FFI_ArgType type, void* arg) {
+    return type == XLA_FFI_ArgType_BUFFER;
+  }
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<AnyBuffer> Decode(XLA_FFI_ArgType type, void* arg,
+                                         DiagnosticEngine& diagnostic) {
+    if (XLA_FFI_PREDICT_FALSE(type != XLA_FFI_ArgType_BUFFER)) {
+      return diagnostic.Emit("Wrong argument type: expected ")
+             << XLA_FFI_ArgType_BUFFER << " but got " << type;
+    }
+    return AnyBuffer(reinterpret_cast<XLA_FFI_Buffer*>(arg));
+  }
+};
+
+template <DataType dtype, size_t rank>
+struct ArgDecoding<Buffer<dtype, rank>> {
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static bool Isa(XLA_FFI_ArgType type, void* arg) {
+    return type == XLA_FFI_ArgType_BUFFER &&
+           internal::IsaBuffer<dtype, rank>(
+               reinterpret_cast<XLA_FFI_Buffer*>(arg));
+  }
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<Buffer<dtype, rank>> Decode(
+      XLA_FFI_ArgType type, void* arg, DiagnosticEngine& diagnostic) {
+    if (XLA_FFI_PREDICT_FALSE(type != XLA_FFI_ArgType_BUFFER)) {
+      return diagnostic.Emit("Wrong argument type: expected ")
+             << XLA_FFI_ArgType_BUFFER << " but got " << type;
+    }
+
+    return internal::DecodeBuffer<dtype, rank>(
+        reinterpret_cast<XLA_FFI_Buffer*>(arg), diagnostic);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Type-safe wrapper for accessing a variable number of arguments.
+//===----------------------------------------------------------------------===//
+
+class RemainingArgs : public internal::RemainingArgsBase {
+ public:
+  using internal::RemainingArgsBase::RemainingArgsBase;
+
+  template <typename T>
+  ErrorOr<T> get(size_t index) const {
+    size_t idx = offset() + index;
+    if (XLA_FFI_PREDICT_FALSE(idx >= args()->size)) {
+      return Unexpected(
+          Error(ErrorCode::kInvalidArgument, "Index out of range"));
+    }
+
+    DiagnosticEngine diagnostic;
+    std::optional<T> value = ArgDecoding<T>::Decode(
+        args()->types[idx], args()->args[idx], diagnostic);
+    if (XLA_FFI_PREDICT_FALSE(!value.has_value())) {
+      return Unexpected(Error::Internal(diagnostic.Result()));
+    }
+
+    return *value;
+  }
+};
+
+template <>
+struct internal::Decode<internal::RemainingArgsTag> {
+  static std::optional<RemainingArgs> call(DecodingOffsets& offsets,
+                                           DecodingContext& ctx,
+                                           DiagnosticEngine& diagnostic) {
+    return RemainingArgs(&ctx.call_frame->args, offsets.args);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Results decoding
+//===----------------------------------------------------------------------===//
+
+inline std::ostream& operator<<(std::ostream& os, const XLA_FFI_RetType type) {
+  switch (type) {
+    case XLA_FFI_RetType_BUFFER:
+      return os << "buffer";
+  }
+}
+
+template <>
+struct RetDecoding<AnyBuffer> {
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static bool Isa(XLA_FFI_RetType type, void* ret) {
+    return type == XLA_FFI_RetType_BUFFER;
+  }
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<Result<AnyBuffer>> Decode(XLA_FFI_RetType type,
+                                                 void* ret,
+                                                 DiagnosticEngine& diagnostic) {
+    if (XLA_FFI_PREDICT_FALSE(type != XLA_FFI_RetType_BUFFER)) {
+      return diagnostic.Emit("Wrong result type: expected ")
+             << XLA_FFI_RetType_BUFFER << " but got " << type;
+    }
+    return AnyBuffer(reinterpret_cast<XLA_FFI_Buffer*>(ret));
+  }
+};
+
+template <DataType dtype, size_t rank>
+struct RetDecoding<Buffer<dtype, rank>> {
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static bool Isa(XLA_FFI_RetType type, void* ret) {
+    return type == XLA_FFI_RetType_BUFFER &&
+           internal::IsaBuffer<dtype, rank>(
+               reinterpret_cast<XLA_FFI_Buffer*>(ret));
+  }
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<Result<Buffer<dtype, rank>>> Decode(
+      XLA_FFI_RetType type, void* ret, DiagnosticEngine& diagnostic) {
+    if (XLA_FFI_PREDICT_FALSE(type != XLA_FFI_RetType_BUFFER)) {
+      return diagnostic.Emit("Wrong result type: expected ")
+             << XLA_FFI_RetType_BUFFER << " but got " << type;
+    }
+
+    return internal::DecodeBuffer<dtype, rank>(
+        reinterpret_cast<XLA_FFI_Buffer*>(ret), diagnostic);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Type-safe wrapper for accessing a variable number of results.
+//===----------------------------------------------------------------------===//
+
+class RemainingRets : public internal::RemainingRetsBase {
+ public:
+  using internal::RemainingRetsBase::RemainingRetsBase;
+
+  template <typename T>
+  ErrorOr<Result<T>> get(size_t index) const {
+    size_t idx = offset() + index;
+    if (XLA_FFI_PREDICT_FALSE(idx >= rets()->size)) {
+      return Unexpected(
+          Error(ErrorCode::kInvalidArgument, "Index out of range"));
+    }
+
+    DiagnosticEngine diagnostic;
+    std::optional<Result<T>> value = RetDecoding<T>::Decode(
+        rets()->types[idx], rets()->rets[idx], diagnostic);
+    if (XLA_FFI_PREDICT_FALSE(!value.has_value())) {
+      return Unexpected(Error::Internal(diagnostic.Result()));
+    }
+
+    return *value;
+  }
+};
+
+template <>
+struct internal::Decode<internal::RemainingRetsTag> {
+  static std::optional<RemainingRets> call(DecodingOffsets& offsets,
+                                           DecodingContext& ctx,
+                                           DiagnosticEngine& diagnostic) {
+    return RemainingRets(&ctx.call_frame->rets, offsets.rets);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Attributes decoding
+//===----------------------------------------------------------------------===//
+
+#define XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(T, TYPE)                       \
+  template <>                                                               \
+  struct AttrDecoding<Span<const T>> {                                      \
+    using Type = Span<const T>;                                             \
+                                                                            \
+    XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(      \
+        XLA_FFI_AttrType type, void* attr, DiagnosticEngine& diagnostic) {  \
+      if (XLA_FFI_PREDICT_FALSE(type != XLA_FFI_AttrType_ARRAY)) {          \
+        return diagnostic.Emit("Wrong attribute type: expected ")           \
+               << XLA_FFI_AttrType_ARRAY << " but got " << type;            \
+      }                                                                     \
+                                                                            \
+      auto* array = reinterpret_cast<XLA_FFI_Array*>(attr);                 \
+      if (XLA_FFI_PREDICT_FALSE(array->dtype != TYPE)) {                    \
+        return diagnostic.Emit("Wrong array data type: expected ")          \
+               << TYPE << " but got " << array->dtype;                      \
+      }                                                                     \
+                                                                            \
+      return Span<const T>(reinterpret_cast<T*>(array->data), array->size); \
+    }                                                                       \
+  }
+
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(int8_t, XLA_FFI_DataType_S8);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(int16_t, XLA_FFI_DataType_S16);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(int32_t, XLA_FFI_DataType_S32);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(int64_t, XLA_FFI_DataType_S64);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(uint8_t, XLA_FFI_DataType_U8);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(uint16_t, XLA_FFI_DataType_U16);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(uint32_t, XLA_FFI_DataType_U32);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(uint64_t, XLA_FFI_DataType_U64);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(float, XLA_FFI_DataType_F32);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(double, XLA_FFI_DataType_F64);
+
+#undef XLA_FFI_REGISTER_ARRAY_ATTR_DECODING
+
+template <>
+struct AttrDecoding<std::string_view> {
+  using Type = std::string_view;
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static bool Isa(XLA_FFI_AttrType type,
+                                                  void* attr) {
+    return type == XLA_FFI_AttrType_STRING;
+  }
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<std::string_view> Decode(
+      XLA_FFI_AttrType type, void* attr, DiagnosticEngine& diagnostic) {
+    if (XLA_FFI_PREDICT_FALSE(type != XLA_FFI_AttrType_STRING)) {
+      return diagnostic.Emit("Wrong attribute type: expected ")
+             << XLA_FFI_AttrType_STRING << " but got " << type;
+    }
+
+    auto* span = reinterpret_cast<XLA_FFI_ByteSpan*>(attr);
+    return std::string_view(span->ptr, span->len);
+  }
+};
+
+// A type tag to mark i64 attributes as pointers to `T`.
+template <typename T>
+struct Pointer {};
+
+template <typename T>
+struct AttrDecoding<Pointer<T>> {
+  using Type = T*;
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(
+      XLA_FFI_AttrType type, void* attr, DiagnosticEngine& diagnostic) {
+    auto* scalar = reinterpret_cast<XLA_FFI_Scalar*>(attr);
+    if (XLA_FFI_PREDICT_FALSE(type != XLA_FFI_AttrType_SCALAR ||
+                              scalar->dtype != XLA_FFI_DataType_S64)) {
+      return diagnostic.Emit("Wrong attribute type: ")
+             << "expected i64 scalar for passing pointer but got " << type;
+    }
+
+    static_assert(sizeof(uintptr_t) == sizeof(int64_t));
+    uintptr_t ptr = *reinterpret_cast<uintptr_t*>(scalar->value);
+    return reinterpret_cast<Type>(ptr);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Type-safe wrapper for accessing dictionary attributes.
+//===----------------------------------------------------------------------===//
+
+class Dictionary : public internal::DictionaryBase {
+ public:
+  using internal::DictionaryBase::DictionaryBase;
+
+  template <typename T>
+  ErrorOr<T> get(const Iterator& it) const {
+    DiagnosticEngine diagnostic;
+    auto value = internal::DictionaryBase::get<T>(it, diagnostic);
+    if (XLA_FFI_PREDICT_FALSE(!value.has_value())) {
+      return Unexpected(Error::Internal(diagnostic.Result()));
+    }
+    return *value;
+  }
+
+  template <typename T>
+  ErrorOr<T> get(std::string_view name) const {
+    DiagnosticEngine diagnostic;
+    auto value = internal::DictionaryBase::get<T>(name, diagnostic);
+    if (XLA_FFI_PREDICT_FALSE(!value.has_value())) {
+      return Unexpected(Error::Internal(diagnostic.Result()));
+    }
+    return *value;
+  }
+};
+
+// Decode `AttrsTag` (all attributes) into a `Dictionary`.
+template <>
+struct internal::Decode<internal::AttrsTag<Dictionary>> {
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Dictionary> call(
+      DecodingOffsets& offsets, DecodingContext& ctx,
+      DiagnosticEngine& diagnostic) {
+    return Dictionary(&ctx.call_frame->attrs);
+  }
+};
+
+// Decode individual attribute into `Dictionary` type.
+template <>
+struct AttrDecoding<Dictionary> {
+  using Type = Dictionary;
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Dictionary> Decode(
+      XLA_FFI_AttrType type, void* attr, DiagnosticEngine& diagnostic) {
+    if (XLA_FFI_PREDICT_FALSE(type != XLA_FFI_AttrType_DICTIONARY)) {
+      return diagnostic.Emit("Wrong attribute type: expected ")
+             << XLA_FFI_AttrType_DICTIONARY << " but got " << type;
+    }
+    return Dictionary(reinterpret_cast<XLA_FFI_Attrs*>(attr));
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Type-safe wrapper for accessing context.
+//===----------------------------------------------------------------------===//
+
+class Context : public internal::ContextBase {
+ public:
+  using internal::ContextBase::ContextBase;
+
+  template <typename T>
+  ErrorOr<typename CtxDecoding<T>::Type> get() const {
+    DiagnosticEngine diagnostic;
+    auto value = internal::ContextBase::get<T>(diagnostic);
+    if (XLA_FFI_PREDICT_FALSE(!value.has_value())) {
+      return Unexpected(Error::Internal(diagnostic.Result()));
+    }
+    return *value;
+  }
+};
+
+// Context decoding for catch-all `Context` type.
+template <>
+struct CtxDecoding<Context> {
+  using Type = Context;
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<Context> Decode(const XLA_FFI_Api* api,
+                                       XLA_FFI_ExecutionContext* ctx,
+                                       DiagnosticEngine&) {
+    return Context(api, ctx);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Error helpers
+//===----------------------------------------------------------------------===//
+
+namespace internal {
+
+inline XLA_FFI_Error* CreateError(const XLA_FFI_Api* api, const Error& error) {
+  XLA_FFI_Error_Create_Args args;
+  args.struct_size = XLA_FFI_Error_Create_Args_STRUCT_SIZE;
+  args.extension_start = nullptr;
+  args.errc = static_cast<XLA_FFI_Error_Code>(*error.errc());
+  args.message = error.message().c_str();
+  return api->XLA_FFI_Error_Create(&args);
+}
+
+}  // namespace internal
+
+//===----------------------------------------------------------------------===//
+// Result encoding
+//===----------------------------------------------------------------------===//
+
+// Encodes `Error` as an FFI error.
+template <ExecutionStage stage>
+struct ResultEncoding<stage, Error> {
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static XLA_FFI_Error* Encode(const XLA_FFI_Api* api,
+                               XLA_FFI_ExecutionContext* ctx, Error error) {
+    if (XLA_FFI_PREDICT_TRUE(error.success())) {
+      return nullptr;
+    }
+
+    return internal::CreateError(api, error);
+  }
+};
+
+// Encodes `ErrorOr<std::unique_ptr<T>>` as an FFI state.
+template <typename T>
+struct ResultEncoding<ExecutionStage::kInstantiate,
+                      ErrorOr<std::unique_ptr<T>>> {
+  static_assert(std::is_same_v<decltype(T::id), TypeId>,
+                "State type must have a static `TypeId id` field");
+
+  static XLA_FFI_TypeId state_type_id() { return T::id; }
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static XLA_FFI_Error* Encode(const XLA_FFI_Api* api,
+                               XLA_FFI_ExecutionContext* ctx,
+                               ErrorOr<std::unique_ptr<T>> state) {
+    if (XLA_FFI_PREDICT_TRUE(state.has_value())) {
+      XLA_FFI_State_Set_Args args;
+      args.struct_size = XLA_FFI_State_Set_Args_STRUCT_SIZE;
+      args.extension_start = nullptr;
+      args.ctx = ctx;
+      args.type_id = &T::id;
+      args.state = state.value().release();
+      return api->XLA_FFI_State_Set(&args);
+    }
+
+    return internal::CreateError(api, state.error());
+  }
+};
+
+// Encodes `Future` as an asynchronous FFI result.
+template <ExecutionStage stage>
+struct ResultEncoding<stage, Future> {
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::variant<XLA_FFI_Error*, XLA_FFI_Future*> Encode(
+      const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx, Future future) {
+    // Create XLA_FFI_Future object that will signal completion to the runtime.
+    XLA_FFI_Future_Create_Args args;
+    args.struct_size = XLA_FFI_Future_Create_Args_STRUCT_SIZE;
+    args.extension_start = nullptr;
+    args.future = nullptr;
+
+    if (auto* err = api->XLA_FFI_Future_Create(&args)) {
+      return err;
+    }
+
+    assert(args.future != nullptr && "XLA_FFI_Future_Create failed");
+
+    future.OnReady([api, f = args.future](const std::optional<Error>& error) {
+      // When the OnReady callback is invoked, we no longer have access to the
+      // diagnostics, and can't signal an error to the runtime. We chose to
+      // abort execution, because otherwise it will lead to a deadlock. However
+      // we should never get to this point, because execution must be aborted on
+      // a synchronous path when checking XLA FFI version compatibility.
+      auto abort_on_error = [api](XLA_FFI_Error* err) {
+        if (XLA_FFI_PREDICT_TRUE(err == nullptr)) {
+          return;
+        }
+
+        std::cerr << "Failed to signal XLA_FFI_Future completion: "
+                  << internal::GetErrorMessage(api, err) << std::endl;
+        internal::DestroyError(api, err);
+        std::abort();
+      };
+
+      if (XLA_FFI_PREDICT_FALSE(error.has_value())) {
+        XLA_FFI_Future_SetError_Args args;
+        args.struct_size = XLA_FFI_Future_SetError_Args_STRUCT_SIZE;
+        args.extension_start = nullptr;
+        args.future = f;
+        args.error = internal::CreateError(api, *error);
+
+        abort_on_error(api->XLA_FFI_Future_SetError(&args));
+
+      } else {
+        XLA_FFI_Future_SetAvailable_Args args;
+        args.struct_size = XLA_FFI_Future_SetAvailable_Args_STRUCT_SIZE;
+        args.extension_start = nullptr;
+        args.future = f;
+
+        abort_on_error(api->XLA_FFI_Future_SetAvailable(&args));
+      }
+    });
+
+    return args.future;
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// PlatformStream
+//===----------------------------------------------------------------------===//
+
+template <typename T>
+struct PlatformStream {};
+
+// Context decoding for platform stream.
+//
+// Example: Ffi::Bind().Ctx<PlatformStream<cudaStream_t>()
+//                     .To([](cudaStream_t stream) { ... });
+template <typename T>
+struct CtxDecoding<PlatformStream<T>> {
+  using Type = T;
+
+  static_assert(std::is_pointer_v<T>, "stream type must be a pointer");
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<Type> Decode(const XLA_FFI_Api* api,
+                                    XLA_FFI_ExecutionContext* ctx,
+                                    DiagnosticEngine& diagnostic) {
+    XLA_FFI_Stream_Get_Args args;
+    args.struct_size = XLA_FFI_Stream_Get_Args_STRUCT_SIZE;
+    args.extension_start = nullptr;
+    args.ctx = ctx;
+    args.stream = nullptr;
+
+    if (XLA_FFI_Error* error = api->XLA_FFI_Stream_Get(&args)) {
+      diagnostic.Emit("Failed to get platform stream: ")
+          << internal::GetErrorMessage(api, error);
+      internal::DestroyError(api, error);
+      return std::nullopt;
+    }
+
+    return reinterpret_cast<T>(args.stream);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// ScratchAllocator
+//===----------------------------------------------------------------------===//
+
+// Interface for "scratch" allocator for device memory, which deallocates all
+// buffers it has allocated at destruction.
+//
+// WARNING: It is illegal to keep scratch allocator alive after returning from
+// the FFI handler as it relies on execution context whose lifetime is bound to
+// the particular call to FFI handler.
+class ScratchAllocator {
+ public:
+  ~ScratchAllocator();
+
+  ScratchAllocator(ScratchAllocator&&) = default;
+  ScratchAllocator& operator=(ScratchAllocator&&) = delete;
+
+  std::optional<void*> Allocate(size_t size, size_t alignment = 1);
+
+ private:
+  friend struct CtxDecoding<ScratchAllocator>;
+
+  ScratchAllocator(const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx,
+                   DiagnosticEngine& diagnostic);
+
+  struct Allocation {
+    size_t size;
+    void* data;
+  };
+
+  const XLA_FFI_Api* api_;
+  XLA_FFI_ExecutionContext* ctx_;
+
+  DiagnosticEngine& diagnostic_;
+  std::vector<Allocation> allocations_;
+};
+
+// Context decoding for scratch allocator.
+//
+// Example: Ffi::Bind().Ctx<ScratchAllocator>()
+//                     .To([](ScratchAllocator scratch) { ... });
+template <>
+struct CtxDecoding<ScratchAllocator> {
+  using Type = ScratchAllocator;
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(
+      const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx,
+      DiagnosticEngine& diagnostic) {
+    return ScratchAllocator(api, ctx, diagnostic);
+  }
+};
+
+inline std::optional<void*> ScratchAllocator::Allocate(size_t size,
+                                                       size_t alignment) {
+  XLA_FFI_DeviceMemory_Allocate_Args args;
+  args.struct_size = XLA_FFI_DeviceMemory_Allocate_Args_STRUCT_SIZE;
+  args.extension_start = nullptr;
+  args.ctx = ctx_;
+  args.size = size;
+  args.alignment = alignment;
+  args.data = nullptr;
+  if (XLA_FFI_Error* error = api_->XLA_FFI_DeviceMemory_Allocate(&args)) {
+    diagnostic_.Emit("Failed to allocate scratch memory: ")
+        << internal::GetErrorMessage(api_, error);
+    internal::DestroyError(api_, error);
+    return std::nullopt;
+  }
+  allocations_.push_back({size, args.data});
+  return args.data;
+}
+
+inline ScratchAllocator::ScratchAllocator(const XLA_FFI_Api* api,
+                                          XLA_FFI_ExecutionContext* ctx,
+                                          DiagnosticEngine& diagnostic)
+    : api_(api), ctx_(ctx), diagnostic_(diagnostic) {}
+
+inline ScratchAllocator::~ScratchAllocator() {
+  for (Allocation& alloc : allocations_) {
+    XLA_FFI_DeviceMemory_Free_Args args;
+    args.struct_size = XLA_FFI_DeviceMemory_Free_Args_STRUCT_SIZE;
+    args.extension_start = nullptr;
+    args.ctx = ctx_;
+    args.size = alloc.size;
+    args.data = alloc.data;
+    if (XLA_FFI_Error* error = api_->XLA_FFI_DeviceMemory_Free(&args)) {
+      diagnostic_.Emit("Failed to free scratch memory: ")
+          << internal::GetErrorMessage(api_, error);
+      internal::DestroyError(api_, error);
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// ThreadPool
+//===----------------------------------------------------------------------===//
+
+class ThreadPool {
+ public:
+  template <typename F>
+  void Schedule(F&& f) {
+    XLA_FFI_Task* task = +[](void* data) {
+      auto* f = reinterpret_cast<F*>(data);
+      (*f)();
+      delete f;
+    };
+
+    F* data = new F(std::forward<F>(f));
+
+    XLA_FFI_ThreadPool_Schedule_Args args;
+    args.struct_size = XLA_FFI_ThreadPool_Schedule_Args_STRUCT_SIZE;
+    args.extension_start = nullptr;
+    args.ctx = ctx_;
+    args.task = task;
+    args.data = data;
+
+    if (XLA_FFI_Error* error = api_->XLA_FFI_ThreadPool_Schedule(&args)) {
+      diagnostic_.Emit("Failed to schedule task on a thread pool: ")
+          << internal::GetErrorMessage(api_, error);
+      internal::DestroyError(api_, error);
+
+      // If thread pool is not available, we execute the task in the caller
+      // thread. We choose not to return error from `Schedule` for consistency
+      // with Eigen thread pool implementation, and because it would make
+      // recursive work scheduling more difficult.
+      task(data);
+    }
+  }
+
+  int64_t num_threads() const {
+    int64_t num_threads = 0;
+
+    XLA_FFI_ThreadPool_NumThreads_Args args;
+    args.struct_size = XLA_FFI_ThreadPool_NumThreads_Args_STRUCT_SIZE;
+    args.extension_start = nullptr;
+    args.ctx = ctx_;
+    args.num_threads = &num_threads;
+
+    // Silently ignore errors if we can't get the number of threads.
+    if (XLA_FFI_Error* error = api_->XLA_FFI_ThreadPool_NumThreads(&args)) {
+      internal::DestroyError(api_, error);
+    }
+
+    return num_threads;
+  }
+
+ private:
+  friend struct CtxDecoding<ThreadPool>;
+
+  ThreadPool(const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx,
+             DiagnosticEngine& diagnostic);
+
+  const XLA_FFI_Api* api_;
+  XLA_FFI_ExecutionContext* ctx_;
+  DiagnosticEngine& diagnostic_;
+};
+
+// Context decoding for thread pool.
+//
+// Example: Ffi::Bind().Ctx<ThreadPool>()
+//                     .To([](ThreadPool thread_pool) { ... });
+template <>
+struct CtxDecoding<ThreadPool> {
+  using Type = ThreadPool;
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(
+      const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx,
+      DiagnosticEngine& diagnostic) {
+    return ThreadPool(api, ctx, diagnostic);
+  }
+};
+
+inline ThreadPool::ThreadPool(const XLA_FFI_Api* api,
+                              XLA_FFI_ExecutionContext* ctx,
+                              DiagnosticEngine& diagnostic)
+    : api_(api), ctx_(ctx), diagnostic_(diagnostic) {}
+
+//===----------------------------------------------------------------------===//
+// Type Registration
+//===----------------------------------------------------------------------===//
+
+template <typename T>
+constexpr XLA_FFI_TypeInfo MakeTypeInfo() {
+  return XLA_FFI_TypeInfo{
+      XLA_FFI_TypeInfo_STRUCT_SIZE,
+      /*extension_start=*/nullptr,
+      /*deleter=*/[](void* ptr) { delete static_cast<T*>(ptr); },
+  };
+}
+
+#define XLA_FFI_REGISTER_TYPE(API, NAME, TYPE_ID, TYPE_INFO) \
+  XLA_FFI_REGISTER_TYPE_(API, NAME, TYPE_ID, TYPE_INFO, __COUNTER__)
+#define XLA_FFI_REGISTER_TYPE_(API, NAME, TYPE_ID, TYPE_INFO, N) \
+  XLA_FFI_REGISTER_TYPE__(API, NAME, TYPE_ID, TYPE_INFO, N)
+#define XLA_FFI_REGISTER_TYPE__(API, NAME, TYPE_ID, TYPE_INFO, N)              \
+  [[maybe_unused]] static const XLA_FFI_Error*                                 \
+      xla_ffi_type_##N##_registered_ = [] {                                    \
+        return ::xla::ffi::Ffi::RegisterTypeId(API, NAME, TYPE_ID, TYPE_INFO); \
+      }()
+
+//===----------------------------------------------------------------------===//
+// UserData
+//===----------------------------------------------------------------------===//
+
+// A type tag for automatic user data decoding passed via the execution
+// context.
+template <typename T>
+struct UserData {};
+
+// Context decoding for user data of type `T`.
+//
+// Example: Ffi::Bind().Ctx<UserData<MyData>>()
+//                     .To([](MyData* data) { ... });
+template <typename T>
+struct CtxDecoding<UserData<T>> {
+  using Type = T*;
+
+  static_assert(std::is_same_v<decltype(T::id), TypeId>,
+                "UserData type must have a static `TypeId id` field");
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(
+      const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx,
+      DiagnosticEngine& diagnostic) {
+    XLA_FFI_ExecutionContext_Get_Args args;
+    args.struct_size = XLA_FFI_ExecutionContext_Get_Args_STRUCT_SIZE;
+    args.extension_start = nullptr;
+    args.ctx = ctx;
+    args.type_id = &T::id;
+    args.data = nullptr;
+
+    assert(args.type_id->type_id > 0 && "type must be registered with XLA FFI");
+
+    if (XLA_FFI_Error* err = api->XLA_FFI_ExecutionContext_Get(&args); err) {
+      diagnostic.Emit("Failed to get user data from execution context: ")
+          << internal::GetErrorMessage(api, err);
+      internal::DestroyError(api, err);
+      return std::nullopt;
+    }
+
+    return static_cast<Type>(args.data);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// State
+//===----------------------------------------------------------------------===//
+
+// A type tag for automatic state decoding passed via the execution
+// context.
+template <typename T>
+struct State {};
+
+// Context decoding for state of type `T`.
+//
+// Example: Ffi::Bind().Ctx<State<MyState>>()
+//                     .To([](MyState* state) { ... });
+template <typename T>
+struct CtxDecoding<State<T>> {
+  using Type = T*;
+
+  static_assert(std::is_same_v<decltype(T::id), TypeId>,
+                "State type must have a static `TypeId id` field");
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(
+      const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx,
+      DiagnosticEngine& diagnostic) {
+    XLA_FFI_State_Get_Args args;
+    args.struct_size = XLA_FFI_State_Get_Args_STRUCT_SIZE;
+    args.extension_start = nullptr;
+    args.ctx = ctx;
+    args.type_id = &T::id;
+    args.state = nullptr;
+
+    assert(args.type_id->type_id > 0 && "type must be registered with XLA FFI");
+
+    if (XLA_FFI_Error* err = api->XLA_FFI_State_Get(&args); err) {
+      diagnostic.Emit("Failed to get state from execution context: ")
+          << internal::GetErrorMessage(api, err);
+      internal::DestroyError(api, err);
+      return std::nullopt;
+    }
+
+    return static_cast<Type>(args.state);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// RunId
+//===----------------------------------------------------------------------===//
+
+struct RunId {
+  int64_t run_id;
+};
+
+// Context decoding for RunId (unique identifier of a logical execution).
+//
+// Example: Ffi::Bind().Ctx<RunId>()
+//                     .To([](RunId run_id) { ... });
+template <>
+struct CtxDecoding<RunId> {
+  using Type = RunId;
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(
+      const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx,
+      DiagnosticEngine& diagnostic) {
+    XLA_FFI_RunId_Get_Args args;
+    args.struct_size = XLA_FFI_ExecutionContext_Get_Args_STRUCT_SIZE;
+    args.extension_start = nullptr;
+    args.ctx = ctx;
+    args.run_id = 0;
+
+    if (XLA_FFI_Error* err = api->XLA_FFI_RunId_Get(&args); err) {
+      diagnostic.Emit("Failed to get run id from execution context: ")
+          << internal::GetErrorMessage(api, err);
+      internal::DestroyError(api, err);
+      return std::nullopt;
+    }
+
+    return RunId{args.run_id};
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// DeviceOrdinal
+//===----------------------------------------------------------------------===//
+
+struct DeviceOrdinal {};
+
+// Context decoding for DeviceOrdinal.
+//
+// Example: Ffi::Bind().Ctx<DeviceOrdinal>()
+//                     .To([](int32_t device_ordinal) { ... });
+template <>
+struct CtxDecoding<DeviceOrdinal> {
+  using Type = int32_t;
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(
+      const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx,
+      DiagnosticEngine& diagnostic) {
+    XLA_FFI_DeviceOrdinal_Get_Args args;
+    args.struct_size = XLA_FFI_DeviceOrdinal_Get_Args_STRUCT_SIZE;
+    args.extension_start = nullptr;
+    args.ctx = ctx;
+    args.device_ordinal = 0;
+
+    if (XLA_FFI_Error* err = api->XLA_FFI_DeviceOrdinal_Get(&args); err) {
+      diagnostic.Emit("Failed to get device ordinal from execution context: ")
+          << internal::GetErrorMessage(api, err);
+      internal::DestroyError(api, err);
+      return std::nullopt;
+    }
+
+    return args.device_ordinal;
+  }
+};
+
+}  // namespace xla::ffi
+
+#endif  // XLA_FFI_API_FFI_H_

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ option(BUILD_TESTS "Whether to build mori CPP tests" ON)
 option(ENABLE_PROFILER "Enable kernel profiling" OFF)
 option(ENABLE_DEBUG_PRINTF "Enable debug printf in device kernels" OFF)
 option(ENABLE_STANDARD_MOE_ADAPT "Enable standard moe adapt" OFF)
+option(ENABLE_XLA_FFI "Build XLA FFI custom call handlers for JAX integration" OFF)
 
 # ---------------------------------------------------------------------------
 # Host NIC: link all available NIC libraries (can be multiple).
@@ -390,6 +391,11 @@ endif()
 
 if(BUILD_PYBINDS)
   add_subdirectory(src/pybind)
+endif()
+
+if(ENABLE_XLA_FFI)
+  message(STATUS "ENABLE_XLA_FFI = ON")
+  add_subdirectory(src/ffi)
 endif()
 
 if(BUILD_TESTS)

--- a/python/mori/__init__.py
+++ b/python/mori/__init__.py
@@ -20,13 +20,20 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import os
+import importlib
 
-from . import cpp
-from . import ops
-from . import shmem
-from . import io
-from . import ir
-from . import kernel_profiler
+# All submodules are lazy-imported so that `import mori` (or any
+# subpackage like mori.jax) does not eagerly pull in heavy dependencies
+# such as torch. Submodules are loaded on first attribute access.
+_LAZY_MODULES = {"cpp", "ops", "shmem", "io", "ir", "kernel_profiler", "jax"}
+
+
+def __getattr__(name):
+    if name in _LAZY_MODULES:
+        mod = importlib.import_module(f".{name}", __name__)
+        globals()[name] = mod
+        return mod
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 if os.environ.get("MORI_PRECOMPILE", "").lower() in ("1", "true", "on"):
     from .jit import precompile

--- a/python/mori/jax/__init__.py
+++ b/python/mori/jax/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+# MIT License
+#
+# Based on PR #173 by Chao Chen <cchen104@amd.com>
+"""Mori JAX integration -- XLA FFI custom call handlers for MoE ops."""
+
+from mori.jax._ffi_registry import register_ffi_targets  # noqa: F401
+from mori.jax.ops import EpDispatchCombineOp  # noqa: F401

--- a/python/mori/jax/_ffi_registry.py
+++ b/python/mori/jax/_ffi_registry.py
@@ -1,0 +1,176 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+# MIT License
+#
+# Based on PR #173 by Chao Chen <cchen104@amd.com>
+# Adapted for refactored build layout (shared libs with RPATH).
+"""Load libmori_xla_ffi_ops.so and register FFI targets with JAX."""
+
+import ctypes
+import os
+import pathlib
+
+_lib = None
+_FFI_TARGET_NAMES = [
+    "mori_ep_dispatch",
+    "mori_ep_combine",
+    "mori_ep_dispatch_recv",
+    "mori_ep_combine_recv",
+    "mori_ep_reset",
+]
+
+
+def _find_library() -> str:
+    """Locate libmori_xla_ffi_ops.so."""
+    pkg_dir = pathlib.Path(__file__).resolve().parent
+
+    candidates = [
+        pkg_dir.parent / "libmori_xla_ffi_ops.so",
+        pkg_dir.parent / "lib" / "libmori_xla_ffi_ops.so",
+        pkg_dir.parent.parent / "lib" / "libmori_xla_ffi_ops.so",
+    ]
+    for p in candidates:
+        if p.exists():
+            return str(p)
+
+    env_path = os.environ.get("MORI_XLA_FFI_LIB")
+    if env_path and os.path.exists(env_path):
+        return env_path
+
+    raise FileNotFoundError(
+        "Cannot find libmori_xla_ffi_ops.so. "
+        "Build mori with -DENABLE_XLA_FFI=ON or set MORI_XLA_FFI_LIB."
+    )
+
+
+def _load_dependencies():
+    """Pre-load shared libraries that libmori_xla_ffi_ops.so depends on."""
+    pkg_dir = pathlib.Path(__file__).resolve().parent.parent
+    for name in [
+        "libmori_ops.so",
+        "libmori_shmem.so",
+        "libmori_application.so",
+        "libmori_io.so",
+    ]:
+        lib_path = pkg_dir / name
+        if lib_path.exists():
+            ctypes.CDLL(str(lib_path), mode=ctypes.RTLD_GLOBAL)
+
+
+def _load_library():
+    global _lib
+    if _lib is not None:
+        return _lib
+    _load_dependencies()
+    lib_path = _find_library()
+    _lib = ctypes.CDLL(lib_path)
+
+    _lib.mori_ffi_create_handle.restype = ctypes.c_int64
+    _lib.mori_ffi_create_handle.argtypes = [
+        ctypes.c_int,  # rank
+        ctypes.c_int,  # world_size
+        ctypes.c_int,  # hidden_dim
+        ctypes.c_int,  # scale_dim
+        ctypes.c_int,  # scale_type_size
+        ctypes.c_int,  # max_token_type_size
+        ctypes.c_int,  # max_num_inp_token_per_rank
+        ctypes.c_int,  # num_experts_per_rank
+        ctypes.c_int,  # num_experts_per_token
+        ctypes.c_int,  # warp_num_per_block
+        ctypes.c_int,  # block_num
+        ctypes.c_int,  # kernel_type
+        ctypes.c_int,  # gpu_per_node
+        ctypes.c_int,  # rdma_block_num
+        ctypes.c_int,  # num_qp_per_pe
+    ]
+
+    _lib.mori_ffi_destroy_handle.restype = None
+    _lib.mori_ffi_destroy_handle.argtypes = [ctypes.c_int64]
+
+    _lib.mori_ffi_register_kernel_module.restype = None
+    _lib.mori_ffi_register_kernel_module.argtypes = [
+        ctypes.c_int,
+        ctypes.c_char_p,
+    ]
+
+    return _lib
+
+
+def register_ffi_targets():
+    """Register all mori FFI handler symbols with JAX.
+
+    Call this once at import time. Requires jax to be importable.
+    """
+    try:
+        import jax
+    except ImportError:
+        raise ImportError(
+            "jax is required to register FFI targets. "
+            "Install jax first (pip install jax[rocm])."
+        )
+
+    # jax.extend.ffi was removed in JAX 0.7.0; use jax.ffi instead
+    if hasattr(jax, "ffi"):
+        jax_ffi = jax.ffi
+    else:
+        from jax.extend import ffi as jax_ffi
+
+    lib = _load_library()
+    for name in _FFI_TARGET_NAMES:
+        fn_ptr = ctypes.cast(getattr(lib, name), ctypes.c_void_p).value
+        capsule = ctypes.pythonapi.PyCapsule_New(
+            ctypes.c_void_p(fn_ptr),
+            b"xla._CUSTOM_CALL_TARGET",
+            None,
+        )
+        jax_ffi.register_ffi_target(name, capsule, platform="rocm")
+
+
+def register_kernel_module(kernel_type: int, hsaco_path: str):
+    """Register a pre-compiled .hsaco kernel module for FFI kernel launch.
+
+    This must be called before using dispatch/combine FFI ops. The Python
+    JIT system (mori.jit.core.compile_genco) can be used to produce the
+    .hsaco file.
+
+    Args:
+        kernel_type: KernelType enum value (0=IntraNode, 1=InterNode, etc.)
+        hsaco_path: Path to the compiled .hsaco file
+    """
+    lib = _load_library()
+    lib.mori_ffi_register_kernel_module(kernel_type, hsaco_path.encode())
+
+
+def create_handle(
+    rank: int,
+    world_size: int,
+    hidden_dim: int,
+    scale_dim: int = 0,
+    scale_type_size: int = 0,
+    max_token_type_size: int = 4,
+    max_num_inp_token_per_rank: int = 128,
+    num_experts_per_rank: int = 1,
+    num_experts_per_token: int = 2,
+    warp_num_per_block: int = 1,
+    block_num: int = 1,
+    kernel_type: int = 0,
+    gpu_per_node: int = 8,
+    rdma_block_num: int = 0,
+    num_qp_per_pe: int = 1,
+) -> int:
+    """Create an EpDispatchCombineHandle and return its integer ID."""
+    lib = _load_library()
+    return lib.mori_ffi_create_handle(
+        rank, world_size, hidden_dim,
+        scale_dim, scale_type_size,
+        max_token_type_size, max_num_inp_token_per_rank,
+        num_experts_per_rank, num_experts_per_token,
+        warp_num_per_block, block_num,
+        kernel_type, gpu_per_node,
+        rdma_block_num, num_qp_per_pe,
+    )
+
+
+def destroy_handle(handle_id: int) -> None:
+    """Destroy an EpDispatchCombineHandle by its ID."""
+    lib = _load_library()
+    lib.mori_ffi_destroy_handle(handle_id)

--- a/python/mori/jax/_ffi_registry.py
+++ b/python/mori/jax/_ffi_registry.py
@@ -174,3 +174,17 @@ def destroy_handle(handle_id: int) -> None:
     """Destroy an EpDispatchCombineHandle by its ID."""
     lib = _load_library()
     lib.mori_ffi_destroy_handle(handle_id)
+
+
+def shmem_module_init_for_kernel(kernel_type: int):
+    """Initialize globalGpuStates in a registered kernel module.
+
+    Must be called after both shmem_init and register_kernel_module.
+    This copies the shmem peer addresses and PE info into the kernel
+    module's device symbols so that shmem device functions work.
+
+    Args:
+        kernel_type: KernelType enum value matching a previously registered module
+    """
+    lib = _load_library()
+    lib.mori_ffi_shmem_module_init_from_kernel(kernel_type)

--- a/python/mori/jax/ops.py
+++ b/python/mori/jax/ops.py
@@ -1,0 +1,102 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+# MIT License
+#
+# Based on PR #173 by Chao Chen <cchen104@amd.com>
+# Adapted for refactored architecture with JIT kernel compilation.
+"""High-level JAX wrappers for mori MoE dispatch/combine operations."""
+
+from mori.jax import _ffi_registry
+
+# Kernel type constants (mirrors mori::moe::KernelType)
+INTRA_NODE = 0
+INTER_NODE = 1
+INTER_NODE_V1 = 2
+INTER_NODE_V1_LL = 3
+ASYNC_LL = 4
+
+_KERNEL_TYPE_TO_HIP = {
+    INTRA_NODE: "ep_intranode",
+    INTER_NODE: "ep_internode",
+    INTER_NODE_V1: "ep_internode_v1",
+    INTER_NODE_V1_LL: "ep_internode_v1ll",
+    ASYNC_LL: "ep_async_ll",
+}
+
+
+class EpDispatchCombineOp:
+    """Manages an EpDispatchCombine handle and exposes dispatch/combine as
+    JAX-compatible operations via XLA FFI custom calls.
+
+    Usage::
+
+        op = EpDispatchCombineOp(
+            rank=0, world_size=8, hidden_dim=4096,
+            num_experts_per_rank=8, num_experts_per_token=2,
+            max_num_inp_token_per_rank=128)
+        # ... use op.handle_id as an FFI attribute in custom calls ...
+        op.close()
+    """
+
+    def __init__(
+        self,
+        rank: int,
+        world_size: int,
+        hidden_dim: int,
+        scale_dim: int = 0,
+        scale_type_size: int = 0,
+        max_token_type_size: int = 4,
+        max_num_inp_token_per_rank: int = 128,
+        num_experts_per_rank: int = 1,
+        num_experts_per_token: int = 2,
+        warp_num_per_block: int = 1,
+        block_num: int = 1,
+        kernel_type: int = INTRA_NODE,
+        gpu_per_node: int = 8,
+        rdma_block_num: int = 0,
+        num_qp_per_pe: int = 1,
+    ):
+        self._ensure_kernels(kernel_type)
+        self.handle_id = _ffi_registry.create_handle(
+            rank=rank,
+            world_size=world_size,
+            hidden_dim=hidden_dim,
+            scale_dim=scale_dim,
+            scale_type_size=scale_type_size,
+            max_token_type_size=max_token_type_size,
+            max_num_inp_token_per_rank=max_num_inp_token_per_rank,
+            num_experts_per_rank=num_experts_per_rank,
+            num_experts_per_token=num_experts_per_token,
+            warp_num_per_block=warp_num_per_block,
+            block_num=block_num,
+            kernel_type=kernel_type,
+            gpu_per_node=gpu_per_node,
+            rdma_block_num=rdma_block_num,
+            num_qp_per_pe=num_qp_per_pe,
+        )
+        self._kernel_type = kernel_type
+        self._closed = False
+
+    @staticmethod
+    def _ensure_kernels(kernel_type: int):
+        """JIT-compile and register .hsaco kernels for the given kernel_type."""
+        from mori.jit.core import compile_genco
+
+        if kernel_type not in _KERNEL_TYPE_TO_HIP:
+            raise ValueError(f"Unknown kernel_type: {kernel_type}")
+        hip_name = _KERNEL_TYPE_TO_HIP[kernel_type]
+        hsaco_path = compile_genco(hip_name)
+        _ffi_registry.register_kernel_module(kernel_type, hsaco_path)
+
+    def close(self):
+        if not self._closed:
+            _ffi_registry.destroy_handle(self.handle_id)
+            self._closed = True
+
+    def __del__(self):
+        self.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()

--- a/python/mori/jax/ops.py
+++ b/python/mori/jax/ops.py
@@ -78,7 +78,11 @@ class EpDispatchCombineOp:
 
     @staticmethod
     def _ensure_kernels(kernel_type: int):
-        """JIT-compile and register .hsaco kernels for the given kernel_type."""
+        """JIT-compile and register .hsaco kernels for the given kernel_type.
+
+        Also initializes globalGpuStates in the loaded module so that shmem
+        device functions work correctly. Requires shmem to be initialized.
+        """
         from mori.jit.core import compile_genco
 
         if kernel_type not in _KERNEL_TYPE_TO_HIP:
@@ -86,6 +90,14 @@ class EpDispatchCombineOp:
         hip_name = _KERNEL_TYPE_TO_HIP[kernel_type]
         hsaco_path = compile_genco(hip_name)
         _ffi_registry.register_kernel_module(kernel_type, hsaco_path)
+        # globalGpuStates is now initialized automatically inside
+        # KernelManager::RegisterModule via ShmemModuleInit.
+        # If shmem was initialized after module registration, call
+        # shmem_module_init_for_kernel to re-initialize.
+        try:
+            _ffi_registry.shmem_module_init_for_kernel(kernel_type)
+        except Exception:
+            pass
 
     def close(self):
         if not self._closed:

--- a/python/mori/jax/shmem.py
+++ b/python/mori/jax/shmem.py
@@ -2,7 +2,9 @@
 # MIT License
 """JAX-native shmem initialization and array interop helpers.
 
-Allows using mori shmem from JAX without any torch dependency.
+Fully torch-free: uses ctypes to call shmem functions from
+libmori_xla_ffi_ops.so directly, bypassing the mori pybind module
+and its torch dependency.
 
 Usage::
 
@@ -12,38 +14,260 @@ Usage::
     from mori.jax.shmem import shmem_jax_init, jax_data_ptr, shmem_ptr_to_jax
     shmem_jax_init()
 
-    # Register a jax array for RDMA
-    from mori.shmem import api as shmem
-    shmem.shmem_buffer_register(jax_data_ptr(arr), arr.nbytes)
-
-    # Wrap shmem-allocated memory as jax.Array
-    import jax.numpy as jnp
-    ptr = shmem.shmem_malloc(size)
+    # Allocate symmetric memory
+    ptr = shmem_malloc(size)
     arr = shmem_ptr_to_jax(ptr, (M, N), jnp.float32)
+
+    # Register a jax array for RDMA
+    shmem_register_jax_array(arr)
 """
 
 import ctypes
 
-from mori.tensor_utils import GpuTensorView, kDLFloat, kDLInt, kDLUInt, kDLBfloat
+from mori.jax._ffi_registry import _load_library
+
+# ---------------------------------------------------------------------------
+# DLPack constants and GpuTensorView (self-contained, no mori.tensor_utils)
+# ---------------------------------------------------------------------------
+kDLCUDA = 2
+kDLROCM = 10
+kDLFloat = 2
+kDLInt = 0
+kDLUInt = 1
+kDLBfloat = 4
+
+_DL_GPU_DEVICE_TYPE = None
+
+
+def _get_dl_gpu_device_type():
+    global _DL_GPU_DEVICE_TYPE
+    if _DL_GPU_DEVICE_TYPE is not None:
+        return _DL_GPU_DEVICE_TYPE
+    import os
+    _DL_GPU_DEVICE_TYPE = kDLROCM if os.path.isdir("/opt/rocm") else kDLCUDA
+    return _DL_GPU_DEVICE_TYPE
+
+
+class _DLDataType(ctypes.Structure):
+    _fields_ = [("code", ctypes.c_uint8), ("bits", ctypes.c_uint8), ("lanes", ctypes.c_uint16)]
+
+
+class _DLDevice(ctypes.Structure):
+    _fields_ = [("device_type", ctypes.c_int32), ("device_id", ctypes.c_int32)]
+
+
+class _DLTensor(ctypes.Structure):
+    _fields_ = [
+        ("data", ctypes.c_void_p), ("device", _DLDevice), ("ndim", ctypes.c_int32),
+        ("dtype", _DLDataType), ("shape", ctypes.POINTER(ctypes.c_int64)),
+        ("strides", ctypes.POINTER(ctypes.c_int64)), ("byte_offset", ctypes.c_uint64),
+    ]
+
+
+_DL_DELETER = ctypes.CFUNCTYPE(None, ctypes.c_void_p)
+
+
+@_DL_DELETER
+def _dl_noop_deleter(_ptr):
+    pass
+
+
+class _DLManagedTensor(ctypes.Structure):
+    _fields_ = [
+        ("dl_tensor", _DLTensor), ("manager_ctx", ctypes.c_void_p), ("deleter", _DL_DELETER),
+    ]
+
+
+_PyCapsule_New = ctypes.pythonapi.PyCapsule_New
+_PyCapsule_New.restype = ctypes.py_object
+_PyCapsule_New.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p]
+
+
+class GpuTensorView:
+    """Non-owning GPU array view with DLPack + __cuda_array_interface__."""
+
+    def __init__(self, ptr, shape, *, dl_dtype, typestr, device_id=0):
+        self._ptr = ptr
+        self._shape = tuple(shape)
+        self._dl_code, self._dl_bits = dl_dtype
+        self._device_id = device_id
+        self.__cuda_array_interface__ = {
+            "data": (ptr, False), "shape": self._shape, "typestr": typestr, "version": 2,
+        }
+        self._dlpack_refs = None
+
+    def __dlpack__(self, *, stream=None):
+        ndim = len(self._shape)
+        shape_arr = (ctypes.c_int64 * ndim)(*self._shape)
+        managed = _DLManagedTensor()
+        managed.dl_tensor.data = ctypes.c_void_p(self._ptr)
+        managed.dl_tensor.device = _DLDevice(_get_dl_gpu_device_type(), self._device_id)
+        managed.dl_tensor.ndim = ndim
+        managed.dl_tensor.dtype = _DLDataType(self._dl_code, self._dl_bits, 1)
+        managed.dl_tensor.shape = shape_arr
+        managed.dl_tensor.strides = None
+        managed.dl_tensor.byte_offset = 0
+        managed.manager_ctx = None
+        managed.deleter = _dl_noop_deleter
+        self._dlpack_refs = (managed, shape_arr)
+        return _PyCapsule_New(ctypes.byref(managed), b"dltensor", None)
+
+    def __dlpack_device__(self):
+        return (_get_dl_gpu_device_type(), self._device_id)
+
+
+# ---------------------------------------------------------------------------
+# Shmem C API wrappers (via ctypes, torch-free)
+# ---------------------------------------------------------------------------
+
+_shmem_lib_setup_done = False
+MORI_SHMEM_UNIQUE_ID_BYTES = 128
+
+
+def _setup_shmem_ctypes():
+    global _shmem_lib_setup_done
+    if _shmem_lib_setup_done:
+        return
+    lib = _load_library()
+
+    lib.mori_ffi_shmem_get_unique_id.restype = ctypes.c_int
+    lib.mori_ffi_shmem_get_unique_id.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_int)]
+
+    lib.mori_ffi_shmem_init_attr.restype = ctypes.c_int64
+    lib.mori_ffi_shmem_init_attr.argtypes = [
+        ctypes.c_uint, ctypes.c_int, ctypes.c_int, ctypes.c_void_p, ctypes.c_int,
+    ]
+
+    lib.mori_ffi_shmem_finalize.restype = ctypes.c_int64
+    lib.mori_ffi_shmem_finalize.argtypes = []
+
+    lib.mori_ffi_load_shmem_module.restype = ctypes.c_int64
+    lib.mori_ffi_load_shmem_module.argtypes = [ctypes.c_char_p]
+
+    lib.mori_ffi_shmem_module_init.restype = ctypes.c_int64
+    lib.mori_ffi_shmem_module_init.argtypes = [ctypes.c_uint64]
+
+    lib.mori_ffi_shmem_mype.restype = ctypes.c_int
+    lib.mori_ffi_shmem_npes.restype = ctypes.c_int
+    lib.mori_ffi_shmem_barrier_all.restype = None
+    lib.mori_ffi_shmem_barrier_on_stream.restype = None
+    lib.mori_ffi_shmem_barrier_on_stream.argtypes = [ctypes.c_int64]
+
+    lib.mori_ffi_shmem_malloc.restype = ctypes.c_uint64
+    lib.mori_ffi_shmem_malloc.argtypes = [ctypes.c_uint64]
+    lib.mori_ffi_shmem_free.restype = None
+    lib.mori_ffi_shmem_free.argtypes = [ctypes.c_uint64]
+
+    lib.mori_ffi_shmem_buffer_register.restype = ctypes.c_int64
+    lib.mori_ffi_shmem_buffer_register.argtypes = [ctypes.c_uint64, ctypes.c_uint64]
+    lib.mori_ffi_shmem_buffer_deregister.restype = ctypes.c_int64
+    lib.mori_ffi_shmem_buffer_deregister.argtypes = [ctypes.c_uint64, ctypes.c_uint64]
+
+    lib.mori_ffi_shmem_ptr_p2p.restype = ctypes.c_uint64
+    lib.mori_ffi_shmem_ptr_p2p.argtypes = [ctypes.c_uint64, ctypes.c_int, ctypes.c_int]
+
+    lib.mori_ffi_shmem_num_qp_per_pe.restype = ctypes.c_int
+    lib.mori_ffi_shmem_init_flag_uniqueid.restype = ctypes.c_uint
+
+    _shmem_lib_setup_done = True
+
+
+def shmem_get_unique_id() -> bytes:
+    _setup_shmem_ctypes()
+    lib = _load_library()
+    buf = (ctypes.c_uint8 * MORI_SHMEM_UNIQUE_ID_BYTES)()
+    size = ctypes.c_int(0)
+    lib.mori_ffi_shmem_get_unique_id(buf, ctypes.byref(size))
+    return bytes(buf[:size.value])
+
+
+def shmem_init_attr(flags, rank, nranks, uid_bytes):
+    _setup_shmem_ctypes()
+    lib = _load_library()
+    uid_buf = (ctypes.c_uint8 * len(uid_bytes))(*uid_bytes)
+    return lib.mori_ffi_shmem_init_attr(flags, rank, nranks, uid_buf, len(uid_bytes))
+
+
+def shmem_finalize():
+    _setup_shmem_ctypes()
+    return _load_library().mori_ffi_shmem_finalize()
+
+
+def shmem_malloc(size):
+    _setup_shmem_ctypes()
+    return _load_library().mori_ffi_shmem_malloc(size)
+
+
+def shmem_free(ptr):
+    _setup_shmem_ctypes()
+    _load_library().mori_ffi_shmem_free(ptr)
+
+
+def shmem_buffer_register(ptr, size):
+    _setup_shmem_ctypes()
+    return _load_library().mori_ffi_shmem_buffer_register(ptr, size)
+
+
+def shmem_buffer_deregister(ptr, size):
+    _setup_shmem_ctypes()
+    return _load_library().mori_ffi_shmem_buffer_deregister(ptr, size)
+
+
+def shmem_barrier_all():
+    _setup_shmem_ctypes()
+    _load_library().mori_ffi_shmem_barrier_all()
+
+
+def shmem_barrier_on_stream(stream=0):
+    _setup_shmem_ctypes()
+    _load_library().mori_ffi_shmem_barrier_on_stream(stream)
+
+
+def shmem_ptr_p2p(dest_ptr, my_pe, dest_pe):
+    _setup_shmem_ctypes()
+    return _load_library().mori_ffi_shmem_ptr_p2p(dest_ptr, my_pe, dest_pe)
+
+
+def shmem_mype():
+    _setup_shmem_ctypes()
+    return _load_library().mori_ffi_shmem_mype()
+
+
+def shmem_npes():
+    _setup_shmem_ctypes()
+    return _load_library().mori_ffi_shmem_npes()
+
+
+_shmem_module_loaded = False
+
+
+def _ensure_shmem_module():
+    """JIT-compile and load the shmem device module."""
+    global _shmem_module_loaded
+    if _shmem_module_loaded:
+        return
+    _setup_shmem_ctypes()
+    from mori.jit.core import compile_genco
+    hsaco = compile_genco("shmem_kernels")
+    _load_library().mori_ffi_load_shmem_module(hsaco.encode())
+    _shmem_module_loaded = True
+
+
+# ---------------------------------------------------------------------------
+# JAX-native shmem init
+# ---------------------------------------------------------------------------
 
 
 def shmem_jax_init():
     """Initialize shmem from JAX distributed runtime.
 
     Requires ``jax.distributed.initialize()`` to have been called first.
-    Broadcasts UniqueId from process 0 to all processes.
 
     Returns:
         Status code (0 for success).
     """
     import jax
     import numpy as np
-    from mori.shmem.api import (
-        _ensure_shmem_module,
-        shmem_get_unique_id,
-        shmem_init_attr,
-        MORI_SHMEM_INIT_WITH_UNIQUEID,
-    )
 
     _ensure_shmem_module()
 
@@ -57,41 +281,36 @@ def shmem_jax_init():
         uid_arr = None
 
     from jax.experimental.multihost_utils import broadcast_one_to_all
-
     uid_arr = broadcast_one_to_all(uid_arr)
     uid_bytes = uid_arr.tobytes()
 
-    return shmem_init_attr(MORI_SHMEM_INIT_WITH_UNIQUEID, rank, world_size, uid_bytes)
+    _setup_shmem_ctypes()
+    flag = _load_library().mori_ffi_shmem_init_flag_uniqueid()
+    return shmem_init_attr(flag, rank, world_size, uid_bytes)
+
+
+# ---------------------------------------------------------------------------
+# JAX array interop
+# ---------------------------------------------------------------------------
 
 
 def jax_data_ptr(arr) -> int:
-    """Extract raw GPU device pointer from a single-device jax.Array.
-
-    Args:
-        arr: A single-device jax.Array on GPU.
-
-    Returns:
-        Integer device pointer address.
-    """
-    import jax
-
+    """Extract raw GPU device pointer from a single-device jax.Array."""
     if hasattr(arr, "addressable_data"):
         buf = arr.addressable_data(0)
     else:
         buf = arr
-
     if hasattr(buf, "unsafe_buffer_pointer"):
         return buf.unsafe_buffer_pointer()
-
-    dl_capsule = jax.dlpack.to_dlpack(buf)
+    dl_capsule = arr.__dlpack__()
     managed = ctypes.cast(
         ctypes.pythonapi.PyCapsule_GetPointer(
             ctypes.py_object(dl_capsule), b"dltensor"
         ),
-        ctypes.POINTER(_DLManagedTensorCompat),
+        ctypes.POINTER(_DLManagedTensor),
     )
     return managed.contents.dl_tensor.data
-    
+
 
 _JAX_DTYPE_TO_DL = None
 
@@ -101,7 +320,6 @@ def _init_jax_dtype_map():
     if _JAX_DTYPE_TO_DL is not None:
         return
     import jax.numpy as jnp
-
     _JAX_DTYPE_TO_DL = {
         jnp.float32: (kDLFloat, 32, "<f4"),
         jnp.float64: (kDLFloat, 64, "<f8"),
@@ -115,11 +333,14 @@ def _init_jax_dtype_map():
     }
 
 
+_dlpack_prevent_gc = []
+
+
 def shmem_ptr_to_jax(ptr, shape, dtype, device_id=0):
     """Wrap a shmem-allocated GPU pointer as a jax.Array (zero-copy via DLPack).
 
     Args:
-        ptr: int64 device pointer address (e.g. from shmem_malloc).
+        ptr: int64 device pointer address.
         shape: tuple of dimensions.
         dtype: jax.numpy dtype (e.g. jnp.float32).
         device_id: GPU device ordinal (default 0).
@@ -136,45 +357,16 @@ def shmem_ptr_to_jax(ptr, shape, dtype, device_id=0):
     dl_code, dl_bits, typestr = info
 
     view = GpuTensorView(
-        ptr, shape,
-        dl_dtype=(dl_code, dl_bits),
-        typestr=typestr,
-        device_id=device_id,
+        ptr, shape, dl_dtype=(dl_code, dl_bits), typestr=typestr, device_id=device_id,
     )
-    return jax.dlpack.from_dlpack(view)
+    _dlpack_prevent_gc.append(view)
+    result = jax.dlpack.from_dlpack(view)
+    if len(_dlpack_prevent_gc) > 64:
+        del _dlpack_prevent_gc[:32]
+    return result
 
 
 def shmem_register_jax_array(arr) -> int:
-    """Register a jax.Array for shmem RDMA operations.
-
-    Args:
-        arr: A single-device jax.Array on GPU.
-
-    Returns:
-        Status code (0 for success).
-    """
-    from mori.shmem.api import shmem_buffer_register
-
+    """Register a jax.Array for shmem RDMA operations."""
     ptr = jax_data_ptr(arr)
     return shmem_buffer_register(ptr, arr.nbytes)
-
-
-# Minimal DLPack structures for pointer extraction fallback
-class _DLTensorCompat(ctypes.Structure):
-    _fields_ = [
-        ("data", ctypes.c_void_p),
-        ("device", ctypes.c_int32 * 2),
-        ("ndim", ctypes.c_int32),
-        ("dtype", ctypes.c_uint8 * 4),
-        ("shape", ctypes.c_void_p),
-        ("strides", ctypes.c_void_p),
-        ("byte_offset", ctypes.c_uint64),
-    ]
-
-
-class _DLManagedTensorCompat(ctypes.Structure):
-    _fields_ = [
-        ("dl_tensor", _DLTensorCompat),
-        ("manager_ctx", ctypes.c_void_p),
-        ("deleter", ctypes.c_void_p),
-    ]

--- a/python/mori/jax/shmem.py
+++ b/python/mori/jax/shmem.py
@@ -1,0 +1,180 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+# MIT License
+"""JAX-native shmem initialization and array interop helpers.
+
+Allows using mori shmem from JAX without any torch dependency.
+
+Usage::
+
+    import jax
+    jax.distributed.initialize()
+
+    from mori.jax.shmem import shmem_jax_init, jax_data_ptr, shmem_ptr_to_jax
+    shmem_jax_init()
+
+    # Register a jax array for RDMA
+    from mori.shmem import api as shmem
+    shmem.shmem_buffer_register(jax_data_ptr(arr), arr.nbytes)
+
+    # Wrap shmem-allocated memory as jax.Array
+    import jax.numpy as jnp
+    ptr = shmem.shmem_malloc(size)
+    arr = shmem_ptr_to_jax(ptr, (M, N), jnp.float32)
+"""
+
+import ctypes
+
+from mori.tensor_utils import GpuTensorView, kDLFloat, kDLInt, kDLUInt, kDLBfloat
+
+
+def shmem_jax_init():
+    """Initialize shmem from JAX distributed runtime.
+
+    Requires ``jax.distributed.initialize()`` to have been called first.
+    Broadcasts UniqueId from process 0 to all processes.
+
+    Returns:
+        Status code (0 for success).
+    """
+    import jax
+    import numpy as np
+    from mori.shmem.api import (
+        _ensure_shmem_module,
+        shmem_get_unique_id,
+        shmem_init_attr,
+        MORI_SHMEM_INIT_WITH_UNIQUEID,
+    )
+
+    _ensure_shmem_module()
+
+    rank = jax.process_index()
+    world_size = jax.process_count()
+
+    if rank == 0:
+        uid_bytes = shmem_get_unique_id()
+        uid_arr = np.frombuffer(uid_bytes, dtype=np.uint8).copy()
+    else:
+        uid_arr = None
+
+    from jax.experimental.multihost_utils import broadcast_one_to_all
+
+    uid_arr = broadcast_one_to_all(uid_arr)
+    uid_bytes = uid_arr.tobytes()
+
+    return shmem_init_attr(MORI_SHMEM_INIT_WITH_UNIQUEID, rank, world_size, uid_bytes)
+
+
+def jax_data_ptr(arr) -> int:
+    """Extract raw GPU device pointer from a single-device jax.Array.
+
+    Args:
+        arr: A single-device jax.Array on GPU.
+
+    Returns:
+        Integer device pointer address.
+    """
+    import jax
+
+    if hasattr(arr, "addressable_data"):
+        buf = arr.addressable_data(0)
+    else:
+        buf = arr
+
+    if hasattr(buf, "unsafe_buffer_pointer"):
+        return buf.unsafe_buffer_pointer()
+
+    dl_capsule = jax.dlpack.to_dlpack(buf)
+    managed = ctypes.cast(
+        ctypes.pythonapi.PyCapsule_GetPointer(
+            ctypes.py_object(dl_capsule), b"dltensor"
+        ),
+        ctypes.POINTER(_DLManagedTensorCompat),
+    )
+    return managed.contents.dl_tensor.data
+    
+
+_JAX_DTYPE_TO_DL = None
+
+
+def _init_jax_dtype_map():
+    global _JAX_DTYPE_TO_DL
+    if _JAX_DTYPE_TO_DL is not None:
+        return
+    import jax.numpy as jnp
+
+    _JAX_DTYPE_TO_DL = {
+        jnp.float32: (kDLFloat, 32, "<f4"),
+        jnp.float64: (kDLFloat, 64, "<f8"),
+        jnp.float16: (kDLFloat, 16, "<f2"),
+        jnp.bfloat16: (kDLBfloat, 16, "<u2"),
+        jnp.int32: (kDLInt, 32, "<i4"),
+        jnp.int64: (kDLInt, 64, "<i8"),
+        jnp.int8: (kDLInt, 8, "<i1"),
+        jnp.uint8: (kDLUInt, 8, "<u1"),
+        jnp.uint32: (kDLUInt, 32, "<u4"),
+    }
+
+
+def shmem_ptr_to_jax(ptr, shape, dtype, device_id=0):
+    """Wrap a shmem-allocated GPU pointer as a jax.Array (zero-copy via DLPack).
+
+    Args:
+        ptr: int64 device pointer address (e.g. from shmem_malloc).
+        shape: tuple of dimensions.
+        dtype: jax.numpy dtype (e.g. jnp.float32).
+        device_id: GPU device ordinal (default 0).
+
+    Returns:
+        A jax.Array backed by the given device memory.
+    """
+    import jax
+
+    _init_jax_dtype_map()
+    info = _JAX_DTYPE_TO_DL.get(dtype)
+    if info is None:
+        raise ValueError(f"Unsupported JAX dtype: {dtype}")
+    dl_code, dl_bits, typestr = info
+
+    view = GpuTensorView(
+        ptr, shape,
+        dl_dtype=(dl_code, dl_bits),
+        typestr=typestr,
+        device_id=device_id,
+    )
+    return jax.dlpack.from_dlpack(view)
+
+
+def shmem_register_jax_array(arr) -> int:
+    """Register a jax.Array for shmem RDMA operations.
+
+    Args:
+        arr: A single-device jax.Array on GPU.
+
+    Returns:
+        Status code (0 for success).
+    """
+    from mori.shmem.api import shmem_buffer_register
+
+    ptr = jax_data_ptr(arr)
+    return shmem_buffer_register(ptr, arr.nbytes)
+
+
+# Minimal DLPack structures for pointer extraction fallback
+class _DLTensorCompat(ctypes.Structure):
+    _fields_ = [
+        ("data", ctypes.c_void_p),
+        ("device", ctypes.c_int32 * 2),
+        ("ndim", ctypes.c_int32),
+        ("dtype", ctypes.c_uint8 * 4),
+        ("shape", ctypes.c_void_p),
+        ("strides", ctypes.c_void_p),
+        ("byte_offset", ctypes.c_uint64),
+    ]
+
+
+class _DLManagedTensorCompat(ctypes.Structure):
+    _fields_ = [
+        ("dl_tensor", _DLTensorCompat),
+        ("manager_ctx", ctypes.c_void_p),
+        ("deleter", ctypes.c_void_p),
+    ]

--- a/src/ffi/CMakeLists.txt
+++ b/src/ffi/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_library(mori_xla_ffi_ops SHARED mori_xla_ffi_ops.cpp)
+
+target_include_directories(
+  mori_xla_ffi_ops
+  PRIVATE ${CMAKE_SOURCE_DIR}/3rdparty/xla_ffi
+          ${CMAKE_SOURCE_DIR}/include
+          ${CMAKE_SOURCE_DIR}/)
+
+target_link_libraries(
+  mori_xla_ffi_ops
+  PRIVATE mori_ops mori_shmem mori_application mori_logging
+          hip::host hip::device)
+
+set_target_properties(
+  mori_xla_ffi_ops
+  PROPERTIES BUILD_RPATH "$ORIGIN"
+             INSTALL_RPATH "$ORIGIN"
+             BUILD_WITH_INSTALL_RPATH TRUE
+             POSITION_INDEPENDENT_CODE ON)

--- a/src/ffi/mori_xla_ffi_handle_mgr.hpp
+++ b/src/ffi/mori_xla_ffi_handle_mgr.hpp
@@ -1,0 +1,72 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <unordered_map>
+
+#include "mori/ops/dispatch_combine/dispatch_combine.hpp"
+
+namespace mori::ffi {
+
+class HandleManager {
+ public:
+  static HandleManager& Instance() {
+    static HandleManager instance;
+    return instance;
+  }
+
+  int64_t CreateHandle(moe::EpDispatchCombineConfig config) {
+    std::lock_guard<std::mutex> lock(mu_);
+    int64_t id = next_id_++;
+    handles_.emplace(id, std::make_unique<moe::EpDispatchCombineHandle>(config));
+    return id;
+  }
+
+  moe::EpDispatchCombineHandle* GetHandle(int64_t id) {
+    std::lock_guard<std::mutex> lock(mu_);
+    auto it = handles_.find(id);
+    if (it == handles_.end()) {
+      throw std::runtime_error("mori FFI: invalid handle id " + std::to_string(id));
+    }
+    return it->second.get();
+  }
+
+  void DestroyHandle(int64_t id) {
+    std::lock_guard<std::mutex> lock(mu_);
+    handles_.erase(id);
+  }
+
+ private:
+  HandleManager() = default;
+  HandleManager(const HandleManager&) = delete;
+  HandleManager& operator=(const HandleManager&) = delete;
+
+  std::mutex mu_;
+  int64_t next_id_ = 1;
+  std::unordered_map<int64_t, std::unique_ptr<moe::EpDispatchCombineHandle>> handles_;
+};
+
+}  // namespace mori::ffi

--- a/src/ffi/mori_xla_ffi_ops.cpp
+++ b/src/ffi/mori_xla_ffi_ops.cpp
@@ -1,0 +1,482 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Based on PR #173 by Chao Chen <cchen104@amd.com>
+// Adapted for the refactored architecture (raw pointer args + hipModuleLaunchKernel).
+
+#include "xla/ffi/api/ffi.h"
+
+#include <hip/hip_runtime.h>
+
+#include <cstring>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+
+#include "mori/ops/dispatch_combine/dispatch_combine.hpp"
+#include "src/ffi/mori_xla_ffi_handle_mgr.hpp"
+
+namespace ffi = xla::ffi;
+
+// ---------------------------------------------------------------------------
+// Kernel module management
+// ---------------------------------------------------------------------------
+
+static constexpr int WARP_SIZE = 64;
+static constexpr int PTR_SIZE = 8;
+
+class KernelManager {
+ public:
+  static KernelManager& Instance() {
+    static KernelManager instance;
+    return instance;
+  }
+
+  void RegisterModule(int kernel_type, const std::string& hsaco_path) {
+    std::lock_guard<std::mutex> lock(mu_);
+    hipModule_t mod;
+    hipError_t err = hipModuleLoad(&mod, hsaco_path.c_str());
+    if (err != hipSuccess) {
+      throw std::runtime_error("Failed to load hsaco: " + hsaco_path +
+                               " (" + hipGetErrorString(err) + ")");
+    }
+    modules_[kernel_type] = mod;
+  }
+
+  hipFunction_t GetFunction(int kernel_type, const std::string& name) {
+    std::lock_guard<std::mutex> lock(mu_);
+    auto it = modules_.find(kernel_type);
+    if (it == modules_.end()) {
+      throw std::runtime_error(
+          "No kernel module registered for kernel_type=" +
+          std::to_string(kernel_type) +
+          ". Call mori_ffi_register_kernel_module() first.");
+    }
+    auto key = std::make_pair(kernel_type, name);
+    auto fit = func_cache_.find(name + "@" + std::to_string(kernel_type));
+    if (fit != func_cache_.end()) return fit->second;
+
+    hipFunction_t func;
+    hipError_t err = hipModuleGetFunction(&func, it->second, name.c_str());
+    if (err != hipSuccess) {
+      throw std::runtime_error("Failed to get function '" + name +
+                               "': " + hipGetErrorString(err));
+    }
+    func_cache_[name + "@" + std::to_string(kernel_type)] = func;
+    return func;
+  }
+
+ private:
+  KernelManager() = default;
+  std::mutex mu_;
+  std::unordered_map<int, hipModule_t> modules_;
+  std::unordered_map<std::string, hipFunction_t> func_cache_;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static hipDataType FfiDataTypeToHip(ffi::DataType dtype) {
+  switch (dtype) {
+    case ffi::DataType::F32:  return HIP_R_32F;
+    case ffi::DataType::F16:  return HIP_R_16F;
+    case ffi::DataType::BF16: return HIP_R_16BF;
+    default:
+      throw std::runtime_error("mori FFI: unsupported element type");
+  }
+}
+
+static const char* HipDataTypeToSuffix(hipDataType dtype) {
+  switch (dtype) {
+    case HIP_R_32F:          return "f32";
+    case HIP_R_16BF:         return "bf16";
+    case HIP_R_8F_E4M3:      return "fp8_ocp";
+    case HIP_R_8F_E4M3_FNUZ: return "fp8_fnuz";
+    default:
+      throw std::runtime_error("mori FFI: unsupported dtype for kernel suffix");
+  }
+}
+
+static int DispatchSharedMem(const mori::moe::EpDispatchCombineConfig& cfg, int warp_per_block) {
+  return (cfg.worldSize * warp_per_block +
+          cfg.numExpertPerRank * warp_per_block +
+          cfg.numExpertPerRank) * 4;
+}
+
+static int CombineSharedMem(const mori::moe::EpDispatchCombineConfig& cfg, int warp_per_block) {
+  return warp_per_block * cfg.numExpertPerToken * (PTR_SIZE + PTR_SIZE);
+}
+
+static void LaunchKernel(int kernel_type, const std::string& func_name,
+                         dim3 grid, dim3 block, int shared_mem,
+                         hipStream_t stream, void* args_ptr) {
+  hipFunction_t func = KernelManager::Instance().GetFunction(kernel_type, func_name);
+  void* config[] = {
+      HIP_LAUNCH_PARAM_BUFFER_POINTER, args_ptr,
+      HIP_LAUNCH_PARAM_BUFFER_SIZE, &shared_mem,
+      HIP_LAUNCH_PARAM_END};
+  size_t args_size = sizeof(mori::moe::EpDispatchCombineArgsRaw);
+  void* launch_params[] = {
+      HIP_LAUNCH_PARAM_BUFFER_POINTER, args_ptr,
+      HIP_LAUNCH_PARAM_BUFFER_SIZE, &args_size,
+      HIP_LAUNCH_PARAM_END};
+  hipError_t err = hipModuleLaunchKernel(
+      func, grid.x, grid.y, grid.z, block.x, block.y, block.z,
+      shared_mem, stream, nullptr, launch_params);
+  if (err != hipSuccess) {
+    throw std::runtime_error("hipModuleLaunchKernel failed for '" + func_name +
+                             "': " + hipGetErrorString(err));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// mori_ep_dispatch
+// ---------------------------------------------------------------------------
+static ffi::Error MoriEpDispatchImpl(
+    ffi::AnyBuffer input, ffi::AnyBuffer topk_ids,
+    ffi::Result<ffi::AnyBuffer> out_tokens,
+    ffi::Result<ffi::AnyBuffer> out_weights,
+    ffi::Result<ffi::AnyBuffer> out_indices,
+    ffi::Result<ffi::AnyBuffer> total_recv_token_num,
+    int64_t handle_id, int64_t block_num, int64_t rdma_block_num,
+    int64_t warp_per_block, int64_t hidden_dim) {
+  try {
+    auto* handle = mori::ffi::HandleManager::Instance().GetHandle(handle_id);
+    auto hip_dtype = FfiDataTypeToHip(input.element_type());
+    int num_tokens = static_cast<int>(input.dimensions()[0]);
+    int h_dim = (hidden_dim > 0) ? static_cast<int>(hidden_dim)
+                                 : static_cast<int>(input.dimensions()[1]);
+
+    handle->PrepareInference(
+        hip_dtype, input.untyped_data(), nullptr,
+        static_cast<float*>(out_weights->untyped_data()),
+        nullptr,
+        static_cast<mori::moe::index_t*>(topk_ids.untyped_data()),
+        num_tokens);
+
+    auto args = mori::moe::GetEpDispatchCombineArgsRaw(*handle, static_cast<int>(rdma_block_num));
+    if (hidden_dim > 0) args.config.hiddenDim = static_cast<int>(hidden_dim);
+
+    hipStream_t stream = nullptr;
+    int kt = static_cast<int>(handle->config.kernelType);
+    const char* sfx = HipDataTypeToSuffix(hip_dtype);
+    int bn = (block_num > 0) ? static_cast<int>(block_num) : handle->config.blockNum;
+    int wpb = (warp_per_block > 0) ? static_cast<int>(warp_per_block)
+                                   : handle->config.warpNumPerBlock;
+    dim3 grid(bn);
+    dim3 block(WARP_SIZE * wpb);
+    int shmem = DispatchSharedMem(handle->config, wpb);
+
+    using KT = mori::moe::KernelType;
+    switch (static_cast<KT>(kt)) {
+      case KT::IntraNode:
+        LaunchKernel(kt, std::string("EpDispatchIntraNodeKernel_") + sfx,
+                     grid, block, shmem, stream, &args);
+        break;
+      case KT::InterNode:
+        LaunchKernel(kt, std::string("EpDispatchInterNodeKernel_") + sfx,
+                     grid, block, shmem, stream, &args);
+        break;
+      case KT::InterNodeV1: {
+        dim3 mp_grid(handle->multiProcessorCount);
+        LaunchKernel(kt, std::string("EpDispatchCopyToStaging_") + sfx,
+                     mp_grid, block, 0, stream, &args);
+        LaunchKernel(kt, std::string("EpDispatchInterNodeV1Kernel_") + sfx,
+                     grid, block, shmem, stream, &args);
+        break;
+      }
+      case KT::InterNodeV1LL: {
+        dim3 mp_grid(handle->multiProcessorCount);
+        LaunchKernel(kt, std::string("EpDispatchCopyToStaging_") + sfx,
+                     mp_grid, block, 0, stream, &args);
+        LaunchKernel(kt, std::string("EpDispatchInterNodeV1KernelLowLatency_") + sfx,
+                     grid, block, shmem, stream, &args);
+        break;
+      }
+      case KT::AsyncLL:
+        LaunchKernel(kt, std::string("EpDispatchLowLatencyAsyncSend_") + sfx,
+                     grid, block, shmem, stream, &args);
+        break;
+      default:
+        return ffi::Error(ffi::ErrorCode::kInvalidArgument,
+                          "Unsupported dispatch kernel_type");
+    }
+    return ffi::Error::Success();
+  } catch (const std::exception& e) {
+    return ffi::Error(ffi::ErrorCode::kInternal, std::string(e.what()));
+  }
+}
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    mori_ep_dispatch, MoriEpDispatchImpl,
+    ffi::Ffi::Bind()
+        .Arg<ffi::AnyBuffer>()   // input
+        .Arg<ffi::AnyBuffer>()   // topk_ids
+        .Ret<ffi::AnyBuffer>()   // out_tokens
+        .Ret<ffi::AnyBuffer>()   // out_weights
+        .Ret<ffi::AnyBuffer>()   // out_indices
+        .Ret<ffi::AnyBuffer>()   // total_recv_token_num
+        .Attr<int64_t>("handle_id")
+        .Attr<int64_t>("block_num")
+        .Attr<int64_t>("rdma_block_num")
+        .Attr<int64_t>("warp_per_block")
+        .Attr<int64_t>("hidden_dim"));
+
+// ---------------------------------------------------------------------------
+// mori_ep_combine
+// ---------------------------------------------------------------------------
+static ffi::Error MoriEpCombineImpl(
+    ffi::AnyBuffer input, ffi::AnyBuffer topk_ids,
+    ffi::Result<ffi::AnyBuffer> out_tokens,
+    int64_t handle_id, int64_t block_num, int64_t rdma_block_num,
+    int64_t warp_per_block, int64_t use_external_inp_buf, int64_t hidden_dim) {
+  try {
+    auto* handle = mori::ffi::HandleManager::Instance().GetHandle(handle_id);
+    auto hip_dtype = FfiDataTypeToHip(input.element_type());
+    int h_dim = (hidden_dim > 0) ? static_cast<int>(hidden_dim)
+                                 : static_cast<int>(input.dimensions()[1]);
+
+    handle->PrepareInference(
+        hip_dtype, input.untyped_data(), nullptr,
+        nullptr, nullptr,
+        static_cast<mori::moe::index_t*>(topk_ids.untyped_data()),
+        handle->curRankNumToken);
+
+    auto args = mori::moe::GetEpDispatchCombineArgsRaw(*handle, static_cast<int>(rdma_block_num));
+    if (hidden_dim > 0) args.config.hiddenDim = static_cast<int>(hidden_dim);
+    if (use_external_inp_buf >= 0)
+      args.config.useExternalInpBuffer = static_cast<bool>(use_external_inp_buf);
+
+    hipStream_t stream = nullptr;
+    int kt = static_cast<int>(handle->config.kernelType);
+    const char* sfx = HipDataTypeToSuffix(hip_dtype);
+    int bn = (block_num > 0) ? static_cast<int>(block_num) : handle->config.blockNum;
+    int wpb = (warp_per_block > 0) ? static_cast<int>(warp_per_block)
+                                   : handle->config.warpNumPerBlock;
+    dim3 grid(bn);
+    dim3 block(WARP_SIZE * wpb);
+    int shmem = CombineSharedMem(handle->config, wpb);
+
+    bool ext = (use_external_inp_buf >= 0)
+                   ? static_cast<bool>(use_external_inp_buf)
+                   : handle->config.useExternalInpBuffer;
+
+    using KT = mori::moe::KernelType;
+    switch (static_cast<KT>(kt)) {
+      case KT::IntraNode:
+        if (ext) {
+          LaunchKernel(kt, std::string("EpCombineIntraNodeKernel_") + sfx + "_nop2p",
+                       grid, block, shmem, stream, &args);
+        } else {
+          LaunchKernel(kt, std::string("EpCombineIntraNodeKernel_") + sfx + "_p2p",
+                       grid, block, shmem, stream, &args);
+        }
+        break;
+      case KT::InterNode:
+        LaunchKernel(kt, std::string("EpCombineInterNodeKernel_") + sfx,
+                     grid, block, shmem, stream, &args);
+        break;
+      case KT::InterNodeV1: {
+        dim3 mp_grid(handle->multiProcessorCount);
+        LaunchKernel(kt, std::string("EpCombineSync_") + sfx,
+                     mp_grid, block, 0, stream, &args);
+        LaunchKernel(kt, std::string("EpCombineSyncBarrier_") + sfx,
+                     dim3(1), dim3(WARP_SIZE), 0, stream, &args);
+        LaunchKernel(kt, std::string("EpCombineInterNodeV1Kernel_") + sfx,
+                     grid, block, shmem, stream, &args);
+        LaunchKernel(kt, std::string("EpCombineAll_") + sfx,
+                     mp_grid, block, shmem, stream, &args);
+        break;
+      }
+      case KT::InterNodeV1LL: {
+        dim3 mp_grid(handle->multiProcessorCount);
+        LaunchKernel(kt, std::string("EpCombineSync_") + sfx,
+                     mp_grid, block, 0, stream, &args);
+        LaunchKernel(kt, std::string("EpCombineSyncBarrier_") + sfx,
+                     dim3(1), dim3(WARP_SIZE), 0, stream, &args);
+        LaunchKernel(kt, std::string("EpCombineInterNodeV1KernelLowLatency_") + sfx,
+                     grid, block, shmem, stream, &args);
+        LaunchKernel(kt, std::string("EpCombineAll_") + sfx,
+                     mp_grid, block, shmem, stream, &args);
+        break;
+      }
+      case KT::AsyncLL:
+        LaunchKernel(kt, std::string("EpCombineLowLatencyAsyncSend_") + sfx,
+                     grid, block, shmem, stream, &args);
+        break;
+      default:
+        return ffi::Error(ffi::ErrorCode::kInvalidArgument,
+                          "Unsupported combine kernel_type");
+    }
+    return ffi::Error::Success();
+  } catch (const std::exception& e) {
+    return ffi::Error(ffi::ErrorCode::kInternal, std::string(e.what()));
+  }
+}
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    mori_ep_combine, MoriEpCombineImpl,
+    ffi::Ffi::Bind()
+        .Arg<ffi::AnyBuffer>()   // input
+        .Arg<ffi::AnyBuffer>()   // topk_ids
+        .Ret<ffi::AnyBuffer>()   // out_tokens
+        .Attr<int64_t>("handle_id")
+        .Attr<int64_t>("block_num")
+        .Attr<int64_t>("rdma_block_num")
+        .Attr<int64_t>("warp_per_block")
+        .Attr<int64_t>("use_external_inp_buf")
+        .Attr<int64_t>("hidden_dim"));
+
+// ---------------------------------------------------------------------------
+// mori_ep_dispatch_recv  (AsyncLL only)
+// ---------------------------------------------------------------------------
+static ffi::Error MoriEpDispatchRecvImpl(
+    int64_t handle_id, int64_t block_num, int64_t warp_per_block) {
+  try {
+    auto* handle = mori::ffi::HandleManager::Instance().GetHandle(handle_id);
+    int kt = static_cast<int>(handle->config.kernelType);
+    if (static_cast<mori::moe::KernelType>(kt) != mori::moe::KernelType::AsyncLL) {
+      return ffi::Error(ffi::ErrorCode::kInvalidArgument,
+                        "dispatch_recv only supports AsyncLL");
+    }
+    auto args = mori::moe::GetEpDispatchCombineArgsRaw(*handle, 0);
+    int bn = (block_num > 0) ? static_cast<int>(block_num) : handle->config.blockNum;
+    int wpb = (warp_per_block > 0) ? static_cast<int>(warp_per_block)
+                                   : handle->config.warpNumPerBlock;
+    const char* sfx = HipDataTypeToSuffix(handle->inputType);
+    hipStream_t stream = nullptr;
+    LaunchKernel(kt, std::string("EpDispatchLowLatencyAsyncRecv_") + sfx,
+                 dim3(bn), dim3(WARP_SIZE * wpb),
+                 DispatchSharedMem(handle->config, wpb), stream, &args);
+    return ffi::Error::Success();
+  } catch (const std::exception& e) {
+    return ffi::Error(ffi::ErrorCode::kInternal, std::string(e.what()));
+  }
+}
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    mori_ep_dispatch_recv, MoriEpDispatchRecvImpl,
+    ffi::Ffi::Bind()
+        .Attr<int64_t>("handle_id")
+        .Attr<int64_t>("block_num")
+        .Attr<int64_t>("warp_per_block"));
+
+// ---------------------------------------------------------------------------
+// mori_ep_combine_recv  (AsyncLL only)
+// ---------------------------------------------------------------------------
+static ffi::Error MoriEpCombineRecvImpl(
+    int64_t handle_id, int64_t block_num, int64_t warp_per_block) {
+  try {
+    auto* handle = mori::ffi::HandleManager::Instance().GetHandle(handle_id);
+    int kt = static_cast<int>(handle->config.kernelType);
+    if (static_cast<mori::moe::KernelType>(kt) != mori::moe::KernelType::AsyncLL) {
+      return ffi::Error(ffi::ErrorCode::kInvalidArgument,
+                        "combine_recv only supports AsyncLL");
+    }
+    auto args = mori::moe::GetEpDispatchCombineArgsRaw(*handle, 0);
+    int bn = (block_num > 0) ? static_cast<int>(block_num) : handle->config.blockNum;
+    int wpb = (warp_per_block > 0) ? static_cast<int>(warp_per_block)
+                                   : handle->config.warpNumPerBlock;
+    const char* sfx = HipDataTypeToSuffix(handle->inputType);
+    hipStream_t stream = nullptr;
+    LaunchKernel(kt, std::string("EpCombineLowLatencyAsyncRecv_") + sfx,
+                 dim3(bn), dim3(WARP_SIZE * wpb),
+                 CombineSharedMem(handle->config, wpb), stream, &args);
+    return ffi::Error::Success();
+  } catch (const std::exception& e) {
+    return ffi::Error(ffi::ErrorCode::kInternal, std::string(e.what()));
+  }
+}
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    mori_ep_combine_recv, MoriEpCombineRecvImpl,
+    ffi::Ffi::Bind()
+        .Attr<int64_t>("handle_id")
+        .Attr<int64_t>("block_num")
+        .Attr<int64_t>("warp_per_block"));
+
+// ---------------------------------------------------------------------------
+// mori_ep_reset
+// ---------------------------------------------------------------------------
+static ffi::Error MoriEpResetImpl(int64_t handle_id) {
+  try {
+    auto* handle = mori::ffi::HandleManager::Instance().GetHandle(handle_id);
+    handle->LaunchReset(nullptr);
+    return ffi::Error::Success();
+  } catch (const std::exception& e) {
+    return ffi::Error(ffi::ErrorCode::kInternal, std::string(e.what()));
+  }
+}
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    mori_ep_reset, MoriEpResetImpl,
+    ffi::Ffi::Bind().Attr<int64_t>("handle_id"));
+
+// ---------------------------------------------------------------------------
+// Handle lifecycle + kernel module registration (plain C for ctypes)
+// ---------------------------------------------------------------------------
+extern "C" {
+
+int64_t mori_ffi_create_handle(
+    int rank, int world_size, int hidden_dim,
+    int scale_dim, int scale_type_size,
+    int max_token_type_size, int max_num_inp_token_per_rank,
+    int num_experts_per_rank, int num_experts_per_token,
+    int warp_num_per_block, int block_num,
+    int kernel_type, int gpu_per_node,
+    int rdma_block_num, int num_qp_per_pe) {
+  mori::moe::EpDispatchCombineConfig config;
+  config.rank = rank;
+  config.worldSize = world_size;
+  config.hiddenDim = hidden_dim;
+  config.scaleDim = scale_dim;
+  config.scaleTypeSize = scale_type_size;
+  config.maxTokenTypeSize = max_token_type_size;
+  config.maxNumInpTokenPerRank = max_num_inp_token_per_rank;
+  config.numExpertPerRank = num_experts_per_rank;
+  config.numExpertPerToken = num_experts_per_token;
+  config.warpNumPerBlock = warp_num_per_block;
+  config.blockNum = block_num;
+  config.kernelType = static_cast<mori::moe::KernelType>(kernel_type);
+  config.gpuPerNode = gpu_per_node;
+  config.rdmaBlockNum = rdma_block_num;
+  config.numQpPerPe = num_qp_per_pe;
+  return mori::ffi::HandleManager::Instance().CreateHandle(config);
+}
+
+void mori_ffi_destroy_handle(int64_t handle_id) {
+  mori::ffi::HandleManager::Instance().DestroyHandle(handle_id);
+}
+
+void mori_ffi_register_kernel_module(int kernel_type, const char* hsaco_path) {
+  KernelManager::Instance().RegisterModule(kernel_type, hsaco_path);
+}
+
+void mori_ffi_shmem_module_init_from_kernel(int kernel_type) {
+  // After registering a kernel module, initialize shmem globalGpuStates in it.
+  // This delegates to shmem's module init with the hipModule_t.
+  // NOTE: callers should use the Python shmem_module_init path for this.
+}
+
+}  // extern "C"

--- a/src/ffi/mori_xla_ffi_ops.cpp
+++ b/src/ffi/mori_xla_ffi_ops.cpp
@@ -34,6 +34,7 @@
 #include <unordered_map>
 
 #include "mori/ops/dispatch_combine/dispatch_combine.hpp"
+#include "mori/shmem/shmem.hpp"
 #include "src/ffi/mori_xla_ffi_handle_mgr.hpp"
 
 namespace ffi = xla::ffi;
@@ -61,6 +62,13 @@ class KernelManager {
                                " (" + hipGetErrorString(err) + ")");
     }
     modules_[kernel_type] = mod;
+  }
+
+  hipModule_t GetModule(int kernel_type) {
+    std::lock_guard<std::mutex> lock(mu_);
+    auto it = modules_.find(kernel_type);
+    if (it == modules_.end()) return nullptr;
+    return it->second;
   }
 
   hipFunction_t GetFunction(int kernel_type, const std::string& name) {
@@ -222,6 +230,7 @@ static ffi::Error MoriEpDispatchImpl(
         return ffi::Error(ffi::ErrorCode::kInvalidArgument,
                           "Unsupported dispatch kernel_type");
     }
+
     return ffi::Error::Success();
   } catch (const std::exception& e) {
     return ffi::Error(ffi::ErrorCode::kInternal, std::string(e.what()));
@@ -329,6 +338,7 @@ static ffi::Error MoriEpCombineImpl(
         return ffi::Error(ffi::ErrorCode::kInvalidArgument,
                           "Unsupported combine kernel_type");
     }
+
     return ffi::Error::Success();
   } catch (const std::exception& e) {
     return ffi::Error(ffi::ErrorCode::kInternal, std::string(e.what()));
@@ -474,9 +484,75 @@ void mori_ffi_register_kernel_module(int kernel_type, const char* hsaco_path) {
 }
 
 void mori_ffi_shmem_module_init_from_kernel(int kernel_type) {
-  // After registering a kernel module, initialize shmem globalGpuStates in it.
-  // This delegates to shmem's module init with the hipModule_t.
-  // NOTE: callers should use the Python shmem_module_init path for this.
+  hipModule_t mod = KernelManager::Instance().GetModule(kernel_type);
+  if (mod) {
+    mori::shmem::ShmemModuleInit(reinterpret_cast<void*>(mod));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shmem C API (torch-free, for JAX-only usage via ctypes)
+// ---------------------------------------------------------------------------
+
+int mori_ffi_shmem_get_unique_id(void* uid_out, int* uid_size) {
+  mori::shmem::mori_shmem_uniqueid_t uid;
+  mori::shmem::ShmemGetUniqueId(&uid);
+  std::memcpy(uid_out, uid.data(), uid.size());
+  *uid_size = static_cast<int>(uid.size());
+  return 0;
+}
+
+int64_t mori_ffi_shmem_init_attr(unsigned int flags, int rank, int nranks,
+                                  const void* uid_data, int uid_size) {
+  mori::shmem::mori_shmem_init_attr_t attr;
+  mori::shmem::mori_shmem_uniqueid_t uid;
+  std::memcpy(uid.data(), uid_data, uid_size);
+  mori::shmem::ShmemSetAttrUniqueIdArgs(rank, nranks, &uid, &attr);
+  return mori::shmem::ShmemInitAttr(flags, &attr);
+}
+
+int64_t mori_ffi_shmem_finalize() { return mori::shmem::ShmemFinalize(); }
+
+int64_t mori_ffi_shmem_module_init(uint64_t hip_module) {
+  return mori::shmem::ShmemModuleInit(reinterpret_cast<void*>(hip_module));
+}
+
+int64_t mori_ffi_load_shmem_module(const char* hsaco_path) {
+  return mori::shmem::LoadShmemModule(hsaco_path);
+}
+
+int mori_ffi_shmem_mype() { return mori::shmem::ShmemMyPe(); }
+int mori_ffi_shmem_npes() { return mori::shmem::ShmemNPes(); }
+void mori_ffi_shmem_barrier_all() { mori::shmem::ShmemBarrierAll(); }
+
+void mori_ffi_shmem_barrier_on_stream(int64_t stream) {
+  mori::shmem::ShmemBarrierOnStream(reinterpret_cast<hipStream_t>(stream));
+}
+
+uint64_t mori_ffi_shmem_malloc(uint64_t size) {
+  return reinterpret_cast<uint64_t>(mori::shmem::ShmemMalloc(size));
+}
+
+void mori_ffi_shmem_free(uint64_t ptr) {
+  mori::shmem::ShmemFree(reinterpret_cast<void*>(ptr));
+}
+
+int64_t mori_ffi_shmem_buffer_register(uint64_t ptr, uint64_t size) {
+  return mori::shmem::ShmemBufferRegister(reinterpret_cast<void*>(ptr), size);
+}
+
+int64_t mori_ffi_shmem_buffer_deregister(uint64_t ptr, uint64_t size) {
+  return mori::shmem::ShmemBufferDeregister(reinterpret_cast<void*>(ptr), size);
+}
+
+uint64_t mori_ffi_shmem_ptr_p2p(uint64_t dest_ptr, int my_pe, int dest_pe) {
+  return mori::shmem::ShmemPtrP2p(dest_ptr, my_pe, dest_pe);
+}
+
+int mori_ffi_shmem_num_qp_per_pe() { return mori::shmem::ShmemNumQpPerPe(); }
+
+unsigned int mori_ffi_shmem_init_flag_uniqueid() {
+  return mori::shmem::MORI_SHMEM_INIT_WITH_UNIQUEID;
 }
 
 }  // extern "C"

--- a/src/ops/CMakeLists.txt
+++ b/src/ops/CMakeLists.txt
@@ -14,7 +14,8 @@ set_target_properties(
   mori_ops
   PROPERTIES BUILD_RPATH "$ORIGIN"
              INSTALL_RPATH "$ORIGIN"
-             BUILD_WITH_INSTALL_RPATH TRUE)
+             BUILD_WITH_INSTALL_RPATH TRUE
+             POSITION_INDEPENDENT_CODE ON)
 
 if(ENABLE_PROFILER)
   target_link_libraries(mori_ops PUBLIC mori_profiler_interface)

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -23,3 +23,10 @@ add_executable(test_topology application/test_topology.cpp)
 target_include_directories(test_topology PUBLIC ${CMAKE_SOURCE_DIR}/include)
 target_include_directories(test_topology PUBLIC ${CMAKE_SOURCE_DIR})
 target_link_libraries(test_topology mori_application mori_io)
+
+if(ENABLE_XLA_FFI)
+  add_executable(test_ffi_contract ffi/test_ffi_contract.cpp)
+  target_include_directories(test_ffi_contract
+    PUBLIC ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR})
+  target_link_libraries(test_ffi_contract mori_xla_ffi_ops mori_ops)
+endif()

--- a/tests/cpp/ffi/test_ffi_contract.cpp
+++ b/tests/cpp/ffi/test_ffi_contract.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+// MIT License
+//
+// Based on PR #173 by Chao Chen <cchen104@amd.com>
+// Adapted for the refactored architecture.
+//
+// Compile-time contract test: verifies that the FFI handler C symbols and the
+// handle manager API exist with the expected signatures. If someone changes
+// dispatch_combine.hpp or mori_xla_ffi_ops.cpp in an incompatible way, this
+// test will fail to compile.
+
+#include <cstdint>
+#include <type_traits>
+
+#include "mori/ops/dispatch_combine/dispatch_combine.hpp"
+#include "src/ffi/mori_xla_ffi_handle_mgr.hpp"
+
+// Verify HandleManager singleton API
+static_assert(std::is_same_v<
+    decltype(&mori::ffi::HandleManager::Instance),
+    mori::ffi::HandleManager& (*)()>,
+    "HandleManager::Instance() signature changed");
+
+// Verify EpDispatchCombineConfig fields used by FFI handle creation
+static_assert(std::is_same_v<decltype(mori::moe::EpDispatchCombineConfig::rank), int>);
+static_assert(std::is_same_v<decltype(mori::moe::EpDispatchCombineConfig::worldSize), int>);
+static_assert(std::is_same_v<decltype(mori::moe::EpDispatchCombineConfig::hiddenDim), int>);
+static_assert(std::is_same_v<decltype(mori::moe::EpDispatchCombineConfig::scaleDim), int>);
+static_assert(std::is_same_v<decltype(mori::moe::EpDispatchCombineConfig::maxNumInpTokenPerRank), int>);
+static_assert(std::is_same_v<decltype(mori::moe::EpDispatchCombineConfig::numExpertPerRank), int>);
+static_assert(std::is_same_v<decltype(mori::moe::EpDispatchCombineConfig::numExpertPerToken), int>);
+
+// Verify EpDispatchCombineHandle key member types used by FFI ops
+static_assert(std::is_same_v<decltype(mori::moe::EpDispatchCombineHandle::curRankNumToken),
+                             mori::moe::index_t>);
+
+// Verify extern "C" symbols exist (linker will catch if missing)
+extern "C" {
+int64_t mori_ffi_create_handle(int, int, int, int, int, int, int, int, int, int, int, int, int, int, int);
+void mori_ffi_destroy_handle(int64_t);
+void mori_ffi_register_kernel_module(int, const char*);
+}
+
+int main() {
+  auto& mgr = mori::ffi::HandleManager::Instance();
+  (void)mgr;
+
+  auto create_fn = &mori_ffi_create_handle;
+  auto destroy_fn = &mori_ffi_destroy_handle;
+  auto register_fn = &mori_ffi_register_kernel_module;
+  (void)create_fn;
+  (void)destroy_fn;
+  (void)register_fn;
+
+  return 0;
+}

--- a/tests/python/test_jax_integration.py
+++ b/tests/python/test_jax_integration.py
@@ -117,13 +117,11 @@ class TestFFILifecycle(unittest.TestCase):
         self.assertTrue(os.path.isfile(hsaco))
         register_kernel_module(0, hsaco)
 
-    def test_handle_create_destroy(self):
-        from mori.jit.core import compile_genco
-        from mori.jax._ffi_registry import _load_library, register_kernel_module
+    def _init_shmem(self):
         from mori.jax.shmem import (
-            _ensure_shmem_module, shmem_get_unique_id,
-            shmem_init_attr, shmem_finalize,
+            _ensure_shmem_module, shmem_get_unique_id, shmem_init_attr,
         )
+        from mori.jax._ffi_registry import _load_library
 
         _ensure_shmem_module()
         lib = _load_library()
@@ -132,15 +130,100 @@ class TestFFILifecycle(unittest.TestCase):
         rc = shmem_init_attr(flag, 0, 1, uid)
         self.assertEqual(rc, 0)
 
+    def test_handle_create_destroy(self):
+        from mori.jit.core import compile_genco
+        from mori.jax._ffi_registry import _load_library, register_kernel_module
+        from mori.jax.shmem import shmem_finalize
+
+        self._init_shmem()
         try:
             hsaco = compile_genco("ep_intranode")
             register_kernel_module(0, hsaco)
 
+            lib = _load_library()
             handle_id = lib.mori_ffi_create_handle(
                 0, 1, 4096, 0, 0, 4, 128, 1, 2, 1, 1, 0, 1, 0, 1,
             )
             self.assertGreater(handle_id, 0)
             lib.mori_ffi_destroy_handle(handle_id)
+        finally:
+            shmem_finalize()
+
+    def test_shmem_malloc_dlpack_roundtrip(self):
+        """shmem-allocated memory can be wrapped as jax.Array via DLPack."""
+        import jax.numpy as jnp
+        from mori.jax.shmem import (
+            shmem_malloc, shmem_free, shmem_finalize,
+            shmem_ptr_to_jax, jax_data_ptr,
+        )
+
+        self._init_shmem()
+        try:
+            ptr = shmem_malloc(1024 * 2)
+            self.assertGreater(ptr, 0)
+
+            arr = shmem_ptr_to_jax(ptr, (32, 32), jnp.bfloat16)
+            self.assertEqual(arr.shape, (32, 32))
+            self.assertEqual(arr.dtype, jnp.bfloat16)
+
+            ptr_back = jax_data_ptr(arr)
+            self.assertEqual(ptr, ptr_back)
+
+            for dt, shape in [
+                (jnp.float32, (256,)),
+                (jnp.int32, (256,)),
+                (jnp.float16, (32, 16)),
+                (jnp.uint8, (2048,)),
+            ]:
+                with self.subTest(dtype=dt):
+                    a = shmem_ptr_to_jax(ptr, shape, dt)
+                    self.assertEqual(a.shape, shape)
+                    self.assertEqual(a.dtype, dt)
+
+            shmem_free(ptr)
+        finally:
+            shmem_finalize()
+
+    def test_kernel_launch_single_process(self):
+        """JIT-compiled shmem kernel can be launched on GPU via the JAX path.
+
+        Full torch-free chain: mori.jax.shmem (ctypes) → mori.jit (pure Python)
+        → HipModule (ctypes) → hipModuleLaunchKernel → GPU execution.
+        """
+        import ctypes as ct
+        from mori.jit.core import compile_genco
+        from mori.jit.hip_driver import HipModule
+        from mori.jax._ffi_registry import _load_library
+        from mori.jax.shmem import shmem_finalize
+
+        self._init_shmem()
+        try:
+            lib = _load_library()
+
+            hsaco = compile_genco("shmem_kernels")
+            mod = HipModule(hsaco)
+            lib.mori_ffi_shmem_module_init(mod._module.value)
+
+            func = mod.get_function("mori_shmem_barrier_all_block")
+            self.assertIsNotNone(func._func)
+
+            _hip = ct.CDLL("libamdhip64.so")
+            _hip.hipModuleLaunchKernel.restype = ct.c_int
+            _hip.hipModuleLaunchKernel.argtypes = [
+                ct.c_void_p,
+                ct.c_uint, ct.c_uint, ct.c_uint,
+                ct.c_uint, ct.c_uint, ct.c_uint,
+                ct.c_uint, ct.c_void_p, ct.c_void_p, ct.c_void_p,
+            ]
+
+            err = _hip.hipModuleLaunchKernel(
+                func._func, 1, 1, 1, 64, 1, 1, 0, None, None, None,
+            )
+            self.assertEqual(err, 0, f"hipModuleLaunchKernel failed: {err}")
+
+            _hip.hipDeviceSynchronize.restype = ct.c_int
+            err = _hip.hipDeviceSynchronize()
+            self.assertEqual(err, 0, f"hipDeviceSynchronize failed: {err}")
         finally:
             shmem_finalize()
 

--- a/tests/python/test_jax_integration.py
+++ b/tests/python/test_jax_integration.py
@@ -1,0 +1,149 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+# MIT License
+"""JAX integration tests for mori XLA FFI and shmem interop.
+
+Requires:
+    - ROCm GPU(s) available
+    - jax[rocm] installed
+    - libmori_xla_ffi_ops.so built (ENABLE_XLA_FFI=ON)
+
+Run with:
+    LD_LIBRARY_PATH=build_ffi/src/ops:build_ffi/src/shmem:build_ffi/src/application:build_ffi/src/io:build_ffi/src/ffi \
+    MORI_XLA_FFI_LIB=build_ffi/src/ffi/libmori_xla_ffi_ops.so \
+    PYTHONPATH=python \
+    python -m pytest tests/python/test_jax_integration.py -v
+"""
+import ctypes
+import os
+import unittest
+
+
+def _jax_available():
+    try:
+        import jax
+        return len(jax.devices()) > 0
+    except (ImportError, RuntimeError):
+        return False
+
+
+def _ffi_lib_available():
+    try:
+        from mori.jax._ffi_registry import _find_library
+        _find_library()
+        return True
+    except (ImportError, FileNotFoundError):
+        return False
+
+
+@unittest.skipUnless(_jax_available(), "JAX with GPU not available")
+class TestJaxArrayInterop(unittest.TestCase):
+    """Test JAX array <-> raw GPU pointer conversion."""
+
+    def test_jax_data_ptr_returns_nonzero(self):
+        import jax.numpy as jnp
+        from mori.jax.shmem import jax_data_ptr
+
+        arr = jnp.ones((4, 8), dtype=jnp.float32)
+        ptr = jax_data_ptr(arr)
+        self.assertIsInstance(ptr, int)
+        self.assertGreater(ptr, 0)
+
+    def test_shmem_ptr_to_jax_roundtrip(self):
+        import jax.numpy as jnp
+        from mori.jax.shmem import jax_data_ptr, shmem_ptr_to_jax
+
+        arr = jnp.ones((4, 8), dtype=jnp.float32)
+        ptr = jax_data_ptr(arr)
+        arr2 = shmem_ptr_to_jax(ptr, (4, 8), jnp.float32)
+        self.assertEqual(arr2.shape, (4, 8))
+        self.assertTrue(jnp.allclose(arr, arr2))
+
+    def test_multi_dtype_roundtrip(self):
+        import jax.numpy as jnp
+        from mori.jax.shmem import jax_data_ptr, shmem_ptr_to_jax
+
+        for dt in [jnp.float32, jnp.bfloat16, jnp.int32, jnp.float16]:
+            with self.subTest(dtype=dt):
+                arr = jnp.zeros((2, 3), dtype=dt)
+                ptr = jax_data_ptr(arr)
+                arr2 = shmem_ptr_to_jax(ptr, (2, 3), dt)
+                self.assertEqual(arr2.shape, (2, 3))
+                self.assertEqual(arr2.dtype, dt)
+
+    def test_unsupported_dtype_raises(self):
+        from mori.jax.shmem import shmem_ptr_to_jax
+        with self.assertRaises(ValueError):
+            shmem_ptr_to_jax(0xDEAD, (1,), "bad_dtype")
+
+
+@unittest.skipUnless(_jax_available(), "JAX with GPU not available")
+@unittest.skipUnless(_ffi_lib_available(), "libmori_xla_ffi_ops.so not found")
+class TestFFIRegistration(unittest.TestCase):
+    """Test FFI library loading and JAX target registration."""
+
+    def test_load_library(self):
+        from mori.jax._ffi_registry import _load_library
+        lib = _load_library()
+        self.assertIsNotNone(lib)
+
+    def test_ffi_symbols_present(self):
+        from mori.jax._ffi_registry import _load_library
+        lib = _load_library()
+        expected = [
+            "mori_ep_dispatch", "mori_ep_combine",
+            "mori_ep_dispatch_recv", "mori_ep_combine_recv",
+            "mori_ep_reset",
+            "mori_ffi_create_handle", "mori_ffi_destroy_handle",
+            "mori_ffi_register_kernel_module",
+        ]
+        for sym in expected:
+            self.assertTrue(hasattr(lib, sym), f"Missing symbol: {sym}")
+
+    def test_register_ffi_targets(self):
+        from mori.jax._ffi_registry import register_ffi_targets
+        register_ffi_targets()
+
+
+@unittest.skipUnless(_jax_available(), "JAX with GPU not available")
+@unittest.skipUnless(_ffi_lib_available(), "libmori_xla_ffi_ops.so not found")
+class TestFFILifecycle(unittest.TestCase):
+    """Test JIT compilation, kernel module registration, and handle lifecycle."""
+
+    def test_jit_compile_and_register(self):
+        from mori.jit.core import compile_genco
+        from mori.jax._ffi_registry import register_kernel_module
+
+        hsaco = compile_genco("ep_intranode")
+        self.assertTrue(os.path.isfile(hsaco))
+        register_kernel_module(0, hsaco)
+
+    def test_handle_create_destroy(self):
+        from mori.jit.core import compile_genco
+        from mori.jax._ffi_registry import _load_library, register_kernel_module
+        from mori.jax.shmem import (
+            _ensure_shmem_module, shmem_get_unique_id,
+            shmem_init_attr, shmem_finalize,
+        )
+
+        _ensure_shmem_module()
+        lib = _load_library()
+        flag = lib.mori_ffi_shmem_init_flag_uniqueid()
+        uid = shmem_get_unique_id()
+        rc = shmem_init_attr(flag, 0, 1, uid)
+        self.assertEqual(rc, 0)
+
+        try:
+            hsaco = compile_genco("ep_intranode")
+            register_kernel_module(0, hsaco)
+
+            handle_id = lib.mori_ffi_create_handle(
+                0, 1, 4096, 0, 0, 4, 128, 1, 2, 1, 1, 0, 1, 0, 1,
+            )
+            self.assertGreater(handle_id, 0)
+            lib.mori_ffi_destroy_handle(handle_id)
+        finally:
+            shmem_finalize()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_shim_parity.py
+++ b/tests/python/test_shim_parity.py
@@ -1,0 +1,99 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+# MIT License
+#
+# Based on PR #173 by Chao Chen <cchen104@amd.com>
+# Adapted for refactored pybind function names.
+"""Shim parity test: verifies that the Torch pybind shim and the XLA FFI shim
+expose the same set of logical MoE operations.
+
+Run with:
+    python -m pytest tests/python/test_shim_parity.py -v
+"""
+import ctypes
+import pathlib
+import unittest
+
+REQUIRED_OPS = {
+    "dispatch",
+    "combine",
+    "dispatch_recv",
+    "combine_recv",
+    "reset",
+}
+
+FFI_SYMBOLS = {
+    "dispatch": "mori_ep_dispatch",
+    "combine": "mori_ep_combine",
+    "dispatch_recv": "mori_ep_dispatch_recv",
+    "combine_recv": "mori_ep_combine_recv",
+    "reset": "mori_ep_reset",
+}
+
+TORCH_FUNCTIONS = {
+    "dispatch": "prepare_and_build_args",
+    "combine": "prepare_and_build_args",
+    "dispatch_recv": "prepare_and_build_args",
+    "combine_recv": "prepare_and_build_args",
+    "reset": "launch_reset",
+}
+
+
+def _find_so(name: str):
+    """Search for a .so in common build output locations."""
+    mori_root = pathlib.Path(__file__).resolve().parent.parent.parent
+    candidates = [
+        mori_root / "build" / f"src/ffi/{name}",
+        mori_root / "build_ffi" / f"src/ffi/{name}",
+        mori_root / "build" / f"src/pybind/{name}",
+        mori_root / "python" / "mori" / name,
+    ]
+    for p in candidates:
+        if p.exists():
+            return str(p)
+    return None
+
+
+class TestShimParity(unittest.TestCase):
+    """Ensure both the XLA FFI shim and the Torch pybind shim cover the
+    required set of logical MoE operations."""
+
+    def test_ffi_symbols_present(self):
+        """All required FFI C symbols exist in libmori_xla_ffi_ops.so."""
+        lib_path = _find_so("libmori_xla_ffi_ops.so")
+        if lib_path is None:
+            self.skipTest("libmori_xla_ffi_ops.so not found (ENABLE_XLA_FFI=OFF?)")
+        lib = ctypes.CDLL(lib_path)
+        missing = []
+        for op, sym in FFI_SYMBOLS.items():
+            if not hasattr(lib, sym):
+                missing.append(f"{op} -> {sym}")
+        self.assertEqual(missing, [], f"Missing FFI symbols: {missing}")
+
+    def test_ffi_handle_lifecycle(self):
+        """Handle create/destroy C symbols exist in libmori_xla_ffi_ops.so."""
+        lib_path = _find_so("libmori_xla_ffi_ops.so")
+        if lib_path is None:
+            self.skipTest("libmori_xla_ffi_ops.so not found")
+        lib = ctypes.CDLL(lib_path)
+        self.assertTrue(hasattr(lib, "mori_ffi_create_handle"))
+        self.assertTrue(hasattr(lib, "mori_ffi_destroy_handle"))
+        self.assertTrue(hasattr(lib, "mori_ffi_register_kernel_module"))
+
+    def test_torch_functions_present(self):
+        """All required Torch pybind functions exist."""
+        try:
+            from mori import cpp as mori_cpp
+        except (ImportError, ModuleNotFoundError):
+            self.skipTest("mori.cpp not available")
+        self.assertTrue(hasattr(mori_cpp, "prepare_and_build_args"))
+        self.assertTrue(hasattr(mori_cpp, "launch_reset"))
+        self.assertTrue(hasattr(mori_cpp, "EpDispatchCombineHandle"))
+
+    def test_required_ops_covered(self):
+        """Both symbol maps cover every required op."""
+        self.assertEqual(set(FFI_SYMBOLS.keys()), REQUIRED_OPS)
+        self.assertEqual(set(TORCH_FUNCTIONS.keys()), REQUIRED_OPS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Supersedes PR #173 (by @i-chaochen  and @pemeliya ), adapted for the refactored architecture (PR #182).

Add JAX support to MORI via XLA FFI custom calls, enabling JAX users to use mori kernels and shmem **without any torch dependency**.

## Technical Details

### XLA FFI Framework
- FFI handlers for `dispatch` / `combine` / `dispatch_recv` / `combine_recv` / `reset` with `hipModuleLaunchKernel`
- `HandleManager` singleton for thread-safe handle lifecycle
- `KernelManager` singleton for JIT-compiled `.hsaco` module loading
- New `ENABLE_XLA_FFI` cmake option (default OFF), builds `libmori_xla_ffi_ops.so`

### Torch-Free JAX Path
- All submodules in `mori/__init__.py` are now lazy-imported via `__getattr__`, so `import mori.jax.*` does **not** trigger `import torch`
- 15 shmem C API functions exported as `extern "C"` from `libmori_xla_ffi_ops.so`
- `mori.jax.shmem` is fully self-contained: calls shmem via ctypes, includes inline DLPack/GpuTensorView, never touches `mori.cpp` or pybind

### JAX Array Interop
- `jax_data_ptr(arr)` — extract raw GPU pointer from `jax.Array`
- `shmem_ptr_to_jax(ptr, shape, dtype)` — wrap shmem memory as `jax.Array` via DLPack (zero-copy)
- `shmem_register_jax_array(arr)` — register JAX array for RDMA
- Supports float32, bfloat16, float16, int32, uint8 and more

### JIT + globalGpuStates Integration
- `EpDispatchCombineOp` auto-compiles `.hsaco` kernels and registers with FFI `KernelManager`
- `shmem_module_init_for_kernel()` initializes `globalGpuStates` in loaded kernel modules

## TODO

- [ ] Set up multi-process JAX + shmem environment (resolve PJRT device model vs shmem single-GPU binding conflict), then:
  - [ ] Verify `shmem_jax_init()` multi-process UniqueId broadcast
  - [ ] Implement `dispatch()` / `combine()` in `ops.py` via `jax.ffi.ffi_call`, add shmem output
  - [ ] End-to-end dispatch/combine kernel launch test
- [ ] Add mori-io `extern "C"` exports to `libmori_xla_ffi_ops.so` if JAX users need IO

## Key differences from #173

| | PR #173 | This PR |
|---|---|---|
| Python FFI registration | `_jax.register_custom_call_target` (internal API) | `jax.ffi.register_ffi_target` (public API, JAX 0.7+) |
| Shmem for JAX | Not included | Full ctypes-based shmem API (15 functions), torch-free |
| DLPack | Not included | `GpuTensorView` with GC-safe capsule lifecycle |
| torch dependency | Reduced but still imported | Fully eliminated for `mori.jax.*` |

## Test Plan

Verified on ROCm 7.1 + JAX 0.7.1 + 8x MI300X (gfx942):
- [x] C++ contract test: compile-time type check + linker symbol verification
- [x] Python shim parity (4 tests): FFI and pybind expose same op set
- [x] JAX array interop (4 tests): `jax_data_ptr` + `shmem_ptr_to_jax` round-trip, multi-dtype
- [x] FFI registration (3 tests): library loading, 8 symbols, `jax.ffi.register_ffi_target`
- [x] FFI lifecycle (4 tests): JIT compile + register, handle create/destroy, shmem malloc DLPack, **GPU kernel launch** (shmem barrier kernel, fully torch-free path)
- [x] torch-free: `from mori.jax.*` does not import torch
- [x] torch regression: `mori.ops` / `mori.cpp` / `mori.shmem` / `mori.io` / `mori.ir` unchanged

## Acknowledgements

This PR is based on the original work in #173 . The XLA FFI framework design, vendored headers, and handle manager are from their contribution.

Co-authored-by: @i-chaochen <cchen104@amd.com>
Co-authored-by: @pemeliya <pavel.emeliyanenko@amd.com>
Co-authored-by: @jhchouuu <jiahzhou@amd.com>