### PR TITLE
tools: auto detect ionic env problem.

### DIFF
--- a/tools/env_check.sh
+++ b/tools/env_check.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# TODO: adapt for MLX (Mellanox/NVIDIA) and BRCM (Broadcom) NICs —
+#       currently ionic-specific (device detection, PFC/DCQCN knobs, port enumeration).
+
 set -uo pipefail
 
 # ============================ config ============================

--- a/tools/env_check.sh
+++ b/tools/env_check.sh
@@ -1,0 +1,317 @@
+#!/bin/bash
+
+set -uo pipefail
+
+# ============================ config ============================
+
+PEER_IP="${1:-}"
+BW_THRESHOLD=300    # Gbps
+LAT_THRESHOLD=10    # microseconds
+MSG_SIZE=65536      # 64K
+LAT_MSG_SIZE=2      # bytes (small message for latency)
+LAT_ITERS=5000      # iterations for latency test
+TEST_DURATION=2     # seconds
+IB_PORT=18515       # base port for ib_write_bw / ib_write_lat
+
+# ============================ helpers ===========================
+
+STEP=0
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+step()      { STEP=$((STEP + 1)); echo ""; echo -e "${CYAN}=== Step $STEP: $* ===${NC}"; }
+log_ok()    { echo -e "${GREEN}[OK]${NC}   $*"; }
+log_fail()  { echo -e "${RED}[FAIL]${NC} $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_skip()  { echo -e "${YELLOW}[SKIP]${NC} $*"; }
+
+die() { log_fail "$@"; exit 1; }
+
+require_cmd() {
+    command -v "$1" > /dev/null 2>&1 || die "$1 not found. Please install it first."
+}
+
+# query_rdma_devices [host]
+#   prints one RDMA device name per line; empty host = local
+query_rdma_devices() {
+    local host="${1:-}"
+    if [[ -z "$host" || "$host" == "localhost" || "$host" == "127.0.0.1" ]]; then
+        ibv_devices 2>/dev/null | awk '/^\s+[a-z]/ && $1 != "device" {print $1}'
+    else
+        ssh -o ConnectTimeout=5 "$host" "ibv_devices 2>/dev/null" \
+            | awk '/^\s+[a-z]/ && $1 != "device" {print $1}'
+    fi
+}
+
+# run_ib_bw_test <client_dev> <server_dev> <server_host> [check_threshold]
+#   check_threshold: if "true" (default), compare BW against BW_THRESHOLD
+run_ib_bw_test() {
+    local client_dev="$1" server_dev="$2" server_host="$3"
+    local check="${4:-true}"
+    local port=$((IB_PORT++))
+    local label="$client_dev -> $server_dev@$server_host"
+    local ib_args="-x 1 -p $port -s $MSG_SIZE -D $TEST_DURATION \
+        --report_gbits --sl $MORI_RDMA_SL"
+
+    if [[ "$server_host" == "localhost" || "$server_host" == "127.0.0.1" ]]; then
+        ib_write_bw -d "$server_dev" $ib_args &>/dev/null &
+    else
+        ssh "$server_host" "ib_write_bw -d $server_dev $ib_args" &>/dev/null &
+    fi
+    local server_pid=$!
+    sleep 1
+
+    local output rc=0
+    output=$(ib_write_bw -d "$client_dev" $ib_args "$server_host" 2>&1) || rc=$?
+    wait "$server_pid" 2>/dev/null
+
+    if [[ $rc -ne 0 ]]; then
+        log_fail "$label : ib_write_bw failed (rc=$rc)"; return 1
+    fi
+
+    # parse BW from the data line (format: "65536  ...  <BW_avg>  ...")
+    local bw
+    bw=$(echo "$output" | grep "^[[:space:]]*$MSG_SIZE" | awk '{print $(NF-1)}')
+    if [[ -z "$bw" ]]; then
+        log_fail "$label : cannot parse bandwidth"; return 1
+    fi
+
+    if [[ "$check" == "true" ]]; then
+        if (( $(echo "$bw >= $BW_THRESHOLD" | bc -l) )); then
+            log_ok "$label : ${bw} Gbps"
+        else
+            log_fail "$label : ${bw} Gbps (threshold: ${BW_THRESHOLD} Gbps)"; return 1
+        fi
+    else
+        log_ok "$label : ${bw} Gbps"
+    fi
+}
+
+# run_ib_lat_test <client_dev> <server_dev> <server_host>
+#   returns 0 if avg latency <= threshold, 1 otherwise
+run_ib_lat_test() {
+    local client_dev="$1" server_dev="$2" server_host="$3"
+    local port=$((IB_PORT++))
+    local label="$client_dev -> $server_dev@$server_host"
+    local ib_args="-x 1 -p $port -s $LAT_MSG_SIZE -n $LAT_ITERS --sl $MORI_RDMA_SL"
+
+    ssh "$server_host" "ib_write_lat -d $server_dev $ib_args" &>/dev/null &
+    local server_pid=$!
+    sleep 1
+
+    local output rc=0
+    output=$(ib_write_lat -d "$client_dev" $ib_args "$server_host" 2>&1) || rc=$?
+    wait "$server_pid" 2>/dev/null
+
+    if [[ $rc -ne 0 ]]; then
+        log_fail "$label : ib_write_lat failed (rc=$rc)"; return 1
+    fi
+
+    # columns: #bytes #iterations t_min t_max t_typical t_avg t_stdev 99% 99.9%
+    local avg_lat
+    avg_lat=$(echo "$output" | grep "^[[:space:]]*$LAT_MSG_SIZE" | awk '{print $6}')
+    if [[ -z "$avg_lat" ]]; then
+        log_fail "$label : cannot parse latency"; return 1
+    fi
+
+    if (( $(echo "$avg_lat <= $LAT_THRESHOLD" | bc -l) )); then
+        log_ok "$label : ${avg_lat} us"
+    else
+        log_fail "$label : ${avg_lat} us (threshold: ${LAT_THRESHOLD} us)"; return 1
+    fi
+}
+
+# ======================== check functions =======================
+
+check_versions() {
+    step "check ainic firmware and driver version"
+
+    local fw_output sw_output
+    fw_output=$(nicctl show version firmware)
+    sw_output=$(nicctl show version host-software)
+
+    local fw_versions fw_count
+    fw_versions=$(echo "$fw_output" | grep "Firmware-A" | awk '{print $NF}' | sort -u)
+    fw_count=$(echo "$fw_versions" | wc -l)
+    if [[ $fw_count -ne 1 ]]; then
+        log_warn "firmware versions not consistent across NICs:"
+        echo "$fw_versions"
+    else
+        log_ok "firmware         : $fw_versions"
+    fi
+
+    local nicctl_ver
+    nicctl_ver=$(echo "$sw_output" | grep "nicctl" | awk '{print $NF}')
+    [[ -n "$nicctl_ver" ]] && log_ok "nicctl           : $nicctl_ver" \
+                           || log_fail "cannot determine nicctl version"
+
+    local ionic_ver
+    ionic_ver=$(echo "$sw_output" | grep "ionic driver" | awk '{print $NF}')
+    [[ -n "$ionic_ver" ]] && log_ok "ionic driver     : $ionic_ver" \
+                           || log_fail "cannot determine ionic driver version"
+}
+
+check_qos() {
+    step "check QoS"
+
+    local qos_output
+    qos_output=$(nicctl show qos)
+
+    # classification type
+    local class_type
+    class_type=$(echo "$qos_output" | grep "Classification type" | head -1 | awk '{print $NF}')
+    [[ "$class_type" == "DSCP" ]] || die "classification type is '$class_type', expected 'DSCP'"
+    log_ok "classification type : DSCP"
+
+    # no-drop priority
+    ND_PRIO=$(echo "$qos_output" | grep "PFC no-drop priorities" | head -1 | awk '{print $NF}')
+    [[ -n "$ND_PRIO" ]] || die "cannot find PFC no-drop priority"
+    log_ok "no-drop priority : $ND_PRIO"
+
+    # PFC bitmap
+    local pfc_bitmap
+    pfc_bitmap=$(echo "$qos_output" | grep "PFC priority bitmap" | head -1 | awk '{print $NF}')
+    [[ -n "$pfc_bitmap" && "$pfc_bitmap" != "0x0" ]] || die "PFC is not enabled (bitmap=$pfc_bitmap)"
+    (( pfc_bitmap & (1 << ND_PRIO) )) || die "PFC bitmap $pfc_bitmap does not cover priority $ND_PRIO"
+    log_ok "PFC enabled for priority $ND_PRIO (bitmap=$pfc_bitmap)"
+
+    # scheduling info
+    local sched_line
+    sched_line=$(echo "$qos_output" | grep -E "^\s+${ND_PRIO}\s+" | head -1)
+    if [[ -n "$sched_line" ]]; then
+        log_ok "scheduling for priority $ND_PRIO : $(echo "$sched_line" | awk '{print $2}')  bandwidth=$(echo "$sched_line" | awk '{print $3}')"
+    else
+        log_warn "cannot find scheduling info for priority $ND_PRIO"
+    fi
+
+    # DSCP -> traffic class
+    # example line: "    DSCP : 24, 26, 46 ==> priority : 0"
+    local dscp_line nd_dscp tc
+    dscp_line=$(echo "$qos_output" | grep "DSCP" | grep "==>" | grep -v "bitmap" | grep ": ${ND_PRIO}$" | head -1)
+    nd_dscp=$(echo "$dscp_line" | awk -F': ' '{print $2}' | grep -o '[0-9]*' | head -1)
+    [[ -n "$nd_dscp" ]] || die "cannot find DSCP mapped to no-drop priority $ND_PRIO"
+
+    # TC = DSCP << 2 (DSCP sits in the upper 6 bits of the 8-bit TC field)
+    tc=$(( nd_dscp * 4 ))
+
+    export MORI_RDMA_SL=$ND_PRIO
+    export MORI_RDMA_TC=$tc
+
+    log_ok "no-drop DSCP     : $nd_dscp"
+    log_ok "traffic class    : $tc"
+    log_ok "MORI_RDMA_SL=$MORI_RDMA_SL  MORI_RDMA_TC=$MORI_RDMA_TC"
+}
+
+check_dcqcn() {
+    step "check DCQCN"
+
+    local dcqcn_output
+    dcqcn_output=$(nicctl show dcqcn)
+
+    local total
+    total=$(echo "$dcqcn_output" | grep -c "ROCE device")
+    [[ $total -gt 0 ]] || die "no ROCE devices found in dcqcn output"
+
+    local disabled
+    disabled=$(echo "$dcqcn_output" | grep "Status" | grep -v "Enabled" || true)
+    [[ -z "$disabled" ]] || { log_fail "some ROCE devices have DCQCN disabled:"; echo "$disabled"; exit 1; }
+    log_ok "DCQCN enabled on all $total ROCE devices"
+
+    local cnp_values cnp_count
+    cnp_values=$(echo "$dcqcn_output" | grep "DSCP value used for CNP" | awk '{print $NF}' | sort -u)
+    cnp_count=$(echo "$cnp_values" | wc -l)
+    [[ $cnp_count -eq 1 ]] || die "CNP DSCP not consistent across NICs: $cnp_values"
+    log_ok "CNP DSCP = $cnp_values (consistent across all NICs)"
+}
+
+check_intra_node_bw() {
+    step "intra-node bandwidth check"
+
+    command -v ib_write_bw > /dev/null 2>&1 || { log_warn "ib_write_bw not found, skipping"; return 0; }
+
+    LOCAL_DEVS=($(query_rdma_devices))
+    local count=${#LOCAL_DEVS[@]}
+    [[ $count -gt 0 ]] || { log_fail "no local RDMA devices found (check ibv_devices)"; return 1; }
+    log_ok "local RDMA devices ($count): ${LOCAL_DEVS[*]}"
+
+    if [[ $count -lt 2 ]]; then
+        log_skip "only 1 local RDMA device, skipping intra-node test"; return 0
+    fi
+
+    for (( i=1; i<count; i++ )); do
+        run_ib_bw_test "${LOCAL_DEVS[0]}" "${LOCAL_DEVS[$i]}" "localhost" "false"
+    done
+}
+
+check_inter_node_bw() {
+    step "inter-node bandwidth check"
+
+    command -v ib_write_bw > /dev/null 2>&1 || { log_warn "ib_write_bw not found, skipping"; return 0; }
+
+    if [[ -z "$PEER_IP" ]]; then
+        log_skip "no peer IP provided (usage: $0 <peer_ip>)"; return 0
+    fi
+
+    ping -c 2 -W 2 "$PEER_IP" > /dev/null 2>&1 || die "cannot ping $PEER_IP, skip inter-node bandwidth test"
+    log_ok "ping $PEER_IP reachable"
+
+    local remote_devs
+    remote_devs=($(query_rdma_devices "$PEER_IP"))
+    [[ ${#remote_devs[@]} -gt 0 ]] || { log_fail "no RDMA devices on $PEER_IP (check ibv_devices / ssh)"; return 1; }
+    log_ok "remote RDMA devices: ${remote_devs[*]}"
+
+    [[ ${#LOCAL_DEVS[@]} -gt 0 ]] || { log_fail "no local RDMA devices available"; return 1; }
+
+    local fail=0
+    for rdev in "${remote_devs[@]}"; do
+        run_ib_bw_test "${LOCAL_DEVS[0]}" "$rdev" "$PEER_IP" || fail=1
+    done
+
+    [[ $fail -eq 0 ]] && log_ok  "all inter-node pairs passed (>= ${BW_THRESHOLD} Gbps)" \
+                       || log_fail "some inter-node pairs failed"
+}
+
+check_inter_node_lat() {
+    step "inter-node latency check"
+
+    command -v ib_write_lat > /dev/null 2>&1 || { log_warn "ib_write_lat not found, skipping"; return 0; }
+
+    if [[ -z "$PEER_IP" ]]; then
+        log_skip "no peer IP provided (usage: $0 <peer_ip>)"; return 0
+    fi
+
+    ping -c 1 -W 2 "$PEER_IP" > /dev/null 2>&1 || die "cannot ping $PEER_IP, skip inter-node latency test"
+
+    local remote_devs
+    remote_devs=($(query_rdma_devices "$PEER_IP"))
+    [[ ${#remote_devs[@]} -gt 0 ]] || { log_fail "no RDMA devices on $PEER_IP"; return 1; }
+    [[ ${#LOCAL_DEVS[@]} -gt 0 ]]  || { log_fail "no local RDMA devices available"; return 1; }
+
+    local fail=0
+    for rdev in "${remote_devs[@]}"; do
+        run_ib_lat_test "${LOCAL_DEVS[0]}" "$rdev" "$PEER_IP" || fail=1
+    done
+
+    [[ $fail -eq 0 ]] && log_ok  "all inter-node pairs passed (<= ${LAT_THRESHOLD} us)" \
+                       || log_fail "some inter-node pairs failed"
+}
+
+# ============================= main =============================
+
+require_cmd nicctl
+[[ $EUID -eq 0 ]] || die "please run as root"
+
+LOCAL_DEVS=()
+
+check_versions
+check_qos
+check_dcqcn
+check_intra_node_bw
+check_inter_node_bw
+check_inter_node_lat
+
+echo ""
+echo "=== All checks completed ==="

--- a/tools/env_check.sh
+++ b/tools/env_check.sh
@@ -12,6 +12,8 @@ LAT_MSG_SIZE=2      # bytes (small message for latency)
 LAT_ITERS=5000      # iterations for latency test
 TEST_DURATION=2     # seconds
 IB_PORT=18515       # base port for ib_write_bw / ib_write_lat
+MORI_RDMA_SL=0      # overwritten by check_qos()
+MORI_RDMA_TC=0      # overwritten by check_qos()
 
 # ============================ helpers ===========================
 
@@ -155,7 +157,7 @@ check_versions() {
 }
 
 check_qos() {
-    step "check QoS"
+    step "check QoS and derive SL/TC"
 
     local qos_output
     qos_output=$(nicctl show qos)
@@ -167,42 +169,40 @@ check_qos() {
     log_ok "classification type : DSCP"
 
     # no-drop priority
-    ND_PRIO=$(echo "$qos_output" | grep "PFC no-drop priorities" | head -1 | awk '{print $NF}')
-    [[ -n "$ND_PRIO" ]] || die "cannot find PFC no-drop priority"
-    log_ok "no-drop priority : $ND_PRIO"
+    local nd_prio
+    nd_prio=$(echo "$qos_output" | grep "PFC no-drop priorities" | head -1 | awk '{print $NF}')
+    [[ -n "$nd_prio" ]] || die "cannot find PFC no-drop priority"
+    log_ok "no-drop priority : $nd_prio"
 
     # PFC bitmap
     local pfc_bitmap
     pfc_bitmap=$(echo "$qos_output" | grep "PFC priority bitmap" | head -1 | awk '{print $NF}')
     [[ -n "$pfc_bitmap" && "$pfc_bitmap" != "0x0" ]] || die "PFC is not enabled (bitmap=$pfc_bitmap)"
-    (( pfc_bitmap & (1 << ND_PRIO) )) || die "PFC bitmap $pfc_bitmap does not cover priority $ND_PRIO"
-    log_ok "PFC enabled for priority $ND_PRIO (bitmap=$pfc_bitmap)"
+    (( pfc_bitmap & (1 << nd_prio) )) || die "PFC bitmap $pfc_bitmap does not cover priority $nd_prio"
+    log_ok "PFC enabled for priority $nd_prio (bitmap=$pfc_bitmap)"
 
     # scheduling info
     local sched_line
-    sched_line=$(echo "$qos_output" | grep -E "^\s+${ND_PRIO}\s+" | head -1)
+    sched_line=$(echo "$qos_output" | grep -E "^\s+${nd_prio}\s+" | head -1)
     if [[ -n "$sched_line" ]]; then
-        log_ok "scheduling for priority $ND_PRIO : $(echo "$sched_line" | awk '{print $2}')  bandwidth=$(echo "$sched_line" | awk '{print $3}')"
+        log_ok "scheduling for priority $nd_prio : $(echo "$sched_line" | awk '{print $2}')  bw=$(echo "$sched_line" | awk '{print $3}')"
     else
-        log_warn "cannot find scheduling info for priority $ND_PRIO"
+        log_warn "cannot find scheduling info for priority $nd_prio"
     fi
 
     # DSCP -> traffic class
-    # example line: "    DSCP : 24, 26, 46 ==> priority : 0"
-    local dscp_line nd_dscp tc
-    dscp_line=$(echo "$qos_output" | grep "DSCP" | grep "==>" | grep -v "bitmap" | grep ": ${ND_PRIO}$" | head -1)
+    local dscp_line nd_dscp
+    dscp_line=$(echo "$qos_output" | grep "DSCP" | grep "==>" | grep -v "bitmap" | grep ": ${nd_prio}$" | head -1)
     nd_dscp=$(echo "$dscp_line" | awk -F': ' '{print $2}' | grep -o '[0-9]*' | head -1)
-    [[ -n "$nd_dscp" ]] || die "cannot find DSCP mapped to no-drop priority $ND_PRIO"
+    [[ -n "$nd_dscp" ]] || die "cannot find DSCP mapped to no-drop priority $nd_prio"
 
-    # TC = DSCP << 2 (DSCP sits in the upper 6 bits of the 8-bit TC field)
-    tc=$(( nd_dscp * 4 ))
-
-    export MORI_RDMA_SL=$ND_PRIO
-    export MORI_RDMA_TC=$tc
+    # TC = DSCP << 2 (DSCP occupies the upper 6 bits of the 8-bit TC/TOS field)
+    MORI_RDMA_SL="$nd_prio"
+    MORI_RDMA_TC=$(( nd_dscp * 4 ))
 
     log_ok "no-drop DSCP     : $nd_dscp"
-    log_ok "traffic class    : $tc"
-    log_ok "MORI_RDMA_SL=$MORI_RDMA_SL  MORI_RDMA_TC=$MORI_RDMA_TC"
+    log_ok "traffic class    : $MORI_RDMA_TC"
+    log_ok "SL=$MORI_RDMA_SL  TC=$MORI_RDMA_TC"
 }
 
 check_dcqcn() {

--- a/tools/env_check.sh
+++ b/tools/env_check.sh
@@ -43,7 +43,7 @@ query_rdma_devices() {
     if [[ -z "$host" || "$host" == "localhost" || "$host" == "127.0.0.1" ]]; then
         ibv_devices 2>/dev/null | awk '/^\s+[a-z]/ && $1 != "device" {print $1}'
     else
-        ssh -o ConnectTimeout=5 "$host" "ibv_devices 2>/dev/null" \
+        ssh -o ConnectTimeout=5 "$(whoami)"@"$host" "ibv_devices 2>/dev/null" \
             | awk '/^\s+[a-z]/ && $1 != "device" {print $1}'
     fi
 }
@@ -61,7 +61,7 @@ run_ib_bw_test() {
     if [[ "$server_host" == "localhost" || "$server_host" == "127.0.0.1" ]]; then
         ib_write_bw -d "$server_dev" $ib_args &>/dev/null &
     else
-        ssh "$server_host" "ib_write_bw -d $server_dev $ib_args" &>/dev/null &
+        ssh "$(whoami)"@"$server_host" "ib_write_bw -d $server_dev $ib_args" &>/dev/null &
     fi
     local server_pid=$!
     sleep 1
@@ -100,7 +100,7 @@ run_ib_lat_test() {
     local label="$client_dev -> $server_dev@$server_host"
     local ib_args="-x 1 -p $port -s $LAT_MSG_SIZE -n $LAT_ITERS --sl $MORI_RDMA_SL"
 
-    ssh "$server_host" "ib_write_lat -d $server_dev $ib_args" &>/dev/null &
+    ssh "$(whoami)"@"$server_host" "ib_write_lat -d $server_dev $ib_args" &>/dev/null &
     local server_pid=$!
     sleep 1
 
@@ -132,11 +132,11 @@ check_versions() {
     step "check ainic firmware and driver version"
 
     local fw_output sw_output
-    fw_output=$(nicctl show version firmware)
-    sw_output=$(nicctl show version host-software)
+    fw_output=$(sudo nicctl show version firmware)
+    sw_output=$(sudo nicctl show version host-software)
 
     local fw_versions fw_count
-    fw_versions=$(echo "$fw_output" | grep "Firmware-A" | awk '{print $NF}' | sort -u)
+    fw_versions=$(echo "$fw_output" | grep -i "firmware" | awk '{print $NF}' | sort -u)
     fw_count=$(echo "$fw_versions" | wc -l)
     if [[ $fw_count -ne 1 ]]; then
         log_warn "firmware versions not consistent across NICs:"
@@ -160,7 +160,7 @@ check_qos() {
     step "check QoS and derive SL/TC"
 
     local qos_output
-    qos_output=$(nicctl show qos)
+    qos_output=$(sudo nicctl show qos)
 
     # classification type
     local class_type
@@ -209,7 +209,7 @@ check_dcqcn() {
     step "check DCQCN"
 
     local dcqcn_output
-    dcqcn_output=$(nicctl show dcqcn)
+    dcqcn_output=$(sudo nicctl show dcqcn)
 
     local total
     total=$(echo "$dcqcn_output" | grep -c "ROCE device")
@@ -302,7 +302,7 @@ check_inter_node_lat() {
 # ============================= main =============================
 
 require_cmd nicctl
-[[ $EUID -eq 0 ]] || die "please run as root"
+# [[ $EUID -eq 0 ]] || die "please run as root"
 
 LOCAL_DEVS=()
 

--- a/tools/env_setup.sh
+++ b/tools/env_setup.sh
@@ -37,7 +37,7 @@ command -v nicctl &>/dev/null || { die "ionic devices found but nicctl not avail
 
 mori_env_setup() {
     local qos
-    qos=$(nicctl show qos) || die "nicctl show qos failed"
+    qos=$(sudo nicctl show qos) || die "nicctl show qos failed"
 
     local class_type
     class_type=$(echo "$qos" | grep "Classification type" | head -1 | awk '{print $NF}')
@@ -72,7 +72,7 @@ mori_env_setup() {
 setup_dcqcn() {
     local dev
     for dev in $IONIC_DEVS; do
-        nicctl update dcqcn -r "$dev" -i 1 \
+        sudo nicctl update dcqcn -r "$dev" -i 1 \
             --token-bucket-size 800000 \
             --ai-rate 160 \
             --alpha-update-interval 1 \

--- a/tools/env_setup.sh
+++ b/tools/env_setup.sh
@@ -8,7 +8,7 @@
 #   dcqcn  — configure DCQCN on all ionic ROCE devices only
 #   all    — both (default)
 #
-# Requires: nicctl, root
+# Requires: nicctl
 
 IONIC_VENDOR_ID="0x1dd8"
 
@@ -25,8 +25,6 @@ query_ionic_devices() {
         [[ "$vendor" == "$IONIC_VENDOR_ID" ]] && echo "$dev"
     done
 }
-
-[[ $EUID -eq 0 ]] || { die "please run as root"; return 2>/dev/null || exit 1; }
 
 IONIC_DEVS=$(query_ionic_devices)
 if [[ -z "$IONIC_DEVS" ]]; then

--- a/tools/env_setup.sh
+++ b/tools/env_setup.sh
@@ -2,13 +2,14 @@
 #
 # env_setup.sh — setup ionic NIC environment for mori.
 #
-# Usage:  source env_setup.sh [mori|dcqcn|all]
+# Steps (in order):
+#   1. setup_pfc         — configure PFC / DSCP / scheduling on all ionic ports
+#   2. setup_dcqcn       — configure DCQCN on all ionic ROCE devices
+#   3. mori_env_setup    — export MORI_RDMA_SL / MORI_RDMA_TC from QoS config
 #
-#   mori   — export MORI_RDMA_SL / MORI_RDMA_TC only
-#   dcqcn  — configure DCQCN on all ionic ROCE devices only
-#   all    — both (default)
+# Usage:  source env_setup.sh
 #
-# Requires: nicctl
+# Requires: nicctl, sudo
 
 IONIC_VENDOR_ID="0x1dd8"
 
@@ -32,6 +33,37 @@ if [[ -z "$IONIC_DEVS" ]]; then
     return 2>/dev/null || exit 0
 fi
 command -v nicctl &>/dev/null || { die "ionic devices found but nicctl not available"; return 2>/dev/null || exit 1; }
+
+setup_pfc() {
+    sudo nicctl update qos --classification-type dscp                          || { die "set classification-type failed"; return 1; }
+    sudo nicctl update port --all --pause-type pfc --rx-pause enable --tx-pause enable || { die "set pause failed"; return 1; }
+    sudo nicctl update qos dscp-to-priority --dscp 26 --priority 3             || { die "map DSCP 26 -> priority 3 failed"; return 1; }
+    sudo nicctl update qos dscp-to-priority --dscp 48 --priority 6             || { die "map DSCP 48 -> priority 6 failed"; return 1; }
+    sudo nicctl update qos pfc --priority 3 --no-drop enable                   || { die "enable PFC no-drop on priority 3 failed"; return 1; }
+    sudo nicctl update qos scheduling --priority 0,3,6 --dwrr 10,90,0 --rate-limit 0,0,0 || { die "set scheduling failed"; return 1; }
+    sudo nicctl update port --all --admin-state up                             || { die "set admin-state up failed"; return 1; }
+    log_ok "PFC / DSCP / scheduling configured"
+}
+
+setup_dcqcn() {
+    local dev
+    for dev in $IONIC_DEVS; do
+        sudo nicctl update dcqcn -r "$dev" -i 1 \
+            --token-bucket-size 800000 \
+            --ai-rate 160 \
+            --alpha-update-interval 1 \
+            --alpha-update-g 512 \
+            --initial-alpha-value 64 \
+            --rate-increase-byte-count 431068 \
+            --hai-rate 300 \
+            --rate-reduce-monitor-period 1 \
+            --rate-increase-threshold 1 \
+            --rate-increase-interval 1 \
+            --cnp-dscp 46 \
+            || { die "DCQCN setup failed for $dev"; return 1; }
+        log_ok "DCQCN configured on $dev"
+    done
+}
 
 mori_env_setup() {
     local qos
@@ -67,34 +99,7 @@ mori_env_setup() {
     log_ok "export MORI_RDMA_TC=$MORI_RDMA_TC"
 }
 
-setup_dcqcn() {
-    local dev
-    for dev in $IONIC_DEVS; do
-        sudo nicctl update dcqcn -r "$dev" -i 1 \
-            --token-bucket-size 800000 \
-            --ai-rate 160 \
-            --alpha-update-interval 1 \
-            --alpha-update-g 512 \
-            --initial-alpha-value 64 \
-            --rate-increase-byte-count 431068 \
-            --hai-rate 300 \
-            --rate-reduce-monitor-period 1 \
-            --rate-increase-threshold 1 \
-            --rate-increase-interval 1 \
-            --cnp-dscp 46 \
-            || { die "DCQCN setup failed for $dev"; return 1; }
-        log_ok "DCQCN configured on $dev"
-    done
-}
+setup_pfc && setup_dcqcn && mori_env_setup
 
-MODE="${1:-all}"
-
-case "$MODE" in
-    mori)  mori_env_setup ;;
-    dcqcn) setup_dcqcn ;;
-    all)   mori_env_setup; setup_dcqcn ;;
-    *)     echo "Usage: source env_setup.sh [mori|dcqcn|all]" ;;
-esac
-
-unset -f mori_env_setup setup_dcqcn query_ionic_devices log_ok log_warn die
-unset IONIC_VENDOR_ID IONIC_DEVS MODE GREEN RED YELLOW NC
+unset -f setup_pfc setup_dcqcn mori_env_setup query_ionic_devices log_ok log_warn die
+unset IONIC_VENDOR_ID IONIC_DEVS GREEN RED YELLOW NC

--- a/tools/env_setup.sh
+++ b/tools/env_setup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 #
+# TODO: adapt for MLX (Mellanox/NVIDIA) and BRCM (Broadcom) NICs —
+#       currently ionic-specific (PFC/DSCP setup, DCQCN config, device enumeration).
+#
 # env_setup.sh — setup ionic NIC environment for mori.
 #
 # Steps (in order):

--- a/tools/env_setup.sh
+++ b/tools/env_setup.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+#
+# env_setup.sh — setup ionic NIC environment for mori.
+#
+# Usage:  source env_setup.sh [mori|dcqcn|all]
+#
+#   mori   — export MORI_RDMA_SL / MORI_RDMA_TC only
+#   dcqcn  — configure DCQCN on all ionic ROCE devices only
+#   all    — both (default)
+#
+# Requires: nicctl, root
+
+IONIC_VENDOR_ID="0x1dd8"
+
+GREEN='\033[0;32m' RED='\033[0;31m' YELLOW='\033[0;33m' NC='\033[0m'
+
+log_ok()   { echo -e "${GREEN}[OK]${NC}   $*"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+die()      { echo -e "${RED}[FAIL]${NC} $*"; return 1; }
+
+query_ionic_devices() {
+    local dev vendor
+    for dev in $(ibv_devices 2>/dev/null | awk '/^\s+[a-z]/ && $1 != "device" {print $1}'); do
+        vendor=$(cat "/sys/class/infiniband/$dev/device/vendor" 2>/dev/null)
+        [[ "$vendor" == "$IONIC_VENDOR_ID" ]] && echo "$dev"
+    done
+}
+
+[[ $EUID -eq 0 ]] || { die "please run as root"; return 2>/dev/null || exit 1; }
+
+IONIC_DEVS=$(query_ionic_devices)
+if [[ -z "$IONIC_DEVS" ]]; then
+    log_warn "no ionic devices found (vendor=$IONIC_VENDOR_ID)"
+    return 2>/dev/null || exit 0
+fi
+command -v nicctl &>/dev/null || { die "ionic devices found but nicctl not available"; return 2>/dev/null || exit 1; }
+
+mori_env_setup() {
+    local qos
+    qos=$(nicctl show qos) || die "nicctl show qos failed"
+
+    local class_type
+    class_type=$(echo "$qos" | grep "Classification type" | head -1 | awk '{print $NF}')
+    [[ "$class_type" == "DSCP" ]] || die "classification type is '$class_type', expected 'DSCP'"
+
+    local nd_prio
+    nd_prio=$(echo "$qos" | grep "PFC no-drop priorities" | head -1 | awk '{print $NF}')
+    [[ -n "$nd_prio" ]] || die "cannot find PFC no-drop priority"
+
+    local pfc_bitmap
+    pfc_bitmap=$(echo "$qos" | grep "PFC priority bitmap" | head -1 | awk '{print $NF}')
+    if [[ -z "$pfc_bitmap" || "$pfc_bitmap" == "0x0" ]]; then
+        log_warn "PFC not enabled (bitmap=$pfc_bitmap)"
+    elif ! (( pfc_bitmap & (1 << nd_prio) )); then
+        log_warn "PFC bitmap $pfc_bitmap does not cover priority $nd_prio"
+    fi
+
+    local dscp_line nd_dscp
+    dscp_line=$(echo "$qos" | grep "DSCP" | grep "==>" | grep -v "bitmap" | grep ": ${nd_prio}$" | head -1)
+    nd_dscp=$(echo "$dscp_line" | awk -F': ' '{print $2}' | grep -o '[0-9]*' | head -1)
+    [[ -n "$nd_dscp" ]] || die "cannot find DSCP mapped to no-drop priority $nd_prio"
+
+    local tc=$(( nd_dscp * 4 ))
+
+    export MORI_RDMA_SL="$nd_prio"
+    export MORI_RDMA_TC="$tc"
+
+    log_ok "export MORI_RDMA_SL=$MORI_RDMA_SL"
+    log_ok "export MORI_RDMA_TC=$MORI_RDMA_TC"
+}
+
+setup_dcqcn() {
+    local dev
+    for dev in $IONIC_DEVS; do
+        nicctl update dcqcn -r "$dev" -i 1 \
+            --token-bucket-size 800000 \
+            --ai-rate 160 \
+            --alpha-update-interval 1 \
+            --alpha-update-g 512 \
+            --initial-alpha-value 64 \
+            --rate-increase-byte-count 431068 \
+            --hai-rate 300 \
+            --rate-reduce-monitor-period 1 \
+            --rate-increase-threshold 1 \
+            --rate-increase-interval 1 \
+            --cnp-dscp 46 \
+            || { die "DCQCN setup failed for $dev"; return 1; }
+        log_ok "DCQCN configured on $dev"
+    done
+}
+
+MODE="${1:-all}"
+
+case "$MODE" in
+    mori)  mori_env_setup ;;
+    dcqcn) setup_dcqcn ;;
+    all)   mori_env_setup; setup_dcqcn ;;
+    *)     echo "Usage: source env_setup.sh [mori|dcqcn|all]" ;;
+esac
+
+unset -f mori_env_setup setup_dcqcn query_ionic_devices log_ok log_warn die
+unset IONIC_VENDOR_ID IONIC_DEVS MODE GREEN RED YELLOW NC


### PR DESCRIPTION
## Summary

- Add `env_check.sh` — validates ionic NIC environment (firmware/driver version, QoS/DSCP/PFC config, DCQCN, intra/inter-node RDMA bandwidth and latency)
- Add `env_setup.sh` — configures ionic NIC environment (exports `MORI_RDMA_SL`/`MORI_RDMA_TC` from QoS config, sets DCQCN parameters on all ionic devices)

## Details

### `env_check.sh`
- 6-step validation: firmware version, QoS (DSCP classification, PFC, scheduling), DCQCN, intra-node BW, inter-node BW, inter-node latency
- Auto-discovers local/remote RDMA devices via `ibv_devices`
- Configurable thresholds (BW >= 300 Gbps, latency <= 10 us, 64K messages)
- Usage: 
- intra node: `./tools/env_check.sh`
- inter node: `./tools/env_check.sh [peer_ip]`

### `env_setup.sh`
- Detects ionic devices by vendor ID (`0x1dd8`) via sysfs, not device name
- Three modes: `mori` (export env vars), `dcqcn` (configure DCQCN), `all` (both, default)
- Usage: `source env_setup.sh [mori|dcqcn|all]`

## Test plan
- [ ] Run `sudo ./env_check.sh` on a single node — all QoS/DCQCN checks pass
- [ ] Run `sudo ./env_check.sh <peer_ip>` — inter-node BW and latency checks pass
- [ ] Run `source env_setup.sh mori` — `MORI_RDMA_SL` and `MORI_RDMA_TC` exported correctly
- [ ] Run `source env_setup.sh dcqcn` — DCQCN configured on all ionic devices
- [ ] Run `source env_setup.sh all` — both of the above