### PR TITLE
warn when AsyncLL runs without SDMA

### DIFF
--- a/src/ops/dispatch_combine/dispatch_combine.cpp
+++ b/src/ops/dispatch_combine/dispatch_combine.cpp
@@ -114,6 +114,12 @@ EpDispatchCombineHandle::EpDispatchCombineHandle(EpDispatchCombineConfig config_
   config.enableSdma = env::IsEnvVarEnabled("MORI_ENABLE_SDMA");
   MORI_OPS_INFO("EpDispatchCombine SDMA {} (currently only effective for AsyncLL kernel type)",
                 config.enableSdma ? "enabled" : "disabled");
+  if (config.kernelType == KernelType::AsyncLL && !config.enableSdma && config.rank == 0) {
+    MORI_OPS_WARN(
+        "Mori AsyncLL is selected but SDMA is disabled. AsyncLL without SDMA uses compute units "
+        "for communication, which provides little overlap benefit and can severely degrade "
+        "performance. Use a non-AsyncLL kernel path or set MORI_ENABLE_SDMA=1.");
+  }
   if (config.maxTotalRecvTokens > 0) {
     int worstCase = config.worldSize * config.maxNumInpTokenPerRank;
     if (config.maxTotalRecvTokens > worstCase) {


### PR DESCRIPTION
## Motivation


- Add a warning when `KernelType::AsyncLL` is selected while `MORI_ENABLE_SDMA` is not enabled.
- AsyncLL without SDMA still uses compute units for communication, which limits overlap benefits and can severely degrade performance.
- Recommend using a non-AsyncLL kernel path or enabling SDMA with `MORI_ENABLE_SDMA=1`.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
