### PR TITLE
feat(cli): add 'mori' console entry point for env helper scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ python/mori/spdk_proxy
 .cache/
 CMakeFiles/
 python/mori/_jit_sources/
+
+# Bundled tools/*.sh files copied into the package at build time
+python/mori/tools/*.sh

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,10 @@ prune 3rdparty/msgpack-c/.git
 include CMakeLists.txt
 recursive-include src CMakeLists.txt
 include tools/build_shmem_bitcode.sh
-recursive-include python *.py *.md *.bc *.json
+include tools/env_check.sh
+include tools/env_setup.sh
+include tools/diagnose_env.sh
+recursive-include python *.py *.md *.bc *.json *.sh
 include pyproject.toml
 include setup.py
 include LICENSE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,6 @@ dependencies = []
 [project.urls]
 Homepage = "https://github.com/ROCm/mori"
 Repository = "https://github.com/ROCm/mori"
+
+[project.scripts]
+mori = "mori.cli:main"

--- a/python/mori/cli.py
+++ b/python/mori/cli.py
@@ -1,0 +1,237 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Command-line entry point for the ``mori`` package.
+
+Exposes the bundled environment helper shell scripts (originally under
+``tools/`` in the source repo) as subcommands so users can run e.g.::
+
+    mori check [peer_ip]
+    source $(mori setup --path)
+
+after a plain ``pip install amd_mori``.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent / "tools"
+
+_SCRIPT_FILES = {
+    "check": "env_check.sh",
+    "setup": "env_setup.sh",
+    "diagnose": "diagnose_env.sh",
+}
+
+
+def _script_path(name: str) -> Path:
+    fname = _SCRIPT_FILES[name]
+    p = _SCRIPTS_DIR / fname
+    if not p.is_file():
+        raise FileNotFoundError(
+            f"bundled script '{fname}' not found at {p}. "
+            "The mori package may have been installed incorrectly."
+        )
+    return p
+
+
+def _ensure_bash() -> str:
+    bash = shutil.which("bash")
+    if not bash:
+        print(
+            "[mori] bash not found in PATH; cannot run shell helpers.", file=sys.stderr
+        )
+        sys.exit(127)
+    return bash
+
+
+def _run_script(name: str, args: List[str]) -> int:
+    path = _script_path(name)
+    # Make sure it's executable for the user; harmless if already is.
+    try:
+        os.chmod(path, os.stat(path).st_mode | 0o111)
+    except OSError:
+        pass
+    bash = _ensure_bash()
+    os.execv(bash, [bash, str(path), *args])
+    return 0  # unreachable
+
+
+def _cmd_check(rest: List[str]) -> int:
+    return _run_script("check", rest)
+
+
+def _cmd_diagnose(rest: List[str]) -> int:
+    return _run_script("diagnose", rest)
+
+
+def _cmd_setup(rest: List[str]) -> int:
+    """Handle ``mori setup``.
+
+    ``env_setup.sh`` does two things:
+
+    1. Configures PFC / DSCP / DCQCN on the ionic NICs via ``sudo
+       nicctl``. These are system-side changes that persist beyond the
+       calling process — running the script as a normal subprocess is
+       sufficient.
+    2. Exports ``MORI_RDMA_SL`` / ``MORI_RDMA_TC`` for the calling
+       shell. A Python entry point cannot mutate its parent shell's
+       environment, so getting these into your current shell requires
+       *sourcing* the script (e.g. ``source $(mori setup --path)``).
+
+    Default behavior (``mori setup``): execute the script as a
+    subprocess so the NIC configuration is applied. The exported
+    variables will be lost once the script returns; if you need them in
+    your shell, re-run via ``source $(mori setup --path)``.
+
+    ``mori setup --path``: print only the absolute path, suitable for
+    shell substitution: ``source $(mori setup --path)``.
+    """
+    parser = argparse.ArgumentParser(
+        prog="mori setup",
+        description=(
+            "Run env_setup.sh to configure PFC / DSCP / DCQCN on ionic NICs. "
+            "To also pick up the exported MORI_RDMA_SL / MORI_RDMA_TC variables "
+            "in your current shell, source the script instead: "
+            "`source $(mori setup --path)`."
+        ),
+        epilog=(
+            "Examples:\n"
+            "    mori setup                   # apply NIC config (env vars do NOT persist)\n"
+            "    source $(mori setup --path)  # apply NIC config AND export MORI_RDMA_SL/TC\n"
+            "    mori setup --path            # print only the absolute script path\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--path",
+        action="store_true",
+        help=(
+            "print only the absolute path of env_setup.sh and exit "
+            "(use with `source $(mori setup --path)` to export env vars)"
+        ),
+    )
+    ns = parser.parse_args(rest)
+
+    path = _script_path("setup")
+    if ns.path:
+        print(path)
+        return 0
+
+    # Run the script as a subprocess so NIC-side config (sudo nicctl ...)
+    # is applied. Note the exported MORI_RDMA_SL / MORI_RDMA_TC will not
+    # propagate back to the caller's shell — for that, source the script.
+    print(
+        "[mori] running env_setup.sh (NIC config will be applied; "
+        "to also export MORI_RDMA_SL/TC into your shell run: "
+        "source $(mori setup --path))",
+        file=sys.stderr,
+    )
+    return _run_script("setup", [])
+
+
+def _cmd_path(rest: List[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="mori path",
+        description="Print the absolute path of a bundled mori script.",
+    )
+    parser.add_argument(
+        "name",
+        choices=sorted(_SCRIPT_FILES.keys()),
+        help="bundled script name",
+    )
+    ns = parser.parse_args(rest)
+    print(_script_path(ns.name))
+    return 0
+
+
+def _cmd_version(_rest: List[str]) -> int:
+    try:
+        from . import __version__  # type: ignore[attr-defined]
+    except Exception:
+        try:
+            from ._version import __version__  # type: ignore
+        except Exception:
+            __version__ = "unknown"
+    print(f"mori {__version__}")
+    return 0
+
+
+_COMMANDS = {
+    "check": (_cmd_check, "run the environment check script (env_check.sh)"),
+    "setup": (
+        _cmd_setup,
+        "run env_setup.sh (use `source $(mori setup --path)` to export env vars)",
+    ),
+    "diagnose": (_cmd_diagnose, "run diagnose_env.sh"),
+    "path": (_cmd_path, "print the absolute path of a bundled script"),
+    "version": (_cmd_version, "print mori version"),
+}
+
+
+def _print_usage() -> None:
+    lines = [
+        "usage: mori <command> [args...]",
+        "",
+        "Commands:",
+    ]
+    width = max(len(c) for c in _COMMANDS)
+    for name, (_fn, desc) in _COMMANDS.items():
+        lines.append(f"  {name:<{width}}  {desc}")
+    lines.extend(
+        [
+            "",
+            "Examples:",
+            "  mori check 10.0.0.2          # run env_check.sh against a peer",
+            "  mori setup                   # configure NICs (env vars do NOT persist in shell)",
+            "  source $(mori setup --path)  # configure NICs AND export MORI_RDMA_SL/TC",
+            "  mori path check              # print path to env_check.sh",
+        ]
+    )
+    print("\n".join(lines))
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+
+    if not args or args[0] in {"-h", "--help", "help"}:
+        _print_usage()
+        return 0
+
+    cmd, *rest = args
+    entry = _COMMANDS.get(cmd)
+    if entry is None:
+        print(f"mori: unknown command '{cmd}'\n", file=sys.stderr)
+        _print_usage()
+        return 2
+
+    fn, _desc = entry
+    return fn(rest) or 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/python/mori/tools/__init__.py
+++ b/python/mori/tools/__init__.py
@@ -1,0 +1,27 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Bundled shell scripts for mori environment management.
+#
+# The actual .sh files are copied here from the repo's tools/ directory at
+# package build time (see setup.py). At runtime the package exposes their
+# absolute paths through helpers in mori.cli.

--- a/setup.py
+++ b/setup.py
@@ -510,8 +510,38 @@ def _try_precompile(root_dir: Path) -> None:
         print(f"[mori] Precompilation skipped: {e}")
 
 
+_BUNDLED_SCRIPTS = ("env_check.sh", "env_setup.sh", "diagnose_env.sh")
+
+
+def _sync_bundled_scripts() -> None:
+    """Copy ``tools/*.sh`` into ``python/mori/scripts/`` so they ship in the wheel.
+
+    Keeps a single source of truth (``tools/``) while still letting the
+    installed package expose them via the ``mori`` console script.
+    """
+    here = Path(__file__).resolve().parent
+    src_dir = here / "tools"
+    dst_dir = here / "python" / "mori" / "tools"
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    for name in _BUNDLED_SCRIPTS:
+        src = src_dir / name
+        if not src.is_file():
+            continue
+        dst = dst_dir / name
+        try:
+            if not dst.is_file() or dst.read_bytes() != src.read_bytes():
+                shutil.copy2(src, dst)
+            os.chmod(dst, os.stat(dst).st_mode | 0o111)
+        except OSError as exc:
+            print(f"[mori] WARN: failed to bundle {name}: {exc}")
+
+
+_sync_bundled_scripts()
+
+
 class CustomBuild(_build):
     def run(self) -> None:
+        _sync_bundled_scripts()
         self.run_command("build_ext")
         super().run()
 
@@ -544,6 +574,7 @@ mori_package_data = [
     "_jit-sources/3rdparty/**/*.hpp",
     "_jit-sources/tools/**/*.py",
     "ops/tuning_configs/*.json",
+    "tools/*.sh",
 ]
 if _env_flag("BUILD_UMBP", "OFF"):
     mori_package_data.append("spdk_proxy")
@@ -554,6 +585,7 @@ setup(
     package_data={
         "mori": mori_package_data,
         "mori.ir": ["*.bc"],
+        "mori.tools": ["*.sh"],
     },
     exclude_package_data={
         "mori": ["*.a"],
@@ -564,4 +596,9 @@ setup(
     },
     ext_modules=extensions,
     include_package_data=True,
+    entry_points={
+        "console_scripts": [
+            "mori = mori.cli:main",
+        ],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -596,9 +596,4 @@ setup(
     },
     ext_modules=extensions,
     include_package_data=True,
-    entry_points={
-        "console_scripts": [
-            "mori = mori.cli:main",
-        ],
-    },
 )


### PR DESCRIPTION
## Summary

`mori` ships two operator-facing shell helpers under [tools/](tools/):

- [tools/env_check.sh](tools/env_check.sh) — verifies firmware/driver
  versions, QoS/PFC/DCQCN config, and intra/inter-node RDMA bandwidth
  & latency.
- [tools/env_setup.sh](tools/env_setup.sh) — configures PFC/DSCP/DCQCN
  on ionic NICs and exports `MORI_RDMA_SL` / `MORI_RDMA_TC` for the
  current shell.

Today users have to `git clone` the repo and `cd tools/` to run them,
which is awkward when `mori` itself is consumed as a `pip install
amd_mori` dependency.

This PR exposes those scripts (plus `diagnose_env.sh`) as subcommands
of a new `mori` console entry point. After a plain
`pip install amd_mori`, the helpers are available as:

```bash
mori check [peer_ip]            # runs env_check.sh
mori setup                      # runs env_setup.sh (apply NIC config)
source $(mori setup --path)     # runs env_setup.sh AND exports MORI_RDMA_SL/TC
mori diagnose                   # runs diagnose_env.sh
mori path check                 # print absolute path of a bundled script
mori version                    # print mori version
mori --help                     # full usage
mori setup --help               # detailed setup instructions
```

## `mori setup` — two ways to invoke

`env_setup.sh` does two distinct things:

1. **System-side**: configure PFC / DSCP / DCQCN on the ionic NICs via
   `sudo nicctl ...`. These settings persist in the kernel/NIC firmware
   regardless of the calling shell.
2. **Shell-side**: `export MORI_RDMA_SL` / `MORI_RDMA_TC` for the
   calling shell.

A Python entry point cannot mutate its parent shell's environment, so:

| Invocation | Applies NIC config? | Exports `MORI_RDMA_SL`/`TC` to current shell? |
| --- | --- | --- |
| `mori setup` | ✅ | ❌ (variables are set inside the subprocess and discarded on exit) |
| `source $(mori setup --path)` | ✅ | ✅ |
| `mori setup --path` | n/a (just prints the path) | n/a |

`mori setup` (no flag) runs the script as a subprocess so the NIC
configuration is applied. If you also need `MORI_RDMA_SL`/`TC` in your
current shell — typically before launching a `mori`-based job — re-run
via `source $(mori setup --path)`.

## Implementation

- **New** [python/mori/cli.py](python/mori/cli.py): argparse-based
  dispatcher. `check` / `diagnose` / `setup` `execv` into
  `bash <bundled-script>` and forward arguments transparently. `setup
  --path` short-circuits to print only the path. `path` and `version`
  are pure helpers.
- **New** `python/mori/tools/` package (mirrors the repo's top-level
  [tools/](tools/) layout, so the in-package directory name matches
  what contributors already know).
- **[setup.py](setup.py)**:
  - `_sync_bundled_scripts()` copies
    `tools/{env_check,env_setup,diagnose_env}.sh` into
    `python/mori/tools/` before `setup()` runs and again inside
    `CustomBuild.run()`. This keeps the repo's `tools/` as the single
    source of truth — no duplicate maintenance.
  - Adds `tools/*.sh` to `package_data` and registers
    `console_scripts: mori = mori.cli:main`.
- **[MANIFEST.in](MANIFEST.in)**: include the three `tools/*.sh` files
  and `python/**/*.sh` so sdists are complete.
- **[.gitignore](.gitignore)**: ignore `python/mori/tools/*.sh` so the
  build-time copies are never committed by mistake.

## Layout after install

```text
site-packages/mori/tools/
├── __init__.py
├── env_check.sh
├── env_setup.sh
└── diagnose_env.sh
```

Names match the repo's top-level `tools/` directory.

## Backwards compatibility

- No public Python API change.
- The original scripts remain in [tools/](tools/) unchanged; existing
  `git clone`-based workflows keep working.
- Zero new runtime dependencies.

## Testing

Validated end-to-end in a fresh `conda` environment (`mori-cli-test`,
Python 3.10) — both the standard wheel install and editable installs:

### 1. Standard wheel install (`pip install`)

```bash
$ pip install <wheel-built-with-this-PR>
$ which mori
~/miniforge3/envs/mori-cli-test/bin/mori

$ mori --help
usage: mori <command> [args...]

Commands:
  check     run the environment check script (env_check.sh)
  setup     run env_setup.sh (use `source $(mori setup --path)` to export env vars)
  diagnose  run diagnose_env.sh
  path      print the absolute path of a bundled script
  version   print mori version

Examples:
  mori check 10.0.0.2          # run env_check.sh against a peer
  mori setup                   # configure NICs (env vars do NOT persist in shell)
  source $(mori setup --path)  # configure NICs AND export MORI_RDMA_SL/TC
  mori path check              # print path to env_check.sh

$ mori check
[FAIL] nicctl not found. Please install it first.   # expected: no NIC tooling on the test box

$ mori setup
[mori] running env_setup.sh (NIC config will be applied; to also export
       MORI_RDMA_SL/TC into your shell run: source $(mori setup --path))
[WARN] no ionic devices found (vendor=0x1dd8)        # expected: no ionic NICs in the test env

$ mori setup --path
~/miniforge3/envs/mori-cli-test/lib/python3.10/site-packages/mori/tools/env_setup.sh

$ source $(mori setup --path)
[WARN] no ionic devices found (vendor=0x1dd8)
```

### 2. Editable install (`pip install -e .`)

```bash
$ pip install -e .
$ mori path check
<repo>/python/mori/tools/env_check.sh        # resolves to the source tree
$ mori check
[FAIL] nicctl not found. Please install it first.
```

### 3. Legacy editable install (`python setup.py develop`)

```bash
$ python setup.py develop
$ mori path check
<repo>/python/mori/tools/env_check.sh
$ mori check
[FAIL] nicctl not found. Please install it first.
```

In editable mode the `.sh` files are synced into `python/mori/tools/`
during `build_editable`, then resolved relative to the source tree at
runtime, so subsequent edits to [tools/*.sh](tools/) (after a rerun of
`pip install -e .`) propagate immediately. The synced copies are
gitignored to avoid accidental commits.

The `[FAIL] nicctl not found` and `[WARN] no ionic devices found`
messages come from the bundled scripts themselves and are the correct
behavior on a host without ionic NIC tooling — the CLI dispatch is
working as intended.

## Files changed

- `python/mori/cli.py` (new)
- `python/mori/tools/__init__.py` (new)
- `setup.py`
- `MANIFEST.in`
- `.gitignore`
