### PR TITLE
io: enable hidden-device xgmi ipc

### DIFF
--- a/src/io/engine.cpp
+++ b/src/io/engine.cpp
@@ -24,6 +24,7 @@
 #include <hip/hip_runtime_api.h>
 #include <unistd.h>
 
+#include <cctype>
 #include <cstdlib>
 
 #include "mori/io/env.hpp"
@@ -47,7 +48,11 @@ std::string QueryDeviceBusId(int deviceId) {
     MORI_IO_WARN("Failed to query PCI bus id for device {}: {}", deviceId, hipGetErrorString(err));
     return "";
   }
-  return std::string(busId);
+  std::string result(busId);
+  for (auto& c : result) {
+    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  }
+  return result;
 }
 
 }  // namespace

--- a/src/io/xgmi/backend_impl.cpp
+++ b/src/io/xgmi/backend_impl.cpp
@@ -26,9 +26,13 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <cctype>
 #include <climits>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
 #include <functional>
 #include <numeric>
 #include <sstream>
@@ -62,6 +66,21 @@ int getScatterGatherKernelThreshold() {
     return INT_MAX;
   }();
   return threshold;
+}
+
+// Lowercase a PCI bus ID for consistent comparison across HIP APIs and sysfs.
+// hipDeviceGetPCIBusId may return uppercase hex (e.g. "0000:C1:00.0") while
+// sysfs directory names are lowercase ("0000:c1:00.0").
+std::string NormalizeBusId(const std::string& busId) {
+  std::string result = busId;
+  for (auto& c : result) {
+    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  }
+  return result;
+}
+
+bool IsIpcHandleEmpty(const std::array<char, kIpcHandleSize>& handle) {
+  return std::all_of(handle.begin(), handle.end(), [](char c) { return c == 0; });
 }
 
 // Keep caller-visible HIP current device unchanged across MORI internals.
@@ -549,7 +568,7 @@ void XgmiBackend::InitializeP2PAccess() {
     char busId[32] = {0};
     err = hipDeviceGetPCIBusId(busId, sizeof(busId), i);
     if (err == hipSuccess) {
-      localDeviceByBusId[std::string(busId)] = i;
+      localDeviceByBusId[NormalizeBusId(std::string(busId))] = i;
     } else {
       MORI_IO_WARN("XGMI: Failed to query PCI bus id for device {}: {}", i, hipGetErrorString(err));
     }
@@ -589,6 +608,8 @@ void XgmiBackend::InitializeP2PAccess() {
       }
     }
   }
+
+  BuildTopologyMap();
 }
 
 bool XgmiBackend::IsP2PAccessible(int srcDevice, int dstDevice) const {
@@ -596,6 +617,118 @@ bool XgmiBackend::IsP2PAccessible(int srcDevice, int dstDevice) const {
     return false;
   }
   return p2pMatrix[srcDevice][dstDevice];
+}
+
+void XgmiBackend::BuildTopologyMap() {
+  namespace fs = std::filesystem;
+
+  // Primary: parse KFD topology to get hive_id per GPU.
+  // KFD provides hive_id (shared across all GPUs in the same XGMI mesh) and
+  // location_id + domain (which encode the PCI BDF address).
+  const fs::path kfdNodes("/sys/class/kfd/kfd/topology/nodes");
+  std::error_code ec;
+  if (fs::is_directory(kfdNodes, ec)) {
+    for (const auto& nodeEntry : fs::directory_iterator(kfdNodes, ec)) {
+      if (ec) break;
+      fs::path propsFile = nodeEntry.path() / "properties";
+      std::ifstream f(propsFile);
+      if (!f.is_open()) continue;
+
+      uint64_t hiveId = 0;
+      uint64_t locationId = 0;
+      uint64_t domain = 0;
+      std::string key;
+      uint64_t val;
+      while (f >> key >> val) {
+        if (key == "hive_id")
+          hiveId = val;
+        else if (key == "location_id")
+          locationId = val;
+        else if (key == "domain")
+          domain = val;
+      }
+
+      // hive_id == 0 means CPU node or non-XGMI device
+      if (hiveId == 0 || locationId == 0) continue;
+
+      // Decode PCI BDF from location_id: bus[15:8] device[7:3] function[2:0]
+      unsigned bus = (locationId >> 8) & 0xff;
+      unsigned device = (locationId >> 3) & 0x1f;
+      unsigned function = locationId & 0x7;
+      char bdf[24];
+      std::snprintf(bdf, sizeof(bdf), "%04x:%02x:%02x.%x", static_cast<unsigned>(domain), bus,
+                    device, function);
+      gpuTopoByBusId[NormalizeBusId(std::string(bdf))] = hiveId;
+    }
+  }
+
+  if (!gpuTopoByBusId.empty()) {
+    MORI_IO_INFO("XGMI: Topology map built from KFD with {} GPU entries", gpuTopoByBusId.size());
+    return;
+  }
+
+  // Fallback: if KFD is unavailable, use xgmi_physical_id existence as a
+  // coarse hive indicator.  All devices that have xgmi_physical_id are treated
+  // as belonging to the same hive (assigned a synthetic shared hive ID of 1).
+  // This is correct for single-node MI300X where all GPUs are fully connected.
+  const fs::path sysDevices("/sys/bus/pci/devices");
+  if (!fs::is_directory(sysDevices, ec)) {
+    MORI_IO_TRACE("XGMI: sysfs PCI device directory not available, hidden-device XGMI disabled");
+    return;
+  }
+
+  for (const auto& entry : fs::directory_iterator(sysDevices, ec)) {
+    if (ec) break;
+    fs::path xgmiFile = entry.path() / "xgmi_physical_id";
+    if (!fs::exists(xgmiFile, ec)) continue;
+
+    std::ifstream f(xgmiFile);
+    int physicalId;
+    if (f.is_open() && (f >> physicalId)) {
+      std::string busId = NormalizeBusId(entry.path().filename().string());
+      gpuTopoByBusId[busId] = 1;  // synthetic shared hive ID
+    }
+  }
+
+  if (!gpuTopoByBusId.empty()) {
+    MORI_IO_INFO("XGMI: Topology map built from xgmi_physical_id fallback with {} GPU entries",
+                 gpuTopoByBusId.size());
+  }
+}
+
+std::optional<int> XgmiBackend::LookupVisibleDevice(const std::string& busId) const {
+  auto it = localDeviceByBusId.find(NormalizeBusId(busId));
+  if (it == localDeviceByBusId.end()) {
+    return std::nullopt;
+  }
+  return it->second;
+}
+
+bool XgmiBackend::IsTopologyEligible(int localDeviceId, const std::string& remoteBusId) const {
+  if (gpuTopoByBusId.empty()) {
+    return false;
+  }
+
+  // Find local device's bus ID by reverse lookup
+  std::string localBusId;
+  for (const auto& [busId, devId] : localDeviceByBusId) {
+    if (devId == localDeviceId) {
+      localBusId = busId;
+      break;
+    }
+  }
+  if (localBusId.empty()) {
+    return false;
+  }
+
+  std::string normalizedRemote = NormalizeBusId(remoteBusId);
+  auto localIt = gpuTopoByBusId.find(localBusId);
+  auto remoteIt = gpuTopoByBusId.find(normalizedRemote);
+  if (localIt == gpuTopoByBusId.end() || remoteIt == gpuTopoByBusId.end()) {
+    return false;
+  }
+
+  return localIt->second == remoteIt->second;
 }
 
 std::optional<int> XgmiBackend::ResolveVisibleDeviceId(const MemoryDesc& desc) const {
@@ -611,7 +744,7 @@ std::optional<int> XgmiBackend::ResolveVisibleDeviceId(const MemoryDesc& desc) c
     return std::nullopt;
   }
 
-  auto it = localDeviceByBusId.find(desc.deviceBusId);
+  auto it = localDeviceByBusId.find(NormalizeBusId(desc.deviceBusId));
   if (it == localDeviceByBusId.end()) {
     return std::nullopt;
   }
@@ -764,28 +897,40 @@ void XgmiBackend::BatchReadWrite(const MemoryDesc& localDest, const SizeVec& loc
 
 BackendSession* XgmiBackend::CreateSession(const MemoryDesc& local, const MemoryDesc& remote) {
   int localDevice = local.deviceId;
-  auto remoteDeviceOpt = ResolveVisibleDeviceId(remote);
-  if (!remoteDeviceOpt.has_value()) {
-    MORI_IO_WARN("XGMI: Remote memory id={} bus_id={} is not visible in local process", remote.id,
-                 remote.deviceBusId);
-    return nullptr;
-  }
-  int remoteDevice = remoteDeviceOpt.value();
   void* localAddr = GetRemappedAddress(local, localDevice);
+
+  auto visibleRemote = LookupVisibleDevice(remote.deviceBusId);
+  if (visibleRemote.has_value()) {
+    // Visible path: remote GPU is in HIP_VISIBLE_DEVICES
+    int remoteDevice = visibleRemote.value();
+    void* remoteAddr = GetRemappedAddress(remote, localDevice);
+    if (localAddr == nullptr || remoteAddr == nullptr) {
+      MORI_IO_WARN("XGMI: Failed to remap memory (local id={}, remote id={})", local.id, remote.id);
+      return nullptr;
+    }
+    bool ipcSession = (remote.engineKey != myEngKey);
+
+    if (!IsP2PAccessible(localDevice, remoteDevice)) {
+      MORI_IO_WARN("XGMI: P2P access not available between devices {} and {}", localDevice,
+                   remoteDevice);
+    }
+
+    return new XgmiBackendSession(config, localAddr, remoteAddr, localDevice, remoteDevice,
+                                  ipcSession, this, streamPool.get(), eventPool.get());
+  }
+
+  // Hidden-device path: remote GPU is not visible, use IPC on localDevice
   void* remoteAddr = GetRemappedAddress(remote, localDevice);
   if (localAddr == nullptr || remoteAddr == nullptr) {
-    MORI_IO_WARN("XGMI: Failed to remap memory (local id={}, remote id={})", local.id, remote.id);
+    MORI_IO_WARN("XGMI: Failed to remap hidden-device memory (local id={}, remote id={})", local.id,
+                 remote.id);
     return nullptr;
   }
-  bool ipcSession = (remote.engineKey != myEngKey);
 
-  if (!IsP2PAccessible(localDevice, remoteDevice)) {
-    MORI_IO_WARN("XGMI: P2P access not available between devices {} and {}", localDevice,
-                 remoteDevice);
-  }
-
-  return new XgmiBackendSession(config, localAddr, remoteAddr, localDevice, remoteDevice,
-                                ipcSession, this, streamPool.get(), eventPool.get());
+  MORI_IO_INFO("XGMI: Created hidden-device IPC session (local id={}, remote id={}, device={})",
+               local.id, remote.id, localDevice);
+  return new XgmiBackendSession(config, localAddr, remoteAddr, localDevice, localDevice, true, this,
+                                streamPool.get(), eventPool.get());
 }
 
 XgmiBackendSession* XgmiBackend::GetOrCreateSessionCached(const MemoryDesc& local,
@@ -800,13 +945,23 @@ XgmiBackendSession* XgmiBackend::GetOrCreateSessionCached(const MemoryDesc& loca
 
   void* localAddr = reinterpret_cast<void*>(local.data);
   int localDevice = local.deviceId;
-  auto remoteDeviceOpt = ResolveVisibleDeviceId(remote);
-  if (!remoteDeviceOpt.has_value()) {
-    MORI_IO_WARN("XGMI: Remote memory id={} bus_id={} is not visible in local process", remote.id,
-                 remote.deviceBusId);
-    return nullptr;
+
+  int remoteDevice;
+  bool ipcSession;
+  auto visibleRemote = LookupVisibleDevice(remote.deviceBusId);
+  if (visibleRemote.has_value()) {
+    remoteDevice = visibleRemote.value();
+    ipcSession = (remote.engineKey != myEngKey);
+    if (!IsP2PAccessible(localDevice, remoteDevice)) {
+      MORI_IO_WARN("XGMI: P2P access not available between devices {} and {}", localDevice,
+                   remoteDevice);
+    }
+  } else {
+    // Hidden-device path
+    remoteDevice = localDevice;
+    ipcSession = true;
   }
-  int remoteDevice = remoteDeviceOpt.value();
+
   void* remoteAddr = GetRemappedAddress(remote, localDevice);
   if (remoteAddr == nullptr) {
     MORI_IO_WARN(
@@ -814,12 +969,6 @@ XgmiBackendSession* XgmiBackend::GetOrCreateSessionCached(const MemoryDesc& loca
         "localDevice={}, remoteDevice={})",
         local.id, remote.id, localDevice, remoteDevice);
     return nullptr;
-  }
-  bool ipcSession = (remote.engineKey != myEngKey);
-
-  if (!IsP2PAccessible(localDevice, remoteDevice)) {
-    MORI_IO_WARN("XGMI: P2P access not available between devices {} and {}", localDevice,
-                 remoteDevice);
   }
 
   auto sess =
@@ -854,16 +1003,25 @@ bool XgmiBackend::CanHandle(const MemoryDesc& local, const MemoryDesc& remote) c
     return false;
   }
 
-  auto remoteDeviceOpt = ResolveVisibleDeviceId(remote);
-  if (!remoteDeviceOpt.has_value()) {
+  if (!IsSameNodeEngine(remote.engineKey)) {
     return false;
   }
 
-  if (!IsP2PAccessible(local.deviceId, remoteDeviceOpt.value())) {
+  if (remote.deviceBusId.empty()) {
     return false;
   }
 
-  return IsSameNodeEngine(remote.engineKey);
+  // Visible fast path: remote GPU is in this process's HIP_VISIBLE_DEVICES
+  auto visibleRemote = LookupVisibleDevice(remote.deviceBusId);
+  if (visibleRemote.has_value()) {
+    return IsP2PAccessible(local.deviceId, visibleRemote.value());
+  }
+
+  // Hidden-device path: remote GPU is not visible but may be on the same XGMI hive
+  if (IsIpcHandleEmpty(remote.ipcHandle)) {
+    return false;
+  }
+  return IsTopologyEligible(local.deviceId, remote.deviceBusId);
 }
 
 }  // namespace io

--- a/src/io/xgmi/backend_impl.hpp
+++ b/src/io/xgmi/backend_impl.hpp
@@ -103,6 +103,9 @@ class XgmiBackend : public Backend {
  private:
   void InitializeP2PAccess();
   std::optional<int> ResolveVisibleDeviceId(const MemoryDesc& desc) const;
+  std::optional<int> LookupVisibleDevice(const std::string& busId) const;
+  bool IsTopologyEligible(int localDeviceId, const std::string& remoteBusId) const;
+  void BuildTopologyMap();
   bool IsSameProcessEngine(const EngineKey& engineKey) const;
   bool IsSameNodeEngine(const EngineKey& engineKey) const;
   void* GetRemappedAddress(const MemoryDesc& desc, int localDeviceId);
@@ -143,6 +146,7 @@ class XgmiBackend : public Backend {
   int numDevices{0};
   std::vector<std::vector<bool>> p2pMatrix;
   std::unordered_map<std::string, int> localDeviceByBusId;
+  std::unordered_map<std::string, uint64_t> gpuTopoByBusId;  // normalized bus ID -> XGMI hive ID
 
   struct IpcHandleEntry {
     hipIpcMemHandle_t handle;

--- a/tests/cpp/io/test_engine.cpp
+++ b/tests/cpp/io/test_engine.cpp
@@ -22,10 +22,15 @@
 #include <arpa/inet.h>
 #include <fcntl.h>
 #include <hip/hip_runtime_api.h>
+#include <limits.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
+#include <algorithm>
+#include <array>
+#include <cctype>
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
@@ -383,6 +388,315 @@ void CaseRdmaNotificationInvalidEnvKeepsConfig() {
               std::to_string(inbound.CodeUint32()) + ", msg='" + inbound.Message() + "'");
 }
 
+// Mirror of the NormalizeBusId logic in src/io/xgmi/backend_impl.cpp for testing.
+std::string TestNormalizeBusId(const std::string& busId) {
+  std::string result = busId;
+  for (auto& c : result) {
+    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  }
+  return result;
+}
+
+void CaseNormalizeBusId() {
+  Require(TestNormalizeBusId("0000:C1:00.0") == "0000:c1:00.0",
+          "uppercase hex should be lowercased");
+  Require(TestNormalizeBusId("0000:c1:00.0") == "0000:c1:00.0",
+          "already lowercase should be unchanged");
+  Require(TestNormalizeBusId("0000:AB:CD.0") == "0000:ab:cd.0",
+          "mixed case should be fully lowered");
+  Require(TestNormalizeBusId("") == "", "empty string should remain empty");
+}
+
+void CaseIsIpcHandleEmpty() {
+  constexpr size_t kSize = 64;
+  std::array<char, kSize> zeroHandle{};
+  Require(std::all_of(zeroHandle.begin(), zeroHandle.end(), [](char c) { return c == 0; }),
+          "zero-initialized handle should be empty");
+
+  std::array<char, kSize> nonZeroFirst{};
+  nonZeroFirst[0] = 1;
+  Require(!std::all_of(nonZeroFirst.begin(), nonZeroFirst.end(), [](char c) { return c == 0; }),
+          "handle with non-zero first byte should not be empty");
+
+  std::array<char, kSize> nonZeroLast{};
+  nonZeroLast[kSize - 1] = 1;
+  Require(!std::all_of(nonZeroLast.begin(), nonZeroLast.end(), [](char c) { return c == 0; }),
+          "handle with non-zero last byte should not be empty");
+}
+
+void CaseXgmiVisibleDeviceRegression() {
+  if (GetGpuCount() < 2) throw TestSkip("requires at least 2 GPUs");
+
+  IOEngineConfig cfg;
+  cfg.host = "127.0.0.1";
+  cfg.port = 0;
+  IOEngine engine("xgmi_visible_regression_engine", cfg);
+  XgmiBackendConfig xgmiCfg{};
+  engine.CreateBackend(BackendType::XGMI, xgmiCfg);
+
+  auto src = RegisterGpuMemory(&engine, 1024 * 1024, 0);
+  auto dst = RegisterGpuMemory(&engine, 1024 * 1024, 1);
+
+  TransferStatus status;
+  TransferUniqueId uid = engine.AllocateTransferUniqueId();
+  engine.Write(src.desc, 0, dst.desc, 0, 1024 * 1024, &status, uid);
+
+  std::string err;
+  Require(WaitTransferDone(&status, 5000, &err),
+          "xgmi visible-device regression transfer timeout: " + err);
+  Require(status.Succeeded(), "xgmi visible-device regression transfer failed: code=" +
+                                  std::to_string(status.CodeUint32()) + ", msg='" +
+                                  status.Message() + "'");
+}
+
+void CaseXgmiCrossEngineIpc() {
+  // Tests cross-engine XGMI IPC: two IOEngines in the same process exchange
+  // data between GPU 0 and GPU 1 using IPC handles.
+  //
+  // NOTE: This exercises the cross-engine IPC handle open/remap path but NOT
+  // the hidden-device branch (LookupVisibleDevice returns nullopt).  In a
+  // single process all GPUs are visible, so CreateSession always takes the
+  // visible-remote path.  The true hidden-device path (split HIP_VISIBLE_DEVICES)
+  // is tested by CaseXgmiHiddenDeviceSplitVisibility which launches a subprocess.
+  if (GetGpuCount() < 2) throw TestSkip("requires at least 2 GPUs");
+
+  IOEngineConfig cfgA;
+  cfgA.host = "127.0.0.1";
+  cfgA.port = 0;
+  auto engineA = std::make_unique<IOEngine>("xgmi_cross_A", cfgA);
+
+  IOEngineConfig cfgB;
+  cfgB.host = "127.0.0.1";
+  cfgB.port = 0;
+  auto engineB = std::make_unique<IOEngine>("xgmi_cross_B", cfgB);
+
+  XgmiBackendConfig xgmiCfg{};
+  engineA->CreateBackend(BackendType::XGMI, xgmiCfg);
+  engineB->CreateBackend(BackendType::XGMI, xgmiCfg);
+
+  engineA->RegisterRemoteEngine(engineB->GetEngineDesc());
+  engineB->RegisterRemoteEngine(engineA->GetEngineDesc());
+
+  constexpr size_t kSize = 1024 * 1024;
+  auto srcMem = RegisterGpuMemory(engineA.get(), kSize, 0);
+  auto dstMem = RegisterGpuMemory(engineB.get(), kSize, 1);
+
+  HIP_RUNTIME_CHECK(hipSetDevice(0));
+  HIP_RUNTIME_CHECK(hipMemset(srcMem.ptr, 0xAB, kSize));
+  HIP_RUNTIME_CHECK(hipSetDevice(1));
+  HIP_RUNTIME_CHECK(hipMemset(dstMem.ptr, 0x00, kSize));
+  HIP_RUNTIME_CHECK(hipDeviceSynchronize());
+
+  TransferStatus status;
+  TransferUniqueId uid = engineA->AllocateTransferUniqueId();
+  engineA->Write(srcMem.desc, 0, dstMem.desc, 0, kSize, &status, uid);
+
+  std::string err;
+  Require(WaitTransferDone(&status, 5000, &err), "xgmi cross-engine IPC transfer timeout: " + err);
+  Require(status.Succeeded(),
+          "xgmi cross-engine IPC transfer failed: code=" + std::to_string(status.CodeUint32()) +
+              ", msg='" + status.Message() + "'");
+
+  std::vector<uint8_t> hostBuf(kSize);
+  HIP_RUNTIME_CHECK(hipSetDevice(1));
+  HIP_RUNTIME_CHECK(hipMemcpy(hostBuf.data(), dstMem.ptr, kSize, hipMemcpyDeviceToHost));
+  bool allMatch = true;
+  for (size_t i = 0; i < kSize; ++i) {
+    if (hostBuf[i] != 0xAB) {
+      allMatch = false;
+      break;
+    }
+  }
+  Require(allMatch, "xgmi cross-engine IPC data verification failed");
+}
+
+// --------------------------------------------------------------------------
+// Subprocess-based hidden-device test.
+//
+// The real hidden-device path requires a bus ID that is NOT in the importing
+// process's HIP_VISIBLE_DEVICES.  In a single process all GPUs are visible, so
+// we can never trigger LookupVisibleDevice() -> nullopt.  To test it properly
+// we launch a subprocess with restricted HIP_VISIBLE_DEVICES.
+//
+// Protocol (via shared memory file in /dev/shm):
+//   1. Exporter (this process, GPU 0):  allocates GPU memory, registers it with
+//      an IOEngine to populate the IPC handle, writes a MemoryDesc blob to the
+//      shared file, and waits for the importer to signal completion.
+//   2. Importer (subprocess, HIP_VISIBLE_DEVICES=<last_gpu>):  reads the
+//      MemoryDesc, creates its own IOEngine, and does a Write from its local
+//      GPU to the exporter's memory.  The exporter's bus ID is NOT in the
+//      importer's localDeviceByBusId, so it must go through the hidden-device
+//      branch.
+// --------------------------------------------------------------------------
+int RunHiddenDeviceImporter(const char* shmPath) {
+  // This function runs in a subprocess with restricted HIP_VISIBLE_DEVICES.
+  // It only sees one GPU (the last physical GPU), while the exporter used GPU 0.
+  SetLogLevel("info");
+  int gpuCount = GetGpuCount();
+  if (gpuCount < 1) {
+    std::fprintf(stderr, "importer: no GPUs visible\n");
+    return 1;
+  }
+
+  // Read serialized MemoryDesc from shared file
+  int fd = open(shmPath, O_RDONLY);
+  if (fd < 0) {
+    std::fprintf(stderr, "importer: failed to open shm\n");
+    return 1;
+  }
+
+  // Read msgpack blob
+  char buf[4096];
+  ssize_t n = read(fd, buf, sizeof(buf));
+  close(fd);
+  if (n <= 0) {
+    std::fprintf(stderr, "importer: failed to read shm\n");
+    return 1;
+  }
+
+  // Deserialize remote MemoryDesc
+  msgpack::object_handle oh = msgpack::unpack(buf, static_cast<size_t>(n));
+  MemoryDesc remoteDesc;
+  oh.get().convert(remoteDesc);
+
+  std::fprintf(stderr, "importer: remote bus_id=%s engineKey=%s ipcHandle[0]=%d\n",
+               remoteDesc.deviceBusId.c_str(), remoteDesc.engineKey.c_str(),
+               static_cast<int>(remoteDesc.ipcHandle[0]));
+
+  // Create local engine with XGMI backend
+  IOEngineConfig cfg;
+  cfg.host = "127.0.0.1";
+  cfg.port = 0;
+  IOEngine engine("importer_engine", cfg);
+  XgmiBackendConfig xgmiCfg{};
+  engine.CreateBackend(BackendType::XGMI, xgmiCfg);
+
+  // Register the remote engine so IsSameNodeEngine returns true
+  EngineDesc remoteEngDesc;
+  remoteEngDesc.key = remoteDesc.engineKey;
+  {
+    char hostname[HOST_NAME_MAX];
+    gethostname(hostname, HOST_NAME_MAX);
+    remoteEngDesc.hostname = std::string(hostname);
+    remoteEngDesc.nodeId = remoteEngDesc.hostname;
+  }
+  remoteEngDesc.host = "127.0.0.1";
+  remoteEngDesc.port = 0;
+  remoteEngDesc.pid = 0;
+  engine.RegisterRemoteEngine(remoteEngDesc);
+
+  // Allocate local memory on device 0 (importer's only visible GPU)
+  constexpr size_t kSize = 1024 * 1024;
+  auto localMem = RegisterGpuMemory(&engine, kSize, 0);
+
+  // Fill local source with 0xCD
+  HIP_RUNTIME_CHECK(hipSetDevice(0));
+  HIP_RUNTIME_CHECK(hipMemset(localMem.ptr, 0xCD, kSize));
+  HIP_RUNTIME_CHECK(hipDeviceSynchronize());
+
+  // Create a session from local to remote (hidden-device path!)
+  auto session = engine.CreateSession(localMem.desc, remoteDesc);
+  if (!session.has_value()) {
+    std::fprintf(stderr, "importer: CreateSession failed\n");
+    return 1;
+  }
+
+  // Write local data to remote memory
+  TransferStatus status;
+  TransferUniqueId uid = engine.AllocateTransferUniqueId();
+  session->Write(0, 0, kSize, &status, uid);
+
+  std::string err;
+  bool ok = WaitTransferDone(&status, 5000, &err);
+  if (!ok || !status.Succeeded()) {
+    std::fprintf(stderr, "importer: transfer failed: %s\n", err.c_str());
+    return 1;
+  }
+
+  std::fprintf(stderr, "importer: transfer succeeded\n");
+
+  // Signal completion by writing "done" to shm
+  int wfd = open(shmPath, O_WRONLY | O_TRUNC);
+  if (wfd >= 0) {
+    const char* msg = "done";
+    (void)write(wfd, msg, 4);
+    close(wfd);
+  }
+
+  return 0;
+}
+
+void CaseXgmiHiddenDeviceSplitVisibility() {
+  int totalGpus = GetGpuCount();
+  if (totalGpus < 2) throw TestSkip("requires at least 2 GPUs");
+
+  // Create shared memory file for IPC
+  std::string shmPath = "/dev/shm/mori_test_hidden_" + std::to_string(getpid());
+  int shmFd = open(shmPath.c_str(), O_CREAT | O_RDWR | O_TRUNC, 0600);
+  Require(shmFd >= 0, "failed to create shared memory file");
+
+  // Exporter: allocate on GPU 0, register, and serialize the descriptor
+  IOEngineConfig cfg;
+  cfg.host = "127.0.0.1";
+  cfg.port = 0;
+  IOEngine engine("exporter_engine", cfg);
+  XgmiBackendConfig xgmiCfg{};
+  engine.CreateBackend(BackendType::XGMI, xgmiCfg);
+
+  constexpr size_t kSize = 1024 * 1024;
+  auto exportMem = RegisterGpuMemory(&engine, kSize, 0);
+
+  // Clear export buffer
+  HIP_RUNTIME_CHECK(hipSetDevice(0));
+  HIP_RUNTIME_CHECK(hipMemset(exportMem.ptr, 0x00, kSize));
+  HIP_RUNTIME_CHECK(hipDeviceSynchronize());
+
+  // Serialize MemoryDesc via msgpack
+  msgpack::sbuffer sbuf;
+  msgpack::pack(sbuf, exportMem.desc);
+  ssize_t written = write(shmFd, sbuf.data(), sbuf.size());
+  close(shmFd);
+  Require(written == static_cast<ssize_t>(sbuf.size()), "failed to write descriptor to shm");
+
+  // Get our own executable path
+  char selfExe[PATH_MAX];
+  ssize_t len = readlink("/proc/self/exe", selfExe, sizeof(selfExe) - 1);
+  Require(len > 0, "failed to read /proc/self/exe");
+  selfExe[len] = '\0';
+
+  // Launch importer subprocess with the LAST GPU only visible
+  // (so GPU 0's bus ID is NOT in the importer's localDeviceByBusId)
+  std::string visibleDevices = std::to_string(totalGpus - 1);
+  std::string cmd = "HIP_VISIBLE_DEVICES=" + visibleDevices + " " + std::string(selfExe) +
+                    " --hidden-device-importer " + shmPath + " 2>&1";
+  int rc = system(cmd.c_str());
+  int exitCode = WIFEXITED(rc) ? WEXITSTATUS(rc) : -1;
+  Require(exitCode == 0, "importer subprocess failed with exit code " + std::to_string(exitCode));
+
+  // Read back the signal from shm
+  shmFd = open(shmPath.c_str(), O_RDONLY);
+  char doneBuf[8] = {};
+  if (shmFd >= 0) {
+    (void)read(shmFd, doneBuf, sizeof(doneBuf));
+    close(shmFd);
+  }
+  unlink(shmPath.c_str());
+  Require(std::string(doneBuf, 4) == "done", "importer did not signal completion");
+
+  // Verify the exporter's GPU 0 buffer now contains 0xCD (written by importer)
+  std::vector<uint8_t> hostBuf(kSize);
+  HIP_RUNTIME_CHECK(hipSetDevice(0));
+  HIP_RUNTIME_CHECK(hipMemcpy(hostBuf.data(), exportMem.ptr, kSize, hipMemcpyDeviceToHost));
+  bool allMatch = true;
+  for (size_t i = 0; i < kSize; ++i) {
+    if (hostBuf[i] != 0xCD) {
+      allMatch = false;
+      break;
+    }
+  }
+  Require(allMatch, "hidden-device data verification failed: expected 0xCD in exporter buffer");
+}
+
 void CaseXgmiInboundNotificationIsUnsupported() {
   if (GetGpuCount() < 1) throw TestSkip("requires at least one GPU");
 
@@ -453,7 +767,12 @@ struct TestCase {
 
 }  // namespace
 
-int main() {
+int main(int argc, char* argv[]) {
+  // Subprocess entry point for hidden-device importer
+  if (argc >= 3 && std::string(argv[1]) == "--hidden-device-importer") {
+    return RunHiddenDeviceImporter(argv[2]);
+  }
+
   SetLogLevel("info");
   std::vector<TestCase> cases = {
       {"submission_ledger_basic", CaseSubmissionLedgerBasic},
@@ -463,6 +782,11 @@ int main() {
       {"rdma_notification_disabled_behavior", CaseRdmaNotificationDisabledBehavior},
       {"rdma_notification_env_override_disables", CaseRdmaNotificationEnvOverrideDisables},
       {"rdma_notification_invalid_env_keeps_config", CaseRdmaNotificationInvalidEnvKeepsConfig},
+      {"normalize_bus_id", CaseNormalizeBusId},
+      {"is_ipc_handle_empty", CaseIsIpcHandleEmpty},
+      {"xgmi_visible_device_regression", CaseXgmiVisibleDeviceRegression},
+      {"xgmi_cross_engine_ipc", CaseXgmiCrossEngineIpc},
+      {"xgmi_hidden_device_split_visibility", CaseXgmiHiddenDeviceSplitVisibility},
       {"xgmi_inbound_notification_is_unsupported", CaseXgmiInboundNotificationIsUnsupported},
       {"xgmi_concurrent_wait_and_poll_is_safe", CaseXgmiConcurrentWaitAndPollIsSafe},
   };


### PR DESCRIPTION
## Summary
- add hidden-device XGMI topology discovery using KFD `hive_id` with `xgmi_physical_id` fallback
- normalize PCI bus IDs across HIP and sysfs lookups
- allow XGMI session creation when the remote GPU is hidden by `HIP_VISIBLE_DEVICES`
- add regression coverage for visible-device, cross-engine IPC, and split-visibility hidden-device paths

## Testing
- `/root/mori/build/tests/cpp/test_engine`
- split-visibility XGMI benchmark smoke test (`HIP_VISIBLE_DEVICES=0,1,2,3` vs `4,5,6,7`)
