### PR TITLE
feat(ep): add profiler support to intranode dispatch/combine

### DIFF
--- a/docs/MORI-EP-BENCHMARK.md
+++ b/docs/MORI-EP-BENCHMARK.md
@@ -3,10 +3,11 @@
 ## Table of Contents
 
 - [Intra-node](#intra-node)
+  - [Profiling intranode kernels](#profiling-intranode-kernels)
 - [Inter-node](#inter-node)
-- [NIC Selection](#nic-selection)
-- [Bandwidth Computation](#bandwidth-computation)
-- [Profiling EP Kernels](#profiling-ep-kernels)
+  - [NIC Selection](#nic-selection)
+  - [Bandwidth Computation](#bandwidth-computation)
+  - [Profiling Internode Kernels](#profiling-internode-kernels)
 
 ## Intra-node
 
@@ -17,6 +18,31 @@ export PYTHONPATH=/path/to/mori:$PYTHONPATH
 # Benchmark performance
 python3 tests/python/ops/bench_dispatch_combine.py
 ```
+
+### Profiling intranode kernels
+
+**1. Build with profiler enabled**
+
+```bash
+ENABLE_PROFILER=ON pip3 install -e . --no-build-isolation -v
+```
+
+**2. Clear the JIT cache**
+
+```bash
+rm -rf ~/.mori
+```
+
+**3. Run the profiling job**
+
+```bash
+export ENABLE_PROFILER=ON
+
+torchrun --nnodes=1 --nproc_per_node=8 \
+    tests/python/ops/bench_dispatch_combine.py --cmd profile
+```
+
+Traces land as `trace_intranode_rank<rank>_<timestamp>.json` in the current working directory — one file per rank.  Open them in [Perfetto UI](https://ui.perfetto.dev) or analyze with `analyze_ep_kernel_trace.py` as described in the [Profiling EP Kernels](#profiling-ep-kernels) section.
 
 ## Inter-node
 
@@ -37,7 +63,7 @@ The output includes total number of tokens received, total number of RDMA tokens
 RDMA BW = Total BW × (RDMA tokens / Total tokens)
 ```
 
-## NIC Selection
+### NIC Selection
 
 For RoCE networks, you can specify which RDMA devices to use with the `MORI_RDMA_DEVICES` environment variable:
 
@@ -45,7 +71,7 @@ For RoCE networks, you can specify which RDMA devices to use with the `MORI_RDMA
 - **Exclude devices**: `MORI_RDMA_DEVICES=^mlx5_2,mlx5_3` (use `^` prefix to exclude specified devices)
 - **Default**: If not set, all available RDMA devices will be used
 
-## Bandwidth Computation
+### Bandwidth Computation
 
 Two fabrics are measured: **RDMA** (inter-node) and **NVL/XGMI** (intra-node).
 
@@ -350,7 +376,7 @@ if __name__ == '__main__':
 
 ---
 
-## Profiling EP Kernels
+### Profiling Internode Kernels
 
 Mori ships a profiler that emits Perfetto-compatible JSON traces for each EP kernel invocation.
 

--- a/src/ops/dispatch_combine/intranode.hpp
+++ b/src/ops/dispatch_combine/intranode.hpp
@@ -24,10 +24,15 @@
 #include <type_traits>
 
 #include "mori/core/core.hpp"
+#include "mori/core/profiler/constants.hpp"
+#include "mori/core/profiler/kernel_profiler.hpp"
 #include "mori/ops/dispatch_combine/dispatch_combine.hpp"
 #include "mori/shmem/shmem.hpp"
 #include "src/ops/dispatch_combine/common.hpp"
 #include "src/ops/dispatch_combine/convert.hpp"
+#ifdef ENABLE_PROFILER
+#include "mori/profiler/profiler.hpp"
+#endif
 
 namespace mori {
 namespace moe {
@@ -91,6 +96,11 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   int myPe = config.rank;
   int npes = config.worldSize;
   size_t hiddenDim = config.HiddenDimSz();
+
+  IF_ENABLE_PROFILER(
+      INTRANODE_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
+  MORI_TRACE_SEQ(seq, profiler);
+  MORI_TRACE_NEXT(seq, Slot::DispatchSendTokens);
 
   if (args.tokenIndices && args.inpTokenBuf) {
     // Phase1: send token
@@ -163,6 +173,7 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   if (thdId == 0) atomicAdd(args.dispatchGridBarrier, 1);
 
   // Send token num & token to expert mapping to other ranks
+  MORI_TRACE_NEXT(seq, Slot::DispatchNotifyPeer);
   if (globalWarpId == 0) {
     for (int destPe = laneId; destPe < npes; destPe += warpSize) {
       // Wait until all tokens are sent
@@ -179,6 +190,7 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
 
   // Phase 2: recv token
   // Each warp wait until sender finished by waiting token number signal
+  MORI_TRACE_NEXT(seq, Slot::DispatchWaitPeerToken);
   index_t* recvTokenNums = args.recvTokenNumMemObj->template GetAs<index_t*>();
   if (globalWarpId == 0) {
     for (int destPe = laneId; destPe < npes; destPe += warpSize) {
@@ -233,6 +245,11 @@ __device__ void EpCombineIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
 
   int myPe = config.rank;
   int npes = config.worldSize;
+
+  IF_ENABLE_PROFILER(
+      INTRANODE_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
+  MORI_TRACE_SEQ(seq, profiler);
+  MORI_TRACE_NEXT(seq, Slot::CombineCopyInput);
 
   const uint64_t crossDeviceBarrierFlag = args.crossDeviceBarrierFlag[0];
   // Copy input to shmem registered buffer so that other GPUs can access directly
@@ -292,10 +309,12 @@ __device__ void EpCombineIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   }
 
   // Make sure copy on all GPUs are finished
+  MORI_TRACE_NEXT(seq, Slot::CombineBarrier);
   CrossDeviceBarrierIntraNodeKernel(args, crossDeviceBarrierFlag);
   *args.totalRecvTokenNum = 0;
   if (args.curRankNumToken == 0) return;
 
+  MORI_TRACE_NEXT(seq, Slot::CombineAccum);
   extern __shared__ char sharedMem[];
   TokT** srcPtrs = reinterpret_cast<TokT**>(sharedMem) + warpId * config.numExpertPerToken;
   float** srcWeightsPtr = reinterpret_cast<float**>(sharedMem) +

--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -172,6 +172,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
                     all_rank_indices[self.config.rank],
                     block_num=dispatch_block_num,
                     warp_per_block=dispatch_warp_per_block,
+                    call_local_expert_count=call_local_expert_count,
                 )
                 e2e_combine_arg = self._get_combine_input(op, e2e_dispatch_output)
                 e2e_combine_output, _ = op.combine(
@@ -342,12 +343,8 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
         round_end_events = [
             torch.cuda.Event(enable_timing=True) for _ in range(graph_replay_iters)
         ]
-        e2e_start_events = [
-            torch.cuda.Event(enable_timing=True) for _ in range(graph_replay_iters)
-        ]
-        e2e_end_events = [
-            torch.cuda.Event(enable_timing=True) for _ in range(graph_replay_iters)
-        ]
+        e2e_start_events = [torch.cuda.Event(enable_timing=True)]
+        e2e_end_events = [torch.cuda.Event(enable_timing=True)]
 
         dist.barrier()
         for i in range(graph_replay_iters):
@@ -571,7 +568,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
         call_local_expert_count=False,
     ):
         """Warmup, then capture capture_iters dispatch+combine iters and export per-warp Perfetto traces."""
-        if not hasattr(mori.cpp, "get_debug_time_buf"):
+        if not hasattr(op, "get_debug_time_buf"):
             raise RuntimeError(
                 "To use --cmd profile, re-compile Mori with ENABLE_PROFILER=ON"
             )

--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -145,6 +145,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
         combine_warp_per_block,
         total_recv_num_token,
         call_local_expert_count=False,
+        graph_replay_iters=1,
     ):
         (
             _,
@@ -156,31 +157,31 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
 
         e2e_graph = torch.cuda.CUDAGraph()
         with torch.cuda.graph(e2e_graph):
-            (
-                e2e_dispatch_output,
-                _,
-                _,
-                e2e_dispatch_indices,
-                e2e_dispatch_recv_num_token,
-            ) = op.dispatch(
-                all_rank_input[self.config.rank],
-                all_rank_weights[self.config.rank],
-                # None,
-                all_rank_scales[self.config.rank],
-                all_rank_indices[self.config.rank],
-                block_num=dispatch_block_num,
-                warp_per_block=dispatch_warp_per_block,
-                call_local_expert_count=call_local_expert_count,
-            )
-            e2e_combine_arg = self._get_combine_input(op, e2e_dispatch_output)
-            e2e_combine_output, _ = op.combine(
-                e2e_combine_arg,
-                # dispatch_weights,
-                None,
-                e2e_dispatch_indices,
-                block_num=combine_block_num,
-                warp_per_block=combine_warp_per_block,
-            )
+            for _ in range(graph_replay_iters):
+                (
+                    e2e_dispatch_output,
+                    _,
+                    _,
+                    e2e_dispatch_indices,
+                    e2e_dispatch_recv_num_token,
+                ) = op.dispatch(
+                    all_rank_input[self.config.rank],
+                    all_rank_weights[self.config.rank],
+                    # None,
+                    all_rank_scales[self.config.rank],
+                    all_rank_indices[self.config.rank],
+                    block_num=dispatch_block_num,
+                    warp_per_block=dispatch_warp_per_block,
+                )
+                e2e_combine_arg = self._get_combine_input(op, e2e_dispatch_output)
+                e2e_combine_output, _ = op.combine(
+                    e2e_combine_arg,
+                    # dispatch_weights,
+                    None,
+                    e2e_dispatch_indices,
+                    block_num=combine_block_num,
+                    warp_per_block=combine_warp_per_block,
+                )
         self.sync()
 
         return e2e_graph
@@ -329,6 +330,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
                 combine_warp_per_block,
                 total_recv_num_token,
                 call_local_expert_count=call_local_expert_count,
+                graph_replay_iters=graph_replay_iters,
             )
 
         round_start_events = [
@@ -347,6 +349,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
             torch.cuda.Event(enable_timing=True) for _ in range(graph_replay_iters)
         ]
 
+        dist.barrier()
         for i in range(graph_replay_iters):
             round_start_events[i].record()
             dispatch_graph.replay()
@@ -354,10 +357,13 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
             combine_graph.replay()
             round_end_events[i].record()
 
-            if e2e_graph is not None:
-                e2e_start_events[i].record()
-                e2e_graph.replay()
-                e2e_end_events[i].record()
+        torch.cuda.synchronize()
+
+        if e2e_graph is not None:
+            dist.barrier()
+            e2e_start_events[0].record()
+            e2e_graph.replay()
+            e2e_end_events[0].record()
 
         torch.cuda.synchronize()
         disp_duration = (
@@ -376,11 +382,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
         )
         if e2e_graph is not None:
             e2e_duration = (
-                sum(
-                    start_event.elapsed_time(end_event)
-                    for start_event, end_event in zip(e2e_start_events, e2e_end_events)
-                )
-                / graph_replay_iters
+                e2e_start_events[0].elapsed_time(e2e_end_events[0]) / graph_replay_iters
             )
         else:
             e2e_duration = -1.0
@@ -556,6 +558,67 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
             min_disp_latency_us,
             min_comb_latency_us,
         )
+
+    def profile(
+        self,
+        op,
+        dispatch_block_num,
+        dispatch_warp_per_block,
+        combine_block_num,
+        combine_warp_per_block,
+        warmup=5,
+        capture_iters=3,
+        call_local_expert_count=False,
+    ):
+        """Warmup, then capture capture_iters dispatch+combine iters and export per-warp Perfetto traces."""
+        if not hasattr(mori.cpp, "get_debug_time_buf"):
+            raise RuntimeError(
+                "To use --cmd profile, re-compile Mori with ENABLE_PROFILER=ON"
+            )
+        test_data = self.gen_test_data()
+
+        # Warm-up: run several iters to JIT-compile and reach steady state
+        for _ in range(warmup):
+            self.run_once_test(
+                op,
+                test_data,
+                dispatch_block_num,
+                dispatch_warp_per_block,
+                combine_block_num,
+                combine_warp_per_block,
+                check=False,
+                call_local_expert_count=call_local_expert_count,
+            )
+
+        # Clear the trace buffer, then run capture_iters profiled iterations
+        trace_buf = op.get_debug_time_buf()
+        trace_buf.zero_()
+        if hasattr(mori.cpp, "get_debug_time_offset"):
+            op.get_debug_time_offset().zero_()
+
+        for _ in range(capture_iters):
+            self.run_once_test(
+                op,
+                test_data,
+                dispatch_block_num,
+                dispatch_warp_per_block,
+                combine_block_num,
+                combine_warp_per_block,
+                check=False,
+                call_local_expert_count=call_local_expert_count,
+            )
+
+        import time
+
+        output_filename = f"trace_intranode_rank{self.config.rank}_{time.strftime('%m%d_%H%M%S')}.json"
+        slot_map = getattr(mori.cpp, "IntranodeSlots", None)
+        mori.kernel_profiler.export_to_perfetto(
+            trace_buf, output_filename, slot_map=slot_map
+        )
+        if self.config.rank == 0:
+            print(
+                f"Profiling trace exported to {output_filename} ({capture_iters} iters)"
+            )
 
     def stress(
         self,
@@ -877,6 +940,22 @@ def _bench_dispatch_combine(
                 call_local_expert_count=call_local_expert_count,
             )
 
+        elif cmd == "profile":
+            if rank == 0:
+                print(f"\n{'=' * 60}")
+                print(
+                    f"Profiling with dispatch_block_num={dispatch_block_num}, dispatch_warp_per_block={dispatch_warp_per_block} combine_block_num={combine_block_num}, combine_warp_per_block={combine_warp_per_block}"
+                )
+                print(f"{'=' * 60}")
+            benchmark.profile(
+                op,
+                dispatch_block_num=dispatch_block_num,
+                dispatch_warp_per_block=dispatch_warp_per_block,
+                combine_block_num=combine_block_num,
+                combine_warp_per_block=combine_warp_per_block,
+                call_local_expert_count=call_local_expert_count,
+            )
+
         elif cmd == "tuning":
             if rank == 0 and any(
                 x is not None
@@ -1133,8 +1212,8 @@ if __name__ == "__main__":
         "--cmd",
         type=str,
         default="bench",
-        choices=["bench", "stress", "tuning"],
-        help="Available subcommands: bench (single config), stress (stress test), tuning (test multiple configs)",
+        choices=["bench", "stress", "tuning", "profile"],
+        help="Available subcommands: bench (single config), stress (stress test), tuning (test multiple configs), profile (export Perfetto trace; requires ENABLE_PROFILER=ON build)",
     )
     parser.add_argument(
         "--zero-copy",

--- a/tools/profiler/generate_profiler_bindings.py
+++ b/tools/profiler/generate_profiler_bindings.py
@@ -214,13 +214,14 @@ def main():
 
     all_usages = []
     scanned_files = 0
-    for cpp_file in source_dir.rglob("*.cpp"):
-        scanned_files += 1
-        usages = extract_slots_from_file(cpp_file)
-        if usages:
-            unique_slots = len(set(u.slot_name for u in usages))
-            print(f"  ✓ {cpp_file.relative_to(source_dir)}: {unique_slots} slot(s)")
-            all_usages.extend(usages)
+    for pattern in ("*.cpp", "*.hpp"):
+        for cpp_file in source_dir.rglob(pattern):
+            scanned_files += 1
+            usages = extract_slots_from_file(cpp_file)
+            if usages:
+                unique_slots = len(set(u.slot_name for u in usages))
+                print(f"  ✓ {cpp_file.relative_to(source_dir)}: {unique_slots} slot(s)")
+                all_usages.extend(usages)
 
     print(f"\n  Scanned {scanned_files} file(s), found {len(all_usages)} slot usage(s)")
 

--- a/tools/profiler/generate_profiler_bindings.py
+++ b/tools/profiler/generate_profiler_bindings.py
@@ -215,12 +215,14 @@ def main():
     all_usages = []
     scanned_files = 0
     for pattern in ("*.cpp", "*.hpp"):
-        for cpp_file in source_dir.rglob(pattern):
+        for source_file in source_dir.rglob(pattern):
             scanned_files += 1
-            usages = extract_slots_from_file(cpp_file)
+            usages = extract_slots_from_file(source_file)
             if usages:
                 unique_slots = len(set(u.slot_name for u in usages))
-                print(f"  ✓ {cpp_file.relative_to(source_dir)}: {unique_slots} slot(s)")
+                print(
+                    f"  ✓ {source_file.relative_to(source_dir)}: {unique_slots} slot(s)"
+                )
                 all_usages.extend(usages)
 
     print(f"\n  Scanned {scanned_files} file(s), found {len(all_usages)} slot usage(s)")


### PR DESCRIPTION
## Summary

- Instruments `EpDispatchIntraNodeKernel_body` and `EpCombineIntraNodeKernel_body` with `MORI_TRACE_*` macros to track phase-level timing (SendTokens, NotifyPeer, WaitPeerToken, CopyInput, Barrier, Accum)
- Adds `profile` subcommand to `bench_dispatch_combine.py` — runs warmup iterations then exports per-warp Perfetto traces (requires `ENABLE_PROFILER=ON` build)
- Fixes `generate_profiler_bindings.py` to scan `.hpp` files in addition to `.cpp` files so intranode slot usages are picked up correctly
- Refactors e2e graph capture in the bench harness: supports `graph_replay_iters` inside a single CUDA graph, adds `dist.barrier()` before timing loops for cleaner cross-rank synchronization

## Test plan

- [x] Build with `ENABLE_PROFILER=ON` and run `--cmd profile` on intranode config, verify Perfetto JSON is exported
- [x] Build without profiler flag, confirm normal `bench`/`stress`/`tuning` modes are unaffected
- [x] Verify `generate_profiler_bindings.py` picks up `IntranodeSlots` from `.hpp` sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)