### PR TITLE
Fix: EP index overflow

### DIFF
--- a/include/mori/ops/dispatch_combine/dispatch_combine.hpp
+++ b/include/mori/ops/dispatch_combine/dispatch_combine.hpp
@@ -143,6 +143,10 @@ struct EpDispatchCombineConfig {
   }
   inline __host__ __device__ size_t SrcTokenIdBytes() const { return sizeof(index_t); }
   inline __host__ __device__ size_t ScaleBytes() const { return scaleDim * scaleTypeSize; }
+  // Size_t accessors for fields used in token-offset arithmetic.
+  // Use these instead of the raw int members to avoid int32 overflow when
+  // multiplying by token counts (e.g. tokenId * HiddenDimSz() is size_t * size_t).
+  inline __host__ __device__ size_t HiddenDimSz() const { return (size_t)hiddenDim; }
 
   inline __host__ __device__ size_t XferBytesPerToken(size_t tokenTypeSize) const {
     return HiddenBytes(tokenTypeSize) + IndexBytes() + WeightBytes() + SrcTokenIdBytes() +

--- a/src/ops/dispatch_combine/common.hpp
+++ b/src/ops/dispatch_combine/common.hpp
@@ -60,6 +60,29 @@ inline __device__ int NullSendBufSlotOffset(const EpDispatchCombineConfig& confi
   return config.worldSize * config.MaxNumTokensToSendPerRank();
 }
 
+// Partitions a loop over (numItems x dimSize) work across globalWarpNum warps.
+// When there are more warps than items, multiple warps collaborate on a single item
+// by splitting dimSize; when there are fewer warps, each warp handles multiple items.
+struct MultiWarpIter {
+  int warpsPerItem;
+  size_t dimPerWarp;
+  size_t dimSize;
+
+  inline __device__ MultiWarpIter(int globalWarpNum, int numItems, size_t dimSize_)
+      : dimSize(dimSize_) {
+    warpsPerItem = (globalWarpNum + numItems - 1) / numItems;
+    dimPerWarp = (dimSize + warpsPerItem - 1) / warpsPerItem;
+  }
+
+  inline __device__ void Decode(int i, int& itemId, int& inItemPartId, size_t& dimOffset,
+                                size_t& dimChunk) const {
+    itemId = i / warpsPerItem;
+    inItemPartId = i % warpsPerItem;
+    dimOffset = (size_t)inItemPartId * dimPerWarp;
+    dimChunk = (dimOffset < dimSize) ? std::min(dimSize - dimOffset, dimPerWarp) : size_t{0};
+  }
+};
+
 #define DEF_COMMON_VARS                                    \
   const EpDispatchCombineConfig& config = args.config;     \
   int thdId = threadIdx.x;                                 \
@@ -80,6 +103,7 @@ inline __device__ int NullSendBufSlotOffset(const EpDispatchCombineConfig& confi
   int nNodes = npes / config.gpuPerNode;                   \
   int numExpertPerToken = config.numExpertPerToken;        \
   assert(numExpertPerToken < warpSize);                    \
+  size_t hiddenDim = config.HiddenDimSz();                 \
   size_t hiddenBytes = config.HiddenBytes(sizeof(T));      \
   size_t indexBytes = config.IndexBytes();                 \
   size_t weightBytes = config.WeightBytes();               \

--- a/src/ops/dispatch_combine/convert.hpp
+++ b/src/ops/dispatch_combine/convert.hpp
@@ -252,7 +252,7 @@ __device__ inline void ConvertDispatchOutputDevice(ConvertDispatchOutputArgs arg
   const int64_t maxNumTokenPerRank = config.maxNumInpTokenPerRank;
   const int64_t maxTokensPerExpert =
       static_cast<int64_t>(config.worldSize) * config.maxNumInpTokenPerRank;
-  const size_t hiddenBytes = static_cast<size_t>(config.hiddenDim) * config.maxTokenTypeSize;
+  const size_t hiddenBytes = config.HiddenDimSz() * config.maxTokenTypeSize;
 
   const auto* topkIdx = reinterpret_cast<const index_t*>(args.dispatchOutTopkIdx);
   const auto* dispatchSrcTokenPos = args.dispatchSrcTokenPos;
@@ -332,7 +332,7 @@ __device__ inline void ConvertDispatchOutputDevice(ConvertDispatchOutputArgs arg
 
   const int64_t maxTokensPerExpert =
       static_cast<int64_t>(config.worldSize) * config.maxNumInpTokenPerRank;
-  const size_t hiddenBytes = static_cast<size_t>(config.hiddenDim) * config.maxTokenTypeSize;
+  const size_t hiddenBytes = config.HiddenDimSz() * config.maxTokenTypeSize;
 
   const auto* topkIdx = reinterpret_cast<const index_t*>(args.dispatchOutTopkIdx);
   const auto* dispatchSrcTokenPos = args.dispatchSrcTokenPos;
@@ -434,8 +434,8 @@ __device__ inline void ConvertCombineInputDevice(ConvertCombineInputArgs& args) 
   PROFILE_COMBINE_RECORD(ts, tsCount, kTsMax, laneId);
 
   const int topk = config.numExpertPerToken;
-  const int64_t hiddenDim = config.hiddenDim;
-  const int64_t hiddenBytes = config.hiddenDim * sizeof(T);
+  const int64_t hiddenDim = (int64_t)config.HiddenDimSz();
+  const int64_t hiddenBytes = hiddenDim * sizeof(T);
 
   // Number of T elements per vector load (int4 = 16 bytes)
   constexpr int kElemsPerVec = sizeof(int4) / sizeof(T);
@@ -530,7 +530,7 @@ __device__ inline void ConvertCombineInputDevice(ConvertCombineInputArgs& args) 
   PROFILE_COMBINE_RECORD(ts, tsCount, kTsMax, laneId);
 
   const int topk = config.numExpertPerToken;
-  const int64_t hiddenDim = config.hiddenDim;
+  const int64_t hiddenDim = (int64_t)config.HiddenDimSz();
 
   auto* dispTokToEpSlotMap = args.dispTokToEpSlotMap;
   const auto* packedRecvX = reinterpret_cast<const T*>(args.packedRecvX);

--- a/src/ops/dispatch_combine/dispatch_combine.cpp
+++ b/src/ops/dispatch_combine/dispatch_combine.cpp
@@ -155,9 +155,9 @@ mori::application::SymmMemObjPtr ShmemMallocAndReturnMemObjPtr(size_t size, unsi
 
 void EpDispatchCombineHandle::InitializeShmemBuf() {
   size_t combineOutSize = static_cast<ssize_t>(config.MaxNumTokensToSendPerRank()) *
-                          config.hiddenDim * config.maxTokenTypeSize;
-  size_t dispatchOutSize = static_cast<ssize_t>(config.MaxNumTokensToRecv()) * config.hiddenDim *
-                           config.maxTokenTypeSize;
+                          config.HiddenDimSz() * config.maxTokenTypeSize;
+  size_t dispatchOutSize = static_cast<ssize_t>(config.MaxNumTokensToRecv()) *
+                           config.HiddenDimSz() * config.maxTokenTypeSize;
   size_t maxStagingSize =
       static_cast<ssize_t>(config.MaxNumTokensToRecv()) * config.MaxXferBytesPerToken();
 

--- a/src/ops/dispatch_combine/internode.hpp
+++ b/src/ops/dispatch_combine/internode.hpp
@@ -73,7 +73,7 @@ __device__ void EpDispatchInterNodeKernel_body(EpDispatchCombineArgs<T> args) {
   int numExpertPerToken = config.numExpertPerToken;
   assert(numExpertPerToken < warpSize);
 
-  size_t weightOffset = config.hiddenDim * sizeof(T);
+  size_t weightOffset = config.HiddenDimSz() * sizeof(T);
   size_t indicesOffset = weightOffset + sizeof(float) * numExpertPerToken;
   size_t scalesOffset = indicesOffset + sizeof(index_t) * numExpertPerToken;
   size_t stagingOffset = scalesOffset + config.scaleTypeSize * config.scaleDim;
@@ -153,12 +153,12 @@ __device__ void EpDispatchInterNodeKernel_body(EpDispatchCombineArgs<T> args) {
       const index_t mapIdx = destPe * MaxNumTokensToRecvPerRank + startIdx + idx;
       size_t mapIdxOffset = mapIdx * stagingOffset;
       const index_t tokenId = args.destPeTokenIdxMap[mapIdx];
-      size_t tokenOffset = tokenId * size_t(config.hiddenDim) * sizeof(T);
+      size_t tokenOffset = tokenId * config.HiddenDimSz() * sizeof(T);
       const index_t peSortedId = myPe * MaxNumTokensToRecvPerRank + startIdx + idx;
       size_t peSortedOffset = peSortedId * stagingOffset;
       core::WarpCopy(args.interNodeTokBufs.staging->template GetAs<char*>() + mapIdxOffset,
                      reinterpret_cast<char*>(args.inpTokenBuf) + tokenOffset,
-                     config.hiddenDim * sizeof(T));
+                     config.HiddenDimSz() * sizeof(T));
       if (args.weightsBuf) {
         core::WarpCopy(
             args.interNodeTokBufs.staging->template GetAs<char*>() + mapIdxOffset + weightOffset,
@@ -223,12 +223,12 @@ __device__ void EpDispatchInterNodeKernel_body(EpDispatchCombineArgs<T> args) {
         const index_t mapIdx = destPe * MaxNumTokensToRecvPerRank + startIdx + idx;
         size_t mapIdxOffset = mapIdx * stagingOffset;
         const index_t tokenId = args.destPeTokenIdxMap[mapIdx];
-        size_t tokenOffset = tokenId * size_t(config.hiddenDim) * sizeof(T);
+        size_t tokenOffset = tokenId * config.HiddenDimSz() * sizeof(T);
         // const index_t peSortedId = myPe * MaxNumTokensToRecvPerRank + startIdx + idx;
-        // size_t peSortedOffset = peSortedId * size_t(config.hiddenDim);
+        // size_t peSortedOffset = peSortedId * config.HiddenDimSz();
         core::WarpCopy(args.interNodeTokBufs.staging->template GetAs<char*>() + mapIdxOffset,
                        reinterpret_cast<char*>(args.inpTokenBuf) + tokenOffset,
-                       config.hiddenDim * sizeof(T));
+                       config.HiddenDimSz() * sizeof(T));
         if (args.weightsBuf) {
           core::WarpCopy(
               args.interNodeTokBufs.staging->template GetAs<char*>() + mapIdxOffset + weightOffset,
@@ -294,12 +294,12 @@ __device__ void EpDispatchInterNodeKernel_body(EpDispatchCombineArgs<T> args) {
     localTokenIdx = __shfl(localTokenIdx, 0);
     index_t peSortedId = destPe * MaxNumTokensToRecvPerRank + startRecvIdx + idx;
 
-    size_t localTokenOffset = size_t(localTokenIdx) * size_t(config.hiddenDim) * sizeof(T);
+    size_t localTokenOffset = size_t(localTokenIdx) * config.HiddenDimSz() * sizeof(T);
     size_t peSortedTokenOffset = size_t(peSortedId) * stagingOffset;
 
     core::WarpCopy(args.interNodeTokBufs.dispatchOut->template GetAs<char*>() + localTokenOffset,
                    args.interNodeTokBufs.dispatchInp->template GetAs<char*>() + peSortedTokenOffset,
-                   config.hiddenDim * sizeof(T));
+                   config.HiddenDimSz() * sizeof(T));
     core::WarpCopy(args.shmemDispatchOutWeightsMemObj->template GetAs<char*>() +
                        localTokenIdx * config.numExpertPerToken * sizeof(float),
                    args.interNodeTokBufs.dispatchInp->template GetAs<char*>() +
@@ -412,7 +412,7 @@ __device__ void EpCombineInterNodeKernel_body(EpDispatchCombineArgs<T> args) {
   const int startIdx = localBlockId * baseChunk + min(localBlockId, remainder);
   const int endIdx = startIdx + myChunkSize;
 
-  const size_t tokenSize = config.hiddenDim * sizeof(T);
+  const size_t tokenSize = config.HiddenDimSz() * sizeof(T);
   const size_t weightSize = args.weightsBuf ? config.numExpertPerToken * sizeof(float) : 0;
   const size_t tokenPackSize = tokenSize + weightSize;
 
@@ -531,14 +531,12 @@ __device__ void EpCombineInterNodeKernel_body(EpDispatchCombineArgs<T> args) {
   float** srcWeightsPtr = reinterpret_cast<float**>(sharedMem) +
                           warpNum * config.numExpertPerToken + warpId * config.numExpertPerToken;
 
-  int warpsPerToken = (globalWarpNum + args.curRankNumToken - 1) / args.curRankNumToken;
-  size_t hiddenDimPerWarp = (config.hiddenDim + warpsPerToken - 1) / warpsPerToken;
+  MultiWarpIter mwIter(globalWarpNum, args.curRankNumToken, config.HiddenDimSz());
 
-  for (int i = globalWarpId; i < (args.curRankNumToken * warpsPerToken); i += globalWarpNum) {
-    int tokenId = i / warpsPerToken;
-    int inTokenPartId = i % warpsPerToken;
-    size_t hiddenDimOffset = inTokenPartId * hiddenDimPerWarp;
-    size_t hiddenDimSize = std::min(config.hiddenDim - hiddenDimOffset, hiddenDimPerWarp);
+  for (int i = globalWarpId; i < (args.curRankNumToken * mwIter.warpsPerItem); i += globalWarpNum) {
+    int tokenId, inTokenPartId;
+    size_t hiddenDimOffset, hiddenDimSize;
+    mwIter.Decode(i, tokenId, inTokenPartId, hiddenDimOffset, hiddenDimSize);
 
     // Prepare data pointers on different GPUs
     for (int j = laneId; j < config.numExpertPerToken; j += warpSize) {
@@ -558,11 +556,11 @@ __device__ void EpCombineInterNodeKernel_body(EpDispatchCombineArgs<T> args) {
       }
     }
 
-    size_t offset = size_t(tokenId) * size_t(config.hiddenDim) + hiddenDimOffset;
+    size_t offset = size_t(tokenId) * config.HiddenDimSz() + hiddenDimOffset;
     core::WarpAccum<T, 8>(args.interNodeTokBufs.combineOut->template GetAs<T*>() + offset, srcPtrs,
                           nullptr, config.numExpertPerToken, hiddenDimSize);
 
-    if (args.weightsBuf && inTokenPartId == warpsPerToken - 1) {
+    if (args.weightsBuf && inTokenPartId == mwIter.warpsPerItem - 1) {
       core::WarpAccum<float, 4>(args.shmemCombineOutWeightsMemObj->template GetAs<float*>() +
                                     tokenId * config.numExpertPerToken,
                                 srcWeightsPtr, nullptr, config.numExpertPerToken,

--- a/src/ops/dispatch_combine/internode_v1.cpp
+++ b/src/ops/dispatch_combine/internode_v1.cpp
@@ -62,12 +62,12 @@ inline __device__ void DispatchIntraNodeBlock(EpDispatchCombineArgs<T>& args, in
   }
   if (laneId == (destPe % config.gpuPerNode)) localPeTokenCounter++;
   destTokId = __shfl(destTokId, 0);
-  size_t srcTokOffset = tokenId * config.hiddenDim;
-  size_t destTokOffset = destTokId * config.hiddenDim;
+  size_t srcTokOffset = tokenId * hiddenDim;
+  size_t destTokOffset = destTokId * hiddenDim;
 
   T* remoteTokenPtr = args.interNodeV1TokBufs.dispatchOut->template GetAs<T*>(destPe);
   const T* localTokenPtr = args.inpTokenBuf;
-  core::WarpCopy(remoteTokenPtr + destTokOffset, localTokenPtr + srcTokOffset, config.hiddenDim);
+  core::WarpCopy(remoteTokenPtr + destTokOffset, localTokenPtr + srcTokOffset, hiddenDim);
 
   index_t* remoteIndexPtr = args.shmemOutIndicesMemObj->template GetAs<index_t*>(destPe);
   const index_t* localIndexPtr = args.tokenIndices;
@@ -600,16 +600,13 @@ __device__ void EpDispatchCopyToStaging_body(EpDispatchCombineArgs<T> args) {
   MORI_TRACE_SPAN(profiler, Slot::EpDispatchCopyToStaging);
   if (args.curRankNumToken == 0) return;
 
-  index_t warpsPerToken = (globalWarpNum + args.curRankNumToken - 1) / args.curRankNumToken;
-  index_t hiddenDimPerWarp = (config.hiddenDim + warpsPerToken - 1) / warpsPerToken;
+  MultiWarpIter mwIter(globalWarpNum, args.curRankNumToken, hiddenDim);
 
   // First copy to staging buffer
-  for (int i = globalWarpId; i < (args.curRankNumToken * warpsPerToken); i += globalWarpNum) {
-    index_t tokenId = i / warpsPerToken;
-    index_t inTokenPartId = i % warpsPerToken;
-    index_t hiddenDimOffset = inTokenPartId * hiddenDimPerWarp;
-    index_t hiddenDimSize =
-        std::max(0, std::min(config.hiddenDim - hiddenDimOffset, hiddenDimPerWarp));
+  for (int i = globalWarpId; i < (args.curRankNumToken * mwIter.warpsPerItem); i += globalWarpNum) {
+    int tokenId, inTokenPartId;
+    size_t hiddenDimOffset, hiddenDimSize;
+    mwIter.Decode(i, tokenId, inTokenPartId, hiddenDimOffset, hiddenDimSize);
 
     uint8_t* stagingPtr = args.interNodeV1TokBufs.staging->template GetAs<uint8_t*>();
     size_t stagingTokOffset = tokenId * xferBytes;
@@ -683,12 +680,11 @@ inline __device__ void CombineSync(EpDispatchCombineArgs<T>& args) {
       using Fp8T = core::CombineInternalFp8;
       Fp8T* dst = args.interNodeV1TokBufs.combineInp->template GetAs<Fp8T*>();
       const T* src = args.inpTokenBuf;
-      const int base = tokenId * config.hiddenDim;
-      core::WarpCastBf16ToCombineInternalFp8<T>(dst + base, src + base, config.hiddenDim, laneId);
+      const size_t base = tokenId * hiddenDim;
+      core::WarpCastBf16ToCombineInternalFp8<T>(dst + base, src + base, hiddenDim, laneId);
     } else {
-      core::WarpCopy(
-          args.interNodeV1TokBufs.combineInp->template GetAs<T*>() + tokenId * config.hiddenDim,
-          args.inpTokenBuf + tokenId * config.hiddenDim, config.hiddenDim);
+      core::WarpCopy(args.interNodeV1TokBufs.combineInp->template GetAs<T*>() + tokenId * hiddenDim,
+                     args.inpTokenBuf + tokenId * hiddenDim, hiddenDim);
     }
   }
 #endif
@@ -733,13 +729,13 @@ __forceinline__ __device__ void CombineIntraNodeTyped(EpDispatchCombineArgs<T>& 
       if (destNode == myNode) {
         index_t destLocalTokId = LocalTokIdFromFlatTokenIndex(config, destTokId);
         srcPtrs[laneId] = args.interNodeV1TokBufs.combineInp->template GetAs<TokT*>(destPe) +
-                          destLocalTokId * config.hiddenDim;
+                          destLocalTokId * hiddenDim;
         srcWeightsPtr[laneId] = args.shmemInpWeightsMemObj->template GetAs<float*>(destPe) +
                                 destLocalTokId * config.numExpertPerToken;
       }
     }
     core::WarpAccum<TokT, 4>(reinterpret_cast<TokT*>(stagingPtr + tokenId * tokCombXferBytes),
-                             srcPtrs, nullptr, config.numExpertPerToken, config.hiddenDim);
+                             srcPtrs, nullptr, config.numExpertPerToken, hiddenDim);
     if (args.weightsBuf) {
       core::WarpAccum<float, 4>(
           reinterpret_cast<float*>(stagingPtr + tokenId * tokCombXferBytes + tokHiddenBytes),
@@ -766,16 +762,13 @@ __forceinline__ __device__ void CombineIntraNodeLLTyped(EpDispatchCombineArgs<T>
   uint8_t* stagingPtr = args.interNodeV1TokBufs.staging->template GetAs<uint8_t*>() +
                         SendBufSlotOffset(config, nNodes + myNode, 0) * tokCombXferBytes;
 
-  index_t warpsPerToken = (xgmiWarpNum + args.curRankNumToken - 1) / args.curRankNumToken;
-  index_t hiddenDimPerWarp = (config.hiddenDim + warpsPerToken - 1) / warpsPerToken;
+  MultiWarpIter mwIter(xgmiWarpNum, args.curRankNumToken, hiddenDim);
 
-  for (int i = globalWarpId - blockOffset * warpNum; i < (args.curRankNumToken * warpsPerToken);
-       i += xgmiWarpNum) {
-    index_t tokenId = i / warpsPerToken;
-    index_t inTokenPartId = i % warpsPerToken;
-    index_t hiddenDimOffset = inTokenPartId * hiddenDimPerWarp;
-    index_t hiddenDimSize =
-        std::max(0, std::min(config.hiddenDim - hiddenDimOffset, hiddenDimPerWarp));
+  for (int i = globalWarpId - blockOffset * warpNum;
+       i < (args.curRankNumToken * mwIter.warpsPerItem); i += xgmiWarpNum) {
+    int tokenId, inTokenPartId;
+    size_t hiddenDimOffset, hiddenDimSize;
+    mwIter.Decode(i, tokenId, inTokenPartId, hiddenDimOffset, hiddenDimSize);
 
     if (laneId < config.numExpertPerToken) {
       srcPtrs[laneId] = nullptr;
@@ -786,7 +779,7 @@ __forceinline__ __device__ void CombineIntraNodeLLTyped(EpDispatchCombineArgs<T>
       if (destNode == myNode) {
         index_t destLocalTokId = LocalTokIdFromFlatTokenIndex(config, destTokId);
         srcPtrs[laneId] = args.interNodeV1TokBufs.combineInp->template GetAs<TokT*>(destPe) +
-                          destLocalTokId * config.hiddenDim + hiddenDimOffset;
+                          destLocalTokId * hiddenDim + hiddenDimOffset;
         srcWeightsPtr[laneId] = args.shmemInpWeightsMemObj->template GetAs<float*>(destPe) +
                                 destLocalTokId * config.numExpertPerToken;
       }
@@ -794,7 +787,7 @@ __forceinline__ __device__ void CombineIntraNodeLLTyped(EpDispatchCombineArgs<T>
     core::WarpAccum<TokT, 4>(
         reinterpret_cast<TokT*>(stagingPtr + tokenId * tokCombXferBytes) + hiddenDimOffset, srcPtrs,
         nullptr, config.numExpertPerToken, hiddenDimSize);
-    if (args.weightsBuf && (inTokenPartId == warpsPerToken - 1)) {
+    if (args.weightsBuf && (inTokenPartId == mwIter.warpsPerItem - 1)) {
       core::WarpAccum<float, 4>(
           reinterpret_cast<float*>(stagingPtr + tokenId * tokCombXferBytes + tokHiddenBytes),
           srcWeightsPtr, nullptr, config.numExpertPerToken, config.numExpertPerToken);
@@ -882,7 +875,7 @@ __forceinline__ __device__ void CombineInterNodeTyped(EpDispatchCombineArgs<T>& 
                   index_t destLocalTokId = LocalTokIdFromFlatTokenIndex(config, destTokId);
                   srcPtrs[laneId] =
                       args.interNodeV1TokBufs.combineInp->template GetAs<TokT*>(destPe) +
-                      destLocalTokId * config.hiddenDim;
+                      destLocalTokId * hiddenDim;
                   srcWeightsPtr[laneId] =
                       args.shmemInpWeightsMemObj->template GetAs<float*>(destPe) +
                       destLocalTokId * config.numExpertPerToken;
@@ -892,7 +885,7 @@ __forceinline__ __device__ void CombineInterNodeTyped(EpDispatchCombineArgs<T>& 
 
               core::WarpAccum<TokT, 4>(
                   reinterpret_cast<TokT*>(stagingPtr + tokIdx * tokCombXferBytes), srcPtrs, nullptr,
-                  config.numExpertPerToken, config.hiddenDim);
+                  config.numExpertPerToken, hiddenDim);
 
               if (args.weightsBuf) {
                 core::WarpAccum<float, 4>(
@@ -1003,7 +996,7 @@ __forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs<T>
     // NOTE: Using a fixed value of 4 for warpsPerToken instead of the dynamic formula above is
     // an intentional tuning choice.
     int warpsPerToken = 4;
-    int hiddenDimPerWarp = (config.hiddenDim + warpsPerToken - 1) / warpsPerToken;
+    size_t hiddenDimPerWarp = (hiddenDim + warpsPerToken - 1) / warpsPerToken;
 
     for (int i = globalWarpId; i < (nodeCount * warpsPerToken); i += rdmaWarpNum) {
       int tokenId = i / warpsPerToken;
@@ -1013,9 +1006,10 @@ __forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs<T>
       thisChunkTokenNum -= (thisChunkTokenNum > 0) ? 1 : 0;
       if ((tokenId - startTokenIdx) < thisChunkTokenNum) {
         int inTokenPartId = i % warpsPerToken;
-        int hiddenDimOffset = inTokenPartId * hiddenDimPerWarp;
-        int hiddenDimSize =
-            std::max(0, std::min(config.hiddenDim - hiddenDimOffset, hiddenDimPerWarp));
+        size_t hiddenDimOffset = inTokenPartId * hiddenDimPerWarp;
+        size_t hiddenDimSize = (hiddenDimOffset < hiddenDim)
+                                   ? std::min(hiddenDim - hiddenDimOffset, hiddenDimPerWarp)
+                                   : size_t{0};
 
         int globalTokenId = SendBufSlotOffset(config, node, tokenId);
         if (laneId < config.numExpertPerToken) {
@@ -1028,7 +1022,7 @@ __forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs<T>
           if (destNode == myNode) {
             index_t destLocalTokId = LocalTokIdFromFlatTokenIndex(config, destTokId);
             srcPtrs[laneId] = args.interNodeV1TokBufs.combineInp->template GetAs<TokT*>(destPe) +
-                              destLocalTokId * config.hiddenDim + hiddenDimOffset;
+                              destLocalTokId * hiddenDim + hiddenDimOffset;
             srcWeightsPtr[laneId] = args.shmemInpWeightsMemObj->template GetAs<float*>(destPe) +
                                     destLocalTokId * config.numExpertPerToken;
           }
@@ -1118,7 +1112,7 @@ inline __device__ void CombineIntraNode(EpDispatchCombineArgs<T>& args) {
   MORI_TRACE_SPAN(profiler, Slot::CombineIntraNode);
   if (args.config.quantType == QuantType::Fp8DirectCast) {
     using TokT = core::CombineInternalFp8;
-    const size_t tokHiddenBytes = config.hiddenDim * sizeof(TokT);
+    const size_t tokHiddenBytes = hiddenDim * sizeof(TokT);
     const size_t tokCombXferBytes =
         (args.weightsBuf == nullptr) ? tokHiddenBytes : tokHiddenBytes + weightBytes;
     combine_impl::CombineIntraNodeTyped<TokT>(args, tokHiddenBytes, tokCombXferBytes);
@@ -1136,7 +1130,7 @@ inline __device__ void CombineIntraNodeLL(EpDispatchCombineArgs<T>& args) {
   if (args.curRankNumToken == 0) return;
   if (args.config.quantType == QuantType::Fp8DirectCast) {
     using TokT = core::CombineInternalFp8;
-    const size_t tokHiddenBytes = config.hiddenDim * sizeof(TokT);
+    const size_t tokHiddenBytes = hiddenDim * sizeof(TokT);
     const size_t tokCombXferBytes =
         (args.weightsBuf == nullptr) ? tokHiddenBytes : tokHiddenBytes + weightBytes;
     combine_impl::CombineIntraNodeLLTyped<TokT>(args, tokHiddenBytes, tokCombXferBytes);
@@ -1152,7 +1146,7 @@ inline __device__ void CombineInterNode(EpDispatchCombineArgs<T>& args) {
 
   if (args.config.quantType == QuantType::Fp8DirectCast) {
     using TokT = core::CombineInternalFp8;
-    const size_t tokHiddenBytes = config.hiddenDim * sizeof(TokT);
+    const size_t tokHiddenBytes = hiddenDim * sizeof(TokT);
     const size_t tokCombXferBytes =
         (args.weightsBuf == nullptr) ? tokHiddenBytes : tokHiddenBytes + weightBytes;
     combine_impl::CombineInterNodeTyped<TokT>(args, tokHiddenBytes, tokCombXferBytes);
@@ -1167,7 +1161,7 @@ inline __device__ void CombineInterNodeLL(EpDispatchCombineArgs<T>& args) {
   MORI_TRACE_SPAN(profiler, Slot::CombineInterNodeLL);
   if (args.config.quantType == QuantType::Fp8DirectCast) {
     using TokT = core::CombineInternalFp8;
-    const size_t tokHiddenBytes = config.hiddenDim * sizeof(TokT);
+    const size_t tokHiddenBytes = hiddenDim * sizeof(TokT);
     const size_t tokCombXferBytes =
         (args.weightsBuf == nullptr) ? tokHiddenBytes : tokHiddenBytes + weightBytes;
     combine_impl::CombineInterNodeLLTyped<TokT>(args, tokHiddenBytes, tokCombXferBytes);
@@ -1209,15 +1203,12 @@ __forceinline__ __device__ void EpCombineAllInternalFp8(EpDispatchCombineArgs<T>
   uint8_t* stagingPtr = args.interNodeV1TokBufs.staging->template GetAs<uint8_t*>() +
                         SendBufSlotOffset(config, nNodes, 0) * fp8CombXferBytes;
 
-  index_t warpsPerToken = (globalWarpNum + args.curRankNumToken - 1) / args.curRankNumToken;
-  index_t hiddenDimPerWarp = (config.hiddenDim + warpsPerToken - 1) / warpsPerToken;
+  MultiWarpIter mwIter(globalWarpNum, args.curRankNumToken, hiddenDim);
 
-  for (int i = globalWarpId; i < (args.curRankNumToken * warpsPerToken); i += globalWarpNum) {
-    index_t tokenId = i / warpsPerToken;
-    index_t inTokenPartId = i % warpsPerToken;
-    index_t hiddenDimOffset = inTokenPartId * hiddenDimPerWarp;
-    index_t hiddenDimSize =
-        std::max(0, std::min(config.hiddenDim - hiddenDimOffset, hiddenDimPerWarp));
+  for (int i = globalWarpId; i < (args.curRankNumToken * mwIter.warpsPerItem); i += globalWarpNum) {
+    int tokenId, inTokenPartId;
+    size_t hiddenDimOffset, hiddenDimSize;
+    mwIter.Decode(i, tokenId, inTokenPartId, hiddenDimOffset, hiddenDimSize);
 
     int lanePe = -1, laneNode = -1;
     if (laneId < config.numExpertPerToken) {
@@ -1239,12 +1230,12 @@ __forceinline__ __device__ void EpCombineAllInternalFp8(EpDispatchCombineArgs<T>
       }
     }
 
-    T* out = args.interNodeV1TokBufs.combineOut->template GetAs<T*>() + tokenId * config.hiddenDim +
+    T* out = args.interNodeV1TokBufs.combineOut->template GetAs<T*>() + tokenId * hiddenDim +
              hiddenDimOffset;
     core::WarpAccumCombineInternalFp8ToBf16(out, reinterpret_cast<const Fp8T* const*>(srcPtrs),
                                             nNodes, laneId, hiddenDimSize);
 
-    if (args.weightsBuf && (inTokenPartId == warpsPerToken - 1)) {
+    if (args.weightsBuf && (inTokenPartId == mwIter.warpsPerItem - 1)) {
       core::WarpAccum<float, 4>(args.shmemCombineOutWeightsMemObj->template GetAs<float*>() +
                                     tokenId * config.numExpertPerToken,
                                 srcWeightsPtrs, nullptr, nNodes, config.numExpertPerToken);
@@ -1263,15 +1254,12 @@ __forceinline__ __device__ void EpCombineAllGeneric(EpDispatchCombineArgs<T>& ar
   uint8_t* stagingPtr = args.interNodeV1TokBufs.staging->template GetAs<uint8_t*>() +
                         SendBufSlotOffset(config, nNodes, 0) * combXferBytes;
 
-  index_t warpsPerToken = (globalWarpNum + args.curRankNumToken - 1) / args.curRankNumToken;
-  index_t hiddenDimPerWarp = (config.hiddenDim + warpsPerToken - 1) / warpsPerToken;
+  MultiWarpIter mwIter(globalWarpNum, args.curRankNumToken, hiddenDim);
 
-  for (int i = globalWarpId; i < (args.curRankNumToken * warpsPerToken); i += globalWarpNum) {
-    index_t tokenId = i / warpsPerToken;
-    index_t inTokenPartId = i % warpsPerToken;
-    index_t hiddenDimOffset = inTokenPartId * hiddenDimPerWarp;
-    index_t hiddenDimSize =
-        std::max(0, std::min(config.hiddenDim - hiddenDimOffset, hiddenDimPerWarp));
+  for (int i = globalWarpId; i < (args.curRankNumToken * mwIter.warpsPerItem); i += globalWarpNum) {
+    int tokenId, inTokenPartId;
+    size_t hiddenDimOffset, hiddenDimSize;
+    mwIter.Decode(i, tokenId, inTokenPartId, hiddenDimOffset, hiddenDimSize);
 
     int lanePe = -1, laneNode = -1;
     if (laneId < config.numExpertPerToken) {
@@ -1293,9 +1281,9 @@ __forceinline__ __device__ void EpCombineAllGeneric(EpDispatchCombineArgs<T>& ar
       }
     }
     core::WarpAccum<T, 4>(args.interNodeV1TokBufs.combineOut->template GetAs<T*>() +
-                              tokenId * config.hiddenDim + hiddenDimOffset,
+                              tokenId * hiddenDim + hiddenDimOffset,
                           srcPtrs, nullptr, nNodes, hiddenDimSize);
-    if (args.weightsBuf && (inTokenPartId == warpsPerToken - 1)) {
+    if (args.weightsBuf && (inTokenPartId == mwIter.warpsPerItem - 1)) {
       core::WarpAccum<float, 4>(args.shmemCombineOutWeightsMemObj->template GetAs<float*>() +
                                     tokenId * config.numExpertPerToken,
                                 srcWeightsPtrs, nullptr, nNodes, config.numExpertPerToken);
@@ -1317,7 +1305,7 @@ __device__ void EpCombineAll_body(EpDispatchCombineArgs<T> args) {
   if (args.curRankNumToken == 0) return;
   if (args.config.quantType == QuantType::Fp8DirectCast) {
     using Fp8T = core::CombineInternalFp8;
-    const size_t fp8HiddenBytes = config.hiddenDim * sizeof(Fp8T);
+    const size_t fp8HiddenBytes = hiddenDim * sizeof(Fp8T);
     const size_t fp8CombXferBytes =
         (args.weightsBuf == nullptr) ? fp8HiddenBytes : fp8HiddenBytes + weightBytes;
     combine_all_impl::EpCombineAllInternalFp8(args, fp8HiddenBytes, fp8CombXferBytes);

--- a/src/ops/dispatch_combine/intranode.hpp
+++ b/src/ops/dispatch_combine/intranode.hpp
@@ -90,6 +90,7 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
 
   int myPe = config.rank;
   int npes = config.worldSize;
+  size_t hiddenDim = config.HiddenDimSz();
 
   if (args.tokenIndices && args.inpTokenBuf) {
     // Phase1: send token
@@ -151,11 +152,11 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
             args.scalesBuf + srcScaleOffset, config.scaleDim * config.scaleTypeSize);
       }
 
-      size_t srcTokOffset = (size_t)srcTokId * config.hiddenDim;
-      size_t destTokOffset = (size_t)destTokId * config.hiddenDim;
+      size_t srcTokOffset = srcTokId * hiddenDim;
+      size_t destTokOffset = destTokId * hiddenDim;
 
       core::WarpCopy(args.intraNodeTokBufs.dispatchOut->template GetAs<T*>(destPe) + destTokOffset,
-                     args.inpTokenBuf + srcTokOffset, config.hiddenDim);
+                     args.inpTokenBuf + srcTokOffset, hiddenDim);
     }
   }
   __syncthreads();
@@ -237,7 +238,8 @@ __device__ void EpCombineIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   // Copy input to shmem registered buffer so that other GPUs can access directly
   index_t totalRecvTokenNum = args.totalRecvTokenNum[0];
   // When TokT != T (e.g. fp8 combine), staging layout uses TokT-sized tokens
-  const size_t hiddenBytes = config.hiddenDim * sizeof(TokT);
+  const size_t hiddenDim = config.HiddenDimSz();
+  const size_t hiddenBytes = hiddenDim * sizeof(TokT);
   const size_t weightBytes =
       (args.weightsBuf == nullptr) ? 0 : config.numExpertPerToken * sizeof(float);
   const size_t combXferBytes = hiddenBytes + weightBytes;
@@ -251,13 +253,11 @@ __device__ void EpCombineIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
       for (int i = globalWarpId; i < totalRecvTokenNum; i += globalWarpNum) {
         if constexpr (!std::is_same_v<T, TokT> && std::is_same_v<TokT, core::CombineInternalFp8>) {
           core::WarpCastBf16ToCombineInternalFp8<T>(
-              args.intraNodeTokBufs.combineInp->template GetAs<TokT*>() +
-                  (size_t)i * config.hiddenDim,
-              args.inpTokenBuf + (size_t)i * config.hiddenDim, config.hiddenDim, laneId);
+              args.intraNodeTokBufs.combineInp->template GetAs<TokT*>() + i * hiddenDim,
+              args.inpTokenBuf + i * hiddenDim, hiddenDim, laneId);
         } else {
-          core::WarpCopy(
-              args.intraNodeTokBufs.combineInp->template GetAs<T*>() + (size_t)i * config.hiddenDim,
-              args.inpTokenBuf + (size_t)i * config.hiddenDim, config.hiddenDim);
+          core::WarpCopy(args.intraNodeTokBufs.combineInp->template GetAs<T*>() + i * hiddenDim,
+                         args.inpTokenBuf + i * hiddenDim, hiddenDim);
         }
       }
     }
@@ -276,12 +276,12 @@ __device__ void EpCombineIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
       uint8_t* destStagingPtr = args.intraNodeTokBufs.combineInp->template GetAs<uint8_t*>(destPe) +
                                 SendBufSlotOffset(config, myPe, destLocalTokId) * combXferBytes;
       if constexpr (!std::is_same_v<T, TokT> && std::is_same_v<TokT, core::CombineInternalFp8>) {
-        core::WarpCastBf16ToCombineInternalFp8<T>(
-            reinterpret_cast<TokT*>(destStagingPtr),
-            args.inpTokenBuf + (size_t)tokenIdx * config.hiddenDim, config.hiddenDim, laneId);
+        core::WarpCastBf16ToCombineInternalFp8<T>(reinterpret_cast<TokT*>(destStagingPtr),
+                                                  args.inpTokenBuf + tokenIdx * hiddenDim,
+                                                  hiddenDim, laneId);
       } else {
         core::WarpCopy(reinterpret_cast<T*>(destStagingPtr),
-                       args.inpTokenBuf + (size_t)tokenIdx * config.hiddenDim, config.hiddenDim);
+                       args.inpTokenBuf + tokenIdx * hiddenDim, hiddenDim);
       }
       if (args.weightsBuf) {
         core::WarpCopy(reinterpret_cast<float*>(destStagingPtr + hiddenBytes),
@@ -301,16 +301,13 @@ __device__ void EpCombineIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   float** srcWeightsPtr = reinterpret_cast<float**>(sharedMem) +
                           warpNum * config.numExpertPerToken + warpId * config.numExpertPerToken;
 
-  index_t warpsPerToken = (globalWarpNum + args.curRankNumToken - 1) / args.curRankNumToken;
-  index_t hiddenDimPerWarp = (config.hiddenDim + warpsPerToken - 1) / warpsPerToken;
+  MultiWarpIter mwIter(globalWarpNum, args.curRankNumToken, hiddenDim);
 
   assert(config.numExpertPerToken < warpSize);
-  for (int i = globalWarpId; i < (args.curRankNumToken * warpsPerToken); i += globalWarpNum) {
-    index_t tokenId = i / warpsPerToken;
-    index_t inTokenPartId = i % warpsPerToken;
-    index_t hiddenDimOffset = inTokenPartId * hiddenDimPerWarp;
-    index_t hiddenDimSize =
-        std::max(0, std::min(config.hiddenDim - hiddenDimOffset, hiddenDimPerWarp));
+  for (int i = globalWarpId; i < (args.curRankNumToken * mwIter.warpsPerItem); i += globalWarpNum) {
+    int tokenId, inTokenPartId;
+    size_t hiddenDimOffset, hiddenDimSize;
+    mwIter.Decode(i, tokenId, inTokenPartId, hiddenDimOffset, hiddenDimSize);
 
     // Prepare data pointers on different GPUs
     for (int j = laneId; j < config.numExpertPerToken; j += warpSize) {
@@ -321,7 +318,7 @@ __device__ void EpCombineIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
         if constexpr (UseP2PRead) {
           index_t destLocalTokId = LocalTokIdFromFlatTokenIndex(config, destTokId);
           srcPtrs[j] = args.intraNodeTokBufs.combineInp->template GetAs<TokT*>(destPe) +
-                       (size_t)destLocalTokId * config.hiddenDim + hiddenDimOffset;
+                       destLocalTokId * hiddenDim + hiddenDimOffset;
           srcWeightsPtr[j] = args.shmemInpWeightsMemObj->template GetAs<float*>(destPe) +
                              destLocalTokId * config.numExpertPerToken;
         } else {
@@ -339,8 +336,8 @@ __device__ void EpCombineIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
       }
     }
 
-    T* outPtr = args.intraNodeTokBufs.combineOut->template GetAs<T*>() +
-                tokenId * config.hiddenDim + hiddenDimOffset;
+    T* outPtr = args.intraNodeTokBufs.combineOut->template GetAs<T*>() + tokenId * hiddenDim +
+                hiddenDimOffset;
 
     int validAccumCount = config.numExpertPerToken;
     if (config.worldSize <= 4) {
@@ -367,7 +364,7 @@ __device__ void EpCombineIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
       core::WarpAccum<T, 4>(outPtr, srcPtrs, nullptr, validAccumCount, hiddenDimSize);
     }
 
-    if (args.weightsBuf && inTokenPartId == warpsPerToken - 1) {
+    if (args.weightsBuf && inTokenPartId == mwIter.warpsPerItem - 1) {
       core::WarpAccum<float, 4>(args.shmemCombineOutWeightsMemObj->template GetAs<float*>() +
                                     tokenId * config.numExpertPerToken,
                                 srcWeightsPtr, nullptr, config.numExpertPerToken,

--- a/src/ops/dispatch_combine/low_latency_async.cpp
+++ b/src/ops/dispatch_combine/low_latency_async.cpp
@@ -383,7 +383,7 @@ __device__ void EpCombineLowLatencyAsyncSendCopy_body(EpDispatchCombineArgs<T> a
   using TokT = std::conditional_t<UseFp8DirectCast, core::CombineInternalFp8, T>;
   static_assert(!UseFp8DirectCast || std::is_same_v<T, hip_bfloat16>,
                 "Fp8 direct cast combine currently only supports bf16 input");
-  const size_t tokHiddenBytes = config.hiddenDim * sizeof(TokT);
+  const size_t tokHiddenBytes = hiddenDim * sizeof(TokT);
 
   // Copy token onto staging buffer for later IBGDA transfer
   index_t totalRecvTokenNum = args.totalRecvTokenNum[0];
@@ -395,7 +395,7 @@ __device__ void EpCombineLowLatencyAsyncSendCopy_body(EpDispatchCombineArgs<T> a
     if constexpr (UseFp8DirectCast) {
       core::WarpCastBf16ToCombineInternalFp8<T>(
           reinterpret_cast<TokT*>(stagingPtr + stagingTokId * tokHiddenBytes),
-          args.inpTokenBuf + tokenId * config.hiddenDim, config.hiddenDim, laneId);
+          args.inpTokenBuf + tokenId * hiddenDim, hiddenDim, laneId);
     } else {
       core::WarpCopy<uint8_t, 4>(
           stagingPtr + stagingTokId * tokHiddenBytes,
@@ -414,7 +414,7 @@ __device__ void EpCombineLowLatencyAsyncSendTransfer_body(EpDispatchCombineArgs<
   using TokT = std::conditional_t<UseFp8DirectCast, core::CombineInternalFp8, T>;
   static_assert(!UseFp8DirectCast || std::is_same_v<T, hip_bfloat16>,
                 "Fp8 direct cast combine currently only supports bf16 input");
-  const size_t tokHiddenBytes = config.hiddenDim * sizeof(TokT);
+  const size_t tokHiddenBytes = hiddenDim * sizeof(TokT);
 
   uint64_t* recvTokenNums = args.recvTokenNumMemObj->template GetAs<uint64_t*>();
   for (int destPe = blockId; destPe < npes; destPe += blockNum) {
@@ -497,15 +497,13 @@ __device__ void EpCombineLowLatencyAsyncRecvCopy_body(EpDispatchCombineArgs<T> a
   TokT** srcPtrs = reinterpret_cast<TokT**>(sharedMem) + warpId * config.numExpertPerToken;
 
   if (args.curRankNumToken != 0) {
-    index_t warpsPerToken = (globalWarpNum + args.curRankNumToken - 1) / args.curRankNumToken;
-    index_t hiddenDimPerWarp = (config.hiddenDim + warpsPerToken - 1) / warpsPerToken;
+    MultiWarpIter mwIter(globalWarpNum, args.curRankNumToken, hiddenDim);
 
-    for (int i = globalWarpId; i < (args.curRankNumToken * warpsPerToken); i += globalWarpNum) {
-      index_t tokenId = i / warpsPerToken;
-      index_t inTokenPartId = i % warpsPerToken;
-      index_t hiddenDimOffset = inTokenPartId * hiddenDimPerWarp;
-      index_t hiddenDimSize =
-          std::max(0, std::min(config.hiddenDim - hiddenDimOffset, hiddenDimPerWarp));
+    for (int i = globalWarpId; i < (args.curRankNumToken * mwIter.warpsPerItem);
+         i += globalWarpNum) {
+      int tokenId, inTokenPartId;
+      size_t hiddenDimOffset, hiddenDimSize;
+      mwIter.Decode(i, tokenId, inTokenPartId, hiddenDimOffset, hiddenDimSize);
 
       for (int j = laneId; j < config.numExpertPerToken; j += warpSize) {
         index_t destTokId = args.dispDestTokIdMap[tokenId * config.numExpertPerToken + j];
@@ -515,14 +513,14 @@ __device__ void EpCombineLowLatencyAsyncRecvCopy_body(EpDispatchCombineArgs<T> a
                                ? args.interNodeTokBufs.combineInp->template GetAs<TokT*>()
                                : args.interNodeTokBufs.staging->template GetAs<TokT*>();
         if (destPe < npes) {
-          srcPtrs[j] = stagingPtr + destTokId * config.hiddenDim + hiddenDimOffset;
+          srcPtrs[j] = stagingPtr + destTokId * hiddenDim + hiddenDimOffset;
         } else {
           srcPtrs[j] = nullptr;
         }
       }
 
-      T* outPtr = args.interNodeTokBufs.combineOut->template GetAs<T*>() +
-                  tokenId * config.hiddenDim + hiddenDimOffset;
+      T* outPtr = args.interNodeTokBufs.combineOut->template GetAs<T*>() + tokenId * hiddenDim +
+                  hiddenDimOffset;
       if constexpr (UseFp8DirectCast) {
         core::WarpAccumCombineInternalFp8ToBf16(outPtr,
                                                 reinterpret_cast<const TokT* const*>(srcPtrs),

--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -187,6 +187,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
         dispatch_warp_per_block,
         combine_block_num,
         combine_warp_per_block,
+        check=True,
     ):
         (
             all_rank_num_token,
@@ -211,15 +212,16 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
             block_num=dispatch_block_num,
             warp_per_block=dispatch_warp_per_block,
         )
-        self.check_dispatch_result(
-            op,
-            test_data,
-            dispatch_output,
-            dispatch_weights,
-            dispatch_scales,
-            dispatch_indices,
-            dispatch_recv_num_token,
-        )
+        if check:
+            self.check_dispatch_result(
+                op,
+                test_data,
+                dispatch_output,
+                dispatch_weights,
+                dispatch_scales,
+                dispatch_indices,
+                dispatch_recv_num_token,
+            )
 
         total_recv_num_token = dispatch_recv_num_token[0].item()
 
@@ -248,12 +250,13 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
             block_num=combine_block_num,
             warp_per_block=combine_warp_per_block,
         )
-        self.check_combine_result(
-            op,
-            test_data,
-            combine_output,
-            combine_data_type=self.combine_data_type,
-        )
+        if check:
+            self.check_combine_result(
+                op,
+                test_data,
+                combine_output,
+                combine_data_type=self.combine_data_type,
+            )
         self.sync()
         return total_recv_num_token
 
@@ -287,6 +290,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
             dispatch_warp_per_block,
             combine_block_num,
             combine_warp_per_block,
+            check=False,
         )
 
         # Split dispatch/combine into two graphs so we can time each replay
@@ -430,8 +434,6 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
         disp_avg_bytes_MB_list = []
         comb_avg_bytes_MB_list = []
 
-        test_data_list = [self.gen_test_data() for i in range(iters)]
-
         for i in range(iters):
             self.sync()
             (
@@ -445,7 +447,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
                 ll_mode_scale,
             ) = self.run_once_bench(
                 op,
-                test_data_list[i],
+                test_data,
                 dispatch_block_num,
                 dispatch_warp_per_block,
                 combine_block_num,
@@ -560,6 +562,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
             dispatch_warp_per_block,
             combine_block_num,
             combine_warp_per_block,
+            check=False,
         )
         g = self._capture_e2e_graph(
             op,

--- a/tests/python/ops/conftest.py
+++ b/tests/python/ops/conftest.py
@@ -1,0 +1,52 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import os
+
+import pytest
+from tests.python.ops.dispatch_combine_test_utils import (
+    start_torch_dist_process_manager,
+)
+
+
+@pytest.fixture(scope="session")
+def torch_dist_process_manager():
+    """Single shared worker pool for all ops tests."""
+    manager = start_torch_dist_process_manager(world_size=8)
+    yield manager
+    manager.shutdown()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def set_shmem_heap_size():
+    # Set shmem heap size for all tests in this directory.
+    # 32G is the minimum required by the large-token internode_v1 test
+    # (~17.7 GB per rank).  Using a session-scoped fixture (instead of
+    # pytest_configure) so the override is scoped to ops/ tests only and
+    # does not bleed into other test directories (e.g. shmem/) when the
+    # full suite is collected together.
+    prev = os.environ.get("MORI_SHMEM_HEAP_SIZE")
+    os.environ["MORI_SHMEM_HEAP_SIZE"] = "32G"
+    yield
+    if prev is None:
+        os.environ.pop("MORI_SHMEM_HEAP_SIZE", None)
+    else:
+        os.environ["MORI_SHMEM_HEAP_SIZE"] = prev

--- a/tests/python/ops/dispatch_combine_test_utils.py
+++ b/tests/python/ops/dispatch_combine_test_utils.py
@@ -384,7 +384,7 @@ class EpDispatchCombineTestCase:
                     )
                 assert weight_match
 
-    def run_test_once(self, op, test_data):
+    def run_test_once(self, op, test_data, check_results=True):
         (
             _,
             all_rank_indices,
@@ -405,15 +405,16 @@ class EpDispatchCombineTestCase:
             all_rank_indices[self.config.rank],
         )
         self.sync()
-        self.check_dispatch_result(
-            op,
-            test_data,
-            dispatch_output,
-            dispatch_weights,
-            dispatch_scales,
-            dispatch_indices,
-            dispatch_recv_num_token,
-        )
+        if check_results:
+            self.check_dispatch_result(
+                op,
+                test_data,
+                dispatch_output,
+                dispatch_weights,
+                dispatch_scales,
+                dispatch_indices,
+                dispatch_recv_num_token,
+            )
 
         total_recv_num_token = dispatch_recv_num_token[0].item()
         if not self.config.use_external_inp_buf:
@@ -427,7 +428,10 @@ class EpDispatchCombineTestCase:
             dispatch_output, dispatch_weights, dispatch_indices, call_reset=False
         )
         self.sync()
-        self.check_combine_result(op, test_data, combine_output, combine_output_weight)
+        if check_results:
+            self.check_combine_result(
+                op, test_data, combine_output, combine_output_weight
+            )
 
 
 def run_ep_dispatch_combine_test(
@@ -436,6 +440,7 @@ def run_ep_dispatch_combine_test(
     use_max_token_num=False,
     routing=None,
     num_token_override=None,
+    check_results=True,
 ):
     op = mori.ops.EpDispatchCombineOp(config)
     test_case = test_case_cls(config)
@@ -447,4 +452,4 @@ def run_ep_dispatch_combine_test(
     if num_token_override is not None:
         gen_kwargs["num_token_override"] = num_token_override
     test_data = test_case.gen_test_data(**gen_kwargs)
-    test_case.run_test_once(op, test_data)
+    test_case.run_test_once(op, test_data, check_results=check_results)

--- a/tests/python/ops/test_dispatch_combine_async_ll.py
+++ b/tests/python/ops/test_dispatch_combine_async_ll.py
@@ -19,9 +19,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-import os
-
 import mori
+import os
 import pytest
 import torch
 from tests.python.ops.dispatch_combine_test_utils import (
@@ -30,10 +29,7 @@ from tests.python.ops.dispatch_combine_test_utils import (
     EpDispatchCombineTestCase,
     assert_worker_results,
     run_ep_dispatch_combine_test,
-    start_torch_dist_process_manager,
 )
-
-os.environ.setdefault("MORI_SHMEM_HEAP_SIZE", "32G")
 
 
 class AsyncLLDispatchCombineTestCase(EpDispatchCombineTestCase):
@@ -85,13 +81,6 @@ class AsyncLLDispatchCombineTestCase(EpDispatchCombineTestCase):
             self.check_combine_result(op, test_data, combine_output, None)
 
 
-@pytest.fixture(scope="session")
-def torch_dist_process_manager():
-    manager = start_torch_dist_process_manager(world_size=8)
-    yield manager
-    manager.shutdown()
-
-
 def _make_asyncll_config(
     rank,
     world_size,
@@ -141,27 +130,31 @@ def _test_dispatch_combine(
     num_token_override=None,
     check_results=True,
 ):
-    config = _make_asyncll_config(
-        rank=rank,
-        world_size=world_size,
-        data_type=data_type,
-        hidden_dim=hidden_dim,
-        max_num_inp_token_per_rank=max_num_inp_token_per_rank,
-        num_experts_per_rank=num_experts_per_rank,
-        num_experts_per_token=num_experts_per_token,
-        scale_dim=scale_dim,
-        scale_type_size=scale_type_size,
-        quant_type=quant_type,
-        max_total_recv_tokens=max_total_recv_tokens,
-    )
-    run_ep_dispatch_combine_test(
-        config,
-        AsyncLLDispatchCombineTestCase,
-        use_max_token_num=use_max_token_num,
-        routing=routing,
-        num_token_override=num_token_override,
-        check_results=check_results,
-    )
+    os.environ["MORI_DISABLE_P2P"] = "1"
+    try:
+        config = _make_asyncll_config(
+            rank=rank,
+            world_size=world_size,
+            data_type=data_type,
+            hidden_dim=hidden_dim,
+            max_num_inp_token_per_rank=max_num_inp_token_per_rank,
+            num_experts_per_rank=num_experts_per_rank,
+            num_experts_per_token=num_experts_per_token,
+            scale_dim=scale_dim,
+            scale_type_size=scale_type_size,
+            quant_type=quant_type,
+            max_total_recv_tokens=max_total_recv_tokens,
+        )
+        run_ep_dispatch_combine_test(
+            config,
+            AsyncLLDispatchCombineTestCase,
+            use_max_token_num=use_max_token_num,
+            routing=routing,
+            num_token_override=num_token_override,
+            check_results=check_results,
+        )
+    finally:
+        os.environ.pop("MORI_DISABLE_P2P", None)
 
 
 def _test_dispatch_combine_multi_iteration(
@@ -178,26 +171,30 @@ def _test_dispatch_combine_multi_iteration(
     quant_type="none",
     routing="round_robin",
 ):
-    config = _make_asyncll_config(
-        rank=rank,
-        world_size=world_size,
-        data_type=data_type,
-        hidden_dim=hidden_dim,
-        max_num_inp_token_per_rank=max_num_inp_token_per_rank,
-        num_experts_per_rank=num_experts_per_rank,
-        num_experts_per_token=num_experts_per_token,
-        scale_dim=scale_dim,
-        scale_type_size=scale_type_size,
-        quant_type=quant_type,
-    )
-    op = mori.ops.EpDispatchCombineOp(config)
-    test_case = AsyncLLDispatchCombineTestCase(config)
-
-    for num_token_override in num_token_patterns:
-        test_data = test_case.gen_test_data(
-            routing=routing, num_token_override=num_token_override
+    os.environ["MORI_DISABLE_P2P"] = "1"
+    try:
+        config = _make_asyncll_config(
+            rank=rank,
+            world_size=world_size,
+            data_type=data_type,
+            hidden_dim=hidden_dim,
+            max_num_inp_token_per_rank=max_num_inp_token_per_rank,
+            num_experts_per_rank=num_experts_per_rank,
+            num_experts_per_token=num_experts_per_token,
+            scale_dim=scale_dim,
+            scale_type_size=scale_type_size,
+            quant_type=quant_type,
         )
-        test_case.run_test_once(op, test_data)
+        op = mori.ops.EpDispatchCombineOp(config)
+        test_case = AsyncLLDispatchCombineTestCase(config)
+
+        for num_token_override in num_token_patterns:
+            test_data = test_case.gen_test_data(
+                routing=routing, num_token_override=num_token_override
+            )
+            test_case.run_test_once(op, test_data)
+    finally:
+        os.environ.pop("MORI_DISABLE_P2P", None)
 
 
 @pytest.mark.parametrize("world_size", (8,))

--- a/tests/python/ops/test_dispatch_combine_async_ll.py
+++ b/tests/python/ops/test_dispatch_combine_async_ll.py
@@ -33,11 +33,11 @@ from tests.python.ops.dispatch_combine_test_utils import (
     start_torch_dist_process_manager,
 )
 
-os.environ.setdefault("MORI_SHMEM_HEAP_SIZE", "6G")
+os.environ.setdefault("MORI_SHMEM_HEAP_SIZE", "32G")
 
 
 class AsyncLLDispatchCombineTestCase(EpDispatchCombineTestCase):
-    def run_test_once(self, op, test_data):
+    def run_test_once(self, op, test_data, check_results=True):
         (
             _,
             all_rank_indices,
@@ -60,15 +60,16 @@ class AsyncLLDispatchCombineTestCase(EpDispatchCombineTestCase):
         op.dispatch_recv()
 
         self.sync()
-        self.check_dispatch_result(
-            op,
-            test_data,
-            dispatch_output,
-            dispatch_weights,
-            dispatch_scales,
-            dispatch_indices,
-            dispatch_recv_num_token,
-        )
+        if check_results:
+            self.check_dispatch_result(
+                op,
+                test_data,
+                dispatch_output,
+                dispatch_weights,
+                dispatch_scales,
+                dispatch_indices,
+                dispatch_recv_num_token,
+            )
 
         # AsyncLL combine weight reconstruction is not exercised in the
         # reference example yet, so validate token reconstruction only.
@@ -80,7 +81,8 @@ class AsyncLLDispatchCombineTestCase(EpDispatchCombineTestCase):
         op.combine_recv()
 
         self.sync()
-        self.check_combine_result(op, test_data, combine_output, None)
+        if check_results:
+            self.check_combine_result(op, test_data, combine_output, None)
 
 
 @pytest.fixture(scope="session")
@@ -137,6 +139,7 @@ def _test_dispatch_combine(
     routing=None,
     use_max_token_num=False,
     num_token_override=None,
+    check_results=True,
 ):
     config = _make_asyncll_config(
         rank=rank,
@@ -157,6 +160,7 @@ def _test_dispatch_combine(
         use_max_token_num=use_max_token_num,
         routing=routing,
         num_token_override=num_token_override,
+        check_results=check_results,
     )
 
 

--- a/tests/python/ops/test_dispatch_combine_internode.py
+++ b/tests/python/ops/test_dispatch_combine_internode.py
@@ -19,7 +19,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-import os
 import pytest
 import mori
 from tests.python.ops.dispatch_combine_test_utils import (
@@ -27,10 +26,7 @@ from tests.python.ops.dispatch_combine_test_utils import (
     _is_fp4x2_dtype,
     EpDispatchCombineTestCase,
     assert_worker_results,
-    start_torch_dist_process_manager,
 )
-
-os.environ.setdefault("MORI_SHMEM_HEAP_SIZE", "6G")
 
 
 class InterNodeDispatchCombineTestCase(EpDispatchCombineTestCase):
@@ -64,13 +60,6 @@ class InterNodeDispatchCombineTestCase(EpDispatchCombineTestCase):
 
         op.combine(dispatch_output, dispatch_weights, dispatch_indices, call_reset=True)
         self.sync()
-
-
-@pytest.fixture(scope="session")
-def torch_dist_process_manager():
-    manager = start_torch_dist_process_manager(world_size=8, disable_p2p=True)
-    yield manager
-    manager.shutdown()
 
 
 def _test_dispatch_combine(

--- a/tests/python/ops/test_dispatch_combine_internode_v1.py
+++ b/tests/python/ops/test_dispatch_combine_internode_v1.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 import os
 import pytest
+import torch
 import mori
 from tests.python.ops.dispatch_combine_test_utils import (
     _all_data_types,
@@ -31,7 +32,7 @@ from tests.python.ops.dispatch_combine_test_utils import (
     start_torch_dist_process_manager,
 )
 
-os.environ.setdefault("MORI_SHMEM_HEAP_SIZE", "6G")
+os.environ.setdefault("MORI_SHMEM_HEAP_SIZE", "32G")
 
 # Kernel-type string → (EpDispatchCombineKernelType, block_num, rdma_block_num, warp_num_per_block)
 _KERNEL_CONFIGS = {
@@ -48,45 +49,6 @@ _KERNEL_CONFIGS = {
         8,  # warp_num_per_block
     ),
 }
-
-
-class InterNodeV1DispatchCombineTestCase(EpDispatchCombineTestCase):
-    def run_test_once(self, op, test_data):
-        (
-            _,
-            all_rank_indices,
-            all_rank_input,
-            all_rank_weights,
-            all_rank_scales,
-        ) = test_data
-        (
-            dispatch_output,
-            dispatch_weights,
-            dispatch_scales,
-            dispatch_indices,
-            dispatch_recv_num_token,
-        ) = op.dispatch(
-            all_rank_input[self.config.rank],
-            all_rank_weights[self.config.rank],
-            all_rank_scales[self.config.rank],
-            all_rank_indices[self.config.rank],
-        )
-        self.sync()
-        self.check_dispatch_result(
-            op,
-            test_data,
-            dispatch_output,
-            dispatch_weights,
-            dispatch_scales,
-            dispatch_indices,
-            dispatch_recv_num_token,
-        )
-
-        combine_output, combine_output_weight = op.combine(
-            dispatch_output, dispatch_weights, dispatch_indices, call_reset=False
-        )
-        self.sync()
-        self.check_combine_result(op, test_data, combine_output, combine_output_weight)
 
 
 @pytest.fixture(scope="session")
@@ -148,6 +110,7 @@ def _test_dispatch_combine(
     max_total_recv_tokens=0,
     routing=None,
     use_max_token_num=False,
+    check_results=True,
 ):
     config = _make_internode_v1_config(
         rank=rank,
@@ -165,9 +128,10 @@ def _test_dispatch_combine(
     )
     run_ep_dispatch_combine_test(
         config,
-        InterNodeV1DispatchCombineTestCase,
+        EpDispatchCombineTestCase,
         use_max_token_num=use_max_token_num,
         routing=routing,
+        check_results=check_results,
     )
 
 
@@ -339,3 +303,48 @@ def test_dispatch_combine_max_total_recv_tokens_under_budget(
         )
 
     assert_worker_results(torch_dist_process_manager, world_size)
+
+
+# ---------------------------------------------------------------------------
+# Large token num test (InterNodeV1 / InterNodeV1LL)
+#
+# Stress-test with 65536 tokens per rank (512K tokens total across 8 ranks)
+# and hidden_dim=7168.  Only checks that dispatch+combine complete without
+# error; correctness checks are skipped because they are too slow at this scale.
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_combine_large_token_num(
+    torch_dist_process_manager,
+):
+    """Dispatch + combine with max_num_inp_token_per_rank=65536, hidden_dim=7168.
+
+    Tested for both InterNodeV1 and InterNodeV1LL kernel types.
+    Correctness is not verified — only that the kernel completes without error.
+    """
+    world_size = 8
+    for kernel_type in ("internode_v1", "internode_v1_ll"):
+        for _ in range(world_size):
+            torch_dist_process_manager.task_queue.put(
+                (
+                    _test_dispatch_combine,
+                    [
+                        world_size,
+                        kernel_type,
+                        torch.bfloat16,  # data_type
+                        7168,  # hidden_dim
+                        65536,  # max_num_inp_token_per_rank
+                        32,  # num_experts_per_rank
+                        8,  # num_experts_per_token
+                        8,  # gpu_per_node
+                        0,  # scale_dim
+                        1,  # scale_type_size
+                        0,  # max_total_recv_tokens
+                        None,  # routing
+                        True,  # use_max_token_num
+                        False,  # check_results
+                    ],
+                )
+            )
+
+        assert_worker_results(torch_dist_process_manager, world_size)

--- a/tests/python/ops/test_dispatch_combine_internode_v1.py
+++ b/tests/python/ops/test_dispatch_combine_internode_v1.py
@@ -19,7 +19,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-import os
 import pytest
 import torch
 import mori
@@ -29,10 +28,7 @@ from tests.python.ops.dispatch_combine_test_utils import (
     EpDispatchCombineTestCase,
     assert_worker_results,
     run_ep_dispatch_combine_test,
-    start_torch_dist_process_manager,
 )
-
-os.environ.setdefault("MORI_SHMEM_HEAP_SIZE", "32G")
 
 # Kernel-type string → (EpDispatchCombineKernelType, block_num, rdma_block_num, warp_num_per_block)
 _KERNEL_CONFIGS = {
@@ -49,13 +45,6 @@ _KERNEL_CONFIGS = {
         8,  # warp_num_per_block
     ),
 }
-
-
-@pytest.fixture(scope="session")
-def torch_dist_process_manager():
-    manager = start_torch_dist_process_manager(world_size=8, disable_p2p=True)
-    yield manager
-    manager.shutdown()
 
 
 def _make_internode_v1_config(

--- a/tests/python/ops/test_dispatch_combine_intranode.py
+++ b/tests/python/ops/test_dispatch_combine_intranode.py
@@ -19,7 +19,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-import os
 import pytest
 import mori
 import torch
@@ -29,17 +28,7 @@ from tests.python.ops.dispatch_combine_test_utils import (
     EpDispatchCombineTestCase,
     assert_worker_results,
     run_ep_dispatch_combine_test,
-    start_torch_dist_process_manager,
 )
-
-os.environ.setdefault("MORI_SHMEM_HEAP_SIZE", "32G")
-
-
-@pytest.fixture(scope="session")
-def torch_dist_process_manager():
-    manager = start_torch_dist_process_manager(world_size=8)
-    yield manager
-    manager.shutdown()
 
 
 def _make_intranode_config(

--- a/tests/python/ops/test_dispatch_combine_intranode.py
+++ b/tests/python/ops/test_dispatch_combine_intranode.py
@@ -32,7 +32,7 @@ from tests.python.ops.dispatch_combine_test_utils import (
     start_torch_dist_process_manager,
 )
 
-os.environ.setdefault("MORI_SHMEM_HEAP_SIZE", "4G")
+os.environ.setdefault("MORI_SHMEM_HEAP_SIZE", "32G")
 
 
 @pytest.fixture(scope="session")
@@ -67,8 +67,8 @@ def _make_intranode_config(
         num_experts_per_rank=num_experts_per_rank,
         num_experts_per_token=num_experts_per_token,
         max_token_type_size=4,
-        block_num=40,
-        warp_num_per_block=8,
+        block_num=256,
+        warp_num_per_block=16,
         use_external_inp_buf=use_external_inp_buf,
         kernel_type=mori.ops.EpDispatchCombineKernelType.IntraNode,
         max_total_recv_tokens=max_total_recv_tokens,
@@ -91,6 +91,7 @@ def _test_dispatch_combine(
     max_total_recv_tokens=0,
     routing=None,
     use_max_token_num=False,
+    check_results=True,
 ):
     config = _make_intranode_config(
         rank=rank,
@@ -111,6 +112,7 @@ def _test_dispatch_combine(
         EpDispatchCombineTestCase,
         use_max_token_num=use_max_token_num,
         routing=routing,
+        check_results=check_results,
     )
 
 
@@ -284,62 +286,43 @@ def test_dispatch_combine_max_total_recv_tokens_under_budget(
 
 
 # ---------------------------------------------------------------------------
-# Overflow assert test (IntraNode only, isolated subprocess)
+# Large token num test (IntraNode only)
+#
+# Stress-test with 65536 tokens per rank (512K tokens total across 8 ranks)
+# and hidden_dim=7168.  Only checks that dispatch+combine complete without
+# error; correctness checks are skipped because they are too slow at this scale.
 # ---------------------------------------------------------------------------
 
 
-# def _overflow_subprocess(rank, world_size, port):
-#     """Run in a spawned subprocess so the device assert doesn't poison the main test process."""
-#     from tests.python.utils import TorchDistContext
+def test_dispatch_combine_large_token_num(
+    torch_dist_process_manager,
+):
+    """Dispatch + combine with max_num_inp_token_per_rank=65536, hidden_dim=7168.
 
-#     with TorchDistContext(rank=rank, world_size=world_size, master_port=port):
-#         mori.shmem.shmem_torch_process_group_init("default")
-#         config = mori.ops.EpDispatchCombineConfig(
-#             data_type=torch.bfloat16,
-#             rank=rank,
-#             world_size=world_size,
-#             hidden_dim=4096,
-#             scale_dim=0,
-#             scale_type_size=1,
-#             max_token_type_size=4,
-#             max_num_inp_token_per_rank=32,
-#             num_experts_per_rank=32,
-#             num_experts_per_token=1,
-#             max_total_recv_tokens=64,  # per-PE limit = ceil(64/8) = 8
-#             block_num=40,
-#             warp_num_per_block=8,
-#             use_external_inp_buf=True,
-#             kernel_type=mori.ops.EpDispatchCombineKernelType.IntraNode,
-#         )
-#         op = mori.ops.EpDispatchCombineOp(config)
-#         test_case = EpDispatchCombineTestCase(config)
-#         # all_to_one: all tokens -> expert 0 (PE 0).
-#         # PE 0 receives 32 * 7 = 224 tokens but per-PE limit is 8 -> overflow.
-#         test_data = test_case.gen_test_data(
-#             use_max_token_num=True, routing="all_to_one"
-#         )
-#         (_, all_rank_indices, all_rank_input, all_rank_weights, all_rank_scales) = (
-#             test_data
-#         )
-#         op.dispatch(
-#             all_rank_input[rank],
-#             all_rank_weights[rank],
-#             all_rank_scales[rank],
-#             all_rank_indices[rank],
-#         )
-#         torch.cuda.synchronize()  # device assert surfaces here
+    Correctness is not verified — only that the kernel completes without error.
+    """
+    world_size = 8
+    for _ in range(world_size):
+        torch_dist_process_manager.task_queue.put(
+            (
+                _test_dispatch_combine,
+                [
+                    world_size,
+                    torch.bfloat16,  # data_type
+                    7168,  # hidden_dim
+                    65536,  # max_num_inp_token_per_rank
+                    32,  # num_experts_per_rank
+                    8,  # num_experts_per_token
+                    True,  # use_external_inp_buf
+                    0,  # scale_dim
+                    1,  # scale_type_size
+                    "none",  # quant_type
+                    0,  # max_total_recv_tokens
+                    None,  # routing
+                    True,  # use_max_token_num
+                    False,  # check_results
+                ],
+            )
+        )
 
-
-# def test_dispatch_combine_overflow_assert():
-#     """Verify per-PE overflow assert fires when routing exceeds maxTotalRecvTokens budget."""
-#     from tests.python.utils import get_free_port
-
-#     port = get_free_port()
-#     # spawn must raise due to device assert in at least one worker
-#     with pytest.raises(Exception):
-#         torch.multiprocessing.spawn(
-#             _overflow_subprocess,
-#             args=(8, port),
-#             nprocs=8,
-#             join=True,
-#         )
+    assert_worker_results(torch_dist_process_manager, world_size)

--- a/tests/python/shmem/conftest.py
+++ b/tests/python/shmem/conftest.py
@@ -1,0 +1,36 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def set_shmem_heap_size():
+    # Limit shmem heap size for shmem/ tests to 4 GB.
+    prev = os.environ.get("MORI_SHMEM_HEAP_SIZE")
+    os.environ["MORI_SHMEM_HEAP_SIZE"] = "4G"
+    yield
+    if prev is None:
+        os.environ.pop("MORI_SHMEM_HEAP_SIZE", None)
+    else:
+        os.environ["MORI_SHMEM_HEAP_SIZE"] = prev


### PR DESCRIPTION
- Add config.HiddenDimSz() of size_t for correct index computation
- Refactor combine multi-warp index computation
- Add overflow test for large token number