### PR TITLE
Update Docker environment for MI355X benchmark reproducibility

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+build
+__pycache__
+*.pyc
+*.pyo
+*.egg-info
+*.egg
+dist
+*.csv
+*.jpg
+*.png

--- a/README.md
+++ b/README.md
@@ -96,20 +96,64 @@ Benchmark result on the following configurations:
 
 ## Installation
 
-### Prerequisites
+### Docker (recommended for MI355X)
 
-- pytorch:rocm >= 6.4.0
-- Linux packages: see packages in dockerfile
+Build a self-contained image with all dependencies pre-installed:
 
-Or build docker image with:
-```
-cd mori && docker build -t rocm/mori:dev -f docker/Dockerfile.dev .
+```bash
+cd mori
+docker build -t rocm/mori:benchmark -f docker/Dockerfile.dev .
 ```
 
-### Install with Python
+Launch a container with GPU access:
+
+```bash
+bash docker/run_benchmark.sh
+# or manually:
+docker run --rm -it \
+  --device=/dev/kfd --device=/dev/dri \
+  --ipc=host --security-opt seccomp=unconfined \
+  --cap-add=SYS_PTRACE --group-add video --group-add render \
+  rocm/mori:benchmark bash
 ```
-# NOTE: for venv build, add --no-build-isolation at the end
-cd mori && pip install -r requirements-build.txt && git submodule update --init --recursive && pip3 install .
+
+Run CCL benchmarks inside the container:
+
+```bash
+# AllReduce sweep (2-256 MB)
+bash tests/python/ccl/bench_allreduce_sweep.sh
+
+# AllGather / ReduceScatter standalone latency sweep
+bash tests/python/ccl/bench_allgather_sweep.sh
+bash tests/python/ccl/bench_reducescatter_sweep.sh
+
+# AllGather / ReduceScatter + GEMM overlap sweep
+bash tests/python/ccl/bench_ag_overlap_sweep.sh
+bash tests/python/ccl/bench_rs_overlap_sweep.sh
+```
+
+> **Note**: The default `MORI_GPU_ARCHS` is `gfx950` (MI355X). To build for MI300X, pass `--build-arg MORI_GPU_ARCHS=gfx942`.
+
+### Install without Docker
+
+Prerequisites:
+- PyTorch with ROCm (version must match your system ROCm, e.g. `pip install torch --index-url https://download.pytorch.org/whl/rocm7.1`)
+- Linux packages: `git`, `cython3`, `ibverbs-utils`, `openmpi-bin`, `libopenmpi-dev`, `libpci-dev`, `cmake`, `libdw1`, `locales`
+- For GEMM overlap tests: `pip install amd-aiter ninja`
+
+```bash
+cd mori
+pip install -r requirements-build.txt
+git submodule update --init --recursive
+export MORI_GPU_ARCHS=gfx950   # or gfx942 for MI300X
+pip3 install .                  # add --no-build-isolation if using venv
+```
+
+Required environment variables:
+
+```bash
+export PYTHONPATH=/path/to/mori:$PYTHONPATH
+export HSA_NO_SCRATCH_RECLAIM=1
 ```
 
 ### Test dispatch / combine

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,5 +1,4 @@
-# FROM rocm/pytorch:rocm6.4.1_ubuntu22.04_py3.12_pytorch_release_2.5.1
-FROM rocm/pytorch:rocm6.4.3_ubuntu22.04_py3.10_pytorch_release_2.5.1
+FROM rocm/pytorch:rocm7.1.1_ubuntu22.04_py3.10_pytorch_release_2.10.0
 
 RUN apt-get update && \
     apt-get install -y \
@@ -11,4 +10,24 @@ RUN apt-get update && \
     libpci-dev \
     cmake \
     libdw1 \
-    locales
+    locales && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir \
+    amd-aiter ninja prettytable pytest-assume \
+    setuptools-scm cmake 'setuptools>=65'
+
+COPY . /workspace/mori
+WORKDIR /workspace/mori
+
+ARG MORI_GPU_ARCHS=gfx950
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=0.1.0
+RUN MORI_GPU_ARCHS=${MORI_GPU_ARCHS} \
+    PYTORCH_ROCM_ARCH=${MORI_GPU_ARCHS} \
+    pip3 install . --no-cache-dir --no-build-isolation
+
+ENV PYTHONPATH=/workspace/mori:${PYTHONPATH}
+ENV HSA_NO_SCRATCH_RECLAIM=1
+ENV PATH=/root/.local/bin:${PATH}
+
+CMD ["/bin/bash"]

--- a/docker/run_benchmark.sh
+++ b/docker/run_benchmark.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+IMAGE_NAME="${1:-rocm/mori:benchmark}"
+
+docker run --rm -it \
+  --device=/dev/kfd \
+  --device=/dev/dri \
+  --ipc=host \
+  --security-opt seccomp=unconfined \
+  --cap-add=SYS_PTRACE \
+  --group-add video \
+  --group-add render \
+  "$IMAGE_NAME" \
+  bash


### PR DESCRIPTION
## Summary

Update `docker/Dockerfile.dev` to produce a self-contained Docker image that allows users to reproduce all CCL benchmark experiments (AllReduce, AllGather, ReduceScatter, and GEMM overlap tests) on any MI355X machine with a single `docker run`. Also update README with comprehensive Docker and installation instructions.

### Changes

| File | Status | Description |
|------|--------|-------------|
| `docker/Dockerfile.dev` | Modified | Upgrade base image to ROCm 7.1.1, add all dependencies, build MORI inside image |
| `.dockerignore` | New | Exclude `.git/`, `build/`, `*.csv`, etc. from build context |
| `docker/run_benchmark.sh` | New | Helper script to launch container with correct GPU flags |
| `README.md` | Modified | Add Docker usage, benchmark commands, non-Docker install guide |

### Key changes in Dockerfile

- **Base image**: `rocm/pytorch:rocm6.4.3_ubuntu22.04_py3.10` to `rocm/pytorch:rocm7.1.1_ubuntu22.04_py3.10_pytorch_release_2.10.0`
- **New Python deps**: `amd-aiter` (INT8 GEMM for overlap tests), `ninja`, `prettytable`, `pytest-assume`, `setuptools-scm`
- **MORI build**: `COPY` source, compile with `MORI_GPU_ARCHS=gfx950` + `--no-build-isolation`
- **Environment**: `HSA_NO_SCRATCH_RECLAIM=1`, `PYTHONPATH`, `SETUPTOOLS_SCM_PRETEND_VERSION`

### Usage

Build:
cd mori
docker build -t rocm/mori:benchmark -f docker/Dockerfile.dev .

Run:
bash docker/run_benchmark.sh

Inside container:
bash tests/python/ccl/bench_allgather_sweep.sh
bash tests/python/ccl/bench_reducescatter_sweep.sh
bash tests/python/ccl/bench_ag_overlap_sweep.sh
bash tests/python/ccl/bench_rs_overlap_sweep.sh

## Test plan

- [x] `docker build` succeeds from clean `git clone` (~1 min with cached base image)
- [x] Import verification: `torch`, `mori.shmem`, `mori.ccl.AllreduceSdma`, `mori.ccl.ReduceScatterSdma`, `aiter`
- [x] GPU detection: 8x MI355X, gfx950
- [x] AllReduce SDMA + RCCL (All Tests PASSED, 41.89 GB/s @ 2MB)
- [x] AllGather SDMA standalone (8/8 PE passed, 237.36 GB/s @ 10MB)
- [x] ReduceScatter SDMA standalone (8/8 PE passed, 353.31 GB/s @ 10MB)