### PR TITLE
refactor: decouple device compilation and public headers from host-only deps

### DIFF
--- a/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
+++ b/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
@@ -1237,7 +1237,7 @@ class EpDispatchCombineTestCase:
         [disp_rdma_bw, disp_xgmi_bw, disp_lat_us,
          comb_rdma_bw, comb_xgmi_bw, comb_lat_us].
         """
-        (disp_dur, disp_rdma, disp_xgmi, comb_dur, comb_rdma, comb_xgmi, ll_scale) = (
+        disp_dur, disp_rdma, disp_xgmi, comb_dur, comb_rdma, comb_xgmi, ll_scale = (
             bench_result
         )
         repeat = len(disp_dur)

--- a/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
+++ b/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
@@ -28,7 +28,7 @@ import argparse
 import time
 from tqdm import tqdm
 
-os.environ.setdefault("MORI_SHMEM_HEAP_SIZE", "64G")
+os.environ.setdefault("MORI_SHMEM_HEAP_SIZE", "16G")
 
 kernel_type_map = {
     "v0": mori.ops.EpDispatchCombineKernelType.InterNode,

--- a/include/mori/application/application_device_types.hpp
+++ b/include/mori/application/application_device_types.hpp
@@ -1,0 +1,156 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Device-safe subset of mori::application types.
+// Contains only POD structs, enums, and types with __device__ __host__ methods.
+// No C++ STL (std::vector/map/etc.), no ibverbs, no host-only class definitions.
+// Safe to include from both host and device (HIP/CUDA) compilation units.
+//
+// Host code should continue to include "mori/application/application.hpp" for the full API
+// (SymmMemManager, RdmaDevice, Context, etc.).
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "mori/application/transport/sdma/anvil_device.hpp"
+#include "mori/core/transport/rdma/core_device_types.hpp"
+#include "mori/hip_compat.hpp"
+
+namespace mori {
+namespace application {
+
+/* ---------------------------------------------------------------------------------------------- */
+/*                                       Transport Types                                          */
+/* ---------------------------------------------------------------------------------------------- */
+
+enum TransportType { RDMA = 0, P2P = 1, SDMA = 2 };
+
+/* ---------------------------------------------------------------------------------------------- */
+/*                                      RDMA Types (device-safe)                                  */
+/* ---------------------------------------------------------------------------------------------- */
+
+enum class RdmaDeviceVendorId : uint32_t {
+  Unknown = 0,
+  Mellanox = 0x02c9,
+  Broadcom = 0x14E4,
+  Pensando = 0x1dd8,
+};
+
+struct RdmaMemoryRegion {
+  uintptr_t addr{0};
+  uint32_t lkey{0};
+  uint32_t rkey{0};
+  size_t length{0};
+};
+
+/* ---------------------------------------------------------------------------------------------- */
+/*                                    Symmetric Memory Types */
+/* ---------------------------------------------------------------------------------------------- */
+
+// Heap type for memory allocation
+enum class HeapType {
+  Normal,   // Normal cached memory
+  Uncached  // Uncached memory
+};
+
+struct VMMChunkKey {
+  uint32_t key;         // RDMA lkey or rkey
+  uintptr_t next_addr;  // Address of next chunk boundary (for calculating chunk_size)
+
+  VMMChunkKey() : key(0), next_addr(0) {}
+  VMMChunkKey(uint32_t k, uintptr_t addr) : key(k), next_addr(addr) {}
+};
+
+struct SymmMemObj {
+  void* localPtr{nullptr};
+  uintptr_t* peerPtrs{nullptr};
+  uintptr_t* p2pPeerPtrs{nullptr};
+  size_t size{0};
+  // For Rdma
+  uint32_t lkey{0};
+  uint32_t* peerRkeys{nullptr};
+
+  // For VMM allocations: chunk key information (nvshmem-style)
+  // vmmLkeyInfo[i] contains lkey and next_addr for chunk i
+  // vmmRkeyInfo[i * worldSize + pe] contains rkey and next_addr for chunk i, PE pe
+  VMMChunkKey* vmmLkeyInfo{nullptr};
+  VMMChunkKey* vmmRkeyInfo{nullptr};
+  size_t vmmNumChunks{0};  // Total number of chunks in VMM heap
+  int worldSize{0};
+  // For IPC
+  hipIpcMemHandle_t* ipcMemHandles{nullptr};  // should only placed on cpu
+
+  // For Sdma
+  anvil::SdmaQueueDeviceHandle** deviceHandles_d = nullptr;  // should only placed on GPU
+  HSAuint64* signalPtrs = nullptr;                           // should only placed on GPU
+  uint32_t sdmaNumQueue = 2;                                 // number of sdma queue
+  HSAuint64* expectSignalsPtr = nullptr;                     // should only placed on GPU
+  // Remote signal: peerSignalPtrs[pe] points to PE pe's signalPtrs mapped into local address space.
+  // SdmaPutThread writes ATOMIC to peerSignalPtrs[remotePe] + myPe*sdmaNumQueue + qId,
+  // so the remote PE can directly read its own signalPtrs to detect completion.
+  HSAuint64** peerSignalPtrs = nullptr;  // should only placed on GPU
+
+  __device__ __host__ RdmaMemoryRegion GetRdmaMemoryRegion(int pe) const {
+    RdmaMemoryRegion mr;
+    mr.addr = peerPtrs[pe];
+    mr.lkey = lkey;
+    mr.rkey = peerRkeys[pe];
+    mr.length = size;
+    return mr;
+  }
+
+  // Get pointers
+  inline __device__ __host__ void* Get() const { return localPtr; }
+  inline __device__ __host__ void* Get(int pe) const {
+    return reinterpret_cast<void*>(p2pPeerPtrs[pe]);
+  }
+
+  template <typename T>
+  inline __device__ __host__ T GetAs() const {
+    return reinterpret_cast<T>(localPtr);
+  }
+  template <typename T>
+  inline __device__ __host__ T GetAs(int pe) const {
+    return reinterpret_cast<T>(p2pPeerPtrs[pe]);
+  }
+};
+
+struct SymmMemObjPtr {
+  SymmMemObj* cpu{nullptr};
+  SymmMemObj* gpu{nullptr};
+
+  bool IsValid() { return (cpu != nullptr) && (gpu != nullptr); }
+
+#if defined(__HIPCC__) || defined(__CUDACC__)
+  __host__ SymmMemObj* operator->() { return cpu; }
+  __device__ SymmMemObj* operator->() { return gpu; }
+  __host__ const SymmMemObj* operator->() const { return cpu; }
+  __device__ const SymmMemObj* operator->() const { return gpu; }
+#else
+  SymmMemObj* operator->() { return cpu; }
+  const SymmMemObj* operator->() const { return cpu; }
+#endif
+};
+
+}  // namespace application
+}  // namespace mori

--- a/include/mori/application/memory/symmetric_memory.hpp
+++ b/include/mori/application/memory/symmetric_memory.hpp
@@ -21,6 +21,9 @@
 // SOFTWARE.
 #pragma once
 
+// VMMChunkKey, HeapType, SymmMemObj, SymmMemObjPtr, RdmaMemoryRegion are defined in
+// application_device_types.hpp so that device (HIP/CUDA) compilation units can include
+// them without pulling in STL or ibverbs headers.
 #include <hip/hip_runtime_api.h>
 #include <linux/types.h>
 #include <stdint.h>
@@ -29,6 +32,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "mori/application/application_device_types.hpp"
 #include "mori/application/bootstrap/bootstrap.hpp"
 #include "mori/application/context/context.hpp"
 #include "mori/application/memory/va_manager.hpp"
@@ -38,91 +42,6 @@
 
 namespace mori {
 namespace application {
-
-// Heap type for memory allocation
-enum class HeapType {
-  Normal,   // Normal cached memory
-  Uncached  // Uncached memory
-};
-
-struct VMMChunkKey {
-  uint32_t key;         // RDMA lkey or rkey
-  uintptr_t next_addr;  // Address of next chunk boundary (for calculating chunk_size)
-
-  VMMChunkKey() : key(0), next_addr(0) {}
-  VMMChunkKey(uint32_t k, uintptr_t addr) : key(k), next_addr(addr) {}
-};
-
-struct SymmMemObj {
-  void* localPtr{nullptr};
-  uintptr_t* peerPtrs{nullptr};
-  uintptr_t* p2pPeerPtrs{nullptr};
-  size_t size{0};
-  // For Rdma
-  uint32_t lkey{0};
-  uint32_t* peerRkeys{nullptr};
-
-  // For VMM allocations: chunk key information (nvshmem-style)
-  // vmmLkeyInfo[i] contains lkey and next_addr for chunk i
-  // vmmRkeyInfo[i * worldSize + pe] contains rkey and next_addr for chunk i, PE pe
-  VMMChunkKey* vmmLkeyInfo{nullptr};
-  VMMChunkKey* vmmRkeyInfo{nullptr};
-  size_t vmmNumChunks{0};  // Total number of chunks in VMM heap
-  int worldSize{0};
-  // For IPC
-  hipIpcMemHandle_t* ipcMemHandles{nullptr};  // should only placed on cpu
-
-  // For Sdma
-  anvil::SdmaQueueDeviceHandle** deviceHandles_d = nullptr;  // should only placed on GPU
-  HSAuint64* signalPtrs = nullptr;                           // should only placed on GPU
-  uint32_t sdmaNumQueue = 2;                                 // number of sdma queue
-  HSAuint64* expectSignalsPtr = nullptr;                     // should only placed on GPU
-  // Remote signal: peerSignalPtrs[pe] points to PE pe's signalPtrs mapped into local address space.
-  // SdmaPutThread writes ATOMIC to peerSignalPtrs[remotePe] + myPe*sdmaNumQueue + qId,
-  // so the remote PE can directly read its own signalPtrs to detect completion.
-  HSAuint64** peerSignalPtrs = nullptr;  // should only placed on GPU
-
-  __device__ __host__ RdmaMemoryRegion GetRdmaMemoryRegion(int pe) const {
-    RdmaMemoryRegion mr;
-    mr.addr = peerPtrs[pe];
-    mr.lkey = lkey;
-    mr.rkey = peerRkeys[pe];
-    mr.length = size;
-    return mr;
-  }
-
-  // Get pointers
-  inline __device__ __host__ void* Get() const { return localPtr; }
-  inline __device__ __host__ void* Get(int pe) const {
-    return reinterpret_cast<void*>(p2pPeerPtrs[pe]);
-  }
-
-  template <typename T>
-  inline __device__ __host__ T GetAs() const {
-    return reinterpret_cast<T>(localPtr);
-  }
-  template <typename T>
-  inline __device__ __host__ T GetAs(int pe) const {
-    return reinterpret_cast<T>(p2pPeerPtrs[pe]);
-  }
-};
-
-struct SymmMemObjPtr {
-  SymmMemObj* cpu{nullptr};
-  SymmMemObj* gpu{nullptr};
-
-  bool IsValid() { return (cpu != nullptr) && (gpu != nullptr); }
-
-#if defined(__HIPCC__) || defined(__CUDACC__)
-  __host__ SymmMemObj* operator->() { return cpu; }
-  __device__ SymmMemObj* operator->() { return gpu; }
-  __host__ const SymmMemObj* operator->() const { return cpu; }
-  __device__ const SymmMemObj* operator->() const { return gpu; }
-#else
-  SymmMemObj* operator->() { return cpu; }
-  const SymmMemObj* operator->() const { return cpu; }
-#endif
-};
 
 class SymmMemManager {
  public:

--- a/include/mori/application/transport/rdma/providers/dv_loader.hpp
+++ b/include/mori/application/transport/rdma/providers/dv_loader.hpp
@@ -29,27 +29,11 @@
 
 #include <string>
 
-#include "mori/utils/mori_log.hpp"
-
 // Load a shared library at runtime. Returns the handle, or nullptr on failure.
-inline void* DvLoadLibrary(const char* lib_name) {
-  void* handle = dlopen(lib_name, RTLD_LAZY | RTLD_LOCAL);
-  if (!handle) {
-    MORI_APP_TRACE("dlopen({}) failed: {}", lib_name, dlerror());
-  } else {
-    MORI_APP_TRACE("dlopen({}) succeeded", lib_name);
-  }
-  return handle;
-}
+void* DvLoadLibrary(const char* lib_name);
 
 // Load a symbol from a library handle. Returns nullptr on failure.
-inline void* DvLoadSymbol(void* handle, const char* symbol_name) {
-  void* sym = dlsym(handle, symbol_name);
-  if (!sym) {
-    MORI_APP_WARN("dlsym({}) failed: {}", symbol_name, dlerror());
-  }
-  return sym;
-}
+void* DvLoadSymbol(void* handle, const char* symbol_name);
 
 // ============================================================================
 // MLX5 direct-verbs function pointers

--- a/include/mori/application/transport/rdma/providers/dv_loader.hpp
+++ b/include/mori/application/transport/rdma/providers/dv_loader.hpp
@@ -27,6 +27,7 @@
 
 #include <dlfcn.h>
 
+#include <cstdint>
 #include <string>
 
 // Load a shared library at runtime. Returns the handle, or nullptr on failure.

--- a/include/mori/application/transport/rdma/rdma.hpp
+++ b/include/mori/application/transport/rdma/rdma.hpp
@@ -21,6 +21,8 @@
 // SOFTWARE.
 #pragma once
 
+// RdmaDeviceVendorId and RdmaMemoryRegion are defined in application_device_types.hpp
+// so that device (HIP/CUDA) compilation units can use them without ibverbs/STL dependencies.
 #include <unistd.h>
 
 #include <cassert>
@@ -32,9 +34,9 @@
 #include <vector>
 
 #include "infiniband/verbs.h"
+#include "mori/application/application_device_types.hpp"
 #include "mori/core/transport/rdma/rdma.hpp"
 #include "mori/hip_compat.hpp"
-// #include "mori/core/transport/rdma/primitives.hpp"
 
 namespace mori {
 namespace application {
@@ -49,12 +51,8 @@ enum class RdmaBackendType : uint32_t {
   IBVerbs = 2,
 };
 
-enum class RdmaDeviceVendorId : uint32_t {
-  Unknown = 0,
-  Mellanox = 0x02c9,
-  Broadcom = 0x14E4,
-  Pensando = 0x1dd8,
-};
+// RdmaDeviceVendorId is defined in application_device_types.hpp (included above).
+// template helper for vendor ID conversion stays here (host-only use):
 
 template <typename T>
 RdmaDeviceVendorId ToRdmaDeviceVendorId(T v) {
@@ -150,12 +148,7 @@ struct WorkQueueAttrs {
   uint32_t offset{0};
 };
 
-struct RdmaMemoryRegion {
-  uintptr_t addr{0};
-  uint32_t lkey{0};
-  uint32_t rkey{0};
-  size_t length{0};
-};
+// RdmaMemoryRegion is defined in application_device_types.hpp (included above).
 
 struct RdmaEndpoint {
   RdmaDeviceVendorId vendorId{RdmaDeviceVendorId::Unknown};

--- a/include/mori/application/transport/transport.hpp
+++ b/include/mori/application/transport/transport.hpp
@@ -21,13 +21,8 @@
 // SOFTWARE.
 #pragma once
 
+#include "mori/application/application_device_types.hpp"
 #include "mori/application/transport/p2p/p2p.hpp"
 #include "mori/application/transport/rdma/rdma.hpp"
 
-namespace mori {
-namespace application {
-
-enum TransportType { RDMA = 0, P2P = 1, SDMA = 2 };
-
-}  // namespace application
-}  // namespace mori
+// TransportType is defined in application_device_types.hpp

--- a/include/mori/core/transport/rdma/core_device_types.hpp
+++ b/include/mori/core/transport/rdma/core_device_types.hpp
@@ -1,0 +1,161 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Device-safe subset of core RDMA types.
+// Only contains POD structs and enums — no ibverbs, no C++ STL.
+// Safe to include from both host and device (HIP/CUDA) compilation units.
+#pragma once
+
+#include <limits.h>
+#include <stdint.h>
+
+namespace mori {
+namespace core {
+
+enum ProviderType {
+  Unknown = 0,
+  // Mellanox direct verbs
+  MLX5 = 1,
+  // Broadcom direct verbs
+  BNXT = 2,
+  // Pensando direct verbs
+  PSD = 3,
+  // Ib verbs
+  IBVERBS = 4,
+};
+
+typedef enum {
+  AMO_ACK = 1,
+  AMO_INC,
+  AMO_SET,
+  AMO_ADD,
+  AMO_AND,
+  AMO_OR,
+  AMO_XOR,
+  AMO_SIGNAL,
+  SIGNAL_SET,
+  SIGNAL_ADD,
+  AMO_SIGNAL_SET = SIGNAL_SET,
+  AMO_SIGNAL_ADD = SIGNAL_ADD,
+  AMO_END_OF_NONFETCH,
+  AMO_FETCH,
+  AMO_FETCH_INC,
+  AMO_FETCH_ADD,
+  AMO_FETCH_AND,
+  AMO_FETCH_OR,
+  AMO_FETCH_XOR,
+  AMO_SWAP,
+  AMO_COMPARE_SWAP,
+  AMO_OP_SENTINEL = INT_MAX,
+} atomicType;
+
+#define OUTSTANDING_TABLE_SIZE (65536)
+struct WorkQueueHandle {
+  uint32_t postIdx{0};     // numbers of wqe that post to work queue
+  uint32_t dbTouchIdx{0};  // numbers of wqe that touched doorbell
+  uint32_t doneIdx{0};     // numbers of wqe that have been consumed by nic
+  uint32_t readyIdx{0};
+  union {
+    struct {
+      uint32_t msntblSlotIdx;
+      uint32_t psnIdx;  // for bnxt msn psn index calculate
+    };
+    uint64_t msnPack{0};
+  };
+  void* sqAddr{nullptr};
+  void* msntblAddr{nullptr};  // for bnxt
+  void* rqAddr{nullptr};
+  void* dbrRecAddr{nullptr};
+  void* dbrAddr{nullptr};
+  void* rqdbrAddr{nullptr};
+  uint32_t mtuSize{4096};
+  uint32_t sqWqeNum{0};
+  uint32_t msntblNum{0};
+  uint32_t rqWqeNum{0};
+  uint32_t postSendLock{0};
+  uint64_t outstandingWqe[OUTSTANDING_TABLE_SIZE]{0};
+  bool color;
+  uint64_t sq_dbval{0};
+  uint64_t rq_dbval{0};
+};
+
+struct CompletionQueueHandle {
+  void* cqAddr{nullptr};
+  void* dbrRecAddr{nullptr};
+  void* dbrAddr{nullptr};
+  uint32_t consIdx{0};      // numbers of cqe that have been completed
+  uint32_t needConsIdx{0};  // numbers of cqe that should be consumed
+  uint32_t activeIdx{0};    // numbers of cqe that under processing but not completed
+  uint32_t cq_consumer{0};
+  uint32_t cq_dbpos{0};
+  uint32_t cqeNum{0};
+  uint32_t cqeSize{0};
+  uint32_t pollCqLock{0};
+  uint64_t cq_dbval{0};
+};
+
+struct IbufHandle {
+  uintptr_t addr{0};
+  uint32_t lkey{0};
+  uint32_t rkey{0};
+  uint32_t nslots{0};
+  uint32_t head{0};
+  uint32_t tail{0};
+};
+
+/* ---------------------------------------------------------------------------------------------- */
+/*                                        Utility Functions                                       */
+/* ---------------------------------------------------------------------------------------------- */
+#define BSWAP64(x)                                                                 \
+  ((((x) & 0xff00000000000000ull) >> 56) | (((x) & 0x00ff000000000000ull) >> 40) | \
+   (((x) & 0x0000ff0000000000ull) >> 24) | (((x) & 0x000000ff00000000ull) >> 8) |  \
+   (((x) & 0x00000000ff000000ull) << 8) | (((x) & 0x0000000000ff0000ull) << 24) |  \
+   (((x) & 0x000000000000ff00ull) << 40) | (((x) & 0x00000000000000ffull) << 56))
+
+#define BSWAP32(x)                                                                      \
+  ((((x) & 0xff000000) >> 24) | (((x) & 0x00ff0000) >> 8) | (((x) & 0x0000ff00) << 8) | \
+   (((x) & 0x000000ff) << 24))
+
+#define BSWAP16(x) ((((x) & 0xff00) >> 8) | (((x) & 0x00ff) << 8))
+
+#define HTOBE64(x) BSWAP64(x)
+#define HTOBE32(x) BSWAP32(x)
+#define HTOBE16(x) BSWAP16(x)
+
+#if BYTE_ORDER == LITTLE_ENDIAN
+#define BE16TOH(x) BSWAP16(x)
+#define BE32TOH(x) BSWAP32(x)
+#define BE64TOH(x) BSWAP64(x)
+#define LE16TOH(x) (x)
+#define LE32TOH(x) (x)
+#define LE64TOH(x) (x)
+#elif BYTE_ORDER == BIG_ENDIAN
+#define BE16TOH(x) (x)
+#define BE32TOH(x) (x)
+#define BE64TOH(x) (x)
+#define LE16TOH(x) BSWAP16(x)
+#define LE32TOH(x) BSWAP32(x)
+#define LE64TOH(x) BSWAP64(x)
+#endif
+
+}  // namespace core
+}  // namespace mori

--- a/include/mori/core/transport/rdma/device_primitives.hpp
+++ b/include/mori/core/transport/rdma/device_primitives.hpp
@@ -22,7 +22,7 @@
 #pragma once
 
 // #include "mori/application/transport/rdma/rdma.hpp"
-#include "primitives.hpp"
+#include "mori/core/transport/rdma/core_device_types.hpp"
 
 // using namespace mori::application;
 

--- a/include/mori/core/transport/rdma/primitives.hpp
+++ b/include/mori/core/transport/rdma/primitives.hpp
@@ -21,146 +21,21 @@
 // SOFTWARE.
 #pragma once
 
-#include <limits.h>
-#include <stdint.h>
-
 #include "infiniband/verbs.h"
+#include "mori/core/transport/rdma/core_device_types.hpp"
 
 namespace mori {
 namespace core {
 
-enum ProviderType {
-  Unknown = 0,
-  // Mellanox direct verbs
-  MLX5 = 1,
-  // Broadcom direct verbs
-  BNXT = 2,
-  // Pensando direct verbs
-  PSD = 3,
-  // Ib verbs
-  IBVERBS = 4,
-};
-
-typedef enum {
-  AMO_ACK = 1,
-  AMO_INC,
-  AMO_SET,
-  AMO_ADD,
-  AMO_AND,
-  AMO_OR,
-  AMO_XOR,
-  AMO_SIGNAL,
-  SIGNAL_SET,
-  SIGNAL_ADD,
-  AMO_SIGNAL_SET = SIGNAL_SET,
-  AMO_SIGNAL_ADD = SIGNAL_ADD,
-  AMO_END_OF_NONFETCH,
-  AMO_FETCH,
-  AMO_FETCH_INC,
-  AMO_FETCH_ADD,
-  AMO_FETCH_AND,
-  AMO_FETCH_OR,
-  AMO_FETCH_XOR,
-  AMO_SWAP,
-  AMO_COMPARE_SWAP,
-  AMO_OP_SENTINEL = INT_MAX,
-} atomicType;
-
-#define OUTSTANDING_TABLE_SIZE (65536)
-struct WorkQueueHandle {
-  uint32_t postIdx{0};     // numbers of wqe that post to work queue
-  uint32_t dbTouchIdx{0};  // numbers of wqe that touched doorbell
-  uint32_t doneIdx{0};     // numbers of wqe that have been consumed by nic
-  uint32_t readyIdx{0};
-  union {
-    struct {
-      uint32_t msntblSlotIdx;
-      uint32_t psnIdx;  // for bnxt msn psn index calculate
-    };
-    uint64_t msnPack{0};
-  };
-  void* sqAddr{nullptr};
-  void* msntblAddr{nullptr};  // for bnxt
-  void* rqAddr{nullptr};
-  void* dbrRecAddr{nullptr};
-  void* dbrAddr{nullptr};
-  void* rqdbrAddr{nullptr};
-  uint32_t mtuSize{4096};
-  uint32_t sqWqeNum{0};
-  uint32_t msntblNum{0};
-  uint32_t rqWqeNum{0};
-  uint32_t postSendLock{0};
-  uint64_t outstandingWqe[OUTSTANDING_TABLE_SIZE]{0};
-  bool color;
-  uint64_t sq_dbval{0};
-  uint64_t rq_dbval{0};
-};
-
-struct CompletionQueueHandle {
-  void* cqAddr{nullptr};
-  void* dbrRecAddr{nullptr};
-  void* dbrAddr{nullptr};
-  uint32_t consIdx{0};      // numbers of cqe that have been completed
-  uint32_t needConsIdx{0};  // numbers of cqe that should be consumed
-  uint32_t activeIdx{0};    // numbers of cqe that under processing but not completed
-  uint32_t cq_consumer{0};
-  uint32_t cq_dbpos{0};
-  uint32_t cqeNum{0};
-  uint32_t cqeSize{0};
-  uint32_t pollCqLock{0};
-  uint64_t cq_dbval{0};
-};
-
+// IBVerbsHandle is host-only: ibv_qp/ibv_cq/etc. are ibverbs objects managed on the host.
+// Device code must not access these fields. For device-side RDMA, use WorkQueueHandle /
+// CompletionQueueHandle instead (defined in core_device_types.hpp).
 struct IBVerbsHandle {
   ibv_qp* qp{nullptr};
   ibv_cq* cq{nullptr};
   ibv_srq* srq{nullptr};
   ibv_comp_channel* compCh{nullptr};
 };
-
-struct IbufHandle {
-  uintptr_t addr{0};
-  uint32_t lkey{0};
-  uint32_t rkey{0};
-  uint32_t nslots{0};
-  uint32_t head{0};
-  uint32_t tail{0};
-};
-
-/* ---------------------------------------------------------------------------------------------- */
-/*                                        Utility Functions                                       */
-/* ---------------------------------------------------------------------------------------------- */
-#define BSWAP64(x)                                                                 \
-  ((((x) & 0xff00000000000000ull) >> 56) | (((x) & 0x00ff000000000000ull) >> 40) | \
-   (((x) & 0x0000ff0000000000ull) >> 24) | (((x) & 0x000000ff00000000ull) >> 8) |  \
-   (((x) & 0x00000000ff000000ull) << 8) | (((x) & 0x0000000000ff0000ull) << 24) |  \
-   (((x) & 0x000000000000ff00ull) << 40) | (((x) & 0x00000000000000ffull) << 56))
-
-#define BSWAP32(x)                                                                      \
-  ((((x) & 0xff000000) >> 24) | (((x) & 0x00ff0000) >> 8) | (((x) & 0x0000ff00) << 8) | \
-   (((x) & 0x000000ff) << 24))
-
-#define BSWAP16(x) ((((x) & 0xff00) >> 8) | (((x) & 0x00ff) << 8))
-
-#define HTOBE64(x) BSWAP64(x)
-#define HTOBE32(x) BSWAP32(x)
-#define HTOBE16(x) BSWAP16(x)
-
-#if BYTE_ORDER == LITTLE_ENDIAN
-#define BE16TOH(x) BSWAP16(x)
-#define BE32TOH(x) BSWAP32(x)
-#define BE64TOH(x) BSWAP64(x)
-#define LE16TOH(x) (x)
-#define LE32TOH(x) (x)
-#define LE64TOH(x) (x)
-#elif BYTE_ORDER == BIG_ENDIAN
-#define BE16TOH(x) (x)
-#define BE32TOH(x) (x)
-#define BE64TOH(x) (x)
-#define LE16TOH(x) BSWAP16(x)
-#define LE32TOH(x) BSWAP32(x)
-#define LE64TOH(x) BSWAP64(x)
-#endif
 
 }  // namespace core
 }  // namespace mori

--- a/include/mori/shmem/internal.hpp
+++ b/include/mori/shmem/internal.hpp
@@ -23,6 +23,7 @@
 
 // Device-safe includes: no STL, no ibverbs, safe for HIP/CUDA device compilation.
 #include "mori/application/application_device_types.hpp"
+#include "mori/core/utils.hpp"
 #include "mori/hip_compat.hpp"
 
 // Host-only includes: STL, ibverbs, application management classes.

--- a/include/mori/shmem/internal.hpp
+++ b/include/mori/shmem/internal.hpp
@@ -147,6 +147,7 @@ struct ShmemRdmaEndpoint {
     } else if (vendorId == application::RdmaDeviceVendorId::Pensando) {
       return core::ProviderType::PSD;
     } else {
+      MORI_PRINTF("ShmemRdmaEndpoint: unknown vendorId %u\n", static_cast<uint32_t>(vendorId));
       assert(false);
       return core::ProviderType::Unknown;
     }

--- a/include/mori/shmem/internal.hpp
+++ b/include/mori/shmem/internal.hpp
@@ -21,6 +21,13 @@
 // SOFTWARE.
 #pragma once
 
+// Device-safe includes: no STL, no ibverbs, safe for HIP/CUDA device compilation.
+#include "mori/application/application_device_types.hpp"
+#include "mori/hip_compat.hpp"
+
+// Host-only includes: STL, ibverbs, application management classes.
+// Guarded so device compilation units (.hip files) do not pull them in.
+#if !defined(__HIPCC__) && !defined(__CUDACC__)
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -28,10 +35,16 @@
 
 #include "mori/application/application.hpp"
 #include "mori/application/bootstrap/bootstrap.hpp"
-#include "mori/hip_compat.hpp"
+#endif
 
 namespace mori {
 namespace shmem {
+
+/* ---------------------------------------------------------------------------------------------- */
+/*                               Host-only shmem state structures                                 */
+/* ---------------------------------------------------------------------------------------------- */
+
+#if !defined(__HIPCC__) && !defined(__CUDACC__)
 
 // Shmem operation mode
 enum class ShmemMode {
@@ -109,12 +122,43 @@ struct ShmemStates {
   }
 };
 
+#endif  // !defined(__HIPCC__) && !defined(__CUDACC__)
+
+/* ---------------------------------------------------------------------------------------------- */
+/*                          Device-safe GPU-side structures */
+/* ---------------------------------------------------------------------------------------------- */
+
+// GPU-side RDMA endpoint: only the fields used by device kernels.
+// Excludes host-only fields: ibvHandle (ibverbs objects) and unused handle sub-fields (psn, portId,
+// mac, gid). Only qpn from handle is needed by device kernels (for doorbell posting).
+// Populated from application::RdmaEndpoint by init.cpp before hipMemcpy to device.
+struct ShmemRdmaEndpoint {
+  application::RdmaDeviceVendorId vendorId{application::RdmaDeviceVendorId::Unknown};
+  uint32_t qpn{0};  // QP number — extracted from application::RdmaEndpoint::handle.qpn
+  core::WorkQueueHandle wqHandle;
+  core::CompletionQueueHandle cqHandle;
+  core::IbufHandle atomicIbuf;
+
+  __device__ __host__ core::ProviderType GetProviderType() {
+    if (vendorId == application::RdmaDeviceVendorId::Mellanox) {
+      return core::ProviderType::MLX5;
+    } else if (vendorId == application::RdmaDeviceVendorId::Broadcom) {
+      return core::ProviderType::BNXT;
+    } else if (vendorId == application::RdmaDeviceVendorId::Pensando) {
+      return core::ProviderType::PSD;
+    } else {
+      assert(false);
+      return core::ProviderType::Unknown;
+    }
+  }
+};
+
 struct GpuStates {
   int rank{-1};
   int worldSize{-1};
   int numQpPerPe{4};  // Default to 4 QPs per peer, consistent with Context default
   application::TransportType* transportTypes{nullptr};
-  application::RdmaEndpoint* rdmaEndpoints{nullptr};
+  ShmemRdmaEndpoint* rdmaEndpoints{nullptr};
   uint32_t* endpointLock{nullptr};
 
   // Heap information (supports both static and VMM modes)
@@ -144,6 +188,12 @@ struct RemoteAddrInfo {
   __device__ RemoteAddrInfo(uintptr_t r, uintptr_t k) : raddr(r), rkey(k), valid(true) {}
 };
 
+/* ---------------------------------------------------------------------------------------------- */
+/*                               Host-only internal functions                                     */
+/* ---------------------------------------------------------------------------------------------- */
+
+#if !defined(__HIPCC__) && !defined(__CUDACC__)
+
 // Internal functions shared between init.cpp and runtime.cpp
 void CopyGpuStatesToDevice(const GpuStates* gpuStates);
 void FinalizeRuntime();
@@ -158,6 +208,8 @@ class ShmemStatesSingleton {
     return &states;
   }
 };
+
+#endif  // !defined(__HIPCC__) && !defined(__CUDACC__)
 
 }  // namespace shmem
 }  // namespace mori

--- a/include/mori/shmem/shmem_device_api.hpp
+++ b/include/mori/shmem/shmem_device_api.hpp
@@ -23,7 +23,7 @@
 
 #include <assert.h>
 
-#include "mori/application/application.hpp"
+#include "mori/application/application_device_types.hpp"
 #include "mori/core/core.hpp"
 #include "mori/shmem/internal.hpp"
 #include "mori/shmem/shmem_device_kernels.hpp"

--- a/include/mori/shmem/shmem_device_kernels.hpp
+++ b/include/mori/shmem/shmem_device_kernels.hpp
@@ -21,7 +21,7 @@
 // SOFTWARE.
 #pragma once
 
-#include "mori/application/application.hpp"
+#include "mori/application/application_device_types.hpp"
 
 namespace mori {
 namespace shmem {

--- a/include/mori/shmem/shmem_ibgda_kernels.hpp
+++ b/include/mori/shmem/shmem_ibgda_kernels.hpp
@@ -23,7 +23,7 @@
 
 #include <assert.h>
 
-#include "mori/application/application.hpp"
+#include "mori/application/application_device_types.hpp"
 #include "mori/core/core.hpp"
 #include "mori/shmem/internal.hpp"
 #include "mori/shmem/shmem_api.hpp"
@@ -47,7 +47,7 @@ namespace shmem {
 
 #define DISPATCH_PROVIDER_TYPE(func, ...)                             \
   GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();               \
-  application::RdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;     \
+  ShmemRdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;             \
   core::ProviderType prvdType = ep[pe].GetProviderType();             \
   if (DISPATCH_MLX5 && prvdType == core::ProviderType::MLX5) {        \
     func<core::ProviderType::MLX5>(__VA_ARGS__);                      \
@@ -174,7 +174,7 @@ inline __device__ void VmmLookupRemote(uintptr_t addr, int pe, uintptr_t& out_ra
 inline __device__ void ShmemQuietThreadKernelSerialImpl(int pe, int qpId) {
   if (core::GetActiveLaneNum() != 0) return;
   GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
-  application::RdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
+  ShmemRdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
   int epIndex = pe * globalGpuStates->numQpPerPe + (qpId % globalGpuStates->numQpPerPe);
   core::WorkQueueHandle& wq = ep[epIndex].wqHandle;
   core::CompletionQueueHandle& cq = ep[epIndex].cqHandle;
@@ -287,7 +287,7 @@ inline __device__ void ShmemQuietThreadKernelPsdImpl(int pe, int qpId) {
 
 inline __device__ void ShmemQuietThreadKernelMlnxImpl(int pe, int qpId) {
   GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
-  application::RdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
+  ShmemRdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
   int epIndex = pe * globalGpuStates->numQpPerPe + (qpId % globalGpuStates->numQpPerPe);
   core::WorkQueueHandle& wq = ep[epIndex].wqHandle;
   core::CompletionQueueHandle& cq = ep[epIndex].cqHandle;
@@ -410,7 +410,7 @@ inline __device__ void ShmemQuietThreadKernel<application::TransportType::RDMA>(
 template <>
 inline __device__ void ShmemQuietThreadKernel<application::TransportType::RDMA>(int pe, int qpId) {
   GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
-  application::RdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
+  ShmemRdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
   int rank = globalGpuStates->rank;
   if (pe == rank) return;
   if (globalGpuStates->transportTypes[pe] != application::TransportType::RDMA) return;
@@ -429,11 +429,11 @@ inline __device__ void ShmemPutMemNbiThreadKernelImpl(const application::SymmMem
   if (bytes == 0) return;
 
   GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
-  application::RdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
+  ShmemRdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
   int epIndex = pe * globalGpuStates->numQpPerPe + (qpId % globalGpuStates->numQpPerPe);
   core::WorkQueueHandle* wq = &ep[epIndex].wqHandle;
   core::CompletionQueueHandle* cq = &ep[epIndex].cqHandle;
-  uint32_t qpn = ep[epIndex].handle.qpn;
+  uint32_t qpn = ep[epIndex].qpn;
 
   bool needsChunking = globalGpuStates->useVMMHeap;
   size_t currentOffset = 0;
@@ -672,11 +672,11 @@ inline __device__ void ShmemPutSizeImmNbiThreadKernelImpl(const application::Sym
     raddr = dest->peerPtrs[pe] + destOffset;
     rkey = dest->peerRkeys[pe];
   }
-  application::RdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
+  ShmemRdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
   int epIndex = pe * globalGpuStates->numQpPerPe + (qpId % globalGpuStates->numQpPerPe);
   core::WorkQueueHandle* wq = &ep[epIndex].wqHandle;
   core::CompletionQueueHandle* cq = &ep[epIndex].cqHandle;
-  uint32_t qpn = ep[epIndex].handle.qpn;
+  uint32_t qpn = ep[epIndex].qpn;
 
   uint64_t activemask = core::GetActiveLaneMask();
   uint8_t num_active_lanes = core::GetActiveLaneCount(activemask);
@@ -813,11 +813,11 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelImpl(
   // assert(sourceOffset + bytes <= source->size && destOffset + bytes <= dest->size);
 
   GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
-  application::RdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
+  ShmemRdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
   int epIndex = pe * globalGpuStates->numQpPerPe + (qpId % globalGpuStates->numQpPerPe);
   core::WorkQueueHandle* wq = &ep[epIndex].wqHandle;
   core::CompletionQueueHandle* cq = &ep[epIndex].cqHandle;
-  uint32_t qpn = ep[epIndex].handle.qpn;
+  uint32_t qpn = ep[epIndex].qpn;
 
   bool needsChunking = globalGpuStates->useVMMHeap;
   size_t currentOffset = 0;
@@ -1175,11 +1175,11 @@ inline __device__ void ShmemAtomicSizeNonFetchThreadKernelImpl(
   // assert(destOffset + bytes <= dest->size);
 
   GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
-  application::RdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
+  ShmemRdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
   int epIndex = pe * globalGpuStates->numQpPerPe + (qpId % globalGpuStates->numQpPerPe);
   core::WorkQueueHandle* wq = &ep[epIndex].wqHandle;
   core::CompletionQueueHandle* cq = &ep[epIndex].cqHandle;
-  uint32_t qpn = ep[epIndex].handle.qpn;
+  uint32_t qpn = ep[epIndex].qpn;
   core::IbufHandle* ibuf = &ep[epIndex].atomicIbuf;
 
   // Get correct rkey for VMM heap or use direct rkey for Isolation/Static Heap
@@ -1360,11 +1360,11 @@ inline __device__ T ShmemAtomicTypeFetchThreadKernelImpl(const application::Symm
                                                          int qpId) {
   // assert(destOffset + bytes <= dest->size);
   GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
-  application::RdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
+  ShmemRdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
   int epIndex = pe * globalGpuStates->numQpPerPe + (qpId % globalGpuStates->numQpPerPe);
   core::WorkQueueHandle* wq = &ep[epIndex].wqHandle;
   core::CompletionQueueHandle* cq = &ep[epIndex].cqHandle;
-  uint32_t qpn = ep[epIndex].handle.qpn;
+  uint32_t qpn = ep[epIndex].qpn;
   core::IbufHandle* ibuf = &ep[epIndex].atomicIbuf;
 
   uint64_t activemask = core::GetActiveLaneMask();
@@ -1595,11 +1595,11 @@ inline __device__ void ShmemPutMemNbiThreadKernelAddrImpl(const void* dest, cons
   if (bytes == 0) return;
 
   GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
-  application::RdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
+  ShmemRdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
   int epIndex = pe * globalGpuStates->numQpPerPe + (qpId % globalGpuStates->numQpPerPe);
   core::WorkQueueHandle* wq = &ep[epIndex].wqHandle;
   core::CompletionQueueHandle* cq = &ep[epIndex].cqHandle;
-  uint32_t qpn = ep[epIndex].handle.qpn;
+  uint32_t qpn = ep[epIndex].qpn;
 
   // Determine if chunking is needed (VMM heap mode)
   bool needsChunking = globalGpuStates->useVMMHeap;
@@ -1809,11 +1809,11 @@ inline __device__ void ShmemPutSizeImmNbiThreadKernelAddrImpl(const void* dest, 
   if (bytes == 0) return;
 
   GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
-  application::RdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
+  ShmemRdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
   int epIndex = pe * globalGpuStates->numQpPerPe + (qpId % globalGpuStates->numQpPerPe);
   core::WorkQueueHandle* wq = &ep[epIndex].wqHandle;
   core::CompletionQueueHandle* cq = &ep[epIndex].cqHandle;
-  uint32_t qpn = ep[epIndex].handle.qpn;
+  uint32_t qpn = ep[epIndex].qpn;
 
   // Convert addresses to remote addresses (supports both Static Heap and VMM Heap)
   uintptr_t raddr;
@@ -1948,11 +1948,11 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelAddrImpl(
   if (bytes == 0) return;
 
   GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
-  application::RdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
+  ShmemRdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
   int epIndex = pe * globalGpuStates->numQpPerPe + (qpId % globalGpuStates->numQpPerPe);
   core::WorkQueueHandle* wq = &ep[epIndex].wqHandle;
   core::CompletionQueueHandle* cq = &ep[epIndex].cqHandle;
-  uint32_t qpn = ep[epIndex].handle.qpn;
+  uint32_t qpn = ep[epIndex].qpn;
 
   // Determine if chunking is needed (VMM heap mode)
   bool needsChunking = globalGpuStates->useVMMHeap;
@@ -2290,11 +2290,11 @@ inline __device__ void ShmemAtomicSizeNonFetchThreadKernelAddrImpl(const void* d
   if (bytes == 0) return;
 
   GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
-  application::RdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
+  ShmemRdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
   int epIndex = pe * globalGpuStates->numQpPerPe + (qpId % globalGpuStates->numQpPerPe);
   core::WorkQueueHandle* wq = &ep[epIndex].wqHandle;
   core::CompletionQueueHandle* cq = &ep[epIndex].cqHandle;
-  uint32_t qpn = ep[epIndex].handle.qpn;
+  uint32_t qpn = ep[epIndex].qpn;
   core::IbufHandle* ibuf = &ep[epIndex].atomicIbuf;
 
   // Convert addresses to remote addresses (supports both Static Heap and VMM Heap)
@@ -2439,11 +2439,11 @@ inline __device__ T ShmemAtomicTypeFetchThreadKernelAddrImpl(const void* dest, v
                                                              core::atomicType amoType, int pe,
                                                              int qpId) {
   GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
-  application::RdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
+  ShmemRdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
   int epIndex = pe * globalGpuStates->numQpPerPe + (qpId % globalGpuStates->numQpPerPe);
   core::WorkQueueHandle* wq = &ep[epIndex].wqHandle;
   core::CompletionQueueHandle* cq = &ep[epIndex].cqHandle;
-  uint32_t qpn = ep[epIndex].handle.qpn;
+  uint32_t qpn = ep[epIndex].qpn;
   core::IbufHandle* ibuf = &ep[epIndex].atomicIbuf;
 
   uint64_t activemask = core::GetActiveLaneMask();
@@ -2629,11 +2629,11 @@ inline __device__ void ShmemGetMemNbiThreadKernelImpl(const application::SymmMem
   if (bytes == 0) return;
 
   GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
-  application::RdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
+  ShmemRdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
   int epIndex = pe * globalGpuStates->numQpPerPe + (qpId % globalGpuStates->numQpPerPe);
   core::WorkQueueHandle* wq = &ep[epIndex].wqHandle;
   core::CompletionQueueHandle* cq = &ep[epIndex].cqHandle;
-  uint32_t qpn = ep[epIndex].handle.qpn;
+  uint32_t qpn = ep[epIndex].qpn;
 
   bool needsChunking = globalGpuStates->useVMMHeap;
   size_t currentOffset = 0;
@@ -2845,11 +2845,11 @@ inline __device__ void ShmemGetMemNbiThreadKernelAddrImpl(void* dest, const void
   if (bytes == 0) return;
 
   GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
-  application::RdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
+  ShmemRdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
   int epIndex = pe * globalGpuStates->numQpPerPe + (qpId % globalGpuStates->numQpPerPe);
   core::WorkQueueHandle* wq = &ep[epIndex].wqHandle;
   core::CompletionQueueHandle* cq = &ep[epIndex].cqHandle;
-  uint32_t qpn = ep[epIndex].handle.qpn;
+  uint32_t qpn = ep[epIndex].qpn;
 
   bool needsChunking = globalGpuStates->useVMMHeap;
 

--- a/include/mori/shmem/shmem_p2p_kernels.hpp
+++ b/include/mori/shmem/shmem_p2p_kernels.hpp
@@ -25,7 +25,7 @@
 
 #include <type_traits>
 
-#include "mori/application/application.hpp"
+#include "mori/application/application_device_types.hpp"
 #include "mori/core/core.hpp"
 #include "mori/shmem/internal.hpp"
 #include "mori/shmem/shmem_api.hpp"

--- a/include/mori/shmem/shmem_sdma_kernels.hpp
+++ b/include/mori/shmem/shmem_sdma_kernels.hpp
@@ -25,7 +25,7 @@
 
 #include <type_traits>
 
-#include "mori/application/application.hpp"
+#include "mori/application/application_device_types.hpp"
 #include "mori/core/core.hpp"
 #include "mori/shmem/internal.hpp"
 #include "mori/shmem/shmem_api.hpp"

--- a/src/application/CMakeLists.txt
+++ b/src/application/CMakeLists.txt
@@ -50,6 +50,7 @@ list(
   APPEND
   MORI_APP_SOURCES
   transport/rdma/rdma.cpp
+  transport/rdma/providers/dv_loader.cpp
   transport/rdma/providers/mlx5/mlx5.cpp
   transport/rdma/providers/bnxt/bnxt.cpp
   transport/rdma/providers/ionic/ionic.cpp

--- a/src/application/transport/rdma/providers/dv_loader.cpp
+++ b/src/application/transport/rdma/providers/dv_loader.cpp
@@ -1,0 +1,45 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mori/application/transport/rdma/providers/dv_loader.hpp"
+
+#include <dlfcn.h>
+
+#include "mori/utils/mori_log.hpp"
+
+void* DvLoadLibrary(const char* lib_name) {
+  void* handle = dlopen(lib_name, RTLD_LAZY | RTLD_LOCAL);
+  if (!handle) {
+    MORI_APP_TRACE("dlopen({}) failed: {}", lib_name, dlerror());
+  } else {
+    MORI_APP_TRACE("dlopen({}) succeeded", lib_name);
+  }
+  return handle;
+}
+
+void* DvLoadSymbol(void* handle, const char* symbol_name) {
+  void* sym = dlsym(handle, symbol_name);
+  if (!sym) {
+    MORI_APP_WARN("dlsym({}) failed: {}", symbol_name, dlerror());
+  }
+  return sym;
+}

--- a/src/shmem/init.cpp
+++ b/src/shmem/init.cpp
@@ -355,12 +355,24 @@ static void CopyRdmaEndpointsToGpu(GpuStates* gpuStates, const ShmemStates* stat
 
   size_t numEndpoints = gpuStates->worldSize * gpuStates->numQpPerPe;
 
-  // Allocate and copy endpoints
-  HIP_RUNTIME_CHECK(
-      hipMalloc(&gpuStates->rdmaEndpoints, sizeof(application::RdmaEndpoint) * numEndpoints));
-  HIP_RUNTIME_CHECK(hipMemcpy(
-      gpuStates->rdmaEndpoints, states->rdmaStates->commContext->GetRdmaEndpoints().data(),
-      sizeof(application::RdmaEndpoint) * numEndpoints, hipMemcpyHostToDevice));
+  // Allocate and copy endpoints.
+  // Convert from host-side application::RdmaEndpoint (which contains ibverbs handles and QP
+  // connection parameters unused by device kernels) to the GPU-side ShmemRdmaEndpoint that
+  // only contains the fields device kernels actually access.
+  HIP_RUNTIME_CHECK(hipMalloc(&gpuStates->rdmaEndpoints, sizeof(ShmemRdmaEndpoint) * numEndpoints));
+  {
+    const auto& hostEndpoints = states->rdmaStates->commContext->GetRdmaEndpoints();
+    std::vector<ShmemRdmaEndpoint> shmemEndpoints(numEndpoints);
+    for (size_t i = 0; i < numEndpoints; i++) {
+      shmemEndpoints[i].vendorId = hostEndpoints[i].vendorId;
+      shmemEndpoints[i].qpn = hostEndpoints[i].handle.qpn;
+      shmemEndpoints[i].wqHandle = hostEndpoints[i].wqHandle;
+      shmemEndpoints[i].cqHandle = hostEndpoints[i].cqHandle;
+      shmemEndpoints[i].atomicIbuf = hostEndpoints[i].atomicIbuf;
+    }
+    HIP_RUNTIME_CHECK(hipMemcpy(gpuStates->rdmaEndpoints, shmemEndpoints.data(),
+                                sizeof(ShmemRdmaEndpoint) * numEndpoints, hipMemcpyHostToDevice));
+  }
 
   // Allocate and initialize endpoint locks
   size_t lockSize = numEndpoints * sizeof(uint32_t);


### PR DESCRIPTION
Fixes two related issues where mori headers leaked host-only dependencies (ibverbs/STL/spdlog) into downstream compilation, causing failures in environments like XLA integration and HIP/CUDA device compilation.

## 1. Eliminate ibverbs/STL from device compilation path

`shmem_device_api.hpp` previously included `application.hpp` unconditionally, pulling ibverbs and STL into device (HIP/CUDA) compilation.

- **`core_device_types.hpp`**: POD-only RDMA types (WorkQueueHandle, CompletionQueueHandle, IbufHandle, ProviderType) — no ibverbs
- **`application_device_types.hpp`**: device-safe application types (TransportType, RdmaDeviceVendorId, SymmMemObj, etc.) — no STL
- **`ShmemRdmaEndpoint`**: GPU-side replacement for `application::RdmaEndpoint` in `GpuStates`, containing only fields used by device kernels (drops `ibvHandle` and unused connection params)
- **`device_primitives.hpp`**: now includes `core_device_types.hpp` instead of `primitives.hpp`, breaking the remaining ibverbs transitive dependency
- All shmem device headers switched from `application.hpp` to `application_device_types.hpp`
- Host-only code in `internal.hpp` guarded with `!defined(__HIPCC__) && !defined(__CUDACC__)`
- `init.cpp` converts `RdmaEndpoint` → `ShmemRdmaEndpoint` before `hipMemcpy` to device

## 2. Drop spdlog from public headers via dv_loader

`dv_loader.hpp` had inline functions calling `MORI_APP_TRACE/WARN`, forcing every header transitively including it (e.g. `application.hpp` → `bnxt.hpp` → `dv_loader.hpp`) to drag in spdlog. This broke downstream builds (e.g. XLA) compiling against mori headers without spdlog on the include path.

- Move `DvLoadLibrary`/`DvLoadSymbol` implementations to a new `dv_loader.cpp`
- Remove `mori_log.hpp` include from `dv_loader.hpp`
- Verified zero spdlog/mori_log in `dv_loader.hpp` transitive deps