### PR TITLE
Fix [UMBP]: change integration default test mode to tp

### DIFF
--- a/src/umbp/scripts/test_umbp_inner.sh
+++ b/src/umbp/scripts/test_umbp_inner.sh
@@ -13,7 +13,7 @@ MORI_BRANCH="${1:-main}"
 # ===========================================================================
 
 run_bench_hicache() {
-    local MODE="${1:-dp_ep}"
+    local MODE="${1:-tp}"
     local SERVER_LOG="server_hicache_$(date +%Y%m%d_%H%M%S).log"
     local SERVER_PORT=30000
     local BENCH_DIR="/apps/ditian12/sglang/benchmark/gsm8k"


### PR DESCRIPTION
For integration test, use tp as default test mode since dp_ep + mla currently does not touch DRAM/SSD with current design.