### PR TITLE
ccl: fail fast when MORI_ENABLE_SDMA is not enabled

### DIFF
--- a/python/mori/ccl/collective.py
+++ b/python/mori/ccl/collective.py
@@ -20,9 +20,28 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import os
+
 import torch
 from mori import cpp as mori_cpp
 from typing import Optional
+
+
+def _require_sdma_env(class_name: str) -> None:
+    """Fail fast if MORI_ENABLE_SDMA is not enabled.
+
+    Without it, SymmMemManager::Malloc falls back to cached hipMalloc instead
+    of hipExtMallocWithFlags(hipDeviceMallocUncached), and the SDMA kernel
+    NULL-faults on first use ("Memory access fault by GPU node-X on address
+    (nil)") with no actionable error.
+    """
+    raw = os.environ.get("MORI_ENABLE_SDMA", "").strip().lower()
+    if raw in ("", "0", "false", "no", "off"):
+        raise RuntimeError(
+            f"{class_name} requires MORI_ENABLE_SDMA=1 in the process "
+            f"environment (got MORI_ENABLE_SDMA={os.environ.get('MORI_ENABLE_SDMA')!r}). "
+            f"Export it before launch on every rank."
+        )
 
 
 _TORCH_DTYPE_TO_NUMPY = {
@@ -122,6 +141,7 @@ class All2allSdma:
         transit_buffer_size: Optional[int] = None,
         copy_output_to_user: bool = True,
     ):
+        _require_sdma_env("All2allSdma")
         self.my_pe = my_pe
         self.npes = npes
         handle_class = _cpp_all2all_factory("All2allSdmaHandle")
@@ -200,6 +220,7 @@ class AllgatherSdma:
         transit_buffer_size: Optional[int] = None,
         copy_output_to_user: bool = True,
     ):
+        _require_sdma_env("AllgatherSdma")
         self.my_pe = my_pe
         self.npes = npes
         handle_class = _cpp_allgather_factory("AllgatherSdmaHandle")
@@ -310,6 +331,7 @@ class AllreduceSdma:
         dtype: torch.dtype = torch.uint32,
         mode: str = "eager",
     ):
+        _require_sdma_env("AllreduceSdma")
         self.my_pe = my_pe
         self.npes = npes
         self.dtype = dtype


### PR DESCRIPTION
Without MORI_ENABLE_SDMA, the symmetric-memory pool ends up as cached GPU memory. The SDMA engine reads/writes through xGMI/PCIe and bypasses the L2 cache, so on the very first SDMA kernel launch every rank faults:
```
Memory access fault by GPU node-2 (Agent handle: 0x1f41ea80) on address (nil). Reason: Unknown.
Memory access fault by GPU node-3 (Agent handle: 0x2d1ee7f0) on address (nil). Reason: Unknown.
```
... (one per GPU)
Construction of the SDMA collective objects succeeds — Flags allocated, Input transit buffer, Output transit buffer all print normal addresses — so the user has no signal that they're misconfigured until the first collective call, where the only diagnostic is an opaque GPU fault that also typically triggers a multi-GB GPU coredump per rank.

This was hit when integrating AllgatherSdma into a DeepSpeed ZeRO-3 fork: the launcher (deepspeed --num_gpus 8 ...) didn't propagate MORI_ENABLE_SDMA, every rank crashed identically, and the only way to diagnose it was to read SymmMemManager::Malloc source.
cc @wuyl1 
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
