### PR TITLE
fix(ci): remove stale --batch-non-contiguous arg from internode benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,6 @@ jobs:
             --iters 8 \
             --enable-batch-transfer \
             --enable-sess \
-            --batch-non-contiguous \
             --poll_cq_mode event \
             --num-qp-per-transfer 2 \
             --num-worker-threads 2 \


### PR DESCRIPTION
PR #240 renamed --batch-non-contiguous to --batch-contiguous and made non-contiguous the default behavior. The CI workflow added in PR #241 still passed the old flag, causing benchmark.py to fail with "unrecognized arguments". Remove it since non-contiguous is now the default.
