### PR TITLE
Feat(shmem): implement GET (remote read) device API with blocking and non-blocking

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -50,6 +50,7 @@ target_link_libraries(atomic_gpu mori_application hip::host hip::device)
 # --- Shmem examples (HIP compiled, contain device kernels) ---
 add_shmem_example(put_thread_allgather       SOURCES shmem/put_thread_allgather.cpp)
 add_shmem_example(concurrent_put_thread      SOURCES shmem/concurrent_put_thread.cpp)
+add_shmem_example(concurrent_get_thread      SOURCES shmem/concurrent_get_thread.cpp)
 add_shmem_example(test_put_schar_nbi_thread  SOURCES shmem/test_put_schar_nbi_thread.cpp)
 add_shmem_example(concurrent_put_imm_thread  SOURCES shmem/concurrent_put_imm_thread.cpp)
 add_shmem_example(concurrent_put_signal_thread SOURCES shmem/concurrent_put_signal_thread.cpp)

--- a/examples/shmem/concurrent_get_thread.cpp
+++ b/examples/shmem/concurrent_get_thread.cpp
@@ -133,6 +133,35 @@ __global__ void ConcurrentGetBlockKernel_PureAddr(int myPe, uint32_t* localBuff,
   }
 }
 
+// Blocking GET: Legacy API (Thread scope) — no separate quiet needed
+__global__ void BlockingGetThreadKernel(int myPe, const SymmMemObjPtr srcMemObj,
+                                        const SymmMemObjPtr dstMemObj) {
+  constexpr int getPe = 0;
+  constexpr int remotePe = 1;
+
+  int globalTid = blockIdx.x * blockDim.x + threadIdx.x;
+  int threadOffset = globalTid * sizeof(uint32_t);
+
+  if (myPe == getPe) {
+    ShmemGetMemThread(dstMemObj, threadOffset, srcMemObj, threadOffset, sizeof(uint32_t),
+                      remotePe, 1);
+  }
+}
+
+// Blocking GET: Pure address API (Thread scope)
+__global__ void BlockingGetThreadKernel_PureAddr(int myPe, uint32_t* localBuff,
+                                                 uint32_t* remoteBuff, size_t numElements) {
+  constexpr int getPe = 0;
+  constexpr int remotePe = 1;
+
+  int globalTid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (globalTid >= numElements) return;
+
+  if (myPe == getPe) {
+    ShmemGetMemThread(localBuff + globalTid, remoteBuff + globalTid, sizeof(uint32_t), remotePe, 1);
+  }
+}
+
 // ============================================================================
 // Test Functions
 // ============================================================================
@@ -462,6 +491,129 @@ void Test3_LargeMultiChunk(int myPe) {
   ShmemFree(localBuff);
 }
 
+void Test4_BlockingLegacyAPI(int myPe) {
+  if (myPe == 0) {
+    printf("\n--- Test 4: Blocking GET Legacy API (Thread scope) ---\n");
+  }
+
+  constexpr int threadNum = 128;
+  constexpr int blockNum = 3;
+  int numEle = threadNum * blockNum;
+  int buffSize = numEle * sizeof(uint32_t);
+
+  void* srcBuff = ShmemMalloc(buffSize);
+  void* dstBuff = ShmemMalloc(buffSize);
+
+  if (myPe == 1) {
+    HIP_RUNTIME_CHECK(hipMemsetD32(reinterpret_cast<uint32_t*>(srcBuff), 1, numEle));
+  } else {
+    HIP_RUNTIME_CHECK(hipMemsetD32(reinterpret_cast<uint32_t*>(srcBuff), 0, numEle));
+  }
+  HIP_RUNTIME_CHECK(hipMemsetD32(reinterpret_cast<uint32_t*>(dstBuff), 0xDEAD, numEle));
+  HIP_RUNTIME_CHECK(hipDeviceSynchronize());
+
+  SymmMemObjPtr srcObj = ShmemQueryMemObjPtr(srcBuff);
+  SymmMemObjPtr dstObj = ShmemQueryMemObjPtr(dstBuff);
+  assert(srcObj.IsValid());
+  assert(dstObj.IsValid());
+
+  if (myPe == 0) {
+    printf("Running blocking GET legacy API test...\n");
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+  BlockingGetThreadKernel<<<blockNum, threadNum>>>(myPe, srcObj, dstObj);
+  HIP_RUNTIME_CHECK(hipDeviceSynchronize());
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  if (myPe == 0) {
+    std::vector<uint32_t> hostBuff(numEle);
+    HIP_RUNTIME_CHECK(hipMemcpy(hostBuff.data(), dstBuff, buffSize, hipMemcpyDeviceToHost));
+
+    bool success = true;
+    for (int i = 0; i < numEle; i++) {
+      if (hostBuff[i] != 1) {
+        printf("Error at index %d: expected 1, got %u\n", i, hostBuff[i]);
+        success = false;
+        break;
+      }
+    }
+    if (success) {
+      printf("✓ Blocking GET legacy API test PASSED! All %d elements verified.\n", numEle);
+    } else {
+      printf("✗ Blocking GET legacy API test FAILED!\n");
+    }
+  }
+
+  ShmemFree(srcBuff);
+  ShmemFree(dstBuff);
+}
+
+void Test5_BlockingPureAddressAPI(int myPe) {
+  if (myPe == 0) {
+    printf("\n--- Test 5: Blocking GET Pure Address API (Thread scope) ---\n");
+  }
+
+  const char* shmemMode = std::getenv("MORI_SHMEM_MODE");
+  bool skipPureAddress = (shmemMode != nullptr && std::string(shmemMode) == "ISOLATION");
+
+  if (skipPureAddress) {
+    if (myPe == 0) {
+      printf("⊘ SKIPPED (MORI_SHMEM_MODE=ISOLATION)\n");
+    }
+    return;
+  }
+
+  constexpr int threadNum = 128;
+  constexpr int blockNum = 3;
+  int numEle = threadNum * blockNum;
+  int buffSize = numEle * sizeof(uint32_t);
+
+  void* remoteBuff = ShmemMalloc(buffSize);
+  void* localBuff = ShmemMalloc(buffSize);
+
+  if (myPe == 1) {
+    HIP_RUNTIME_CHECK(hipMemsetD32(reinterpret_cast<uint32_t*>(remoteBuff), 1, numEle));
+  } else {
+    HIP_RUNTIME_CHECK(hipMemsetD32(reinterpret_cast<uint32_t*>(remoteBuff), 0, numEle));
+  }
+  HIP_RUNTIME_CHECK(hipMemsetD32(reinterpret_cast<uint32_t*>(localBuff), 0xDEAD, numEle));
+  HIP_RUNTIME_CHECK(hipDeviceSynchronize());
+
+  if (myPe == 0) {
+    printf("Running blocking GET pure address API test...\n");
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+  BlockingGetThreadKernel_PureAddr<<<blockNum, threadNum>>>(
+      myPe, reinterpret_cast<uint32_t*>(localBuff), reinterpret_cast<uint32_t*>(remoteBuff),
+      numEle);
+  HIP_RUNTIME_CHECK(hipDeviceSynchronize());
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  if (myPe == 0) {
+    std::vector<uint32_t> hostBuff(numEle);
+    HIP_RUNTIME_CHECK(hipMemcpy(hostBuff.data(), localBuff, buffSize, hipMemcpyDeviceToHost));
+
+    bool success = true;
+    for (int i = 0; i < numEle; i++) {
+      if (hostBuff[i] != 1) {
+        printf("Error at index %d: expected 1, got %u\n", i, hostBuff[i]);
+        success = false;
+        break;
+      }
+    }
+    if (success) {
+      printf("✓ Blocking GET pure address API test PASSED! All %d elements verified.\n", numEle);
+    } else {
+      printf("✗ Blocking GET pure address API test FAILED!\n");
+    }
+  }
+
+  ShmemFree(remoteBuff);
+  ShmemFree(localBuff);
+}
+
 // ============================================================================
 // Main
 // ============================================================================
@@ -501,16 +653,20 @@ void ConcurrentGetThread() {
   Test2_PureAddressAPI(myPe);
   Test2_PureAddressAPI_Block(myPe);
   Test3_LargeMultiChunk(myPe);
+  Test4_BlockingLegacyAPI(myPe);
+  Test5_BlockingPureAddressAPI(myPe);
 
   if (myPe == 0) {
     printf("\n=================================================================\n");
     printf("All GET tests completed!\n");
     printf("Summary:\n");
-    printf("  - Test 1:  Legacy API GET (Thread scope)\n");
-    printf("  - Test 1B: Legacy API GET (Block scope)\n");
-    printf("  - Test 2:  Pure Address API GET (Thread scope)\n");
-    printf("  - Test 2B: Pure Address API GET (Block scope)\n");
-    printf("  - Test 3:  Large Multi-Chunk GET (>200MB)\n");
+    printf("  - Test 1:  Nbi GET Legacy API (Thread scope)\n");
+    printf("  - Test 1B: Nbi GET Legacy API (Block scope)\n");
+    printf("  - Test 2:  Nbi GET Pure Address API (Thread scope)\n");
+    printf("  - Test 2B: Nbi GET Pure Address API (Block scope)\n");
+    printf("  - Test 3:  Nbi GET Large Multi-Chunk (>200MB)\n");
+    printf("  - Test 4:  Blocking GET Legacy API (Thread scope)\n");
+    printf("  - Test 5:  Blocking GET Pure Address API (Thread scope)\n");
     printf("=================================================================\n");
   }
 

--- a/examples/shmem/concurrent_get_thread.cpp
+++ b/examples/shmem/concurrent_get_thread.cpp
@@ -1,0 +1,524 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#include <mpi.h>
+
+#include <cassert>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+#include "mori/application/utils/check.hpp"
+#include "mori/shmem/shmem.hpp"
+
+using namespace mori::core;
+using namespace mori::shmem;
+using namespace mori::application;
+
+// ============================================================================
+// Test Suite Overview
+// ============================================================================
+// Test 1: Legacy API GET with SymmMemObjPtr + offset (Thread scope)
+// Test 1B: Legacy API GET with SymmMemObjPtr + offset (Block scope)
+// Test 2: Pure address API GET (Thread scope)
+// Test 2B: Pure address API GET (Block scope)
+// Test 3: Large multi-chunk GET (>200MB spanning multiple 64MB chunks)
+// ============================================================================
+
+// ============================================================================
+// GPU Kernels
+// ============================================================================
+
+// Legacy API: GET using SymmMemObjPtr + offset (Thread scope)
+// PE 0 reads from PE 1's buffer into its own local buffer
+__global__ void ConcurrentGetThreadKernel(int myPe, const SymmMemObjPtr srcMemObj,
+                                          const SymmMemObjPtr dstMemObj) {
+  constexpr int getPe = 0;
+  constexpr int remotePe = 1;
+
+  int globalTid = blockIdx.x * blockDim.x + threadIdx.x;
+  int threadOffset = globalTid * sizeof(uint32_t);
+
+  if (myPe == getPe) {
+    ShmemGetMemNbiThread(dstMemObj, threadOffset, srcMemObj, threadOffset, sizeof(uint32_t),
+                         remotePe, 1);
+    ShmemQuietThread(remotePe, 1);
+  }
+}
+
+// Legacy API: GET using SymmMemObjPtr + offset (Block scope)
+__global__ void ConcurrentGetBlockKernel(int myPe, const SymmMemObjPtr srcMemObj,
+                                         const SymmMemObjPtr dstMemObj, size_t numElements) {
+  constexpr int getPe = 0;
+  constexpr int remotePe = 1;
+
+  int globalTid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (globalTid >= static_cast<int>(numElements)) {
+    return;
+  }
+
+  size_t blockElemOffset = static_cast<size_t>(blockIdx.x) * blockDim.x;
+  size_t blockByteOffset = blockElemOffset * sizeof(uint32_t);
+  size_t blockBytes = static_cast<size_t>(blockDim.x) * sizeof(uint32_t);
+
+  if (myPe == getPe) {
+    ShmemGetMemNbiBlock(dstMemObj, blockByteOffset, srcMemObj, blockByteOffset, blockBytes,
+                        remotePe, 1);
+    if (threadIdx.x == 0) {
+      ShmemQuietThread(remotePe, 1);
+    }
+  }
+}
+
+// Pure address API: GET using raw pointers (Thread scope)
+// PE 0 reads from PE 1's remoteBuff into its own localBuff
+__global__ void ConcurrentGetThreadKernel_PureAddr(int myPe, uint32_t* localBuff,
+                                                   uint32_t* remoteBuff, size_t numElements) {
+  constexpr int getPe = 0;
+  constexpr int remotePe = 1;
+
+  int globalTid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (globalTid >= numElements) {
+    return;
+  }
+
+  if (myPe == getPe) {
+    uint32_t* dest = localBuff + globalTid;
+    uint32_t* src = remoteBuff + globalTid;
+
+    ShmemGetMemNbiThread(dest, src, sizeof(uint32_t), remotePe, 1);
+    ShmemQuietThread(remotePe, 1);
+  }
+}
+
+// Pure address API: GET using raw pointers (Block scope)
+__global__ void ConcurrentGetBlockKernel_PureAddr(int myPe, uint32_t* localBuff,
+                                                  uint32_t* remoteBuff, size_t numElements) {
+  constexpr int getPe = 0;
+  constexpr int remotePe = 1;
+
+  int globalTid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (globalTid >= static_cast<int>(numElements)) {
+    return;
+  }
+
+  size_t blockElemOffset = static_cast<size_t>(blockIdx.x) * blockDim.x;
+  size_t blockBytes = static_cast<size_t>(blockDim.x) * sizeof(uint32_t);
+  uint32_t* dest = localBuff + blockElemOffset;
+  uint32_t* src = remoteBuff + blockElemOffset;
+
+  if (myPe == getPe) {
+    ShmemGetMemNbiBlock(dest, src, blockBytes, remotePe, 1);
+    if (threadIdx.x == 0) {
+      ShmemQuietThread(remotePe, 1);
+    }
+  }
+}
+
+// ============================================================================
+// Test Functions
+// ============================================================================
+
+void Test1_LegacyAPI(int myPe) {
+  if (myPe == 0) {
+    printf("\n--- Test 1: Legacy API GET (SymmMemObjPtr + offset, Thread scope) ---\n");
+  }
+
+  constexpr int threadNum = 128;
+  constexpr int blockNum = 3;
+  int numEle = threadNum * blockNum;
+  int buffSize = numEle * sizeof(uint32_t);
+
+  // srcBuff: PE 1 fills with known pattern, PE 0 will GET from PE 1
+  void* srcBuff = ShmemMalloc(buffSize);
+  // dstBuff: PE 0 will receive GET data here
+  void* dstBuff = ShmemMalloc(buffSize);
+
+  // PE 1 fills source with its rank (1), PE 0 fills with 0xDEAD (sentinel)
+  if (myPe == 1) {
+    HIP_RUNTIME_CHECK(hipMemsetD32(reinterpret_cast<uint32_t*>(srcBuff), 1, numEle));
+  } else {
+    HIP_RUNTIME_CHECK(hipMemsetD32(reinterpret_cast<uint32_t*>(srcBuff), 0, numEle));
+  }
+  HIP_RUNTIME_CHECK(hipMemsetD32(reinterpret_cast<uint32_t*>(dstBuff), 0xDEAD, numEle));
+  HIP_RUNTIME_CHECK(hipDeviceSynchronize());
+
+  SymmMemObjPtr srcObj = ShmemQueryMemObjPtr(srcBuff);
+  SymmMemObjPtr dstObj = ShmemQueryMemObjPtr(dstBuff);
+  assert(srcObj.IsValid());
+  assert(dstObj.IsValid());
+
+  if (myPe == 0) {
+    printf("Running legacy API GET test (thread scope)...\n");
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+  ConcurrentGetThreadKernel<<<blockNum, threadNum>>>(myPe, srcObj, dstObj);
+  HIP_RUNTIME_CHECK(hipDeviceSynchronize());
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  if (myPe == 0) {
+    std::vector<uint32_t> hostBuff(numEle);
+    HIP_RUNTIME_CHECK(hipMemcpy(hostBuff.data(), dstBuff, buffSize, hipMemcpyDeviceToHost));
+
+    bool success = true;
+    for (int i = 0; i < numEle; i++) {
+      if (hostBuff[i] != 1) {
+        printf("Error at index %d: expected 1 (PE 1's data), got %u\n", i, hostBuff[i]);
+        success = false;
+        break;
+      }
+    }
+    if (success) {
+      printf("✓ Legacy API GET test PASSED! All %d elements verified.\n", numEle);
+    } else {
+      printf("✗ Legacy API GET test FAILED!\n");
+    }
+  }
+
+  ShmemFree(srcBuff);
+  ShmemFree(dstBuff);
+}
+
+void Test1_LegacyAPI_Block(int myPe) {
+  if (myPe == 0) {
+    printf("\n--- Test 1B: Legacy API GET Block Scope ---\n");
+  }
+
+  constexpr int threadNum = 128;
+  constexpr int blockNum = 3;
+  int numEle = threadNum * blockNum;
+  int buffSize = numEle * sizeof(uint32_t);
+
+  void* srcBuff = ShmemMalloc(buffSize);
+  void* dstBuff = ShmemMalloc(buffSize);
+
+  if (myPe == 1) {
+    HIP_RUNTIME_CHECK(hipMemsetD32(reinterpret_cast<uint32_t*>(srcBuff), 1, numEle));
+  } else {
+    HIP_RUNTIME_CHECK(hipMemsetD32(reinterpret_cast<uint32_t*>(srcBuff), 0, numEle));
+  }
+  HIP_RUNTIME_CHECK(hipMemsetD32(reinterpret_cast<uint32_t*>(dstBuff), 0xDEAD, numEle));
+  HIP_RUNTIME_CHECK(hipDeviceSynchronize());
+
+  SymmMemObjPtr srcObj = ShmemQueryMemObjPtr(srcBuff);
+  SymmMemObjPtr dstObj = ShmemQueryMemObjPtr(dstBuff);
+  assert(srcObj.IsValid());
+  assert(dstObj.IsValid());
+
+  if (myPe == 0) {
+    printf("Running legacy API GET test (block scope)...\n");
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+  ConcurrentGetBlockKernel<<<blockNum, threadNum>>>(myPe, srcObj, dstObj, numEle);
+  HIP_RUNTIME_CHECK(hipDeviceSynchronize());
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  if (myPe == 0) {
+    std::vector<uint32_t> hostBuff(numEle);
+    HIP_RUNTIME_CHECK(hipMemcpy(hostBuff.data(), dstBuff, buffSize, hipMemcpyDeviceToHost));
+
+    bool success = true;
+    for (int i = 0; i < numEle; i++) {
+      if (hostBuff[i] != 1) {
+        printf("Error at index %d: expected 1, got %u\n", i, hostBuff[i]);
+        success = false;
+        break;
+      }
+    }
+    if (success) {
+      printf("✓ Legacy API GET block test PASSED! All %d elements verified.\n", numEle);
+    } else {
+      printf("✗ Legacy API GET block test FAILED!\n");
+    }
+  }
+
+  ShmemFree(srcBuff);
+  ShmemFree(dstBuff);
+}
+
+void Test2_PureAddressAPI(int myPe) {
+  if (myPe == 0) {
+    printf("\n--- Test 2: Pure Address API GET (Thread scope) ---\n");
+  }
+
+  const char* shmemMode = std::getenv("MORI_SHMEM_MODE");
+  bool skipPureAddress = (shmemMode != nullptr && std::string(shmemMode) == "ISOLATION");
+
+  if (skipPureAddress) {
+    if (myPe == 0) {
+      printf("⊘ SKIPPED (MORI_SHMEM_MODE=ISOLATION)\n");
+    }
+    return;
+  }
+
+  constexpr int threadNum = 128;
+  constexpr int blockNum = 3;
+  int numEle = threadNum * blockNum;
+  int buffSize = numEle * sizeof(uint32_t);
+
+  // remoteBuff: symmetric allocation, PE 1 fills with pattern
+  void* remoteBuff = ShmemMalloc(buffSize);
+  // localBuff: PE 0's destination for GET
+  void* localBuff = ShmemMalloc(buffSize);
+
+  if (myPe == 1) {
+    HIP_RUNTIME_CHECK(hipMemsetD32(reinterpret_cast<uint32_t*>(remoteBuff), 1, numEle));
+  } else {
+    HIP_RUNTIME_CHECK(hipMemsetD32(reinterpret_cast<uint32_t*>(remoteBuff), 0, numEle));
+  }
+  HIP_RUNTIME_CHECK(hipMemsetD32(reinterpret_cast<uint32_t*>(localBuff), 0xDEAD, numEle));
+  HIP_RUNTIME_CHECK(hipDeviceSynchronize());
+
+  if (myPe == 0) {
+    printf("Running pure address API GET test (thread scope)...\n");
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+  ConcurrentGetThreadKernel_PureAddr<<<blockNum, threadNum>>>(
+      myPe, reinterpret_cast<uint32_t*>(localBuff), reinterpret_cast<uint32_t*>(remoteBuff),
+      numEle);
+  HIP_RUNTIME_CHECK(hipDeviceSynchronize());
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  if (myPe == 0) {
+    std::vector<uint32_t> hostBuff(numEle);
+    HIP_RUNTIME_CHECK(hipMemcpy(hostBuff.data(), localBuff, buffSize, hipMemcpyDeviceToHost));
+
+    bool success = true;
+    for (int i = 0; i < numEle; i++) {
+      if (hostBuff[i] != 1) {
+        printf("Error at index %d: expected 1, got %u\n", i, hostBuff[i]);
+        success = false;
+        break;
+      }
+    }
+    if (success) {
+      printf("✓ Pure address API GET test PASSED! All %d elements verified.\n", numEle);
+    } else {
+      printf("✗ Pure address API GET test FAILED!\n");
+    }
+  }
+
+  ShmemFree(remoteBuff);
+  ShmemFree(localBuff);
+}
+
+void Test2_PureAddressAPI_Block(int myPe) {
+  if (myPe == 0) {
+    printf("\n--- Test 2B: Pure Address API GET Block Scope ---\n");
+  }
+
+  const char* shmemMode = std::getenv("MORI_SHMEM_MODE");
+  bool skipPureAddress = (shmemMode != nullptr && std::string(shmemMode) == "ISOLATION");
+
+  if (skipPureAddress) {
+    if (myPe == 0) {
+      printf("⊘ SKIPPED (MORI_SHMEM_MODE=ISOLATION)\n");
+    }
+    return;
+  }
+
+  constexpr int threadNum = 128;
+  constexpr int blockNum = 3;
+  int numEle = threadNum * blockNum;
+  int buffSize = numEle * sizeof(uint32_t);
+
+  void* remoteBuff = ShmemMalloc(buffSize);
+  void* localBuff = ShmemMalloc(buffSize);
+
+  if (myPe == 1) {
+    HIP_RUNTIME_CHECK(hipMemsetD32(reinterpret_cast<uint32_t*>(remoteBuff), 1, numEle));
+  } else {
+    HIP_RUNTIME_CHECK(hipMemsetD32(reinterpret_cast<uint32_t*>(remoteBuff), 0, numEle));
+  }
+  HIP_RUNTIME_CHECK(hipMemsetD32(reinterpret_cast<uint32_t*>(localBuff), 0xDEAD, numEle));
+  HIP_RUNTIME_CHECK(hipDeviceSynchronize());
+
+  if (myPe == 0) {
+    printf("Running pure address API GET test (block scope)...\n");
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+  ConcurrentGetBlockKernel_PureAddr<<<blockNum, threadNum>>>(
+      myPe, reinterpret_cast<uint32_t*>(localBuff), reinterpret_cast<uint32_t*>(remoteBuff),
+      numEle);
+  HIP_RUNTIME_CHECK(hipDeviceSynchronize());
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  if (myPe == 0) {
+    std::vector<uint32_t> hostBuff(numEle);
+    HIP_RUNTIME_CHECK(hipMemcpy(hostBuff.data(), localBuff, buffSize, hipMemcpyDeviceToHost));
+
+    bool success = true;
+    for (int i = 0; i < numEle; i++) {
+      if (hostBuff[i] != 1) {
+        printf("Error at index %d: expected 1, got %u\n", i, hostBuff[i]);
+        success = false;
+        break;
+      }
+    }
+    if (success) {
+      printf("✓ Pure address API GET block test PASSED! All %d elements verified.\n", numEle);
+    } else {
+      printf("✗ Pure address API GET block test FAILED!\n");
+    }
+  }
+
+  ShmemFree(remoteBuff);
+  ShmemFree(localBuff);
+}
+
+void Test3_LargeMultiChunk(int myPe) {
+  if (myPe == 0) {
+    printf("\n--- Test 3: Large Multi-Chunk GET (>200MB) ---\n");
+  }
+
+  const char* shmemMode = std::getenv("MORI_SHMEM_MODE");
+  bool skipPureAddress = (shmemMode != nullptr && std::string(shmemMode) == "ISOLATION");
+
+  if (skipPureAddress) {
+    if (myPe == 0) {
+      printf("⊘ SKIPPED (MORI_SHMEM_MODE=ISOLATION)\n");
+    }
+    return;
+  }
+
+  constexpr size_t largeSize = 200 * 1024 * 1024;
+  constexpr size_t largeNumEle = largeSize / sizeof(uint32_t);
+
+  if (myPe == 0) {
+    printf("Allocating %zu MB (%zu elements)...\n", largeSize / (1024 * 1024), largeNumEle);
+  }
+
+  void* remoteBuff = ShmemMalloc(largeSize);
+  void* localBuff = ShmemMalloc(largeSize);
+  assert(remoteBuff != nullptr);
+  assert(localBuff != nullptr);
+
+  if (myPe == 1) {
+    HIP_RUNTIME_CHECK(hipMemsetD32(reinterpret_cast<uint32_t*>(remoteBuff), 1, largeNumEle));
+  } else {
+    HIP_RUNTIME_CHECK(hipMemsetD32(reinterpret_cast<uint32_t*>(remoteBuff), 0, largeNumEle));
+  }
+  HIP_RUNTIME_CHECK(hipMemsetD32(reinterpret_cast<uint32_t*>(localBuff), 0xDEAD, largeNumEle));
+  HIP_RUNTIME_CHECK(hipDeviceSynchronize());
+
+  if (myPe == 0) {
+    printf("Testing large data GET with pure address API...\n");
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+  constexpr int largeBlockNum = 1024;
+  constexpr int largeThreadNum = 256;
+  constexpr size_t testElements = largeBlockNum * largeThreadNum;
+
+  ConcurrentGetThreadKernel_PureAddr<<<largeBlockNum, largeThreadNum>>>(
+      myPe, reinterpret_cast<uint32_t*>(localBuff), reinterpret_cast<uint32_t*>(remoteBuff),
+      testElements);
+  HIP_RUNTIME_CHECK(hipDeviceSynchronize());
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  if (myPe == 0) {
+    std::vector<uint32_t> hostBuff(testElements);
+    HIP_RUNTIME_CHECK(
+        hipMemcpy(hostBuff.data(), localBuff, testElements * sizeof(uint32_t), hipMemcpyDeviceToHost));
+
+    bool success = true;
+    for (size_t i = 0; i < testElements; i++) {
+      if (hostBuff[i] != 1) {
+        printf("Error at index %zu: expected 1, got %u\n", i, hostBuff[i]);
+        success = false;
+        break;
+      }
+    }
+    if (success) {
+      printf("✓ Large multi-chunk GET test PASSED! Verified %zu elements.\n", testElements);
+    } else {
+      printf("✗ Large multi-chunk GET test FAILED!\n");
+    }
+  }
+
+  ShmemFree(remoteBuff);
+  ShmemFree(localBuff);
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+void ConcurrentGetThread() {
+  MPI_Init(NULL, NULL);
+
+  MPI_Comm localComm;
+  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &localComm);
+
+  int localRank;
+  MPI_Comm_rank(localComm, &localRank);
+
+  int deviceCount;
+  HIP_RUNTIME_CHECK(hipGetDeviceCount(&deviceCount));
+  int deviceId = localRank % deviceCount;
+  HIP_RUNTIME_CHECK(hipSetDevice(deviceId));
+
+  printf("Local rank %d setting GPU device %d (total %d devices)\n", localRank, deviceId,
+         deviceCount);
+
+  int status = ShmemMpiInit(MPI_COMM_WORLD);
+  assert(!status);
+
+  int myPe = ShmemMyPe();
+  int npes = ShmemNPes();
+  assert(npes == 2);
+
+  if (myPe == 0) {
+    printf("=================================================================\n");
+    printf("MORI SHMEM GET Test Suite\n");
+    printf("=================================================================\n");
+  }
+
+  Test1_LegacyAPI(myPe);
+  Test1_LegacyAPI_Block(myPe);
+  Test2_PureAddressAPI(myPe);
+  Test2_PureAddressAPI_Block(myPe);
+  Test3_LargeMultiChunk(myPe);
+
+  if (myPe == 0) {
+    printf("\n=================================================================\n");
+    printf("All GET tests completed!\n");
+    printf("Summary:\n");
+    printf("  - Test 1:  Legacy API GET (Thread scope)\n");
+    printf("  - Test 1B: Legacy API GET (Block scope)\n");
+    printf("  - Test 2:  Pure Address API GET (Thread scope)\n");
+    printf("  - Test 2B: Pure Address API GET (Block scope)\n");
+    printf("  - Test 3:  Large Multi-Chunk GET (>200MB)\n");
+    printf("=================================================================\n");
+  }
+
+  MPI_Comm_free(&localComm);
+  ShmemFinalize();
+}
+
+int main(int argc, char* argv[]) {
+  ConcurrentGetThread();
+  return 0;
+}

--- a/examples/shmem/ir/test_triton_shmem.py
+++ b/examples/shmem/ir/test_triton_shmem.py
@@ -39,12 +39,20 @@ def shmem_put_kernel(symm_buf_ptr, value):
 
 
 @triton.jit
-def shmem_get_kernel(local_buf_ptr, remote_buf_ptr, nbytes):
+def shmem_get_nbi_kernel(local_buf_ptr, remote_buf_ptr, nbytes):
     mype = mori_shmem_device.my_pe()
     npes = mori_shmem_device.n_pes()
     src_pe = (mype + 1) % npes
     mori_shmem_device.getmem_nbi_thread(local_buf_ptr, remote_buf_ptr, nbytes, src_pe, 0)
     mori_shmem_device.quiet_thread()
+
+
+@triton.jit
+def shmem_get_blocking_kernel(local_buf_ptr, remote_buf_ptr, nbytes):
+    mype = mori_shmem_device.my_pe()
+    npes = mori_shmem_device.n_pes()
+    src_pe = (mype + 1) % npes
+    mori_shmem_device.getmem_thread(local_buf_ptr, remote_buf_ptr, nbytes, src_pe, 0)
 
 
 # ===================================================================
@@ -108,31 +116,54 @@ def test_put(mype, npes, extern_libs):
     print(f"[PE {mype}] [Triton] put    PASS")
 
 
-def test_get(mype, npes, extern_libs):
+def test_get_nbi(mype, npes, extern_libs):
     import mori.shmem as ms
     from mori.shmem import mori_shmem_create_tensor
 
-    print(f"\n[PE {mype}] === Triton: shmem_get_kernel ===")
-    # remote_buf: each PE fills with its own rank * 100 + 42
+    print(f"\n[PE {mype}] === Triton: shmem_get_nbi_kernel ===")
     remote_buf = mori_shmem_create_tensor((1,), torch.int32)
     remote_buf.fill_(mype * 100 + 42)
-    # local_buf: destination for GET, fill with sentinel
     local_buf = mori_shmem_create_tensor((1,), torch.int32)
     local_buf.fill_(-1)
     torch.cuda.synchronize()
     ms.shmem_barrier_all()
 
-    nbytes = 4  # sizeof(int32)
-    shmem_get_kernel[(1,)](local_buf, remote_buf, nbytes, extern_libs=extern_libs)
+    nbytes = 4
+    shmem_get_nbi_kernel[(1,)](local_buf, remote_buf, nbytes, extern_libs=extern_libs)
     torch.cuda.synchronize()
     ms.shmem_barrier_all()
 
     src_pe = (mype + 1) % npes
     exp = src_pe * 100 + 42
     got = local_buf.item()
-    print(f"[PE {mype}] local_buf={got}, expected={exp} (GET from PE {src_pe})")
+    print(f"[PE {mype}] local_buf={got}, expected={exp} (GET nbi from PE {src_pe})")
     assert got == exp, f"PE {mype}: expected {exp}, got {got}"
-    print(f"[PE {mype}] [Triton] get    PASS")
+    print(f"[PE {mype}] [Triton] get_nbi      PASS")
+
+
+def test_get_blocking(mype, npes, extern_libs):
+    import mori.shmem as ms
+    from mori.shmem import mori_shmem_create_tensor
+
+    print(f"\n[PE {mype}] === Triton: shmem_get_blocking_kernel ===")
+    remote_buf = mori_shmem_create_tensor((1,), torch.int32)
+    remote_buf.fill_(mype * 200 + 99)
+    local_buf = mori_shmem_create_tensor((1,), torch.int32)
+    local_buf.fill_(-1)
+    torch.cuda.synchronize()
+    ms.shmem_barrier_all()
+
+    nbytes = 4
+    shmem_get_blocking_kernel[(1,)](local_buf, remote_buf, nbytes, extern_libs=extern_libs)
+    torch.cuda.synchronize()
+    ms.shmem_barrier_all()
+
+    src_pe = (mype + 1) % npes
+    exp = src_pe * 200 + 99
+    got = local_buf.item()
+    print(f"[PE {mype}] local_buf={got}, expected={exp} (GET blocking from PE {src_pe})")
+    assert got == exp, f"PE {mype}: expected {exp}, got {got}"
+    print(f"[PE {mype}] [Triton] get_blocking  PASS")
 
 
 # ===================================================================
@@ -146,7 +177,8 @@ def main():
     try:
         test_basic(mype, npes, extern_libs)
         test_put(mype, npes, extern_libs)
-        test_get(mype, npes, extern_libs)
+        test_get_nbi(mype, npes, extern_libs)
+        test_get_blocking(mype, npes, extern_libs)
         if mype == 0:
             print(f"\n{'=' * 60}")
             print(f"  All tests PASSED on {npes} PEs (Triton + mori shmem)")

--- a/examples/shmem/ir/test_triton_shmem.py
+++ b/examples/shmem/ir/test_triton_shmem.py
@@ -38,6 +38,15 @@ def shmem_put_kernel(symm_buf_ptr, value):
     mori_shmem_device.quiet_thread()
 
 
+@triton.jit
+def shmem_get_kernel(local_buf_ptr, remote_buf_ptr, nbytes):
+    mype = mori_shmem_device.my_pe()
+    npes = mori_shmem_device.n_pes()
+    src_pe = (mype + 1) % npes
+    mori_shmem_device.getmem_nbi_thread(local_buf_ptr, remote_buf_ptr, nbytes, src_pe, 0)
+    mori_shmem_device.quiet_thread()
+
+
 # ===================================================================
 # 2. Distributed setup
 # ===================================================================
@@ -99,6 +108,33 @@ def test_put(mype, npes, extern_libs):
     print(f"[PE {mype}] [Triton] put    PASS")
 
 
+def test_get(mype, npes, extern_libs):
+    import mori.shmem as ms
+    from mori.shmem import mori_shmem_create_tensor
+
+    print(f"\n[PE {mype}] === Triton: shmem_get_kernel ===")
+    # remote_buf: each PE fills with its own rank * 100 + 42
+    remote_buf = mori_shmem_create_tensor((1,), torch.int32)
+    remote_buf.fill_(mype * 100 + 42)
+    # local_buf: destination for GET, fill with sentinel
+    local_buf = mori_shmem_create_tensor((1,), torch.int32)
+    local_buf.fill_(-1)
+    torch.cuda.synchronize()
+    ms.shmem_barrier_all()
+
+    nbytes = 4  # sizeof(int32)
+    shmem_get_kernel[(1,)](local_buf, remote_buf, nbytes, extern_libs=extern_libs)
+    torch.cuda.synchronize()
+    ms.shmem_barrier_all()
+
+    src_pe = (mype + 1) % npes
+    exp = src_pe * 100 + 42
+    got = local_buf.item()
+    print(f"[PE {mype}] local_buf={got}, expected={exp} (GET from PE {src_pe})")
+    assert got == exp, f"PE {mype}: expected {exp}, got {got}"
+    print(f"[PE {mype}] [Triton] get    PASS")
+
+
 # ===================================================================
 # main
 # ===================================================================
@@ -110,6 +146,7 @@ def main():
     try:
         test_basic(mype, npes, extern_libs)
         test_put(mype, npes, extern_libs)
+        test_get(mype, npes, extern_libs)
         if mype == 0:
             print(f"\n{'=' * 60}")
             print(f"  All tests PASSED on {npes} PEs (Triton + mori shmem)")

--- a/include/mori/core/transport/rdma/device_primitives.hpp
+++ b/include/mori/core/transport/rdma/device_primitives.hpp
@@ -95,25 +95,47 @@ template <ProviderType PrvdType>
 inline __device__ uint64_t PostRecv(WorkQueueHandle& wq, uint32_t qpn, uintptr_t laddr,
                                     uint64_t lkey, size_t bytes);
 
+template <ProviderType PrvdType, bool IsRead>
+inline __device__ uint64_t PostReadWrite(WorkQueueHandle& wq, uint32_t curPostIdx,
+                                         uint32_t curMsntblSlotIdx, uint32_t curPsnIdx,
+                                         bool cqeSignal, uint32_t qpn, uintptr_t laddr,
+                                         uint64_t lkey, uintptr_t raddr, uint64_t rkey,
+                                         size_t bytes);
+
+template <ProviderType PrvdType, bool IsRead>
+inline __device__ uint64_t PostReadWrite(WorkQueueHandle& wq, uint32_t qpn, uintptr_t laddr,
+                                         uint64_t lkey, uintptr_t raddr, uint64_t rkey,
+                                         size_t bytes);
+
 template <ProviderType PrvdType>
 inline __device__ uint64_t PostWrite(WorkQueueHandle& wq, uint32_t curPostIdx,
                                      uint32_t curMsntblSlotIdx, uint32_t curPsnIdx, bool cqeSignal,
                                      uint32_t qpn, uintptr_t laddr, uint64_t lkey, uintptr_t raddr,
-                                     uint64_t rkey, size_t bytes);
+                                     uint64_t rkey, size_t bytes) {
+  return PostReadWrite<PrvdType, false>(wq, curPostIdx, curMsntblSlotIdx, curPsnIdx, cqeSignal, qpn,
+                                        laddr, lkey, raddr, rkey, bytes);
+}
 
 template <ProviderType PrvdType>
 inline __device__ uint64_t PostRead(WorkQueueHandle& wq, uint32_t curPostIdx,
                                     uint32_t curMsntblSlotIdx, uint32_t curPsnIdx, bool cqeSignal,
                                     uint32_t qpn, uintptr_t laddr, uint64_t lkey, uintptr_t raddr,
-                                    uint64_t rkey, size_t bytes);
+                                    uint64_t rkey, size_t bytes) {
+  return PostReadWrite<PrvdType, true>(wq, curPostIdx, curMsntblSlotIdx, curPsnIdx, cqeSignal, qpn,
+                                       laddr, lkey, raddr, rkey, bytes);
+}
 
 template <ProviderType PrvdType>
 inline __device__ uint64_t PostWrite(WorkQueueHandle& wq, uint32_t qpn, uintptr_t laddr,
-                                     uint64_t lkey, uintptr_t raddr, uint64_t rkey, size_t bytes);
+                                     uint64_t lkey, uintptr_t raddr, uint64_t rkey, size_t bytes) {
+  return PostReadWrite<PrvdType, false>(wq, qpn, laddr, lkey, raddr, rkey, bytes);
+}
 
 template <ProviderType PrvdType>
 inline __device__ uint64_t PostRead(WorkQueueHandle& wq, uint32_t qpn, uintptr_t laddr,
-                                    uint64_t lkey, uintptr_t raddr, uint64_t rkey, size_t bytes);
+                                    uint64_t lkey, uintptr_t raddr, uint64_t rkey, size_t bytes) {
+  return PostReadWrite<PrvdType, true>(wq, qpn, laddr, lkey, raddr, rkey, bytes);
+}
 
 template <ProviderType PrvdType>
 inline __device__ uint64_t PostWriteInline(WorkQueueHandle& wq, uint32_t curPostIdx,

--- a/include/mori/core/transport/rdma/providers/bnxt/bnxt_device_primitives.hpp
+++ b/include/mori/core/transport/rdma/providers/bnxt/bnxt_device_primitives.hpp
@@ -261,15 +261,14 @@ inline __device__ uint64_t PostRecv<ProviderType::BNXT>(WorkQueueHandle& wq, uin
 /* ---------------------------------------------------------------------------------------------- */
 /*                                        Read / Write APIs                                       */
 /* ---------------------------------------------------------------------------------------------- */
-// TODO: convert raddr/rkey laddr/lkey to big endien in advance to save cycles
-inline __device__ uint64_t BnxtPostReadWrite(WorkQueueHandle& wq, uint32_t curPostIdx,
-                                             uint32_t curMsntblSlotIdx, uint32_t curPsnIdx,
-                                             bool cqeSignal, uint32_t qpn, uintptr_t laddr,
-                                             uint64_t lkey, uintptr_t raddr, uint64_t rkey,
-                                             size_t bytes, bool isRead) {
-  uint32_t opcode = isRead ? BNXT_RE_WR_OPCD_RDMA_READ : BNXT_RE_WR_OPCD_RDMA_WRITE;
+template <bool IsRead>
+inline __device__ uint64_t BnxtPostReadWriteImpl(WorkQueueHandle& wq, uint32_t curPostIdx,
+                                                  uint32_t curMsntblSlotIdx, uint32_t curPsnIdx,
+                                                  bool cqeSignal, uint32_t qpn, uintptr_t laddr,
+                                                  uint64_t lkey, uintptr_t raddr, uint64_t rkey,
+                                                  size_t bytes) {
+  constexpr uint32_t opcode = IsRead ? BNXT_RE_WR_OPCD_RDMA_READ : BNXT_RE_WR_OPCD_RDMA_WRITE;
   uint8_t signalFlag = cqeSignal ? BNXT_RE_WR_FLAGS_SIGNALED : 0x00;
-  // In bnxt, wqeNum mean total sq slot num
   void* queueBuffAddr = wq.sqAddr;
   void* msntblAddr = wq.msntblAddr;
   uint32_t wqeNum = wq.sqWqeNum;
@@ -279,12 +278,7 @@ inline __device__ uint64_t BnxtPostReadWrite(WorkQueueHandle& wq, uint32_t curPo
   struct bnxt_re_rdma rdma;
   struct bnxt_re_sge sge;
 
-  // constexpr int sendWqeSize =
-  //     sizeof(struct bnxt_re_bsqe) + sizeof(struct bnxt_re_rdma) + sizeof(struct bnxt_re_sge);
-  // constexpr int slotsNum = CeilDiv(sendWqeSize, BNXT_RE_SLOT_SIZE);
-
   int psnCnt = (bytes == 0) ? 1 : (bytes + mtuSize - 1) / mtuSize;
-  // psn index needs to be strictly ordered
 
   uint32_t wqeIdx = curPostIdx & (wqeNum - 1);
   uint32_t slotIdx = wqeIdx * BNXT_RE_NUM_SLOT_PER_WQE;
@@ -309,13 +303,9 @@ inline __device__ uint64_t BnxtPostReadWrite(WorkQueueHandle& wq, uint32_t curPo
   ThreadCopy<char>(base + 1 * BNXT_RE_SLOT_SIZE, reinterpret_cast<char*>(&rdma), sizeof(rdma));
   ThreadCopy<char>(base + 2 * BNXT_RE_SLOT_SIZE, reinterpret_cast<char*>(&sge), sizeof(sge));
 
-  // fill psns in msn Table for retransmissions
   uint32_t msntblIdx = curMsntblSlotIdx % wq.msntblNum;
   bnxt_re_fill_psns_for_msntbl(msntblAddr, slotIdx, curPsnIdx, psnCnt, msntblIdx);
 
-  // get doorbell header
-  // struct bnxt_re_db_hdr hdr;
-  // uint8_t flags = ((curPostIdx + 1) / wqeNum) & 0x1;
   uint8_t flags = ((curPostIdx + 1) >> (__ffs(wqeNum) - 1)) & 0x1;
   uint32_t epoch = (flags & BNXT_RE_FLAG_EPOCH_TAIL_MASK) << BNXT_RE_DB_EPOCH_TAIL_SHIFT;
 
@@ -324,59 +314,48 @@ inline __device__ uint64_t BnxtPostReadWrite(WorkQueueHandle& wq, uint32_t curPo
 }
 
 template <>
-inline __device__ uint64_t PostWrite<ProviderType::BNXT>(WorkQueueHandle& wq, uint32_t curPostIdx,
-                                                         uint32_t curMsntblSlotIdx,
-                                                         uint32_t curPsnIdx, bool cqeSignal,
-                                                         uint32_t qpn, uintptr_t laddr,
-                                                         uint64_t lkey, uintptr_t raddr,
-                                                         uint64_t rkey, size_t bytes) {
-  return BnxtPostReadWrite(wq, curPostIdx, curMsntblSlotIdx, curPsnIdx, cqeSignal, qpn, laddr, lkey,
-                           raddr, rkey, bytes, false);
+inline __device__ uint64_t PostReadWrite<ProviderType::BNXT, false>(
+    WorkQueueHandle& wq, uint32_t curPostIdx, uint32_t curMsntblSlotIdx, uint32_t curPsnIdx,
+    bool cqeSignal, uint32_t qpn, uintptr_t laddr, uint64_t lkey, uintptr_t raddr, uint64_t rkey,
+    size_t bytes) {
+  return BnxtPostReadWriteImpl<false>(wq, curPostIdx, curMsntblSlotIdx, curPsnIdx, cqeSignal, qpn,
+                                      laddr, lkey, raddr, rkey, bytes);
 }
 
 template <>
-inline __device__ uint64_t PostRead<ProviderType::BNXT>(WorkQueueHandle& wq, uint32_t curPostIdx,
-                                                        uint32_t curMsntblSlotIdx,
-                                                        uint32_t curPsnIdx, bool cqeSignal,
-                                                        uint32_t qpn, uintptr_t laddr,
-                                                        uint64_t lkey, uintptr_t raddr,
-                                                        uint64_t rkey, size_t bytes) {
-  return BnxtPostReadWrite(wq, curPostIdx, curMsntblSlotIdx, curPsnIdx, cqeSignal, qpn, laddr, lkey,
-                           raddr, rkey, bytes, true);
+inline __device__ uint64_t PostReadWrite<ProviderType::BNXT, true>(
+    WorkQueueHandle& wq, uint32_t curPostIdx, uint32_t curMsntblSlotIdx, uint32_t curPsnIdx,
+    bool cqeSignal, uint32_t qpn, uintptr_t laddr, uint64_t lkey, uintptr_t raddr, uint64_t rkey,
+    size_t bytes) {
+  return BnxtPostReadWriteImpl<true>(wq, curPostIdx, curMsntblSlotIdx, curPsnIdx, cqeSignal, qpn,
+                                     laddr, lkey, raddr, rkey, bytes);
 }
 
-template <>
-inline __device__ uint64_t PostWrite<ProviderType::BNXT>(WorkQueueHandle& wq, uint32_t qpn,
-                                                         uintptr_t laddr, uint64_t lkey,
-                                                         uintptr_t raddr, uint64_t rkey,
-                                                         size_t bytes) {
+template <bool IsRead>
+inline __device__ uint64_t BnxtPostReadWriteSimple(WorkQueueHandle& wq, uint32_t qpn,
+                                                    uintptr_t laddr, uint64_t lkey, uintptr_t raddr,
+                                                    uint64_t rkey, size_t bytes) {
   uint32_t mtuSize = wq.mtuSize;
-
   int psnCnt = (bytes == 0) ? 1 : (bytes + mtuSize - 1) / mtuSize;
-  // psn index needs to be strictly ordered
-  uint32_t curMsntblSlotIdx, curPsnIdx, curPostIdx;
-  // psn index needs to be strictly ordered
+  uint32_t curMsntblSlotIdx, curPsnIdx;
   atomic_add_packed_msn_and_psn(&wq.msnPack, 1, psnCnt, &curMsntblSlotIdx, &curPsnIdx);
-  curPostIdx = curMsntblSlotIdx;
-  return BnxtPostReadWrite(wq, curPostIdx, curMsntblSlotIdx, curPsnIdx, true, qpn, laddr, lkey,
-                           raddr, rkey, bytes, false);
+  uint32_t curPostIdx = curMsntblSlotIdx;
+  return BnxtPostReadWriteImpl<IsRead>(wq, curPostIdx, curMsntblSlotIdx, curPsnIdx, true, qpn,
+                                        laddr, lkey, raddr, rkey, bytes);
 }
 
 template <>
-inline __device__ uint64_t PostRead<ProviderType::BNXT>(WorkQueueHandle& wq, uint32_t qpn,
-                                                        uintptr_t laddr, uint64_t lkey,
-                                                        uintptr_t raddr, uint64_t rkey,
-                                                        size_t bytes) {
-  uint32_t mtuSize = wq.mtuSize;
+inline __device__ uint64_t PostReadWrite<ProviderType::BNXT, false>(
+    WorkQueueHandle& wq, uint32_t qpn, uintptr_t laddr, uint64_t lkey, uintptr_t raddr,
+    uint64_t rkey, size_t bytes) {
+  return BnxtPostReadWriteSimple<false>(wq, qpn, laddr, lkey, raddr, rkey, bytes);
+}
 
-  int psnCnt = (bytes == 0) ? 1 : (bytes + mtuSize - 1) / mtuSize;
-  // psn index needs to be strictly ordered
-  uint32_t curMsntblSlotIdx, curPsnIdx, curPostIdx;
-  // psn index needs to be strictly ordered
-  atomic_add_packed_msn_and_psn(&wq.msnPack, 1, psnCnt, &curMsntblSlotIdx, &curPsnIdx);
-  curPostIdx = curMsntblSlotIdx;
-  return BnxtPostReadWrite(wq, curPostIdx, curMsntblSlotIdx, curPsnIdx, true, qpn, laddr, lkey,
-                           raddr, rkey, bytes, true);
+template <>
+inline __device__ uint64_t PostReadWrite<ProviderType::BNXT, true>(
+    WorkQueueHandle& wq, uint32_t qpn, uintptr_t laddr, uint64_t lkey, uintptr_t raddr,
+    uint64_t rkey, size_t bytes) {
+  return BnxtPostReadWriteSimple<true>(wq, qpn, laddr, lkey, raddr, rkey, bytes);
 }
 
 /* ---------------------------------------------------------------------------------------------- */

--- a/include/mori/core/transport/rdma/providers/ionic/ionic_device_primitives.hpp
+++ b/include/mori/core/transport/rdma/providers/ionic/ionic_device_primitives.hpp
@@ -143,11 +143,12 @@ inline __device__ uint64_t PostRecv<ProviderType::PSD>(WorkQueueHandle& wq, uint
 /* ---------------------------------------------------------------------------------------------- */
 /*                                        Read / Write APIs                                       */
 /* ---------------------------------------------------------------------------------------------- */
-// TODO: convert raddr/rkey laddr/lkey to big endien in advance to save cycles
-inline __device__ uint64_t IonicPostReadWrite(WorkQueueHandle& wq, uint32_t curPostIdx,
-                                              bool cqeSignal, uint32_t qpn, uintptr_t laddr,
-                                              uint64_t lkey, uintptr_t raddr, uint64_t rkey,
-                                              size_t bytes, bool isRead) {
+template <bool IsRead>
+inline __device__ uint64_t IonicPostReadWriteImpl(WorkQueueHandle& wq, uint32_t curPostIdx,
+                                                   bool cqeSignal, uint32_t qpn, uintptr_t laddr,
+                                                   uint64_t lkey, uintptr_t raddr, uint64_t rkey,
+                                                   size_t bytes) {
+  constexpr uint8_t opcode = IsRead ? IONIC_V2_OP_RDMA_READ : IONIC_V2_OP_RDMA_WRITE;
   void* queueBuffAddr = wq.sqAddr;
   uint32_t wqeNum = wq.sqWqeNum;
   int32_t size = (int32_t)bytes;
@@ -156,8 +157,6 @@ inline __device__ uint64_t IonicPostReadWrite(WorkQueueHandle& wq, uint32_t curP
   struct ionic_v1_wqe* wqe = reinterpret_cast<ionic_v1_wqe*>(wqeAddr);
   uint16_t wqe_flags = 0;
 
-  // MORI_PRINTF("IonicPostReadWrite, wqe:%p, curPostIdx:%d, wqeIdx:%d\n", wqe, curPostIdx, wqeIdx);
-  // to do: need to clear memory
   if ((wqeNum & curPostIdx) == 0) {
     wqe_flags |= HTOBE16(IONIC_V1_FLAG_COLOR);
   }
@@ -167,7 +166,7 @@ inline __device__ uint64_t IonicPostReadWrite(WorkQueueHandle& wq, uint32_t curP
   }
 
   wqe->base.wqe_idx = curPostIdx;
-  wqe->base.op = isRead ? IONIC_V2_OP_RDMA_READ : IONIC_V2_OP_RDMA_WRITE;
+  wqe->base.op = opcode;
   wqe->base.num_sge_key = size ? 1 : 0;
   wqe->base.imm_data_key = HTOBE32(0);
 
@@ -182,61 +181,41 @@ inline __device__ uint64_t IonicPostReadWrite(WorkQueueHandle& wq, uint32_t curP
 
   __hip_atomic_store(&wqe->base.flags, wqe_flags, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
 
-#if 0
-  MORI_PRINTF("dump wqe at addr:%p\n", wqeAddr);
-  for (int i = 0; i < 64; i++) {
-    MORI_PRINTF("%02x", (unsigned char)wqeAddr[i]);
-    if ((i+1)%4 == 0)
-      MORI_PRINTF("\n");
-  }
-#endif
-#if 0
-  MORI_PRINTF("Write, block:%u, warp:%u, lane:%u, wqe:%p, raddr:%p, rkey:%lu, len:%u, curPostIdx:%u, wqeIdx:%u, doorbell:0x%x\n",
-         blockIdx.x, threadIdx.x/warpSize, __lane_id(),
-	 wqe, raddr, rkey, size, curPostIdx, curPostIdx, ((curPostIdx + 1) & (wqeNum - 1)));
-#endif
-  //__threadfence_system();
-  // asm volatile("" ::: "memory");
-  // return doorbell value
   return wq.sq_dbval | ((curPostIdx + 1) & (wqeNum - 1));
 }
 
 template <>
-inline __device__ uint64_t PostWrite<ProviderType::PSD>(WorkQueueHandle& wq, uint32_t curPostIdx,
-                                                        uint32_t curMsntblSlotIdx,
-                                                        uint32_t curPsnIdx, bool cqeSignal,
-                                                        uint32_t qpn, uintptr_t laddr,
-                                                        uint64_t lkey, uintptr_t raddr,
-                                                        uint64_t rkey, size_t bytes) {
-  return IonicPostReadWrite(wq, curPostIdx, cqeSignal, qpn, laddr, lkey, raddr, rkey, bytes, false);
+inline __device__ uint64_t PostReadWrite<ProviderType::PSD, false>(
+    WorkQueueHandle& wq, uint32_t curPostIdx, uint32_t curMsntblSlotIdx, uint32_t curPsnIdx,
+    bool cqeSignal, uint32_t qpn, uintptr_t laddr, uint64_t lkey, uintptr_t raddr, uint64_t rkey,
+    size_t bytes) {
+  return IonicPostReadWriteImpl<false>(wq, curPostIdx, cqeSignal, qpn, laddr, lkey, raddr, rkey,
+                                       bytes);
 }
 
 template <>
-inline __device__ uint64_t PostRead<ProviderType::PSD>(WorkQueueHandle& wq, uint32_t curPostIdx,
-                                                       uint32_t curMsntblSlotIdx,
-                                                       uint32_t curPsnIdx, bool cqeSignal,
-                                                       uint32_t qpn, uintptr_t laddr, uint64_t lkey,
-                                                       uintptr_t raddr, uint64_t rkey,
-                                                       size_t bytes) {
-  return IonicPostReadWrite(wq, curPostIdx, cqeSignal, qpn, laddr, lkey, raddr, rkey, bytes, true);
+inline __device__ uint64_t PostReadWrite<ProviderType::PSD, true>(
+    WorkQueueHandle& wq, uint32_t curPostIdx, uint32_t curMsntblSlotIdx, uint32_t curPsnIdx,
+    bool cqeSignal, uint32_t qpn, uintptr_t laddr, uint64_t lkey, uintptr_t raddr, uint64_t rkey,
+    size_t bytes) {
+  return IonicPostReadWriteImpl<true>(wq, curPostIdx, cqeSignal, qpn, laddr, lkey, raddr, rkey,
+                                      bytes);
 }
 
 template <>
-inline __device__ uint64_t PostWrite<ProviderType::PSD>(WorkQueueHandle& wq, uint32_t qpn,
-                                                        uintptr_t laddr, uint64_t lkey,
-                                                        uintptr_t raddr, uint64_t rkey,
-                                                        size_t bytes) {
+inline __device__ uint64_t PostReadWrite<ProviderType::PSD, false>(
+    WorkQueueHandle& wq, uint32_t qpn, uintptr_t laddr, uint64_t lkey, uintptr_t raddr,
+    uint64_t rkey, size_t bytes) {
   uint32_t curPostIdx = atomicAdd(&wq.postIdx, 1);
-  return IonicPostReadWrite(wq, curPostIdx, true, qpn, laddr, lkey, raddr, rkey, bytes, false);
+  return IonicPostReadWriteImpl<false>(wq, curPostIdx, true, qpn, laddr, lkey, raddr, rkey, bytes);
 }
 
 template <>
-inline __device__ uint64_t PostRead<ProviderType::PSD>(WorkQueueHandle& wq, uint32_t qpn,
-                                                       uintptr_t laddr, uint64_t lkey,
-                                                       uintptr_t raddr, uint64_t rkey,
-                                                       size_t bytes) {
+inline __device__ uint64_t PostReadWrite<ProviderType::PSD, true>(
+    WorkQueueHandle& wq, uint32_t qpn, uintptr_t laddr, uint64_t lkey, uintptr_t raddr,
+    uint64_t rkey, size_t bytes) {
   uint32_t curPostIdx = atomicAdd(&wq.postIdx, 1);
-  return IonicPostReadWrite(wq, curPostIdx, true, qpn, laddr, lkey, raddr, rkey, bytes, true);
+  return IonicPostReadWriteImpl<true>(wq, curPostIdx, true, qpn, laddr, lkey, raddr, rkey, bytes);
 }
 
 /* ---------------------------------------------------------------------------------------------- */

--- a/include/mori/core/transport/rdma/providers/mlx5/mlx5_device_primitives.hpp
+++ b/include/mori/core/transport/rdma/providers/mlx5/mlx5_device_primitives.hpp
@@ -123,12 +123,12 @@ static constexpr int SendWqeSize =
 static constexpr int SendWqeNumOctoWords = CeilDiv(SendWqeSize, 16);
 static constexpr int SendWqeNumWqeBb = CeilDiv(SendWqeNumOctoWords * 16, int(MLX5_SEND_WQE_BB));
 
-// TODO: convert raddr/rkey laddr/lkey to big endien in advance to save cycles
-inline __device__ uint64_t Mlx5PostReadWrite(WorkQueueHandle& wq, uint32_t curPostIdx,
-                                             bool cqeSignal, uint32_t qpn, uintptr_t laddr,
-                                             uint64_t lkey, uintptr_t raddr, uint64_t rkey,
-                                             size_t bytes, bool isRead) {
-  uint32_t opcode = isRead ? MLX5_OPCODE_RDMA_READ : MLX5_OPCODE_RDMA_WRITE;
+template <bool IsRead>
+inline __device__ uint64_t Mlx5PostReadWriteImpl(WorkQueueHandle& wq, uint32_t curPostIdx,
+                                                  bool cqeSignal, uint32_t qpn, uintptr_t laddr,
+                                                  uint64_t lkey, uintptr_t raddr, uint64_t rkey,
+                                                  size_t bytes) {
+  constexpr uint32_t opcode = IsRead ? MLX5_OPCODE_RDMA_READ : MLX5_OPCODE_RDMA_WRITE;
   uint8_t signalFlag = cqeSignal ? MLX5_WQE_CTRL_CQ_UPDATE : 0x00;
   void* queueBuffAddr = wq.sqAddr;
   uint32_t wqeNum = wq.sqWqeNum;
@@ -156,41 +156,37 @@ inline __device__ uint64_t Mlx5PostReadWrite(WorkQueueHandle& wq, uint32_t curPo
 }
 
 template <>
-inline __device__ uint64_t PostWrite<ProviderType::MLX5>(WorkQueueHandle& wq, uint32_t curPostIdx,
-                                                         uint32_t curMsntblSlotIdx,
-                                                         uint32_t curPsnIdx, bool cqeSignal,
-                                                         uint32_t qpn, uintptr_t laddr,
-                                                         uint64_t lkey, uintptr_t raddr,
-                                                         uint64_t rkey, size_t bytes) {
-  return Mlx5PostReadWrite(wq, curPostIdx, cqeSignal, qpn, laddr, lkey, raddr, rkey, bytes, false);
+inline __device__ uint64_t PostReadWrite<ProviderType::MLX5, false>(
+    WorkQueueHandle& wq, uint32_t curPostIdx, uint32_t curMsntblSlotIdx, uint32_t curPsnIdx,
+    bool cqeSignal, uint32_t qpn, uintptr_t laddr, uint64_t lkey, uintptr_t raddr, uint64_t rkey,
+    size_t bytes) {
+  return Mlx5PostReadWriteImpl<false>(wq, curPostIdx, cqeSignal, qpn, laddr, lkey, raddr, rkey,
+                                      bytes);
 }
 
 template <>
-inline __device__ uint64_t PostRead<ProviderType::MLX5>(WorkQueueHandle& wq, uint32_t curPostIdx,
-                                                        uint32_t curMsntblSlotIdx,
-                                                        uint32_t curPsnIdx, bool cqeSignal,
-                                                        uint32_t qpn, uintptr_t laddr,
-                                                        uint64_t lkey, uintptr_t raddr,
-                                                        uint64_t rkey, size_t bytes) {
-  return Mlx5PostReadWrite(wq, curPostIdx, cqeSignal, qpn, laddr, lkey, raddr, rkey, bytes, true);
+inline __device__ uint64_t PostReadWrite<ProviderType::MLX5, true>(
+    WorkQueueHandle& wq, uint32_t curPostIdx, uint32_t curMsntblSlotIdx, uint32_t curPsnIdx,
+    bool cqeSignal, uint32_t qpn, uintptr_t laddr, uint64_t lkey, uintptr_t raddr, uint64_t rkey,
+    size_t bytes) {
+  return Mlx5PostReadWriteImpl<true>(wq, curPostIdx, cqeSignal, qpn, laddr, lkey, raddr, rkey,
+                                     bytes);
 }
 
 template <>
-inline __device__ uint64_t PostWrite<ProviderType::MLX5>(WorkQueueHandle& wq, uint32_t qpn,
-                                                         uintptr_t laddr, uint64_t lkey,
-                                                         uintptr_t raddr, uint64_t rkey,
-                                                         size_t bytes) {
+inline __device__ uint64_t PostReadWrite<ProviderType::MLX5, false>(
+    WorkQueueHandle& wq, uint32_t qpn, uintptr_t laddr, uint64_t lkey, uintptr_t raddr,
+    uint64_t rkey, size_t bytes) {
   uint32_t curPostIdx = atomicAdd(&wq.postIdx, 1);
-  return Mlx5PostReadWrite(wq, curPostIdx, true, qpn, laddr, lkey, raddr, rkey, bytes, false);
+  return Mlx5PostReadWriteImpl<false>(wq, curPostIdx, true, qpn, laddr, lkey, raddr, rkey, bytes);
 }
 
 template <>
-inline __device__ uint64_t PostRead<ProviderType::MLX5>(WorkQueueHandle& wq, uint32_t qpn,
-                                                        uintptr_t laddr, uint64_t lkey,
-                                                        uintptr_t raddr, uint64_t rkey,
-                                                        size_t bytes) {
+inline __device__ uint64_t PostReadWrite<ProviderType::MLX5, true>(
+    WorkQueueHandle& wq, uint32_t qpn, uintptr_t laddr, uint64_t lkey, uintptr_t raddr,
+    uint64_t rkey, size_t bytes) {
   uint32_t curPostIdx = atomicAdd(&wq.postIdx, 1);
-  return Mlx5PostReadWrite(wq, curPostIdx, true, qpn, laddr, lkey, raddr, rkey, bytes, true);
+  return Mlx5PostReadWriteImpl<true>(wq, curPostIdx, true, qpn, laddr, lkey, raddr, rkey, bytes);
 }
 
 /* ---------------------------------------------------------------------------------------------- */

--- a/include/mori/shmem/shmem_device_api.hpp
+++ b/include/mori/shmem/shmem_device_api.hpp
@@ -237,6 +237,81 @@ DEFINE_SHMEM_PUT_TYPE_NBI_API(Float, float, Block)
 DEFINE_SHMEM_PUT_TYPE_NBI_API(Double, double, Block)
 
 /* ---------------------------------------------------------------------------------------------- */
+/*                                         GetNbi APIs                                            */
+/* ---------------------------------------------------------------------------------------------- */
+#define DEFINE_SHMEM_GET_MEM_NBI_API_TEMPLATE(Scope)                                      \
+  inline __device__ void ShmemGetMemNbi##Scope(                                           \
+      const application::SymmMemObjPtr dest, size_t destOffset,                           \
+      const application::SymmMemObjPtr source, size_t sourceOffset, size_t bytes, int pe, \
+      int qpId = 0) {                                                                     \
+    DISPATCH_TRANSPORT_TYPE(ShmemGetMemNbi##Scope##Kernel, pe, dest, destOffset, source,  \
+                            sourceOffset, bytes, pe, qpId);                               \
+  }
+
+DEFINE_SHMEM_GET_MEM_NBI_API_TEMPLATE(Thread)
+DEFINE_SHMEM_GET_MEM_NBI_API_TEMPLATE(Warp)
+DEFINE_SHMEM_GET_MEM_NBI_API_TEMPLATE(Block)
+
+#define DEFINE_SHMEM_GET_TYPE_NBI_API_TEMPLATE(Scope)                                      \
+  template <typename T>                                                                    \
+  inline __device__ void ShmemGetTypeNbi##Scope(                                           \
+      const application::SymmMemObjPtr dest, size_t destElmOffset,                         \
+      const application::SymmMemObjPtr source, size_t srcElmOffset, size_t nelems, int pe, \
+      int qpId = 0) {                                                                      \
+    constexpr size_t typeSize = sizeof(T);                                                 \
+    ShmemGetMemNbi##Scope(dest, destElmOffset * typeSize, source, srcElmOffset * typeSize, \
+                          nelems * typeSize, pe, qpId);                                    \
+  }
+
+DEFINE_SHMEM_GET_TYPE_NBI_API_TEMPLATE(Thread)
+DEFINE_SHMEM_GET_TYPE_NBI_API_TEMPLATE(Warp)
+DEFINE_SHMEM_GET_TYPE_NBI_API_TEMPLATE(Block)
+
+#define DEFINE_SHMEM_GET_TYPE_NBI_API(TypeName, T, Scope)                                   \
+  inline __device__ void ShmemGet##TypeName##Nbi##Scope(                                    \
+      const application::SymmMemObjPtr dest, size_t destElmOffset,                          \
+      const application::SymmMemObjPtr source, size_t srcElmOffset, size_t nelems, int pe,  \
+      int qpId = 0) {                                                                       \
+    ShmemGetTypeNbi##Scope<T>(dest, destElmOffset, source, srcElmOffset, nelems, pe, qpId); \
+  }
+
+DEFINE_SHMEM_GET_TYPE_NBI_API(Uint8, uint8_t, Thread)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Int8, int8_t, Thread)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Schar, signed char, Thread)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Uint16, uint16_t, Thread)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Int16, int16_t, Thread)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Uint32, uint32_t, Thread)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Int32, int32_t, Thread)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Uint64, uint64_t, Thread)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Int64, int64_t, Thread)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Float, float, Thread)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Double, double, Thread)
+
+DEFINE_SHMEM_GET_TYPE_NBI_API(Uint8, uint8_t, Warp)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Int8, int8_t, Warp)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Schar, signed char, Warp)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Uint16, uint16_t, Warp)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Int16, int16_t, Warp)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Uint32, uint32_t, Warp)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Int32, int32_t, Warp)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Uint64, uint64_t, Warp)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Int64, int64_t, Warp)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Float, float, Warp)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Double, double, Warp)
+
+DEFINE_SHMEM_GET_TYPE_NBI_API(Uint8, uint8_t, Block)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Int8, int8_t, Block)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Schar, signed char, Block)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Uint16, uint16_t, Block)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Int16, int16_t, Block)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Uint32, uint32_t, Block)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Int32, int32_t, Block)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Uint64, uint64_t, Block)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Int64, int64_t, Block)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Float, float, Block)
+DEFINE_SHMEM_GET_TYPE_NBI_API(Double, double, Block)
+
+/* ---------------------------------------------------------------------------------------------- */
 /*                                       PutNbi Inline APIs                                       */
 /* ---------------------------------------------------------------------------------------------- */
 // TODO: deal with bytes count limit
@@ -695,6 +770,72 @@ DEFINE_SHMEM_PUT_TYPE_NBI_SIGNAL_ADDR_API(Uint64, uint64_t, Block)
 DEFINE_SHMEM_PUT_TYPE_NBI_SIGNAL_ADDR_API(Int64, int64_t, Block)
 DEFINE_SHMEM_PUT_TYPE_NBI_SIGNAL_ADDR_API(Float, float, Block)
 DEFINE_SHMEM_PUT_TYPE_NBI_SIGNAL_ADDR_API(Double, double, Block)
+
+/* ---------------------------------------------------------------------------------------------- */
+/*                                        GetNbi APIs (Address-Based)                             */
+/* ---------------------------------------------------------------------------------------------- */
+#define DEFINE_SHMEM_GET_MEM_NBI_ADDR_API_TEMPLATE(Scope)                                      \
+  inline __device__ void ShmemGetMemNbi##Scope(void* dest, const void* source, size_t bytes,   \
+                                               int pe, int qpId = 0) {                         \
+    DISPATCH_TRANSPORT_TYPE(ShmemGetMemNbi##Scope##Kernel, pe, dest, source, bytes, pe, qpId); \
+  }
+
+DEFINE_SHMEM_GET_MEM_NBI_ADDR_API_TEMPLATE(Thread)
+DEFINE_SHMEM_GET_MEM_NBI_ADDR_API_TEMPLATE(Warp)
+DEFINE_SHMEM_GET_MEM_NBI_ADDR_API_TEMPLATE(Block)
+
+#define DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API_TEMPLATE(Scope)                                       \
+  template <typename T>                                                                          \
+  inline __device__ void ShmemGetTypeNbi##Scope(T* dest, const T* source, size_t nelems, int pe, \
+                                                int qpId = 0) {                                  \
+    ShmemGetMemNbi##Scope(dest, source, nelems * sizeof(T), pe, qpId);                           \
+  }
+
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API_TEMPLATE(Thread)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API_TEMPLATE(Warp)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API_TEMPLATE(Block)
+
+#define DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(TypeName, T, Scope)                                   \
+  inline __device__ void ShmemGet##TypeName##Nbi##Scope(T* dest, const T* source, size_t nelems, \
+                                                        int pe, int qpId = 0) {                  \
+    ShmemGetTypeNbi##Scope<T>(dest, source, nelems, pe, qpId);                                   \
+  }
+
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Uint8, uint8_t, Thread)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Int8, int8_t, Thread)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Schar, signed char, Thread)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Uint16, uint16_t, Thread)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Int16, int16_t, Thread)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Uint32, uint32_t, Thread)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Int32, int32_t, Thread)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Uint64, uint64_t, Thread)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Int64, int64_t, Thread)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Float, float, Thread)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Double, double, Thread)
+
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Uint8, uint8_t, Warp)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Int8, int8_t, Warp)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Schar, signed char, Warp)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Uint16, uint16_t, Warp)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Int16, int16_t, Warp)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Uint32, uint32_t, Warp)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Int32, int32_t, Warp)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Uint64, uint64_t, Warp)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Int64, int64_t, Warp)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Float, float, Warp)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Double, double, Warp)
+
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Uint8, uint8_t, Block)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Int8, int8_t, Block)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Schar, signed char, Block)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Uint16, uint16_t, Block)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Int16, int16_t, Block)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Uint32, uint32_t, Block)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Int32, int32_t, Block)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Uint64, uint64_t, Block)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Int64, int64_t, Block)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Float, float, Block)
+DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Double, double, Block)
 
 #define SHMEM_ATOMIC_SIZE_NONFETCH_ADDR_API_TEMPLATE(Scope)                                        \
   inline __device__ void ShmemAtomicSizeNonFetch##Scope(                                           \

--- a/include/mori/shmem/shmem_device_api.hpp
+++ b/include/mori/shmem/shmem_device_api.hpp
@@ -312,6 +312,81 @@ DEFINE_SHMEM_GET_TYPE_NBI_API(Float, float, Block)
 DEFINE_SHMEM_GET_TYPE_NBI_API(Double, double, Block)
 
 /* ---------------------------------------------------------------------------------------------- */
+/*                                     Blocking GET APIs                                          */
+/* ---------------------------------------------------------------------------------------------- */
+#define DEFINE_SHMEM_GET_MEM_API_TEMPLATE(Scope)                                              \
+  inline __device__ void ShmemGetMem##Scope(                                                  \
+      const application::SymmMemObjPtr dest, size_t destOffset,                               \
+      const application::SymmMemObjPtr source, size_t sourceOffset, size_t bytes, int pe,     \
+      int qpId = 0) {                                                                         \
+    ShmemGetMemNbi##Scope(dest, destOffset, source, sourceOffset, bytes, pe, qpId);           \
+    ShmemQuietThread(pe, qpId);                                                               \
+  }
+
+DEFINE_SHMEM_GET_MEM_API_TEMPLATE(Thread)
+DEFINE_SHMEM_GET_MEM_API_TEMPLATE(Warp)
+DEFINE_SHMEM_GET_MEM_API_TEMPLATE(Block)
+
+#define DEFINE_SHMEM_GET_TYPE_API_TEMPLATE(Scope)                                              \
+  template <typename T>                                                                        \
+  inline __device__ void ShmemGetType##Scope(                                                  \
+      const application::SymmMemObjPtr dest, size_t destElmOffset,                             \
+      const application::SymmMemObjPtr source, size_t srcElmOffset, size_t nelems, int pe,     \
+      int qpId = 0) {                                                                          \
+    constexpr size_t typeSize = sizeof(T);                                                     \
+    ShmemGetMem##Scope(dest, destElmOffset * typeSize, source, srcElmOffset * typeSize,        \
+                       nelems * typeSize, pe, qpId);                                           \
+  }
+
+DEFINE_SHMEM_GET_TYPE_API_TEMPLATE(Thread)
+DEFINE_SHMEM_GET_TYPE_API_TEMPLATE(Warp)
+DEFINE_SHMEM_GET_TYPE_API_TEMPLATE(Block)
+
+#define DEFINE_SHMEM_GET_TYPE_API(TypeName, T, Scope)                                          \
+  inline __device__ void ShmemGet##TypeName##Scope(                                            \
+      const application::SymmMemObjPtr dest, size_t destElmOffset,                             \
+      const application::SymmMemObjPtr source, size_t srcElmOffset, size_t nelems, int pe,     \
+      int qpId = 0) {                                                                          \
+    ShmemGetType##Scope<T>(dest, destElmOffset, source, srcElmOffset, nelems, pe, qpId);       \
+  }
+
+DEFINE_SHMEM_GET_TYPE_API(Uint8, uint8_t, Thread)
+DEFINE_SHMEM_GET_TYPE_API(Int8, int8_t, Thread)
+DEFINE_SHMEM_GET_TYPE_API(Schar, signed char, Thread)
+DEFINE_SHMEM_GET_TYPE_API(Uint16, uint16_t, Thread)
+DEFINE_SHMEM_GET_TYPE_API(Int16, int16_t, Thread)
+DEFINE_SHMEM_GET_TYPE_API(Uint32, uint32_t, Thread)
+DEFINE_SHMEM_GET_TYPE_API(Int32, int32_t, Thread)
+DEFINE_SHMEM_GET_TYPE_API(Uint64, uint64_t, Thread)
+DEFINE_SHMEM_GET_TYPE_API(Int64, int64_t, Thread)
+DEFINE_SHMEM_GET_TYPE_API(Float, float, Thread)
+DEFINE_SHMEM_GET_TYPE_API(Double, double, Thread)
+
+DEFINE_SHMEM_GET_TYPE_API(Uint8, uint8_t, Warp)
+DEFINE_SHMEM_GET_TYPE_API(Int8, int8_t, Warp)
+DEFINE_SHMEM_GET_TYPE_API(Schar, signed char, Warp)
+DEFINE_SHMEM_GET_TYPE_API(Uint16, uint16_t, Warp)
+DEFINE_SHMEM_GET_TYPE_API(Int16, int16_t, Warp)
+DEFINE_SHMEM_GET_TYPE_API(Uint32, uint32_t, Warp)
+DEFINE_SHMEM_GET_TYPE_API(Int32, int32_t, Warp)
+DEFINE_SHMEM_GET_TYPE_API(Uint64, uint64_t, Warp)
+DEFINE_SHMEM_GET_TYPE_API(Int64, int64_t, Warp)
+DEFINE_SHMEM_GET_TYPE_API(Float, float, Warp)
+DEFINE_SHMEM_GET_TYPE_API(Double, double, Warp)
+
+DEFINE_SHMEM_GET_TYPE_API(Uint8, uint8_t, Block)
+DEFINE_SHMEM_GET_TYPE_API(Int8, int8_t, Block)
+DEFINE_SHMEM_GET_TYPE_API(Schar, signed char, Block)
+DEFINE_SHMEM_GET_TYPE_API(Uint16, uint16_t, Block)
+DEFINE_SHMEM_GET_TYPE_API(Int16, int16_t, Block)
+DEFINE_SHMEM_GET_TYPE_API(Uint32, uint32_t, Block)
+DEFINE_SHMEM_GET_TYPE_API(Int32, int32_t, Block)
+DEFINE_SHMEM_GET_TYPE_API(Uint64, uint64_t, Block)
+DEFINE_SHMEM_GET_TYPE_API(Int64, int64_t, Block)
+DEFINE_SHMEM_GET_TYPE_API(Float, float, Block)
+DEFINE_SHMEM_GET_TYPE_API(Double, double, Block)
+
+/* ---------------------------------------------------------------------------------------------- */
 /*                                       PutNbi Inline APIs                                       */
 /* ---------------------------------------------------------------------------------------------- */
 // TODO: deal with bytes count limit
@@ -836,6 +911,73 @@ DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Uint64, uint64_t, Block)
 DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Int64, int64_t, Block)
 DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Float, float, Block)
 DEFINE_SHMEM_GET_TYPE_NBI_ADDR_API(Double, double, Block)
+
+/* ---------------------------------------------------------------------------------------------- */
+/*                                Blocking GET APIs (Address-Based)                               */
+/* ---------------------------------------------------------------------------------------------- */
+#define DEFINE_SHMEM_GET_MEM_ADDR_API_TEMPLATE(Scope)                                          \
+  inline __device__ void ShmemGetMem##Scope(void* dest, const void* source, size_t bytes,      \
+                                            int pe, int qpId = 0) {                            \
+    ShmemGetMemNbi##Scope(dest, source, bytes, pe, qpId);                                      \
+    ShmemQuietThread(pe, qpId);                                                                \
+  }
+
+DEFINE_SHMEM_GET_MEM_ADDR_API_TEMPLATE(Thread)
+DEFINE_SHMEM_GET_MEM_ADDR_API_TEMPLATE(Warp)
+DEFINE_SHMEM_GET_MEM_ADDR_API_TEMPLATE(Block)
+
+#define DEFINE_SHMEM_GET_TYPE_ADDR_API_TEMPLATE(Scope)                                            \
+  template <typename T>                                                                           \
+  inline __device__ void ShmemGetType##Scope(T* dest, const T* source, size_t nelems, int pe,     \
+                                             int qpId = 0) {                                      \
+    ShmemGetMem##Scope(dest, source, nelems * sizeof(T), pe, qpId);                               \
+  }
+
+DEFINE_SHMEM_GET_TYPE_ADDR_API_TEMPLATE(Thread)
+DEFINE_SHMEM_GET_TYPE_ADDR_API_TEMPLATE(Warp)
+DEFINE_SHMEM_GET_TYPE_ADDR_API_TEMPLATE(Block)
+
+#define DEFINE_SHMEM_GET_TYPE_ADDR_API(TypeName, T, Scope)                                        \
+  inline __device__ void ShmemGet##TypeName##Scope(T* dest, const T* source, size_t nelems,       \
+                                                   int pe, int qpId = 0) {                        \
+    ShmemGetType##Scope<T>(dest, source, nelems, pe, qpId);                                       \
+  }
+
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Uint8, uint8_t, Thread)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Int8, int8_t, Thread)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Schar, signed char, Thread)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Uint16, uint16_t, Thread)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Int16, int16_t, Thread)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Uint32, uint32_t, Thread)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Int32, int32_t, Thread)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Uint64, uint64_t, Thread)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Int64, int64_t, Thread)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Float, float, Thread)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Double, double, Thread)
+
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Uint8, uint8_t, Warp)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Int8, int8_t, Warp)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Schar, signed char, Warp)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Uint16, uint16_t, Warp)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Int16, int16_t, Warp)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Uint32, uint32_t, Warp)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Int32, int32_t, Warp)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Uint64, uint64_t, Warp)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Int64, int64_t, Warp)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Float, float, Warp)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Double, double, Warp)
+
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Uint8, uint8_t, Block)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Int8, int8_t, Block)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Schar, signed char, Block)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Uint16, uint16_t, Block)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Int16, int16_t, Block)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Uint32, uint32_t, Block)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Int32, int32_t, Block)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Uint64, uint64_t, Block)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Int64, int64_t, Block)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Float, float, Block)
+DEFINE_SHMEM_GET_TYPE_ADDR_API(Double, double, Block)
 
 #define SHMEM_ATOMIC_SIZE_NONFETCH_ADDR_API_TEMPLATE(Scope)                                        \
   inline __device__ void ShmemAtomicSizeNonFetch##Scope(                                           \

--- a/include/mori/shmem/shmem_device_api_wrapper.hpp
+++ b/include/mori/shmem/shmem_device_api_wrapper.hpp
@@ -103,6 +103,60 @@ __device__ __attribute__((visibility("default"))) int mori_shmem_put_double_nbi_
 
 
 // ============================================================================
+// GetNbi APIs - Thread Scope (Address-based only)
+// ============================================================================
+__device__ __attribute__((visibility("default"))) int mori_shmem_getmem_nbi_thread(
+    void* dest, const void* source, size_t bytes, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint32_nbi_thread(
+    uint32_t* dest, const uint32_t* source, size_t nelems, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint64_nbi_thread(
+    uint64_t* dest, const uint64_t* source, size_t nelems, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_float_nbi_thread(
+    float* dest, const float* source, size_t nelems, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_double_nbi_thread(
+    double* dest, const double* source, size_t nelems, int pe, int qpId);
+
+// ============================================================================
+// GetNbi APIs - Warp Scope (Address-based only)
+// ============================================================================
+__device__ __attribute__((visibility("default"))) int mori_shmem_getmem_nbi_warp(
+    void* dest, const void* source, size_t bytes, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint32_nbi_warp(
+    uint32_t* dest, const uint32_t* source, size_t nelems, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint64_nbi_warp(
+    uint64_t* dest, const uint64_t* source, size_t nelems, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_float_nbi_warp(
+    float* dest, const float* source, size_t nelems, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_double_nbi_warp(
+    double* dest, const double* source, size_t nelems, int pe, int qpId);
+
+// ============================================================================
+// GetNbi APIs - Block Scope (Address-based only)
+// ============================================================================
+__device__ __attribute__((visibility("default"))) int mori_shmem_getmem_nbi_block(
+    void* dest, const void* source, size_t bytes, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint32_nbi_block(
+    uint32_t* dest, const uint32_t* source, size_t nelems, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint64_nbi_block(
+    uint64_t* dest, const uint64_t* source, size_t nelems, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_float_nbi_block(
+    float* dest, const float* source, size_t nelems, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_double_nbi_block(
+    double* dest, const double* source, size_t nelems, int pe, int qpId);
+
+// ============================================================================
 // PutNbi with Signal APIs - Thread Scope
 // ============================================================================
 __device__ __attribute__((visibility("default"))) int mori_shmem_putmem_nbi_signal_thread(

--- a/include/mori/shmem/shmem_device_api_wrapper.hpp
+++ b/include/mori/shmem/shmem_device_api_wrapper.hpp
@@ -157,6 +157,60 @@ __device__ __attribute__((visibility("default"))) int mori_shmem_get_double_nbi_
     double* dest, const double* source, size_t nelems, int pe, int qpId);
 
 // ============================================================================
+// Blocking GET APIs - Thread Scope (Address-based only)
+// ============================================================================
+__device__ __attribute__((visibility("default"))) int mori_shmem_getmem_thread(
+    void* dest, const void* source, size_t bytes, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint32_thread(
+    uint32_t* dest, const uint32_t* source, size_t nelems, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint64_thread(
+    uint64_t* dest, const uint64_t* source, size_t nelems, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_float_thread(
+    float* dest, const float* source, size_t nelems, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_double_thread(
+    double* dest, const double* source, size_t nelems, int pe, int qpId);
+
+// ============================================================================
+// Blocking GET APIs - Warp Scope (Address-based only)
+// ============================================================================
+__device__ __attribute__((visibility("default"))) int mori_shmem_getmem_warp(
+    void* dest, const void* source, size_t bytes, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint32_warp(
+    uint32_t* dest, const uint32_t* source, size_t nelems, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint64_warp(
+    uint64_t* dest, const uint64_t* source, size_t nelems, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_float_warp(
+    float* dest, const float* source, size_t nelems, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_double_warp(
+    double* dest, const double* source, size_t nelems, int pe, int qpId);
+
+// ============================================================================
+// Blocking GET APIs - Block Scope (Address-based only)
+// ============================================================================
+__device__ __attribute__((visibility("default"))) int mori_shmem_getmem_block(
+    void* dest, const void* source, size_t bytes, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint32_block(
+    uint32_t* dest, const uint32_t* source, size_t nelems, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint64_block(
+    uint64_t* dest, const uint64_t* source, size_t nelems, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_float_block(
+    float* dest, const float* source, size_t nelems, int pe, int qpId);
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_double_block(
+    double* dest, const double* source, size_t nelems, int pe, int qpId);
+
+// ============================================================================
 // PutNbi with Signal APIs - Thread Scope
 // ============================================================================
 __device__ __attribute__((visibility("default"))) int mori_shmem_putmem_nbi_signal_thread(

--- a/include/mori/shmem/shmem_device_kernels.hpp
+++ b/include/mori/shmem/shmem_device_kernels.hpp
@@ -174,6 +174,47 @@ inline __device__ T ShmemAtomicTypeFetchWarpKernel(const application::SymmMemObj
                                                    int qpId = 0);
 
 /* ---------------------------------------------------------------------------------------------- */
+/*                         Pure Address-Based GetNbi (New API)                                     */
+/* ---------------------------------------------------------------------------------------------- */
+
+template <application::TransportType TsptType>
+inline __device__ void ShmemGetMemNbiThreadKernel(void* dest, const void* source, size_t bytes,
+                                                  int pe, int qpId = 0);
+
+template <application::TransportType TsptType>
+inline __device__ void ShmemGetMemNbiWarpKernel(void* dest, const void* source, size_t bytes,
+                                                int pe, int qpId = 0);
+
+template <application::TransportType TsptType>
+inline __device__ void ShmemGetMemNbiBlockKernel(void* dest, const void* source, size_t bytes,
+                                                 int pe, int qpId = 0);
+
+/* ---------------------------------------------------------------------------------------------- */
+/*                         SymmMemObjPtr-Based GetNbi                                              */
+/* ---------------------------------------------------------------------------------------------- */
+
+template <application::TransportType TsptType>
+inline __device__ void ShmemGetMemNbiThreadKernel(const application::SymmMemObjPtr dest,
+                                                  size_t destOffset,
+                                                  const application::SymmMemObjPtr source,
+                                                  size_t sourceOffset, size_t bytes, int pe,
+                                                  int qpId = 0);
+
+template <application::TransportType TsptType>
+inline __device__ void ShmemGetMemNbiWarpKernel(const application::SymmMemObjPtr dest,
+                                                size_t destOffset,
+                                                const application::SymmMemObjPtr source,
+                                                size_t sourceOffset, size_t bytes, int pe,
+                                                int qpId = 0);
+
+template <application::TransportType TsptType>
+inline __device__ void ShmemGetMemNbiBlockKernel(const application::SymmMemObjPtr dest,
+                                                 size_t destOffset,
+                                                 const application::SymmMemObjPtr source,
+                                                 size_t sourceOffset, size_t bytes, int pe,
+                                                 int qpId = 0);
+
+/* ---------------------------------------------------------------------------------------------- */
 /*                                         Synchronization                                        */
 /* ---------------------------------------------------------------------------------------------- */
 template <application::TransportType>

--- a/include/mori/shmem/shmem_ibgda_kernels.hpp
+++ b/include/mori/shmem/shmem_ibgda_kernels.hpp
@@ -2618,5 +2618,428 @@ DEFINE_SHMEM_ATOMIC_TYPE_FETCH_WARP_KERNEL_RDMA_ADDR(Uint64, uint64_t)
 DEFINE_SHMEM_ATOMIC_TYPE_FETCH_WARP_KERNEL_RDMA_ADDR(Int32, int32_t)
 DEFINE_SHMEM_ATOMIC_TYPE_FETCH_WARP_KERNEL_RDMA_ADDR(Int64, int64_t)
 
+/* ---------------------------------------------------------------------------------------------- */
+/*                                    GetMemNbi (SymmMemObjPtr)                                   */
+/* ---------------------------------------------------------------------------------------------- */
+template <core::ProviderType PrvdType>
+inline __device__ void ShmemGetMemNbiThreadKernelImpl(const application::SymmMemObjPtr dest,
+                                                      size_t destOffset,
+                                                      const application::SymmMemObjPtr source,
+                                                      size_t sourceOffset, size_t bytes, int pe,
+                                                      int qpId) {
+  if (bytes == 0) return;
+
+  GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
+  application::RdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
+  int epIndex = pe * globalGpuStates->numQpPerPe + (qpId % globalGpuStates->numQpPerPe);
+  core::WorkQueueHandle* wq = &ep[epIndex].wqHandle;
+  core::CompletionQueueHandle* cq = &ep[epIndex].cqHandle;
+  uint32_t qpn = ep[epIndex].handle.qpn;
+
+  bool needsChunking = globalGpuStates->useVMMHeap;
+  size_t currentOffset = 0;
+  size_t remaining = bytes;
+
+  while (true) {
+    bool has_remaining = (remaining > 0);
+
+    uint64_t activemask = __ballot(has_remaining);
+    if (activemask == 0) {
+      break;
+    }
+
+    uint8_t num_active_lanes = core::GetActiveLaneCount(activemask);
+    uint8_t my_logical_lane_id = core::GetActiveLaneNum(activemask);
+    bool is_leader{my_logical_lane_id == num_active_lanes - 1};
+    const uint64_t leader_phys_lane_id = core::GetLastActiveLaneID(activemask);
+
+    if (!has_remaining) {
+      continue;
+    }
+
+    uint32_t lkey, rkey;
+    uintptr_t destAddr, raddr;
+    size_t transfer_size;
+
+    if (!needsChunking) {
+      lkey = dest->lkey;
+      destAddr = reinterpret_cast<uintptr_t>(dest->localPtr) + destOffset + currentOffset;
+      raddr = source->peerPtrs[pe] + sourceOffset + currentOffset;
+      rkey = source->peerRkeys[pe];
+      transfer_size = remaining;
+    } else {
+      destAddr = reinterpret_cast<uintptr_t>(dest->localPtr) + destOffset + currentOffset;
+      size_t dst_chunk_size;
+      VmmQueryLocalKey(destAddr, remaining, lkey, dst_chunk_size);
+
+      uintptr_t srcAddr =
+          reinterpret_cast<uintptr_t>(source->localPtr) + sourceOffset + currentOffset;
+      size_t src_chunk_size;
+      VmmQueryRemoteAddr(srcAddr, pe, remaining, raddr, rkey, src_chunk_size);
+
+      transfer_size = dst_chunk_size < src_chunk_size ? dst_chunk_size : src_chunk_size;
+    }
+
+    uint32_t warp_sq_counter{0};
+    uint32_t warp_msntbl_counter{0}, warp_psn_counter{0};
+    uint32_t my_sq_counter{0}, my_msntbl_counter{0}, my_psn_counter{0};
+    uint32_t psnCnt = 0;
+
+    if constexpr (PrvdType == core::ProviderType::BNXT) {
+      psnCnt = (transfer_size + wq->mtuSize - 1) / wq->mtuSize;
+    }
+    if (is_leader) {
+      if constexpr (PrvdType == core::ProviderType::MLX5) {
+        warp_sq_counter = __hip_atomic_fetch_add(&wq->postIdx, num_active_lanes, __ATOMIC_RELAXED,
+                                                 __HIP_MEMORY_SCOPE_AGENT);
+      } else if constexpr (PrvdType == core::ProviderType::BNXT) {
+        core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_active_lanes,
+                                            psnCnt * num_active_lanes, &warp_msntbl_counter,
+                                            &warp_psn_counter);
+        warp_sq_counter = warp_msntbl_counter;
+        __hip_atomic_fetch_max(&wq->postIdx, warp_sq_counter + num_active_lanes, __ATOMIC_RELAXED,
+                               __HIP_MEMORY_SCOPE_AGENT);
+      } else if constexpr (PrvdType == core::ProviderType::PSD) {
+        warp_sq_counter = __hip_atomic_fetch_add(&wq->postIdx, num_active_lanes, __ATOMIC_RELAXED,
+                                                 __HIP_MEMORY_SCOPE_AGENT);
+      } else {
+        static_assert(false);
+      }
+    }
+    warp_sq_counter = __shfl(warp_sq_counter, leader_phys_lane_id);
+    if constexpr (PrvdType == core::ProviderType::MLX5) {
+      my_sq_counter = warp_sq_counter + my_logical_lane_id;
+    } else if constexpr (PrvdType == core::ProviderType::BNXT) {
+      warp_msntbl_counter = __shfl(warp_msntbl_counter, leader_phys_lane_id);
+      warp_psn_counter = __shfl(warp_psn_counter, leader_phys_lane_id);
+      my_sq_counter = warp_sq_counter + my_logical_lane_id;
+      my_msntbl_counter = warp_msntbl_counter + my_logical_lane_id;
+      my_psn_counter = warp_psn_counter + psnCnt * my_logical_lane_id;
+    } else if constexpr (PrvdType == core::ProviderType::PSD) {
+      my_sq_counter = warp_sq_counter + my_logical_lane_id;
+    } else {
+      static_assert(false);
+    }
+
+    while (true) {
+      uint64_t db_touched =
+          __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      uint64_t db_done =
+          __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      uint64_t num_active_sq_entries = db_touched - db_done;
+      uint64_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
+      uint64_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
+      if (num_free_entries > num_entries_until_warp_last_entry) {
+        break;
+      }
+      ShmemQuietThreadKernelImpl<PrvdType>(pe, qpId);
+    }
+
+    uint64_t dbr_val;
+    if constexpr (PrvdType == core::ProviderType::MLX5) {
+      wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
+      dbr_val =
+          core::PostRead<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter, is_leader,
+                                   qpn, destAddr, lkey, raddr, rkey, transfer_size);
+    } else if constexpr (PrvdType == core::ProviderType::BNXT) {
+      wq->outstandingWqe[my_sq_counter % wq->sqWqeNum] = my_sq_counter;
+      dbr_val =
+          core::PostRead<PrvdType>(*wq, my_sq_counter, my_msntbl_counter, my_psn_counter,
+                                   is_leader, qpn, destAddr, lkey, raddr, rkey, transfer_size);
+    } else if constexpr (PrvdType == core::ProviderType::PSD) {
+      wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
+      dbr_val =
+          core::PostRead<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter, is_leader,
+                                   qpn, destAddr, lkey, raddr, rkey, transfer_size);
+    } else {
+      static_assert(false);
+    }
+    __threadfence_system();
+    if (is_leader) {
+      uint64_t db_touched{0};
+      do {
+        db_touched = __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      } while (db_touched != warp_sq_counter);
+
+      core::UpdateSendDbrRecord<PrvdType>(wq->dbrRecAddr, warp_sq_counter + num_active_lanes);
+      __threadfence_system();
+      core::RingDoorbell<PrvdType>(wq->dbrAddr, dbr_val);
+      __threadfence_system();
+
+      __hip_atomic_fetch_add(&cq->needConsIdx, 1, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      __hip_atomic_store(&wq->dbTouchIdx, warp_sq_counter + num_active_lanes, __ATOMIC_RELAXED,
+                         __HIP_MEMORY_SCOPE_AGENT);
+    }
+    __threadfence_system();
+
+    currentOffset += transfer_size;
+    remaining -= transfer_size;
+  }
+}
+
+template <>
+inline __device__ void ShmemGetMemNbiThreadKernel<application::TransportType::RDMA>(
+    const application::SymmMemObjPtr dest, size_t destOffset,
+    const application::SymmMemObjPtr source, size_t sourceOffset, size_t bytes, int pe, int qpId) {
+  bool need_turn{true};
+  uint64_t turns = __ballot(need_turn);
+  while (turns) {
+    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
+    int pe_turn = __shfl(pe, lane);
+    if (pe_turn == pe) {
+      DISPATCH_PROVIDER_TYPE_COMPILE_TIME(ShmemGetMemNbiThreadKernelImpl, dest, destOffset, source,
+                                          sourceOffset, bytes, pe, qpId);
+      need_turn = false;
+    }
+    turns = __ballot(need_turn);
+  }
+}
+
+template <core::ProviderType PrvdType>
+inline __device__ void ShmemGetMemNbiWarpKernelImpl(const application::SymmMemObjPtr dest,
+                                                    size_t destOffset,
+                                                    const application::SymmMemObjPtr source,
+                                                    size_t sourceOffset, size_t bytes, int pe,
+                                                    int qpId) {
+  int laneId = threadIdx.x & (warpSize - 1);
+  if (laneId == 0) {
+    ShmemGetMemNbiThreadKernelImpl<PrvdType>(dest, destOffset, source, sourceOffset, bytes, pe,
+                                             qpId);
+  }
+}
+
+template <core::ProviderType PrvdType>
+inline __device__ void ShmemGetMemNbiBlockKernelImpl(const application::SymmMemObjPtr dest,
+                                                     size_t destOffset,
+                                                     const application::SymmMemObjPtr source,
+                                                     size_t sourceOffset, size_t bytes, int pe,
+                                                     int qpId) {
+  int threadId = core::FlatBlockThreadId();
+  if (threadId == 0) {
+    ShmemGetMemNbiThreadKernelImpl<PrvdType>(dest, destOffset, source, sourceOffset, bytes, pe,
+                                             qpId);
+  }
+}
+
+template <>
+inline __device__ void ShmemGetMemNbiWarpKernel<application::TransportType::RDMA>(
+    const application::SymmMemObjPtr dest, size_t destOffset,
+    const application::SymmMemObjPtr source, size_t sourceOffset, size_t bytes, int pe, int qpId) {
+  DISPATCH_PROVIDER_TYPE_COMPILE_TIME(ShmemGetMemNbiWarpKernelImpl, dest, destOffset, source,
+                                      sourceOffset, bytes, pe, qpId);
+}
+
+template <>
+inline __device__ void ShmemGetMemNbiBlockKernel<application::TransportType::RDMA>(
+    const application::SymmMemObjPtr dest, size_t destOffset,
+    const application::SymmMemObjPtr source, size_t sourceOffset, size_t bytes, int pe, int qpId) {
+  DISPATCH_PROVIDER_TYPE_COMPILE_TIME(ShmemGetMemNbiBlockKernelImpl, dest, destOffset, source,
+                                      sourceOffset, bytes, pe, qpId);
+}
+
+/* ---------------------------------------------------------------------------------------------- */
+/*                               GetMemNbi (Pure Address-Based)                                   */
+/* ---------------------------------------------------------------------------------------------- */
+template <core::ProviderType PrvdType>
+inline __device__ void ShmemGetMemNbiThreadKernelAddrImpl(void* dest, const void* source,
+                                                          size_t bytes, int pe, int qpId) {
+  if (bytes == 0) return;
+
+  GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
+  application::RdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
+  int epIndex = pe * globalGpuStates->numQpPerPe + (qpId % globalGpuStates->numQpPerPe);
+  core::WorkQueueHandle* wq = &ep[epIndex].wqHandle;
+  core::CompletionQueueHandle* cq = &ep[epIndex].cqHandle;
+  uint32_t qpn = ep[epIndex].handle.qpn;
+
+  bool needsChunking = globalGpuStates->useVMMHeap;
+
+  uintptr_t destStartAddr = reinterpret_cast<uintptr_t>(dest);
+  uintptr_t srcStartAddr = reinterpret_cast<uintptr_t>(source);
+  size_t remaining = bytes;
+  size_t currentOffset = 0;
+
+  while (true) {
+    bool has_remaining = (remaining > 0);
+
+    uint64_t activemask = __ballot(has_remaining);
+    if (activemask == 0) {
+      break;
+    }
+
+    uint8_t num_active_lanes = core::GetActiveLaneCount(activemask);
+    uint8_t my_logical_lane_id = core::GetActiveLaneNum(activemask);
+    bool is_leader{my_logical_lane_id == num_active_lanes - 1};
+    const uint64_t leader_phys_lane_id = core::GetLastActiveLaneID(activemask);
+
+    if (!has_remaining) {
+      continue;
+    }
+
+    uintptr_t destAddr = destStartAddr + currentOffset;
+    uintptr_t srcAddr = srcStartAddr + currentOffset;
+    uint32_t lkey = globalGpuStates->heapObj->lkey;
+    uintptr_t raddr;
+    uint32_t rkey;
+    size_t transfer_size;
+
+    if (!needsChunking) {
+      transfer_size = remaining;
+      size_t offset = srcAddr - globalGpuStates->heapBaseAddr;
+      raddr = globalGpuStates->heapObj->peerPtrs[pe] + offset;
+      rkey = globalGpuStates->heapObj->peerRkeys[pe];
+    } else {
+      size_t dst_chunk_size, src_chunk_size;
+      VmmQueryLocalKey(destAddr, remaining, lkey, dst_chunk_size);
+      VmmQueryRemoteAddr(srcAddr, pe, remaining, raddr, rkey, src_chunk_size);
+      transfer_size = dst_chunk_size < src_chunk_size ? dst_chunk_size : src_chunk_size;
+    }
+
+    uint32_t warp_sq_counter{0};
+    uint32_t warp_msntbl_counter{0}, warp_psn_counter{0};
+    uint32_t my_sq_counter{0}, my_msntbl_counter{0}, my_psn_counter{0};
+    uint32_t psnCnt = 0;
+
+    if constexpr (PrvdType == core::ProviderType::BNXT) {
+      psnCnt = (transfer_size + wq->mtuSize - 1) / wq->mtuSize;
+    }
+    if (is_leader) {
+      if constexpr (PrvdType == core::ProviderType::MLX5) {
+        warp_sq_counter = __hip_atomic_fetch_add(&wq->postIdx, num_active_lanes, __ATOMIC_RELAXED,
+                                                 __HIP_MEMORY_SCOPE_AGENT);
+      } else if constexpr (PrvdType == core::ProviderType::BNXT) {
+        core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_active_lanes,
+                                            psnCnt * num_active_lanes, &warp_msntbl_counter,
+                                            &warp_psn_counter);
+        warp_sq_counter = warp_msntbl_counter;
+        __hip_atomic_fetch_max(&wq->postIdx, warp_sq_counter + num_active_lanes, __ATOMIC_RELAXED,
+                               __HIP_MEMORY_SCOPE_AGENT);
+      } else if constexpr (PrvdType == core::ProviderType::PSD) {
+        warp_sq_counter = __hip_atomic_fetch_add(&wq->postIdx, num_active_lanes, __ATOMIC_RELAXED,
+                                                 __HIP_MEMORY_SCOPE_AGENT);
+      } else {
+        static_assert(false);
+      }
+    }
+    warp_sq_counter = __shfl(warp_sq_counter, leader_phys_lane_id);
+    if constexpr (PrvdType == core::ProviderType::MLX5) {
+      my_sq_counter = warp_sq_counter + my_logical_lane_id;
+    } else if constexpr (PrvdType == core::ProviderType::BNXT) {
+      warp_msntbl_counter = __shfl(warp_msntbl_counter, leader_phys_lane_id);
+      warp_psn_counter = __shfl(warp_psn_counter, leader_phys_lane_id);
+      my_sq_counter = warp_sq_counter + my_logical_lane_id;
+      my_msntbl_counter = warp_msntbl_counter + my_logical_lane_id;
+      my_psn_counter = warp_psn_counter + my_logical_lane_id * psnCnt;
+    } else if constexpr (PrvdType == core::ProviderType::PSD) {
+      my_sq_counter = warp_sq_counter + my_logical_lane_id;
+    } else {
+      static_assert(false);
+    }
+
+    while (true) {
+      uint64_t db_touched =
+          __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      uint64_t db_done =
+          __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      uint64_t num_active_sq_entries = db_touched - db_done;
+      uint64_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
+      uint64_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
+      if (num_free_entries > num_entries_until_warp_last_entry) {
+        break;
+      }
+      ShmemQuietThreadKernelImpl<PrvdType>(pe, qpId);
+    }
+
+    uint64_t dbr_val;
+    if constexpr (PrvdType == core::ProviderType::MLX5) {
+      wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
+      dbr_val =
+          core::PostRead<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter, is_leader,
+                                   qpn, destAddr, lkey, raddr, rkey, transfer_size);
+    } else if constexpr (PrvdType == core::ProviderType::BNXT) {
+      wq->outstandingWqe[my_sq_counter % wq->sqWqeNum] = my_sq_counter;
+      dbr_val =
+          core::PostRead<PrvdType>(*wq, my_sq_counter, my_msntbl_counter, my_psn_counter,
+                                   is_leader, qpn, destAddr, lkey, raddr, rkey, transfer_size);
+    } else if constexpr (PrvdType == core::ProviderType::PSD) {
+      wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
+      dbr_val =
+          core::PostRead<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter, is_leader,
+                                   qpn, destAddr, lkey, raddr, rkey, transfer_size);
+    } else {
+      static_assert(false);
+    }
+
+    __threadfence_system();
+    if (is_leader) {
+      uint64_t db_touched{0};
+      do {
+        db_touched = __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      } while (db_touched != warp_sq_counter);
+
+      core::UpdateSendDbrRecord<PrvdType>(wq->dbrRecAddr, warp_sq_counter + num_active_lanes);
+      __threadfence_system();
+      core::RingDoorbell<PrvdType>(wq->dbrAddr, dbr_val);
+      __threadfence_system();
+
+      __hip_atomic_fetch_add(&cq->needConsIdx, 1, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      __hip_atomic_store(&wq->dbTouchIdx, warp_sq_counter + num_active_lanes, __ATOMIC_RELAXED,
+                         __HIP_MEMORY_SCOPE_AGENT);
+    }
+    __threadfence_system();
+
+    currentOffset += transfer_size;
+    remaining -= transfer_size;
+  }
+}
+
+template <>
+inline __device__ void ShmemGetMemNbiThreadKernel<application::TransportType::RDMA>(
+    void* dest, const void* source, size_t bytes, int pe, int qpId) {
+  bool need_turn{true};
+  uint64_t turns = __ballot(need_turn);
+  while (turns) {
+    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
+    int pe_turn = __shfl(pe, lane);
+    if (pe_turn == pe) {
+      DISPATCH_PROVIDER_TYPE_COMPILE_TIME(ShmemGetMemNbiThreadKernelAddrImpl, dest, source, bytes,
+                                          pe, qpId);
+      need_turn = false;
+    }
+    turns = __ballot(need_turn);
+  }
+}
+
+template <core::ProviderType PrvdType>
+inline __device__ void ShmemGetMemNbiWarpKernelAddrImpl(void* dest, const void* source,
+                                                        size_t bytes, int pe, int qpId) {
+  int laneId = threadIdx.x & (warpSize - 1);
+  if (laneId == 0) {
+    ShmemGetMemNbiThreadKernelAddrImpl<PrvdType>(dest, source, bytes, pe, qpId);
+  }
+}
+
+template <core::ProviderType PrvdType>
+inline __device__ void ShmemGetMemNbiBlockKernelAddrImpl(void* dest, const void* source,
+                                                         size_t bytes, int pe, int qpId) {
+  if (core::FlatBlockThreadId() == 0) {
+    ShmemGetMemNbiThreadKernelAddrImpl<PrvdType>(dest, source, bytes, pe, qpId);
+  }
+}
+
+template <>
+inline __device__ void ShmemGetMemNbiWarpKernel<application::TransportType::RDMA>(
+    void* dest, const void* source, size_t bytes, int pe, int qpId) {
+  DISPATCH_PROVIDER_TYPE_COMPILE_TIME(ShmemGetMemNbiWarpKernelAddrImpl, dest, source, bytes, pe,
+                                      qpId);
+}
+
+template <>
+inline __device__ void ShmemGetMemNbiBlockKernel<application::TransportType::RDMA>(
+    void* dest, const void* source, size_t bytes, int pe, int qpId) {
+  DISPATCH_PROVIDER_TYPE_COMPILE_TIME(ShmemGetMemNbiBlockKernelAddrImpl, dest, source, bytes, pe,
+                                      qpId);
+}
+
 }  // namespace shmem
 }  // namespace mori

--- a/include/mori/shmem/shmem_p2p_kernels.hpp
+++ b/include/mori/shmem/shmem_p2p_kernels.hpp
@@ -533,6 +533,39 @@ DEFINE_SHMEM_ATOMIC_TYPE_FETCH_WARP_KERNEL_P2P(Int32, int32_t)
 DEFINE_SHMEM_ATOMIC_TYPE_FETCH_WARP_KERNEL_P2P(Int64, int64_t)
 
 /* ---------------------------------------------------------------------------------------------- */
+/*                                    GetMemNbi (SymmMemObjPtr)                                   */
+/* ---------------------------------------------------------------------------------------------- */
+template <>
+inline __device__ void ShmemGetMemNbiThreadKernel<application::TransportType::P2P>(
+    const application::SymmMemObjPtr dest, size_t destOffset,
+    const application::SymmMemObjPtr source, size_t sourceOffset, size_t bytes, int pe, int qpId) {
+  uint8_t* srcPtr = reinterpret_cast<uint8_t*>(source->peerPtrs[pe] + sourceOffset);
+  uint8_t* destPtr =
+      reinterpret_cast<uint8_t*>(reinterpret_cast<uintptr_t>(dest->localPtr) + destOffset);
+  core::ThreadCopy<uint8_t>(destPtr, srcPtr, bytes);
+}
+
+template <>
+inline __device__ void ShmemGetMemNbiWarpKernel<application::TransportType::P2P>(
+    const application::SymmMemObjPtr dest, size_t destOffset,
+    const application::SymmMemObjPtr source, size_t sourceOffset, size_t bytes, int pe, int qpId) {
+  uint8_t* srcPtr = reinterpret_cast<uint8_t*>(source->peerPtrs[pe] + sourceOffset);
+  uint8_t* destPtr =
+      reinterpret_cast<uint8_t*>(reinterpret_cast<uintptr_t>(dest->localPtr) + destOffset);
+  core::WarpCopy<uint8_t>(destPtr, srcPtr, bytes);
+}
+
+template <>
+inline __device__ void ShmemGetMemNbiBlockKernel<application::TransportType::P2P>(
+    const application::SymmMemObjPtr dest, size_t destOffset,
+    const application::SymmMemObjPtr source, size_t sourceOffset, size_t bytes, int pe, int qpId) {
+  uint8_t* srcPtr = reinterpret_cast<uint8_t*>(source->peerPtrs[pe] + sourceOffset);
+  uint8_t* destPtr =
+      reinterpret_cast<uint8_t*>(reinterpret_cast<uintptr_t>(dest->localPtr) + destOffset);
+  core::BlockCopy<uint8_t>(destPtr, srcPtr, bytes);
+}
+
+/* ---------------------------------------------------------------------------------------------- */
 /*                            Pure Address-Based Point-to-Point (New)                             */
 /* ---------------------------------------------------------------------------------------------- */
 
@@ -1069,6 +1102,48 @@ DEFINE_SHMEM_ATOMIC_TYPE_FETCH_WARP_KERNEL_P2P_ADDR(Uint32, uint32_t)
 DEFINE_SHMEM_ATOMIC_TYPE_FETCH_WARP_KERNEL_P2P_ADDR(Uint64, uint64_t)
 DEFINE_SHMEM_ATOMIC_TYPE_FETCH_WARP_KERNEL_P2P_ADDR(Int32, int32_t)
 DEFINE_SHMEM_ATOMIC_TYPE_FETCH_WARP_KERNEL_P2P_ADDR(Int64, int64_t)
+
+/* ---------------------------------------------------------------------------------------------- */
+/*                               GetMemNbi (Pure Address-Based)                                   */
+/* ---------------------------------------------------------------------------------------------- */
+template <>
+inline __device__ void ShmemGetMemNbiThreadKernel<application::TransportType::P2P>(
+    void* dest, const void* source, size_t bytes, int pe, int qpId) {
+  GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
+
+  uintptr_t srcAddr = reinterpret_cast<uintptr_t>(source);
+  size_t offset = srcAddr - globalGpuStates->heapBaseAddr;
+
+  uint8_t* srcPtr = reinterpret_cast<uint8_t*>(globalGpuStates->heapObj->peerPtrs[pe] + offset);
+  uint8_t* destPtr = reinterpret_cast<uint8_t*>(dest);
+  core::ThreadCopy<uint8_t>(destPtr, srcPtr, bytes);
+}
+
+template <>
+inline __device__ void ShmemGetMemNbiWarpKernel<application::TransportType::P2P>(
+    void* dest, const void* source, size_t bytes, int pe, int qpId) {
+  GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
+
+  uintptr_t srcAddr = reinterpret_cast<uintptr_t>(source);
+  size_t offset = srcAddr - globalGpuStates->heapBaseAddr;
+
+  uint8_t* srcPtr = reinterpret_cast<uint8_t*>(globalGpuStates->heapObj->peerPtrs[pe] + offset);
+  uint8_t* destPtr = reinterpret_cast<uint8_t*>(dest);
+  core::WarpCopy<uint8_t>(destPtr, srcPtr, bytes);
+}
+
+template <>
+inline __device__ void ShmemGetMemNbiBlockKernel<application::TransportType::P2P>(
+    void* dest, const void* source, size_t bytes, int pe, int qpId) {
+  GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
+
+  uintptr_t srcAddr = reinterpret_cast<uintptr_t>(source);
+  size_t offset = srcAddr - globalGpuStates->heapBaseAddr;
+
+  uint8_t* srcPtr = reinterpret_cast<uint8_t*>(globalGpuStates->heapObj->peerPtrs[pe] + offset);
+  uint8_t* destPtr = reinterpret_cast<uint8_t*>(dest);
+  core::BlockCopy<uint8_t>(destPtr, srcPtr, bytes);
+}
 
 /* ---------------------------------------------------------------------------------------------- */
 /*                                         Synchronization                                        */

--- a/include/mori/shmem/shmem_sdma_kernels.hpp
+++ b/include/mori/shmem/shmem_sdma_kernels.hpp
@@ -403,6 +403,56 @@ inline __device__ void ShmemAtomicSizeNonFetchWarpKernel<application::TransportT
 }
 
 /* ---------------------------------------------------------------------------------------------- */
+/*                                    GetMemNbi (SymmMemObjPtr)                                   */
+/* ---------------------------------------------------------------------------------------------- */
+// TODO: implement SDMA-specific GET, delegating to P2P for now
+template <>
+inline __device__ void ShmemGetMemNbiThreadKernel<application::TransportType::SDMA>(
+    const application::SymmMemObjPtr dest, size_t destOffset,
+    const application::SymmMemObjPtr source, size_t sourceOffset, size_t bytes, int pe, int qpId) {
+  ShmemGetMemNbiThreadKernel<application::TransportType::P2P>(dest, destOffset, source,
+                                                               sourceOffset, bytes, pe, qpId);
+}
+
+template <>
+inline __device__ void ShmemGetMemNbiWarpKernel<application::TransportType::SDMA>(
+    const application::SymmMemObjPtr dest, size_t destOffset,
+    const application::SymmMemObjPtr source, size_t sourceOffset, size_t bytes, int pe, int qpId) {
+  ShmemGetMemNbiWarpKernel<application::TransportType::P2P>(dest, destOffset, source, sourceOffset,
+                                                             bytes, pe, qpId);
+}
+
+template <>
+inline __device__ void ShmemGetMemNbiBlockKernel<application::TransportType::SDMA>(
+    const application::SymmMemObjPtr dest, size_t destOffset,
+    const application::SymmMemObjPtr source, size_t sourceOffset, size_t bytes, int pe, int qpId) {
+  ShmemGetMemNbiBlockKernel<application::TransportType::P2P>(dest, destOffset, source,
+                                                              sourceOffset, bytes, pe, qpId);
+}
+
+/* ---------------------------------------------------------------------------------------------- */
+/*                               GetMemNbi (Pure Address-Based)                                   */
+/* ---------------------------------------------------------------------------------------------- */
+// TODO: implement SDMA-specific GET, delegating to P2P for now
+template <>
+inline __device__ void ShmemGetMemNbiThreadKernel<application::TransportType::SDMA>(
+    void* dest, const void* source, size_t bytes, int pe, int qpId) {
+  ShmemGetMemNbiThreadKernel<application::TransportType::P2P>(dest, source, bytes, pe, qpId);
+}
+
+template <>
+inline __device__ void ShmemGetMemNbiWarpKernel<application::TransportType::SDMA>(
+    void* dest, const void* source, size_t bytes, int pe, int qpId) {
+  ShmemGetMemNbiWarpKernel<application::TransportType::P2P>(dest, source, bytes, pe, qpId);
+}
+
+template <>
+inline __device__ void ShmemGetMemNbiBlockKernel<application::TransportType::SDMA>(
+    void* dest, const void* source, size_t bytes, int pe, int qpId) {
+  ShmemGetMemNbiBlockKernel<application::TransportType::P2P>(dest, source, bytes, pe, qpId);
+}
+
+/* ---------------------------------------------------------------------------------------------- */
 /*                                         Synchronization                                        */
 /* ---------------------------------------------------------------------------------------------- */
 

--- a/python/mori/ir/ops.py
+++ b/python/mori/ir/ops.py
@@ -166,6 +166,87 @@ MORI_DEVICE_FUNCTIONS = {
         "ret": "int32",
     },
 
+    # ==== GetNbi – Thread ====
+    "getmem_nbi_thread": {
+        "symbol": "mori_shmem_getmem_nbi_thread",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_uint32_nbi_thread": {
+        "symbol": "mori_shmem_get_uint32_nbi_thread",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_uint64_nbi_thread": {
+        "symbol": "mori_shmem_get_uint64_nbi_thread",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_float_nbi_thread": {
+        "symbol": "mori_shmem_get_float_nbi_thread",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_double_nbi_thread": {
+        "symbol": "mori_shmem_get_double_nbi_thread",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+
+    # ==== GetNbi – Warp ====
+    "getmem_nbi_warp": {
+        "symbol": "mori_shmem_getmem_nbi_warp",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_uint32_nbi_warp": {
+        "symbol": "mori_shmem_get_uint32_nbi_warp",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_uint64_nbi_warp": {
+        "symbol": "mori_shmem_get_uint64_nbi_warp",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_float_nbi_warp": {
+        "symbol": "mori_shmem_get_float_nbi_warp",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_double_nbi_warp": {
+        "symbol": "mori_shmem_get_double_nbi_warp",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+
+    # ==== GetNbi – Block ====
+    "getmem_nbi_block": {
+        "symbol": "mori_shmem_getmem_nbi_block",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_uint32_nbi_block": {
+        "symbol": "mori_shmem_get_uint32_nbi_block",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_uint64_nbi_block": {
+        "symbol": "mori_shmem_get_uint64_nbi_block",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_float_nbi_block": {
+        "symbol": "mori_shmem_get_float_nbi_block",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_double_nbi_block": {
+        "symbol": "mori_shmem_get_double_nbi_block",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+
     # ==== PutNbi with Signal ====
     "putmem_nbi_signal_thread": {
         "symbol": "mori_shmem_putmem_nbi_signal_thread",

--- a/python/mori/ir/ops.py
+++ b/python/mori/ir/ops.py
@@ -247,6 +247,87 @@ MORI_DEVICE_FUNCTIONS = {
         "ret": "int32",
     },
 
+    # ==== Blocking GET – Thread ====
+    "getmem_thread": {
+        "symbol": "mori_shmem_getmem_thread",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_uint32_thread": {
+        "symbol": "mori_shmem_get_uint32_thread",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_uint64_thread": {
+        "symbol": "mori_shmem_get_uint64_thread",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_float_thread": {
+        "symbol": "mori_shmem_get_float_thread",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_double_thread": {
+        "symbol": "mori_shmem_get_double_thread",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+
+    # ==== Blocking GET – Warp ====
+    "getmem_warp": {
+        "symbol": "mori_shmem_getmem_warp",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_uint32_warp": {
+        "symbol": "mori_shmem_get_uint32_warp",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_uint64_warp": {
+        "symbol": "mori_shmem_get_uint64_warp",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_float_warp": {
+        "symbol": "mori_shmem_get_float_warp",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_double_warp": {
+        "symbol": "mori_shmem_get_double_warp",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+
+    # ==== Blocking GET – Block ====
+    "getmem_block": {
+        "symbol": "mori_shmem_getmem_block",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_uint32_block": {
+        "symbol": "mori_shmem_get_uint32_block",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_uint64_block": {
+        "symbol": "mori_shmem_get_uint64_block",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_float_block": {
+        "symbol": "mori_shmem_get_float_block",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+    "get_double_block": {
+        "symbol": "mori_shmem_get_double_block",
+        "args": ["uint64", "uint64", "uint64", "int32", "int32"],
+        "ret": "int32",
+    },
+
     # ==== PutNbi with Signal ====
     "putmem_nbi_signal_thread": {
         "symbol": "mori_shmem_putmem_nbi_signal_thread",

--- a/src/shmem/shmem_device_api_wrapper.cpp
+++ b/src/shmem/shmem_device_api_wrapper.cpp
@@ -173,6 +173,105 @@ __device__ __attribute__((visibility("default"))) int mori_shmem_put_double_nbi_
 }
 
 // ============================================================================
+// GetNbi APIs - Address-based only
+// ============================================================================
+__device__ __attribute__((visibility("default"))) int mori_shmem_getmem_nbi_thread(
+    void* dest, const void* source, size_t bytes, int pe, int qpId) {
+  mori::shmem::ShmemGetMemNbiThread(dest, source, bytes, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint32_nbi_thread(
+    uint32_t* dest, const uint32_t* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetUint32NbiThread(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint64_nbi_thread(
+    uint64_t* dest, const uint64_t* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetUint64NbiThread(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_float_nbi_thread(
+    float* dest, const float* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetFloatNbiThread(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_double_nbi_thread(
+    double* dest, const double* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetDoubleNbiThread(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+// ============================================================================
+// GetNbi APIs - Warp Scope (Address-based only)
+// ============================================================================
+__device__ __attribute__((visibility("default"))) int mori_shmem_getmem_nbi_warp(
+    void* dest, const void* source, size_t bytes, int pe, int qpId) {
+  mori::shmem::ShmemGetMemNbiWarp(dest, source, bytes, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint32_nbi_warp(
+    uint32_t* dest, const uint32_t* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetUint32NbiWarp(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint64_nbi_warp(
+    uint64_t* dest, const uint64_t* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetUint64NbiWarp(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_float_nbi_warp(
+    float* dest, const float* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetFloatNbiWarp(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_double_nbi_warp(
+    double* dest, const double* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetDoubleNbiWarp(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+// ============================================================================
+// GetNbi APIs - Block Scope (Address-based only)
+// ============================================================================
+__device__ __attribute__((visibility("default"))) int mori_shmem_getmem_nbi_block(
+    void* dest, const void* source, size_t bytes, int pe, int qpId) {
+  mori::shmem::ShmemGetMemNbiBlock(dest, source, bytes, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint32_nbi_block(
+    uint32_t* dest, const uint32_t* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetUint32NbiBlock(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint64_nbi_block(
+    uint64_t* dest, const uint64_t* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetUint64NbiBlock(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_float_nbi_block(
+    float* dest, const float* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetFloatNbiBlock(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_double_nbi_block(
+    double* dest, const double* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetDoubleNbiBlock(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+// ============================================================================
 // PutNbi with Signal APIs
 // ============================================================================
 __device__ __attribute__((visibility("default"))) int mori_shmem_putmem_nbi_signal_thread(

--- a/src/shmem/shmem_device_api_wrapper.cpp
+++ b/src/shmem/shmem_device_api_wrapper.cpp
@@ -272,6 +272,99 @@ __device__ __attribute__((visibility("default"))) int mori_shmem_get_double_nbi_
 }
 
 // ============================================================================
+// Blocking GET APIs - Address-based only
+// ============================================================================
+__device__ __attribute__((visibility("default"))) int mori_shmem_getmem_thread(
+    void* dest, const void* source, size_t bytes, int pe, int qpId) {
+  mori::shmem::ShmemGetMemThread(dest, source, bytes, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint32_thread(
+    uint32_t* dest, const uint32_t* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetUint32Thread(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint64_thread(
+    uint64_t* dest, const uint64_t* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetUint64Thread(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_float_thread(
+    float* dest, const float* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetFloatThread(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_double_thread(
+    double* dest, const double* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetDoubleThread(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_getmem_warp(
+    void* dest, const void* source, size_t bytes, int pe, int qpId) {
+  mori::shmem::ShmemGetMemWarp(dest, source, bytes, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint32_warp(
+    uint32_t* dest, const uint32_t* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetUint32Warp(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint64_warp(
+    uint64_t* dest, const uint64_t* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetUint64Warp(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_float_warp(
+    float* dest, const float* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetFloatWarp(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_double_warp(
+    double* dest, const double* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetDoubleWarp(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_getmem_block(
+    void* dest, const void* source, size_t bytes, int pe, int qpId) {
+  mori::shmem::ShmemGetMemBlock(dest, source, bytes, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint32_block(
+    uint32_t* dest, const uint32_t* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetUint32Block(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_uint64_block(
+    uint64_t* dest, const uint64_t* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetUint64Block(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_float_block(
+    float* dest, const float* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetFloatBlock(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+__device__ __attribute__((visibility("default"))) int mori_shmem_get_double_block(
+    double* dest, const double* source, size_t nelems, int pe, int qpId) {
+  mori::shmem::ShmemGetDoubleBlock(dest, source, nelems, pe, qpId);
+  return 0;
+}
+
+// ============================================================================
 // PutNbi with Signal APIs
 // ============================================================================
 __device__ __attribute__((visibility("default"))) int mori_shmem_putmem_nbi_signal_thread(


### PR DESCRIPTION
## Motivation

MORI shmem currently only supports PUT (remote write) operations. To align with the OpenSHMEM standard and enable use cases like remote data fetch in MoE combine kernels, this PR adds GET (remote read) — the counterpart to PUT. GET allows a PE to read data from a remote PE's symmetric heap into its own local memory, complementing the existing PUT-based communication model.

## Technical Details

### Non-blocking GET (`ShmemGetMemNbi*`)
- **P2P transport**: direct GPU memory copy from `peerPtrs[pe]` to local, using `ThreadCopy`/`WarpCopy`/`BlockCopy`
- **IBGDA/RDMA transport**: posts RDMA READ WQEs via `PostRead` (NIC fetches remote data to local GPU memory); user must call `ShmemQuietThread` before accessing data
- **SDMA transport**: delegates to P2P (native SDMA GET is TODO)
- Supports both `SymmMemObjPtr`-based and pure address-based APIs
- Thread/Warp/Block scope, typed variants for all 11 data types

### Blocking GET (`ShmemGetMem*`)
- Wraps `GetMemNbi + ShmemQuietThread` — data is ready when the call returns
- Follows OpenSHMEM `shmem_getmem` / `shmem_TYPE_get` semantics

### PostReadWrite template refactor
- Unified `PostWrite`/`PostRead` into `PostReadWrite<PrvdType, IsRead>` compile-time template across MLX5, BNXT, and Ionic providers
- Opcode selection is now `constexpr` instead of runtime branch
- `PostWrite`/`PostRead` retained as inline wrappers for backward compatibility

### Triton IR integration
- C wrapper functions (`mori_shmem_getmem_nbi_*`, `mori_shmem_getmem_*`) compiled to device bitcode
- Python `mori.ir.ops` metadata for `@core.extern` Triton kernel integration

## Test Plan

### C++ tests (`concurrent_get_thread`, via `mpirun -np 2`)

| Test | Description |
|------|-------------|
| Test 1 | Nbi GET Legacy API (SymmMemObjPtr, Thread scope) |
| Test 1B | Nbi GET Legacy API (Block scope) |
| Test 2 | Nbi GET Pure Address API (Thread scope) |
| Test 2B | Nbi GET Pure Address API (Block scope) |
| Test 3 | Nbi GET Large Multi-Chunk (>200MB, VMM chunk boundary crossing) |
| Test 4 | Blocking GET Legacy API (Thread scope) |
| Test 5 | Blocking GET Pure Address API (Thread scope) |

### Triton bitcode tests (`torchrun --nproc_per_node=2`)

| Test | Description |
|------|-------------|
| `shmem_get_nbi_kernel` | Non-blocking GET via `getmem_nbi_thread` + `quiet_thread` |
| `shmem_get_blocking_kernel` | Blocking GET via `getmem_thread` (no separate quiet) |

### Test matrix (all PASSED)

| | MLX5 P2P | MLX5 IBGDA | BNXT P2P | BNXT IBGDA | AINIC P2P | AINIC IBGDA |
|---|:---:|:---:|:---:|:---:|:---:|:---:|
| C++ Nbi GET (5 tests) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| C++ Blocking GET (2 tests) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| Triton get_nbi | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| Triton get_blocking | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

- **Hardware**: MLX5 + MI300X, BNXT Thor2 + MI325X, AINIC Pollara + MI350X
- **Modes tested**: Static Heap, VMM Heap (`MORI_SHMEM_MODE=VMM_HEAP`)