### PR TITLE
tune(mi355x): add IntraNode FP4 entries for >4k tokens on EP2/EP4

### DIFF
--- a/python/mori/ops/tuning_configs/gfx950_mi355x_IntraNode_ep2_combine.json
+++ b/python/mori/ops/tuning_configs/gfx950_mi355x_IntraNode_ep2_combine.json
@@ -92,6 +92,18 @@
     },
     {
       "dtype": "bf16",
+      "num_tokens": 12288,
+      "hidden_dim": 7168,
+      "zero_copy": false,
+      "quant_type": "fp8_direct_cast",
+      "block_num": 256,
+      "rdma_block_num": 0,
+      "warp_per_block": 16,
+      "bandwidth_gbps": 204.47,
+      "latency_us": 1716.85
+    },
+    {
+      "dtype": "bf16",
       "num_tokens": 64,
       "hidden_dim": 7168,
       "zero_copy": false,
@@ -173,6 +185,18 @@
       "warp_per_block": 16,
       "bandwidth_gbps": 101.9,
       "latency_us": 1148.1
+    },
+    {
+      "dtype": "bf16",
+      "num_tokens": 8192,
+      "hidden_dim": 7168,
+      "zero_copy": false,
+      "quant_type": "none",
+      "block_num": 256,
+      "rdma_block_num": 0,
+      "warp_per_block": 16,
+      "bandwidth_gbps": 103.04,
+      "latency_us": 2272.75
     },
     {
       "dtype": "bf16",

--- a/python/mori/ops/tuning_configs/gfx950_mi355x_IntraNode_ep2_dispatch.json
+++ b/python/mori/ops/tuning_configs/gfx950_mi355x_IntraNode_ep2_dispatch.json
@@ -77,6 +77,26 @@
       "latency_us": 341.55
     },
     {
+      "dtype": "fp4",
+      "num_tokens": 8192,
+      "hidden_dim": 3584,
+      "block_num": 256,
+      "rdma_block_num": 0,
+      "warp_per_block": 16,
+      "bandwidth_gbps": 89.7,
+      "latency_us": 652.65
+    },
+    {
+      "dtype": "fp4",
+      "num_tokens": 12288,
+      "hidden_dim": 3584,
+      "block_num": 256,
+      "rdma_block_num": 0,
+      "warp_per_block": 16,
+      "bandwidth_gbps": 90.94,
+      "latency_us": 965.0
+    },
+    {
       "dtype": "fp8_e4m3",
       "num_tokens": 64,
       "hidden_dim": 7168,


### PR DESCRIPTION
move from https://github.com/ROCm/mori/pull/269