### PR TITLE
io: disable auto XGMI backend for cross-process IPC transfers

### DIFF
--- a/src/io/engine.cpp
+++ b/src/io/engine.cpp
@@ -204,15 +204,16 @@ bool IOEngine::SupportsXgmiBackendByP2P() const {
 }
 
 void IOEngine::EnsureXgmiBackendCreatedIfSupported() {
-  bool isAutoXgmiDisabled = false;
   const char* disableAutoXgmi = std::getenv("MORI_DISABLE_AUTO_XGMI");
-  if (disableAutoXgmi != nullptr) {
-    isAutoXgmiDisabled = disableAutoXgmi[0] != '\0' && disableAutoXgmi[0] != '0';
-    if (isAutoXgmiDisabled) {
+  // Default: do not auto-create XGMI. Set MORI_DISABLE_AUTO_XGMI=0 to enable.
+  if (disableAutoXgmi == nullptr || disableAutoXgmi[0] != '0') {
+    if (disableAutoXgmi != nullptr && disableAutoXgmi[0] != '\0' && disableAutoXgmi[0] != '0') {
       MORI_IO_INFO("Auto XGMI creation is disabled by MORI_DISABLE_AUTO_XGMI");
-      return;
     }
+    return;
   }
+
+  MORI_IO_INFO("Auto XGMI creation is enabled by MORI_DISABLE_AUTO_XGMI=0");
 
   if (backends.find(BackendType::XGMI) != backends.end()) {
     return;

--- a/tests/python/io/test_engine.py
+++ b/tests/python/io/test_engine.py
@@ -160,7 +160,8 @@ def test_engine_desc_node_id_env_override(monkeypatch):
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="requires GPU")
-def test_rdmabackend_auto_creates_xgmi_backend_for_gpu_mem():
+def test_rdmabackend_auto_creates_xgmi_backend_for_gpu_mem(monkeypatch):
+    monkeypatch.setenv("MORI_DISABLE_AUTO_XGMI", "0")
     config = IOEngineConfig(
         host="127.0.0.1",
         port=get_free_port(),
@@ -193,7 +194,8 @@ def test_rdmabackend_auto_xgmi_can_be_disabled(monkeypatch):
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires 2 GPUs")
-def test_intra_node_prefers_xgmi_after_rdma_creation():
+def test_intra_node_prefers_xgmi_after_rdma_creation(monkeypatch):
+    monkeypatch.setenv("MORI_DISABLE_AUTO_XGMI", "0")
     config = IOEngineConfig(
         host="127.0.0.1",
         port=get_free_port(),


### PR DESCRIPTION
## Motivation
  Cross-process XGMI IPC via `hipIpcOpenMemHandle` produces data corruption under concurrent multi-handle workloads (36+ MemoryDescs, 72+ BatchWrite submissions), as seen in SGLang PD disaggregation on MI300X.
The corruption is non-deterministic and occurs regardless of:
  - device visibility (`CUDA_VISIBLE_DEVICES` vs `--base-gpu-id`)
  - copy API (hipMemcpyAsync D2D, hipMemcpyPeerAsync, scatter/gather kernel)
  - session semantics (hidden-device vs visible-device path)

Root cause is unreliable `hipIpcOpenMemHandle` mappings at scale — the call returns `hipSuccess` but the resulting pointers intermittently map to incorrect physical memory.

Disable auto XGMI creation by default. Users can re-enable it by setting `MORI_DISABLE_AUTO_XGMI=0` for intra-node workloads that do not use cross-process IPC at scale.