### PR TITLE
pybind: release GIL for all UMBPClient methods to fix distributed-mod…

### DIFF
--- a/src/pybind/pybind_umbp.cpp
+++ b/src/pybind/pybind_umbp.cpp
@@ -132,20 +132,25 @@ void RegisterMoriUmbp(py::module_& m) {
 
   py::class_<UMBPClient>(m, "UMBPClient")
       .def(py::init<const UMBPConfig&>(), py::arg("config") = UMBPConfig{})
-      .def("put_from_ptr", &UMBPClient::PutFromPtr, py::arg("key"), py::arg("src"), py::arg("size"))
-      .def("get_into_ptr", &UMBPClient::GetIntoPtr, py::arg("key"), py::arg("dst"), py::arg("size"))
-      .def("exists", &UMBPClient::Exists, py::arg("key"))
-      .def("remove", &UMBPClient::Remove, py::arg("key"))
+      .def("put_from_ptr", &UMBPClient::PutFromPtr, py::arg("key"), py::arg("src"), py::arg("size"),
+           py::call_guard<py::gil_scoped_release>())
+      .def("get_into_ptr", &UMBPClient::GetIntoPtr, py::arg("key"), py::arg("dst"), py::arg("size"),
+           py::call_guard<py::gil_scoped_release>())
+      .def("exists", &UMBPClient::Exists, py::arg("key"), py::call_guard<py::gil_scoped_release>())
+      .def("remove", &UMBPClient::Remove, py::arg("key"), py::call_guard<py::gil_scoped_release>())
       .def("batch_put_from_ptr", &UMBPClient::BatchPutFromPtr, py::arg("keys"), py::arg("ptrs"),
-           py::arg("sizes"))
+           py::arg("sizes"), py::call_guard<py::gil_scoped_release>())
       .def("batch_put_from_ptr_with_depth", &UMBPClient::BatchPutFromPtrWithDepth, py::arg("keys"),
-           py::arg("ptrs"), py::arg("sizes"), py::arg("depths"))
+           py::arg("ptrs"), py::arg("sizes"), py::arg("depths"),
+           py::call_guard<py::gil_scoped_release>())
       .def("batch_get_into_ptr", &UMBPClient::BatchGetIntoPtr, py::arg("keys"), py::arg("ptrs"),
-           py::arg("sizes"))
-      .def("batch_exists", &UMBPClient::BatchExists, py::arg("keys"))
-      .def("batch_exists_consecutive", &UMBPClient::BatchExistsConsecutive, py::arg("keys"))
-      .def("clear", &UMBPClient::Clear)
-      .def("flush", &UMBPClient::Flush)
+           py::arg("sizes"), py::call_guard<py::gil_scoped_release>())
+      .def("batch_exists", &UMBPClient::BatchExists, py::arg("keys"),
+           py::call_guard<py::gil_scoped_release>())
+      .def("batch_exists_consecutive", &UMBPClient::BatchExistsConsecutive, py::arg("keys"),
+           py::call_guard<py::gil_scoped_release>())
+      .def("clear", &UMBPClient::Clear, py::call_guard<py::gil_scoped_release>())
+      .def("flush", &UMBPClient::Flush, py::call_guard<py::gil_scoped_release>())
       .def("is_distributed", &UMBPClient::IsDistributed);
 }
 


### PR DESCRIPTION
## Summary

- Add `py::call_guard<py::gil_scoped_release>()` to all `UMBPClient` pybind methods that may perform I/O, network (gRPC), or storage operations
- This prevents the Python GIL from being held during potentially long-running C++ calls in distributed UMBP mode

## Problem

In distributed UMBP mode, methods like `BatchExistsConsecutive` and `BatchGetIntoPtr` perform **synchronous gRPC `RouteGet` calls per key** inside C++. Without releasing the GIL, this starves the SGLang scheduler thread for **tens of seconds to minutes**, causing inference to completely stall while `/metrics` HTTP requests continue to succeed normally.

### Root Cause

`UMBPClient` pybind bindings did not release the GIL before entering C++. In local mode this was harmless (local lookups are microsecond-level), but in distributed mode each key miss triggers a blocking `RouteGet` RPC, and `BatchExistsConsecutive` calls `Exists` in a tight loop — holding the GIL for the entire duration.