### PR TITLE
add FlyDSL integration for mori shmem device API

### DIFF
--- a/python/mori/ir/bitcode.py
+++ b/python/mori/ir/bitcode.py
@@ -37,10 +37,11 @@ import os
 from pathlib import Path
 
 _BC_FILENAME = "libmori_shmem_device.bc"
-_cached_path: str | None = None
+# Per-cov caches: {cov: path}
+_cached_paths: dict[int | None, str] = {}
 
 
-def _find_jit_cached_bitcode() -> str | None:
+def _find_jit_cached_bitcode(*, cov: int | None = None) -> str | None:
     """Look for a previously JIT-compiled bitcode in the cache directory."""
     try:
         from mori.jit.config import (
@@ -62,7 +63,7 @@ def _find_jit_cached_bitcode() -> str | None:
             mori_root / "include" / "mori" / "shmem",
             mori_root / "include" / "mori" / "core",
         ]
-        cache_dir = get_cache_dir(cfg.arch, source_paths, nic)
+        cache_dir = get_cache_dir(cfg.arch, source_paths, nic, cov=cov)
         bc_path = cache_dir / _BC_FILENAME
         if bc_path.is_file():
             return str(bc_path)
@@ -71,35 +72,43 @@ def _find_jit_cached_bitcode() -> str | None:
     return None
 
 
-def find_bitcode() -> str:
+def find_bitcode(*, cov: int | None = None) -> str:
     """Return the absolute path to ``libmori_shmem_device.bc``.
+
+    Args:
+        cov: AMDGPU code object version.  ``None`` (default) uses the
+             legacy search (pre-built bitcode or JIT with default cov=5,
+             compatible with Triton).  Pass ``cov=6`` for FlyDSL which
+             uses ABI 600.
 
     Prefers JIT-cached bitcode (compiled with the correct NIC branch for the
     runtime hardware) over pre-built bitcode that may lack NIC-specific symbols.
 
     Raises ``FileNotFoundError`` if the bitcode cannot be located or built.
     """
-    global _cached_path
-    if _cached_path is not None:
-        return _cached_path
+    cached = _cached_paths.get(cov)
+    if cached is not None:
+        return cached
 
     env = os.environ.get("MORI_SHMEM_BC")
     if env and os.path.isfile(env):
-        _cached_path = env
+        _cached_paths[cov] = env
         return env
 
-    jit_cached = _find_jit_cached_bitcode()
+    jit_cached = _find_jit_cached_bitcode(cov=cov)
     if jit_cached:
-        _cached_path = jit_cached
+        _cached_paths[cov] = jit_cached
         return jit_cached
 
+    # Pre-built bitcode (only valid when cov is not specified)
     pre_built: list[str] = []
-    here = Path(__file__).resolve().parent
-    pre_built.append(str(here / _BC_FILENAME))
+    if cov is None:
+        here = Path(__file__).resolve().parent
+        pre_built.append(str(here / _BC_FILENAME))
 
-    mori_root = here.parent.parent.parent
-    pre_built.append(str(mori_root / "lib" / _BC_FILENAME))
-    pre_built.append(str(mori_root / "build" / "lib" / _BC_FILENAME))
+        mori_root = here.parent.parent.parent
+        pre_built.append(str(mori_root / "lib" / _BC_FILENAME))
+        pre_built.append(str(mori_root / "build" / "lib" / _BC_FILENAME))
 
     jit_disabled = os.environ.get("MORI_DISABLE_JIT", "").lower() in ("1", "true", "on")
 
@@ -107,21 +116,25 @@ def find_bitcode() -> str:
         try:
             from mori.jit.core import ensure_bitcode
 
-            _cached_path = ensure_bitcode()
-            return _cached_path
+            jit_cov = cov if cov is not None else 5
+            path = ensure_bitcode(cov=jit_cov)
+            _cached_paths[cov] = path
+            return path
         except Exception:
             pass
 
     for p in pre_built:
         if os.path.isfile(p):
-            _cached_path = p
+            _cached_paths[cov] = p
             return p
 
     raise FileNotFoundError(
-        f"{_BC_FILENAME} not found. Searched: {pre_built}\n"
+        f"{_BC_FILENAME} not found (cov={cov}). Searched: {pre_built}\n"
         "Enable JIT compilation (unset MORI_DISABLE_JIT) or run:\n"
         "  MORI_PRECOMPILE=1 python -c 'import mori'"
     )
 
 
-get_bitcode_path = find_bitcode
+def get_bitcode_path(*, cov: int | None = None) -> str:
+    """Alias for :func:`find_bitcode`."""
+    return find_bitcode(cov=cov)

--- a/python/mori/ir/flydsl/__init__.py
+++ b/python/mori/ir/flydsl/__init__.py
@@ -1,0 +1,28 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+# MIT License
+"""
+mori.ir.flydsl — FlyDSL integration for mori shmem device API.
+
+Quick start::
+
+    from mori.ir import flydsl as mori_shmem
+    from mori.ir.flydsl import get_bitcode_path, install_hook
+
+    install_hook()
+
+    @flyc.kernel
+    def my_kernel(buf: fx.Tensor):
+        pe = mori_shmem.my_pe()
+        mori_shmem.putmem_nbi_warp(buf, buf, 64, (pe + 1) % 2, 0)
+        mori_shmem.quiet_thread_pe((pe + 1) % 2)
+
+Usage (with shmem compile helper)::
+
+    kernel_callable = compile_shmem_kernel(my_kernel, dummy_args, chip="gfx942")
+"""
+
+from .ops import *  # noqa: F401,F403
+from .ops import __all__ as _ops_all
+from .runtime import get_bitcode_path, install_hook
+
+__all__ = _ops_all + ["get_bitcode_path", "install_hook"]

--- a/python/mori/ir/flydsl/__init__.py
+++ b/python/mori/ir/flydsl/__init__.py
@@ -1,5 +1,24 @@
-# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
 # MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 """
 mori.ir.flydsl — FlyDSL integration for mori shmem device API.
 

--- a/python/mori/ir/flydsl/ops.py
+++ b/python/mori/ir/flydsl/ops.py
@@ -1,5 +1,24 @@
-# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
 # MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 """
 FlyDSL @flyc.kernel wrappers for mori shmem device functions.
 

--- a/python/mori/ir/flydsl/ops.py
+++ b/python/mori/ir/flydsl/ops.py
@@ -1,0 +1,54 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+# MIT License
+"""
+FlyDSL @flyc.kernel wrappers for mori shmem device functions.
+
+Auto-generated from ``mori.ir.ops.MORI_DEVICE_FUNCTIONS`` metadata.
+Each function maps 1-to-1 to a C symbol in ``libmori_shmem_device.bc``
+and is callable inside ``@flyc.kernel`` functions.
+
+Usage::
+
+    from mori.ir import flydsl as mori_shmem
+
+    @flyc.kernel
+    def my_kernel(buf: fx.Tensor):
+        pe  = mori_shmem.my_pe()
+        npe = mori_shmem.n_pes()
+        mori_shmem.quiet_thread_pe(pe)
+"""
+
+from mori.ir.ops import MORI_DEVICE_FUNCTIONS, SIGNAL_SET, SIGNAL_ADD
+
+# ExternFunction is provided by FlyDSL (Part B).
+# We use a lazy import so mori.ir.flydsl can be imported without FlyDSL installed;
+# ExternFunction is only needed when building a @flyc.kernel.
+def _get_extern_cls():
+    try:
+        from flydsl.expr.extern import ExternFunction
+        return ExternFunction
+    except ImportError as e:
+        raise ImportError(
+            "flydsl.expr.extern not found. "
+            "Make sure FlyDSL is installed and flydsl/expr/extern.py exists."
+        ) from e
+
+
+def _build_all():
+    """Populate module globals from MORI_DEVICE_FUNCTIONS."""
+    ExternFunction = _get_extern_cls()
+    ns = {}
+    for name, meta in MORI_DEVICE_FUNCTIONS.items():
+        ns[name] = ExternFunction(
+            symbol    = meta["symbol"],
+            arg_types = meta["args"],
+            ret_type  = meta["ret"],
+            is_pure   = meta.get("pure", False),
+        )
+    return ns
+
+
+_all_ops = _build_all()
+globals().update(_all_ops)
+
+__all__ = list(_all_ops.keys()) + ["SIGNAL_SET", "SIGNAL_ADD"]

--- a/python/mori/ir/flydsl/runtime.py
+++ b/python/mori/ir/flydsl/runtime.py
@@ -1,5 +1,24 @@
-# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
 # MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 """
 FlyDSL-specific runtime helpers for mori shmem integration.
 
@@ -12,14 +31,14 @@ from mori.ir.bitcode import find_bitcode
 
 
 def get_bitcode_path() -> str:
-    """Return the path to libmori_shmem_device.bc.
+    """Return the path to libmori_shmem_device.bc (compiled with cov=6 for FlyDSL ABI).
 
     Usage::
 
         from mori.ir.flydsl import get_bitcode_path
         bc = get_bitcode_path()
     """
-    return find_bitcode()
+    return find_bitcode(cov=6)
 
 
 def install_hook() -> None:
@@ -44,6 +63,28 @@ def install_hook() -> None:
 
     def _hook(hip_module: int) -> None:
         import mori.shmem as ms
+
         ms.shmem_module_init(hip_module)
 
     sc._shmem_post_compile_hook = _hook
+
+
+def install_jit_hook() -> None:
+    """Install FlyDSL JIT module-load hook for mori shmem.
+
+    When called, registers a callback in libfly_jit_runtime.so so that
+    every GPU module loaded by flyc.jit automatically gets its
+    ``globalGpuStates`` initialized via ``shmem_module_init``.
+
+    Call once before any shmem kernel launch via ``flyc.jit``::
+
+        from mori.ir.flydsl.runtime import install_jit_hook
+        install_jit_hook()
+
+    Note: If using ``@flyc.jit`` with ``ExternFunction`` that declares
+    ``mori_shmem_*`` symbols, the hook is installed automatically.
+    This function provides an explicit entry point for manual control.
+    """
+    from flydsl.compiler.jit_executor import _ensure_shmem_hook
+
+    _ensure_shmem_hook()

--- a/python/mori/ir/flydsl/runtime.py
+++ b/python/mori/ir/flydsl/runtime.py
@@ -1,0 +1,49 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+# MIT License
+"""
+FlyDSL-specific runtime helpers for mori shmem integration.
+
+  - ``get_bitcode_path()``  — returns the path to libmori_shmem_device.bc
+  - ``install_hook()``      — installs the FlyDSL post-compile hook that calls
+                              ``shmem_module_init`` to inject ``globalGpuStates``
+"""
+
+from mori.ir.bitcode import find_bitcode
+
+
+def get_bitcode_path() -> str:
+    """Return the path to libmori_shmem_device.bc.
+
+    Usage::
+
+        from mori.ir.flydsl import get_bitcode_path
+        bc = get_bitcode_path()
+    """
+    return find_bitcode()
+
+
+def install_hook() -> None:
+    """Install FlyDSL post-compile hook for mori shmem.
+
+    The hook calls ``mori.shmem.shmem_module_init(hip_module)`` after each
+    shmem kernel compilation so that the ``globalGpuStates`` device symbol is
+    properly initialized inside the compiled GPU module.
+
+    Call once before any shmem kernel launch::
+
+        from mori.ir.flydsl import install_hook
+        install_hook()
+    """
+    try:
+        from flydsl.compiler import shmem_compile as sc
+    except ImportError:
+        raise ImportError(
+            "flydsl.compiler.shmem_compile not found. "
+            "Make sure FlyDSL is installed with shmem support."
+        )
+
+    def _hook(hip_module: int) -> None:
+        import mori.shmem as ms
+        ms.shmem_module_init(hip_module)
+
+    sc._shmem_post_compile_hook = _hook

--- a/python/mori/jit/cache.py
+++ b/python/mori/jit/cache.py
@@ -60,16 +60,24 @@ def get_cache_dir(
     source_paths: list[Path],
     nic: str = "mlx5",
     profiler: bool = False,
+    *,
+    cov: int | None = None,
 ) -> Path:
     """Return the cache directory for a specific arch + NIC + content combo.
 
-    Structure: ``<cache_root>/<arch>_<nic>[_profiler]/<content_hash>/``
+    Structure: <cache_root>/<arch>_<nic>[_profiler][_cov<N>]/<content_hash>/
 
-    The ``profiler`` flag is encoded in the directory name so that kernels
-    compiled with ``ENABLE_PROFILER`` and without are cached separately.
+    Args:
+        profiler: When True, appends '_profiler' to the directory name so that
+                  kernels compiled with ENABLE_PROFILER are cached separately.
+        cov: AMDGPU code object version. When specified, the version is
+             included in the directory name to separate bitcode compiled
+             with different ABI versions (e.g. cov5 for Triton, cov6 for
+             FlyDSL).  None omits the suffix for backward compatibility.
     """
     content_hash = _hash_tree(source_paths)
     profiler_suffix = "_profiler" if profiler else ""
-    d = get_cache_root() / f"{arch}_{nic}{profiler_suffix}" / content_hash
+    cov_suffix = f"_cov{cov}" if cov is not None else ""
+    d = get_cache_root() / f"{arch}_{nic}{profiler_suffix}{cov_suffix}" / content_hash
     d.mkdir(parents=True, exist_ok=True)
     return d

--- a/python/mori/jit/core.py
+++ b/python/mori/jit/core.py
@@ -96,6 +96,8 @@ def _hipcc_device_bc(
     source: Path,
     include_dirs: list[Path],
     output: Path,
+    *,
+    cov: int = 5,
 ) -> None:
     """Compile a single source file to device-only bitcode."""
     cmd = [
@@ -105,7 +107,7 @@ def _hipcc_device_bc(
         "-emit-llvm",
         f"--offload-arch={cfg.arch}",
         "-fgpu-rdc",
-        "-mcode-object-version=5",
+        f"-mcode-object-version={cov}",
         "-std=c++17",
         "-O2",
         "-D__HIP_PLATFORM_AMD__",
@@ -230,7 +232,9 @@ def _collect_include_dirs(mori_root: Path) -> list[Path]:
     return dirs
 
 
-def _build_bitcode(cfg: BuildConfig, mori_root: Path, output: Path) -> None:
+def _build_bitcode(
+    cfg: BuildConfig, mori_root: Path, output: Path, *, cov: int = 5
+) -> None:
     """Full bitcode build pipeline: compile → link → strip → verify."""
     include_dirs = _collect_include_dirs(mori_root)
     wrapper_src = mori_root / "src" / "shmem" / "shmem_device_api_wrapper.cpp"
@@ -249,14 +253,14 @@ def _build_bitcode(cfg: BuildConfig, mori_root: Path, output: Path) -> None:
 
         nic = detect_nic_type()
         print(
-            f"[mori-jit] Compiling shmem device bitcode for {cfg.arch} (nic={nic}) ..."
+            f"[mori-jit] Compiling shmem device bitcode for {cfg.arch} (nic={nic}, cov={cov}) ..."
         )
 
         wrapper_bc = tmp_dir / "wrapper.bc"
-        _hipcc_device_bc(cfg, wrapper_src, include_dirs, wrapper_bc)
+        _hipcc_device_bc(cfg, wrapper_src, include_dirs, wrapper_bc, cov=cov)
 
         shim_bc = tmp_dir / "shim.bc"
-        _hipcc_device_bc(cfg, shim_src, include_dirs, shim_bc)
+        _hipcc_device_bc(cfg, shim_src, include_dirs, shim_bc, cov=cov)
 
         linked_bc = tmp_dir / "linked.bc"
         _llvm_link(cfg, [wrapper_bc, shim_bc], linked_bc)
@@ -442,8 +446,11 @@ def compile_genco(
     return str(hsaco_path)
 
 
-def ensure_bitcode() -> str:
+def ensure_bitcode(*, cov: int = 5) -> str:
     """Ensure the shmem device bitcode is compiled and cached. Returns the path.
+
+    Args:
+        cov: AMDGPU code object version (5 for Triton, 6 for FlyDSL).
 
     Thread/process safe: uses a file-based lock to prevent concurrent builds.
     """
@@ -463,7 +470,7 @@ def ensure_bitcode() -> str:
         mori_root / "include" / "mori" / "shmem",
         mori_root / "include" / "mori" / "core",
     ]
-    cache_dir = get_cache_dir(cfg.arch, source_paths, nic, profiler=profiler)
+    cache_dir = get_cache_dir(cfg.arch, source_paths, nic, profiler=profiler, cov=cov)
     bc_path = cache_dir / _BC_FILENAME
 
     if bc_path.is_file():
@@ -473,6 +480,6 @@ def ensure_bitcode() -> str:
     with FileBaton(lock_path, wait_for=str(bc_path)) as baton:
         if baton.skipped or bc_path.is_file():
             return str(bc_path)
-        _build_bitcode(cfg, mori_root, bc_path)
+        _build_bitcode(cfg, mori_root, bc_path, cov=cov)
 
     return str(bc_path)

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -73,16 +73,6 @@ def data_type_supported(dtype):
     return True
 
 
-def fp4_x2_to_fp32(tensor):
-    """将 float4_e2m1fn_x2 打包张量转为 float32，用于测试中打印/比对。"""
-    if not hasattr(torch, "float4_e2m1fn_x2") or tensor.dtype != torch.float4_e2m1fn_x2:
-        return tensor
-    try:
-        return tensor.float()
-    except Exception:
-        return tensor
-
-
 class TorchDistContext:
     def __init__(
         self,

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -73,6 +73,16 @@ def data_type_supported(dtype):
     return True
 
 
+def fp4_x2_to_fp32(tensor):
+    """将 float4_e2m1fn_x2 打包张量转为 float32，用于测试中打印/比对。"""
+    if not hasattr(torch, "float4_e2m1fn_x2") or tensor.dtype != torch.float4_e2m1fn_x2:
+        return tensor
+    try:
+        return tensor.float()
+    except Exception:
+        return tensor
+
+
 class TorchDistContext:
     def __init__(
         self,


### PR DESCRIPTION
## Motivation

Enable FlyDSL (`@flyc.kernel`) to call mori shmem device functions directly inside GPU kernels, mirroring the existing `mori.ir.triton` integration pattern. This is required by the FlyDSL-based EP dispatch/combine intranode kernel which relies on shmem P2P barriers and signaling.

## Technical Details

### New module `mori.ir.flydsl` (3 files)

- **`ops.py`** — auto-generates `ExternFunction` wrappers from `MORI_DEVICE_FUNCTIONS` metadata, making every shmem device function callable inside `@flyc.kernel`
- **`runtime.py`** — provides:
  - `get_bitcode_path()`: returns `libmori_shmem_device.bc` compiled with cov=6 for FlyDSL ABI
  - `install_hook()`: post-compile `shmem_module_init` injection
  - `install_jit_hook()`: JIT module-load callback registration
- **`__init__.py`** — re-exports ops + runtime, usage: `import mori.ir.flydsl as mori_shmem`

### COV (Code Object Version) support for JIT bitcode compilation

- **`ir/bitcode.py`** — `find_bitcode(cov=...)` supports per-cov caching; FlyDSL uses cov=6, Triton uses cov=5
- **`jit/cache.py`** — `get_cache_dir()` appends `_cov<N>` suffix to separate different ABI caches
- **`jit/core.py`** — threads `cov` parameter through `ensure_bitcode()` → `_build_bitcode()` → `_hipcc_device_bc()`, controlling `-mcode-object-version=<N>`

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
