### PR TITLE
fix(packaging): rename _jit_sources to _jit-sources to suppress setuptools warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,10 @@ dist/*
 .pytest_cache
 __pycache__
 python/mori/_version.py
-python/mori/_jit_sources/
+python/mori/_jit-sources/
 python/mori/*.so
+python/mori/umbp_master
+python/mori/spdk_proxy
 
 .vscode
 *.log

--- a/python/mori/jit/config.py
+++ b/python/mori/jit/config.py
@@ -292,7 +292,7 @@ def get_mori_source_root() -> Path | None:
 
     Search order:
       1. Development / editable install: repo root (3 levels up from this file)
-      2. Wheel install: _jit_sources/ packaged inside the mori package
+      2. Wheel install: _jit-sources/ packaged inside the mori package
     """
     here = Path(__file__).resolve().parent  # python/mori/jit/
 
@@ -302,7 +302,7 @@ def get_mori_source_root() -> Path | None:
     ).is_dir():
         return candidate
 
-    packaged = here.parent / "_jit_sources"  # mori/_jit_sources/
+    packaged = here.parent / "_jit-sources"  # mori/_jit-sources/
     if (packaged / "include" / "mori").is_dir():
         return packaged
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ from setuptools import Extension, find_packages, setup
 from setuptools.command.build import build as _build
 from setuptools.command.build_ext import build_ext
 
-
 _supported_arch_list = ["gfx942", "gfx950"]
 
 _REQUIRED_SYSTEM_DEPS: list = []
@@ -231,11 +230,11 @@ def _get_gpu_archs() -> str:
 def _copy_jit_sources(root_dir: Path) -> None:
     """Copy JIT-required source files into the package for wheel distribution.
 
-    This creates python/mori/_jit_sources/ with the same directory structure
+    This creates python/mori/_jit-sources/ with the same directory structure
     as the repo root, so that get_mori_source_root() can use it as a drop-in
     replacement when the original source tree is not available.
     """
-    jit_dir = root_dir / "python" / "mori" / "_jit_sources"
+    jit_dir = root_dir / "python" / "mori" / "_jit-sources"
     if jit_dir.exists():
         shutil.rmtree(jit_dir)
 
@@ -515,14 +514,14 @@ mori_package_data = [
     "libmori_application.so",
     "spdk_proxy",
     "umbp_master",
-    "_jit_sources/include/**/*.hpp",
-    "_jit_sources/include/**/*.h",
-    "_jit_sources/src/**/*.hip",
-    "_jit_sources/src/**/*.hpp",
-    "_jit_sources/src/**/*.cpp",
-    "_jit_sources/src/**/*.h",
-    "_jit_sources/3rdparty/**/*.h",
-    "_jit_sources/3rdparty/**/*.hpp",
+    "_jit-sources/include/**/*.hpp",
+    "_jit-sources/include/**/*.h",
+    "_jit-sources/src/**/*.hip",
+    "_jit-sources/src/**/*.hpp",
+    "_jit-sources/src/**/*.cpp",
+    "_jit-sources/src/**/*.h",
+    "_jit-sources/3rdparty/**/*.h",
+    "_jit-sources/3rdparty/**/*.hpp",
 ]
 if _env_flag("BUILD_UMBP", "OFF"):
     mori_package_data.append("spdk_proxy")


### PR DESCRIPTION
## Summary
- Rename `_jit_sources/` to `_jit-sources/` so setuptools no longer treats bundled C++/HIP source directories as implicit namespace packages
- Add `umbp_master` and `spdk_proxy` build artifacts to `.gitignore`

## Details
Since PR #182 introduced `_copy_jit_sources()`, every `pip install -e` produces dozens of "Package would be ignored" warnings from setuptools. The root cause is that `_jit_sources` is a valid Python identifier, so Python 3.3+ namespace package rules make every subdirectory appear importable. Using a hyphenated name (`_jit-sources`) breaks `str.isidentifier()`, which is exactly what setuptools checks.

## Test plan
- [x] `BUILD_UMBP=ON BUILD_TESTS=ON pip install -e . --no-build-isolation -v` produces no "Package would be ignored" warnings
- [x] `python -c "from mori.jit.config import get_mori_source_root; print(get_mori_source_root())"` still resolves correctly