### PR TITLE
fix(rdma): bnxt PollCq/QP bugs and ibverbs path_mtu override

### DIFF
--- a/include/mori/core/transport/rdma/providers/bnxt/bnxt_device_primitives.hpp
+++ b/include/mori/core/transport/rdma/providers/bnxt/bnxt_device_primitives.hpp
@@ -741,7 +741,7 @@ inline __device__ int PollCq<ProviderType::BNXT>(WorkQueueHandle& wqHandle,
 template <>
 inline __device__ void UpdateCqDbrRecord<ProviderType::BNXT>(CompletionQueueHandle& cq,
                                                              uint32_t consIdx) {
-  uint8_t flags = ((consIdx + 1) / cq.cqeNum) & (1UL << BNXT_RE_FLAG_EPOCH_HEAD_SHIFT);
+  uint8_t flags = (((consIdx + 1) / cq.cqeNum) & 0x1) << BNXT_RE_FLAG_EPOCH_HEAD_SHIFT;
   uint32_t epoch = (flags & BNXT_RE_FLAG_EPOCH_TAIL_MASK) << BNXT_RE_DB_EPOCH_TAIL_SHIFT;
   // uint64_t dbrVal = bnxt_re_init_db_hdr(((consIdx + 1) | epoch), 0, flags, BNXT_RE_QUE_TYPE_CQ);
   uint64_t dbrVal =

--- a/src/application/transport/rdma/providers/bnxt/bnxt.cpp
+++ b/src/application/transport/rdma/providers/bnxt/bnxt.cpp
@@ -227,8 +227,8 @@ BnxtQpContainer::BnxtQpContainer(ibv_context* context, const RdmaEndpointConfig&
         hipExtMallocWithFlags(&rqUmemAddr, qpMemInfo.rq_len, hipDeviceMallocUncached));
     HIP_RUNTIME_CHECK(hipMemset(rqUmemAddr, 0, qpMemInfo.rq_len));
   } else {
-    err = posix_memalign(&rqUmemAddr, config.alignment, qpMemInfo.sq_len);
-    memset(rqUmemAddr, 0, qpMemInfo.sq_len);
+    err = posix_memalign(&rqUmemAddr, config.alignment, qpMemInfo.rq_len);
+    memset(rqUmemAddr, 0, qpMemInfo.rq_len);
     assert(!err);
   }
   qpMemInfo.rq_va = reinterpret_cast<uint64_t>(rqUmemAddr);
@@ -395,7 +395,7 @@ void BnxtQpContainer::ModifyInit2Rtr(const RdmaEndpointHandle& local_handle,
 
   memcpy(&attr.ah_attr.grh.dgid, remote_handle.eth.gid, 16);
   attr.ah_attr.grh.sgid_index = local_handle.eth.gidIdx;
-  attr.ah_attr.grh.hop_limit = 1;
+  attr.ah_attr.grh.hop_limit = 255;
   attr.ah_attr.is_global = 1;
   attr.ah_attr.port_num = config.portId;
   attr.ah_attr.sl = ReadRdmaServiceLevelEnv().value_or(1);

--- a/src/application/transport/rdma/providers/ibverbs/ibverbs.cpp
+++ b/src/application/transport/rdma/providers/ibverbs/ibverbs.cpp
@@ -127,7 +127,28 @@ void IBVerbsDeviceContext::ConnectEndpoint(const RdmaEndpointHandle& local,
   assert(portAttr);
   // RTR
   attr.qp_state = IBV_QPS_RTR;
-  attr.path_mtu = portAttr->active_mtu;
+  {
+    ibv_mtu path_mtu = portAttr->active_mtu;
+    const char* envMtu = std::getenv("MORI_IB_PATH_MTU");
+    if (envMtu != nullptr) {
+      int mtuBytes = std::atoi(envMtu);
+      if (mtuBytes == 256)
+        path_mtu = IBV_MTU_256;
+      else if (mtuBytes == 512)
+        path_mtu = IBV_MTU_512;
+      else if (mtuBytes == 1024)
+        path_mtu = IBV_MTU_1024;
+      else if (mtuBytes == 2048)
+        path_mtu = IBV_MTU_2048;
+      else if (mtuBytes == 4096)
+        path_mtu = IBV_MTU_4096;
+      else
+        MORI_APP_WARN("Ignore invalid MORI_IB_PATH_MTU={} (allowed: 256/512/1024/2048/4096)",
+                      envMtu);
+      MORI_APP_INFO("MORI_IB_PATH_MTU override: {} bytes (ibv_mtu={})", mtuBytes, (int)path_mtu);
+    }
+    attr.path_mtu = path_mtu;
+  }
   attr.dest_qp_num = remote.qpn;
   attr.rq_psn = 0;
   attr.max_dest_rd_atomic = devAttr->orig_attr.max_qp_rd_atom;


### PR DESCRIPTION
## Motivation

These issues came up while bringing up MORI on node with 8x MI300X and 8x Broadcom Thor2 NICs (400G, `bnxt_re`).
Three of them are latent bnxt provider bugs that surface on specific code paths or fabric topologies, and the last is a small ibverbs knob for switched fabrics. Sharing upstream in case they're useful to others on similar setups.

## Technical Details

bnxt provider:
- PollCq epoch flag: the bitmask was applied before the shift, producing an incorrect flag value. Isolate the LSB of the wrap count first (`& 0x1`), then shift to `BNXT_RE_FLAG_EPOCH_HEAD_SHIFT`.
- `BnxtQpContainer` ctor: the RQ backing buffer was allocated with `qpMemInfo.sq_len`. Use `rq_len` instead.
- `ModifyInit2Rtr`: `hop_limit = 1` prevents RoCE packets from crossing any router. Use 255 (max) to allow routed fabrics; no effect on flat L2.

ibverbs provider:
- Add `MORI_IB_PATH_MTU` env var override for `attr.path_mtu` in `ConnectEndpoint`, for switched fabrics that negotiate a lower `active_mtu` than the port supports. Accepted values are 256, 512, 1024, 2048, 4096. When unset, preserves current behavior (use `portAttr->active_mtu`).

## Test Plan

These fixes were developed and verified on:
- A 2-node cluster, each node equipped with 8x MI300X and 8x Broadcom Thor2 400G NICs (`bnxt_re`)
- A 10-node cluster, also each node equipped with 8x MI300X and 8x Broadcom Thor2 400G NICs (`bnxt_re`)

We use these as a precondition for our vLLM P/D disaggregated serving stack with the MoRI-IO connector. Without these fixes, MoRI-IO failed at startup.

## Test Result

- vLLM 1P1D (TP=8) disaggregated serving comes up and runs end-to-end with MoRI-IO over Thor2 with these fixes applied.
- Various xPyD setups succeeded in bring-up including 1P3D, 1P4D, etc.

We have not done isolated per-fix regression tests; the fixes were validated as a set during cluster bring-up. Would be happy to provide more targeted reproducers if useful for review.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


Signed-off-by: Chaemin Lim <chaemin.lim@mangoboost.io>