### PR TITLE
Update FlyDSL extern integration

### DIFF
--- a/python/mori/ir/flydsl/__init__.py
+++ b/python/mori/ir/flydsl/__init__.py
@@ -25,10 +25,6 @@ mori.ir.flydsl — FlyDSL integration for mori shmem device API.
 Quick start::
 
     from mori.ir import flydsl as mori_shmem
-    from mori.ir.flydsl import get_bitcode_path, install_hook
-
-    install_hook()
-
     @flyc.kernel
     def my_kernel(buf: fx.Tensor):
         pe = mori_shmem.my_pe()
@@ -42,6 +38,6 @@ Usage (with shmem compile helper)::
 
 from .ops import *  # noqa: F401,F403
 from .ops import __all__ as _ops_all
-from .runtime import get_bitcode_path, install_hook
+from .runtime import get_bitcode_path, install_hook, shmem_module_init
 
-__all__ = _ops_all + ["get_bitcode_path", "install_hook"]
+__all__ = _ops_all + ["get_bitcode_path", "install_hook", "shmem_module_init"]

--- a/python/mori/ir/flydsl/ops.py
+++ b/python/mori/ir/flydsl/ops.py
@@ -38,33 +38,38 @@ Usage::
 """
 
 from mori.ir.ops import MORI_DEVICE_FUNCTIONS, SIGNAL_SET, SIGNAL_ADD
+from mori.ir.flydsl.runtime import get_bitcode_path, shmem_module_init
 
 
-# ExternFunction is provided by FlyDSL (Part B).
-# We use a lazy import so mori.ir.flydsl can be imported without FlyDSL installed;
-# ExternFunction is only needed when building a @flyc.kernel.
-def _get_extern_cls():
+def _get_flydsl_extern_helpers():
+    """Load FlyDSL extern helpers lazily so importing mori does not require FlyDSL."""
     try:
-        from flydsl.expr.extern import ExternFunction
+        from flydsl.expr.extern import ffi
+        from flydsl.compiler.extern_link import link_extern
 
-        return ExternFunction
+        return ffi, link_extern
     except ImportError as e:
         raise ImportError(
-            "flydsl.expr.extern not found. "
-            "Make sure FlyDSL is installed and flydsl/expr/extern.py exists."
+            "FlyDSL extern helpers not found. Make sure FlyDSL provides "
+            "flydsl.expr.extern.ffi and flydsl.compiler.extern_link.link_extern."
         ) from e
 
 
 def _build_all():
     """Populate module globals from MORI_DEVICE_FUNCTIONS."""
-    ExternFunction = _get_extern_cls()
+    ffi, link_extern = _get_flydsl_extern_helpers()
+    bitcode_path = get_bitcode_path()
     ns = {}
     for name, meta in MORI_DEVICE_FUNCTIONS.items():
-        ns[name] = ExternFunction(
-            symbol=meta["symbol"],
-            arg_types=meta["args"],
-            ret_type=meta["ret"],
-            is_pure=meta.get("pure", False),
+        ns[name] = link_extern(
+            ffi(
+                meta["symbol"],
+                meta["args"],
+                meta["ret"],
+                is_pure=meta.get("pure", False),
+            ),
+            bitcode_path=bitcode_path,
+            module_init_fn=shmem_module_init,
         )
     return ns
 

--- a/python/mori/ir/flydsl/runtime.py
+++ b/python/mori/ir/flydsl/runtime.py
@@ -29,6 +29,38 @@ FlyDSL-specific runtime helpers for mori shmem integration.
 
 from mori.ir.bitcode import find_bitcode
 
+_FLYDSL_COV = 6
+_FLYDSL_ROCDL_ABI = 600
+
+
+def _check_flydsl_rocdl_abi() -> None:
+    """Verify FlyDSL still lowers ROCm code objects with ABI 600.
+
+    Mori's FlyDSL device bitcode is compiled with code object version 6.  The
+    matching FlyDSL `rocdl-attach-target` option is `abi=600`; if either side
+    changes, linked kernels can compile but fail later at HIP module load time.
+    """
+    try:
+        from flydsl.compiler.backends import get_backend
+
+        backend = get_backend()
+        fragments = backend.pipeline_fragments(compile_hints={})
+    except Exception as exc:
+        raise RuntimeError(
+            "Unable to inspect FlyDSL ROCm backend ABI settings"
+        ) from exc
+
+    attach_fragments = [frag for frag in fragments if "rocdl-attach-target" in frag]
+    if not attach_fragments:
+        raise RuntimeError("FlyDSL ROCm pipeline has no rocdl-attach-target pass")
+
+    expected = f"abi={_FLYDSL_ROCDL_ABI}"
+    if not any(expected in frag for frag in attach_fragments):
+        raise RuntimeError(
+            "MORI FlyDSL bitcode is built with cov=6 and requires FlyDSL "
+            f"rocdl-attach-target {expected}; got: {attach_fragments}"
+        )
+
 
 def get_bitcode_path() -> str:
     """Return the path to libmori_shmem_device.bc (compiled with cov=6 for FlyDSL ABI).
@@ -38,7 +70,8 @@ def get_bitcode_path() -> str:
         from mori.ir.flydsl import get_bitcode_path
         bc = get_bitcode_path()
     """
-    return find_bitcode(cov=6)
+    _check_flydsl_rocdl_abi()
+    return find_bitcode(cov=_FLYDSL_COV)
 
 
 def shmem_module_init(hip_module: int):

--- a/python/mori/ir/flydsl/runtime.py
+++ b/python/mori/ir/flydsl/runtime.py
@@ -23,8 +23,8 @@
 FlyDSL-specific runtime helpers for mori shmem integration.
 
   - ``get_bitcode_path()``  — returns the path to libmori_shmem_device.bc
-  - ``install_hook()``      — installs the FlyDSL post-compile hook that calls
-                              ``shmem_module_init`` to inject ``globalGpuStates``
+  - ``shmem_module_init()`` — initializes ``globalGpuStates`` for a loaded
+                              FlyDSL HIP module
 """
 
 from mori.ir.bitcode import find_bitcode
@@ -41,50 +41,23 @@ def get_bitcode_path() -> str:
     return find_bitcode(cov=6)
 
 
+def shmem_module_init(hip_module: int):
+    """Initialize globalGpuStates in a FlyDSL-loaded HIP module."""
+    import mori.shmem as ms
+
+    return ms.shmem_module_init(hip_module)
+
+
 def install_hook() -> None:
-    """Install FlyDSL post-compile hook for mori shmem.
+    """Compatibility no-op.
 
-    The hook calls ``mori.shmem.shmem_module_init(hip_module)`` after each
-    shmem kernel compilation so that the ``globalGpuStates`` device symbol is
-    properly initialized inside the compiled GPU module.
-
-    Call once before any shmem kernel launch::
-
-        from mori.ir.flydsl import install_hook
-        install_hook()
+    Modern FlyDSL integration attaches ``shmem_module_init`` directly through
+    ``link_extern(..., module_init_fn=...)`` when constructing the extern
+    wrappers, so no global hook installation is required.
     """
-    try:
-        from flydsl.compiler import shmem_compile as sc
-    except ImportError:
-        raise ImportError(
-            "flydsl.compiler.shmem_compile not found. "
-            "Make sure FlyDSL is installed with shmem support."
-        )
-
-    def _hook(hip_module: int) -> None:
-        import mori.shmem as ms
-
-        ms.shmem_module_init(hip_module)
-
-    sc._shmem_post_compile_hook = _hook
+    return None
 
 
 def install_jit_hook() -> None:
-    """Install FlyDSL JIT module-load hook for mori shmem.
-
-    When called, registers a callback in libfly_jit_runtime.so so that
-    every GPU module loaded by flyc.jit automatically gets its
-    ``globalGpuStates`` initialized via ``shmem_module_init``.
-
-    Call once before any shmem kernel launch via ``flyc.jit``::
-
-        from mori.ir.flydsl.runtime import install_jit_hook
-        install_jit_hook()
-
-    Note: If using ``@flyc.jit`` with ``ExternFunction`` that declares
-    ``mori_shmem_*`` symbols, the hook is installed automatically.
-    This function provides an explicit entry point for manual control.
-    """
-    from flydsl.compiler.jit_executor import _ensure_shmem_hook
-
-    _ensure_shmem_hook()
+    """Compatibility alias for :func:`install_hook`."""
+    return install_hook()


### PR DESCRIPTION
## Summary
- Build FlyDSL shmem wrappers with the new `ffi` + `link_extern` API so mori provides bitcode and module init metadata explicitly.
- Replace the old FlyDSL hook entry points with no-op compatibility shims because module initialization now flows through linked extern metadata.
- Export `shmem_module_init` for FlyDSL wrappers while keeping `get_bitcode_path` available.

## Test plan
- `python -m black python/mori/ir/flydsl/ops.py python/mori/ir/flydsl/runtime.py python/mori/ir/flydsl/__init__.py`
- `python -m py_compile python/mori/ir/flydsl/ops.py python/mori/ir/flydsl/runtime.py python/mori/ir/flydsl/__init__.py`
- `PYTHONPATH=/mnt/raid0/felix/dsl2/build-fly/python_packages python - <<'PY' ... import mori.ir.flydsl ... PY`
- `PYTHONPATH=/mnt/raid0/felix/dsl2/build-fly/python_packages:/mnt/raid0/felix/dsl2 FLYDSL_RUNTIME_ENABLE_CACHE=0 torchrun --nproc_per_node=2 /mnt/raid0/felix/dsl2/tests/kernels/test_flydsl_shmem.py`

