### PR TITLE
fix: unblock JAX gfx950 CI tests and wrap profiler macros 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install mori
         run: |
           $CT exec $CONTAINER bash -c \
-            "cd $GITHUB_WORKSPACE && BUILD_EXAMPLES=ON pip install -e . && pip install prettytable"
+            "cd $GITHUB_WORKSPACE && BUILD_EXAMPLES=ON pip install . && pip install prettytable"
 
       - name: MORI-EP (intranode)
         run: |
@@ -180,52 +180,54 @@ jobs:
           $CT exec $CONTAINER chown -R $(id -u):$(id -g) $GITHUB_WORKSPACE 2>/dev/null || true
           $CT rm -f $CONTAINER || true
 
-  # TODO: add JAX intranode test once conftest.py torch dependency is resolved
-  # and gfx950 JAX image is available.
-  # jax-intranode-test:
-  #   name: mori JAX intranode test (${{ matrix.platform }})
-  #   needs: build
-  #   runs-on: ${{ matrix.runner }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - platform: MI355X_AINIC
-  #           runner: [self-hosted, MI355X-AINIC]
-  #   timeout-minutes: 15
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #       with:
-  #         submodules: true
-  #
-  #     - name: Build JAX CI image
-  #       run: $CT build --network=host --build-arg GPU_TARGET=gfx950 -t rocm/mori:jax-ci -f docker/Dockerfile.jax091-rocm711 .
-  #
-  #     - name: Start container
-  #       run: |
-  #         $CT rm -f ${CONTAINER}_jax 2>/dev/null || true
-  #         CONTAINER_RUNTIME=$CT ./docker/ci_run.sh --name ${CONTAINER}_jax \
-  #           -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
-  #           -w $GITHUB_WORKSPACE \
-  #           rocm/mori:jax-ci sleep infinity
-  #
-  #     - name: Install mori (XLA FFI)
-  #       run: |
-  #         $CT exec ${CONTAINER}_jax bash -c \
-  #           "cd $GITHUB_WORKSPACE && BUILD_XLA_FFI_OPS=ON pip install --break-system-packages -v ."
-  #
-  #     - name: MORI-EP JAX test
-  #       run: |
-  #         $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE ${CONTAINER}_jax bash -c "
-  #           cd $GITHUB_WORKSPACE
-  #           MORI_KERNEL_DIR=\$(ls -d $GITHUB_WORKSPACE/build/lib/gfx* | head -1) \
-  #           timeout 300 pytest tests/python/ops/test_dispatch_combine_jax.py -s -v
-  #         "
-  #
-  #     - name: Cleanup
-  #       if: always()
-  #       run: $CT rm -f ${CONTAINER}_jax || true
+  jax-intranode-test:
+    name: mori JAX intranode test (${{ matrix.platform }})
+    needs: build
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: MI355X_AINIC
+            runner: [self-hosted, MI355X-AINIC]
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Build JAX CI image
+        run: |
+          $CT build --network=host \
+            --build-arg GPU_TARGET=gfx950 \
+            -t rocm/mori:jax-ci \
+            -f docker/Dockerfile.jax091-rocm711 .
+
+      - name: Start container
+        run: |
+          $CT rm -f ${CONTAINER}_jax 2>/dev/null || true
+          CONTAINER_RUNTIME=$CT ./docker/ci_run.sh --name ${CONTAINER}_jax \
+            -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
+            -w $GITHUB_WORKSPACE \
+            rocm/mori:jax-ci sleep infinity
+
+      - name: Install mori (XLA FFI)
+        run: |
+          $CT exec ${CONTAINER}_jax bash -c \
+            "cd $GITHUB_WORKSPACE && BUILD_XLA_FFI_OPS=ON pip install --break-system-packages ."
+
+      - name: MORI-EP JAX test
+        run: |
+          $CT exec ${CONTAINER}_jax bash -c "
+            cd $GITHUB_WORKSPACE
+            MORI_KERNEL_DIR=\$(ls -d $GITHUB_WORKSPACE/build/lib/gfx* | head -1) \
+            timeout 300 pytest tests/python/ops/test_dispatch_combine_jax.py -s -v
+          "
+
+      - name: Cleanup
+        if: always()
+        run: $CT rm -f ${CONTAINER}_jax || true
 
   internode-test:
     name: mori internode test (${{ matrix.platform }})
@@ -311,12 +313,12 @@ jobs:
       - name: Install mori (node1)
         run: |
           $CT exec $CONTAINER bash -c \
-            "cd $GITHUB_WORKSPACE && BUILD_EXAMPLES=ON pip install -e . && pip install prettytable"
+            "cd $GITHUB_WORKSPACE && BUILD_EXAMPLES=ON pip install . && pip install prettytable"
 
       - name: Install mori (node2)
         run: |
           ssh -p $NODE2_PORT $(whoami)@$NODE2_HOST \
-            "$CT exec $CONTAINER bash -c 'cd $GITHUB_WORKSPACE && BUILD_EXAMPLES=ON pip install -e . && pip install prettytable'"
+            "$CT exec $CONTAINER bash -c 'cd $GITHUB_WORKSPACE && BUILD_EXAMPLES=ON pip install . && pip install prettytable'"
 
       - name: MORI-IO internode write sweep
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,15 +219,11 @@ jobs:
           $CT exec ${CONTAINER}_jax bash -c \
             "cd $GITHUB_WORKSPACE && BUILD_XLA_FFI_OPS=ON pip install --break-system-packages ."
 
-      - name: Precompile JIT kernels (needed by XLA FFI C++ AutoLoad)
-        run: |
-          $CT exec ${CONTAINER}_jax bash -c \
-            "MORI_PRECOMPILE=1 python3 -c 'import mori'"
-
       - name: MORI-EP JAX test
         run: |
           $CT exec ${CONTAINER}_jax bash -c "
             cd $GITHUB_WORKSPACE
+            MORI_KERNEL_DIR=\$(ls -d $GITHUB_WORKSPACE/build/lib/gfx* | head -1) \
             timeout 300 pytest tests/python/ops/test_dispatch_combine_jax.py -s -v
           "
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,7 @@ jobs:
         include:
           - platform: MI355X_AINIC
             runner: [self-hosted, MI355X-AINIC]
+            rdma_devices: rocep105s0,rocep121s0,rocep137s0,rocep153s0,rocep233s0,rocep249s0,rocep25s0,rocep9s0
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -199,7 +200,7 @@ jobs:
 
       - name: Build JAX CI image
         run: |
-          $CT build --network=host \
+          $CT build --network=host --isolation=chroot \
             --build-arg GPU_TARGET=gfx950 \
             -t rocm/mori:jax-ci \
             -f docker/Dockerfile.jax091-rocm711 .
@@ -208,6 +209,7 @@ jobs:
         run: |
           $CT rm -f ${CONTAINER}_jax 2>/dev/null || true
           CONTAINER_RUNTIME=$CT ./docker/ci_run.sh --name ${CONTAINER}_jax \
+            -e MORI_RDMA_DEVICES=${{ matrix.rdma_devices }} \
             -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
             -w $GITHUB_WORKSPACE \
             rocm/mori:jax-ci sleep infinity
@@ -221,7 +223,7 @@ jobs:
         run: |
           $CT exec ${CONTAINER}_jax bash -c "
             cd $GITHUB_WORKSPACE
-            MORI_KERNEL_DIR=\$(ls -d $GITHUB_WORKSPACE/build/lib/gfx* | head -1) \
+            MORI_KERNEL_DIR=\$(ls -d $GITHUB_WORKSPACE/build/lib/gfx*_ionic 2>/dev/null | head -1) \
             timeout 300 pytest tests/python/ops/test_dispatch_combine_jax.py -s -v
           "
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,11 @@ jobs:
           $CT exec ${CONTAINER}_jax bash -c \
             "cd $GITHUB_WORKSPACE && BUILD_XLA_FFI_OPS=ON pip install --break-system-packages ."
 
+      - name: Precompile JIT kernels (needed by XLA FFI C++ AutoLoad)
+        run: |
+          $CT exec ${CONTAINER}_jax bash -c \
+            "MORI_PRECOMPILE=1 python3 -c 'import mori'"
+
       - name: MORI-EP JAX test
         run: |
           $CT exec ${CONTAINER}_jax bash -c "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,6 @@ jobs:
         run: |
           $CT exec ${CONTAINER}_jax bash -c "
             cd $GITHUB_WORKSPACE
-            MORI_KERNEL_DIR=\$(ls -d $GITHUB_WORKSPACE/build/lib/gfx*_ionic 2>/dev/null | head -1) \
             timeout 300 pytest tests/python/ops/test_dispatch_combine_jax.py -s -v
           "
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,8 +200,11 @@ jobs:
 
       - name: Build JAX CI image
         run: |
-          $CT build --network=host --isolation=chroot \
-            --build-arg GPU_TARGET=gfx950 \
+          BUILD_ARGS="--network=host --build-arg GPU_TARGET=gfx950"
+          if [ "$CT" = "podman" ]; then
+            BUILD_ARGS="$BUILD_ARGS --isolation=chroot"
+          fi
+          $CT build $BUILD_ARGS \
             -t rocm/mori:jax-ci \
             -f docker/Dockerfile.jax091-rocm711 .
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,56 +153,59 @@ add_library(mori_logging INTERFACE)
 target_include_directories(mori_logging INTERFACE include)
 target_link_libraries(mori_logging INTERFACE spdlog::spdlog)
 
-if(ENABLE_PROFILER)
-  find_package(
-    Python3
-    COMPONENTS Interpreter
-    REQUIRED)
+# ---------------------------------------------------------------------------
+# Profiler slot header generation (always needed — kernel sources
+# unconditionally #include "mori/profiler/profiler.hpp"; the generated
+# headers use #ifdef ENABLE_PROFILER guards so they are safe when OFF)
+# ---------------------------------------------------------------------------
+find_package(
+  Python3
+  COMPONENTS Interpreter
+  REQUIRED)
 
-  set(PROFILER_GEN_SCRIPT
-      ${CMAKE_SOURCE_DIR}/tools/profiler/generate_profiler_bindings.py)
-  set(PROFILER_OUTPUT_INCLUDE
-      ${CMAKE_BINARY_DIR}/generated/include/mori/profiler)
-  set(PROFILER_OUTPUT_PYBIND
-      ${CMAKE_BINARY_DIR}/generated/src/pybind/profiler_bindings_generated.cpp)
+set(PROFILER_GEN_SCRIPT
+    ${CMAKE_SOURCE_DIR}/tools/profiler/generate_profiler_bindings.py)
+set(PROFILER_OUTPUT_INCLUDE
+    ${CMAKE_BINARY_DIR}/generated/include/mori/profiler)
+set(PROFILER_OUTPUT_PYBIND
+    ${CMAKE_BINARY_DIR}/generated/src/pybind/profiler_bindings_generated.cpp)
 
-  file(GLOB_RECURSE KERNEL_SOURCES ${CMAKE_SOURCE_DIR}/src/ops/*.cpp)
+file(GLOB_RECURSE KERNEL_SOURCES ${CMAKE_SOURCE_DIR}/src/ops/*.cpp)
 
-  message(STATUS "Generating profiler bindings at configure time...")
-  execute_process(
-    COMMAND
-      ${Python3_EXECUTABLE} ${PROFILER_GEN_SCRIPT} ${CMAKE_SOURCE_DIR}
-      ${CMAKE_SOURCE_DIR}/src ${PROFILER_OUTPUT_INCLUDE}
-      ${PROFILER_OUTPUT_PYBIND}
-    RESULT_VARIABLE PROFILER_GEN_RESULT
-    OUTPUT_VARIABLE PROFILER_GEN_OUTPUT
-    ERROR_VARIABLE PROFILER_GEN_ERROR)
+message(STATUS "Generating profiler slot headers at configure time...")
+execute_process(
+  COMMAND
+    ${Python3_EXECUTABLE} ${PROFILER_GEN_SCRIPT} ${CMAKE_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/src ${PROFILER_OUTPUT_INCLUDE}
+    ${PROFILER_OUTPUT_PYBIND}
+  RESULT_VARIABLE PROFILER_GEN_RESULT
+  OUTPUT_VARIABLE PROFILER_GEN_OUTPUT
+  ERROR_VARIABLE PROFILER_GEN_ERROR)
 
-  if(NOT PROFILER_GEN_RESULT EQUAL 0)
-    message(
-      FATAL_ERROR
-        "Failed to generate profiler bindings:\nSTDOUT:\n${PROFILER_GEN_OUTPUT}\nSTDERR:\n${PROFILER_GEN_ERROR}"
-    )
-  endif()
-
-  add_custom_command(
-    OUTPUT ${PROFILER_OUTPUT_PYBIND}
-    COMMAND
-      ${Python3_EXECUTABLE} ${PROFILER_GEN_SCRIPT} ${CMAKE_SOURCE_DIR}
-      ${CMAKE_SOURCE_DIR}/src ${PROFILER_OUTPUT_INCLUDE}
-      ${PROFILER_OUTPUT_PYBIND}
-    DEPENDS ${KERNEL_SOURCES} ${PROFILER_GEN_SCRIPT}
-    COMMENT "Regenerating profiler bindings..."
-    VERBATIM)
-
-  add_custom_target(generate_profiler_bindings
-                    DEPENDS ${PROFILER_OUTPUT_PYBIND})
-
-  add_library(mori_profiler_interface INTERFACE)
-  target_include_directories(mori_profiler_interface
-                             INTERFACE ${CMAKE_BINARY_DIR}/generated/include)
-  add_dependencies(mori_profiler_interface generate_profiler_bindings)
+if(NOT PROFILER_GEN_RESULT EQUAL 0)
+  message(
+    FATAL_ERROR
+      "Failed to generate profiler bindings:\nSTDOUT:\n${PROFILER_GEN_OUTPUT}\nSTDERR:\n${PROFILER_GEN_ERROR}"
+  )
 endif()
+
+add_custom_command(
+  OUTPUT ${PROFILER_OUTPUT_PYBIND}
+  COMMAND
+    ${Python3_EXECUTABLE} ${PROFILER_GEN_SCRIPT} ${CMAKE_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/src ${PROFILER_OUTPUT_INCLUDE}
+    ${PROFILER_OUTPUT_PYBIND}
+  DEPENDS ${KERNEL_SOURCES} ${PROFILER_GEN_SCRIPT}
+  COMMENT "Regenerating profiler bindings..."
+  VERBATIM)
+
+add_custom_target(generate_profiler_bindings
+                  DEPENDS ${PROFILER_OUTPUT_PYBIND})
+
+add_library(mori_profiler_interface INTERFACE)
+target_include_directories(mori_profiler_interface
+                           INTERFACE ${CMAKE_BINARY_DIR}/generated/include)
+add_dependencies(mori_profiler_interface generate_profiler_bindings)
 
 if(BUILD_EXAMPLES)
   set(BUILD_APPLICATION ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,59 +153,56 @@ add_library(mori_logging INTERFACE)
 target_include_directories(mori_logging INTERFACE include)
 target_link_libraries(mori_logging INTERFACE spdlog::spdlog)
 
-# ---------------------------------------------------------------------------
-# Profiler slot header generation (always needed — kernel sources
-# unconditionally #include "mori/profiler/profiler.hpp"; the generated
-# headers use #ifdef ENABLE_PROFILER guards so they are safe when OFF)
-# ---------------------------------------------------------------------------
-find_package(
-  Python3
-  COMPONENTS Interpreter
-  REQUIRED)
+if(ENABLE_PROFILER)
+  find_package(
+    Python3
+    COMPONENTS Interpreter
+    REQUIRED)
 
-set(PROFILER_GEN_SCRIPT
-    ${CMAKE_SOURCE_DIR}/tools/profiler/generate_profiler_bindings.py)
-set(PROFILER_OUTPUT_INCLUDE
-    ${CMAKE_BINARY_DIR}/generated/include/mori/profiler)
-set(PROFILER_OUTPUT_PYBIND
-    ${CMAKE_BINARY_DIR}/generated/src/pybind/profiler_bindings_generated.cpp)
+  set(PROFILER_GEN_SCRIPT
+      ${CMAKE_SOURCE_DIR}/tools/profiler/generate_profiler_bindings.py)
+  set(PROFILER_OUTPUT_INCLUDE
+      ${CMAKE_BINARY_DIR}/generated/include/mori/profiler)
+  set(PROFILER_OUTPUT_PYBIND
+      ${CMAKE_BINARY_DIR}/generated/src/pybind/profiler_bindings_generated.cpp)
 
-file(GLOB_RECURSE KERNEL_SOURCES ${CMAKE_SOURCE_DIR}/src/ops/*.cpp)
+  file(GLOB_RECURSE KERNEL_SOURCES ${CMAKE_SOURCE_DIR}/src/ops/*.cpp)
 
-message(STATUS "Generating profiler slot headers at configure time...")
-execute_process(
-  COMMAND
-    ${Python3_EXECUTABLE} ${PROFILER_GEN_SCRIPT} ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/src ${PROFILER_OUTPUT_INCLUDE}
-    ${PROFILER_OUTPUT_PYBIND}
-  RESULT_VARIABLE PROFILER_GEN_RESULT
-  OUTPUT_VARIABLE PROFILER_GEN_OUTPUT
-  ERROR_VARIABLE PROFILER_GEN_ERROR)
+  message(STATUS "Generating profiler bindings at configure time...")
+  execute_process(
+    COMMAND
+      ${Python3_EXECUTABLE} ${PROFILER_GEN_SCRIPT} ${CMAKE_SOURCE_DIR}
+      ${CMAKE_SOURCE_DIR}/src ${PROFILER_OUTPUT_INCLUDE}
+      ${PROFILER_OUTPUT_PYBIND}
+    RESULT_VARIABLE PROFILER_GEN_RESULT
+    OUTPUT_VARIABLE PROFILER_GEN_OUTPUT
+    ERROR_VARIABLE PROFILER_GEN_ERROR)
 
-if(NOT PROFILER_GEN_RESULT EQUAL 0)
-  message(
-    FATAL_ERROR
-      "Failed to generate profiler bindings:\nSTDOUT:\n${PROFILER_GEN_OUTPUT}\nSTDERR:\n${PROFILER_GEN_ERROR}"
-  )
+  if(NOT PROFILER_GEN_RESULT EQUAL 0)
+    message(
+      FATAL_ERROR
+        "Failed to generate profiler bindings:\nSTDOUT:\n${PROFILER_GEN_OUTPUT}\nSTDERR:\n${PROFILER_GEN_ERROR}"
+    )
+  endif()
+
+  add_custom_command(
+    OUTPUT ${PROFILER_OUTPUT_PYBIND}
+    COMMAND
+      ${Python3_EXECUTABLE} ${PROFILER_GEN_SCRIPT} ${CMAKE_SOURCE_DIR}
+      ${CMAKE_SOURCE_DIR}/src ${PROFILER_OUTPUT_INCLUDE}
+      ${PROFILER_OUTPUT_PYBIND}
+    DEPENDS ${KERNEL_SOURCES} ${PROFILER_GEN_SCRIPT}
+    COMMENT "Regenerating profiler bindings..."
+    VERBATIM)
+
+  add_custom_target(generate_profiler_bindings
+                    DEPENDS ${PROFILER_OUTPUT_PYBIND})
+
+  add_library(mori_profiler_interface INTERFACE)
+  target_include_directories(mori_profiler_interface
+                             INTERFACE ${CMAKE_BINARY_DIR}/generated/include)
+  add_dependencies(mori_profiler_interface generate_profiler_bindings)
 endif()
-
-add_custom_command(
-  OUTPUT ${PROFILER_OUTPUT_PYBIND}
-  COMMAND
-    ${Python3_EXECUTABLE} ${PROFILER_GEN_SCRIPT} ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/src ${PROFILER_OUTPUT_INCLUDE}
-    ${PROFILER_OUTPUT_PYBIND}
-  DEPENDS ${KERNEL_SOURCES} ${PROFILER_GEN_SCRIPT}
-  COMMENT "Regenerating profiler bindings..."
-  VERBATIM)
-
-add_custom_target(generate_profiler_bindings
-                  DEPENDS ${PROFILER_OUTPUT_PYBIND})
-
-add_library(mori_profiler_interface INTERFACE)
-target_include_directories(mori_profiler_interface
-                           INTERFACE ${CMAKE_BINARY_DIR}/generated/include)
-add_dependencies(mori_profiler_interface generate_profiler_bindings)
 
 if(BUILD_EXAMPLES)
   set(BUILD_APPLICATION ON)

--- a/docker/Dockerfile.jax091-rocm711
+++ b/docker/Dockerfile.jax091-rocm711
@@ -5,13 +5,15 @@ FROM ghcr.io/rocm/jax-base-ubu24.rocm711:latest AS builder
 
 ARG JAX_BRANCH=rocm-jaxlib-v0.9.1
 ARG BAZEL_VERSION=7.7.0
-ARG GPU_TARGET=gfx942
+ARG GPU_TARGET=gfx942,gfx950
 ARG ROCM_VERSION=7
 
 # Install build tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
         wget \
-        patchelf && \
+        patchelf \
+        clang-18 \
+        libc6-dev && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install Bazel

--- a/python/mori/jit/core.py
+++ b/python/mori/jit/core.py
@@ -181,10 +181,8 @@ def _ensure_generated_include(mori_root: Path) -> Path:
     profiler slot changes in source are picked up without invalidating the JIT cache.
     Returns ``<cache_root>/generated/include/``, which must be passed as ``-I`` to hipcc.
 
-    When the generator script is not available (e.g. wheel install without
-    the full source tree), a minimal stub header is created so that kernel
-    sources can still ``#include "mori/profiler/profiler.hpp"`` with the
-    ``ENABLE_PROFILER`` guard evaluating to nothing.
+    Raises FileNotFoundError if the generator script is not present (e.g. wheel
+    install without the full source tree) — ENABLE_PROFILER requires the source tree.
     """
     gen_script = mori_root / "tools" / "profiler" / "generate_profiler_bindings.py"
 
@@ -192,27 +190,24 @@ def _ensure_generated_include(mori_root: Path) -> Path:
     profiler_include_dir = out_include / "mori" / "profiler"
     pybind_out = get_cache_root() / "generated" / "profiler_bindings.cpp"
 
-    if gen_script.is_file():
-        subprocess.check_call(
-            [
-                sys.executable,
-                str(gen_script),
-                str(mori_root),
-                str(mori_root / "src"),
-                str(profiler_include_dir),
-                str(pybind_out),
-            ],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.STDOUT,
+    if not gen_script.is_file():
+        raise FileNotFoundError(
+            f"Profiler binding generator not found: {gen_script}\n"
+            "JIT compilation with ENABLE_PROFILER requires the mori source tree."
         )
-    else:
-        profiler_include_dir.mkdir(parents=True, exist_ok=True)
-        stub = profiler_include_dir / "profiler.hpp"
-        if not stub.is_file():
-            stub.write_text(
-                "// Auto-generated stub — profiler source tree not available\n"
-                "#pragma once\n"
-            )
+
+    subprocess.check_call(
+        [
+            sys.executable,
+            str(gen_script),
+            str(mori_root),
+            str(mori_root / "src"),
+            str(profiler_include_dir),
+            str(pybind_out),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+    )
 
     return out_include
 

--- a/python/mori/jit/core.py
+++ b/python/mori/jit/core.py
@@ -180,30 +180,39 @@ def _ensure_generated_include(mori_root: Path) -> Path:
     Always runs the generator (which is idempotent via write_if_changed) so that
     profiler slot changes in source are picked up without invalidating the JIT cache.
     Returns ``<cache_root>/generated/include/``, which must be passed as ``-I`` to hipcc.
+
+    When the generator script is not available (e.g. wheel install without
+    the full source tree), a minimal stub header is created so that kernel
+    sources can still ``#include "mori/profiler/profiler.hpp"`` with the
+    ``ENABLE_PROFILER`` guard evaluating to nothing.
     """
     gen_script = mori_root / "tools" / "profiler" / "generate_profiler_bindings.py"
-    if not gen_script.is_file():
-        raise FileNotFoundError(
-            f"Profiler binding generator not found: {gen_script}\n"
-            "JIT compilation with ENABLE_PROFILER requires the mori source tree."
-        )
 
     out_include = get_cache_root() / "generated" / "include"
     profiler_include_dir = out_include / "mori" / "profiler"
     pybind_out = get_cache_root() / "generated" / "profiler_bindings.cpp"
 
-    subprocess.check_call(
-        [
-            sys.executable,
-            str(gen_script),
-            str(mori_root),
-            str(mori_root / "src"),
-            str(profiler_include_dir),
-            str(pybind_out),
-        ],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.STDOUT,
-    )
+    if gen_script.is_file():
+        subprocess.check_call(
+            [
+                sys.executable,
+                str(gen_script),
+                str(mori_root),
+                str(mori_root / "src"),
+                str(profiler_include_dir),
+                str(pybind_out),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.STDOUT,
+        )
+    else:
+        profiler_include_dir.mkdir(parents=True, exist_ok=True)
+        stub = profiler_include_dir / "profiler.hpp"
+        if not stub.is_file():
+            stub.write_text(
+                "// Auto-generated stub — profiler source tree not available\n"
+                "#pragma once\n"
+            )
 
     return out_include
 

--- a/python/mori/jit/core.py
+++ b/python/mori/jit/core.py
@@ -230,11 +230,11 @@ def _collect_include_dirs(mori_root: Path) -> list[Path]:
     if mpi_inc:
         dirs.append(Path(mpi_inc))
 
-    # Generate profiler slot headers JIT into the cache (idempotent, fast).
-    # Always included: kernel sources unconditionally include mori/profiler/profiler.hpp
-    # which lives in the generated dir. The headers have #ifdef ENABLE_PROFILER guards
-    # so they are safe to include even when profiler is disabled.
-    dirs.append(_ensure_generated_include(mori_root))
+    # Profiler slot headers are only needed when ENABLE_PROFILER is set;
+    # kernel sources wrap profiler calls with IF_ENABLE_PROFILER() so the
+    # generated header is not required when profiling is disabled.
+    if is_profiler_enabled():
+        dirs.append(_ensure_generated_include(mori_root))
 
     return dirs
 

--- a/src/ops/CMakeLists.txt
+++ b/src/ops/CMakeLists.txt
@@ -14,7 +14,9 @@ set_target_properties(
              INSTALL_RPATH "$ORIGIN"
              BUILD_WITH_INSTALL_RPATH TRUE)
 
-target_link_libraries(mori_ops PUBLIC mori_profiler_interface)
+if(ENABLE_PROFILER)
+  target_link_libraries(mori_ops PUBLIC mori_profiler_interface)
+endif()
 
 # ---------------------------------------------------------------------------
 # BUILD_OPS_DEVICE: AOT compile EP kernels to .hsaco launch.cpp is always
@@ -38,7 +40,8 @@ if(BUILD_OPS_DEVICE)
 
   set(_extra_defs "")
   if(ENABLE_PROFILER)
-    list(APPEND _extra_defs "-DENABLE_PROFILER")
+    list(APPEND _extra_defs "-DENABLE_PROFILER"
+         "-I${CMAKE_BINARY_DIR}/generated/include")
   endif()
   if(ENABLE_STANDARD_MOE_ADAPT)
     list(APPEND _extra_defs "-DENABLE_STANDARD_MOE_ADAPT")
@@ -74,8 +77,7 @@ if(BUILD_OPS_DEVICE)
         ${HIPCC_EXECUTABLE} --genco "--offload-arch=${GPU_TARGETS}" -std=c++17
         -O2 -D__HIP_PLATFORM_AMD__ -DHIP_ENABLE_WARP_SYNC_BUILTINS ${_nic_defs}
         ${_extra_defs} -I${CMAKE_SOURCE_DIR}/include -I${CMAKE_SOURCE_DIR}
-        -I${CMAKE_SOURCE_DIR}/3rdparty/spdlog/include
-        -I${CMAKE_BINARY_DIR}/generated/include ${_mpi_includes}
+        -I${CMAKE_SOURCE_DIR}/3rdparty/spdlog/include ${_mpi_includes}
         ${_ksrc_path} -o ${_hsaco_output}
       DEPENDS ${_ksrc_path}
       COMMENT "AOT compiling ${_ksrc} -> ${_arch_nic}/${_kname}.hsaco"
@@ -84,7 +86,9 @@ if(BUILD_OPS_DEVICE)
   endforeach()
 
   add_custom_target(mori_ops_kernels ALL DEPENDS ${_all_hsaco_outputs})
-  add_dependencies(mori_ops_kernels generate_profiler_bindings)
+  if(ENABLE_PROFILER)
+    add_dependencies(mori_ops_kernels generate_profiler_bindings)
+  endif()
   add_dependencies(mori_ops mori_ops_kernels)
 
   install(FILES ${_all_hsaco_outputs} DESTINATION "lib/${_arch_nic}")

--- a/src/ops/CMakeLists.txt
+++ b/src/ops/CMakeLists.txt
@@ -14,9 +14,7 @@ set_target_properties(
              INSTALL_RPATH "$ORIGIN"
              BUILD_WITH_INSTALL_RPATH TRUE)
 
-if(ENABLE_PROFILER)
-  target_link_libraries(mori_ops PUBLIC mori_profiler_interface)
-endif()
+target_link_libraries(mori_ops PUBLIC mori_profiler_interface)
 
 # ---------------------------------------------------------------------------
 # BUILD_OPS_DEVICE: AOT compile EP kernels to .hsaco launch.cpp is always
@@ -76,7 +74,8 @@ if(BUILD_OPS_DEVICE)
         ${HIPCC_EXECUTABLE} --genco "--offload-arch=${GPU_TARGETS}" -std=c++17
         -O2 -D__HIP_PLATFORM_AMD__ -DHIP_ENABLE_WARP_SYNC_BUILTINS ${_nic_defs}
         ${_extra_defs} -I${CMAKE_SOURCE_DIR}/include -I${CMAKE_SOURCE_DIR}
-        -I${CMAKE_SOURCE_DIR}/3rdparty/spdlog/include ${_mpi_includes}
+        -I${CMAKE_SOURCE_DIR}/3rdparty/spdlog/include
+        -I${CMAKE_BINARY_DIR}/generated/include ${_mpi_includes}
         ${_ksrc_path} -o ${_hsaco_output}
       DEPENDS ${_ksrc_path}
       COMMENT "AOT compiling ${_ksrc} -> ${_arch_nic}/${_kname}.hsaco"
@@ -85,6 +84,7 @@ if(BUILD_OPS_DEVICE)
   endforeach()
 
   add_custom_target(mori_ops_kernels ALL DEPENDS ${_all_hsaco_outputs})
+  add_dependencies(mori_ops_kernels generate_profiler_bindings)
   add_dependencies(mori_ops mori_ops_kernels)
 
   install(FILES ${_all_hsaco_outputs} DESTINATION "lib/${_arch_nic}")

--- a/src/ops/dispatch_combine/internode_v1.cpp
+++ b/src/ops/dispatch_combine/internode_v1.cpp
@@ -28,7 +28,9 @@
 #include "mori/core/profiler/constants.hpp"
 #include "mori/core/profiler/kernel_profiler.hpp"
 #include "mori/ops/dispatch_combine/dispatch_combine.hpp"
+#ifdef ENABLE_PROFILER
 #include "mori/profiler/profiler.hpp"
+#endif
 #include "mori/shmem/shmem.hpp"
 #include "src/ops/dispatch_combine/common.hpp"
 #include "src/ops/dispatch_combine/convert.hpp"
@@ -87,7 +89,8 @@ inline __device__ void DispatchIntraNodeBlock(EpDispatchCombineArgs<T>& args, in
 template <typename T>
 inline __device__ void DispatchIntraNode(EpDispatchCombineArgs<T>& args) {
   DEF_COMMON_VARS;
-  INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::DispatchIntra);
 
   int blockOffset = args.rdmaBlockNum;
@@ -132,7 +135,8 @@ inline __device__ void DispatchIntraNode(EpDispatchCombineArgs<T>& args) {
 template <typename T, bool DEDUP>
 inline __device__ void DispatchInterNodeSend(EpDispatchCombineArgs<T>& args) {
   DEF_COMMON_VARS;
-  INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::DispatchInterNodeSend);
 
   int maxChunkNum = core::CeilDiv(config.MaxNumTokensToSendPerRank(), warpSize);
@@ -260,7 +264,8 @@ inline __device__ void DispatchInterNodeSend(EpDispatchCombineArgs<T>& args) {
 template <typename T>
 inline __device__ void DispatchInterNodeLLSend(EpDispatchCombineArgs<T>& args) {
   DEF_COMMON_VARS;
-  INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::DispatchInterNodeLLSend);
 
   // Then send to other nodes
@@ -330,7 +335,8 @@ inline __device__ void DispatchInterNodeLLSend(EpDispatchCombineArgs<T>& args) {
 template <typename T>
 inline __device__ void DispatchInterNodeRecv(EpDispatchCombineArgs<T>& args) {
   DEF_COMMON_VARS;
-  INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::DispatchInterNodeRecv);
 
   constexpr int numRecvBlock = 8;
@@ -434,7 +440,8 @@ inline __device__ void DispatchInterNodeRecv(EpDispatchCombineArgs<T>& args) {
 template <typename T>
 inline __device__ void DispatchInterNodeLLRecv(EpDispatchCombineArgs<T>& args) {
   DEF_COMMON_VARS;
-  INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::DispatchInterNodeLLRecv);
 
   int maxChunkNum = core::CeilDiv(config.MaxNumTokensToSendPerRank(), warpSize);
@@ -538,7 +545,8 @@ inline __device__ void DispatchInterNodeLLRecv(EpDispatchCombineArgs<T>& args) {
 template <typename T>
 inline __device__ void DispatchSync(EpDispatchCombineArgs<T>& args) {
   DEF_COMMON_VARS;
-  INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::DispatchSync);
 
   int nodePeOffset = myNode * config.gpuPerNode;
@@ -603,7 +611,8 @@ __global__ void EpDispatchInterNodeV1Kernel(EpDispatchCombineArgs<T> args) {
 template <typename T>
 __device__ void EpDispatchCopyToStaging_body(EpDispatchCombineArgs<T> args) {
   DEF_COMMON_VARS;
-  INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::EpDispatchCopyToStaging);
   if (args.curRankNumToken == 0) return;
 
@@ -675,7 +684,8 @@ namespace v1 {
 template <typename T>
 inline __device__ void CombineSync(EpDispatchCombineArgs<T>& args) {
   DEF_COMMON_VARS;
-  INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::CombineSync);
 
   index_t totalRecvTokenNum = args.totalRecvTokenNum[0];
@@ -1117,7 +1127,8 @@ __forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs<T>
 template <typename T>
 inline __device__ void CombineIntraNode(EpDispatchCombineArgs<T>& args) {
   DEF_COMMON_VARS;
-  INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::CombineIntraNode);
   if (args.config.quantType == QuantType::Fp8DirectCast) {
     using TokT = core::CombineInternalFp8;
@@ -1134,7 +1145,8 @@ inline __device__ void CombineIntraNode(EpDispatchCombineArgs<T>& args) {
 template <typename T>
 inline __device__ void CombineIntraNodeLL(EpDispatchCombineArgs<T>& args) {
   DEF_COMMON_VARS;
-  INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::CombineIntraNodeLL);
 
   if (args.curRankNumToken == 0) return;
@@ -1152,7 +1164,8 @@ inline __device__ void CombineIntraNodeLL(EpDispatchCombineArgs<T>& args) {
 template <typename T>
 inline __device__ void CombineInterNode(EpDispatchCombineArgs<T>& args) {
   DEF_COMMON_VARS;
-  INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::CombineInterNode);
 
   if (args.config.quantType == QuantType::Fp8DirectCast) {
@@ -1169,7 +1182,8 @@ inline __device__ void CombineInterNode(EpDispatchCombineArgs<T>& args) {
 template <typename T>
 inline __device__ void CombineInterNodeLL(EpDispatchCombineArgs<T>& args) {
   DEF_COMMON_VARS;
-  INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::CombineInterNodeLL);
   if (args.config.quantType == QuantType::Fp8DirectCast) {
     using TokT = core::CombineInternalFp8;
@@ -1308,7 +1322,8 @@ __forceinline__ __device__ void EpCombineAllGeneric(EpDispatchCombineArgs<T>& ar
 template <typename T>
 __device__ void EpCombineAll_body(EpDispatchCombineArgs<T> args) {
   DEF_COMMON_VARS;
-  INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::EpCombineAll);
 
   if (globalWarpId == 0) {
@@ -1369,7 +1384,8 @@ __global__ void EpCombineSync(EpDispatchCombineArgs<T> args) {
 template <typename T>
 __device__ void EpCombineSyncBarrier_body(EpDispatchCombineArgs<T> args) {
   DEF_COMMON_VARS;
-  INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::EpCombineSyncBarrier);
   uint64_t barrierFlag = 0;
   if (laneId == 0) {

--- a/src/ops/dispatch_combine/internode_v1.cpp
+++ b/src/ops/dispatch_combine/internode_v1.cpp
@@ -28,9 +28,7 @@
 #include "mori/core/profiler/constants.hpp"
 #include "mori/core/profiler/kernel_profiler.hpp"
 #include "mori/ops/dispatch_combine/dispatch_combine.hpp"
-#ifdef ENABLE_PROFILER
 #include "mori/profiler/profiler.hpp"
-#endif
 #include "mori/shmem/shmem.hpp"
 #include "src/ops/dispatch_combine/common.hpp"
 #include "src/ops/dispatch_combine/convert.hpp"

--- a/src/ops/dispatch_combine/internode_v1.cpp
+++ b/src/ops/dispatch_combine/internode_v1.cpp
@@ -28,7 +28,9 @@
 #include "mori/core/profiler/constants.hpp"
 #include "mori/core/profiler/kernel_profiler.hpp"
 #include "mori/ops/dispatch_combine/dispatch_combine.hpp"
+#ifdef ENABLE_PROFILER
 #include "mori/profiler/profiler.hpp"
+#endif
 #include "mori/shmem/shmem.hpp"
 #include "src/ops/dispatch_combine/common.hpp"
 #include "src/ops/dispatch_combine/convert.hpp"

--- a/src/ops/dispatch_combine/low_latency_async.cpp
+++ b/src/ops/dispatch_combine/low_latency_async.cpp
@@ -32,9 +32,7 @@
 #include "mori/core/profiler/constants.hpp"
 #include "mori/core/profiler/kernel_profiler.hpp"
 #include "mori/ops/dispatch_combine/dispatch_combine.hpp"
-#ifdef ENABLE_PROFILER
 #include "mori/profiler/profiler.hpp"
-#endif
 #include "mori/shmem/shmem.hpp"
 #include "src/ops/dispatch_combine/common.hpp"
 

--- a/src/ops/dispatch_combine/low_latency_async.cpp
+++ b/src/ops/dispatch_combine/low_latency_async.cpp
@@ -32,7 +32,9 @@
 #include "mori/core/profiler/constants.hpp"
 #include "mori/core/profiler/kernel_profiler.hpp"
 #include "mori/ops/dispatch_combine/dispatch_combine.hpp"
+#ifdef ENABLE_PROFILER
 #include "mori/profiler/profiler.hpp"
+#endif
 #include "mori/shmem/shmem.hpp"
 #include "src/ops/dispatch_combine/common.hpp"
 

--- a/src/ops/dispatch_combine/low_latency_async.cpp
+++ b/src/ops/dispatch_combine/low_latency_async.cpp
@@ -32,7 +32,9 @@
 #include "mori/core/profiler/constants.hpp"
 #include "mori/core/profiler/kernel_profiler.hpp"
 #include "mori/ops/dispatch_combine/dispatch_combine.hpp"
+#ifdef ENABLE_PROFILER
 #include "mori/profiler/profiler.hpp"
+#endif
 #include "mori/shmem/shmem.hpp"
 #include "src/ops/dispatch_combine/common.hpp"
 
@@ -50,7 +52,8 @@ using namespace mori::shmem;
 template <typename T>
 __device__ void EpDispatchLowLatencyAsyncSendCopy_body(EpDispatchCombineArgs<T> args) {
   DEF_COMMON_VARS;
-  LOW_LATENCY_ASYNC_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      LOW_LATENCY_ASYNC_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::DispatchAsyncSendCopy);
   for (int i = globalWarpId; i < args.curRankNumToken * config.numExpertPerToken;
        i += globalWarpNum) {
@@ -116,7 +119,8 @@ __device__ void EpDispatchLowLatencyAsyncSendCopy_body(EpDispatchCombineArgs<T> 
 template <typename T>
 __device__ void EpDispatchLowLatencyAsyncSendCopySlotAssign_body(EpDispatchCombineArgs<T> args) {
   DEF_COMMON_VARS;
-  LOW_LATENCY_ASYNC_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      LOW_LATENCY_ASYNC_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::DispatchAsyncSlotAssign);
   int numEpt = config.numExpertPerToken;
   int tokensPerWarp = warpSize / numEpt;
@@ -158,7 +162,8 @@ __device__ void EpDispatchLowLatencyAsyncSendCopySlotAssign_body(EpDispatchCombi
 template <typename T>
 __device__ void EpDispatchLowLatencyAsyncSendCopyMultiBlock_body(EpDispatchCombineArgs<T> args) {
   DEF_COMMON_VARS;
-  LOW_LATENCY_ASYNC_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      LOW_LATENCY_ASYNC_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::DispatchAsyncSendCopyMultiBlock);
   index_t totalEntries = args.curRankNumToken * config.numExpertPerToken;
   index_t warpsPerToken = (globalWarpNum + totalEntries - 1) / totalEntries;
@@ -217,7 +222,8 @@ __device__ void EpDispatchLowLatencyAsyncSendCopyMultiBlock_body(EpDispatchCombi
 template <typename T>
 __device__ void EpDispatchLowLatencyAsyncSendTransfer_body(EpDispatchCombineArgs<T> args) {
   DEF_COMMON_VARS;
-  LOW_LATENCY_ASYNC_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      LOW_LATENCY_ASYNC_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::DispatchAsyncSendTransfer);
   for (int destPe = blockId; destPe < npes; destPe += blockNum) {
     for (int qpId = warpId; qpId < config.numQpPerPe; qpId += warpNum) {
@@ -248,7 +254,8 @@ __device__ void EpDispatchLowLatencyAsyncSendTransfer_body(EpDispatchCombineArgs
 template <typename T>
 __device__ void EpDispatchLowLatencyAsyncRecvTransfer_body(EpDispatchCombineArgs<T> args) {
   DEF_COMMON_VARS;
-  LOW_LATENCY_ASYNC_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      LOW_LATENCY_ASYNC_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::DispatchAsyncRecvTransfer);
   for (int destPe = blockId; destPe < npes; destPe += blockNum) {
     for (int qpId = warpId; qpId < config.numQpPerPe; qpId += warpNum) {
@@ -286,7 +293,8 @@ __device__ void EpDispatchLowLatencyAsyncRecvTransfer_body(EpDispatchCombineArgs
 template <typename T>
 __device__ void EpDispatchLowLatencyAsyncRecvCopyMultiBlock_body(EpDispatchCombineArgs<T> args) {
   DEF_COMMON_VARS;
-  LOW_LATENCY_ASYNC_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      LOW_LATENCY_ASYNC_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::DispatchAsyncRecvCopy);
 
   int blocksPerPe = blockNum / npes;
@@ -395,7 +403,8 @@ __device__ void EpDispatchLowLatencyAsyncRecvCopyMultiBlock_body(EpDispatchCombi
 template <typename T, bool UseFp8DirectCast>
 __device__ void EpCombineLowLatencyAsyncSendCopy_body(EpDispatchCombineArgs<T> args) {
   DEF_COMMON_VARS;
-  LOW_LATENCY_ASYNC_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      LOW_LATENCY_ASYNC_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::CombineAsyncSendCopy);
   using TokT = std::conditional_t<UseFp8DirectCast, core::CombineInternalFp8, T>;
   static_assert(!UseFp8DirectCast || std::is_same_v<T, hip_bfloat16>,
@@ -428,7 +437,8 @@ __device__ void EpCombineLowLatencyAsyncSendCopy_body(EpDispatchCombineArgs<T> a
 template <typename T, bool UseFp8DirectCast>
 __device__ void EpCombineLowLatencyAsyncSendTransfer_body(EpDispatchCombineArgs<T> args) {
   DEF_COMMON_VARS;
-  LOW_LATENCY_ASYNC_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      LOW_LATENCY_ASYNC_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::CombineAsyncSendTransfer);
   using TokT = std::conditional_t<UseFp8DirectCast, core::CombineInternalFp8, T>;
   static_assert(!UseFp8DirectCast || std::is_same_v<T, hip_bfloat16>,
@@ -469,7 +479,8 @@ __device__ void EpCombineLowLatencyAsyncSendTransfer_body(EpDispatchCombineArgs<
 template <typename T, bool UseFp8DirectCast>
 __device__ void EpCombineLowLatencyAsyncRecvTransfer_body(EpDispatchCombineArgs<T> args) {
   DEF_COMMON_VARS;
-  LOW_LATENCY_ASYNC_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      LOW_LATENCY_ASYNC_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::CombineAsyncRecvTransfer);
   using TokT = std::conditional_t<UseFp8DirectCast, core::CombineInternalFp8, T>;
   static_assert(!UseFp8DirectCast || std::is_same_v<T, hip_bfloat16>,
@@ -510,7 +521,8 @@ __device__ void EpCombineLowLatencyAsyncRecvTransfer_body(EpDispatchCombineArgs<
 template <typename T, bool UseFp8DirectCast>
 __device__ void EpCombineLowLatencyAsyncRecvCopy_body(EpDispatchCombineArgs<T> args) {
   DEF_COMMON_VARS;
-  LOW_LATENCY_ASYNC_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId);
+  IF_ENABLE_PROFILER(
+      LOW_LATENCY_ASYNC_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::CombineAsyncRecvCopy);
   using TokT = std::conditional_t<UseFp8DirectCast, core::CombineInternalFp8, T>;
   static_assert(!UseFp8DirectCast || std::is_same_v<T, hip_bfloat16>,

--- a/tests/python/ops/conftest.py
+++ b/tests/python/ops/conftest.py
@@ -22,14 +22,15 @@
 import os
 
 import pytest
-from tests.python.ops.dispatch_combine_test_utils import (
-    start_torch_dist_process_manager,
-)
 
 
 @pytest.fixture(scope="session")
 def torch_dist_process_manager():
     """Single shared worker pool for all ops tests."""
+    from tests.python.ops.dispatch_combine_test_utils import (
+        start_torch_dist_process_manager,
+    )
+
     manager = start_torch_dist_process_manager(world_size=8)
     yield manager
     manager.shutdown()


### PR DESCRIPTION
## Motivation

JAX tests on MI355X + AINIC were blocked by two independent issues:

1. `conftest.py` imports `torch` at module level — pytest collection fails in environments that have JAX but not PyTorch.
2. Kernel sources unconditionally include `mori/profiler/profiler.hpp`, which is only generated when `ENABLE_PROFILER=ON`. With non-editable install (`pip install .`) and `ENABLE_PROFILER=OFF`, JIT compilation fails because the header is missing.

## Changes

**`tests/python/ops/conftest.py`**: Move `torch`-dependent import inside the `torch_dist_process_manager` fixture so JAX-only pytest sessions can collect without torch installed.

**`src/ops/dispatch_combine/internode_v1.cpp`, `low_latency_async.cpp`**: Wrap all `*_PROFILER_INIT_CONTEXT` calls with `IF_ENABLE_PROFILER()` as recommended by `PROFILER.md`. Add `#ifdef ENABLE_PROFILER` guard around `#include "mori/profiler/profiler.hpp"`.

**`python/mori/jit/core.py`**: Only generate profiler slot headers in JIT when `ENABLE_PROFILER` is set. Raise a clear `FileNotFoundError` if the generator script is missing with `ENABLE_PROFILER=ON` instead of silently creating an empty stub that causes confusing JIT compile errors.

**`src/ops/CMakeLists.txt`**: Add `-I${CMAKE_BINARY_DIR}/generated/include` and `generate_profiler_bindings` dependency to AOT `.hsaco` targets when `ENABLE_PROFILER=ON`.

**`.github/workflows/ci.yml`**: Enable `jax-intranode-test` job on `MI355X_AINIC` runners. Switch all CI jobs from `pip install -e .` to `pip install .`. Gate `--isolation=chroot` on `$CT = podman` for Docker portability. Set `MORI_RDMA_DEVICES` for Ionic NICs and `MORI_KERNEL_DIR` for AOT `.hsaco` kernel discovery via C++ AutoLoad.

**`docker/Dockerfile.jax091-rocm711`**: Add `gfx950` to `GPU_TARGET`. Install `clang-18` and `libc6-dev` for Bazel's ROCm toolchain.

## Verification

```bash
# JAX intranode test
BUILD_XLA_FFI_OPS=ON pip install --break-system-packages .
MORI_KERNEL_DIR=$(ls -d build/lib/gfx*_ionic* | head -1) \
  pytest tests/python/ops/test_dispatch_combine_jax.py -s -v
