### PR TITLE
ci: switch intranode tests to MI355X-AINIC-TW

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
   IMAGE: rocm/mori:ci
   BASE_IMAGE: rocm/pytorch:rocm7.2.1_ubuntu24.04_py3.12_pytorch_release_2.8.0
   CONTAINER: mori_ci_${{ github.run_id }}
-  CT: ${{ vars.CONTAINER_RUNTIME || 'podman' }}
+  CT: docker
 
 jobs:
   build:
@@ -23,7 +23,7 @@ jobs:
       matrix:
         include:
           - platform: MI355X_AINIC
-            runner: [self-hosted, MI355X-AINIC]
+            runner: [self-hosted, MI355X-AINIC-TW]
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -68,8 +68,8 @@ jobs:
       matrix:
         include:
           - platform: MI355X_AINIC
-            runner: [self-hosted, MI355X-AINIC]
-            rdma_devices: rocep105s0,rocep121s0,rocep137s0,rocep153s0,rocep233s0,rocep249s0,rocep25s0,rocep9s0
+            runner: [self-hosted, MI355X-AINIC-TW]
+            rdma_devices: rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7
     timeout-minutes: 45
     steps:
       - name: Checkout
@@ -121,9 +121,14 @@ jobs:
             timeout 120 python3 tests/python/ops/bench_dispatch_combine.py
           "
 
-      # MORI-IO: skipped on MI355X-AINIC — intra-node cross-NIC RDMA loopback
-      # is blocked by rail-optimized source routing. Covered by internode-test.
-      # - name: MORI-IO
+      - name: MORI-IO
+        run: |
+          $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
+            cd $GITHUB_WORKSPACE
+            timeout 60 pytest tests/python/io/ -v
+            MORI_IO_XGMI_SCATTER_GATHER_THRESHOLD=4 \
+              timeout 120 pytest tests/python/io/test_discrete_buffer.py -v -k 'not performance'
+          "
 
       - name: MORI-IR
         run: |
@@ -131,7 +136,7 @@ jobs:
             cd $GITHUB_WORKSPACE
             timeout 60 torchrun --nproc_per_node=2 examples/shmem/ir/test_triton_shmem.py
             timeout 60 torchrun --nproc_per_node=8 examples/shmem/ir/test_triton_allreduce.py
-            # MORI_DISABLE_P2P=ON skipped: intra-node RDMA blocked by rail-optimized source routing
+            MORI_DISABLE_P2P=ON timeout 60 torchrun --nproc_per_node=8 examples/shmem/ir/test_triton_allreduce.py
           "
 
       - name: MORI-CPP shmem (P2P)
@@ -140,14 +145,23 @@ jobs:
             cd $GITHUB_WORKSPACE
             timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/concurrent_put_thread
             timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/concurrent_get_thread
+            timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/concurrent_put_imm_thread
             timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/concurrent_put_signal_thread
             timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/atomic_nonfetch_thread
             timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/atomic_fetch_thread
           "
 
-      # MORI-CPP shmem (IBGDA): skipped on MI355X-AINIC — IBGDA path requires
-      # intra-node cross-NIC RDMA which is blocked by rail-optimized source routing.
-      # - name: MORI-CPP shmem (IBGDA)
+      - name: MORI-CPP shmem (IBGDA)
+        run: |
+          $CT exec $CONTAINER bash -c "
+            cd $GITHUB_WORKSPACE
+            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/concurrent_put_thread
+            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/concurrent_get_thread
+            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/concurrent_put_imm_thread
+            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/concurrent_put_signal_thread
+            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/atomic_nonfetch_thread
+            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/atomic_fetch_thread
+          "
 
       - name: MORI-CCL/shmem
         run: |
@@ -189,8 +203,8 @@ jobs:
       matrix:
         include:
           - platform: MI355X_AINIC
-            runner: [self-hosted, MI355X-AINIC]
-            rdma_devices: rocep105s0,rocep121s0,rocep137s0,rocep153s0,rocep233s0,rocep249s0,rocep25s0,rocep9s0
+            runner: [self-hosted, MI355X-AINIC-TW]
+            rdma_devices: rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -253,6 +267,7 @@ jobs:
             rdma_sl: 3
             rdma_tc: 104
     env:
+      CT: podman  # internode runners (MI355X-AINIC) only have podman
       NODE1_HOST: ${{ matrix.node1_host }}
       NODE2_HOST: ${{ matrix.node2_host }}
       NODE2_PORT: ${{ matrix.node2_port }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,12 @@ jobs:
           - platform: MI355X_AINIC
             runner: [self-hosted, MI355X-AINIC-TW]
             rdma_devices: rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7
+            rdma_sl: 3
+            rdma_tc: 104
+    env:
+      MORI_RDMA_DEVICES: ${{ matrix.rdma_devices }}
+      MORI_RDMA_SL: ${{ matrix.rdma_sl }}
+      MORI_RDMA_TC: ${{ matrix.rdma_tc }}
     timeout-minutes: 45
     steps:
       - name: Checkout
@@ -84,7 +90,9 @@ jobs:
         run: |
           $CT rm -f $CONTAINER 2>/dev/null || true
           CONTAINER_RUNTIME=$CT ./docker/ci_run.sh --name $CONTAINER \
-            -e MORI_RDMA_DEVICES=${{ matrix.rdma_devices }} \
+            -e MORI_RDMA_DEVICES=$MORI_RDMA_DEVICES \
+            -e MORI_RDMA_SL=$MORI_RDMA_SL \
+            -e MORI_RDMA_TC=$MORI_RDMA_TC \
             -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
             -w $GITHUB_WORKSPACE \
             $IMAGE sleep infinity
@@ -252,7 +260,7 @@ jobs:
 
   internode-test:
     name: mori internode test (${{ matrix.platform }})
-    needs: [build, intranode-test]
+    needs: build
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,8 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          $CT exec $CONTAINER chown -R $(id -u):$(id -g) $GITHUB_WORKSPACE 2>/dev/null || true
+          $CT run --rm -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE $BASE_IMAGE \
+              chown -R $(id -u):$(id -g) $GITHUB_WORKSPACE 2>/dev/null || true
           $CT rm -f $CONTAINER || true
 
   intranode-test:
@@ -199,7 +200,8 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          $CT exec $CONTAINER chown -R $(id -u):$(id -g) $GITHUB_WORKSPACE 2>/dev/null || true
+          $CT run --rm -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE $IMAGE \
+              chown -R $(id -u):$(id -g) $GITHUB_WORKSPACE 2>/dev/null || true
           $CT rm -f $CONTAINER || true
 
   jax-intranode-test:
@@ -256,7 +258,10 @@ jobs:
 
       - name: Cleanup
         if: always()
-        run: $CT rm -f ${CONTAINER}_jax || true
+        run: |
+          $CT run --rm -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE rocm/mori:jax-ci \
+              chown -R $(id -u):$(id -g) $GITHUB_WORKSPACE 2>/dev/null || true
+          $CT rm -f ${CONTAINER}_jax || true
 
   internode-test:
     name: mori internode test (${{ matrix.platform }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,8 @@ jobs:
             -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
             -w $GITHUB_WORKSPACE \
             rocm/mori:jax-ci sleep infinity
+          $CT exec ${CONTAINER}_jax \
+            git config --global --add safe.directory $GITHUB_WORKSPACE
 
       - name: Install mori (XLA FFI)
         run: |

--- a/examples/shmem/concurrent_put_imm_thread.cpp
+++ b/examples/shmem/concurrent_put_imm_thread.cpp
@@ -130,6 +130,8 @@ void ConcurrentPutImmThread() {
   SymmMemObjPtr buffObj1 = ShmemQueryMemObjPtr(buff1);
   assert(buffObj1.IsValid());
 
+  MPI_Barrier(MPI_COMM_WORLD);
+
   if (myPe == 0) {
     printf("Running legacy API test...\n");
   }


### PR DESCRIPTION
## Summary
Migrate intranode / build / JAX intranode test jobs from the existing `MI355X-AINIC` runner pool to a new self-hosted runner `MI355X-AINIC-TW` on `mia1-p02-g32`, and re-enable three previously-skipped tests.
## Motivation
`mia1-p02-g32` is a MI355X + AINIC host configured to align with the reference node (mia1-p01-g33): AINIC 1.117.5-a-56, libionic 54.0-184 (has `ionic_dv_create_cq_ex`), QoS/DCQCN matching g33, `rdma0..rdma7` renamed by `/usr/local/bin/nic-config.sh`. A new self-hosted GitHub Actions runner with label `MI355X-AINIC-TW` is installed and listening. Moving the intranode-style tests here frees up the existing `MI355X-AINIC` pool and lets us re-enable tests that were previously skipped on that pool.
## Details
- Move `runs-on` to `[self-hosted, MI355X-AINIC-TW]` for:
  - `build`
  - `intranode-test`
  - `jax-intranode-test`
- `internode-test` stays on `MI355X-AINIC` (still needs the existing 2-node setup `10.2.80.22` / `10.2.80.20`).
- Hard-code workflow-level `CT: docker` (was `${{ vars.CONTAINER_RUNTIME || 'podman' }}`). `internode-test` overrides with job-level `CT: podman` since the old runners only have podman.
- Fix `rdma_devices` from default kernel names (`rocep*s0`) to `rdma0..rdma7` for the two jobs now on `MI355X-AINIC-TW`. `g32` uses `nic-config.sh` to rename devices at boot; `internode-test` keeps `rocep*s0` for the old runners.
- Re-enable three previously-skipped steps in `intranode-test`:
  - `MORI-IO` (`pytest tests/python/io/` and `test_discrete_buffer.py`)
  - `MORI-CPP shmem (IBGDA)` (`MORI_DISABLE_P2P=ON` shmem examples)
  - `MORI_DISABLE_P2P=ON` variant of `test_triton_allreduce.py` in `MORI-IR`
- Include `concurrent_put_imm_thread` in both `MORI-CPP shmem (P2P)` and `(IBGDA)` steps.