### PR TITLE
ci: add JAX intranode test job & optimize shmem tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,8 +152,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Install mori (XLA FFI)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,40 @@ jobs:
             PORT=$((PORT + 1))
           done
 
+  jax-intranode-test:
+    name: mori JAX intranode test (platform:${{ matrix.platform }})
+    needs: build
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(vars.CI_MATRIX) }}
+    container:
+      image: rocm/pytorch-private:mori_jax091_rocm711
+      credentials:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+      options: >-
+        --device=/dev/kfd --device=/dev/dri --device=/dev/infiniband
+        --group-add video --ipc=host --privileged
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install mori (XLA FFI)
+        run: |
+          cd $GITHUB_WORKSPACE
+          BUILD_XLA_FFI_OPS=ON \
+          pip install --break-system-packages -v .
+
+      - name: MORI-EP JAX test
+        run: |
+          cd $GITHUB_WORKSPACE
+          MORI_KERNEL_DIR=$(ls -d $GITHUB_WORKSPACE/build/lib/gfx* | head -1) \
+          timeout 300 pytest tests/python/ops/test_dispatch_combine_jax.py -s -v
+
   internode-test:
     name: mori internode test (platform:${{ matrix.platform }})
     needs: [build, intranode-test]

--- a/docker/Dockerfile.jax091-rocm711
+++ b/docker/Dockerfile.jax091-rocm711
@@ -52,9 +52,9 @@ RUN python${PYTHON_VERSION} -m pip install --break-system-packages \
         /tmp/wheels/*.whl && \
     rm -rf /tmp/wheels
 
-# Common runtime dependencies
+# Common runtime and test dependencies
 RUN python${PYTHON_VERSION} -m pip install --break-system-packages \
-        numpy scipy cmake pybind11
+        numpy scipy cmake pybind11 pytest
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         libibverbs-dev \
@@ -67,21 +67,3 @@ RUN python${PYTHON_VERSION} -c \
     || true
 
 WORKDIR /workspace
-
-ARG MORI_BRANCH=pemeliya/jax_integration_upstream
-
-RUN git clone --depth 1 --recurse-submodules --shallow-submodules \
-      --branch ${MORI_BRANCH} \
-        https://github.com/ROCm/mori.git /workspace/mori
-
-RUN cd /workspace/mori && \
-        PYTHONUNBUFFERED=1 \
-        BUILD_XLA_FFI_OPS=ON BUILD_EXAMPLES=OFF BUILD_TESTS=OFF \
-        BUILD_TORCH_BOOTSTRAP=OFF WITH_MPI=OFF \
-        pip install --break-system-packages -v .
-
-# Discover and export MORI_KERNEL_DIR pointing to the built gfx*_* kernel directory
-RUN KERNEL_DIR=$(ls -d /workspace/mori/build/lib/gfx* | head -1) && \
-    echo "MORI_KERNEL_DIR=${KERNEL_DIR}" >> /etc/environment && \
-    ln -sf "${KERNEL_DIR}" /workspace/mori/build/lib/kernels
-ENV MORI_KERNEL_DIR=/workspace/mori/build/lib/kernels

--- a/src/ops/CMakeLists.txt
+++ b/src/ops/CMakeLists.txt
@@ -76,8 +76,8 @@ if(BUILD_OPS_DEVICE)
         ${HIPCC_EXECUTABLE} --genco "--offload-arch=${GPU_TARGETS}" -std=c++17
         -O2 -D__HIP_PLATFORM_AMD__ -DHIP_ENABLE_WARP_SYNC_BUILTINS ${_nic_defs}
         ${_extra_defs} -I${CMAKE_SOURCE_DIR}/include -I${CMAKE_SOURCE_DIR}
-        -I${CMAKE_SOURCE_DIR}/3rdparty/spdlog/include
-        ${_mpi_includes} ${_ksrc_path} -o ${_hsaco_output}
+        -I${CMAKE_SOURCE_DIR}/3rdparty/spdlog/include ${_mpi_includes}
+        ${_ksrc_path} -o ${_hsaco_output}
       DEPENDS ${_ksrc_path}
       COMMENT "AOT compiling ${_ksrc} -> ${_arch_nic}/${_kname}.hsaco"
       VERBATIM)

--- a/src/ops/CMakeLists.txt
+++ b/src/ops/CMakeLists.txt
@@ -76,6 +76,7 @@ if(BUILD_OPS_DEVICE)
         ${HIPCC_EXECUTABLE} --genco "--offload-arch=${GPU_TARGETS}" -std=c++17
         -O2 -D__HIP_PLATFORM_AMD__ -DHIP_ENABLE_WARP_SYNC_BUILTINS ${_nic_defs}
         ${_extra_defs} -I${CMAKE_SOURCE_DIR}/include -I${CMAKE_SOURCE_DIR}
+        -I${CMAKE_SOURCE_DIR}/3rdparty/spdlog/include
         ${_mpi_includes} ${_ksrc_path} -o ${_hsaco_output}
       DEPENDS ${_ksrc_path}
       COMMENT "AOT compiling ${_ksrc} -> ${_arch_nic}/${_kname}.hsaco"

--- a/tests/python/shmem/test_api.py
+++ b/tests/python/shmem/test_api.py
@@ -25,95 +25,52 @@ from tests.python.utils import TorchDistContext, get_free_port
 import torch
 
 
-def _test_torch_init(rank, world_size, port):
-    """Test basic PyTorch-based initialization"""
+def _test_shmem_apis(rank, world_size, port):
+    """Test all shmem APIs under a single torch-based init/finalize cycle."""
     with TorchDistContext(rank=rank, world_size=world_size, master_port=port):
         shmem.shmem_torch_process_group_init("default")
+
+        # -- init --
         assert rank == shmem.shmem_mype()
         assert world_size == shmem.shmem_npes()
-        shmem.shmem_finalize()
 
+        # -- barrier --
+        shmem.shmem_barrier_all()
 
-def _test_shmem_malloc(rank, world_size, port):
-    """Test symmetric memory allocation and deallocation"""
-    with TorchDistContext(rank=rank, world_size=world_size, master_port=port):
-        shmem.shmem_torch_process_group_init("default")
-
-        # Test basic malloc
+        # -- malloc --
         size = 4096
         ptr = shmem.shmem_malloc(size)
         assert ptr != 0, "shmem_malloc returned NULL"
 
-        # Test aligned malloc
         aligned_ptr = shmem.shmem_malloc_align(256, size)
         assert aligned_ptr != 0, "shmem_malloc_align returned NULL"
         assert aligned_ptr % 256 == 0, f"Memory not aligned: 0x{aligned_ptr:x}"
 
-        # Barrier before freeing
         shmem.shmem_barrier_all()
 
-        # Free memory
         shmem.shmem_free(ptr)
         shmem.shmem_free(aligned_ptr)
 
-        shmem.shmem_finalize()
-
-
-def _test_shmem_barrier(rank, world_size, port):
-    """Test global barrier synchronization"""
-    with TorchDistContext(rank=rank, world_size=world_size, master_port=port):
-        shmem.shmem_torch_process_group_init("default")
-
-        # All ranks should pass barrier
-        shmem.shmem_barrier_all()
-
-        # Allocate memory
-        ptr = shmem.shmem_malloc(1024)
-
-        # Another barrier
-        shmem.shmem_barrier_all()
-
-        shmem.shmem_free(ptr)
-        shmem.shmem_finalize()
-
-
-def _test_shmem_barrier_on_stream(rank, world_size, port):
-    """Test device barrier on a HIP stream"""
-    with TorchDistContext(rank=rank, world_size=world_size, master_port=port):
-        shmem.shmem_torch_process_group_init("default")
-
-        # Test with a PyTorch stream
+        # -- barrier on stream --
         stream = torch.cuda.Stream()
         shmem.shmem_barrier_on_stream(stream)
         stream.synchronize()
 
-        # Test with default (null) stream
         shmem.shmem_barrier_on_stream()
         torch.cuda.synchronize()
 
-        # Host barrier to confirm all PEs completed
         shmem.shmem_barrier_all()
 
-        shmem.shmem_finalize()
-
-
-def _test_buffer_register(rank, world_size, port):
-    """Test buffer registration with PyTorch tensors"""
-    with TorchDistContext(rank=rank, world_size=world_size, master_port=port):
-        shmem.shmem_torch_process_group_init("default")
-
-        # Create a GPU tensor
+        # -- buffer register --
         tensor = torch.ones(1024, device="cuda", dtype=torch.float32)
         tensor_ptr = tensor.data_ptr()
         tensor_size = tensor.element_size() * tensor.numel()
 
-        # Register the tensor buffer
         ret = shmem.shmem_buffer_register(tensor_ptr, tensor_size)
         assert ret == 0, f"shmem_buffer_register failed with code {ret}"
 
         shmem.shmem_barrier_all()
 
-        # Deregister the buffer
         ret = shmem.shmem_buffer_deregister(tensor_ptr, tensor_size)
         assert ret == 0, f"shmem_buffer_deregister failed with code {ret}"
 
@@ -234,54 +191,10 @@ def _test_uniqueid_init(rank, world_size, port):
 
 
 @pytest.mark.parametrize("world_size", (2, 4, 8))
-def test_torch_init(world_size):
-    """Test basic initialization"""
+def test_shmem_apis(world_size):
+    """Test shmem APIs (init, malloc, barrier, stream barrier, buffer register)"""
     torch.multiprocessing.spawn(
-        _test_torch_init,
-        args=(world_size, get_free_port()),
-        nprocs=world_size,
-        join=True,
-    )
-
-
-@pytest.mark.parametrize("world_size", (2, 4, 8))
-def test_shmem_malloc(world_size):
-    """Test symmetric memory allocation"""
-    torch.multiprocessing.spawn(
-        _test_shmem_malloc,
-        args=(world_size, get_free_port()),
-        nprocs=world_size,
-        join=True,
-    )
-
-
-@pytest.mark.parametrize("world_size", (2, 4, 8))
-def test_shmem_barrier(world_size):
-    """Test barrier synchronization"""
-    torch.multiprocessing.spawn(
-        _test_shmem_barrier,
-        args=(world_size, get_free_port()),
-        nprocs=world_size,
-        join=True,
-    )
-
-
-@pytest.mark.parametrize("world_size", (2, 4, 8))
-def test_shmem_barrier_on_stream(world_size):
-    """Test device barrier on stream"""
-    torch.multiprocessing.spawn(
-        _test_shmem_barrier_on_stream,
-        args=(world_size, get_free_port()),
-        nprocs=world_size,
-        join=True,
-    )
-
-
-@pytest.mark.parametrize("world_size", (2, 4, 8))
-def test_buffer_register(world_size):
-    """Test buffer registration with PyTorch tensors"""
-    torch.multiprocessing.spawn(
-        _test_buffer_register,
+        _test_shmem_apis,
         args=(world_size, get_free_port()),
         nprocs=world_size,
         join=True,


### PR DESCRIPTION
- Add jax-intranode-test job to CI using pre-built JAX base image
- Fix hipcc missing spdlog include path for .hsaco AOT compilation
- Simplify Dockerfile.jax091-rocm711 into a reusable base image (remove baked-in mori clone/install, add pytest)
- Consolidate shmem test_api.py: merge 5 torch-init tests into one worker per world_size, reducing init/finalize overhead 