### PR TITLE
fix(test): reduce warp_num_per_block in intranode EP

### DIFF
--- a/tests/python/ops/test_dispatch_combine_intranode.py
+++ b/tests/python/ops/test_dispatch_combine_intranode.py
@@ -58,7 +58,7 @@ def _make_intranode_config(
         num_experts_per_token=num_experts_per_token,
         max_token_type_size=4,
         block_num=256,
-        warp_num_per_block=16,
+        warp_num_per_block=4,
         use_external_inp_buf=use_external_inp_buf,
         kernel_type=mori.ops.EpDispatchCombineKernelType.IntraNode,
         max_total_recv_tokens=max_total_recv_tokens,


### PR DESCRIPTION
warp_num_per_block=16 causes EP intranode dispatch kernel to hang on gfx942 MI308X. Reducing to 4 matches a valid hardware configuration and allows the test to complete correctly.