### PR TITLE
Fix: remove unused #include <mpi.h> from shmem kernel headers

### DIFF
--- a/include/mori/shmem/shmem_device_api.hpp
+++ b/include/mori/shmem/shmem_device_api.hpp
@@ -22,7 +22,6 @@
 #pragma once
 
 #include <assert.h>
-#include <mpi.h>
 
 #include "mori/application/application.hpp"
 #include "mori/core/core.hpp"

--- a/include/mori/shmem/shmem_ibgda_kernels.hpp
+++ b/include/mori/shmem/shmem_ibgda_kernels.hpp
@@ -22,7 +22,6 @@
 #pragma once
 
 #include <assert.h>
-#include <mpi.h>
 
 #include "mori/application/application.hpp"
 #include "mori/core/core.hpp"

--- a/include/mori/shmem/shmem_p2p_kernels.hpp
+++ b/include/mori/shmem/shmem_p2p_kernels.hpp
@@ -22,7 +22,6 @@
 #pragma once
 
 #include <assert.h>
-#include <mpi.h>
 
 #include <type_traits>
 

--- a/include/mori/shmem/shmem_sdma_kernels.hpp
+++ b/include/mori/shmem/shmem_sdma_kernels.hpp
@@ -22,7 +22,6 @@
 #pragma once
 
 #include <assert.h>
-#include <mpi.h>
 
 #include <type_traits>
 


### PR DESCRIPTION
These four headers do not call any MPI functions. The include was missed during the optional-MPI refactor in 4512e02d, causing builds without MPI to fail when these headers are pulled in.