### PR TITLE
Some fixes for XLA build, shmem_api includes separation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ if(USE_ROCM)
     elseif(GPU_ARCH MATCHES "^gfx9")
       add_definitions(-D__GFX9__=1)
     endif()
-    set(HIP_HIPCC_FLAGS "--amdgpu-target=${GPU_TARGETS}")
+    set(CMAKE_HIP_ARCHITECTURES "${GPU_TARGETS}")
   endif()
 else()
   set(CUDA_HOME /usr/local/cuda)
@@ -150,6 +150,9 @@ set(SPDLOG_BUILD_BENCH
     CACHE BOOL "" FORCE)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 add_subdirectory(3rdparty/spdlog)
+# Hide spdlog symbols from other libraries to avoid symbol conflicts
+target_compile_options(spdlog PRIVATE -fvisibility=hidden
+                                      -fvisibility-inlines-hidden)
 
 add_library(mori_logging INTERFACE)
 target_include_directories(mori_logging INTERFACE include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,8 @@ target_compile_options(spdlog PRIVATE -fvisibility=hidden
 
 add_library(mori_logging INTERFACE)
 target_include_directories(mori_logging INTERFACE include)
-target_link_libraries(mori_logging INTERFACE spdlog::spdlog)
+target_link_libraries(mori_logging INTERFACE spdlog::spdlog_header_only)
+
 
 if(ENABLE_PROFILER)
   find_package(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,6 @@ add_library(mori_logging INTERFACE)
 target_include_directories(mori_logging INTERFACE include)
 target_link_libraries(mori_logging INTERFACE spdlog::spdlog_header_only)
 
-
 if(ENABLE_PROFILER)
   find_package(
     Python3


### PR DESCRIPTION
- Hide spdlog symbols from mori's public ABI to prevent symbol conflicts when mori is linked into other projects (e.g. XLA) that bundle their own spdlog version. Without this fix, we were getting symbol collisions at runtime:
```
Thread 19 "py_xla_execute" received signal SIGSEGV, Segmentation fault.
[Switching to thread 19 (Thread 0x7fbcf6bff6c0 (LWP 420938))]
0x00000000130767d2 in spdlog::details::registry::initialize_logger(std::shared_ptr<spdlog::logger>) ()
[?2004h[?2004l
[?2004h(gdb) where 
[?2004l
#0  0x00000000130767d2 in spdlog::details::registry::initialize_logger(std::shared_ptr<spdlog::logger>) ()
#1  0x00007fff96c8d156 in std::shared_ptr<spdlog::logger> spdlog::synchronous_factory::create<spdlog::sinks::ansicolor_stdout_sink<spdlog::details::console_mutex>, spdlog::color_mode&>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, spdlog::color_mode&) ()
   from /data/mori/python/mori/libmori_application.so
#2  0x00007fff96c8d037 in std::shared_ptr<spdlog::logger> spdlog::stdout_color_mt<spdlog::synchronous_factory>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, spdlog::color_mode) ()
   from /data/mori/python/mori/libmori_application.so
#3  0x00007fff96cd6555 in mori::ModuleLogger::InitModule(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, mori::ModuleLogger::Level) () from /data/mori/python/mori/libmori_shmem.so
#4  0x00007fff96cd5867 in mori::ModuleLogger::GetLogger(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) ()
   from /data/mori/python/mori/libmori_shmem.so
#5  0x00007fff96cd3757 in mori::shmem::ShmemGetUniqueId(std::array<unsigned char, 128ul>*) () from /data/mori/python/mori/libmori_shmem.so
#6  0x00000000130335a9 in xla::gpu::MoriCollectives::CreateUniqueCliqueId() const ()
#7  0x000000001312c7b9 in std::_Function_handler<absl::lts_20260107::StatusOr<xla::CliqueIds> (xla::CliqueKey const&), xla::gpu::AcquireCollectiveCliques(xla::gpu::CollectiveParams const&, xla::gpu::CollectiveCliqueRequests const&)::$_1>::_M_invoke(std::_Any_data const&, xla::CliqueKey const&) ()
#8  0x0000000013141b4b in xla::gpu::InitializeGpuClique(xla::gpu::GpuCollectives*, stream_executor::StreamExecutor*, xla::RunId, xla::gpu::GpuCliqueKey const&, std::function<absl::lts_20260107::StatusOr<xla::CliqueIds> (xla::CliqueKey const&)> const&, int, tsl::gtl::IntType<xla::RankId_tag_, long>, xla::gpu::GpuCollectives::Config const&)::$_0::operator()(absl::lts_20260107::Span<xla::gpu::InitializeGpuClique(xla::gpu::GpuCollectives*, stream_executor::StreamExecutor*, xla::RunId, xla::gpu::GpuCliqueKey const&, std::function<absl::lts_20260107::StatusOr<xla::CliqueIds> (xla::CliqueKey const&)> const&, int, tsl::gtl::IntType<xla::RankId_tag_, long>, xla::gpu::GpuCollectives::Config const&)::RendezvousArg const* const>) const ()
#9  0x000000001314198f in absl::lts_20260107::StatusOr<std::shared_ptr<xla::Lockable<xla::gpu::GpuClique, xla::gpu::GpuClique::LockableName>::Lock> > xla::InvokeRendezvous<xla::Lockable<xla::gpu::GpuClique, xla::gpu::GpuClique::LockableName>::Lock, xla::gpu::InitializeGpuClique(xla::gpu::GpuCollectives*, stream_executor::StreamExecutor*, xla::RunId, xla::gpu::GpuCliqueKey const&, std::function<absl::lts_20260107::StatusOr<xla::CliqueIds> (xla::CliqueKey const&)> const&, int, tsl::gtl::IntType<xla::RankId_tag_, long>, xla::gpu::GpuCollectives::Config const&)::RendezvousArg, xla::gpu::InitializeGpuClique(xla::gpu::GpuCollectives*, stream_executor::StreamExecutor*, xla::RunId, xla::gpu::GpuCliqueKey const&, std::function<absl::lts_20260107::StatusOr<xla::CliqueIds> (xla::CliqueKey const&)> const&, int, tsl::gtl::IntType<xla::RankId_tag_, long>, xla::gpu::GpuCollectives::Config const&)::$_0>(xla::gpu::InitializeGpuClique(xla::gpu::GpuCollectives*, stream_executor::StreamExecutor*, xla::RunId, xla::gpu::GpuCliqueKey const&, std::function<absl::lts_20260107::StatusOr<xla::CliqueIds> (xla::CliqueKey const&)> const&, int, tsl::gtl::IntType<xla::RankId_tag_, long>, xla::gpu::GpuCollectives::Config const&)::$_0, absl::lts_20260107::Span<xla::gpu::InitializeGpuClique(xla::gpu::GpuCollectives*, stream_executor::StreamExecutor*, xla::RunId, xla::gpu::GpuCliqueKey const&, std::function<absl::lts_20260107::StatusOr<xla::CliqueIds> (xla::CliqueKey const&)> const&, int, tsl::gtl::IntType<xla::RankId_tag_, long>, xla::gpu::GpuCollectives::Config const&)::RendezvousArg*>) ()
#10 0x0000000013133f32 in xla::gpu::AcquireGpuClique(xla::gpu::GpuCollectives*, stream_executor::StreamExecutor*, xla::RunId, xla::gpu::GpuCliqueKey const&, absl::lts_20260107::Span<std::vector<tsl::gtl::IntType<xla::GlobalDeviceId_tag_, int>, std::allocator<tsl::gtl::IntType<xla::GlobalDeviceId_tag_, int> > > const>, std::function<absl::lts_20260107::StatusOr<xla::CliqueIds> (xla::CliqueKey const&)> const&, tsl::gtl::IntType<xla::RankId_tag_, long>, xla::gpu::AcquiredCliquesMap const&, long, bool) ()
```
This is a classic ODR violation across shared library boundaries. Two different spdlog instances exist in the process:
1. One in hlo_runner_main (from XLA/TensorFlow's dependencies)
2. One in libmori_application.so / libmori_shmem.so (from MORI's 3rdparty/spdlog)
Without `-fvisibility=hidden`, the linker merges them. With it, each library uses its own private copy and they don't interfere.

- Modernize the CMake ROCm configuration to use `CMAKE_HIP_ARCHITECTURES` instead of the deprecated `HIP_HIPCC_FLAGS`.

- Make sure spdlog is getting compiled header-only
