### PR TITLE
feat(io): support large-memory RDMA via chunked registration

### DIFF
--- a/include/mori/application/transport/rdma/providers/ibverbs/ibverbs.hpp
+++ b/include/mori/application/transport/rdma/providers/ibverbs/ibverbs.hpp
@@ -33,10 +33,13 @@ class IBVerbsDeviceContext : public RdmaDeviceContext {
   ~IBVerbsDeviceContext() override;
 
   virtual RdmaEndpoint CreateRdmaEndpoint(const RdmaEndpointConfig&) override;
+  virtual void DestroyRdmaEndpoint(const RdmaEndpoint& endpoint) override;
   virtual void ConnectEndpoint(const RdmaEndpointHandle& local, const RdmaEndpointHandle& remote,
                                uint32_t qpId = 0) override;
 
  private:
+  // Create/Connect/Destroy all touch these pools; keep provider-local synchronization explicit.
+  std::mutex epPoolMu_;
   std::unordered_map<void*, ibv_cq*> cqPool;
   std::unordered_map<uint32_t, ibv_qp*> qpPool;
   std::vector<ibv_comp_channel*> compChPool;

--- a/include/mori/application/transport/rdma/rdma.hpp
+++ b/include/mori/application/transport/rdma/rdma.hpp
@@ -25,6 +25,7 @@
 
 #include <cassert>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -210,6 +211,8 @@ class RdmaDeviceContext {
 
   virtual RdmaMemoryRegion RegisterRdmaMemoryRegion(void* ptr, size_t size,
                                                     int accessFlag = MR_DEFAULT_ACCESS_FLAG);
+  virtual std::optional<RdmaMemoryRegion> TryRegisterRdmaMemoryRegion(
+      void* ptr, size_t size, int accessFlag = MR_DEFAULT_ACCESS_FLAG);
   virtual RdmaMemoryRegion RegisterRdmaMemoryRegionDmabuf(void* ptr, size_t size, int dmabuf_fd,
                                                           int accessFlag = MR_DEFAULT_ACCESS_FLAG);
   virtual void DeregisterRdmaMemoryRegion(void* ptr);
@@ -248,6 +251,7 @@ class RdmaDeviceContext {
 
  private:
   RdmaDevice* device;
+  std::mutex mrPoolMu_;
   std::unordered_map<void*, ibv_mr*> mrPool;
 };
 

--- a/include/mori/application/transport/rdma/rdma.hpp
+++ b/include/mori/application/transport/rdma/rdma.hpp
@@ -158,6 +158,27 @@ struct RdmaMemoryRegion {
   size_t length{0};
 };
 
+class RdmaOwnedMr {
+ public:
+  RdmaOwnedMr() = default;
+  RdmaOwnedMr(RdmaMemoryRegion region, ibv_mr* raw);
+  RdmaOwnedMr(RdmaOwnedMr&& other) noexcept;
+  RdmaOwnedMr& operator=(RdmaOwnedMr&& other) noexcept;
+  RdmaOwnedMr(const RdmaOwnedMr&) = delete;
+  RdmaOwnedMr& operator=(const RdmaOwnedMr&) = delete;
+  ~RdmaOwnedMr();
+
+  const RdmaMemoryRegion& Region() const { return region_; }
+  explicit operator bool() const { return raw_ != nullptr; }
+
+ private:
+  void Reset() noexcept;
+
+ private:
+  RdmaMemoryRegion region_{};
+  ibv_mr* raw_{nullptr};
+};
+
 struct RdmaEndpoint {
   RdmaDeviceVendorId vendorId{RdmaDeviceVendorId::Unknown};
   RdmaEndpointHandle handle;
@@ -213,9 +234,14 @@ class RdmaDeviceContext {
                                                     int accessFlag = MR_DEFAULT_ACCESS_FLAG);
   virtual std::optional<RdmaMemoryRegion> TryRegisterRdmaMemoryRegion(
       void* ptr, size_t size, int accessFlag = MR_DEFAULT_ACCESS_FLAG);
+  virtual std::optional<RdmaOwnedMr> TryRegisterOwnedMr(void* ptr, size_t size,
+                                                        int accessFlag = MR_DEFAULT_ACCESS_FLAG);
+  virtual std::optional<RdmaOwnedMr> TryRegisterOwnedMrDmabuf(
+      void* ptr, size_t size, int dmabuf_fd, int accessFlag = MR_DEFAULT_ACCESS_FLAG);
   virtual RdmaMemoryRegion RegisterRdmaMemoryRegionDmabuf(void* ptr, size_t size, int dmabuf_fd,
                                                           int accessFlag = MR_DEFAULT_ACCESS_FLAG);
   virtual void DeregisterRdmaMemoryRegion(void* ptr);
+  virtual void DestroyRdmaEndpoint(const RdmaEndpoint&);
 
   // TODO: query gid entry by ibv_query_gid_table
   virtual RdmaEndpoint CreateRdmaEndpoint(const RdmaEndpointConfig&) {

--- a/include/mori/io/msgpack_adaptor.hpp
+++ b/include/mori/io/msgpack_adaptor.hpp
@@ -50,6 +50,23 @@ MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS) {
   };
 
   template <>
+  struct pack<mori::io::StatusCode> {
+    template <typename Stream>
+    msgpack::packer<Stream>& operator()(msgpack::packer<Stream>& o, mori::io::StatusCode v) const {
+      o.pack(static_cast<uint32_t>(v));
+      return o;
+    }
+  };
+
+  template <>
+  struct convert<mori::io::StatusCode> {
+    const msgpack::object& operator()(const msgpack::object& o, mori::io::StatusCode& v) const {
+      v = static_cast<mori::io::StatusCode>(o.as<uint32_t>());
+      return o;
+    }
+  };
+
+  template <>
   struct pack<mori::io::MemoryLocationType> {
     template <typename Stream>
     msgpack::packer<Stream>& operator()(msgpack::packer<Stream>& o,

--- a/src/application/transport/rdma/providers/ibverbs/ibverbs.cpp
+++ b/src/application/transport/rdma/providers/ibverbs/ibverbs.cpp
@@ -21,6 +21,8 @@
 // SOFTWARE.
 #include "mori/application/transport/rdma/providers/ibverbs/ibverbs.hpp"
 
+#include <algorithm>
+
 #include "mori/application/utils/check.hpp"
 #include "mori/utils/mori_log.hpp"
 namespace mori {
@@ -33,6 +35,7 @@ IBVerbsDeviceContext::IBVerbsDeviceContext(RdmaDevice* rdma_device, ibv_pd* inPd
     : RdmaDeviceContext(rdma_device, inPd) {}
 
 IBVerbsDeviceContext::~IBVerbsDeviceContext() {
+  std::lock_guard<std::mutex> lock(epPoolMu_);
   for (auto& it : qpPool) ibv_destroy_qp(it.second);
   for (auto& it : cqPool) ibv_destroy_cq(it.second);
   for (auto* compCh : compChPool) {
@@ -98,16 +101,43 @@ RdmaEndpoint IBVerbsDeviceContext::CreateRdmaEndpoint(const RdmaEndpointConfig& 
   if (config.enableSrq)
     assert(endpoint.ibvHandle.srq && (endpoint.ibvHandle.qp->srq == endpoint.ibvHandle.srq));
 
-  cqPool.insert({endpoint.ibvHandle.cq, endpoint.ibvHandle.cq});
-  qpPool.insert({endpoint.ibvHandle.qp->qp_num, endpoint.ibvHandle.qp});
-  if (endpoint.ibvHandle.compCh) {
-    compChPool.push_back(endpoint.ibvHandle.compCh);
+  {
+    std::lock_guard<std::mutex> lock(epPoolMu_);
+    cqPool.insert({endpoint.ibvHandle.cq, endpoint.ibvHandle.cq});
+    qpPool.insert({endpoint.ibvHandle.qp->qp_num, endpoint.ibvHandle.qp});
+    if (endpoint.ibvHandle.compCh) {
+      compChPool.push_back(endpoint.ibvHandle.compCh);
+    }
   }
   return endpoint;
 }
 
+void IBVerbsDeviceContext::DestroyRdmaEndpoint(const RdmaEndpoint& endpoint) {
+  std::lock_guard<std::mutex> lock(epPoolMu_);
+
+  auto qpIt = qpPool.find(endpoint.handle.qpn);
+  if (qpIt != qpPool.end()) {
+    ibv_destroy_qp(qpIt->second);
+    qpPool.erase(qpIt);
+  }
+
+  auto cqIt = cqPool.find(endpoint.ibvHandle.cq);
+  if (cqIt != cqPool.end()) {
+    ibv_destroy_cq(cqIt->second);
+    cqPool.erase(cqIt);
+  }
+
+  if (endpoint.ibvHandle.compCh != nullptr) {
+    auto chIt = std::find(compChPool.begin(), compChPool.end(), endpoint.ibvHandle.compCh);
+    if (chIt != compChPool.end()) compChPool.erase(chIt);
+    ibv_destroy_comp_channel(endpoint.ibvHandle.compCh);
+  }
+}
+
 void IBVerbsDeviceContext::ConnectEndpoint(const RdmaEndpointHandle& local,
                                            const RdmaEndpointHandle& remote, uint32_t qpId) {
+  std::lock_guard<std::mutex> lock(epPoolMu_);
+
   ibv_qp_attr attr;
   int flags;
 

--- a/src/application/transport/rdma/rdma.cpp
+++ b/src/application/transport/rdma/rdma.cpp
@@ -318,6 +318,7 @@ RdmaDeviceContext::RdmaDeviceContext(RdmaDevice* device, ibv_pd* inPd) : device(
 }
 
 RdmaDeviceContext::~RdmaDeviceContext() {
+  std::lock_guard<std::mutex> lock(mrPoolMu_);
   for (auto& it : mrPool) {
     ibv_dereg_mr(it.second);
   }
@@ -343,7 +344,34 @@ application::RdmaMemoryRegion RdmaDeviceContext::RegisterRdmaMemoryRegion(void* 
   }
   MORI_APP_TRACE("RegisterRdmaMemoryRegion, addr:{}, size:{}, lkey:{}, rkey:{}\n", ptr, size,
                  mr->lkey, mr->rkey);
-  mrPool.insert({ptr, mr});
+  {
+    std::lock_guard<std::mutex> lock(mrPoolMu_);
+    mrPool.insert({ptr, mr});
+  }
+  application::RdmaMemoryRegion handle;
+  handle.addr = reinterpret_cast<uintptr_t>(ptr);
+  handle.lkey = mr->lkey;
+  handle.rkey = mr->rkey;
+  handle.length = mr->length;
+  return handle;
+}
+
+std::optional<application::RdmaMemoryRegion> RdmaDeviceContext::TryRegisterRdmaMemoryRegion(
+    void* ptr, size_t size, int accessFlag) {
+  int effectiveAccessFlag = MaybeAddRelaxedOrderingFlag(accessFlag);
+  ibv_mr* mr = ibv_reg_mr(pd, ptr, size, effectiveAccessFlag);
+  if (!mr) {
+    MORI_APP_ERROR(
+        "TryRegisterRdmaMemoryRegion failed: addr:{}, size:{}, accessFlag:{}, errno:{} ({})", ptr,
+        size, effectiveAccessFlag, errno, strerror(errno));
+    return std::nullopt;
+  }
+  MORI_APP_TRACE("TryRegisterRdmaMemoryRegion, addr:{}, size:{}, lkey:{}, rkey:{}\n", ptr, size,
+                 mr->lkey, mr->rkey);
+  {
+    std::lock_guard<std::mutex> lock(mrPoolMu_);
+    mrPool.insert({ptr, mr});
+  }
   application::RdmaMemoryRegion handle;
   handle.addr = reinterpret_cast<uintptr_t>(ptr);
   handle.lkey = mr->lkey;
@@ -369,7 +397,10 @@ application::RdmaMemoryRegion RdmaDeviceContext::RegisterRdmaMemoryRegionDmabuf(
   MORI_APP_TRACE(
       "RegisterRdmaMemoryRegionDmabuf, addr:{}, size:{}, dmabuf_fd:{}, lkey:{}, rkey:{}\n", ptr,
       size, dmabuf_fd, mr->lkey, mr->rkey);
-  mrPool.insert({ptr, mr});
+  {
+    std::lock_guard<std::mutex> lock(mrPoolMu_);
+    mrPool.insert({ptr, mr});
+  }
   application::RdmaMemoryRegion handle;
   handle.addr = reinterpret_cast<uintptr_t>(ptr);
   handle.lkey = mr->lkey;
@@ -379,10 +410,11 @@ application::RdmaMemoryRegion RdmaDeviceContext::RegisterRdmaMemoryRegionDmabuf(
 }
 
 void RdmaDeviceContext::DeregisterRdmaMemoryRegion(void* ptr) {
-  if (mrPool.find(ptr) == mrPool.end()) return;
-  ibv_mr* mr = mrPool[ptr];
-  ibv_dereg_mr(mr);
-  mrPool.erase(ptr);
+  std::lock_guard<std::mutex> lock(mrPoolMu_);
+  auto it = mrPool.find(ptr);
+  if (it == mrPool.end()) return;
+  ibv_dereg_mr(it->second);
+  mrPool.erase(it);
 }
 
 ibv_srq* RdmaDeviceContext::CreateRdmaSrqIfNx(const RdmaEndpointConfig& config) {

--- a/src/application/transport/rdma/rdma.cpp
+++ b/src/application/transport/rdma/rdma.cpp
@@ -44,6 +44,15 @@ namespace mori {
 namespace application {
 
 namespace {
+RdmaMemoryRegion MakeRdmaMemoryRegion(ibv_mr* mr) {
+  RdmaMemoryRegion handle;
+  handle.addr = reinterpret_cast<uintptr_t>(mr->addr);
+  handle.lkey = mr->lkey;
+  handle.rkey = mr->rkey;
+  handle.length = mr->length;
+  return handle;
+}
+
 std::string TrimWhitespace(const std::string& input) {
   auto begin = std::find_if_not(input.begin(), input.end(),
                                 [](unsigned char ch) { return std::isspace(ch); });
@@ -313,6 +322,35 @@ int MaybeAddRelaxedOrderingFlag(int accessFlag) {
 /* ---------------------------------------------------------------------------------------------- */
 /*                                        RdmaDeviceContext                                       */
 /* ---------------------------------------------------------------------------------------------- */
+RdmaOwnedMr::RdmaOwnedMr(RdmaMemoryRegion region, ibv_mr* raw) : region_(region), raw_(raw) {}
+
+RdmaOwnedMr::RdmaOwnedMr(RdmaOwnedMr&& other) noexcept : region_(other.region_), raw_(other.raw_) {
+  other.region_ = {};
+  other.raw_ = nullptr;
+}
+
+RdmaOwnedMr& RdmaOwnedMr::operator=(RdmaOwnedMr&& other) noexcept {
+  if (this == &other) return *this;
+  Reset();
+  region_ = other.region_;
+  raw_ = other.raw_;
+  other.region_ = {};
+  other.raw_ = nullptr;
+  return *this;
+}
+
+RdmaOwnedMr::~RdmaOwnedMr() { Reset(); }
+
+void RdmaOwnedMr::Reset() noexcept {
+  if (!raw_) return;
+  if (ibv_dereg_mr(raw_) != 0) {
+    MORI_APP_WARN("ibv_dereg_mr failed for owned MR addr:{}, lkey:{}, errno:{} ({})", region_.addr,
+                  region_.lkey, errno, strerror(errno));
+  }
+  raw_ = nullptr;
+  region_ = {};
+}
+
 RdmaDeviceContext::RdmaDeviceContext(RdmaDevice* device, ibv_pd* inPd) : device(device), pd(inPd) {
   InitializeUdpSportConfiguration();
 }
@@ -348,12 +386,7 @@ application::RdmaMemoryRegion RdmaDeviceContext::RegisterRdmaMemoryRegion(void* 
     std::lock_guard<std::mutex> lock(mrPoolMu_);
     mrPool.insert({ptr, mr});
   }
-  application::RdmaMemoryRegion handle;
-  handle.addr = reinterpret_cast<uintptr_t>(ptr);
-  handle.lkey = mr->lkey;
-  handle.rkey = mr->rkey;
-  handle.length = mr->length;
-  return handle;
+  return MakeRdmaMemoryRegion(mr);
 }
 
 std::optional<application::RdmaMemoryRegion> RdmaDeviceContext::TryRegisterRdmaMemoryRegion(
@@ -372,12 +405,39 @@ std::optional<application::RdmaMemoryRegion> RdmaDeviceContext::TryRegisterRdmaM
     std::lock_guard<std::mutex> lock(mrPoolMu_);
     mrPool.insert({ptr, mr});
   }
-  application::RdmaMemoryRegion handle;
-  handle.addr = reinterpret_cast<uintptr_t>(ptr);
-  handle.lkey = mr->lkey;
-  handle.rkey = mr->rkey;
-  handle.length = mr->length;
-  return handle;
+  return MakeRdmaMemoryRegion(mr);
+}
+
+std::optional<application::RdmaOwnedMr> RdmaDeviceContext::TryRegisterOwnedMr(void* ptr,
+                                                                              size_t size,
+                                                                              int accessFlag) {
+  int effectiveAccessFlag = MaybeAddRelaxedOrderingFlag(accessFlag);
+  ibv_mr* mr = ibv_reg_mr(pd, ptr, size, effectiveAccessFlag);
+  if (!mr) {
+    MORI_APP_ERROR("TryRegisterOwnedMr failed: addr:{}, size:{}, accessFlag:{}, errno:{} ({})", ptr,
+                   size, effectiveAccessFlag, errno, strerror(errno));
+    return std::nullopt;
+  }
+  MORI_APP_TRACE("TryRegisterOwnedMr, addr:{}, size:{}, lkey:{}, rkey:{}\n", ptr, size, mr->lkey,
+                 mr->rkey);
+  return RdmaOwnedMr(MakeRdmaMemoryRegion(mr), mr);
+}
+
+std::optional<application::RdmaOwnedMr> RdmaDeviceContext::TryRegisterOwnedMrDmabuf(
+    void* ptr, size_t size, int dmabuf_fd, int accessFlag) {
+  int effectiveAccessFlag = MaybeAddRelaxedOrderingFlag(accessFlag);
+  ibv_mr* mr = ibv_reg_dmabuf_mr(pd, 0, size, reinterpret_cast<uint64_t>(ptr), dmabuf_fd,
+                                 effectiveAccessFlag);
+  if (!mr) {
+    MORI_APP_ERROR(
+        "TryRegisterOwnedMrDmabuf failed: addr:{}, size:{}, dmabuf_fd:{}, accessFlag:{}, "
+        "errno:{} ({})",
+        ptr, size, dmabuf_fd, effectiveAccessFlag, errno, strerror(errno));
+    return std::nullopt;
+  }
+  MORI_APP_TRACE("TryRegisterOwnedMrDmabuf, addr:{}, size:{}, dmabuf_fd:{}, lkey:{}, rkey:{}\n",
+                 ptr, size, dmabuf_fd, mr->lkey, mr->rkey);
+  return RdmaOwnedMr(MakeRdmaMemoryRegion(mr), mr);
 }
 
 application::RdmaMemoryRegion RdmaDeviceContext::RegisterRdmaMemoryRegionDmabuf(void* ptr,
@@ -401,12 +461,7 @@ application::RdmaMemoryRegion RdmaDeviceContext::RegisterRdmaMemoryRegionDmabuf(
     std::lock_guard<std::mutex> lock(mrPoolMu_);
     mrPool.insert({ptr, mr});
   }
-  application::RdmaMemoryRegion handle;
-  handle.addr = reinterpret_cast<uintptr_t>(ptr);
-  handle.lkey = mr->lkey;
-  handle.rkey = mr->rkey;
-  handle.length = mr->length;
-  return handle;
+  return MakeRdmaMemoryRegion(mr);
 }
 
 void RdmaDeviceContext::DeregisterRdmaMemoryRegion(void* ptr) {
@@ -415,6 +470,11 @@ void RdmaDeviceContext::DeregisterRdmaMemoryRegion(void* ptr) {
   if (it == mrPool.end()) return;
   ibv_dereg_mr(it->second);
   mrPool.erase(it);
+}
+
+void RdmaDeviceContext::DestroyRdmaEndpoint(const RdmaEndpoint&) {
+  MORI_APP_ERROR("DestroyRdmaEndpoint is not implemented for the current RDMA provider");
+  std::abort();
 }
 
 ibv_srq* RdmaDeviceContext::CreateRdmaSrqIfNx(const RdmaEndpointConfig& config) {

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -273,15 +273,19 @@ std::shared_ptr<const RdmaLocalMemoryRegistration> RdmaManager::GetOrMaterialize
   size_t chunkSize = GetEffectiveChunkSize(devCtx);
   if (chunkSize == 0 || desc.size <= chunkSize) {
     // Try single MR first
-    auto mr = devCtx->TryRegisterRdmaMemoryRegion(reinterpret_cast<void*>(desc.data), desc.size);
-    if (mr.has_value()) {
+    auto ownedMr = devCtx->TryRegisterOwnedMr(reinterpret_cast<void*>(desc.data), desc.size);
+    if (ownedMr.has_value()) {
       RdmaMemoryLayout layout;
       layout.rdmaDevId = rdmaDevId;
       layout.baseAddr = desc.data;
       layout.logicalSize = desc.size;
-      layout.chunks.push_back({0, *mr});
+      layout.chunks.push_back({0, ownedMr->Region()});
 
-      auto reg = std::make_shared<RdmaLocalMemoryRegistration>(std::move(layout), devCtx);
+      std::vector<application::RdmaOwnedMr> ownedMrs;
+      ownedMrs.push_back(std::move(*ownedMr));
+
+      auto reg =
+          std::make_shared<RdmaLocalMemoryRegistration>(std::move(layout), std::move(ownedMrs));
       std::unique_lock<std::shared_mutex> lock(mu);
       localRegistrations_[desc.id] = reg;
       return reg;
@@ -297,24 +301,23 @@ std::shared_ptr<const RdmaLocalMemoryRegistration> RdmaManager::GetOrMaterialize
   // Chunked registration
   size_t numChunks = (desc.size + chunkSize - 1) / chunkSize;
   std::vector<RdmaMemoryChunk> chunks;
+  std::vector<application::RdmaOwnedMr> ownedMrs;
   chunks.reserve(numChunks);
+  ownedMrs.reserve(numChunks);
 
   for (size_t i = 0; i < numChunks; ++i) {
     size_t offset = i * chunkSize;
     size_t len = std::min(chunkSize, desc.size - offset);
     void* ptr = reinterpret_cast<void*>(desc.data + offset);
 
-    auto mr = devCtx->TryRegisterRdmaMemoryRegion(ptr, len);
-    if (!mr.has_value()) {
+    auto ownedMr = devCtx->TryRegisterOwnedMr(ptr, len);
+    if (!ownedMr.has_value()) {
       MORI_IO_ERROR("Chunk registration failed for memory {}: chunk {}/{} offset={} len={}",
                     desc.id, i, numChunks, offset, len);
-      // Rollback previously registered chunks
-      for (auto& c : chunks) {
-        devCtx->DeregisterRdmaMemoryRegion(reinterpret_cast<void*>(c.mr.addr));
-      }
       throw std::runtime_error("Failed to register RDMA memory chunk");
     }
-    chunks.push_back({offset, *mr});
+    chunks.push_back({offset, ownedMr->Region()});
+    ownedMrs.push_back(std::move(*ownedMr));
   }
 
   RdmaMemoryLayout layout;
@@ -323,7 +326,7 @@ std::shared_ptr<const RdmaLocalMemoryRegistration> RdmaManager::GetOrMaterialize
   layout.logicalSize = desc.size;
   layout.chunks = std::move(chunks);
 
-  auto reg = std::make_shared<RdmaLocalMemoryRegistration>(std::move(layout), devCtx);
+  auto reg = std::make_shared<RdmaLocalMemoryRegistration>(std::move(layout), std::move(ownedMrs));
   std::unique_lock<std::shared_mutex> lock(mu);
   localRegistrations_[desc.id] = reg;
   MORI_IO_INFO("Materialized local registration for memory {}: {} chunk(s) on rdmaDevId {}",
@@ -339,7 +342,6 @@ void RdmaManager::DeregisterLocalRegistration(const MemoryDesc& desc) {
     localRegistrations_.erase(it);
   }
   memoryDeviceAffinity_.erase(desc.id);
-  materializationMutexes_.erase(desc.id);
 }
 
 /* ---------------------------------- Remote Layout Management ---------------------------------- */
@@ -368,14 +370,22 @@ void RdmaManager::DeregisterRemoteLayout(EngineKey ekey, MemoryUniqueId id) {
 }
 
 /* ------------------------------------- Endpoint Management ------------------------------------ */
-int RdmaManager::CountEndpoint(EngineKey engine, TopoKeyPair key) {
+int RdmaManager::CountEndpoint(EngineKey engine, const ExactRouteKey& key) {
   std::shared_lock<std::shared_mutex> lock(mu);
-  return remotes[engine].rTable[key].size();
+  auto remoteIt = remotes.find(engine);
+  if (remoteIt == remotes.end()) return 0;
+  auto routeIt = remoteIt->second.rTable.find(key);
+  if (routeIt == remoteIt->second.rTable.end()) return 0;
+  return routeIt->second.size();
 }
 
-EpPairVec RdmaManager::GetAllEndpoint(EngineKey engine, TopoKeyPair key) {
+EpPairVec RdmaManager::GetAllEndpoint(EngineKey engine, const ExactRouteKey& key) {
   std::shared_lock<std::shared_mutex> lock(mu);
-  return remotes[engine].rTable[key];
+  auto remoteIt = remotes.find(engine);
+  if (remoteIt == remotes.end()) return {};
+  auto routeIt = remoteIt->second.rTable.find(key);
+  if (routeIt == remoteIt->second.rTable.end()) return {};
+  return routeIt->second;
 }
 
 application::RdmaEndpointConfig RdmaManager::GetRdmaEndpointConfig(int devId) {
@@ -460,17 +470,34 @@ application::RdmaEndpoint RdmaManager::CreateEndpoint(int devId) {
   return rdmaEp;
 }
 
-EndpointId RdmaManager::ConnectEndpoint(EngineKey remoteKey, int devId,
-                                        application::RdmaEndpoint local, int rdevId,
-                                        application::RdmaEndpointHandle remote, TopoKeyPair topoKey,
-                                        int weight) {
+bool RdmaManager::IsValidRdmaDeviceId(int devId) const {
+  std::shared_lock<std::shared_mutex> lock(mu);
+  return devId >= 0 && devId < static_cast<int>(availDevices.size());
+}
+
+void RdmaManager::ConnectLocalEndpoint(int ldevId, const application::RdmaEndpoint& local,
+                                       const application::RdmaEndpointHandle& remote) {
   std::unique_lock<std::shared_mutex> lock(mu);
-  deviceCtxs[devId]->ConnectEndpoint(local.handle, remote);
+  deviceCtxs[ldevId]->ConnectEndpoint(local.handle, remote);
+}
+
+void RdmaManager::DestroyEndpoint(int devId, const application::RdmaEndpoint& endpoint) {
+  std::unique_lock<std::shared_mutex> lock(mu);
+  if (devId < 0 || devId >= static_cast<int>(deviceCtxs.size()) || deviceCtxs[devId] == nullptr) {
+    return;
+  }
+  deviceCtxs[devId]->DestroyRdmaEndpoint(endpoint);
+}
+
+EndpointId RdmaManager::PublishEndpoint(EngineKey remoteKey, const ExactRouteKey& key,
+                                        application::RdmaEndpoint local,
+                                        application::RdmaEndpointHandle remote, int weight) {
+  std::unique_lock<std::shared_mutex> lock(mu);
   RemoteEngineMeta& meta = remotes[remoteKey];
-  auto epConfig = GetRdmaEndpointConfig(devId);
+  auto epConfig = GetRdmaEndpointConfig(key.ldevId);
   EpPair ep{weight,
-            devId,
-            rdevId,
+            key.ldevId,
+            key.rdevId,
             remoteKey,
             local,
             remote,
@@ -478,12 +505,35 @@ EndpointId RdmaManager::ConnectEndpoint(EngineKey remoteKey, int devId,
             static_cast<int>(epConfig.maxMsgsNum),
             std::make_shared<std::atomic<bool>>(false),
             std::make_shared<SubmissionLedger>(config.notifPerQp)};
-  meta.rTable[topoKey].push_back(ep);
+  meta.rTable[key].push_back(ep);
 
   EndpointId id = nextEndpointId_.fetch_add(1);
   auto rt = std::make_shared<EndpointRuntime>(id, ep);
   endpointsById_[id] = rt;
   return id;
+}
+
+bool RdmaManager::UnpublishEndpoint(EngineKey remoteKey, const ExactRouteKey& key, EndpointId id) {
+  std::unique_lock<std::shared_mutex> lock(mu);
+
+  auto rtIt = endpointsById_.find(id);
+  if (rtIt == endpointsById_.end()) return false;
+  uint32_t localQpn = rtIt->second->ep.local.handle.qpn;
+  endpointsById_.erase(rtIt);
+
+  auto remoteIt = remotes.find(remoteKey);
+  if (remoteIt == remotes.end()) return false;
+  auto routeIt = remoteIt->second.rTable.find(key);
+  if (routeIt == remoteIt->second.rTable.end()) return false;
+
+  auto& eps = routeIt->second;
+  auto epIt = std::remove_if(eps.begin(), eps.end(), [localQpn](const EpPair& ep) {
+    return ep.local.handle.qpn == localQpn;
+  });
+  bool removed = epIt != eps.end();
+  eps.erase(epIt, eps.end());
+  if (eps.empty()) remoteIt->second.rTable.erase(routeIt);
+  return removed;
 }
 
 std::shared_ptr<EndpointRuntime> RdmaManager::GetEndpointRuntime(EndpointId id) {
@@ -527,6 +577,8 @@ NotifManager::NotifManager(RdmaManager* rdmaMgr, const RdmaBackendConfig& cfg)
 NotifManager::~NotifManager() { Shutdown(); }
 
 void NotifManager::RegisterEndpoint(const std::shared_ptr<EndpointRuntime>& rt) {
+  if (!rt) return;
+
   if (config.pollCqMode == PollCqMode::EVENT) {
     epoll_event ev;
     ev.events = EPOLLIN;
@@ -576,6 +628,36 @@ void NotifManager::RegisterEndpoint(const std::shared_ptr<EndpointRuntime>& rt) 
     struct ibv_recv_wr* bad = nullptr;
     SYSCALL_RETURN_ZERO(ibv_post_recv(qp, &wr, &bad));
   }
+}
+
+void NotifManager::UnregisterEndpoint(const std::shared_ptr<EndpointRuntime>& rt) {
+  if (!rt) return;
+
+  if (config.pollCqMode == PollCqMode::EVENT && rt->ep.local.ibvHandle.compCh != nullptr) {
+    SYSCALL_RETURN_ZERO_IGNORE_ERROR(
+        epoll_ctl(epfd, EPOLL_CTL_DEL, rt->ep.local.ibvHandle.compCh->fd, NULL), ENOENT);
+  }
+
+  QpNotifContext notifCtx{};
+  bool hasNotifCtx = false;
+  {
+    std::lock_guard<std::mutex> lock(mu);
+    registeredRuntimes_.erase(rt->id);
+    auto it = notifCtxById_.find(rt->id);
+    if (it != notifCtxById_.end()) {
+      notifCtx = it->second;
+      notifCtxById_.erase(it);
+      hasNotifCtx = true;
+    }
+  }
+
+  if (!hasNotifCtx) return;
+
+  application::RdmaDeviceContext* devCtx = rdma->GetRdmaDeviceContext(rt->ep.ldevId);
+  if (devCtx != nullptr) {
+    devCtx->DeregisterRdmaMemoryRegion(reinterpret_cast<void*>(notifCtx.mr.addr));
+  }
+  free(notifCtx.buf);
 }
 
 NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
@@ -894,41 +976,77 @@ void ControlPlaneServer::DeregisterRemoteEngine(const EngineDesc& rdesc) {
   engines.erase(rdesc.key);
 }
 
-void ControlPlaneServer::BuildRdmaConn(EngineKey ekey, TopoKeyPair topo, int ldevId, int rdevId) {
-  application::TCPEndpointHandle tcph;
-  {
-    std::lock_guard<std::mutex> lock(mu);
-    assert((engines.find(ekey) != engines.end()) && "register engine first");
-    EngineDesc& rdesc = engines[ekey];
-    tcph = ctx->Connect(rdesc.host, rdesc.port);
+void ControlPlaneServer::BuildRdmaConn(EngineKey ekey, const ExactRouteKey& key) {
+  application::TCPEndpointHandle tcph{};
+  bool tcpConnected = false;
+  bool localEpCreated = false;
+  bool published = false;
+  EndpointId eid = 0;
+  application::RdmaEndpoint lep;
+  std::shared_ptr<EndpointRuntime> ert;
+
+  try {
+    {
+      std::lock_guard<std::mutex> lock(mu);
+      assert((engines.find(ekey) != engines.end()) && "register engine first");
+      EngineDesc& rdesc = engines[ekey];
+      tcph = ctx->Connect(rdesc.host, rdesc.port);
+      tcpConnected = true;
+    }
+
+    if (!rdma->IsValidRdmaDeviceId(key.ldevId)) {
+      throw std::runtime_error("invalid initiator local RDMA device id " +
+                               std::to_string(key.ldevId));
+    }
+    if (!rdma->IsValidRdmaDeviceId(key.rdevId)) {
+      throw std::runtime_error("invalid responder local RDMA device id " +
+                               std::to_string(key.rdevId));
+    }
+
+    lep = rdma->CreateEndpoint(key.ldevId);
+    localEpCreated = true;
+
+    Protocol p(tcph);
+    p.WriteMessageRegEndpointRequest({myEngKey, key.topo, key.ldevId, key.rdevId, lep.handle});
+    MessageHeader hdr = p.ReadMessageHeader();
+    if (hdr.type != MessageType::RegEndpoint) {
+      throw std::runtime_error("unexpected control-plane response type " +
+                               std::to_string(static_cast<uint8_t>(hdr.type)));
+    }
+
+    MessageRegEndpointResponse msg = p.ReadMessageRegEndpointResponse(hdr.len);
+    if (msg.code != StatusCode::SUCCESS) {
+      throw std::runtime_error("RegEndpoint failed: " + msg.message);
+    }
+    if (msg.responderLocalDevId != key.rdevId) {
+      throw std::runtime_error("RegEndpoint responder local dev mismatch: expected " +
+                               std::to_string(key.rdevId) + " got " +
+                               std::to_string(msg.responderLocalDevId));
+    }
+
+    rdma->ConnectLocalEndpoint(key.ldevId, lep, msg.responderEph);
+    eid = rdma->PublishEndpoint(ekey, key, lep, msg.responderEph, 1);
+    published = true;
+    ert = rdma->GetEndpointRuntime(eid);
+    if (!ert) throw std::runtime_error("failed to resolve published endpoint runtime");
+    notif->RegisterEndpoint(ert);
+    localEpCreated = false;
+    MORI_IO_INFO("Built exact RdmaConn for engine {} local({},{}) remote({},{}) pair({}->{})", ekey,
+                 key.topo.local.deviceId, key.topo.local.loc, key.topo.remote.deviceId,
+                 key.topo.remote.loc, key.ldevId, key.rdevId);
+  } catch (...) {
+    if (published) {
+      notif->UnregisterEndpoint(ert);
+      if (!rdma->UnpublishEndpoint(ekey, key, eid)) {
+        MORI_IO_WARN("Failed to unpublish initiator endpoint {} for exact route cleanup", eid);
+      }
+    }
+    if (localEpCreated) rdma->DestroyEndpoint(key.ldevId, lep);
+    if (tcpConnected) ctx->CloseEndpoint(tcph);
+    throw;
   }
 
-  int devId;
-  int weight;
-  if (ldevId >= 0) {
-    devId = ldevId;
-    weight = 1;
-  } else {
-    auto candidates = rdma->Search(topo.local);
-    assert(!candidates.empty());
-    devId = candidates[0].first;
-    weight = candidates[0].second;
-  }
-
-  application::RdmaEndpoint lep = rdma->CreateEndpoint(devId);
-
-  Protocol p(tcph);
-  p.WriteMessageRegEndpoint({myEngKey, topo, devId, lep.handle, rdevId});
-  MessageHeader hdr = p.ReadMessageHeader();
-  assert(hdr.type == MessageType::RegEndpoint);
-  MessageRegEndpoint msg = p.ReadMessageRegEndpoint(hdr.len);
-
-  EndpointId eid = rdma->ConnectEndpoint(ekey, devId, lep, msg.devId, msg.eph, topo, weight);
-  auto ert = rdma->GetEndpointRuntime(eid);
-  notif->RegisterEndpoint(ert);
-  MORI_IO_INFO("Built RdmaConn for engine {} with topo local({},{}) remote({},{})", ekey,
-               topo.local.deviceId, topo.local.loc, topo.remote.deviceId, topo.remote.loc);
-  ctx->CloseEndpoint(tcph);
+  if (tcpConnected) ctx->CloseEndpoint(tcph);
 }
 
 void ControlPlaneServer::RegisterMemory(MemoryDesc& desc) {
@@ -1026,41 +1144,61 @@ void ControlPlaneServer::HandleControlPlaneProtocol(int fd) {
 
   switch (hdr.type) {
     case MessageType::RegEndpoint: {
-      MessageRegEndpoint msg = p.ReadMessageRegEndpoint(hdr.len);
-      int rdevId = msg.devId;
-      int devId;
-      int weight;
-      if (msg.requestedRemoteDevId >= 0) {
-        devId = msg.requestedRemoteDevId;
-        weight = 1;
-      } else {
-        auto candidates = rdma->Search(msg.topo.remote);
-        assert(!candidates.empty());
-        devId = candidates[0].first;
-        weight = candidates[0].second;
+      MessageRegEndpointRequest msg = p.ReadMessageRegEndpointRequest(hdr.len);
+      application::RdmaEndpoint lep;
+      bool localEpCreated = false;
+      bool published = false;
+      int devId = -1;
+      EndpointId eid = 0;
+      ExactRouteKey reverseKey{};
+      std::shared_ptr<EndpointRuntime> ert;
+
+      try {
+        if (msg.initiatorLocalDevId < 0) {
+          throw std::runtime_error("invalid initiator local RDMA device id");
+        }
+        devId = msg.expectedResponderLocalDevId;
+        if (!rdma->IsValidRdmaDeviceId(devId)) {
+          throw std::runtime_error("invalid responder local RDMA device id " +
+                                   std::to_string(devId));
+        }
+
+        reverseKey.topo = {msg.topo.remote, msg.topo.local};
+        reverseKey.ldevId = devId;
+        reverseKey.rdevId = msg.initiatorLocalDevId;
+
+        lep = rdma->CreateEndpoint(devId);
+        localEpCreated = true;
+        rdma->ConnectLocalEndpoint(devId, lep, msg.initiatorEph);
+        p.WriteMessageRegEndpointResponse({StatusCode::SUCCESS, "", devId, lep.handle});
+      } catch (const std::exception& e) {
+        if (localEpCreated) rdma->DestroyEndpoint(devId, lep);
+        try {
+          p.WriteMessageRegEndpointResponse({StatusCode::ERR_RDMA_OP, e.what(), -1, {}});
+        } catch (...) {
+        }
+        SYSCALL_RETURN_ZERO_IGNORE_ERROR(epoll_ctl(epfd, EPOLL_CTL_DEL, fd, NULL), ENOENT);
+        break;
       }
-      application::RdmaEndpoint lep = rdma->CreateEndpoint(devId);
-      EndpointId eid =
-          rdma->ConnectEndpoint(msg.ekey, devId, lep, rdevId, msg.eph, msg.topo, weight);
-      auto ert = rdma->GetEndpointRuntime(eid);
-      notif->RegisterEndpoint(ert);
-      p.WriteMessageRegEndpoint(MessageRegEndpoint{myEngKey, msg.topo, devId, lep.handle});
-      SYSCALL_RETURN_ZERO(epoll_ctl(epfd, EPOLL_CTL_DEL, fd, NULL));
-      break;
-    }
-    case MessageType::AskMemoryRegion: {
-      // Legacy path kept for protocol compat within this version
-      std::lock_guard<std::mutex> lock(mu);
-      MessageAskMemoryRegion msg = p.ReadMessageAskMemoryRegion(hdr.len);
-      if (mems.find(msg.id) != mems.end()) {
-        MemoryDesc& desc = mems[msg.id];
-        auto reg = rdma->GetOrMaterializeLocalRegistration(desc);
-        const auto& layout = reg->Layout();
-        assert(layout.IsSingleChunk());
-        p.WriteMessageAskMemoryRegion({msg.ekey, msg.devId, msg.id, layout.chunks[0].mr});
-      } else {
-        p.WriteMessageAskMemoryRegion({msg.ekey, msg.devId, msg.id, {}});
+
+      try {
+        eid = rdma->PublishEndpoint(msg.ekey, reverseKey, lep, msg.initiatorEph, 1);
+        published = true;
+        ert = rdma->GetEndpointRuntime(eid);
+        if (!ert) throw std::runtime_error("failed to resolve published endpoint runtime");
+        notif->RegisterEndpoint(ert);
+        localEpCreated = false;
+      } catch (const std::exception& e) {
+        if (published) {
+          notif->UnregisterEndpoint(ert);
+          if (!rdma->UnpublishEndpoint(msg.ekey, reverseKey, eid)) {
+            MORI_IO_WARN("Failed to unpublish responder endpoint {} for exact route cleanup", eid);
+          }
+        }
+        if (localEpCreated) rdma->DestroyEndpoint(devId, lep);
+        MORI_IO_ERROR("RegEndpoint responder post-response setup failed: {}", e.what());
       }
+      SYSCALL_RETURN_ZERO_IGNORE_ERROR(epoll_ctl(epfd, EPOLL_CTL_DEL, fd, NULL), ENOENT);
       break;
     }
     case MessageType::AskMemoryLayout: {
@@ -1190,18 +1328,29 @@ void RdmaBackendSession::ReadWrite(size_t localOffset, size_t remoteOffset, size
     assert(!ret.Init());
     if (ret.Failed() || ret.Succeeded()) status->Update(ret.code, ret.message);
   } else {
-    auto slices = ResolveTransferSlices(local.registration->Layout(), localOffset,
-                                        remote.layout->layout, remoteOffset, size);
-    if (slices.empty() && size > 0) {
+    size_t maxResolvedLanes =
+        executor ? std::min(eps.size(), static_cast<size_t>(executor->MaxParallelTasks()))
+                 : eps.size();
+    auto plan =
+        BuildResolvedTransferPlan(eps, local.registration->Layout(), {localOffset},
+                                  remote.layout->layout, {remoteOffset}, {size}, maxResolvedLanes);
+    if (plan.slices.empty() && size > 0) {
       status->Update(StatusCode::ERR_INVALID_ARGS, "length out of range");
       return;
     }
     auto callbackMeta =
-        std::make_shared<CqCallbackMeta>(status, id, static_cast<int>(slices.size()));
+        std::make_shared<CqCallbackMeta>(status, id, static_cast<int>(plan.slices.size()));
     callbackMeta->localRegRef = local.registration;
     internal::PublishCurrentIoCallDiagnostics(callbackMeta);
-    RdmaOpRet ret =
-        RdmaBatchReadWriteResolved(eps, slices, callbackMeta, id, isRead, config.postBatchSize);
+    RdmaOpRet ret;
+    if (executor) {
+      ResolvedExecutorReq req{eps, plan.slices,          plan.lanes, callbackMeta,
+                              id,  config.postBatchSize, isRead};
+      ret = executor->RdmaBatchReadWriteResolved(req);
+    } else {
+      ret = RdmaSubmitResolvedTransferPlanInline(eps, plan.slices, plan.lanes, callbackMeta, id,
+                                                 isRead, config.postBatchSize);
+    }
     assert(!ret.Init());
     if (ret.Failed() || ret.Succeeded()) status->Update(ret.code, ret.message);
   }
@@ -1238,23 +1387,30 @@ void RdmaBackendSession::BatchReadWrite(const SizeVec& localOffsets, const SizeV
     assert(!ret.Init());
     if (ret.Failed() || ret.Succeeded()) status->Update(ret.code, ret.message);
   } else {
-    // Resolved path: flatten all logical requests into one slice stream
-    std::vector<RdmaTransferSlice> allSlices;
-    for (size_t i = 0; i < sizes.size(); ++i) {
-      auto slices = ResolveTransferSlices(local.registration->Layout(), localOffsets[i],
-                                          remote.layout->layout, remoteOffsets[i], sizes[i]);
-      if (slices.empty() && sizes[i] > 0) {
-        status->Update(StatusCode::ERR_INVALID_ARGS, "length out of range");
-        return;
-      }
-      allSlices.insert(allSlices.end(), slices.begin(), slices.end());
+    size_t maxResolvedLanes =
+        executor ? std::min(eps.size(), static_cast<size_t>(executor->MaxParallelTasks()))
+                 : eps.size();
+    auto plan =
+        BuildResolvedTransferPlan(eps, local.registration->Layout(), localOffsets,
+                                  remote.layout->layout, remoteOffsets, sizes, maxResolvedLanes);
+    if (plan.slices.empty() &&
+        std::any_of(sizes.begin(), sizes.end(), [](size_t sz) { return sz > 0; })) {
+      status->Update(StatusCode::ERR_INVALID_ARGS, "length out of range");
+      return;
     }
     auto callbackMeta =
-        std::make_shared<CqCallbackMeta>(status, id, static_cast<int>(allSlices.size()));
+        std::make_shared<CqCallbackMeta>(status, id, static_cast<int>(plan.slices.size()));
     callbackMeta->localRegRef = local.registration;
     internal::PublishCurrentIoCallDiagnostics(callbackMeta);
-    RdmaOpRet ret =
-        RdmaBatchReadWriteResolved(eps, allSlices, callbackMeta, id, isRead, config.postBatchSize);
+    RdmaOpRet ret;
+    if (executor) {
+      ResolvedExecutorReq req{eps, plan.slices,          plan.lanes, callbackMeta,
+                              id,  config.postBatchSize, isRead};
+      ret = executor->RdmaBatchReadWriteResolved(req);
+    } else {
+      ret = RdmaSubmitResolvedTransferPlanInline(eps, plan.slices, plan.lanes, callbackMeta, id,
+                                                 isRead, config.postBatchSize);
+    }
     assert(!ret.Init());
     if (ret.Failed() || ret.Succeeded()) status->Update(ret.code, ret.message);
   }
@@ -1389,26 +1545,16 @@ std::shared_ptr<RdmaBackendSession> RdmaBackend::CreateSessionImpl(const MemoryD
     rdma->RegisterRemoteLayout(ekey, remote.id, remoteLayout);
   }
 
-  // 3. Create/reuse endpoints, filtered to exact (ldevId, rdevId) pair
+  // 3. Create/reuse endpoints for the exact (ldevId, rdevId) pair
   TopoKey localKey{local.deviceId, local.loc};
   TopoKey remoteKey{remote.deviceId, remote.loc};
   TopoKeyPair kp{localKey, remoteKey};
-  int pinnedLdevId = localLayout.rdmaDevId;
-  int pinnedRdevId = remoteLayout->layout.rdmaDevId;
+  ExactRouteKey exactKey{kp, localLayout.rdmaDevId, remoteLayout->layout.rdmaDevId};
 
-  EpPairVec allEps = rdma->GetAllEndpoint(ekey, kp);
-  EpPairVec epSet;
-  for (auto& ep : allEps) {
-    if (ep.ldevId == pinnedLdevId && ep.rdevId == pinnedRdevId) epSet.push_back(ep);
-  }
-
+  EpPairVec epSet = rdma->GetAllEndpoint(ekey, exactKey);
   while (static_cast<int>(epSet.size()) < config.qpPerTransfer) {
-    server->BuildRdmaConn(ekey, kp, pinnedLdevId, pinnedRdevId);
-    allEps = rdma->GetAllEndpoint(ekey, kp);
-    epSet.clear();
-    for (auto& ep : allEps) {
-      if (ep.ldevId == pinnedLdevId && ep.rdevId == pinnedRdevId) epSet.push_back(ep);
-    }
+    server->BuildRdmaConn(ekey, exactKey);
+    epSet = rdma->GetAllEndpoint(ekey, exactKey);
   }
   epSet.resize(config.qpPerTransfer);
 

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -1491,7 +1491,7 @@ void RdmaBackend::ReadWrite(const MemoryDesc& localDest, size_t localOffset,
                             TransferStatus* status, TransferUniqueId id, bool isRead) {
   MORI_IO_FUNCTION_TIMER;
   try {
-    auto sess = GetOrCreateSessionCached(localDest, remoteSrc);
+    RdmaBackendSession* sess = GetOrCreateSessionCached(localDest, remoteSrc);
     sess->ReadWrite(localOffset, remoteOffset, size, status, id, isRead);
   } catch (const std::exception& e) {
     MORI_IO_ERROR("RdmaBackend::ReadWrite failed: {}", e.what());
@@ -1513,7 +1513,7 @@ void RdmaBackend::BatchReadWrite(const MemoryDesc& localDest, const SizeVec& loc
   }
 
   try {
-    auto sess = GetOrCreateSessionCached(localDest, remoteSrc);
+    RdmaBackendSession* sess = GetOrCreateSessionCached(localDest, remoteSrc);
     sess->BatchReadWrite(localOffsets, remoteOffsets, sizes, status, id, isRead);
   } catch (const std::exception& e) {
     MORI_IO_ERROR("RdmaBackend::BatchReadWrite failed: {}", e.what());
@@ -1582,20 +1582,20 @@ bool RdmaBackend::PopInboundTransferStatus(EngineKey remote, TransferUniqueId id
   return notif->PopInboundTransferStatus(remote, id, status);
 }
 
-std::shared_ptr<RdmaBackendSession> RdmaBackend::GetOrCreateSessionCached(
-    const MemoryDesc& local, const MemoryDesc& remote) {
+RdmaBackendSession* RdmaBackend::GetOrCreateSessionCached(const MemoryDesc& local,
+                                                          const MemoryDesc& remote) {
   SessionCacheKey key{remote.engineKey, local.id, remote.id};
   {
     std::lock_guard<std::mutex> lock(sessionCacheMu);
     auto it = sessionCache.find(key);
-    if (it != sessionCache.end()) return it->second;
+    if (it != sessionCache.end()) return it->second.get();
   }
   auto newSess = CreateSessionImpl(local, remote);
   std::lock_guard<std::mutex> lock(sessionCacheMu);
   auto it = sessionCache.find(key);
-  if (it != sessionCache.end()) return it->second;
+  if (it != sessionCache.end()) return it->second.get();
   auto [emplacedIt, inserted] = sessionCache.emplace(key, std::move(newSess));
-  return emplacedIt->second;
+  return emplacedIt->second.get();
 }
 
 void RdmaBackend::InvalidateSessionsForMemory(MemoryUniqueId id) {

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -154,6 +154,8 @@ RdmaManager::RdmaManager(const RdmaBackendConfig cfg, application::RdmaContext* 
 }
 
 RdmaManager::~RdmaManager() {
+  localRegistrations_.clear();
+
   for (auto* devCtx : deviceCtxs) {
     if (devCtx != nullptr) {
       delete devCtx;
@@ -198,58 +200,170 @@ std::vector<std::pair<int, int>> RdmaManager::Search(TopoKey key) {
 }
 
 /* ----------------------------------- Local Memory Management ---------------------------------- */
-std::optional<application::RdmaMemoryRegion> RdmaManager::GetLocalMemory(int devId,
-                                                                         MemoryUniqueId id) {
-  std::shared_lock<std::shared_mutex> lock(mu);
-  MemoryKey key{devId, id};
-  if (mTable.find(key) == mTable.end()) return std::nullopt;
-  return mTable[key];
+int RdmaManager::PickRdmaDeviceForMemory(const MemoryDesc& desc) {
+  TopoKey tkey{desc.deviceId, desc.loc};
+  auto candidates = Search(tkey);
+  assert(!candidates.empty());
+  return candidates[0].first;
 }
 
-application::RdmaMemoryRegion RdmaManager::RegisterLocalMemory(int devId, const MemoryDesc& desc) {
-  std::unique_lock<std::shared_mutex> lock(mu);
-  MemoryKey key{devId, desc.id};
-  application::RdmaDeviceContext* devCtx = GetOrCreateDeviceContext(devId);
-  mTable[key] = devCtx->RegisterRdmaMemoryRegion(reinterpret_cast<void*>(desc.data), desc.size);
-  return mTable[key];
-}
+size_t RdmaManager::GetEffectiveChunkSize(application::RdmaDeviceContext* devCtx) {
+  auto* device = devCtx->GetRdmaDevice();
+  const auto* attr = device->GetDeviceAttr();
+  size_t deviceMaxMrSize = static_cast<size_t>(attr->orig_attr.max_mr_size);
 
-void RdmaManager::DeregisterLocalMemory(int devId, const MemoryDesc& desc) {
-  std::unique_lock<std::shared_mutex> lock(mu);
-  MemoryKey key{devId, desc.id};
-  if (mTable.find(key) != mTable.end()) {
-    deviceCtxs[devId]->DeregisterRdmaMemoryRegion(reinterpret_cast<void*>(desc.data));
-    mTable.erase(key);
+  size_t effective = deviceMaxMrSize;
+  const char* envOverride = std::getenv("MORI_IO_RDMA_MR_CHUNK_SIZE");
+  if (envOverride) {
+    size_t overrideVal = std::strtoull(envOverride, nullptr, 10);
+    if (overrideVal > 0) {
+      effective = (deviceMaxMrSize > 0) ? std::min(deviceMaxMrSize, overrideVal) : overrideVal;
+    }
   }
+  return effective;
 }
 
-/* ---------------------------------- Remote Memory Management ---------------------------------- */
-std::optional<application::RdmaMemoryRegion> RdmaManager::GetRemoteMemory(EngineKey ekey,
-                                                                          int remRdmaDevId,
-                                                                          MemoryUniqueId id) {
-  std::shared_lock<std::shared_mutex> lock(mu);
-  MemoryKey key{remRdmaDevId, id};
-  RemoteEngineMeta& remote = remotes[ekey];
-  if (remote.mTable.find(key) == remote.mTable.end()) {
-    return std::nullopt;
+std::shared_ptr<const RdmaLocalMemoryRegistration> RdmaManager::GetOrMaterializeLocalRegistration(
+    const MemoryDesc& desc) {
+  // Fast path: check if already materialized
+  {
+    std::shared_lock<std::shared_mutex> lock(mu);
+    auto it = localRegistrations_.find(desc.id);
+    if (it != localRegistrations_.end()) return it->second;
   }
-  return remote.mTable[key];
+
+  // Get or create per-memory mutex for single-flight materialization
+  std::shared_ptr<std::mutex> matMu;
+  {
+    std::unique_lock<std::shared_mutex> lock(mu);
+    auto& ptr = materializationMutexes_[desc.id];
+    if (!ptr) ptr = std::make_shared<std::mutex>();
+    matMu = ptr;
+  }
+
+  std::lock_guard<std::mutex> matLock(*matMu);
+
+  // Re-check after acquiring the per-memory lock
+  {
+    std::shared_lock<std::shared_mutex> lock(mu);
+    auto it = localRegistrations_.find(desc.id);
+    if (it != localRegistrations_.end()) return it->second;
+  }
+
+  // Pin device affinity
+  int rdmaDevId;
+  {
+    std::unique_lock<std::shared_mutex> lock(mu);
+    auto affIt = memoryDeviceAffinity_.find(desc.id);
+    if (affIt != memoryDeviceAffinity_.end()) {
+      rdmaDevId = affIt->second;
+    } else {
+      rdmaDevId = PickRdmaDeviceForMemory(desc);
+      memoryDeviceAffinity_[desc.id] = rdmaDevId;
+    }
+  }
+
+  // Compute chunk plan and register MRs outside the manager lock
+  application::RdmaDeviceContext* devCtx;
+  {
+    std::unique_lock<std::shared_mutex> lock(mu);
+    devCtx = GetOrCreateDeviceContext(rdmaDevId);
+  }
+
+  size_t chunkSize = GetEffectiveChunkSize(devCtx);
+  if (chunkSize == 0 || desc.size <= chunkSize) {
+    // Try single MR first
+    auto mr = devCtx->TryRegisterRdmaMemoryRegion(reinterpret_cast<void*>(desc.data), desc.size);
+    if (mr.has_value()) {
+      RdmaMemoryLayout layout;
+      layout.rdmaDevId = rdmaDevId;
+      layout.baseAddr = desc.data;
+      layout.logicalSize = desc.size;
+      layout.chunks.push_back({0, *mr});
+
+      auto reg = std::make_shared<RdmaLocalMemoryRegistration>(std::move(layout), devCtx);
+      std::unique_lock<std::shared_mutex> lock(mu);
+      localRegistrations_[desc.id] = reg;
+      return reg;
+    }
+    if (chunkSize == 0) {
+      MORI_IO_ERROR("Failed to register single MR for memory {} and no chunk size available",
+                    desc.id);
+      throw std::runtime_error("Failed to register RDMA memory region");
+    }
+    // Fall through to chunked registration
+  }
+
+  // Chunked registration
+  size_t numChunks = (desc.size + chunkSize - 1) / chunkSize;
+  std::vector<RdmaMemoryChunk> chunks;
+  chunks.reserve(numChunks);
+
+  for (size_t i = 0; i < numChunks; ++i) {
+    size_t offset = i * chunkSize;
+    size_t len = std::min(chunkSize, desc.size - offset);
+    void* ptr = reinterpret_cast<void*>(desc.data + offset);
+
+    auto mr = devCtx->TryRegisterRdmaMemoryRegion(ptr, len);
+    if (!mr.has_value()) {
+      MORI_IO_ERROR("Chunk registration failed for memory {}: chunk {}/{} offset={} len={}",
+                    desc.id, i, numChunks, offset, len);
+      // Rollback previously registered chunks
+      for (auto& c : chunks) {
+        devCtx->DeregisterRdmaMemoryRegion(reinterpret_cast<void*>(c.mr.addr));
+      }
+      throw std::runtime_error("Failed to register RDMA memory chunk");
+    }
+    chunks.push_back({offset, *mr});
+  }
+
+  RdmaMemoryLayout layout;
+  layout.rdmaDevId = rdmaDevId;
+  layout.baseAddr = desc.data;
+  layout.logicalSize = desc.size;
+  layout.chunks = std::move(chunks);
+
+  auto reg = std::make_shared<RdmaLocalMemoryRegistration>(std::move(layout), devCtx);
+  std::unique_lock<std::shared_mutex> lock(mu);
+  localRegistrations_[desc.id] = reg;
+  MORI_IO_INFO("Materialized local registration for memory {}: {} chunk(s) on rdmaDevId {}",
+               desc.id, reg->Layout().chunks.size(), rdmaDevId);
+  return reg;
 }
 
-void RdmaManager::RegisterRemoteMemory(EngineKey ekey, int remRdmaDevId, MemoryUniqueId id,
-                                       application::RdmaMemoryRegion mr) {
+void RdmaManager::DeregisterLocalRegistration(const MemoryDesc& desc) {
   std::unique_lock<std::shared_mutex> lock(mu);
-  MemoryKey key{remRdmaDevId, id};
-  RemoteEngineMeta& remote = remotes[ekey];
-  remote.mTable[key] = mr;
+  auto it = localRegistrations_.find(desc.id);
+  if (it != localRegistrations_.end()) {
+    it->second->MarkInvalidated();
+    localRegistrations_.erase(it);
+  }
+  memoryDeviceAffinity_.erase(desc.id);
+  materializationMutexes_.erase(desc.id);
 }
 
-void RdmaManager::DeregisterRemoteMemory(EngineKey ekey, int remRdmaDevId, MemoryUniqueId id) {
+/* ---------------------------------- Remote Layout Management ---------------------------------- */
+std::shared_ptr<const RdmaRemoteMemoryLayout> RdmaManager::GetRemoteLayout(EngineKey ekey,
+                                                                           MemoryUniqueId id) {
+  std::shared_lock<std::shared_mutex> lock(mu);
+  auto remIt = remotes.find(ekey);
+  if (remIt == remotes.end()) return nullptr;
+  auto it = remIt->second.remoteLayouts.find(id);
+  if (it == remIt->second.remoteLayouts.end()) return nullptr;
+  return it->second;
+}
+
+void RdmaManager::RegisterRemoteLayout(EngineKey ekey, MemoryUniqueId id,
+                                       std::shared_ptr<const RdmaRemoteMemoryLayout> layout) {
   std::unique_lock<std::shared_mutex> lock(mu);
-  RemoteEngineMeta& remote = remotes[ekey];
-  MemoryKey key{remRdmaDevId, id};
-  if (remote.mTable.find(key) != remote.mTable.end()) {
-    remote.mTable.erase(key);
+  remotes[ekey].remoteLayouts[id] = std::move(layout);
+}
+
+void RdmaManager::DeregisterRemoteLayout(EngineKey ekey, MemoryUniqueId id) {
+  std::unique_lock<std::shared_mutex> lock(mu);
+  auto remIt = remotes.find(ekey);
+  if (remIt != remotes.end()) {
+    remIt->second.remoteLayouts.erase(id);
   }
 }
 
@@ -780,7 +894,7 @@ void ControlPlaneServer::DeregisterRemoteEngine(const EngineDesc& rdesc) {
   engines.erase(rdesc.key);
 }
 
-void ControlPlaneServer::BuildRdmaConn(EngineKey ekey, TopoKeyPair topo) {
+void ControlPlaneServer::BuildRdmaConn(EngineKey ekey, TopoKeyPair topo, int ldevId, int rdevId) {
   application::TCPEndpointHandle tcph;
   {
     std::lock_guard<std::mutex> lock(mu);
@@ -789,14 +903,22 @@ void ControlPlaneServer::BuildRdmaConn(EngineKey ekey, TopoKeyPair topo) {
     tcph = ctx->Connect(rdesc.host, rdesc.port);
   }
 
-  auto candidates = rdma->Search(topo.local);
-  assert(!candidates.empty());
-  auto [devId, weight] = candidates[0];
+  int devId;
+  int weight;
+  if (ldevId >= 0) {
+    devId = ldevId;
+    weight = 1;
+  } else {
+    auto candidates = rdma->Search(topo.local);
+    assert(!candidates.empty());
+    devId = candidates[0].first;
+    weight = candidates[0].second;
+  }
 
   application::RdmaEndpoint lep = rdma->CreateEndpoint(devId);
 
   Protocol p(tcph);
-  p.WriteMessageRegEndpoint({myEngKey, topo, devId, lep.handle});
+  p.WriteMessageRegEndpoint({myEngKey, topo, devId, lep.handle, rdevId});
   MessageHeader hdr = p.ReadMessageHeader();
   assert(hdr.type == MessageType::RegEndpoint);
   MessageRegEndpoint msg = p.ReadMessageRegEndpoint(hdr.len);
@@ -819,8 +941,8 @@ void ControlPlaneServer::DeregisterMemory(const MemoryDesc& desc) {
   mems.erase(desc.id);
 }
 
-application::RdmaMemoryRegion ControlPlaneServer::AskRemoteMemoryRegion(EngineKey ekey, int rdevId,
-                                                                        MemoryUniqueId id) {
+std::shared_ptr<const RdmaRemoteMemoryLayout> ControlPlaneServer::AskRemoteMemoryLayout(
+    EngineKey ekey, MemoryUniqueId id, size_t expectedSize) {
   application::TCPEndpointHandle tcph;
   {
     std::lock_guard<std::mutex> lock(mu);
@@ -830,12 +952,58 @@ application::RdmaMemoryRegion ControlPlaneServer::AskRemoteMemoryRegion(EngineKe
   }
 
   Protocol p(tcph);
-  p.WriteMessageAskMemoryRegion({ekey, rdevId, id, {}});
+  p.WriteMessageAskMemoryLayoutRequest({ekey, id});
   MessageHeader hdr = p.ReadMessageHeader();
-  assert(hdr.type == MessageType::AskMemoryRegion);
-  MessageAskMemoryRegion msg = p.ReadMessageAskMemoryRegion(hdr.len);
+  if (hdr.type != MessageType::AskMemoryLayout) {
+    ctx->CloseEndpoint(tcph);
+    throw std::runtime_error("AskRemoteMemoryLayout: unexpected message type " +
+                             std::to_string(static_cast<uint8_t>(hdr.type)));
+  }
+  MessageAskMemoryLayoutResponse msg = p.ReadMessageAskMemoryLayoutResponse(hdr.len);
+  ctx->CloseEndpoint(tcph);
 
-  return msg.mr;
+  if (msg.code != StatusCode::SUCCESS) {
+    MORI_IO_ERROR("AskRemoteMemoryLayout failed for memory {}: code={} message={}", id,
+                  static_cast<uint32_t>(msg.code), msg.message);
+    throw std::runtime_error("Remote memory layout materialization failed: " + msg.message);
+  }
+
+  // Validate chunk coverage
+  RdmaMemoryLayout layout;
+  layout.rdmaDevId = msg.rdmaDevId;
+  layout.logicalSize = 0;
+  layout.baseAddr = 0;
+  for (auto& cw : msg.chunks) {
+    application::RdmaMemoryRegion mr;
+    mr.addr = static_cast<uintptr_t>(cw.addr);
+    mr.rkey = cw.rkey;
+    mr.lkey = 0;
+    mr.length = static_cast<size_t>(cw.length);
+    layout.chunks.push_back({static_cast<size_t>(cw.offset), mr});
+    if (layout.baseAddr == 0) layout.baseAddr = mr.addr;
+    layout.logicalSize += mr.length;
+  }
+
+  if (layout.chunks.empty()) {
+    throw std::runtime_error("Remote memory layout for id " + std::to_string(id) +
+                             " returned zero chunks");
+  }
+  if (layout.logicalSize != expectedSize) {
+    throw std::runtime_error("Remote memory layout size mismatch for id " + std::to_string(id) +
+                             ": expected " + std::to_string(expectedSize) + " got " +
+                             std::to_string(layout.logicalSize));
+  }
+  size_t expectedOffset = 0;
+  for (const auto& c : layout.chunks) {
+    if (c.offset != expectedOffset) {
+      throw std::runtime_error("Remote memory layout for id " + std::to_string(id) +
+                               " has non-contiguous chunks: expected offset " +
+                               std::to_string(expectedOffset) + " got " + std::to_string(c.offset));
+    }
+    expectedOffset += c.mr.length;
+  }
+
+  return std::make_shared<RdmaRemoteMemoryLayout>(RdmaRemoteMemoryLayout{std::move(layout)});
 }
 
 void ControlPlaneServer::AcceptRemoteEngineConn() {
@@ -859,10 +1027,18 @@ void ControlPlaneServer::HandleControlPlaneProtocol(int fd) {
   switch (hdr.type) {
     case MessageType::RegEndpoint: {
       MessageRegEndpoint msg = p.ReadMessageRegEndpoint(hdr.len);
-      auto candidates = rdma->Search(msg.topo.remote);
-      assert(!candidates.empty());
       int rdevId = msg.devId;
-      auto [devId, weight] = candidates[0];
+      int devId;
+      int weight;
+      if (msg.requestedRemoteDevId >= 0) {
+        devId = msg.requestedRemoteDevId;
+        weight = 1;
+      } else {
+        auto candidates = rdma->Search(msg.topo.remote);
+        assert(!candidates.empty());
+        devId = candidates[0].first;
+        weight = candidates[0].second;
+      }
       application::RdmaEndpoint lep = rdma->CreateEndpoint(devId);
       EndpointId eid =
           rdma->ConnectEndpoint(msg.ekey, devId, lep, rdevId, msg.eph, msg.topo, weight);
@@ -873,18 +1049,51 @@ void ControlPlaneServer::HandleControlPlaneProtocol(int fd) {
       break;
     }
     case MessageType::AskMemoryRegion: {
+      // Legacy path kept for protocol compat within this version
       std::lock_guard<std::mutex> lock(mu);
       MessageAskMemoryRegion msg = p.ReadMessageAskMemoryRegion(hdr.len);
       if (mems.find(msg.id) != mems.end()) {
         MemoryDesc& desc = mems[msg.id];
-        auto localMr = rdma->GetLocalMemory(msg.devId, msg.id);
-        if (!localMr.has_value()) {
-          localMr = rdma->RegisterLocalMemory(msg.devId, desc);
-        }
-        p.WriteMessageAskMemoryRegion({msg.ekey, msg.devId, msg.id, *localMr});
+        auto reg = rdma->GetOrMaterializeLocalRegistration(desc);
+        const auto& layout = reg->Layout();
+        assert(layout.IsSingleChunk());
+        p.WriteMessageAskMemoryRegion({msg.ekey, msg.devId, msg.id, layout.chunks[0].mr});
       } else {
-        // TODO: we should add status code for NOT_FOUND
         p.WriteMessageAskMemoryRegion({msg.ekey, msg.devId, msg.id, {}});
+      }
+      break;
+    }
+    case MessageType::AskMemoryLayout: {
+      MessageAskMemoryLayoutRequest req = p.ReadMessageAskMemoryLayoutRequest(hdr.len);
+      MemoryDesc desc;
+      bool found = false;
+      {
+        std::lock_guard<std::mutex> lock(mu);
+        auto it = mems.find(req.id);
+        if (it != mems.end()) {
+          desc = it->second;
+          found = true;
+        }
+      }
+      if (!found) {
+        p.WriteMessageAskMemoryLayoutResponse(
+            {req.ekey, req.id, StatusCode::ERR_NOT_FOUND, "memory not found", -1, {}});
+        break;
+      }
+      try {
+        auto reg = rdma->GetOrMaterializeLocalRegistration(desc);
+        const auto& layout = reg->Layout();
+        std::vector<RdmaRemoteMemoryChunkWire> wireChunks;
+        wireChunks.reserve(layout.chunks.size());
+        for (const auto& c : layout.chunks) {
+          wireChunks.push_back({static_cast<uint64_t>(c.offset), static_cast<uint64_t>(c.mr.addr),
+                                c.mr.rkey, static_cast<uint64_t>(c.mr.length)});
+        }
+        p.WriteMessageAskMemoryLayoutResponse(
+            {req.ekey, req.id, StatusCode::SUCCESS, "", layout.rdmaDevId, std::move(wireChunks)});
+      } catch (const std::exception& e) {
+        p.WriteMessageAskMemoryLayoutResponse(
+            {req.ekey, req.id, StatusCode::ERR_RDMA_OP, e.what(), -1, {}});
       }
       break;
     }
@@ -949,31 +1158,57 @@ void ControlPlaneServer::Shutdown() {
 /*                                       RdmaBackendSession */
 /* ----------------------------------------------------------------------------------------------
  */
-RdmaBackendSession::RdmaBackendSession(const RdmaBackendConfig& config,
-                                       const application::RdmaMemoryRegion& l,
-                                       const application::RdmaMemoryRegion& r, const EpPairVec& e,
+RdmaBackendSession::RdmaBackendSession(const RdmaBackendConfig& config, RdmaResolvedLocalMemory l,
+                                       RdmaResolvedRemoteMemory r, const EpPairVec& e,
                                        Executor* exec)
-    : config(config), local(l), remote(r), eps(e), executor(exec) {}
+    : config(config), local(std::move(l)), remote(std::move(r)), eps(e), executor(exec) {}
+
+bool RdmaBackendSession::UseFastPath(const SizeVec& sizes) const {
+  if (!local.singleMrFastPath || !remote.singleMrFastPath) return false;
+  for (auto s : sizes) {
+    if (s > std::numeric_limits<uint32_t>::max()) return false;
+  }
+  return true;
+}
 
 void RdmaBackendSession::ReadWrite(size_t localOffset, size_t remoteOffset, size_t size,
                                    TransferStatus* status, TransferUniqueId id, bool isRead) {
   MORI_IO_FUNCTION_TIMER;
-  status->SetCode(StatusCode::IN_PROGRESS);
-  auto callbackMeta = std::make_shared<CqCallbackMeta>(status, id, 1);
-  internal::PublishCurrentIoCallDiagnostics(callbackMeta);
-
-  RdmaOpRet ret =
-      RdmaReadWrite(eps, local, localOffset, remote, remoteOffset, size, callbackMeta, id, isRead);
-
-  assert(!ret.Init());
-  if (ret.Failed() || ret.Succeeded()) {
-    status->Update(ret.code, ret.message);
+  if (local.registration && local.registration->Invalidated()) {
+    status->Update(StatusCode::ERR_INVALID_ARGS, "local memory has been deregistered");
+    return;
   }
-  if (!ret.Failed() && config.enableNotification) {
-    RdmaOpRet notifRet = RdmaNotifyTransfer(eps, status, id);
-    if (notifRet.Failed()) {
-      status->Update(notifRet.code, notifRet.message);
+  status->SetCode(StatusCode::IN_PROGRESS);
+
+  if (local.singleMrFastPath && remote.singleMrFastPath &&
+      size <= std::numeric_limits<uint32_t>::max()) {
+    auto callbackMeta = std::make_shared<CqCallbackMeta>(status, id, 1);
+    callbackMeta->localRegRef = local.registration;
+    internal::PublishCurrentIoCallDiagnostics(callbackMeta);
+    RdmaOpRet ret = RdmaReadWrite(eps, local.singleMr, localOffset, remote.singleMr, remoteOffset,
+                                  size, callbackMeta, id, isRead);
+    assert(!ret.Init());
+    if (ret.Failed() || ret.Succeeded()) status->Update(ret.code, ret.message);
+  } else {
+    auto slices = ResolveTransferSlices(local.registration->Layout(), localOffset,
+                                        remote.layout->layout, remoteOffset, size);
+    if (slices.empty() && size > 0) {
+      status->Update(StatusCode::ERR_INVALID_ARGS, "length out of range");
+      return;
     }
+    auto callbackMeta =
+        std::make_shared<CqCallbackMeta>(status, id, static_cast<int>(slices.size()));
+    callbackMeta->localRegRef = local.registration;
+    internal::PublishCurrentIoCallDiagnostics(callbackMeta);
+    RdmaOpRet ret =
+        RdmaBatchReadWriteResolved(eps, slices, callbackMeta, id, isRead, config.postBatchSize);
+    assert(!ret.Init());
+    if (ret.Failed() || ret.Succeeded()) status->Update(ret.code, ret.message);
+  }
+
+  if (!status->Failed() && config.enableNotification) {
+    RdmaOpRet notifRet = RdmaNotifyTransfer(eps, status, id);
+    if (notifRet.Failed()) status->Update(notifRet.code, notifRet.message);
   }
 }
 
@@ -981,31 +1216,59 @@ void RdmaBackendSession::BatchReadWrite(const SizeVec& localOffsets, const SizeV
                                         const SizeVec& sizes, TransferStatus* status,
                                         TransferUniqueId id, bool isRead) {
   MORI_IO_FUNCTION_TIMER;
+  if (local.registration && local.registration->Invalidated()) {
+    status->Update(StatusCode::ERR_INVALID_ARGS, "local memory has been deregistered");
+    return;
+  }
   status->SetCode(StatusCode::IN_PROGRESS);
-  auto callbackMeta = std::make_shared<CqCallbackMeta>(status, id, sizes.size());
-  internal::PublishCurrentIoCallDiagnostics(callbackMeta);
-  RdmaOpRet ret;
-  if (executor) {
-    ExecutorReq req{eps,          local, localOffsets,         remote, remoteOffsets, sizes,
-                    callbackMeta, id,    config.postBatchSize, isRead};
-    ret = executor->RdmaBatchReadWrite(req);
-  } else {
-    ret = RdmaBatchReadWrite(eps, local, localOffsets, remote, remoteOffsets, sizes, callbackMeta,
-                             id, isRead, config.postBatchSize);
-  }
-  assert(!ret.Init());
-  if (ret.Failed() || ret.Succeeded()) {
-    status->Update(ret.code, ret.message);
-  }
-  if (!ret.Failed() && config.enableNotification) {
-    RdmaOpRet notifRet = RdmaNotifyTransfer(eps, status, id);
-    if (notifRet.Failed()) {
-      status->Update(notifRet.code, notifRet.message);
+
+  if (UseFastPath(sizes)) {
+    auto callbackMeta = std::make_shared<CqCallbackMeta>(status, id, sizes.size());
+    callbackMeta->localRegRef = local.registration;
+    internal::PublishCurrentIoCallDiagnostics(callbackMeta);
+    RdmaOpRet ret;
+    if (executor) {
+      ExecutorReq req{eps,   local.singleMr, localOffsets, remote.singleMr,      remoteOffsets,
+                      sizes, callbackMeta,   id,           config.postBatchSize, isRead};
+      ret = executor->RdmaBatchReadWrite(req);
+    } else {
+      ret = RdmaBatchReadWrite(eps, local.singleMr, localOffsets, remote.singleMr, remoteOffsets,
+                               sizes, callbackMeta, id, isRead, config.postBatchSize);
     }
+    assert(!ret.Init());
+    if (ret.Failed() || ret.Succeeded()) status->Update(ret.code, ret.message);
+  } else {
+    // Resolved path: flatten all logical requests into one slice stream
+    std::vector<RdmaTransferSlice> allSlices;
+    for (size_t i = 0; i < sizes.size(); ++i) {
+      auto slices = ResolveTransferSlices(local.registration->Layout(), localOffsets[i],
+                                          remote.layout->layout, remoteOffsets[i], sizes[i]);
+      if (slices.empty() && sizes[i] > 0) {
+        status->Update(StatusCode::ERR_INVALID_ARGS, "length out of range");
+        return;
+      }
+      allSlices.insert(allSlices.end(), slices.begin(), slices.end());
+    }
+    auto callbackMeta =
+        std::make_shared<CqCallbackMeta>(status, id, static_cast<int>(allSlices.size()));
+    callbackMeta->localRegRef = local.registration;
+    internal::PublishCurrentIoCallDiagnostics(callbackMeta);
+    RdmaOpRet ret =
+        RdmaBatchReadWriteResolved(eps, allSlices, callbackMeta, id, isRead, config.postBatchSize);
+    assert(!ret.Init());
+    if (ret.Failed() || ret.Succeeded()) status->Update(ret.code, ret.message);
+  }
+
+  if (!status->Failed() && config.enableNotification) {
+    RdmaOpRet notifRet = RdmaNotifyTransfer(eps, status, id);
+    if (notifRet.Failed()) status->Update(notifRet.code, notifRet.message);
   }
 }
 
-bool RdmaBackendSession::Alive() const { return true; }
+bool RdmaBackendSession::Alive() const {
+  return local.registration != nullptr && !local.registration->Invalidated() &&
+         remote.layout != nullptr;
+}
 
 /* ----------------------------------------------------------------------------------------------
  */
@@ -1048,6 +1311,7 @@ RdmaBackend::~RdmaBackend() {
   if (executor.get() != nullptr) {
     executor->Shutdown();
   }
+  sessionCache.clear();
 }
 
 void RdmaBackend::RegisterRemoteEngine(const EngineDesc& rdesc) {
@@ -1062,6 +1326,7 @@ void RdmaBackend::RegisterMemory(MemoryDesc& desc) { server->RegisterMemory(desc
 
 void RdmaBackend::DeregisterMemory(const MemoryDesc& desc) {
   server->DeregisterMemory(desc);
+  rdma->DeregisterLocalRegistration(desc);
   InvalidateSessionsForMemory(desc.id);
 }
 
@@ -1069,8 +1334,13 @@ void RdmaBackend::ReadWrite(const MemoryDesc& localDest, size_t localOffset,
                             const MemoryDesc& remoteSrc, size_t remoteOffset, size_t size,
                             TransferStatus* status, TransferUniqueId id, bool isRead) {
   MORI_IO_FUNCTION_TIMER;
-  RdmaBackendSession* sess = GetOrCreateSessionCached(localDest, remoteSrc);
-  sess->ReadWrite(localOffset, remoteOffset, size, status, id, isRead);
+  try {
+    auto sess = GetOrCreateSessionCached(localDest, remoteSrc);
+    sess->ReadWrite(localOffset, remoteOffset, size, status, id, isRead);
+  } catch (const std::exception& e) {
+    MORI_IO_ERROR("RdmaBackend::ReadWrite failed: {}", e.what());
+    status->Update(StatusCode::ERR_RDMA_OP, e.what());
+  }
 }
 
 void RdmaBackend::BatchReadWrite(const MemoryDesc& localDest, const SizeVec& localOffsets,
@@ -1086,51 +1356,79 @@ void RdmaBackend::BatchReadWrite(const MemoryDesc& localDest, const SizeVec& loc
     return;
   }
 
-  RdmaBackendSession* sess = GetOrCreateSessionCached(localDest, remoteSrc);
-  sess->BatchReadWrite(localOffsets, remoteOffsets, sizes, status, id, isRead);
+  try {
+    auto sess = GetOrCreateSessionCached(localDest, remoteSrc);
+    sess->BatchReadWrite(localOffsets, remoteOffsets, sizes, status, id, isRead);
+  } catch (const std::exception& e) {
+    MORI_IO_ERROR("RdmaBackend::BatchReadWrite failed: {}", e.what());
+    status->Update(StatusCode::ERR_RDMA_OP, e.what());
+  }
 }
 
 BackendSession* RdmaBackend::CreateSession(const MemoryDesc& local, const MemoryDesc& remote) {
-  RdmaBackendSession* sess = new RdmaBackendSession();
-  CreateSession(local, remote, *sess);
-  return sess;
+  try {
+    auto sess = CreateSessionImpl(local, remote);
+    return new RdmaBackendSession(std::move(*sess));
+  } catch (const std::exception& e) {
+    MORI_IO_ERROR("RdmaBackend::CreateSession failed: {}", e.what());
+    return nullptr;
+  }
 }
 
-void RdmaBackend::CreateSession(const MemoryDesc& local, const MemoryDesc& remote,
-                                RdmaBackendSession& sess) {
+std::shared_ptr<RdmaBackendSession> RdmaBackend::CreateSessionImpl(const MemoryDesc& local,
+                                                                   const MemoryDesc& remote) {
+  // 1. Materialize local registration (pins local.rdmaDevId)
+  auto localReg = rdma->GetOrMaterializeLocalRegistration(local);
+  const auto& localLayout = localReg->Layout();
+
+  // 2. Fetch remote layout (gets remote.rdmaDevId)
+  EngineKey ekey = remote.engineKey;
+  auto remoteLayout = rdma->GetRemoteLayout(ekey, remote.id);
+  if (!remoteLayout) {
+    remoteLayout = server->AskRemoteMemoryLayout(ekey, remote.id, remote.size);
+    rdma->RegisterRemoteLayout(ekey, remote.id, remoteLayout);
+  }
+
+  // 3. Create/reuse endpoints, filtered to exact (ldevId, rdevId) pair
   TopoKey localKey{local.deviceId, local.loc};
   TopoKey remoteKey{remote.deviceId, remote.loc};
   TopoKeyPair kp{localKey, remoteKey};
+  int pinnedLdevId = localLayout.rdmaDevId;
+  int pinnedRdevId = remoteLayout->layout.rdmaDevId;
 
-  EngineKey ekey = remote.engineKey;
-
-  // Create a pair of endpoint if none
-  int epNum = rdma->CountEndpoint(ekey, kp);
-  for (int i = 0; i < (config.qpPerTransfer - epNum); i++) {
-    server->BuildRdmaConn(ekey, kp);
-  }
-  EpPairVec eps = rdma->GetAllEndpoint(ekey, kp);
-  assert(!eps.empty());
-
-  EpPairVec epSet = {eps.begin(), eps.begin() + config.qpPerTransfer};
-
-  // TODO: we assume all eps is on same device and has same ldevId/rdevId
-  EpPair ep = epSet[0];
-  auto localMr = rdma->GetLocalMemory(ep.ldevId, local.id);
-  if (!localMr.has_value()) {
-    localMr = rdma->RegisterLocalMemory(ep.ldevId, local);
+  EpPairVec allEps = rdma->GetAllEndpoint(ekey, kp);
+  EpPairVec epSet;
+  for (auto& ep : allEps) {
+    if (ep.ldevId == pinnedLdevId && ep.rdevId == pinnedRdevId) epSet.push_back(ep);
   }
 
-  auto remoteMr = rdma->GetRemoteMemory(ekey, ep.rdevId, remote.id);
-  if (!remoteMr.has_value()) {
-    remoteMr = server->AskRemoteMemoryRegion(ekey, ep.rdevId, remote.id);
-    // TODO: protocol should return status code
-    // Currently we check member equality to ensure correct memory region
-    assert(remoteMr->length == remote.size);
-    rdma->RegisterRemoteMemory(ekey, ep.rdevId, remote.id, remoteMr.value());
+  while (static_cast<int>(epSet.size()) < config.qpPerTransfer) {
+    server->BuildRdmaConn(ekey, kp, pinnedLdevId, pinnedRdevId);
+    allEps = rdma->GetAllEndpoint(ekey, kp);
+    epSet.clear();
+    for (auto& ep : allEps) {
+      if (ep.ldevId == pinnedLdevId && ep.rdevId == pinnedRdevId) epSet.push_back(ep);
+    }
+  }
+  epSet.resize(config.qpPerTransfer);
+
+  // 4. Build resolved memory descriptors with single-MR fast path detection
+  RdmaResolvedLocalMemory resolvedLocal;
+  resolvedLocal.registration = localReg;
+  if (localLayout.IsSingleChunk()) {
+    resolvedLocal.singleMrFastPath = true;
+    resolvedLocal.singleMr = localLayout.chunks[0].mr;
   }
 
-  sess = RdmaBackendSession(config, localMr.value(), remoteMr.value(), epSet, executor.get());
+  RdmaResolvedRemoteMemory resolvedRemote;
+  resolvedRemote.layout = remoteLayout;
+  if (remoteLayout->layout.IsSingleChunk()) {
+    resolvedRemote.singleMrFastPath = true;
+    resolvedRemote.singleMr = remoteLayout->layout.chunks[0].mr;
+  }
+
+  return std::make_shared<RdmaBackendSession>(config, std::move(resolvedLocal),
+                                              std::move(resolvedRemote), epSet, executor.get());
 }
 
 bool RdmaBackend::PopInboundTransferStatus(EngineKey remote, TransferUniqueId id,
@@ -1138,26 +1436,20 @@ bool RdmaBackend::PopInboundTransferStatus(EngineKey remote, TransferUniqueId id
   return notif->PopInboundTransferStatus(remote, id, status);
 }
 
-RdmaBackendSession* RdmaBackend::GetOrCreateSessionCached(const MemoryDesc& local,
-                                                          const MemoryDesc& remote) {
+std::shared_ptr<RdmaBackendSession> RdmaBackend::GetOrCreateSessionCached(
+    const MemoryDesc& local, const MemoryDesc& remote) {
   SessionCacheKey key{remote.engineKey, local.id, remote.id};
   {
     std::lock_guard<std::mutex> lock(sessionCacheMu);
     auto it = sessionCache.find(key);
-    if (it != sessionCache.end()) {
-      return it->second.get();
-    }
+    if (it != sessionCache.end()) return it->second;
   }
-  // create outside lock (CreateSession may allocate / block); then insert
-  auto newSess = std::make_unique<RdmaBackendSession>();
-  CreateSession(local, remote, *newSess);
+  auto newSess = CreateSessionImpl(local, remote);
   std::lock_guard<std::mutex> lock(sessionCacheMu);
   auto it = sessionCache.find(key);
-  if (it != sessionCache.end()) {
-    return it->second.get();
-  }
+  if (it != sessionCache.end()) return it->second;
   auto [emplacedIt, inserted] = sessionCache.emplace(key, std::move(newSess));
-  return emplacedIt->second.get();
+  return emplacedIt->second;
 }
 
 void RdmaBackend::InvalidateSessionsForMemory(MemoryUniqueId id) {

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -299,6 +299,43 @@ std::shared_ptr<const RdmaLocalMemoryRegistration> RdmaManager::GetOrMaterialize
   }
 
   // Chunked registration
+  //
+  // On AMD AINIC (ionic, vendor_id 0x1dd8 / Pensando), the firmware silently
+  // drops the last ~64 bytes of any RDMA WRITE that lands on a chunked MR's
+  // tail when the user-supplied buffer's base VA is NOT 4 KiB page-aligned.
+  // The CQE reports IBV_WC_SUCCESS but the destination bytes retain their
+  // pre-write content. Triggered specifically when:
+  //   1. CPU memory (kernel pin path; GPU goes through dmabuf importer)
+  //   2. Per-chunk MR size >= 1 GiB (firmware path switch)
+  //   3. Buffer base not page-aligned, so MR_a's last bytes share a 4 KiB
+  //      kernel page with MR_b's first bytes (the chunked path produces
+  //      adjacent MRs from one buffer)
+  //
+  // Cross-platform verification: Mellanox mlx5 (vendor 0x02c9) and Broadcom
+  // bnxt_re (vendor 0x14e4) tested CLEAN with the same workload, so this
+  // guard is gated on Pensando vendor id.
+  //
+  // PyTorch's CPU caching allocator returns 64-byte-aligned but non-page-
+  // aligned pointers (typically ending in 0x...040), which trips the bug.
+  // mmap(2), shm_open + mmap, and posix_memalign(PAGESIZE, ...) all return
+  // page-aligned pointers and are safe.
+  if (desc.loc == MemoryLocationType::CPU) {
+    const bool isIonic = (devCtx->GetRdmaDevice()->GetDeviceAttr()->orig_attr.vendor_id ==
+                          static_cast<uint32_t>(application::RdmaDeviceVendorId::Pensando));
+    if (isIonic && (desc.data % PAGESIZE) != 0) {
+      MORI_IO_ERROR(
+          "Chunked CPU registration on ionic requires a 4 KiB page-aligned "
+          "base address. Memory id={} starts at 0x{:x} (offset 0x{:x} into "
+          "a 4 KiB page). Allocate via mmap, shm_open + mmap, or "
+          "posix_memalign(PAGESIZE, ...). PyTorch CPU tensors are NOT page-"
+          "aligned and trigger an ionic firmware bug that silently corrupts "
+          "cross-MR writes.",
+          desc.id, desc.data, desc.data % PAGESIZE);
+      throw std::runtime_error(
+          "Chunked CPU registration on ionic requires page-aligned base address");
+    }
+  }
+
   size_t numChunks = (desc.size + chunkSize - 1) / chunkSize;
   std::vector<RdmaMemoryChunk> chunks;
   std::vector<application::RdmaOwnedMr> ownedMrs;

--- a/src/io/rdma/backend_impl.hpp
+++ b/src/io/rdma/backend_impl.hpp
@@ -55,17 +55,16 @@ class RdmaManager {
   // Topology APIs
   std::vector<std::pair<int, int>> Search(TopoKey);
 
-  // Local memory management APIs
-  std::optional<application::RdmaMemoryRegion> GetLocalMemory(int ldevId, MemoryUniqueId);
-  application::RdmaMemoryRegion RegisterLocalMemory(int ldevId, const MemoryDesc& desc);
-  void DeregisterLocalMemory(int ldevId, const MemoryDesc& desc);
+  // Chunked local memory registration
+  std::shared_ptr<const RdmaLocalMemoryRegistration> GetOrMaterializeLocalRegistration(
+      const MemoryDesc& desc);
+  void DeregisterLocalRegistration(const MemoryDesc& desc);
 
-  // Remote memory management APIs
-  std::optional<application::RdmaMemoryRegion> GetRemoteMemory(EngineKey, int remRdmaDevId,
-                                                               MemoryUniqueId);
-  void RegisterRemoteMemory(EngineKey, int remRdmaDevId, MemoryUniqueId,
-                            application::RdmaMemoryRegion);
-  void DeregisterRemoteMemory(EngineKey, int remRdmaDevId, MemoryUniqueId);
+  // Remote layout management
+  std::shared_ptr<const RdmaRemoteMemoryLayout> GetRemoteLayout(EngineKey, MemoryUniqueId);
+  void RegisterRemoteLayout(EngineKey, MemoryUniqueId,
+                            std::shared_ptr<const RdmaRemoteMemoryLayout>);
+  void DeregisterRemoteLayout(EngineKey, MemoryUniqueId);
 
   // Endpoint management APIs
   int CountEndpoint(EngineKey, TopoKeyPair);
@@ -78,9 +77,11 @@ class RdmaManager {
   std::vector<std::shared_ptr<EndpointRuntime>> SnapshotEndpointRuntimes();
 
   application::RdmaDeviceContext* GetRdmaDeviceContext(int devId);
+  size_t GetEffectiveChunkSize(application::RdmaDeviceContext* devCtx);
 
  private:
   application::RdmaDeviceContext* GetOrCreateDeviceContext(int devId);
+  int PickRdmaDeviceForMemory(const MemoryDesc& desc);
 
  private:
   RdmaBackendConfig config;
@@ -90,7 +91,14 @@ class RdmaManager {
   application::ActiveDevicePortList availDevices;
   std::vector<application::RdmaDeviceContext*> deviceCtxs;
 
-  MemoryTable mTable;
+  // Per-memory device affinity: pinned on first materialization
+  std::unordered_map<MemoryUniqueId, int> memoryDeviceAffinity_;
+  // Local registration cache: MemoryUniqueId -> immutable registration
+  std::unordered_map<MemoryUniqueId, std::shared_ptr<const RdmaLocalMemoryRegistration>>
+      localRegistrations_;
+  // Per-memory single-flight mutex for materialization
+  std::unordered_map<MemoryUniqueId, std::shared_ptr<std::mutex>> materializationMutexes_;
+
   std::unordered_map<EngineKey, RemoteEngineMeta> remotes;
   std::atomic<EndpointId> nextEndpointId_{1};
   std::unordered_map<EndpointId, std::shared_ptr<EndpointRuntime>> endpointsById_;
@@ -198,12 +206,13 @@ class ControlPlaneServer {
   void DeregisterRemoteEngine(const EngineDesc&);
 
   // Endpoint management
-  void BuildRdmaConn(EngineKey, TopoKeyPair);
+  void BuildRdmaConn(EngineKey, TopoKeyPair, int ldevId = -1, int rdevId = -1);
 
   // MemoryRegion management
   void RegisterMemory(MemoryDesc&);
   void DeregisterMemory(const MemoryDesc&);
-  application::RdmaMemoryRegion AskRemoteMemoryRegion(EngineKey, int rdevId, MemoryUniqueId);
+  std::shared_ptr<const RdmaRemoteMemoryLayout> AskRemoteMemoryLayout(EngineKey, MemoryUniqueId,
+                                                                      size_t expectedSize);
 
   // Server management
   void MainLoop();
@@ -234,12 +243,23 @@ class ControlPlaneServer {
 /* ---------------------------------------------------------------------------------------------- */
 /*                                       RdmaBackendSession                                       */
 /* ---------------------------------------------------------------------------------------------- */
+struct RdmaResolvedLocalMemory {
+  bool singleMrFastPath{false};
+  application::RdmaMemoryRegion singleMr{};
+  std::shared_ptr<const RdmaLocalMemoryRegistration> registration;
+};
+
+struct RdmaResolvedRemoteMemory {
+  bool singleMrFastPath{false};
+  application::RdmaMemoryRegion singleMr{};
+  std::shared_ptr<const RdmaRemoteMemoryLayout> layout;
+};
+
 class RdmaBackendSession : public BackendSession {
  public:
   RdmaBackendSession() = default;
-  RdmaBackendSession(const RdmaBackendConfig& config, const application::RdmaMemoryRegion& local,
-                     const application::RdmaMemoryRegion& remote, const EpPairVec& eps,
-                     Executor* executor);
+  RdmaBackendSession(const RdmaBackendConfig& config, RdmaResolvedLocalMemory local,
+                     RdmaResolvedRemoteMemory remote, const EpPairVec& eps, Executor* executor);
   ~RdmaBackendSession() = default;
 
   void ReadWrite(size_t localOffset, size_t remoteOffset, size_t size, TransferStatus* status,
@@ -252,9 +272,11 @@ class RdmaBackendSession : public BackendSession {
   bool Alive() const;
 
  private:
+  bool UseFastPath(const SizeVec& sizes) const;
+
   RdmaBackendConfig config{};
-  application::RdmaMemoryRegion local{};
-  application::RdmaMemoryRegion remote{};
+  RdmaResolvedLocalMemory local{};
+  RdmaResolvedRemoteMemory remote{};
   EpPairVec eps{};
   Executor* executor{nullptr};
 };
@@ -288,10 +310,11 @@ class RdmaBackend : public Backend {
   bool PopInboundTransferStatus(EngineKey remote, TransferUniqueId id, TransferStatus* status);
 
  private:
-  void CreateSession(const MemoryDesc& local, const MemoryDesc& remote, RdmaBackendSession& sess);
+  std::shared_ptr<RdmaBackendSession> CreateSessionImpl(const MemoryDesc& local,
+                                                        const MemoryDesc& remote);
   // Session cache helpers
   struct SessionCacheKey {
-    EngineKey remoteEngineKey;  // use remote memory's engine key
+    EngineKey remoteEngineKey;
     MemoryUniqueId localMemId;
     MemoryUniqueId remoteMemId;
     bool operator==(const SessionCacheKey& o) const {
@@ -302,7 +325,6 @@ class RdmaBackend : public Backend {
   struct SessionCacheKeyHash {
     std::size_t operator()(const SessionCacheKey& k) const noexcept {
       auto hash_combine = [](std::size_t& seed, std::size_t v) {
-        // 64-bit variant of boost::hash_combine / splitmix64 inspired
         seed ^= v + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2);
       };
       std::size_t seed = 0;
@@ -312,7 +334,8 @@ class RdmaBackend : public Backend {
       return seed;
     }
   };
-  RdmaBackendSession* GetOrCreateSessionCached(const MemoryDesc& local, const MemoryDesc& remote);
+  std::shared_ptr<RdmaBackendSession> GetOrCreateSessionCached(const MemoryDesc& local,
+                                                               const MemoryDesc& remote);
   void InvalidateSessionsForMemory(MemoryUniqueId id);
 
  private:
@@ -322,8 +345,7 @@ class RdmaBackend : public Backend {
   std::unique_ptr<NotifManager> notif{nullptr};
   std::unique_ptr<ControlPlaneServer> server{nullptr};
   std::unique_ptr<Executor> executor{nullptr};
-  // session cache
-  std::unordered_map<SessionCacheKey, std::unique_ptr<RdmaBackendSession>, SessionCacheKeyHash>
+  std::unordered_map<SessionCacheKey, std::shared_ptr<RdmaBackendSession>, SessionCacheKeyHash>
       sessionCache;
   std::mutex sessionCacheMu;
 };

--- a/src/io/rdma/backend_impl.hpp
+++ b/src/io/rdma/backend_impl.hpp
@@ -340,8 +340,10 @@ class RdmaBackend : public Backend {
       return seed;
     }
   };
-  std::shared_ptr<RdmaBackendSession> GetOrCreateSessionCached(const MemoryDesc& local,
-                                                               const MemoryDesc& remote);
+  // Cache map owns lifetime via stored shared_ptr; raw return avoids per-call
+  // atomic inc/dec on the hot path. DeregisterMemory must not race with
+  // active transfers.
+  RdmaBackendSession* GetOrCreateSessionCached(const MemoryDesc& local, const MemoryDesc& remote);
   void InvalidateSessionsForMemory(MemoryUniqueId id);
 
  private:

--- a/src/io/rdma/backend_impl.hpp
+++ b/src/io/rdma/backend_impl.hpp
@@ -67,12 +67,17 @@ class RdmaManager {
   void DeregisterRemoteLayout(EngineKey, MemoryUniqueId);
 
   // Endpoint management APIs
-  int CountEndpoint(EngineKey, TopoKeyPair);
-  EpPairVec GetAllEndpoint(EngineKey, TopoKeyPair);
+  int CountEndpoint(EngineKey, const ExactRouteKey&);
+  EpPairVec GetAllEndpoint(EngineKey, const ExactRouteKey&);
   application::RdmaEndpoint CreateEndpoint(int devId);
-  EndpointId ConnectEndpoint(EngineKey remoteKey, int ldevId, application::RdmaEndpoint local,
-                             int rdevId, application::RdmaEndpointHandle remote, TopoKeyPair key,
-                             int weight);
+  bool IsValidRdmaDeviceId(int devId) const;
+  void ConnectLocalEndpoint(int ldevId, const application::RdmaEndpoint& local,
+                            const application::RdmaEndpointHandle& remote);
+  void DestroyEndpoint(int devId, const application::RdmaEndpoint& endpoint);
+  EndpointId PublishEndpoint(EngineKey remoteKey, const ExactRouteKey& key,
+                             application::RdmaEndpoint local,
+                             application::RdmaEndpointHandle remote, int weight);
+  bool UnpublishEndpoint(EngineKey remoteKey, const ExactRouteKey& key, EndpointId id);
   std::shared_ptr<EndpointRuntime> GetEndpointRuntime(EndpointId id);
   std::vector<std::shared_ptr<EndpointRuntime>> SnapshotEndpointRuntimes();
 
@@ -116,6 +121,7 @@ class NotifManager {
   ~NotifManager();
 
   void RegisterEndpoint(const std::shared_ptr<EndpointRuntime>& rt);
+  void UnregisterEndpoint(const std::shared_ptr<EndpointRuntime>& rt);
 
   void RegisterDevice(int devId);
 
@@ -206,7 +212,7 @@ class ControlPlaneServer {
   void DeregisterRemoteEngine(const EngineDesc&);
 
   // Endpoint management
-  void BuildRdmaConn(EngineKey, TopoKeyPair, int ldevId = -1, int rdevId = -1);
+  void BuildRdmaConn(EngineKey, const ExactRouteKey&);
 
   // MemoryRegion management
   void RegisterMemory(MemoryDesc&);

--- a/src/io/rdma/common.cpp
+++ b/src/io/rdma/common.cpp
@@ -589,16 +589,9 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
 /* ---------------------------------------------------------------------------------------------- */
 /*                              RdmaLocalMemoryRegistration                                       */
 /* ---------------------------------------------------------------------------------------------- */
-RdmaLocalMemoryRegistration::RdmaLocalMemoryRegistration(RdmaMemoryLayout layout,
-                                                         application::RdmaDeviceContext* devCtx)
-    : layout_(std::move(layout)), devCtx_(devCtx) {}
-
-RdmaLocalMemoryRegistration::~RdmaLocalMemoryRegistration() {
-  if (!devCtx_) return;
-  for (auto& chunk : layout_.chunks) {
-    devCtx_->DeregisterRdmaMemoryRegion(reinterpret_cast<void*>(chunk.mr.addr));
-  }
-}
+RdmaLocalMemoryRegistration::RdmaLocalMemoryRegistration(
+    RdmaMemoryLayout layout, std::vector<application::RdmaOwnedMr> ownedMrs)
+    : layout_(std::move(layout)), ownedMrs_(std::move(ownedMrs)) {}
 
 /* ---------------------------------------------------------------------------------------------- */
 /*                                  Slice Resolution Algorithm                                    */
@@ -664,18 +657,69 @@ std::vector<RdmaTransferSlice> ResolveTransferSlices(const RdmaMemoryLayout& loc
   return slices;
 }
 
+static std::vector<ResolvedLaneWork> BuildResolvedLaneWork(size_t totalSlices, size_t epCount,
+                                                           size_t maxLanes) {
+  std::vector<ResolvedLaneWork> lanes;
+  if (totalSlices == 0 || epCount == 0) return lanes;
+
+  size_t laneCount = epCount;
+  if (maxLanes > 0) laneCount = std::min(laneCount, maxLanes);
+  laneCount = std::min(laneCount, totalSlices);
+  if (laneCount == 0) return lanes;
+
+  lanes.reserve(laneCount);
+  size_t begin = 0;
+  size_t base = totalSlices / laneCount;
+  size_t remainder = totalSlices % laneCount;
+  for (size_t laneIdx = 0; laneIdx < laneCount; ++laneIdx) {
+    size_t laneSize = base + (laneIdx < remainder ? 1 : 0);
+    size_t end = begin + laneSize;
+    lanes.push_back({static_cast<int>(laneIdx), begin, end});
+    begin = end;
+  }
+  return lanes;
+}
+
+ResolvedTransferPlan BuildResolvedTransferPlan(const EpPairVec& eps, const RdmaMemoryLayout& local,
+                                               const SizeVec& localOffsets,
+                                               const RdmaMemoryLayout& remote,
+                                               const SizeVec& remoteOffsets, const SizeVec& sizes,
+                                               size_t maxLanes) {
+  ResolvedTransferPlan plan;
+  if ((localOffsets.size() != remoteOffsets.size()) || (sizes.size() != remoteOffsets.size())) {
+    return plan;
+  }
+
+  for (size_t i = 0; i < sizes.size(); ++i) {
+    auto slices = ResolveTransferSlices(local, localOffsets[i], remote, remoteOffsets[i], sizes[i]);
+    if (slices.empty() && sizes[i] > 0) {
+      plan.slices.clear();
+      plan.lanes.clear();
+      return plan;
+    }
+    plan.slices.insert(plan.slices.end(), slices.begin(), slices.end());
+  }
+  if (plan.slices.empty()) return plan;
+
+  size_t laneCap = maxLanes > 0 ? maxLanes : eps.size();
+  plan.lanes = BuildResolvedLaneWork(plan.slices.size(), eps.size(), laneCap);
+  return plan;
+}
+
 /* ---------------------------------------------------------------------------------------------- */
-/*                               RdmaBatchReadWriteResolved                                       */
+/*                              Resolved Slice Lane Submission                                    */
 /* ---------------------------------------------------------------------------------------------- */
-RdmaOpRet RdmaBatchReadWriteResolved(const EpPairVec& eps,
-                                     const std::vector<RdmaTransferSlice>& slices,
-                                     std::shared_ptr<CqCallbackMeta> callbackMeta,
-                                     TransferUniqueId id, bool isRead, int postBatchSize) {
+RdmaOpRet RdmaPostResolvedSlicesToSingleEp(const EpPair& ep,
+                                           const std::vector<RdmaTransferSlice>& slices,
+                                           size_t begin, size_t end,
+                                           std::shared_ptr<CqCallbackMeta> callbackMeta,
+                                           TransferUniqueId id, bool isRead, int postBatchSize) {
   MORI_IO_FUNCTION_TIMER;
 
-  size_t batchSize = slices.size();
-  if (batchSize == 0) return {StatusCode::SUCCESS, ""};
-  if (eps.empty()) return {StatusCode::ERR_INVALID_ARGS, "no endpoints"};
+  if (begin > end || end > slices.size()) {
+    return {StatusCode::ERR_INVALID_ARGS, "resolved slice range is invalid"};
+  }
+  if (begin == end) return {StatusCode::SUCCESS, ""};
 
   struct MergedWorkRequest {
     ibv_send_wr wr{};
@@ -684,134 +728,123 @@ RdmaOpRet RdmaBatchReadWriteResolved(const EpPairVec& eps,
     size_t mergedSlices{1};
   };
 
-  const uint32_t maxSge = std::max(eps[0].local.handle.maxSge, 1u);
-
+  const uint32_t maxSge = std::max(ep.local.handle.maxSge, 1u);
   std::vector<MergedWorkRequest> mergedWrs;
-  mergedWrs.reserve(batchSize);
+  mergedWrs.reserve(end - begin);
 
-  auto start_new_wr = [&](const RdmaTransferSlice& s) {
+  auto startNewWr = [&](const RdmaTransferSlice& slice) {
     mergedWrs.emplace_back();
     MergedWorkRequest& mwr = mergedWrs.back();
     mwr.sges.reserve(maxSge);
-    mwr.sges.push_back(ibv_sge{.addr = s.localAddr, .length = s.len, .lkey = s.localLkey});
-    mwr.totalRemoteLength = s.len;
+    mwr.sges.push_back(
+        ibv_sge{.addr = slice.localAddr, .length = slice.len, .lkey = slice.localLkey});
+    mwr.totalRemoteLength = slice.len;
 
     mwr.wr.sg_list = mwr.sges.data();
     mwr.wr.num_sge = 1;
     mwr.wr.opcode = isRead ? IBV_WR_RDMA_READ : IBV_WR_RDMA_WRITE;
     mwr.wr.send_flags = 0;
-    mwr.wr.wr.rdma.remote_addr = s.remoteAddr;
-    mwr.wr.wr.rdma.rkey = s.remoteRkey;
+    mwr.wr.wr.rdma.remote_addr = slice.remoteAddr;
+    mwr.wr.wr.rdma.rkey = slice.remoteRkey;
   };
 
-  for (size_t i = 0; i < batchSize; ++i) {
-    const RdmaTransferSlice& s = slices[i];
+  for (size_t idx = begin; idx < end; ++idx) {
+    const RdmaTransferSlice& slice = slices[idx];
     bool merged = false;
 
     if (!mergedWrs.empty()) {
       MergedWorkRequest& last = mergedWrs.back();
       uint64_t expectedRemote = last.wr.wr.rdma.remote_addr + last.totalRemoteLength;
-      if (expectedRemote == s.remoteAddr && last.wr.wr.rdma.rkey == s.remoteRkey) {
+      if (expectedRemote == slice.remoteAddr && last.wr.wr.rdma.rkey == slice.remoteRkey) {
         ibv_sge& lastSge = last.sges.back();
-        bool localContig = (lastSge.addr + lastSge.length) == s.localAddr;
-        bool sameLkey = lastSge.lkey == s.localLkey;
+        bool localContig = (lastSge.addr + lastSge.length) == slice.localAddr;
+        bool sameLkey = lastSge.lkey == slice.localLkey;
 
         if (localContig && sameLkey) {
-          uint64_t newLen = static_cast<uint64_t>(lastSge.length) + s.len;
+          uint64_t newLen = static_cast<uint64_t>(lastSge.length) + slice.len;
           if (newLen <= std::numeric_limits<uint32_t>::max()) {
             lastSge.length = static_cast<uint32_t>(newLen);
             last.mergedSlices++;
-            last.totalRemoteLength += s.len;
+            last.totalRemoteLength += slice.len;
             merged = true;
           }
         }
         if (!merged && last.sges.size() < maxSge) {
-          last.sges.push_back(ibv_sge{.addr = s.localAddr, .length = s.len, .lkey = s.localLkey});
+          last.sges.push_back(
+              ibv_sge{.addr = slice.localAddr, .length = slice.len, .lkey = slice.localLkey});
           last.wr.num_sge = static_cast<int>(last.sges.size());
           last.mergedSlices++;
-          last.totalRemoteLength += s.len;
+          last.totalRemoteLength += slice.len;
           merged = true;
         }
       }
     }
-    if (!merged) start_new_wr(s);
+    if (!merged) startNewWr(slice);
   }
 
-  // Stabilize sg_list pointers after all merging is complete.
   for (auto& mwr : mergedWrs) {
     mwr.wr.sg_list = mwr.sges.data();
   }
 
   size_t mergedWrCount = mergedWrs.size();
-  size_t epNum = eps.size();
-  size_t epBatchSz = (mergedWrCount + epNum - 1) / epNum;
-
   if (postBatchSize == -1) {
-    postBatchSize = (epBatchSz > static_cast<size_t>(std::numeric_limits<int>::max()))
+    postBatchSize = (mergedWrCount > static_cast<size_t>(std::numeric_limits<int>::max()))
                         ? std::numeric_limits<int>::max()
-                        : static_cast<int>(epBatchSz);
+                        : static_cast<int>(mergedWrCount);
   }
-  {
-    int minMaxSqDepth = std::numeric_limits<int>::max();
-    for (size_t epId = 0; epId < epNum; ++epId) {
-      if (eps[epId].sqDepth && eps[epId].maxSqDepth > 0)
-        minMaxSqDepth = std::min(minMaxSqDepth, eps[epId].maxSqDepth);
-    }
-    if (minMaxSqDepth != std::numeric_limits<int>::max() && postBatchSize > minMaxSqDepth)
-      postBatchSize = minMaxSqDepth;
+  if (ep.sqDepth && ep.maxSqDepth > 0 && postBatchSize > ep.maxSqDepth) {
+    postBatchSize = ep.maxSqDepth;
   }
   if (postBatchSize <= 0) postBatchSize = 1;
   int numPostBatch = (mergedWrCount + postBatchSize - 1) / postBatchSize;
 
-  std::vector<int> epWrsSinceSignal(epNum, 0);
-  std::vector<size_t> epMergedSinceSignal(epNum, 0);
+  int wrsSinceSignal = 0;
+  size_t slicesSinceSignal = 0;
 
-  for (int i = 0; i < numPostBatch; i++) {
-    int st = i * postBatchSize;
-    int end = std::min(static_cast<size_t>(st) + postBatchSize, mergedWrCount);
-    if (end - st == 0) break;
-    int epId = i % epNum;
-    int batchWrNum = end - st;
+  for (int batchIdx = 0; batchIdx < numPostBatch; ++batchIdx) {
+    int st = batchIdx * postBatchSize;
+    int batchEnd = std::min(static_cast<size_t>(st) + postBatchSize, mergedWrCount);
+    int batchWrNum = batchEnd - st;
+    if (batchWrNum <= 0) break;
 
     std::string reserveErr;
     SqReserveFailureKind reserveFailure = SqReserveFailureKind::None;
-    if (!TryReserveSqDepth(eps[epId], batchWrNum, epId, "resolved-batch", &reserveErr,
-                           &reserveFailure)) {
-      AppendHint(&reserveErr, BuildSqDepthHint(eps[epId], epNum, postBatchSize,
-                                               PostSendOpKind::BatchData, reserveFailure));
+    if (!TryReserveSqDepth(ep, batchWrNum, 0, "resolved-lane", &reserveErr, &reserveFailure)) {
+      AppendHint(&reserveErr,
+                 BuildSqDepthHint(ep, 1, postBatchSize, PostSendOpKind::BatchData, reserveFailure));
       return {StatusCode::ERR_RDMA_OP, reserveErr};
     }
 
     size_t mergedSliceSize = 0;
-    for (int j = st; j < end; j++) {
-      mergedWrs[j].wr.wr_id = 0;
-      mergedWrs[j].wr.next = (j + 1 < end) ? &mergedWrs[j + 1].wr : nullptr;
-      mergedSliceSize += mergedWrs[j].mergedSlices;
+    for (int wrIdx = st; wrIdx < batchEnd; ++wrIdx) {
+      mergedWrs[wrIdx].wr.wr_id = 0;
+      mergedWrs[wrIdx].wr.next = (wrIdx + 1 < batchEnd) ? &mergedWrs[wrIdx + 1].wr : nullptr;
+      mergedSliceSize += mergedWrs[wrIdx].mergedSlices;
     }
 
-    epWrsSinceSignal[epId] += batchWrNum;
-    epMergedSinceSignal[epId] += mergedSliceSize;
+    wrsSinceSignal += batchWrNum;
+    slicesSinceSignal += mergedSliceSize;
 
-    bool isLastBatchForEp = ((i + epNum) >= numPostBatch);
-    bool sqNearFull = eps[epId].sqDepth && (epWrsSinceSignal[epId] >= eps[epId].maxSqDepth);
-    bool needSignal = isLastBatchForEp || sqNearFull;
+    bool isLastBatch = (batchIdx + 1 == numPostBatch);
+    bool sqNearFull = ep.sqDepth && (wrsSinceSignal >= ep.maxSqDepth);
+    bool needSignal = isLastBatch || sqNearFull;
 
-    ibv_send_wr& last = mergedWrs[end - 1].wr;
+    ibv_send_wr& last = mergedWrs[batchEnd - 1].wr;
     uint64_t recordId = 0;
     if (needSignal) {
-      if (!eps[epId].ledger) {
-        ReleaseSqDepth(eps[epId], batchWrNum);
+      if (!ep.ledger) {
+        ReleaseSqDepth(ep, batchWrNum);
         return {StatusCode::ERR_RDMA_OP,
                 "submission ledger is not initialized for signaled WR tracking"};
       }
-      recordId = eps[epId].ledger->Insert(epWrsSinceSignal[epId], true, callbackMeta,
-                                          static_cast<int>(epMergedSinceSignal[epId]));
+      recordId = ep.ledger->Insert(wrsSinceSignal, true, callbackMeta,
+                                   static_cast<int>(slicesSinceSignal));
       last.wr_id = recordId;
       last.send_flags = IBV_SEND_SIGNALED;
     }
 
     ibv_send_wr* badWr = nullptr;
-    int ret = ibv_post_send(eps[epId].local.ibvHandle.qp, &mergedWrs[st].wr, &badWr);
+    int ret = ibv_post_send(ep.local.ibvHandle.qp, &mergedWrs[st].wr, &badWr);
     if (ret != 0) {
       int postedCount = 0;
       if (badWr != nullptr) {
@@ -824,54 +857,80 @@ RdmaOpRet RdmaBatchReadWriteResolved(const EpPairVec& eps,
       postedCount = std::max(0, std::min(postedCount, batchWrNum));
       int unpostedCount = batchWrNum - postedCount;
       if (unpostedCount > 0) {
-        ReleaseSqDepth(eps[epId], unpostedCount);
-        epWrsSinceSignal[epId] = std::max(0, epWrsSinceSignal[epId] - unpostedCount);
+        ReleaseSqDepth(ep, unpostedCount);
+        wrsSinceSignal = std::max(0, wrsSinceSignal - unpostedCount);
         size_t mergedUnposted = 0;
-        for (int j = st + postedCount; j < end; ++j) mergedUnposted += mergedWrs[j].mergedSlices;
-        epMergedSinceSignal[epId] = epMergedSinceSignal[epId] >= mergedUnposted
-                                        ? epMergedSinceSignal[epId] - mergedUnposted
-                                        : 0;
+        for (int wrIdx = st + postedCount; wrIdx < batchEnd; ++wrIdx) {
+          mergedUnposted += mergedWrs[wrIdx].mergedSlices;
+        }
+        slicesSinceSignal =
+            slicesSinceSignal >= mergedUnposted ? slicesSinceSignal - mergedUnposted : 0;
       }
 
       bool lastWasPosted = (postedCount == batchWrNum);
-      if (needSignal && lastWasPosted) {
-        // signaled WR posted; CQ path owns release
-      } else if (needSignal) {
+      if (needSignal && !lastWasPosted) {
         int dummy = 0;
-        eps[epId].ledger->ReleaseByCqe(recordId, nullptr, &dummy);
+        ep.ledger->ReleaseByCqe(recordId, nullptr, &dummy);
       }
 
       if (postedCount > 0 && (!needSignal || !lastWasPosted)) {
-        if (eps[epId].degraded) eps[epId].degraded->store(true, std::memory_order_relaxed);
-        if (eps[epId].ledger)
-          eps[epId].ledger->InsertOrphaned(epWrsSinceSignal[epId], callbackMeta,
-                                           static_cast<int>(epMergedSinceSignal[epId]));
+        if (ep.degraded) ep.degraded->store(true, std::memory_order_relaxed);
+        if (ep.ledger) {
+          ep.ledger->InsertOrphaned(wrsSinceSignal, callbackMeta,
+                                    static_cast<int>(slicesSinceSignal));
+        }
       }
 
-      for (size_t otherEpId = 0; otherEpId < epNum; ++otherEpId) {
-        if (static_cast<int>(otherEpId) == epId) continue;
-        if (epWrsSinceSignal[otherEpId] <= 0) continue;
-        if (eps[otherEpId].degraded)
-          eps[otherEpId].degraded->store(true, std::memory_order_relaxed);
-        if (eps[otherEpId].ledger)
-          eps[otherEpId].ledger->InsertOrphaned(epWrsSinceSignal[otherEpId], callbackMeta,
-                                                static_cast<int>(epMergedSinceSignal[otherEpId]));
-      }
-
-      std::string message = "ibv_post_send (resolved) failed with " + std::to_string(ret) + ": " +
-                            strerror(ret) + " (posted " + std::to_string(postedCount) + "/" +
+      std::string message = "ibv_post_send (resolved lane) failed with " + std::to_string(ret) +
+                            ": " + strerror(ret) + " (posted " + std::to_string(postedCount) + "/" +
                             std::to_string(batchWrNum) + " WRs)";
-      AppendHint(&message, BuildPostSendFailureHint(ret, eps[epId], epNum, postBatchSize, badWr,
+      AppendHint(&message, BuildPostSendFailureHint(ret, ep, 1, postBatchSize, badWr,
                                                     PostSendOpKind::BatchData));
       return {StatusCode::ERR_RDMA_OP, std::move(message)};
     }
 
     if (needSignal) {
-      epWrsSinceSignal[epId] = 0;
-      epMergedSinceSignal[epId] = 0;
+      wrsSinceSignal = 0;
+      slicesSinceSignal = 0;
+    }
+    MORI_IO_TRACE("ibv_post_send resolved lane task {} batch range [{}, {})", id, st, batchEnd);
+  }
+
+  return {StatusCode::IN_PROGRESS, ""};
+}
+
+RdmaOpRet RdmaSubmitResolvedTransferPlanInline(const EpPairVec& eps,
+                                               const std::vector<RdmaTransferSlice>& slices,
+                                               const std::vector<ResolvedLaneWork>& lanes,
+                                               std::shared_ptr<CqCallbackMeta> callbackMeta,
+                                               TransferUniqueId id, bool isRead,
+                                               int postBatchSize) {
+  MORI_IO_FUNCTION_TIMER;
+
+  if (slices.empty()) return {StatusCode::SUCCESS, ""};
+  if (eps.empty()) return {StatusCode::ERR_INVALID_ARGS, "no endpoints"};
+  if (lanes.empty()) return {StatusCode::ERR_INVALID_ARGS, "resolved transfer lanes are empty"};
+
+  bool hasFail = false;
+  int numSucc = 0;
+  RdmaOpRet failedRet;
+
+  for (const auto& lane : lanes) {
+    if (lane.epId < 0 || static_cast<size_t>(lane.epId) >= eps.size()) {
+      return {StatusCode::ERR_INVALID_ARGS, "resolved lane endpoint is invalid"};
+    }
+    RdmaOpRet ret = RdmaPostResolvedSlicesToSingleEp(eps[lane.epId], slices, lane.begin, lane.end,
+                                                     callbackMeta, id, isRead, postBatchSize);
+    if (ret.Failed()) {
+      hasFail = true;
+      failedRet = ret;
+    } else if (ret.Succeeded()) {
+      numSucc++;
     }
   }
 
+  if (hasFail) return failedRet;
+  if (numSucc == static_cast<int>(lanes.size())) return {StatusCode::SUCCESS, ""};
   return {StatusCode::IN_PROGRESS, ""};
 }
 

--- a/src/io/rdma/common.cpp
+++ b/src/io/rdma/common.cpp
@@ -21,6 +21,7 @@
 // SOFTWARE.
 #include "src/io/rdma/common.hpp"
 
+#include <algorithm>
 #include <cerrno>
 #include <chrono>
 #include <cstdlib>
@@ -582,6 +583,295 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
     }
     MORI_IO_TRACE("ibv_post_send ep index {} batch index range [{}, {})", epId, st, end);
   }
+  return {StatusCode::IN_PROGRESS, ""};
+}
+
+/* ---------------------------------------------------------------------------------------------- */
+/*                              RdmaLocalMemoryRegistration                                       */
+/* ---------------------------------------------------------------------------------------------- */
+RdmaLocalMemoryRegistration::RdmaLocalMemoryRegistration(RdmaMemoryLayout layout,
+                                                         application::RdmaDeviceContext* devCtx)
+    : layout_(std::move(layout)), devCtx_(devCtx) {}
+
+RdmaLocalMemoryRegistration::~RdmaLocalMemoryRegistration() {
+  if (!devCtx_) return;
+  for (auto& chunk : layout_.chunks) {
+    devCtx_->DeregisterRdmaMemoryRegion(reinterpret_cast<void*>(chunk.mr.addr));
+  }
+}
+
+/* ---------------------------------------------------------------------------------------------- */
+/*                                  Slice Resolution Algorithm                                    */
+/* ---------------------------------------------------------------------------------------------- */
+static size_t FindContainingChunk(const std::vector<RdmaMemoryChunk>& chunks, size_t offset) {
+  size_t lo = 0, hi = chunks.size();
+  while (lo + 1 < hi) {
+    size_t mid = lo + (hi - lo) / 2;
+    if (chunks[mid].offset <= offset)
+      lo = mid;
+    else
+      hi = mid;
+  }
+  return lo;
+}
+
+std::vector<RdmaTransferSlice> ResolveTransferSlices(const RdmaMemoryLayout& local,
+                                                     size_t localOffset,
+                                                     const RdmaMemoryLayout& remote,
+                                                     size_t remoteOffset, size_t totalSize) {
+  if (totalSize == 0) return {};
+
+  if (localOffset > local.logicalSize || totalSize > local.logicalSize - localOffset ||
+      remoteOffset > remote.logicalSize || totalSize > remote.logicalSize - remoteOffset) {
+    return {};
+  }
+
+  std::vector<RdmaTransferSlice> slices;
+  size_t estChunks = (local.chunks.size() > 1 || remote.chunks.size() > 1) ? 4 : 1;
+  slices.reserve(estChunks);
+
+  size_t li = FindContainingChunk(local.chunks, localOffset);
+  size_t ri = FindContainingChunk(remote.chunks, remoteOffset);
+  size_t remaining = totalSize;
+
+  while (remaining > 0) {
+    const auto& lc = local.chunks[li];
+    const auto& rc = remote.chunks[ri];
+
+    uintptr_t localAddr = local.baseAddr + localOffset;
+    uintptr_t remoteAddr = remote.baseAddr + remoteOffset;
+
+    size_t localChunkEnd = lc.offset + lc.mr.length;
+    size_t remoteChunkEnd = rc.offset + rc.mr.length;
+
+    size_t localAvail = localChunkEnd - localOffset;
+    size_t remoteAvail = remoteChunkEnd - remoteOffset;
+
+    size_t sliceLen = std::min({remaining, localAvail, remoteAvail,
+                                static_cast<size_t>(std::numeric_limits<uint32_t>::max())});
+
+    slices.push_back(
+        {localAddr, lc.mr.lkey, remoteAddr, rc.mr.rkey, static_cast<uint32_t>(sliceLen)});
+
+    remaining -= sliceLen;
+    localOffset += sliceLen;
+    remoteOffset += sliceLen;
+
+    if (localOffset >= localChunkEnd && remaining > 0) ++li;
+    if (remoteOffset >= remoteChunkEnd && remaining > 0) ++ri;
+  }
+
+  return slices;
+}
+
+/* ---------------------------------------------------------------------------------------------- */
+/*                               RdmaBatchReadWriteResolved                                       */
+/* ---------------------------------------------------------------------------------------------- */
+RdmaOpRet RdmaBatchReadWriteResolved(const EpPairVec& eps,
+                                     const std::vector<RdmaTransferSlice>& slices,
+                                     std::shared_ptr<CqCallbackMeta> callbackMeta,
+                                     TransferUniqueId id, bool isRead, int postBatchSize) {
+  MORI_IO_FUNCTION_TIMER;
+
+  size_t batchSize = slices.size();
+  if (batchSize == 0) return {StatusCode::SUCCESS, ""};
+  if (eps.empty()) return {StatusCode::ERR_INVALID_ARGS, "no endpoints"};
+
+  struct MergedWorkRequest {
+    ibv_send_wr wr{};
+    std::vector<ibv_sge> sges;
+    size_t totalRemoteLength{0};
+    size_t mergedSlices{1};
+  };
+
+  const uint32_t maxSge = std::max(eps[0].local.handle.maxSge, 1u);
+
+  std::vector<MergedWorkRequest> mergedWrs;
+  mergedWrs.reserve(batchSize);
+
+  auto start_new_wr = [&](const RdmaTransferSlice& s) {
+    mergedWrs.emplace_back();
+    MergedWorkRequest& mwr = mergedWrs.back();
+    mwr.sges.reserve(maxSge);
+    mwr.sges.push_back(ibv_sge{.addr = s.localAddr, .length = s.len, .lkey = s.localLkey});
+    mwr.totalRemoteLength = s.len;
+
+    mwr.wr.sg_list = mwr.sges.data();
+    mwr.wr.num_sge = 1;
+    mwr.wr.opcode = isRead ? IBV_WR_RDMA_READ : IBV_WR_RDMA_WRITE;
+    mwr.wr.send_flags = 0;
+    mwr.wr.wr.rdma.remote_addr = s.remoteAddr;
+    mwr.wr.wr.rdma.rkey = s.remoteRkey;
+  };
+
+  for (size_t i = 0; i < batchSize; ++i) {
+    const RdmaTransferSlice& s = slices[i];
+    bool merged = false;
+
+    if (!mergedWrs.empty()) {
+      MergedWorkRequest& last = mergedWrs.back();
+      uint64_t expectedRemote = last.wr.wr.rdma.remote_addr + last.totalRemoteLength;
+      if (expectedRemote == s.remoteAddr && last.wr.wr.rdma.rkey == s.remoteRkey) {
+        ibv_sge& lastSge = last.sges.back();
+        bool localContig = (lastSge.addr + lastSge.length) == s.localAddr;
+        bool sameLkey = lastSge.lkey == s.localLkey;
+
+        if (localContig && sameLkey) {
+          uint64_t newLen = static_cast<uint64_t>(lastSge.length) + s.len;
+          if (newLen <= std::numeric_limits<uint32_t>::max()) {
+            lastSge.length = static_cast<uint32_t>(newLen);
+            last.mergedSlices++;
+            last.totalRemoteLength += s.len;
+            merged = true;
+          }
+        }
+        if (!merged && last.sges.size() < maxSge) {
+          last.sges.push_back(ibv_sge{.addr = s.localAddr, .length = s.len, .lkey = s.localLkey});
+          last.wr.num_sge = static_cast<int>(last.sges.size());
+          last.mergedSlices++;
+          last.totalRemoteLength += s.len;
+          merged = true;
+        }
+      }
+    }
+    if (!merged) start_new_wr(s);
+  }
+
+  // Stabilize sg_list pointers after all merging is complete.
+  for (auto& mwr : mergedWrs) {
+    mwr.wr.sg_list = mwr.sges.data();
+  }
+
+  size_t mergedWrCount = mergedWrs.size();
+  size_t epNum = eps.size();
+  size_t epBatchSz = (mergedWrCount + epNum - 1) / epNum;
+
+  if (postBatchSize == -1) {
+    postBatchSize = (epBatchSz > static_cast<size_t>(std::numeric_limits<int>::max()))
+                        ? std::numeric_limits<int>::max()
+                        : static_cast<int>(epBatchSz);
+  }
+  {
+    int minMaxSqDepth = std::numeric_limits<int>::max();
+    for (size_t epId = 0; epId < epNum; ++epId) {
+      if (eps[epId].sqDepth && eps[epId].maxSqDepth > 0)
+        minMaxSqDepth = std::min(minMaxSqDepth, eps[epId].maxSqDepth);
+    }
+    if (minMaxSqDepth != std::numeric_limits<int>::max() && postBatchSize > minMaxSqDepth)
+      postBatchSize = minMaxSqDepth;
+  }
+  if (postBatchSize <= 0) postBatchSize = 1;
+  int numPostBatch = (mergedWrCount + postBatchSize - 1) / postBatchSize;
+
+  std::vector<int> epWrsSinceSignal(epNum, 0);
+  std::vector<size_t> epMergedSinceSignal(epNum, 0);
+
+  for (int i = 0; i < numPostBatch; i++) {
+    int st = i * postBatchSize;
+    int end = std::min(static_cast<size_t>(st) + postBatchSize, mergedWrCount);
+    if (end - st == 0) break;
+    int epId = i % epNum;
+    int batchWrNum = end - st;
+
+    std::string reserveErr;
+    SqReserveFailureKind reserveFailure = SqReserveFailureKind::None;
+    if (!TryReserveSqDepth(eps[epId], batchWrNum, epId, "resolved-batch", &reserveErr,
+                           &reserveFailure)) {
+      AppendHint(&reserveErr, BuildSqDepthHint(eps[epId], epNum, postBatchSize,
+                                               PostSendOpKind::BatchData, reserveFailure));
+      return {StatusCode::ERR_RDMA_OP, reserveErr};
+    }
+
+    size_t mergedSliceSize = 0;
+    for (int j = st; j < end; j++) {
+      mergedWrs[j].wr.wr_id = 0;
+      mergedWrs[j].wr.next = (j + 1 < end) ? &mergedWrs[j + 1].wr : nullptr;
+      mergedSliceSize += mergedWrs[j].mergedSlices;
+    }
+
+    epWrsSinceSignal[epId] += batchWrNum;
+    epMergedSinceSignal[epId] += mergedSliceSize;
+
+    bool isLastBatchForEp = ((i + epNum) >= numPostBatch);
+    bool sqNearFull = eps[epId].sqDepth && (epWrsSinceSignal[epId] >= eps[epId].maxSqDepth);
+    bool needSignal = isLastBatchForEp || sqNearFull;
+
+    ibv_send_wr& last = mergedWrs[end - 1].wr;
+    uint64_t recordId = 0;
+    if (needSignal) {
+      if (!eps[epId].ledger) {
+        ReleaseSqDepth(eps[epId], batchWrNum);
+        return {StatusCode::ERR_RDMA_OP,
+                "submission ledger is not initialized for signaled WR tracking"};
+      }
+      recordId = eps[epId].ledger->Insert(epWrsSinceSignal[epId], true, callbackMeta,
+                                          static_cast<int>(epMergedSinceSignal[epId]));
+      last.wr_id = recordId;
+      last.send_flags = IBV_SEND_SIGNALED;
+    }
+
+    ibv_send_wr* badWr = nullptr;
+    int ret = ibv_post_send(eps[epId].local.ibvHandle.qp, &mergedWrs[st].wr, &badWr);
+    if (ret != 0) {
+      int postedCount = 0;
+      if (badWr != nullptr) {
+        ibv_send_wr* cur = &mergedWrs[st].wr;
+        while (cur != nullptr && cur != badWr && postedCount < batchWrNum) {
+          ++postedCount;
+          cur = cur->next;
+        }
+      }
+      postedCount = std::max(0, std::min(postedCount, batchWrNum));
+      int unpostedCount = batchWrNum - postedCount;
+      if (unpostedCount > 0) {
+        ReleaseSqDepth(eps[epId], unpostedCount);
+        epWrsSinceSignal[epId] = std::max(0, epWrsSinceSignal[epId] - unpostedCount);
+        size_t mergedUnposted = 0;
+        for (int j = st + postedCount; j < end; ++j) mergedUnposted += mergedWrs[j].mergedSlices;
+        epMergedSinceSignal[epId] = epMergedSinceSignal[epId] >= mergedUnposted
+                                        ? epMergedSinceSignal[epId] - mergedUnposted
+                                        : 0;
+      }
+
+      bool lastWasPosted = (postedCount == batchWrNum);
+      if (needSignal && lastWasPosted) {
+        // signaled WR posted; CQ path owns release
+      } else if (needSignal) {
+        int dummy = 0;
+        eps[epId].ledger->ReleaseByCqe(recordId, nullptr, &dummy);
+      }
+
+      if (postedCount > 0 && (!needSignal || !lastWasPosted)) {
+        if (eps[epId].degraded) eps[epId].degraded->store(true, std::memory_order_relaxed);
+        if (eps[epId].ledger)
+          eps[epId].ledger->InsertOrphaned(epWrsSinceSignal[epId], callbackMeta,
+                                           static_cast<int>(epMergedSinceSignal[epId]));
+      }
+
+      for (size_t otherEpId = 0; otherEpId < epNum; ++otherEpId) {
+        if (static_cast<int>(otherEpId) == epId) continue;
+        if (epWrsSinceSignal[otherEpId] <= 0) continue;
+        if (eps[otherEpId].degraded)
+          eps[otherEpId].degraded->store(true, std::memory_order_relaxed);
+        if (eps[otherEpId].ledger)
+          eps[otherEpId].ledger->InsertOrphaned(epWrsSinceSignal[otherEpId], callbackMeta,
+                                                static_cast<int>(epMergedSinceSignal[otherEpId]));
+      }
+
+      std::string message = "ibv_post_send (resolved) failed with " + std::to_string(ret) + ": " +
+                            strerror(ret) + " (posted " + std::to_string(postedCount) + "/" +
+                            std::to_string(batchWrNum) + " WRs)";
+      AppendHint(&message, BuildPostSendFailureHint(ret, eps[epId], epNum, postBatchSize, badWr,
+                                                    PostSendOpKind::BatchData));
+      return {StatusCode::ERR_RDMA_OP, std::move(message)};
+    }
+
+    if (needSignal) {
+      epWrsSinceSignal[epId] = 0;
+      epMergedSinceSignal[epId] = 0;
+    }
+  }
+
   return {StatusCode::IN_PROGRESS, ""};
 }
 

--- a/src/io/rdma/common.hpp
+++ b/src/io/rdma/common.hpp
@@ -61,6 +61,16 @@ struct TopoKeyPair {
   MSGPACK_DEFINE(local, remote);
 };
 
+struct ExactRouteKey {
+  TopoKeyPair topo;
+  int ldevId{-1};
+  int rdevId{-1};
+
+  bool operator==(const ExactRouteKey& rhs) const noexcept {
+    return topo == rhs.topo && ldevId == rhs.ldevId && rdevId == rhs.rdevId;
+  }
+};
+
 struct MemoryKey {
   int devId;
   MemoryUniqueId id;
@@ -89,6 +99,18 @@ struct hash<mori::io::TopoKeyPair> {
     std::size_t h1 = std::hash<mori::io::TopoKey>{}(kp.local);
     std::size_t h2 = std::hash<mori::io::TopoKey>{}(kp.remote);
     return h1 ^ (h2 + 0x9e3779b9 + (h1 << 6) + (h1 >> 2));
+  }
+};
+
+template <>
+struct hash<mori::io::ExactRouteKey> {
+  std::size_t operator()(const mori::io::ExactRouteKey& key) const noexcept {
+    std::size_t h1 = std::hash<mori::io::TopoKeyPair>{}(key.topo);
+    std::size_t h2 = std::hash<int>{}(key.ldevId);
+    std::size_t h3 = std::hash<int>{}(key.rdevId);
+    h1 ^= h2 + 0x9e3779b9 + (h1 << 6) + (h1 >> 2);
+    h1 ^= h3 + 0x9e3779b9 + (h1 << 6) + (h1 >> 2);
+    return h1;
   }
 };
 
@@ -208,7 +230,7 @@ struct EndpointRuntime {
 };
 
 using EpPairVec = std::vector<EpPair>;
-using RouteTable = std::unordered_map<TopoKeyPair, EpPairVec>;
+using RouteTable = std::unordered_map<ExactRouteKey, EpPairVec>;
 using MemoryTable = std::unordered_map<MemoryKey, application::RdmaMemoryRegion>;
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -230,8 +252,9 @@ struct RdmaMemoryLayout {
 
 class RdmaLocalMemoryRegistration {
  public:
-  RdmaLocalMemoryRegistration(RdmaMemoryLayout layout, application::RdmaDeviceContext* devCtx);
-  ~RdmaLocalMemoryRegistration();
+  RdmaLocalMemoryRegistration(RdmaMemoryLayout layout,
+                              std::vector<application::RdmaOwnedMr> ownedMrs);
+  ~RdmaLocalMemoryRegistration() = default;
 
   const RdmaMemoryLayout& Layout() const { return layout_; }
   void MarkInvalidated() const { invalidated_.store(true, std::memory_order_release); }
@@ -239,7 +262,7 @@ class RdmaLocalMemoryRegistration {
 
  private:
   RdmaMemoryLayout layout_;
-  application::RdmaDeviceContext* devCtx_;
+  std::vector<application::RdmaOwnedMr> ownedMrs_;
   mutable std::atomic<bool> invalidated_{false};
 };
 
@@ -255,10 +278,26 @@ struct RdmaTransferSlice {
   uint32_t len;
 };
 
+struct ResolvedLaneWork {
+  int epId{-1};
+  size_t begin{0};
+  size_t end{0};
+};
+
+struct ResolvedTransferPlan {
+  std::vector<RdmaTransferSlice> slices;
+  std::vector<ResolvedLaneWork> lanes;
+};
+
 std::vector<RdmaTransferSlice> ResolveTransferSlices(const RdmaMemoryLayout& local,
                                                      size_t localOffset,
                                                      const RdmaMemoryLayout& remote,
                                                      size_t remoteOffset, size_t totalSize);
+ResolvedTransferPlan BuildResolvedTransferPlan(const EpPairVec& eps, const RdmaMemoryLayout& local,
+                                               const SizeVec& localOffsets,
+                                               const RdmaMemoryLayout& remote,
+                                               const SizeVec& remoteOffsets, const SizeVec& sizes,
+                                               size_t maxLanes = 0);
 
 struct RemoteEngineMeta {
   EngineKey key;
@@ -330,10 +369,19 @@ inline RdmaOpRet RdmaWrite(const EpPairVec& eps, const application::RdmaMemoryRe
                        false);
 }
 
-RdmaOpRet RdmaBatchReadWriteResolved(const EpPairVec& eps,
-                                     const std::vector<RdmaTransferSlice>& slices,
-                                     std::shared_ptr<CqCallbackMeta> callbackMeta,
-                                     TransferUniqueId id, bool isRead, int postBatchSize = -1);
+RdmaOpRet RdmaPostResolvedSlicesToSingleEp(const EpPair& ep,
+                                           const std::vector<RdmaTransferSlice>& slices,
+                                           size_t begin, size_t end,
+                                           std::shared_ptr<CqCallbackMeta> callbackMeta,
+                                           TransferUniqueId id, bool isRead,
+                                           int postBatchSize = -1);
+
+RdmaOpRet RdmaSubmitResolvedTransferPlanInline(const EpPairVec& eps,
+                                               const std::vector<RdmaTransferSlice>& slices,
+                                               const std::vector<ResolvedLaneWork>& lanes,
+                                               std::shared_ptr<CqCallbackMeta> callbackMeta,
+                                               TransferUniqueId id, bool isRead,
+                                               int postBatchSize = -1);
 
 }  // namespace io
 }  // namespace mori

--- a/src/io/rdma/common.hpp
+++ b/src/io/rdma/common.hpp
@@ -126,6 +126,8 @@ inline TransferUniqueId ExtractTransferIdFromWrId(uint64_t wr_id) {
 
 uint64_t MakeNotifSendWrId(TransferUniqueId id);
 
+class RdmaLocalMemoryRegistration;
+
 struct CqCallbackMeta {
   CqCallbackMeta(TransferStatus* s, TransferUniqueId id_, int n)
       : status(s), id(id_), totalBatchSize(n) {}
@@ -135,6 +137,7 @@ struct CqCallbackMeta {
   int totalBatchSize{0};
   std::atomic<uint32_t> finishedBatchSize{0};
   internal::IoCallDiagnostics diagnostics{};
+  std::shared_ptr<const RdmaLocalMemoryRegistration> localRegRef;
 };
 
 // SubmissionLedger: tracks per-EP WR submissions and enables precise sqDepth release.
@@ -208,10 +211,60 @@ using EpPairVec = std::vector<EpPair>;
 using RouteTable = std::unordered_map<TopoKeyPair, EpPairVec>;
 using MemoryTable = std::unordered_map<MemoryKey, application::RdmaMemoryRegion>;
 
+/* ---------------------------------------------------------------------------------------------- */
+/*                                  Chunked Memory Layout Types                                   */
+/* ---------------------------------------------------------------------------------------------- */
+struct RdmaMemoryChunk {
+  size_t offset;
+  application::RdmaMemoryRegion mr;
+};
+
+struct RdmaMemoryLayout {
+  int rdmaDevId{-1};
+  uintptr_t baseAddr{0};
+  size_t logicalSize{0};
+  std::vector<RdmaMemoryChunk> chunks;
+
+  bool IsSingleChunk() const { return chunks.size() == 1; }
+};
+
+class RdmaLocalMemoryRegistration {
+ public:
+  RdmaLocalMemoryRegistration(RdmaMemoryLayout layout, application::RdmaDeviceContext* devCtx);
+  ~RdmaLocalMemoryRegistration();
+
+  const RdmaMemoryLayout& Layout() const { return layout_; }
+  void MarkInvalidated() const { invalidated_.store(true, std::memory_order_release); }
+  bool Invalidated() const { return invalidated_.load(std::memory_order_acquire); }
+
+ private:
+  RdmaMemoryLayout layout_;
+  application::RdmaDeviceContext* devCtx_;
+  mutable std::atomic<bool> invalidated_{false};
+};
+
+struct RdmaRemoteMemoryLayout {
+  RdmaMemoryLayout layout;
+};
+
+struct RdmaTransferSlice {
+  uintptr_t localAddr;
+  uint32_t localLkey;
+  uintptr_t remoteAddr;
+  uint32_t remoteRkey;
+  uint32_t len;
+};
+
+std::vector<RdmaTransferSlice> ResolveTransferSlices(const RdmaMemoryLayout& local,
+                                                     size_t localOffset,
+                                                     const RdmaMemoryLayout& remote,
+                                                     size_t remoteOffset, size_t totalSize);
+
 struct RemoteEngineMeta {
   EngineKey key;
   RouteTable rTable;
   MemoryTable mTable;
+  std::unordered_map<MemoryUniqueId, std::shared_ptr<const RdmaRemoteMemoryLayout>> remoteLayouts;
 };
 
 struct RdmaOpRet {
@@ -276,5 +329,11 @@ inline RdmaOpRet RdmaWrite(const EpPairVec& eps, const application::RdmaMemoryRe
   return RdmaReadWrite(eps, local, localOffset, remote, remoteOffset, size, callbackMeta, id,
                        false);
 }
+
+RdmaOpRet RdmaBatchReadWriteResolved(const EpPairVec& eps,
+                                     const std::vector<RdmaTransferSlice>& slices,
+                                     std::shared_ptr<CqCallbackMeta> callbackMeta,
+                                     TransferUniqueId id, bool isRead, int postBatchSize = -1);
+
 }  // namespace io
 }  // namespace mori

--- a/src/io/rdma/executor.cpp
+++ b/src/io/rdma/executor.cpp
@@ -79,7 +79,7 @@ void MultithreadExecutor::Worker::MainLoop() {
 
   MORI_IO_INFO("worker {} enter main loop, running on core {}", workerId, sched_getcpu());
 
-  Task task{nullptr, 0, 0, 0};
+  Task task;
   while (true) {
     {
       std::unique_lock<std::mutex> lock(mu);
@@ -93,23 +93,42 @@ void MultithreadExecutor::Worker::MainLoop() {
       q.pop();
     }
 
-    SizeVec tLoclOffsets(task.req->localOffsets.begin() + task.begin,
-                         task.req->localOffsets.begin() + task.end);
-    SizeVec tRemoteOffsets(task.req->remoteOffsets.begin() + task.begin,
-                           task.req->remoteOffsets.begin() + task.end);
-    SizeVec tSizes(task.req->sizes.begin() + task.begin, task.req->sizes.begin() + task.end);
+    RdmaOpRet ret;
+    TransferUniqueId taskId = 0;
 
-    RdmaOpRet ret = mori::io::RdmaBatchReadWrite(
-        {task.req->eps[task.epId]}, task.req->local, tLoclOffsets, task.req->remote, tRemoteOffsets,
-        tSizes, task.req->callbackMeta, task.req->id, task.req->isRead, task.req->postBatchSize);
+    if (task.kind == Task::Kind::SingleMr) {
+      SizeVec tLoclOffsets(task.singleReq->localOffsets.begin() + task.begin,
+                           task.singleReq->localOffsets.begin() + task.end);
+      SizeVec tRemoteOffsets(task.singleReq->remoteOffsets.begin() + task.begin,
+                             task.singleReq->remoteOffsets.begin() + task.end);
+      SizeVec tSizes(task.singleReq->sizes.begin() + task.begin,
+                     task.singleReq->sizes.begin() + task.end);
+
+      ret = mori::io::RdmaBatchReadWrite({task.singleReq->eps[task.epId]}, task.singleReq->local,
+                                         tLoclOffsets, task.singleReq->remote, tRemoteOffsets,
+                                         tSizes, task.singleReq->callbackMeta, task.singleReq->id,
+                                         task.singleReq->isRead, task.singleReq->postBatchSize);
+      taskId = task.singleReq->id;
+    } else {
+      ret = mori::io::RdmaPostResolvedSlicesToSingleEp(
+          task.resolvedReq->eps[task.epId], task.resolvedReq->slices, task.begin, task.end,
+          task.resolvedReq->callbackMeta, task.resolvedReq->id, task.resolvedReq->isRead,
+          task.resolvedReq->postBatchSize);
+      taskId = task.resolvedReq->id;
+    }
+
     task.ret.set_value(ret);
-    MORI_IO_TRACE("Worker {} execute task {} begin {} end {} ret code {}", workerId, task.req->id,
+    MORI_IO_TRACE("Worker {} execute task {} begin {} end {} ret code {}", workerId, taskId,
                   task.begin, task.end, static_cast<uint32_t>(ret.code));
   }
 }
 
 void MultithreadExecutor::Worker::Submit(Task&& task) {
   MORI_IO_FUNCTION_TIMER;
+  TransferUniqueId taskId =
+      task.kind == Task::Kind::SingleMr ? task.singleReq->id : task.resolvedReq->id;
+  size_t begin = task.begin;
+  size_t end = task.end;
   {
     std::lock_guard<std::mutex> lock(mu);
     if (!running.load()) {
@@ -119,8 +138,7 @@ void MultithreadExecutor::Worker::Submit(Task&& task) {
     q.push(std::move(task));
     cond.notify_all();
   }
-  MORI_IO_TRACE("Submit to worker {} task {} begin {} end {}", workerId, task.req->id, task.begin,
-                task.end);
+  MORI_IO_TRACE("Submit to worker {} task {} begin {} end {}", workerId, taskId, begin, end);
 }
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -135,19 +153,19 @@ MultithreadExecutor::MultithreadExecutor(int n) : numWorker(n) {
 
 MultithreadExecutor::~MultithreadExecutor() { Shutdown(); }
 
-std::vector<std::pair<int, int>> MultithreadExecutor::SplitWork(const ExecutorReq& req) {
-  int numEps = req.eps.size();
-  int totalBatchSize = req.sizes.size();
+std::vector<std::pair<size_t, size_t>> MultithreadExecutor::SplitWork(const ExecutorReq& req) {
+  size_t numEps = req.eps.size();
+  size_t totalBatchSize = req.sizes.size();
 
   assert(numEps > 0);
 
-  int numActiveWorkers = std::min(numEps, numWorker);
-  int perWorkerBatchSize = (totalBatchSize + numActiveWorkers - 1) / numActiveWorkers;
+  size_t numActiveWorkers = std::min(numEps, static_cast<size_t>(numWorker));
+  size_t perWorkerBatchSize = (totalBatchSize + numActiveWorkers - 1) / numActiveWorkers;
 
-  std::vector<std::pair<int, int>> splits;
-  for (int i = 0; i < numActiveWorkers; i++) {
-    int begin = i * perWorkerBatchSize;
-    int end = std::min(begin + perWorkerBatchSize, totalBatchSize);
+  std::vector<std::pair<size_t, size_t>> splits;
+  for (size_t i = 0; i < numActiveWorkers; i++) {
+    size_t begin = i * perWorkerBatchSize;
+    size_t end = std::min(begin + perWorkerBatchSize, totalBatchSize);
     splits.push_back({begin, end});
     if (end >= totalBatchSize) break;
   }
@@ -159,11 +177,11 @@ RdmaOpRet MultithreadExecutor::RdmaBatchReadWrite(const ExecutorReq& req) {
   MORI_IO_FUNCTION_TIMER;
 
   auto splits = SplitWork(req);
-  int numSplits = splits.size();
+  size_t numSplits = splits.size();
   std::vector<std::future<RdmaOpRet>> futs;
 
-  for (int i = 0; i < numSplits; i++) {
-    Task task{&req, i, splits[i].first, splits[i].second};
+  for (size_t i = 0; i < numSplits; i++) {
+    Task task{&req, static_cast<int>(i), splits[i].first, splits[i].second};
     futs.push_back(std::move(task.ret.get_future()));
     pool[i]->Submit(std::move(task));
   }
@@ -187,6 +205,39 @@ RdmaOpRet MultithreadExecutor::RdmaBatchReadWrite(const ExecutorReq& req) {
   }
 
   MORI_IO_TRACE("MultithreadExecutor submit request for RdmaBatchReadWrite done");
+  return {StatusCode::IN_PROGRESS, ""};
+}
+
+RdmaOpRet MultithreadExecutor::RdmaBatchReadWriteResolved(const ResolvedExecutorReq& req) {
+  MORI_IO_FUNCTION_TIMER;
+
+  if (req.slices.empty()) return {StatusCode::SUCCESS, ""};
+  if (req.lanes.empty()) return {StatusCode::ERR_INVALID_ARGS, "resolved transfer lanes are empty"};
+
+  std::vector<std::future<RdmaOpRet>> futs;
+  futs.reserve(req.lanes.size());
+
+  for (size_t i = 0; i < req.lanes.size(); ++i) {
+    const auto& lane = req.lanes[i];
+    Task task{&req, lane.epId, lane.begin, lane.end};
+    futs.push_back(std::move(task.ret.get_future()));
+    pool[i % pool.size()]->Submit(std::move(task));
+  }
+
+  bool hasFail = false;
+  int numSucc = 0;
+  RdmaOpRet failedRet;
+  for (auto& fut : futs) {
+    RdmaOpRet ret = fut.get();
+    if (ret.Failed()) {
+      hasFail = true;
+      failedRet = ret;
+    } else if (ret.Succeeded()) {
+      numSucc++;
+    }
+  }
+  if (hasFail) return failedRet;
+  if (numSucc == static_cast<int>(req.lanes.size())) return {StatusCode::SUCCESS, ""};
   return {StatusCode::IN_PROGRESS, ""};
 }
 

--- a/src/io/rdma/executor.hpp
+++ b/src/io/rdma/executor.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <condition_variable>
+#include <cstdint>
 #include <future>
 #include <memory>
 #include <mutex>
@@ -50,6 +51,16 @@ struct ExecutorReq {
   bool isRead;
 };
 
+struct ResolvedExecutorReq {
+  const EpPairVec& eps;
+  const std::vector<RdmaTransferSlice>& slices;
+  const std::vector<ResolvedLaneWork>& lanes;
+  std::shared_ptr<CqCallbackMeta> callbackMeta;
+  TransferUniqueId id;
+  int postBatchSize;
+  bool isRead;
+};
+
 /* ---------------------------------------------------------------------------------------------- */
 /*                                            Executor                                            */
 /* ---------------------------------------------------------------------------------------------- */
@@ -60,7 +71,9 @@ class Executor {
 
   virtual void Start() = 0;
   virtual void Shutdown() = 0;
+  virtual int MaxParallelTasks() const = 0;
   virtual RdmaOpRet RdmaBatchReadWrite(const ExecutorReq& req) = 0;
+  virtual RdmaOpRet RdmaBatchReadWriteResolved(const ResolvedExecutorReq& req) = 0;
 };
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -72,22 +85,31 @@ class MultithreadExecutor : public Executor {
   ~MultithreadExecutor();
 
   RdmaOpRet RdmaBatchReadWrite(const ExecutorReq& req);
+  RdmaOpRet RdmaBatchReadWriteResolved(const ResolvedExecutorReq& req);
   void Start();
   void Shutdown();
+  int MaxParallelTasks() const { return numWorker; }
 
  private:
   struct Task {
-    const ExecutorReq* req;
+    enum class Kind : uint8_t { SingleMr, Resolved };
+
+    Kind kind{Kind::SingleMr};
+    const ExecutorReq* singleReq{nullptr};
+    const ResolvedExecutorReq* resolvedReq{nullptr};
     int epId{-1};
-    int begin{-1};
-    int end{-1};
+    size_t begin{0};
+    size_t end{0};
     std::promise<RdmaOpRet> ret;
 
-    Task(const ExecutorReq* req_, int epId_, int begin_, int end_)
-        : req(req_), epId(epId_), begin(begin_), end(end_) {}
+    Task() = default;
+    Task(const ExecutorReq* req_, int epId_, size_t begin_, size_t end_)
+        : kind(Kind::SingleMr), singleReq(req_), epId(epId_), begin(begin_), end(end_) {}
+    Task(const ResolvedExecutorReq* req_, int epId_, size_t begin_, size_t end_)
+        : kind(Kind::Resolved), resolvedReq(req_), epId(epId_), begin(begin_), end(end_) {}
   };
 
-  std::vector<std::pair<int, int>> SplitWork(const ExecutorReq& req);
+  std::vector<std::pair<size_t, size_t>> SplitWork(const ExecutorReq& req);
 
   class Worker {
    public:

--- a/src/io/rdma/protocol.cpp
+++ b/src/io/rdma/protocol.cpp
@@ -46,14 +46,14 @@ void Protocol::WriteMessageHeader(const MessageHeader& hdr) {
   SYSCALL_RETURN_ZERO(ep.Send(&len, sizeof(len)));
 }
 
-MessageRegEndpoint Protocol::ReadMessageRegEndpoint(size_t len) {
+MessageRegEndpointRequest Protocol::ReadMessageRegEndpointRequest(size_t len) {
   std::vector<char> buf(len);
   SYSCALL_RETURN_ZERO(ep.Recv(buf.data(), len));
   auto out = msgpack::unpack(buf.data(), len);
-  return out.get().as<MessageRegEndpoint>();
+  return out.get().as<MessageRegEndpointRequest>();
 }
 
-void Protocol::WriteMessageRegEndpoint(const MessageRegEndpoint& msg) {
+void Protocol::WriteMessageRegEndpointRequest(const MessageRegEndpointRequest& msg) {
   msgpack::sbuffer buf;
   msgpack::pack(buf, msg);
   uint32_t len = static_cast<uint32_t>(buf.size());
@@ -61,18 +61,18 @@ void Protocol::WriteMessageRegEndpoint(const MessageRegEndpoint& msg) {
   SYSCALL_RETURN_ZERO(ep.Send(buf.data(), buf.size()));
 }
 
-MessageAskMemoryRegion Protocol::ReadMessageAskMemoryRegion(size_t len) {
+MessageRegEndpointResponse Protocol::ReadMessageRegEndpointResponse(size_t len) {
   std::vector<char> buf(len);
   SYSCALL_RETURN_ZERO(ep.Recv(buf.data(), len));
   auto out = msgpack::unpack(buf.data(), len);
-  return out.get().as<MessageAskMemoryRegion>();
+  return out.get().as<MessageRegEndpointResponse>();
 }
 
-void Protocol::WriteMessageAskMemoryRegion(const MessageAskMemoryRegion& msg) {
+void Protocol::WriteMessageRegEndpointResponse(const MessageRegEndpointResponse& msg) {
   msgpack::sbuffer buf;
   msgpack::pack(buf, msg);
   uint32_t len = static_cast<uint32_t>(buf.size());
-  WriteMessageHeader({MessageType::AskMemoryRegion, len});
+  WriteMessageHeader({MessageType::RegEndpoint, len});
   SYSCALL_RETURN_ZERO(ep.Send(buf.data(), buf.size()));
 }
 

--- a/src/io/rdma/protocol.cpp
+++ b/src/io/rdma/protocol.cpp
@@ -76,5 +76,35 @@ void Protocol::WriteMessageAskMemoryRegion(const MessageAskMemoryRegion& msg) {
   SYSCALL_RETURN_ZERO(ep.Send(buf.data(), buf.size()));
 }
 
+MessageAskMemoryLayoutRequest Protocol::ReadMessageAskMemoryLayoutRequest(size_t len) {
+  std::vector<char> buf(len);
+  SYSCALL_RETURN_ZERO(ep.Recv(buf.data(), len));
+  auto out = msgpack::unpack(buf.data(), len);
+  return out.get().as<MessageAskMemoryLayoutRequest>();
+}
+
+void Protocol::WriteMessageAskMemoryLayoutRequest(const MessageAskMemoryLayoutRequest& msg) {
+  msgpack::sbuffer buf;
+  msgpack::pack(buf, msg);
+  uint32_t len = static_cast<uint32_t>(buf.size());
+  WriteMessageHeader({MessageType::AskMemoryLayout, len});
+  SYSCALL_RETURN_ZERO(ep.Send(buf.data(), buf.size()));
+}
+
+MessageAskMemoryLayoutResponse Protocol::ReadMessageAskMemoryLayoutResponse(size_t len) {
+  std::vector<char> buf(len);
+  SYSCALL_RETURN_ZERO(ep.Recv(buf.data(), len));
+  auto out = msgpack::unpack(buf.data(), len);
+  return out.get().as<MessageAskMemoryLayoutResponse>();
+}
+
+void Protocol::WriteMessageAskMemoryLayoutResponse(const MessageAskMemoryLayoutResponse& msg) {
+  msgpack::sbuffer buf;
+  msgpack::pack(buf, msg);
+  uint32_t len = static_cast<uint32_t>(buf.size());
+  WriteMessageHeader({MessageType::AskMemoryLayout, len});
+  SYSCALL_RETURN_ZERO(ep.Send(buf.data(), buf.size()));
+}
+
 }  // namespace io
 }  // namespace mori

--- a/src/io/rdma/protocol.hpp
+++ b/src/io/rdma/protocol.hpp
@@ -34,8 +34,7 @@ namespace io {
 /* ---------------------------------------------------------------------------------------------- */
 enum class MessageType : uint8_t {
   RegEndpoint = 0,
-  AskMemoryRegion = 1,
-  AskMemoryLayout = 2,
+  AskMemoryLayout = 1,
 };
 
 struct MessageHeader {
@@ -43,21 +42,21 @@ struct MessageHeader {
   uint32_t len;
 };
 
-struct MessageRegEndpoint {
+struct MessageRegEndpointRequest {
   EngineKey ekey;
   TopoKeyPair topo;
-  int devId;
-  application::RdmaEndpointHandle eph;
-  int requestedRemoteDevId{-1};
-  MSGPACK_DEFINE(ekey, topo, devId, eph, requestedRemoteDevId);
+  int initiatorLocalDevId{-1};
+  int expectedResponderLocalDevId{-1};
+  application::RdmaEndpointHandle initiatorEph;
+  MSGPACK_DEFINE(ekey, topo, initiatorLocalDevId, expectedResponderLocalDevId, initiatorEph);
 };
 
-struct MessageAskMemoryRegion {
-  EngineKey ekey;
-  int devId;
-  MemoryUniqueId id;
-  application::RdmaMemoryRegion mr;
-  MSGPACK_DEFINE(ekey, devId, id, mr);
+struct MessageRegEndpointResponse {
+  StatusCode code{StatusCode::ERR_BAD_STATE};
+  std::string message;
+  int responderLocalDevId{-1};
+  application::RdmaEndpointHandle responderEph{};
+  MSGPACK_DEFINE(code, message, responderLocalDevId, responderEph);
 };
 
 struct MessageBuildConn {
@@ -100,11 +99,11 @@ class Protocol {
   MessageHeader ReadMessageHeader();
   void WriteMessageHeader(const MessageHeader&);
 
-  MessageRegEndpoint ReadMessageRegEndpoint(size_t len);
-  void WriteMessageRegEndpoint(const MessageRegEndpoint&);
+  MessageRegEndpointRequest ReadMessageRegEndpointRequest(size_t len);
+  void WriteMessageRegEndpointRequest(const MessageRegEndpointRequest&);
 
-  MessageAskMemoryRegion ReadMessageAskMemoryRegion(size_t len);
-  void WriteMessageAskMemoryRegion(const MessageAskMemoryRegion&);
+  MessageRegEndpointResponse ReadMessageRegEndpointResponse(size_t len);
+  void WriteMessageRegEndpointResponse(const MessageRegEndpointResponse&);
 
   MessageAskMemoryLayoutRequest ReadMessageAskMemoryLayoutRequest(size_t len);
   void WriteMessageAskMemoryLayoutRequest(const MessageAskMemoryLayoutRequest&);

--- a/src/io/rdma/protocol.hpp
+++ b/src/io/rdma/protocol.hpp
@@ -35,6 +35,7 @@ namespace io {
 enum class MessageType : uint8_t {
   RegEndpoint = 0,
   AskMemoryRegion = 1,
+  AskMemoryLayout = 2,
 };
 
 struct MessageHeader {
@@ -47,7 +48,8 @@ struct MessageRegEndpoint {
   TopoKeyPair topo;
   int devId;
   application::RdmaEndpointHandle eph;
-  MSGPACK_DEFINE(ekey, topo, devId, eph);
+  int requestedRemoteDevId{-1};
+  MSGPACK_DEFINE(ekey, topo, devId, eph, requestedRemoteDevId);
 };
 
 struct MessageAskMemoryRegion {
@@ -61,6 +63,30 @@ struct MessageAskMemoryRegion {
 struct MessageBuildConn {
   EngineKey key;
   MSGPACK_DEFINE(key);
+};
+
+struct RdmaRemoteMemoryChunkWire {
+  uint64_t offset;
+  uint64_t addr;
+  uint32_t rkey;
+  uint64_t length;
+  MSGPACK_DEFINE(offset, addr, rkey, length);
+};
+
+struct MessageAskMemoryLayoutRequest {
+  EngineKey ekey;
+  MemoryUniqueId id;
+  MSGPACK_DEFINE(ekey, id);
+};
+
+struct MessageAskMemoryLayoutResponse {
+  EngineKey ekey;
+  MemoryUniqueId id;
+  StatusCode code;
+  std::string message;
+  int rdmaDevId;
+  std::vector<RdmaRemoteMemoryChunkWire> chunks;
+  MSGPACK_DEFINE(ekey, id, code, message, rdmaDevId, chunks);
 };
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -79,6 +105,12 @@ class Protocol {
 
   MessageAskMemoryRegion ReadMessageAskMemoryRegion(size_t len);
   void WriteMessageAskMemoryRegion(const MessageAskMemoryRegion&);
+
+  MessageAskMemoryLayoutRequest ReadMessageAskMemoryLayoutRequest(size_t len);
+  void WriteMessageAskMemoryLayoutRequest(const MessageAskMemoryLayoutRequest&);
+
+  MessageAskMemoryLayoutResponse ReadMessageAskMemoryLayoutResponse(size_t len);
+  void WriteMessageAskMemoryLayoutResponse(const MessageAskMemoryLayoutResponse&);
 
  private:
   application::TCPEndpoint ep;

--- a/tests/python/io/test_engine.py
+++ b/tests/python/io/test_engine.py
@@ -22,6 +22,7 @@
 import pytest
 import os
 import time
+import gc
 from contextlib import contextmanager
 from tests.python.utils import get_free_port
 import torch
@@ -297,6 +298,38 @@ def alloc_and_register_mem(engine_pair, shape):
     return tensor1, tensor2, initiator_mem, target_mem
 
 
+def register_explicit_mem(engine_pair, initiator_tensor, target_tensor):
+    initiator, target = engine_pair
+    initiator_mem = initiator.register_torch_tensor(initiator_tensor)
+    target_mem = target.register_torch_tensor(target_tensor)
+    return initiator_mem, target_mem
+
+
+def cleanup_engine_pair(initiator, target, initiator_mems=(), target_mems=()):
+    if initiator is not None:
+        for mem in initiator_mems:
+            if mem is None:
+                continue
+            try:
+                initiator.deregister_memory(mem)
+            except Exception:
+                pass
+    if target is not None:
+        for mem in target_mems:
+            if mem is None:
+                continue
+            try:
+                target.deregister_memory(mem)
+            except Exception:
+                pass
+
+    del initiator
+    del target
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
 def check_transfer_result(
     engine_pair,
     initiator_status,
@@ -490,6 +523,346 @@ def test_notification_disabled():
         initiator.get_engine_desc().key, transfer_uid
     )
     assert inbound_status is None  # No notification received
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires 2 GPUs")
+@pytest.mark.parametrize("op_type", ("write", "read"))
+def test_rdma_chunked_session_transfer_crosses_multiple_chunks(op_type):
+    with temporary_env("MORI_IO_RDMA_MR_CHUNK_SIZE", "64"):
+        initiator, target = create_connected_engine_pair(
+            "chunked_single",
+            qp_per_transfer=2,
+            post_batch_size=-1,
+            num_worker_threads=1,
+            enable_notification=True,
+        )
+        initiator_mem = None
+        target_mem = None
+        sess = None
+
+        try:
+            total_bytes = 256
+            local_offset = 48
+            transfer_size = 160
+
+            if op_type == "write":
+                initiator_tensor = torch.arange(
+                    total_bytes, dtype=torch.uint8, device=torch.device("cuda", 0)
+                )
+                target_tensor = torch.full(
+                    (total_bytes,),
+                    0xA5,
+                    dtype=torch.uint8,
+                    device=torch.device("cuda", 1),
+                )
+            else:
+                initiator_tensor = torch.full(
+                    (total_bytes,),
+                    0x5A,
+                    dtype=torch.uint8,
+                    device=torch.device("cuda", 0),
+                )
+                target_tensor = torch.arange(
+                    total_bytes, dtype=torch.uint8, device=torch.device("cuda", 1)
+                )
+
+            initiator_before = initiator_tensor.clone()
+            target_before = target_tensor.clone()
+            initiator_mem, target_mem = register_explicit_mem(
+                (initiator, target), initiator_tensor, target_tensor
+            )
+
+            sess = initiator.create_session(initiator_mem, target_mem)
+            assert sess is not None
+            assert sess.alive()
+
+            transfer_uid = sess.allocate_transfer_uid()
+            op = sess.write if op_type == "write" else sess.read
+            status = op(local_offset, local_offset, transfer_size, transfer_uid)
+
+            wait_status(status)
+            assert status.Succeeded(), status.Message()
+
+            inbound = wait_inbound_status_with_timeout(
+                target, initiator.get_engine_desc().key, transfer_uid, timeout_s=3.0
+            )
+            assert (
+                inbound is not None
+            ), "Expected inbound notification for chunked transfer"
+            assert inbound.Succeeded(), inbound.Message()
+
+            if op_type == "write":
+                expected_target = target_before.clone()
+                expected_target[local_offset : local_offset + transfer_size] = (
+                    initiator_before[local_offset : local_offset + transfer_size]
+                )
+                assert torch.equal(target_tensor.cpu(), expected_target.cpu())
+                assert torch.equal(initiator_tensor.cpu(), initiator_before.cpu())
+            else:
+                expected_initiator = initiator_before.clone()
+                expected_initiator[local_offset : local_offset + transfer_size] = (
+                    target_before[local_offset : local_offset + transfer_size]
+                )
+                assert torch.equal(initiator_tensor.cpu(), expected_initiator.cpu())
+                assert torch.equal(target_tensor.cpu(), target_before.cpu())
+        finally:
+            del sess
+            cleanup_engine_pair(initiator, target, [initiator_mem], [target_mem])
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires 2 GPUs")
+def test_rdma_chunked_multithread_batch_crosses_chunks():
+    with temporary_env("MORI_IO_RDMA_MR_CHUNK_SIZE", "64"):
+        initiator, target = create_connected_engine_pair(
+            "chunked_multhd",
+            qp_per_transfer=2,
+            post_batch_size=-1,
+            num_worker_threads=2,
+            enable_notification=True,
+        )
+        initiator_mem = None
+        target_mem = None
+        sess = None
+
+        try:
+            total_bytes = 512
+            initiator_tensor = torch.arange(
+                total_bytes, dtype=torch.uint8, device=torch.device("cuda", 0)
+            )
+            target_tensor = torch.full(
+                (total_bytes,), 0x11, dtype=torch.uint8, device=torch.device("cuda", 1)
+            )
+            target_before = target_tensor.clone()
+
+            initiator_mem, target_mem = register_explicit_mem(
+                (initiator, target), initiator_tensor, target_tensor
+            )
+
+            sess = initiator.create_session(initiator_mem, target_mem)
+            assert sess is not None
+            assert sess.alive()
+
+            offsets = [16, 112, 208, 304]
+            sizes = [96, 96, 96, 96]
+            transfer_uid = sess.allocate_transfer_uid()
+            status = sess.batch_write(offsets, offsets, sizes, transfer_uid)
+
+            wait_status(status)
+            assert status.Succeeded(), status.Message()
+
+            inbound = wait_inbound_status_with_timeout(
+                target, initiator.get_engine_desc().key, transfer_uid, timeout_s=3.0
+            )
+            assert (
+                inbound is not None
+            ), "Expected inbound notification for chunked multithread batch"
+            assert inbound.Succeeded(), inbound.Message()
+
+            expected_target = target_before.clone()
+            for offset, size in zip(offsets, sizes):
+                expected_target[offset : offset + size] = initiator_tensor[
+                    offset : offset + size
+                ]
+            assert torch.equal(target_tensor.cpu(), expected_target.cpu())
+        finally:
+            del sess
+            cleanup_engine_pair(initiator, target, [initiator_mem], [target_mem])
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires 2 GPUs")
+def test_rdma_chunked_session_invalidates_on_deregister_and_reregisters_same_tensor():
+    with temporary_env("MORI_IO_RDMA_MR_CHUNK_SIZE", "64"):
+        initiator, target = create_connected_engine_pair(
+            "chunked_reregister",
+            qp_per_transfer=2,
+            post_batch_size=-1,
+            num_worker_threads=1,
+            enable_notification=True,
+        )
+        initiator_mem = None
+        re_registered_mem = None
+        target_mem = None
+        sess = None
+        recovered_sess = None
+
+        try:
+            total_bytes = 256
+            initiator_tensor = torch.arange(
+                total_bytes, dtype=torch.uint8, device=torch.device("cuda", 0)
+            )
+            target_tensor = torch.zeros(
+                total_bytes, dtype=torch.uint8, device=torch.device("cuda", 1)
+            )
+
+            initiator_mem, target_mem = register_explicit_mem(
+                (initiator, target), initiator_tensor, target_tensor
+            )
+
+            sess = initiator.create_session(initiator_mem, target_mem)
+            assert sess is not None
+            assert sess.alive()
+
+            first_uid = sess.allocate_transfer_uid()
+            first_status = sess.write(0, 0, total_bytes, first_uid)
+            wait_status(first_status)
+            assert first_status.Succeeded(), first_status.Message()
+            inbound = wait_inbound_status_with_timeout(
+                target, initiator.get_engine_desc().key, first_uid, timeout_s=3.0
+            )
+            assert inbound is not None
+            assert inbound.Succeeded(), inbound.Message()
+            assert torch.equal(initiator_tensor.cpu(), target_tensor.cpu())
+
+            target_tensor.zero_()
+            initiator.deregister_memory(initiator_mem)
+            initiator_mem = None
+
+            assert not sess.alive()
+            stale_uid = sess.allocate_transfer_uid()
+            stale_status = sess.write(0, 0, total_bytes, stale_uid)
+            assert stale_status.Failed()
+            assert stale_status.Code() == StatusCode.ERR_INVALID_ARGS
+            assert "deregistered" in stale_status.Message().lower()
+
+            re_registered_mem = initiator.register_torch_tensor(initiator_tensor)
+            assert re_registered_mem.data == initiator_tensor.data_ptr()
+
+            recovered_sess = initiator.create_session(re_registered_mem, target_mem)
+            assert recovered_sess is not None
+            assert recovered_sess.alive()
+
+            recovered_uid = recovered_sess.allocate_transfer_uid()
+            recovered_status = recovered_sess.write(0, 0, total_bytes, recovered_uid)
+            wait_status(recovered_status)
+            assert recovered_status.Succeeded(), recovered_status.Message()
+            inbound = wait_inbound_status_with_timeout(
+                target, initiator.get_engine_desc().key, recovered_uid, timeout_s=3.0
+            )
+            assert inbound is not None
+            assert inbound.Succeeded(), inbound.Message()
+            assert torch.equal(initiator_tensor.cpu(), target_tensor.cpu())
+        finally:
+            del sess
+            del recovered_sess
+            cleanup_engine_pair(
+                initiator, target, [initiator_mem, re_registered_mem], [target_mem]
+            )
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires 2 GPUs")
+def test_rdma_chunked_inflight_dereg_keeps_registration_alive():
+    """In-flight transfers must keep their underlying chunk MRs alive even when
+    the user deregisters the local memory mid-flight.
+
+    Validates the ``CqCallbackMeta::localRegRef`` ownership anchor: if the
+    anchor is missing, deregistering the local memory (which removes the
+    manager's and session cache's references to ``RdmaLocalMemoryRegistration``)
+    would tear down the chunk MRs while WRs are still pending in the SQ, and
+    those in-flight WRs would surface ``LOC_PROT_ERR`` on completion.
+
+    With the patch, the registration object stays alive until the last
+    in-flight transfer's ``CqCallbackMeta`` is released, so all submissions
+    must complete cleanly. Re-registering the same tensor afterward must work
+    against the now-fresh MR set.
+    """
+    with temporary_env("MORI_IO_RDMA_MR_CHUNK_SIZE", "64"):
+        initiator, target = create_connected_engine_pair(
+            "chunked_inflight_dereg",
+            qp_per_transfer=2,
+            post_batch_size=-1,
+            num_worker_threads=1,
+            enable_notification=True,
+        )
+
+        initiator_mem = None
+        target_mem = None
+        re_registered_mem = None
+        recovered_sess = None
+        statuses = []
+
+        try:
+            # Force the resolved (multi-slice) path: small chunk size so each
+            # 4 KiB transfer fans out to ~64 slices, giving the SQ enough
+            # outstanding work that deregistration races with completion.
+            total_bytes = 4096
+            initiator_tensor = torch.arange(
+                total_bytes, dtype=torch.uint8, device=torch.device("cuda", 0)
+            )
+            target_tensor = torch.zeros(
+                total_bytes, dtype=torch.uint8, device=torch.device("cuda", 1)
+            )
+
+            initiator_mem, target_mem = register_explicit_mem(
+                (initiator, target), initiator_tensor, target_tensor
+            )
+
+            # Use the cached path (engine.write) on purpose: when we
+            # deregister, InvalidateSessionsForMemory drops the cache's
+            # session ref so the CqCallbackMeta::localRegRef anchor is the
+            # ONLY thing keeping the registration alive.
+            num_inflight = 64
+            for _ in range(num_inflight):
+                uid = initiator.allocate_transfer_uid()
+                statuses.append(
+                    initiator.write(initiator_mem, 0, target_mem, 0, total_bytes, uid)
+                )
+
+            # Race the deregister against the in-flight WRs. We do NOT wait
+            # before this call.
+            initiator.deregister_memory(initiator_mem)
+            initiator_mem = None  # avoid double-deregister in cleanup
+
+            # All in-flight transfers must still complete successfully. Failure
+            # here (typically with LOC_PROT_ERR) means the chunk MRs got torn
+            # down while WRs were still pending.
+            for i, s in enumerate(statuses):
+                wait_status(s)
+                assert s.Succeeded(), (
+                    f"in-flight transfer #{i} failed after dereg: "
+                    f"code={s.Code()} msg={s.Message()}"
+                )
+            # Final state of target is the last successful write.
+            assert torch.equal(initiator_tensor.cpu(), target_tensor.cpu())
+
+            # Re-registering the same tensor (same data_ptr) at this point
+            # must yield a fresh registration backed by NEW chunk MRs. With
+            # the old address-keyed mrPool, this case used to silently reuse
+            # the stale MR slot; with owned MRs each registration owns its
+            # own ibv_mr* via RAII.
+            target_tensor.zero_()
+            re_registered_mem = initiator.register_torch_tensor(initiator_tensor)
+            assert re_registered_mem.data == initiator_tensor.data_ptr()
+
+            recovered_sess = initiator.create_session(re_registered_mem, target_mem)
+            assert recovered_sess is not None
+            assert recovered_sess.alive()
+
+            recovered_uid = recovered_sess.allocate_transfer_uid()
+            recovered_status = recovered_sess.write(0, 0, total_bytes, recovered_uid)
+            wait_status(recovered_status)
+            assert recovered_status.Succeeded(), recovered_status.Message()
+            inbound = wait_inbound_status_with_timeout(
+                target,
+                initiator.get_engine_desc().key,
+                recovered_uid,
+                timeout_s=3.0,
+            )
+            assert inbound is not None
+            assert inbound.Succeeded(), inbound.Message()
+            assert torch.equal(initiator_tensor.cpu(), target_tensor.cpu())
+        finally:
+            # IMPORTANT: do not clear `statuses` until every transfer has
+            # finished waiting above. CqCallbackMeta keeps a raw pointer to
+            # each TransferStatus, so dropping a status while its WR is still
+            # pending would race with the CQ poll thread.
+            statuses.clear()
+            del recovered_sess
+            cleanup_engine_pair(
+                initiator,
+                target,
+                [initiator_mem, re_registered_mem],
+                [target_mem],
+            )
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires 2 GPUs")

--- a/tests/python/io/test_engine.py
+++ b/tests/python/io/test_engine.py
@@ -964,6 +964,151 @@ def test_rdma_chunked_inflight_dereg_keeps_registration_alive():
             )
 
 
+def _likely_ionic_nic():
+    """Heuristic: returns True if this test is likely to run on AMD AINIC (ionic).
+
+    Checks ``MORI_RDMA_DEVICES`` first, then falls back to /sys/class/infiniband.
+    Returns False conservatively when the answer is ambiguous (e.g. mixed
+    vendors with no env override) so the test only enforces the
+    ionic-specific guard when we're confident the test will hit ionic.
+    """
+    env = os.environ.get("MORI_RDMA_DEVICES", "").strip()
+    if env:
+        first = env.split(",")[0].strip().lower()
+        return first.startswith("ionic")
+    try:
+        devs = os.listdir("/sys/class/infiniband")
+    except OSError:
+        return False
+    has_ionic = any(d.startswith("ionic") for d in devs)
+    has_other = any(d.startswith(("mlx", "bnxt")) for d in devs)
+    return has_ionic and not has_other
+
+
+def test_rdma_chunked_cpu_registration_requires_page_aligned_base():
+    """Verify mori-io refuses non-page-aligned chunked CPU registration on ionic.
+
+    On AMD AINIC (ionic, vendor 0x1dd8 / Pensando), the firmware silently
+    drops the last ~64 bytes of any RDMA WRITE landing on a chunked CPU MR's
+    tail when the user-supplied buffer's base VA is NOT 4 KiB page-aligned
+    (so MR_a's last bytes share a 4 KiB kernel page with MR_b's first bytes).
+    The CQE reports IBV_WC_SUCCESS but bytes go missing. mori-io's chunked
+    materialization path refuses such registrations so the user gets a loud
+    failure instead of silent corruption.
+
+    Cross-platform verification: Mellanox mlx5 (vendor 0x02c9) and Broadcom
+    bnxt_re (vendor 0x14e4) tested clean with the same workload, so the
+    guard is gated on Pensando vendor id.
+
+    This test:
+      - allocates a non-page-aligned CPU buffer (a Python-managed buffer
+        large enough to be sliced into a non-page-aligned region, mimicking
+        the shape PyTorch's CPU caching allocator returns)
+      - forces the chunked path via ``MORI_IO_RDMA_MR_CHUNK_SIZE``
+      - asserts that on ionic ``create_session`` returns ``None`` (the
+        guard threw, ``RdmaBackend::CreateSession`` caught and returned
+        nullptr) and on other NICs it succeeds (no guard, no bug).
+
+    Avoids ``ctypes.CDLL("libc.so.6")`` so the test runs on musl-based
+    distros (Alpine etc.) where the glibc SONAME is absent.
+    """
+    import ctypes
+
+    PAGE_SIZE = 4096
+    OFFSET_INTO_PAGE = 64  # mimic PyTorch's 64-byte tensor metadata padding
+
+    # Small buffer (16 MiB) and even smaller chunk (8 MiB) so the chunked
+    # path fires regardless of NIC pin caps and the test stays fast.
+    nbytes = 16 * 1024 * 1024
+    chunk_size = 8 * 1024 * 1024
+
+    # Allocate slightly oversized Python-managed buffers so we can carve out
+    # a (page-aligned + 64-byte offset) interior pointer that is guaranteed
+    # NOT to be 4 KiB page-aligned. Python keeps the underlying ctypes
+    # storage alive as long as the c_char_Array_* objects do, so we pin them
+    # to local variables for the duration of the test.
+    over_alloc = nbytes + 2 * PAGE_SIZE
+    src_storage = ctypes.create_string_buffer(over_alloc)
+    dst_storage = ctypes.create_string_buffer(over_alloc)
+
+    def non_page_aligned_ptr(storage):
+        base = ctypes.addressof(storage)
+        page_aligned = (base + PAGE_SIZE - 1) & ~(PAGE_SIZE - 1)
+        return page_aligned + OFFSET_INTO_PAGE
+
+    src_ptr = non_page_aligned_ptr(src_storage)
+    dst_ptr = non_page_aligned_ptr(dst_storage)
+    assert (
+        src_ptr % PAGE_SIZE != 0
+    ), "test setup error: src_ptr unexpectedly page-aligned"
+    assert (
+        dst_ptr % PAGE_SIZE != 0
+    ), "test setup error: dst_ptr unexpectedly page-aligned"
+    # Sanity: the non-aligned interior must still fit the requested nbytes
+    # within the over-allocated storage.
+    assert src_ptr + nbytes <= ctypes.addressof(src_storage) + over_alloc
+    assert dst_ptr + nbytes <= ctypes.addressof(dst_storage) + over_alloc
+
+    is_ionic = _likely_ionic_nic()
+    src_mem = None
+    dst_mem = None
+    sess = None
+    initiator = None
+    target = None
+    try:
+        with temporary_env("MORI_IO_RDMA_MR_CHUNK_SIZE", str(chunk_size)):
+            initiator, target = create_connected_engine_pair(
+                "page_align_guard",
+                qp_per_transfer=1,
+                post_batch_size=-1,
+                num_worker_threads=1,
+                enable_notification=False,
+            )
+
+            src_mem = initiator.register_memory(
+                src_ptr, nbytes, -1, MemoryLocationType.CPU
+            )
+            dst_mem = target.register_memory(
+                dst_ptr, nbytes, -1, MemoryLocationType.CPU
+            )
+
+            # create_session triggers materialization on both sides; the
+            # chunked CPU registration path's guard runs here.
+            sess = initiator.create_session(src_mem, dst_mem)
+
+            if is_ionic:
+                assert sess is None, (
+                    "Expected create_session to fail (return None) on ionic with a "
+                    "non-page-aligned CPU buffer + chunked path; got a valid session, "
+                    "which means the page-alignment guard in "
+                    "RdmaManager::GetOrMaterializeLocalRegistration did NOT trigger. "
+                    "If you intended to relax the guard, update both the C++ guard and "
+                    "this test."
+                )
+            else:
+                assert sess is not None, (
+                    "Expected create_session to succeed on a non-ionic NIC with a "
+                    "non-page-aligned CPU buffer (the page-alignment guard is "
+                    "ionic-specific). create_session returned None — either the guard "
+                    "is now applying to non-ionic NICs (intentional?), or registration "
+                    "failed for an unrelated reason. Check the engine error log."
+                )
+    finally:
+        if sess is not None:
+            del sess
+        if src_mem is not None and initiator is not None:
+            try:
+                initiator.deregister_memory(src_mem)
+            except Exception:
+                pass
+        if dst_mem is not None and target is not None:
+            try:
+                target.deregister_memory(dst_mem)
+            except Exception:
+                pass
+        # src_storage / dst_storage go out of scope here; Python frees them.
+
+
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires 2 GPUs")
 def test_multithread_batch_error_path_is_recoverable():
     """Regression for callback meta ownership on error paths.

--- a/tests/python/io/test_engine.py
+++ b/tests/python/io/test_engine.py
@@ -750,6 +750,105 @@ def test_rdma_chunked_session_invalidates_on_deregister_and_reregisters_same_ten
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires 2 GPUs")
+def test_rdma_chunked_large_buffer_cross_boundary():
+    """End-to-end test for chunked registration of a buffer larger than the
+    chunk-size cap, with a transfer that straddles a chunk boundary.
+
+    Why an explicit ``MORI_IO_RDMA_MR_CHUNK_SIZE`` override:
+    NICs like AMD AINIC (ionic) report ``max_mr_size = 0xffffffffffffffff``
+    via ``ibv_query_device_ex``, but the actual hardware/firmware soft limit
+    is much smaller (~2 GiB). The chunked materialization path normally uses
+    the queried ``max_mr_size``, so on such NICs we cannot rely on the
+    "natural" chunked path being triggered without an override. The override
+    forces a 1 GiB chunk, which is comfortably below ionic's real limit and
+    above any reasonable single-page allocation, so registration of a
+    1.05 GiB tensor produces exactly two chunks and a transfer that crosses
+    the 1 GiB boundary exercises the resolved (multi-slice) data path.
+    """
+    chunk_size = 1 << 30  # 1 GiB
+    extra = 64 << 20  # 64 MiB tail in chunk1
+    total_bytes = chunk_size + extra
+    free0, _ = torch.cuda.mem_get_info(0)
+    free1, _ = torch.cuda.mem_get_info(1)
+    if free0 < total_bytes + (256 << 20) or free1 < total_bytes + (256 << 20):
+        pytest.skip(
+            f"requires ~{(total_bytes + (256 << 20)) >> 20} MiB free per GPU; "
+            f"have free0={free0 >> 20} MiB free1={free1 >> 20} MiB"
+        )
+
+    with temporary_env("MORI_IO_RDMA_MR_CHUNK_SIZE", str(chunk_size)):
+        initiator, target = create_connected_engine_pair(
+            "chunked_large_buffer",
+            qp_per_transfer=2,
+            post_batch_size=-1,
+            num_worker_threads=2,
+            enable_notification=True,
+        )
+
+        initiator_mem = None
+        target_mem = None
+        sess = None
+        try:
+            initiator_tensor = torch.full(
+                (total_bytes,), 0xAA, dtype=torch.uint8, device=torch.device("cuda", 0)
+            )
+            target_tensor = torch.full(
+                (total_bytes,), 0xCC, dtype=torch.uint8, device=torch.device("cuda", 1)
+            )
+
+            # Spike a 4 MiB region centered on the 1 GiB chunk boundary with a
+            # deterministic, aperiodic pattern so any cross-chunk slicing bug
+            # (including arbitrary byte/word shifts) shows up in the byte
+            # compare. Each 4-byte word encodes its own position index so the
+            # pattern is unique up to 4 GiB of payload, well above the 4 MiB
+            # spike size.
+            spike_size = 4 << 20  # 4 MiB
+            assert spike_size % 4 == 0
+            spike_lo = chunk_size - (spike_size // 2)
+            spike_hi = chunk_size + (spike_size // 2)
+            pattern = torch.arange(
+                spike_size // 4, dtype=torch.int32, device=initiator_tensor.device
+            ).view(torch.uint8)
+            initiator_tensor[spike_lo:spike_hi].copy_(pattern)
+
+            initiator_mem, target_mem = register_explicit_mem(
+                (initiator, target), initiator_tensor, target_tensor
+            )
+
+            sess = initiator.create_session(initiator_mem, target_mem)
+            assert sess is not None
+            assert sess.alive()
+
+            uid = sess.allocate_transfer_uid()
+            status = sess.write(spike_lo, spike_lo, spike_size, uid)
+            wait_status(status)
+            assert status.Succeeded(), status.Message()
+
+            inbound = wait_inbound_status_with_timeout(
+                target, initiator.get_engine_desc().key, uid, timeout_s=10.0
+            )
+            assert inbound is not None
+            assert inbound.Succeeded(), inbound.Message()
+
+            # The spike region (which crosses the 1 GiB chunk boundary) must
+            # match byte-for-byte after the cross-chunk transfer.
+            spike_target = target_tensor[spike_lo:spike_hi].cpu()
+            spike_expected = pattern.cpu()
+            assert torch.equal(
+                spike_target, spike_expected
+            ), "boundary-crossing data corrupted"
+
+            # Spot check that areas outside the transfer were untouched.
+            assert target_tensor[0].item() == 0xCC
+            assert target_tensor[spike_lo - 1].item() == 0xCC
+            assert target_tensor[spike_hi].item() == 0xCC
+            assert target_tensor[total_bytes - 1].item() == 0xCC
+        finally:
+            del sess
+            cleanup_engine_pair(initiator, target, [initiator_mem], [target_mem])
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires 2 GPUs")
 def test_rdma_chunked_inflight_dereg_keeps_registration_alive():
     """In-flight transfers must keep their underlying chunk MRs alive even when
     the user deregisters the local memory mid-flight.


### PR DESCRIPTION
## Motivation

Today MORI-IO's RDMA backend assumes one logical `MemoryDesc` maps to exactly one `application::RdmaMemoryRegion`. That assumption breaks for very large allocations: when `IOEngine::RegisterMemory()` is called with a buffer whose size exceeds the NIC's `ibv_device_attr_ex::max_mr_size`, `ibv_reg_mr` fails and the legacy code path calls `std::abort()`. A second related issue is that `RdmaBatchReadWrite()` casts each transfer length to `uint32_t`, so a single transfer above `UINT32_MAX` bytes is silently truncated even when the MR itself is small enough.

This PR teaches the RDMA backend to register large memories as multiple chunk MRs underneath one logical descriptor, while keeping every public API (`MemoryDesc`, `register_torch_tensor`, `IOEngine::CreateSession`, `register_memory`, `TransferStatus`, etc.) unchanged. The single-MR fast path is explicitly preserved so common-size transfers see no regression.

## Technical Details

The change has three layered pieces:

### 1. MR ownership: `RdmaOwnedMr`
- Move-only RAII wrapper around `ibv_mr*` (`include/mori/application/transport/rdma/rdma.hpp`). Replaces address-keyed `mrPool` for the chunked path so deregistering one logical memory cannot tear down MRs that another (or in-flight) registration still references at the same virtual address.
- `RdmaLocalMemoryRegistration` now owns `std::vector<RdmaOwnedMr>`; teardown is destructor-driven.
- `CqCallbackMeta::localRegRef` anchors `std::shared_ptr<const RdmaLocalMemoryRegistration>`, guaranteeing in-flight WRs can complete even after the user calls `engine.deregister_memory(...)`.
- `materializationMutexes_` is no longer eagerly erased on deregister, so re-materialization races are still single-flighted.
- `IBVerbsDeviceContext::DestroyRdmaEndpoint` is added so handshake failures can release verbs resources cleanly; provider-local `epPoolMu_` protects the QP/CQ/comp-channel pools.

### 2. Routing: `ExactRouteKey`
- `RouteTable` is now keyed by `ExactRouteKey{TopoKeyPair, ldevId, rdevId}` instead of `TopoKeyPair`, with `std::hash<ExactRouteKey>` added in `src/io/rdma/common.hpp`. Session creation no longer needs to fetch a coarse bucket and post-filter.
- `MessageRegEndpoint` is split into `MessageRegEndpointRequest` and `MessageRegEndpointResponse`, the latter carrying `StatusCode` + `responderLocalDevId` + `responderEph`. Both sides validate the responder bound to the requested device; either side destroys its locally-created EP/QP/CQ resources via `RdmaManager::UnpublishEndpoint` + `DestroyEndpoint` if the handshake fails or `notif->RegisterEndpoint` throws.
- The legacy `MessageType::AskMemoryRegion` flow is removed; `MessageAskMemoryLayoutRequest/Response` is the only metadata exchange.

### 3. Resolved transfer planning + executor integration
- New `ResolvedTransferPlan { slices, lanes }` and `ResolvedExecutorReq` types in `src/io/rdma/common.hpp` / `src/io/rdma/executor.hpp`.
- `BuildResolvedTransferPlan(...)` flattens logical requests into `RdmaTransferSlice` units (each at most one local chunk × one remote chunk, ≤ `UINT32_MAX`), then partitions them into lanes — at most one EP per lane, lane count capped by `min(numWorkerThreads, qpPerTransfer, eps.size())`.
- `RdmaPostResolvedSlicesToSingleEp(...)` is the lane-local primitive: merges adjacent slices into WRs, manages SQ reservation + ledger accounting, posts to one EP only, and keeps orphan / degraded bookkeeping per-EP local.
- `MultithreadExecutor::RdmaBatchReadWriteResolved(...)` dispatches lane tasks; the inline path runs the same lanes sequentially via `RdmaSubmitResolvedTransferPlanInline(...)`. The single-MR fast path in `RdmaBackendSession::ReadWrite` / `BatchReadWrite` is unchanged.
- Completion accounting is in slice units throughout (`callbackMeta.totalBatchSize == slices.size()`).

### Wire-format break
This is a hard wire break for the control plane:
- `MessageType::AskMemoryRegion` is removed.
- `MessageRegEndpoint` payload shape changed.

Mixed-version peers are not supported; both sides of every connection must run this version.

### Performance
The CPU-pinned micro-benchmark (`micro_bench_submission.py`, run with `taskset -c <core>` to remove OS scheduler noise) shows patch within ~100 ns per submission of main on the single-MR fast path. The earlier multi-process e2e benchmark surfaced a ~5–11% regression at 1 MiB transfers, which was traced to `GetOrCreateSessionCached` returning `std::shared_ptr<RdmaBackendSession>` (per-call atomic inc/dec on the session control block plus inhibited inlining of `RdmaBackend::ReadWrite`). The `perf(io)` commit in this PR returns a raw pointer instead — the cache map still owns lifetime via the stored `shared_ptr`, only the per-call return is changed — and the regression is gone.

## Test Plan

New end-to-end Python tests in `tests/python/io/test_engine.py`, all gated on 2 GPUs and using `MORI_IO_RDMA_MR_CHUNK_SIZE=64` to force the chunked / resolved path:

1. `test_rdma_chunked_session_transfer_crosses_multiple_chunks[write|read]` — single transfer that spans four 64 B chunks on both sides, parameterized over read and write, asserts both sides' tensor contents and inbound notification.
2. `test_rdma_chunked_multithread_batch_crosses_chunks` — `qpPerTransfer=2 numWorkerThreads=2`, four-element batch where each element crosses a chunk boundary; exercises the resolved executor path.
3. `test_rdma_chunked_session_invalidates_on_deregister_and_reregisters_same_tensor` — verifies `Session::Alive()` flips, stale submissions return `ERR_INVALID_ARGS` with a `deregistered` message, and re-registering the same tensor at the same `data_ptr` builds a fresh session that succeeds. Pinpoints the original `mrPool` address-collision bug.
4. `test_rdma_chunked_inflight_dereg_keeps_registration_alive` — submits 64 in-flight `engine.write` (cached path) calls, immediately deregisters, then waits. All in-flight transfers must succeed via the `CqCallbackMeta::localRegRef` anchor; without the anchor the chunk MRs would be torn down mid-flight and the WRs would surface `LOC_PROT_ERR`. Re-registers the same tensor afterward and verifies the new MR set works.
5. `test_rdma_chunked_large_buffer_cross_boundary` — registers a 1 GiB + 64 MiB GPU tensor with `MORI_IO_RDMA_MR_CHUNK_SIZE` forced to 1 GiB so registration produces two chunks; transfers a 4 MiB region straddling the 1 GiB chunk boundary and byte-compares with an aperiodic per-position pattern (unique up to 4 GiB) so any cross-chunk slicing bug surfaces. Targets NICs (e.g. AMD AINIC / ionic) that report `max_mr_size = uint64 max` while in practice capping much lower; the explicit chunk-size override is required to exercise the chunked path on those NICs without exceeding the real hardware limit.

The cases are also run together with the next existing test (`test_multithread_batch_error_path_is_recoverable`) to confirm no inter-test resource contamination.

## Test Result

```
tests/python/io/test_engine.py::test_rdma_chunked_session_transfer_crosses_multiple_chunks[write] PASSED
tests/python/io/test_engine.py::test_rdma_chunked_session_transfer_crosses_multiple_chunks[read]  PASSED
tests/python/io/test_engine.py::test_rdma_chunked_multithread_batch_crosses_chunks                PASSED
tests/python/io/test_engine.py::test_rdma_chunked_session_invalidates_on_deregister_and_reregisters_same_tensor  PASSED
tests/python/io/test_engine.py::test_rdma_chunked_large_buffer_cross_boundary                     PASSED
tests/python/io/test_engine.py::test_rdma_chunked_inflight_dereg_keeps_registration_alive         PASSED
tests/python/io/test_engine.py::test_multithread_batch_error_path_is_recoverable                  PASSED
============================== 7 passed ===============================
```

Micro-benchmark, current HEAD (post `perf(io)` fix), CPU-pinned to a single core, ionic NIC loopback, single-MR fast path, notification disabled, qpPerTransfer=1:

```
metric                   main(us)   patch(us)   delta
64B   engine.write          1.620      1.690     +0.07 us  (within noise)
64B   sess.write            1.430      1.470     +0.04 us  (within noise)
1024B engine.write          1.640      1.700     +0.06 us  (within noise)
1024B sess.write            1.430      1.460     +0.03 us  (within noise)
batch=4096                 518.6      520.9      +2.3 us   (+0.45%)
```

End-to-end multi-process benchmark (`tests/python/io/benchmark.py`), 2 GPUs over ionic loopback, `--num-qp-per-transfer 2 --num-worker-threads 2 --batch-contiguous --transfer-batch-size 128`, notification on, median of 3 trials in microseconds (avg latency / iter):

```
size            main       patch      delta
8 B             867.84     871.5      +0.4%
1 KiB           851.59     853.0      +0.2%
65 KiB          862.67     866.4      +0.4%
1 MiB         5425.0     4617.0      -14.9%   (perf fix recovers the regression and improves over main)
```

Without the `perf(io)` fix the patch was ~+5–11% slower at 1 MiB; with the fix it is consistently faster than main at large transfers because the patch's chunked / ExactRouteKey infrastructure removes one layer of post-fetch filtering that main still does.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


<details>

<summary>Micro-benchmark code </summary>

```python
# micro_bench_submission.py
"""Single-process MORI-IO submission micro-benchmark.

Goal: isolate CPU-side submission overhead introduced by the chunked-RDMA patch
(ExactRouteKey / RdmaOwnedMr / Resolved transfer plan). Runs two IOEngines in
one process over RDMA loopback (127.0.0.1 + same NIC), registers single-MR
memory, and measures three things:

  Case A  -- per-call ``ReadWrite`` latency at small buffer sizes (so submission
             CPU cost dominates).
  Case B  -- per-call ``BatchReadWrite`` latency vs batch size (exposes the
             ``UseFastPath`` O(N) sizes scan).
  Case C  -- session lookup latency (exposes ``GetOrCreateSessionCached``
             shared_ptr return overhead).

For each case we report two numbers:

  submission_only  -- time from call entry to function return, BEFORE Wait().
                      This is what the patch can regress.
  end_to_end       -- submission + Wait. Mostly network + completion polling
                      and should be unchanged by the patch.

Important: ``CqCallbackMeta`` stores a raw pointer to the user's
``TransferStatus``. We MUST keep every returned status alive until completion,
otherwise the CQ-poll thread writes to freed memory (this is a pre-existing
constraint of the API). All hot loops keep a status list and drain it before
moving on.

To compare branches:

    git checkout main
    python -m tests.python.io.micro_bench_submission --tag main > /tmp/main.txt
    git checkout feature/mori-io-large-memory-rdma
    python -m tests.python.io.micro_bench_submission --tag patch > /tmp/patch.txt
    diff -u /tmp/main.txt /tmp/patch.txt
"""
import argparse
import gc
import os
import statistics
import sys
import time
from contextlib import contextmanager

import torch

sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))

from tests.python.utils import get_free_port  # noqa: E402

from mori.io import (  # noqa: E402
    BackendType,
    IOEngine,
    IOEngineConfig,
    PollCqMode,
    RdmaBackendConfig,
    set_log_level,
)


# ---------------------------------------------------------------------------
# Setup helpers
# ---------------------------------------------------------------------------


@contextmanager
def temporary_env(env_name: str, value: str):
    old = os.environ.get(env_name)
    os.environ[env_name] = value
    try:
        yield
    finally:
        if old is None:
            os.environ.pop(env_name, None)
        else:
            os.environ[env_name] = old


def create_loopback_pair(
    prefix: str, qp_per_transfer: int, num_worker_threads: int, enable_notification: bool
):
    initiator_cfg = IOEngineConfig(host="127.0.0.1", port=get_free_port())
    initiator = IOEngine(key=f"{prefix}_initiator", config=initiator_cfg)

    target_cfg = IOEngineConfig(host="127.0.0.1", port=get_free_port())
    target = IOEngine(key=f"{prefix}_target", config=target_cfg)

    rdma_cfg = RdmaBackendConfig(
        qp_per_transfer=qp_per_transfer,
        post_batch_size=-1,
        num_worker_threads=num_worker_threads,
        enable_notification=enable_notification,
        poll_cq_mode=PollCqMode.POLLING,
    )
    with temporary_env("MORI_DISABLE_AUTO_XGMI", "1"):
        initiator.create_backend(BackendType.RDMA, rdma_cfg)
        target.create_backend(BackendType.RDMA, rdma_cfg)

    initiator.register_remote_engine(target.get_engine_desc())
    target.register_remote_engine(initiator.get_engine_desc())

    return initiator, target


# ---------------------------------------------------------------------------
# Statistics helpers
# ---------------------------------------------------------------------------


class LatencyStats:
    def __init__(self, samples_ns):
        self._samples = sorted(samples_ns)

    @property
    def n(self):
        return len(self._samples)

    @property
    def median_us(self):
        return statistics.median(self._samples) / 1000.0

    @property
    def mean_us(self):
        return statistics.fmean(self._samples) / 1000.0

    @property
    def stdev_us(self):
        if self.n < 2:
            return 0.0
        return statistics.stdev(self._samples) / 1000.0

    def percentile_us(self, q):
        if not self._samples:
            return 0.0
        idx = max(0, min(self.n - 1, int(round(q * (self.n - 1)))))
        return self._samples[idx] / 1000.0


def fmt_stats(stats: LatencyStats) -> str:
    return (
        f"med={stats.median_us:8.3f}us  "
        f"p50={stats.percentile_us(0.50):8.3f}us  "
        f"p95={stats.percentile_us(0.95):8.3f}us  "
        f"p99={stats.percentile_us(0.99):8.3f}us  "
        f"mean={stats.mean_us:8.3f}us  "
        f"std={stats.stdev_us:8.3f}us"
    )


def drain(statuses):
    """Wait on every TransferStatus, asserting success. Keeps refs alive."""
    for s in statuses:
        s.Wait()
        assert s.Succeeded(), f"transfer failed: {s.Message()}"
    statuses.clear()


def measure_submission_only(submit_fn, iters, warmup):
    """Time ``submit_fn()`` which returns a TransferStatus. Status objects are
    KEPT ALIVE in a list (CqCallbackMeta holds a raw pointer to them) and
    drained at the end before returning."""
    keep_alive = []
    # Warmup: include drains so SQ doesn't fill across measurements.
    for _ in range(warmup):
        keep_alive.append(submit_fn())
    drain(keep_alive)

    samples = []
    for _ in range(iters):
        t0 = time.perf_counter_ns()
        s = submit_fn()
        samples.append(time.perf_counter_ns() - t0)
        keep_alive.append(s)
    drain(keep_alive)
    return LatencyStats(samples)


def measure_end_to_end(submit_fn, iters, warmup):
    """Time submit + Wait + success-check, sequential."""
    for _ in range(warmup):
        s = submit_fn()
        s.Wait()
        assert s.Succeeded(), s.Message()

    samples = []
    for _ in range(iters):
        t0 = time.perf_counter_ns()
        s = submit_fn()
        s.Wait()
        samples.append(time.perf_counter_ns() - t0)
        assert s.Succeeded(), s.Message()
    return LatencyStats(samples)


# ---------------------------------------------------------------------------
# Case A: ReadWrite latency (single-MR fast path)
# ---------------------------------------------------------------------------


def case_readwrite(initiator, target, sizes, iters, warmup, header_tag):
    max_size = max(sizes)
    src = torch.zeros(max_size, dtype=torch.uint8, device="cpu")
    dst = torch.zeros(max_size, dtype=torch.uint8, device="cpu")
    src_mem = initiator.register_torch_tensor(src)
    dst_mem = target.register_torch_tensor(dst)
    sess = initiator.create_session(src_mem, dst_mem)

    print(
        f"\n[{header_tag}] Case A: ReadWrite latency (single-MR fast path)\n"
        f"  iters={iters}, warmup={warmup}, host=loopback"
    )
    print(
        "  size      api               submission_only"
        "                                                            end_to_end"
    )
    print("  " + "-" * 175)

    for size in sizes:
        # Path 1: engine.write — goes through GetOrCreateSessionCached every call.
        def submit_via_engine():
            uid = initiator.allocate_transfer_uid()
            return initiator.write(src_mem, 0, dst_mem, 0, size, uid)

        sub_engine = measure_submission_only(submit_via_engine, iters, warmup)
        e2e_engine = measure_end_to_end(submit_via_engine, iters, warmup)

        # Path 2: sess.write — bypasses the session cache.
        def submit_via_session():
            uid = sess.allocate_transfer_uid()
            return sess.write(0, 0, size, uid)

        sub_sess = measure_submission_only(submit_via_session, iters, warmup)
        e2e_sess = measure_end_to_end(submit_via_session, iters, warmup)

        print(f"  {size:6d}    engine.write      {fmt_stats(sub_engine)}     {fmt_stats(e2e_engine)}")
        print(f"  {size:6d}    sess.write        {fmt_stats(sub_sess)}     {fmt_stats(e2e_sess)}")

    initiator.deregister_memory(src_mem)
    target.deregister_memory(dst_mem)
    del sess
    gc.collect()


# ---------------------------------------------------------------------------
# Case B: BatchReadWrite vs batch size (exposes UseFastPath O(N) scan)
# ---------------------------------------------------------------------------


def case_batch_readwrite(initiator, target, batch_sizes, iters, warmup, header_tag):
    elem = 64  # small per-element transfer so submission CPU dominates
    max_batch = max(batch_sizes)
    stride = elem + 1  # strided offsets prevent WR merging
    total = (max_batch + 1) * stride
    src = torch.zeros(total, dtype=torch.uint8, device="cpu")
    dst = torch.zeros(total, dtype=torch.uint8, device="cpu")
    src_mem = initiator.register_torch_tensor(src)
    dst_mem = target.register_torch_tensor(dst)
    sess = initiator.create_session(src_mem, dst_mem)

    print(
        f"\n[{header_tag}] Case B: BatchReadWrite vs batch size (single-MR fast path)\n"
        f"  iters={iters}, warmup={warmup}, per-element size={elem} B, strided offsets"
    )
    print(
        "  batch     api               submission_only"
        "                                                            end_to_end"
        "                                                            sub/elem  e2e/elem"
    )
    print("  " + "-" * 200)

    for batch in batch_sizes:
        offsets = [i * stride for i in range(batch)]
        sizes = [elem for _ in range(batch)]

        def submit_via_session():
            uid = sess.allocate_transfer_uid()
            return sess.batch_write(offsets, offsets, sizes, uid)

        sub = measure_submission_only(submit_via_session, iters, warmup)
        e2e = measure_end_to_end(submit_via_session, iters, warmup)

        per_elem_sub = sub.median_us / max(batch, 1)
        per_elem_e2e = e2e.median_us / max(batch, 1)
        print(
            f"  {batch:5d}     sess.batch_write  {fmt_stats(sub)}     {fmt_stats(e2e)}"
            f"     {per_elem_sub:6.3f}us  {per_elem_e2e:6.3f}us"
        )

    initiator.deregister_memory(src_mem)
    target.deregister_memory(dst_mem)
    del sess
    gc.collect()


# ---------------------------------------------------------------------------
# Case C: Session creation / cached lookup
# ---------------------------------------------------------------------------


def case_session_lookup(initiator, target, iters, warmup, header_tag):
    src = torch.zeros(64, dtype=torch.uint8, device="cpu")
    dst = torch.zeros(64, dtype=torch.uint8, device="cpu")
    src_mem = initiator.register_torch_tensor(src)
    dst_mem = target.register_torch_tensor(dst)

    print(f"\n[{header_tag}] Case C: Session creation / cached lookup")

    # C.1 -- explicit CreateSession latency, cold then warm.
    create_lat = []
    for i in range(8):
        t0 = time.perf_counter_ns()
        s = initiator.create_session(src_mem, dst_mem)
        create_lat.append(time.perf_counter_ns() - t0)
        del s
    print("  CreateSession latency (cold then warm, us):")
    for i, ns in enumerate(create_lat):
        print(f"    call {i}: {ns / 1000.0:8.3f} us")

    # C.2 -- delta between engine.write and sess.write at submission-only.
    # Both use the same fast-path posting; the difference is the session-cache
    # lookup that engine.write goes through.
    sess_held = initiator.create_session(src_mem, dst_mem)

    def submit_via_engine():
        uid = initiator.allocate_transfer_uid()
        return initiator.write(src_mem, 0, dst_mem, 0, 1, uid)

    def submit_via_sess():
        uid = sess_held.allocate_transfer_uid()
        return sess_held.write(0, 0, 1, uid)

    sub_engine = measure_submission_only(submit_via_engine, iters, warmup)
    sub_sess = measure_submission_only(submit_via_sess, iters, warmup)
    delta_us = sub_engine.median_us - sub_sess.median_us

    print(
        f"  Single 1B write submission-only median:\n"
        f"    via engine.write (cache hit -> shared_ptr return): {sub_engine.median_us:8.3f} us\n"
        f"    via sess.write   (no cache lookup):                {sub_sess.median_us:8.3f} us\n"
        f"    delta (= GetOrCreateSessionCached overhead):       {delta_us:+8.3f} us"
    )

    initiator.deregister_memory(src_mem)
    target.deregister_memory(dst_mem)
    del sess_held
    gc.collect()


# ---------------------------------------------------------------------------
# Main
# ---------------------------------------------------------------------------


def parse_args():
    p = argparse.ArgumentParser(description="MORI-IO submission micro-benchmark")
    p.add_argument("--tag", type=str, default="run")
    p.add_argument("--iters", type=int, default=2000)
    p.add_argument("--warmup", type=int, default=200)
    p.add_argument("--qp-per-transfer", type=int, default=1)
    p.add_argument("--num-worker-threads", type=int, default=1)
    p.add_argument("--sizes", type=str, default="64,1024,65536")
    p.add_argument("--batches", type=str, default="1,8,64,512,4096")
    p.add_argument("--cases", type=str, default="A,B,C")
    p.add_argument(
        "--enable-notification",
        action="store_true",
        help="Enable RDMA notification SEND after each transfer (default off; "
        "off gives the cleanest measurement of the data-path overhead the patch touches).",
    )
    return p.parse_args()


def main():
    args = parse_args()
    set_log_level("warning")

    sizes = [int(s) for s in args.sizes.split(",") if s.strip()]
    batches = [int(s) for s in args.batches.split(",") if s.strip()]
    cases = {c.strip().upper() for c in args.cases.split(",") if c.strip()}

    initiator, target = create_loopback_pair(
        prefix=f"micro_{args.tag}",
        qp_per_transfer=args.qp_per_transfer,
        num_worker_threads=args.num_worker_threads,
        enable_notification=args.enable_notification,
    )

    print(
        f"=== MORI-IO submission micro-benchmark [tag={args.tag}] ===\n"
        f"  qp_per_transfer={args.qp_per_transfer} num_worker_threads={args.num_worker_threads}\n"
        f"  iters={args.iters} warmup={args.warmup} notif={args.enable_notification}"
    )

    if "A" in cases:
        case_readwrite(initiator, target, sizes, args.iters, args.warmup, args.tag)
    if "B" in cases:
        case_batch_readwrite(initiator, target, batches, args.iters, args.warmup, args.tag)
    if "C" in cases:
        case_session_lookup(
            initiator, target, min(args.iters, 500), min(args.warmup, 50), args.tag
        )

    print(f"\n=== Done [tag={args.tag}] ===")


if __name__ == "__main__":
    main()

```

</details>
