### PR TITLE
Fix: async kernel recv launch bug

### DIFF
--- a/python/mori/ops/dispatch_combine.py
+++ b/python/mori/ops/dispatch_combine.py
@@ -533,6 +533,8 @@ class EpDispatchCombineOp:
         sfx = _DTYPE_SUFFIX[self._dispatch_dtype]
         kt = self.config.kernel_type.value
 
+        # Recv kernels must reuse the handle's inference pointers/state prepared by the
+        # preceding dispatch_send/dispatch call, so only rebuild raw args here.
         args_ptr = mori_cpp.build_args(self._handle, rdma_block_num=0)
         if kt == EpDispatchCombineKernelType.AsyncLL.value:
             mp = self._handle_info["multi_processor_count"]
@@ -760,6 +762,8 @@ class EpDispatchCombineOp:
         sfx = _DTYPE_SUFFIX[self._combine_dtype]
         kt = self.config.kernel_type.value
 
+        # Recv kernels must reuse the handle's inference pointers/state prepared by the
+        # preceding combine_send/combine call, so only rebuild raw args here.
         args_ptr = mori_cpp.build_args(self._handle, rdma_block_num=0)
         shared_mem = self._combine_shared_mem(actual_wpb)
         if kt == EpDispatchCombineKernelType.AsyncLL.value:

--- a/python/mori/ops/dispatch_combine.py
+++ b/python/mori/ops/dispatch_combine.py
@@ -399,7 +399,7 @@ class EpDispatchCombineOp:
         self._dispatch_dtype = input.dtype
         sfx = _DTYPE_SUFFIX[input.dtype]
 
-        args_ptr = mori_cpp.prepare_and_build_args(
+        mori_cpp.prepare_inference_args(
             self._handle,
             inp_ptr=input.data_ptr(),
             dtype=dtype_to_int(input.dtype),
@@ -407,6 +407,9 @@ class EpDispatchCombineOp:
             weight_ptr=weight_ptr,
             scale_ptr=scale_ptr,
             indices_ptr=indices.data_ptr(),
+        )
+        args_ptr = mori_cpp.build_args(
+            self._handle,
             rdma_block_num=actual_rbn,
             hidden_dim=hidden_dim,
         )
@@ -530,16 +533,7 @@ class EpDispatchCombineOp:
         sfx = _DTYPE_SUFFIX[self._dispatch_dtype]
         kt = self.config.kernel_type.value
 
-        args_ptr = mori_cpp.prepare_and_build_args(
-            self._handle,
-            inp_ptr=0,
-            dtype=0,
-            num_tokens=0,
-            weight_ptr=0,
-            scale_ptr=0,
-            indices_ptr=0,
-            rdma_block_num=0,
-        )
+        args_ptr = mori_cpp.build_args(self._handle, rdma_block_num=0)
         if kt == EpDispatchCombineKernelType.AsyncLL.value:
             mp = self._handle_info["multi_processor_count"]
             mp_aligned = mp // self.config.world_size * self.config.world_size
@@ -583,7 +577,7 @@ class EpDispatchCombineOp:
         self._combine_dtype = input.dtype
         sfx = _DTYPE_SUFFIX[input.dtype]
 
-        args_ptr = mori_cpp.prepare_and_build_args(
+        mori_cpp.prepare_inference_args(
             self._handle,
             inp_ptr=input.data_ptr(),
             dtype=dtype_to_int(input.dtype),
@@ -591,6 +585,9 @@ class EpDispatchCombineOp:
             weight_ptr=weight_ptr,
             scale_ptr=0,
             indices_ptr=indices.data_ptr(),
+        )
+        args_ptr = mori_cpp.build_args(
+            self._handle,
             rdma_block_num=actual_rbn,
             hidden_dim=hidden_dim,
             use_external_inp_buf=use_external_inp_buf,
@@ -763,16 +760,7 @@ class EpDispatchCombineOp:
         sfx = _DTYPE_SUFFIX[self._combine_dtype]
         kt = self.config.kernel_type.value
 
-        args_ptr = mori_cpp.prepare_and_build_args(
-            self._handle,
-            inp_ptr=0,
-            dtype=0,
-            num_tokens=0,
-            weight_ptr=0,
-            scale_ptr=0,
-            indices_ptr=0,
-            rdma_block_num=0,
-        )
+        args_ptr = mori_cpp.build_args(self._handle, rdma_block_num=0)
         shared_mem = self._combine_shared_mem(actual_wpb)
         if kt == EpDispatchCombineKernelType.AsyncLL.value:
             mp = self._handle_info["multi_processor_count"]
@@ -859,7 +847,7 @@ class EpDispatchCombineOp:
 
         set_fn(self._handle, packed_recv_x.data_ptr(), packed_recv_src_info.data_ptr())
 
-        args_ptr = mori_cpp.prepare_and_build_args(
+        mori_cpp.prepare_inference_args(
             self._handle,
             inp_ptr=input.data_ptr(),
             dtype=dtype_to_int(input.dtype),
@@ -871,6 +859,9 @@ class EpDispatchCombineOp:
                 else 0
             ),
             indices_ptr=indices.data_ptr(),
+        )
+        args_ptr = mori_cpp.build_args(
+            self._handle,
             rdma_block_num=actual_rbn,
             hidden_dim=hidden_dim,
         )
@@ -955,7 +946,7 @@ class EpDispatchCombineOp:
 
         set_fn(self._handle, input.data_ptr(), 0)
 
-        args_ptr = mori_cpp.prepare_and_build_args(
+        mori_cpp.prepare_inference_args(
             self._handle,
             inp_ptr=input.data_ptr(),
             dtype=dtype_to_int(input.dtype),
@@ -967,6 +958,9 @@ class EpDispatchCombineOp:
             ),
             scale_ptr=0,
             indices_ptr=indices.data_ptr(),
+        )
+        args_ptr = mori_cpp.build_args(
+            self._handle,
             rdma_block_num=actual_rbn,
             hidden_dim=hidden_dim,
         )

--- a/src/pybind/pybind_ops.cpp
+++ b/src/pybind/pybind_ops.cpp
@@ -56,26 +56,17 @@ hipDataType IntToHipDataType(int dtype) {
   }
 }
 
-// Merged prepare + build in one call.
-// For recv-only calls (input_ptr == 0), keep the token-count state needed by
-// AsyncLL recv kernels, but clear external input/weight/index pointers so we do
-// not carry stale user tensor addresses across requests.
-int64_t PrepareAndBuildArgs(mori::moe::EpDispatchCombineHandle& handle, int64_t input_ptr,
-                            int input_dtype, int64_t num_tokens, int64_t weight_ptr,
-                            int64_t scale_ptr, int64_t indices_ptr, int rdmaBlockNum, int hiddenDim,
-                            int useExternalInpBuf) {
-  if (input_ptr != 0) {
-    handle.PrepareInference(IntToHipDataType(input_dtype), reinterpret_cast<void*>(input_ptr),
-                            nullptr, weight_ptr ? reinterpret_cast<float*>(weight_ptr) : nullptr,
-                            scale_ptr ? reinterpret_cast<uint8_t*>(scale_ptr) : nullptr,
-                            reinterpret_cast<mori::moe::index_t*>(indices_ptr), num_tokens);
-  } else {
-    const auto recv_num_tokens =
-        static_cast<mori::moe::index_t>((num_tokens > 0) ? num_tokens : handle.curRankNumToken);
-    handle.PrepareInference(HIP_R_32F, nullptr, nullptr, nullptr, nullptr, nullptr,
-                            recv_num_tokens);
-  }
+void PrepareInferenceArgs(mori::moe::EpDispatchCombineHandle& handle, int64_t input_ptr,
+                          int input_dtype, int64_t num_tokens, int64_t weight_ptr,
+                          int64_t scale_ptr, int64_t indices_ptr) {
+  handle.PrepareInference(IntToHipDataType(input_dtype), reinterpret_cast<void*>(input_ptr),
+                          nullptr, weight_ptr ? reinterpret_cast<float*>(weight_ptr) : nullptr,
+                          scale_ptr ? reinterpret_cast<uint8_t*>(scale_ptr) : nullptr,
+                          reinterpret_cast<mori::moe::index_t*>(indices_ptr), num_tokens);
+}
 
+int64_t BuildArgs(mori::moe::EpDispatchCombineHandle& handle, int rdmaBlockNum, int hiddenDim,
+                  int useExternalInpBuf) {
   thread_local mori::moe::EpDispatchCombineArgsRaw args;
   args = mori::moe::GetEpDispatchCombineArgsRaw(handle, rdmaBlockNum);
   // Runtime hidden_dim: dispatch/combine (send) calls pass hiddenDim from input tensor,
@@ -90,6 +81,16 @@ int64_t PrepareAndBuildArgs(mori::moe::EpDispatchCombineHandle& handle, int64_t 
   if (useExternalInpBuf >= 0)
     args.config.useExternalInpBuffer = static_cast<bool>(useExternalInpBuf);
   return reinterpret_cast<int64_t>(&args);
+}
+
+// Backward-compatible helper for call sites that still want a merged API.
+int64_t PrepareAndBuildArgs(mori::moe::EpDispatchCombineHandle& handle, int64_t input_ptr,
+                            int input_dtype, int64_t num_tokens, int64_t weight_ptr,
+                            int64_t scale_ptr, int64_t indices_ptr, int rdmaBlockNum, int hiddenDim,
+                            int useExternalInpBuf) {
+  PrepareInferenceArgs(handle, input_ptr, input_dtype, num_tokens, weight_ptr, scale_ptr,
+                       indices_ptr);
+  return BuildArgs(handle, rdmaBlockNum, hiddenDim, useExternalInpBuf);
 }
 
 py::tuple GetDispatchOutputPtrs(mori::moe::EpDispatchCombineHandle& handle, bool has_scales) {
@@ -244,6 +245,11 @@ void DeclareEpDispatchCombineHandle(pybind11::module& m) {
   m.def("get_dispatch_output_ptrs", &GetDispatchOutputPtrs);
   m.def("get_combine_output_ptrs", &GetCombineOutputPtrs);
   m.def("get_handle_info", &GetHandleInfo);
+  m.def("prepare_inference_args", &PrepareInferenceArgs, py::arg("handle"), py::arg("inp_ptr"),
+        py::arg("dtype"), py::arg("num_tokens"), py::arg("weight_ptr"), py::arg("scale_ptr"),
+        py::arg("indices_ptr"));
+  m.def("build_args", &BuildArgs, py::arg("handle"), py::arg("rdma_block_num") = -1,
+        py::arg("hidden_dim") = -1, py::arg("use_external_inp_buf") = -1);
   m.def("prepare_and_build_args", &PrepareAndBuildArgs, py::arg("handle"), py::arg("inp_ptr"),
         py::arg("dtype"), py::arg("num_tokens"), py::arg("weight_ptr"), py::arg("scale_ptr"),
         py::arg("indices_ptr"), py::arg("rdma_block_num") = -1, py::arg("hidden_dim") = -1,

--- a/tests/python/ops/dispatch_combine_test_utils.py
+++ b/tests/python/ops/dispatch_combine_test_utils.py
@@ -138,9 +138,16 @@ class EpDispatchCombineTestCase:
         torch.cuda.synchronize()
         dist.barrier()
 
-    def gen_test_data(self, use_max_token_num=False, routing="random"):
+    def gen_test_data(
+        self, use_max_token_num=False, routing="random", num_token_override=None
+    ):
         """Generate test data."""
-        if use_max_token_num:
+        if num_token_override is not None:
+            assert len(num_token_override) == self.config.world_size
+            assert min(num_token_override) >= 0
+            assert max(num_token_override) <= self.config.max_num_inp_token_per_rank
+            num_token = torch.tensor(num_token_override, device=self.device)
+        elif use_max_token_num:
             num_token = torch.tensor(
                 [
                     self.config.max_num_inp_token_per_rank
@@ -424,7 +431,11 @@ class EpDispatchCombineTestCase:
 
 
 def run_ep_dispatch_combine_test(
-    config, test_case_cls, use_max_token_num=False, routing=None
+    config,
+    test_case_cls,
+    use_max_token_num=False,
+    routing=None,
+    num_token_override=None,
 ):
     op = mori.ops.EpDispatchCombineOp(config)
     test_case = test_case_cls(config)
@@ -433,5 +444,7 @@ def run_ep_dispatch_combine_test(
         gen_kwargs["use_max_token_num"] = True
     if routing is not None:
         gen_kwargs["routing"] = routing
+    if num_token_override is not None:
+        gen_kwargs["num_token_override"] = num_token_override
     test_data = test_case.gen_test_data(**gen_kwargs)
     test_case.run_test_once(op, test_data)

--- a/tests/python/ops/test_dispatch_combine_async_ll.py
+++ b/tests/python/ops/test_dispatch_combine_async_ll.py
@@ -136,6 +136,7 @@ def _test_dispatch_combine(
     max_total_recv_tokens=0,
     routing=None,
     use_max_token_num=False,
+    num_token_override=None,
 ):
     config = _make_asyncll_config(
         rank=rank,
@@ -155,7 +156,44 @@ def _test_dispatch_combine(
         AsyncLLDispatchCombineTestCase,
         use_max_token_num=use_max_token_num,
         routing=routing,
+        num_token_override=num_token_override,
     )
+
+
+def _test_dispatch_combine_multi_iteration(
+    rank,
+    world_size,
+    data_type,
+    hidden_dim,
+    max_num_inp_token_per_rank,
+    num_experts_per_rank,
+    num_experts_per_token,
+    num_token_patterns,
+    scale_dim=0,
+    scale_type_size=1,
+    quant_type="none",
+    routing="round_robin",
+):
+    config = _make_asyncll_config(
+        rank=rank,
+        world_size=world_size,
+        data_type=data_type,
+        hidden_dim=hidden_dim,
+        max_num_inp_token_per_rank=max_num_inp_token_per_rank,
+        num_experts_per_rank=num_experts_per_rank,
+        num_experts_per_token=num_experts_per_token,
+        scale_dim=scale_dim,
+        scale_type_size=scale_type_size,
+        quant_type=quant_type,
+    )
+    op = mori.ops.EpDispatchCombineOp(config)
+    test_case = AsyncLLDispatchCombineTestCase(config)
+
+    for num_token_override in num_token_patterns:
+        test_data = test_case.gen_test_data(
+            routing=routing, num_token_override=num_token_override
+        )
+        test_case.run_test_once(op, test_data)
 
 
 @pytest.mark.parametrize("world_size", (8,))
@@ -196,6 +234,51 @@ def test_dispatch_combine(
                     scale_dim,
                     scale_type_size,
                     quant_type,
+                ],
+            )
+        )
+
+    assert_worker_results(torch_dist_process_manager, world_size)
+
+
+@pytest.mark.parametrize("world_size", (8,))
+@pytest.mark.parametrize("data_type", _all_data_types())
+@pytest.mark.parametrize("hidden_dim", (4096,))
+@pytest.mark.parametrize("num_experts_per_rank", (32,))
+@pytest.mark.parametrize("num_experts_per_token", (8,))
+def test_dispatch_combine_some_ranks_have_no_tokens_multi_iteration(
+    torch_dist_process_manager,
+    world_size,
+    data_type,
+    hidden_dim,
+    num_experts_per_rank,
+    num_experts_per_token,
+):
+    num_token_patterns = [
+        [4, 0, 3, 0, 2, 0, 1, 0],
+        [0, 5, 0, 4, 0, 3, 0, 2],
+        [6, 1, 0, 0, 5, 0, 0, 2],
+        [0, 0, 7, 1, 0, 0, 4, 3],
+    ]
+    max_num_inp_token_per_rank = max(max(pattern) for pattern in num_token_patterns)
+    routing = "round_robin"
+
+    for _ in range(world_size):
+        torch_dist_process_manager.task_queue.put(
+            (
+                _test_dispatch_combine_multi_iteration,
+                [
+                    world_size,
+                    data_type,
+                    hidden_dim,
+                    max_num_inp_token_per_rank,
+                    num_experts_per_rank,
+                    num_experts_per_token,
+                    num_token_patterns,
+                    0,  # scale_dim
+                    1,  # scale_type_size
+                    "none",  # quant_type
+                    routing,
                 ],
             )
         )


### PR DESCRIPTION
**Fixes a stateful AsyncLL bug in split send/recv execution.**

**Root cause**
dispatch_recv() / combine_recv() used the shared prepare_and_build_args(...) helper with inp_ptr=0. That recv-only path called PrepareInference(...) with null external pointers, which cleared handle state such as tokenIndices while preserving token-count state. In multi-iteration runs, a rank could then enter a later send phase with curRankNumToken > 0 but tokenIndices == nullptr, leading to a device fault in the AsyncLL send kernel.

**Resolution**
Split arg handling into two steps:

prepare_inference_args(...) updates handle inference state
build_args(...) builds raw kernel args from the existing handle state
Send/combine paths now prepare then build, while recv paths only build, so they correctly reuse send-phase inference args instead of nulling them out.

**Validation**
Added multi-iteration regression tests with mixed zero/nonzero per-rank token patterns. These reproduce the bug on the original code and pass with the fix.