### PR TITLE
fix: profile mode detection and doc corrections

### DIFF
--- a/docs/MORI-EP-BENCHMARK.md
+++ b/docs/MORI-EP-BENCHMARK.md
@@ -20,13 +20,13 @@ python3 tests/python/ops/bench_dispatch_combine.py
 
 ## Inter-node
 
-Run the following command on each node and replace `node_rank` with its actual rank. `master_addr` should be the IP of the rank 0 node. `GLOO_SOCKET_IFNAME` should be set to the TCP socket interface you want to use.
+Run the following command on each node and replace `node_rank` with its actual rank. `master_addr` should be the hostname or IP of the rank 0 node. `GLOO_SOCKET_IFNAME` should be set to the TCP socket interface you want to use.
 
 ```bash
-export GLOO_SOCKET_IFNAME=ens14np0
+export GLOO_SOCKET_IFNAME=enp81s0f1
 export MORI_RDMA_DEVICES=^mlx5_0,mlx5_1  # Optional: use `^` prefix to exclude specified devices
 
-torchrun --nnodes=2 --node_rank=0 --nproc_per_node=8 \
+torchrun --nnodes=2 --node_rank=0 --nproc_per_node=1 \
     --master_addr="10.194.129.65" --master_port=1234 \
     examples/ops/dispatch_combine/test_dispatch_combine_internode.py --bench
 ```
@@ -372,10 +372,11 @@ rm -rf ~/.mori
 Run on each node, substituting `node_rank` and `master_addr` as in the [Inter-node](#inter-node) section.  Use `--cmd profile` and pass the desired kernel type via `--kernel-type`:
 
 ```bash
-export GLOO_SOCKET_IFNAME=ens14np0
+export ENABLE_PROFILER=ON
+export GLOO_SOCKET_IFNAME=enp81s0f1
 export MORI_RDMA_DEVICES=^mlx5_0,mlx5_1  # optional
 
-torchrun --nnodes=2 --node_rank=0 --nproc_per_node=8 \
+torchrun --nnodes=2 --node_rank=0 --nproc_per_node=1 \
     --master_addr="10.194.129.65" --master_port=1234 \
     examples/ops/dispatch_combine/test_dispatch_combine_internode.py \
     --cmd profile --kernel-type v1

--- a/docs/MORI-EP-GUIDE.md
+++ b/docs/MORI-EP-GUIDE.md
@@ -504,7 +504,8 @@ if __name__ == "__main__":
 | `MORI_SHMEM_HEAP_SIZE` | — | Symmetric heap size (e.g., `"6G"`, `"2G"`). Must be set before shmem init. |
 | `MORI_RDMA_DEVICES` | all available | RDMA NIC selection. Include: `mlx5_0,mlx5_1`. Exclude: `^mlx5_2,mlx5_3` |
 | `MORI_EP_LAUNCH_CONFIG_MODE` | `"MANUAL"` | Launch config mode: `"MANUAL"` or `"AUTO"` |
-| `GLOO_SOCKET_IFNAME` | — | TCP interface for torch distributed (e.g., `ens14np0`) |
+| `ENABLE_PROFILER` | `""` (disabled) | Enable kernel profiler for JIT-compiled kernels. Set to `ON`, `1`, `true`, or `yes` to enable. Must also build with `ENABLE_PROFILER=ON`. |
+| `GLOO_SOCKET_IFNAME` | — | TCP interface for torch distributed (e.g., `enp81s0f1`) |
 | `MASTER_ADDR` | — | Torch distributed master address |
 | `MASTER_PORT` | — | Torch distributed master port |
 
@@ -524,10 +525,10 @@ python3 tests/python/ops/bench_dispatch_combine.py
 Run on each node (replace `node_rank` and `master_addr`):
 
 ```bash
-export GLOO_SOCKET_IFNAME=ens14np0
+export GLOO_SOCKET_IFNAME=enp81s0f1
 export MORI_RDMA_DEVICES=^mlx5_0,mlx5_1  # Optional: exclude specific NICs
 
-torchrun --nnodes=2 --node_rank=0 --nproc_per_node=8 \
+torchrun --nnodes=2 --node_rank=0 --nproc_per_node=1 \
     --master_addr="10.194.129.65" --master_port=1234 \
     examples/ops/dispatch_combine/test_dispatch_combine_internode.py --bench
 ```

--- a/python/mori/jit/config.py
+++ b/python/mori/jit/config.py
@@ -255,18 +255,13 @@ def detect_nic_type() -> str:
 
 
 def is_profiler_enabled() -> bool:
-    """Detect whether mori was built with ENABLE_PROFILER.
+    """Return True if the ENABLE_PROFILER environment variable is set to a truthy value.
 
-    Checks the compiled C++ extension for a profiler-only symbol
-    (``get_debug_time_buf``) so the result reflects the actual build,
-    not an environment variable that may be absent at inference time.
+    Accepted truthy values (case-insensitive): ``1``, ``true``, ``yes``, ``on``.
+    Any other value (including unset, ``0``, ``false``, ``no``, ``off``) is treated as disabled.
     """
-    try:
-        import mori.cpp  # type: ignore[import]
-
-        return hasattr(mori.cpp, "get_debug_time_buf")
-    except ImportError:
-        return False
+    val = os.environ.get("ENABLE_PROFILER", "")
+    return val.lower() in ("1", "true", "yes", "on")
 
 
 def detect_build_config() -> BuildConfig:

--- a/python/mori/kernel_profiler/__init__.py
+++ b/python/mori/kernel_profiler/__init__.py
@@ -179,7 +179,10 @@ def export_to_perfetto(
 
     if not raw_events:
         warnings.warn(
-            "No trace events found in buffer. The profiler might not have been used."
+            "No trace events found in buffer. Possible causes: "
+            "(1) the kernel does not have profiler instrumentation, or "
+            "(2) the JIT cache was built without ENABLE_PROFILER set "
+            "(clear ~/.mori and re-run with ENABLE_PROFILER=1)."
         )
         return
 


### PR DESCRIPTION
## Summary

- Fix `is_profiler_enabled()` to check the `ENABLE_PROFILER` env var instead of inspecting the compiled C++ extension — the old approach caused circular import deadlock when compile with `MORI_PRECOMPILE=1 python -c "import mori"`
- Improve `export_to_perfetto` warning to surface the likely cause (stale JIT cache built without `ENABLE_PROFILER`)
- Fix docs: update NIC interface names (`enp81s0f1`), add `ENABLE_PROFILER=ON` to profiling examples, correct `nproc_per_node`, add `ENABLE_PROFILER` to env var table