### PR TITLE
feat(ccl): add C++ AllGatherIntoTensor  over SDMA

### DIFF
--- a/include/mori/collective/allgather/allgather_into_tensor.hpp
+++ b/include/mori/collective/allgather/allgather_into_tensor.hpp
@@ -101,15 +101,11 @@ class AllGatherIntoTensor {
   // read zeros.  Hence the safe default is ``false`` — the class falls
   // back to the transit-buffer + post-memcpy path, which is byte-exact
   // and still strictly faster than RCCL on intra-node SDMA-capable links.
-  AllGatherIntoTensor(int my_pe, int npes,
-                      size_t input_buffer_size, size_t output_buffer_size,
-                      bool copy_output_to_user = true,
-                      bool auto_register = false);
+  AllGatherIntoTensor(int my_pe, int npes, size_t input_buffer_size, size_t output_buffer_size,
+                      bool copy_output_to_user = true, bool auto_register = false);
 
-  AllGatherIntoTensor(int my_pe, int npes,
-                      size_t transit_buffer_size = 512 * 1024 * 1024,
-                      bool copy_output_to_user = true,
-                      bool auto_register = false);
+  AllGatherIntoTensor(int my_pe, int npes, size_t transit_buffer_size = 512 * 1024 * 1024,
+                      bool copy_output_to_user = true, bool auto_register = false);
 
   ~AllGatherIntoTensor();
 
@@ -121,12 +117,12 @@ class AllGatherIntoTensor {
   // Returns true on success, false on failure.  Synchronization is the
   // caller's responsibility (record an event on `stream` and wait on it
   // from the consumer stream), matching NCCL's own contract.
-  bool operator()(const void* sendbuff, void* recvbuff, size_t sendcount,
-                  DataType dtype, hipStream_t stream = nullptr);
+  bool operator()(const void* sendbuff, void* recvbuff, size_t sendcount, DataType dtype,
+                  hipStream_t stream = nullptr);
 
   // ----- Two-phase async path (mirrors AllgatherSdma) ---------------------
-  bool start_async(const void* sendbuff, void* recvbuff, size_t sendcount,
-                   DataType dtype, hipStream_t stream = nullptr);
+  bool start_async(const void* sendbuff, void* recvbuff, size_t sendcount, DataType dtype,
+                   hipStream_t stream = nullptr);
   double wait_async(hipStream_t stream = nullptr);
   bool is_async_in_progress() const;
   void cancel_async();

--- a/include/mori/collective/allgather/allgather_into_tensor.hpp
+++ b/include/mori/collective/allgather/allgather_into_tensor.hpp
@@ -84,13 +84,32 @@ class AllGatherIntoTensor {
   // Same constructor flavours as AllgatherSdma: either give one combined
   // transit buffer size (split internally 50/50 between input and output),
   // or give input/output sizes separately.
+  //
+  // ``auto_register`` (default false) controls the experimental zero-copy
+  // path: the first time a given ``recvbuff`` is seen, the class
+  // internally invokes the *collective* ``register_output_buffer`` step
+  // (every rank reaches it simultaneously inside the allgather entry
+  // point, so the collective is well-formed); subsequent calls with the
+  // same buffer hit the cache and the SDMA kernel writes directly into
+  // the user's recv tensor — no transit copy.
+  //
+  // IMPORTANT: this only produces correct results if ``recvbuff`` was
+  // allocated with ``hipExtMallocWithFlags(hipDeviceMallocUncached)``
+  // (i.e. via ``mori.shmem.shmem_malloc`` or equivalent).  PyTorch's
+  // caching allocator uses cached device memory, so the SDMA copy engine
+  // writes will sit in the GPU L2 cache stale and downstream kernels
+  // read zeros.  Hence the safe default is ``false`` — the class falls
+  // back to the transit-buffer + post-memcpy path, which is byte-exact
+  // and still strictly faster than RCCL on intra-node SDMA-capable links.
   AllGatherIntoTensor(int my_pe, int npes,
                       size_t input_buffer_size, size_t output_buffer_size,
-                      bool copy_output_to_user = true);
+                      bool copy_output_to_user = true,
+                      bool auto_register = false);
 
   AllGatherIntoTensor(int my_pe, int npes,
                       size_t transit_buffer_size = 512 * 1024 * 1024,
-                      bool copy_output_to_user = true);
+                      bool copy_output_to_user = true,
+                      bool auto_register = false);
 
   ~AllGatherIntoTensor();
 
@@ -126,12 +145,24 @@ class AllGatherIntoTensor {
   int my_pe() const { return my_pe_; }
   int npes() const { return npes_; }
 
+  // Toggle the lazy auto-registration of recv buffers.  See class header
+  // comment for the collective-correctness contract.
+  void set_auto_register(bool enable) { auto_register_ = enable; }
+  bool auto_register() const { return auto_register_; }
+
   // Exposed for diagnostics / advanced reuse.
   AllgatherSdma<uint32_t>* impl() { return impl_.get(); }
 
  private:
+  // Registers ``recvbuff`` with mori's symmetric memory the first time
+  // we see it, so the next allgather kernel can write directly to the
+  // caller's tensor (zero-copy).  Idempotent and silent on failure (the
+  // call falls back to the transit-buffer path in that case).
+  void maybe_auto_register(void* recvbuff, size_t output_bytes);
+
   int my_pe_;
   int npes_;
+  bool auto_register_;
   std::unique_ptr<AllgatherSdma<uint32_t>> impl_;
 };
 

--- a/include/mori/collective/allgather/allgather_into_tensor.hpp
+++ b/include/mori/collective/allgather/allgather_into_tensor.hpp
@@ -1,0 +1,141 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef MORI_COLLECTIVE_ALLGATHER_INTO_TENSOR_HPP
+#define MORI_COLLECTIVE_ALLGATHER_INTO_TENSOR_HPP
+
+#include <hip/hip_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include "mori/collective/allgather/oneshot_allgather_sdma_class.hpp"
+
+namespace mori {
+namespace collective {
+
+// ---------------------------------------------------------------------------
+// DataType
+// ---------------------------------------------------------------------------
+// Mirrors the subset of ncclDataType_t / at::ScalarType we actually need to
+// dispatch over.  Keeping the enum self-contained avoids dragging the torch
+// headers into the collective core (cf. ncclAllGather, which takes a plain
+// ncclDataType_t and never sees an at::Tensor).
+enum class DataType : int {
+  kInt8 = 0,
+  kUint8 = 1,
+  kInt16 = 2,
+  kUint16 = 3,
+  kInt32 = 4,
+  kUint32 = 5,
+  kInt64 = 6,
+  kUint64 = 7,
+  kFloat16 = 8,
+  kBFloat16 = 9,
+  kFloat32 = 10,
+  kFloat64 = 11,
+};
+
+// Element size in bytes for `dtype`, or 0 for unknown values.
+size_t SizeOf(DataType dtype);
+
+// ---------------------------------------------------------------------------
+// AllGatherIntoTensor
+// ---------------------------------------------------------------------------
+//
+// SDMA-backed equivalent of ncclAllGather / torch.distributed.all_gather_into_tensor.
+//
+//   sendbuff has `sendcount * SizeOf(dtype)` bytes of input on every rank.
+//   recvbuff has `npes * sendcount * SizeOf(dtype)` bytes of output on every rank.
+//
+// The instance owns the SDMA "communicator" state (symmetric input/output
+// transit buffers, completion flags) — analogous to ncclComm_t.
+//
+// Example::
+//
+//   AllGatherIntoTensor ag(my_pe, npes, /*max_input_bytes=*/256*1024*1024);
+//   ag(send_ptr, recv_ptr, numel, DataType::kBFloat16, stream);
+//
+// Internally this is a thin dispatcher on top of AllgatherSdma<uint32_t>:
+// the SDMA kernel is byte/uint32-aligned and dtype-agnostic, exactly the
+// way ncclAllGather treats `datatype` only as a multiplier on `sendcount`.
+class AllGatherIntoTensor {
+ public:
+  // Same constructor flavours as AllgatherSdma: either give one combined
+  // transit buffer size (split internally 50/50 between input and output),
+  // or give input/output sizes separately.
+  AllGatherIntoTensor(int my_pe, int npes,
+                      size_t input_buffer_size, size_t output_buffer_size,
+                      bool copy_output_to_user = true);
+
+  AllGatherIntoTensor(int my_pe, int npes,
+                      size_t transit_buffer_size = 512 * 1024 * 1024,
+                      bool copy_output_to_user = true);
+
+  ~AllGatherIntoTensor();
+
+  AllGatherIntoTensor(const AllGatherIntoTensor&) = delete;
+  AllGatherIntoTensor& operator=(const AllGatherIntoTensor&) = delete;
+
+  // ----- ncclAllGather-equivalent entry point -----------------------------
+  //
+  // Returns true on success, false on failure.  Synchronization is the
+  // caller's responsibility (record an event on `stream` and wait on it
+  // from the consumer stream), matching NCCL's own contract.
+  bool operator()(const void* sendbuff, void* recvbuff, size_t sendcount,
+                  DataType dtype, hipStream_t stream = nullptr);
+
+  // ----- Two-phase async path (mirrors AllgatherSdma) ---------------------
+  bool start_async(const void* sendbuff, void* recvbuff, size_t sendcount,
+                   DataType dtype, hipStream_t stream = nullptr);
+  double wait_async(hipStream_t stream = nullptr);
+  bool is_async_in_progress() const;
+  void cancel_async();
+
+  // ----- Direct-write registration (mirrors AllgatherSdma) ----------------
+  //
+  // Collective: every rank must call register/deregister with matching
+  // pointers and sizes for the kernel to bypass the output transit buffer.
+  void register_output_buffer(void* ptr, size_t size);
+  void deregister_output_buffer(void* ptr);
+  bool is_output_registered(void* ptr) const;
+
+  void resetFlags();
+
+  // ----- Introspection ----------------------------------------------------
+  int my_pe() const { return my_pe_; }
+  int npes() const { return npes_; }
+
+  // Exposed for diagnostics / advanced reuse.
+  AllgatherSdma<uint32_t>* impl() { return impl_.get(); }
+
+ private:
+  int my_pe_;
+  int npes_;
+  std::unique_ptr<AllgatherSdma<uint32_t>> impl_;
+};
+
+}  // namespace collective
+}  // namespace mori
+
+#endif  // MORI_COLLECTIVE_ALLGATHER_INTO_TENSOR_HPP

--- a/python/mori/ccl/__init__.py
+++ b/python/mori/ccl/__init__.py
@@ -24,4 +24,23 @@ from .collective import All2allSdma
 from .collective import AllgatherSdma
 from .collective import AllreduceSdma
 
-__all__ = ["All2allSdma", "AllgatherSdma", "AllreduceSdma"]
+# NCCL/RCCL-style C++ AllGather-into-tensor dispatcher.  The class and its
+# DataType enum are implemented entirely in C++ (see
+# ``include/mori/collective/allgather/allgather_into_tensor.hpp`` and
+# ``src/collective/core/allgather_into_tensor.cpp``); we only re-export the
+# pybind11 symbols here so callers can do
+# ``from mori.ccl import AllGatherIntoTensor, DataType``.
+from mori import cpp as _mori_cpp
+
+AllGatherIntoTensor = _mori_cpp.AllGatherIntoTensor
+DataType = _mori_cpp.DataType
+size_of = _mori_cpp.size_of
+
+__all__ = [
+    "All2allSdma",
+    "AllgatherSdma",
+    "AllreduceSdma",
+    "AllGatherIntoTensor",
+    "DataType",
+    "size_of",
+]

--- a/src/collective/CMakeLists.txt
+++ b/src/collective/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Source files list
 set(COLLECTIVE_SOURCES
     core/oneshot_all2all_sdma_class.cpp core/oneshot_allgather_sdma_class.cpp
+    core/allgather_into_tensor.cpp
     core/twoshot_allreduce_sdma_class.cpp
     # Note: intra_node_executor is header-only template class
 )

--- a/src/collective/CMakeLists.txt
+++ b/src/collective/CMakeLists.txt
@@ -1,8 +1,7 @@
 # Source files list
 set(COLLECTIVE_SOURCES
     core/oneshot_all2all_sdma_class.cpp core/oneshot_allgather_sdma_class.cpp
-    core/allgather_into_tensor.cpp
-    core/twoshot_allreduce_sdma_class.cpp
+    core/allgather_into_tensor.cpp core/twoshot_allreduce_sdma_class.cpp
     # Note: intra_node_executor is header-only template class
 )
 

--- a/src/collective/core/allgather_into_tensor.cpp
+++ b/src/collective/core/allgather_into_tensor.cpp
@@ -1,0 +1,155 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mori/collective/allgather/allgather_into_tensor.hpp"
+
+#include <stdexcept>
+
+namespace mori {
+namespace collective {
+
+// ---------------------------------------------------------------------------
+// DataType helpers
+// ---------------------------------------------------------------------------
+size_t SizeOf(DataType dtype) {
+  switch (dtype) {
+    case DataType::kInt8:
+    case DataType::kUint8:
+      return 1;
+    case DataType::kInt16:
+    case DataType::kUint16:
+    case DataType::kFloat16:
+    case DataType::kBFloat16:
+      return 2;
+    case DataType::kInt32:
+    case DataType::kUint32:
+    case DataType::kFloat32:
+      return 4;
+    case DataType::kInt64:
+    case DataType::kUint64:
+    case DataType::kFloat64:
+      return 8;
+  }
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+namespace {
+
+// Convert (sendcount, dtype) into a uint32-element count, throwing if the
+// total byte length isn't a multiple of sizeof(uint32_t).  The underlying
+// SDMA kernel walks the buffer as packed uint32 lanes; non-aligned byte
+// lengths would silently corrupt one or more PEs' shards.
+size_t bytes_to_u32_count(size_t sendcount, DataType dtype) {
+  size_t bytes = sendcount * SizeOf(dtype);
+  if (bytes == 0) return 0;
+  if ((bytes & 0x3u) != 0) {
+    throw std::runtime_error(
+        "AllGatherIntoTensor: per-rank byte length must be a multiple of 4 "
+        "(SDMA kernel walks the buffer as uint32 lanes)");
+  }
+  return bytes / sizeof(uint32_t);
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Constructors / destructor
+// ---------------------------------------------------------------------------
+AllGatherIntoTensor::AllGatherIntoTensor(int my_pe, int npes,
+                                         size_t input_buffer_size,
+                                         size_t output_buffer_size,
+                                         bool copy_output_to_user)
+    : my_pe_(my_pe),
+      npes_(npes),
+      impl_(std::make_unique<AllgatherSdma<uint32_t>>(
+          my_pe, npes, input_buffer_size, output_buffer_size, copy_output_to_user)) {}
+
+AllGatherIntoTensor::AllGatherIntoTensor(int my_pe, int npes,
+                                         size_t transit_buffer_size,
+                                         bool copy_output_to_user)
+    : my_pe_(my_pe),
+      npes_(npes),
+      impl_(std::make_unique<AllgatherSdma<uint32_t>>(
+          my_pe, npes, transit_buffer_size, copy_output_to_user)) {}
+
+AllGatherIntoTensor::~AllGatherIntoTensor() = default;
+
+// ---------------------------------------------------------------------------
+// ncclAllGather-style synchronous entry point
+// ---------------------------------------------------------------------------
+bool AllGatherIntoTensor::operator()(const void* sendbuff, void* recvbuff,
+                                     size_t sendcount, DataType dtype,
+                                     hipStream_t stream) {
+  size_t u32_count = bytes_to_u32_count(sendcount, dtype);
+  // The const_cast is safe: AllgatherSdma::operator() doesn't write through
+  // the input pointer; we drop const only to reuse the existing entry point
+  // (NCCL has the same situation: ncclAllGather declares sendbuff const but
+  // forwards to internal kernels that accept non-const pointers).
+  auto* in = reinterpret_cast<uint32_t*>(const_cast<void*>(sendbuff));
+  auto* out = reinterpret_cast<uint32_t*>(recvbuff);
+  return (*impl_)(in, out, u32_count, stream);
+}
+
+// ---------------------------------------------------------------------------
+// Async two-phase API
+// ---------------------------------------------------------------------------
+bool AllGatherIntoTensor::start_async(const void* sendbuff, void* recvbuff,
+                                      size_t sendcount, DataType dtype,
+                                      hipStream_t stream) {
+  size_t u32_count = bytes_to_u32_count(sendcount, dtype);
+  auto* in = reinterpret_cast<uint32_t*>(const_cast<void*>(sendbuff));
+  auto* out = reinterpret_cast<uint32_t*>(recvbuff);
+  return impl_->start_async(in, out, u32_count, stream);
+}
+
+double AllGatherIntoTensor::wait_async(hipStream_t stream) {
+  return impl_->wait_async(stream);
+}
+
+bool AllGatherIntoTensor::is_async_in_progress() const {
+  return impl_->is_async_in_progress();
+}
+
+void AllGatherIntoTensor::cancel_async() { impl_->cancel_async(); }
+
+// ---------------------------------------------------------------------------
+// External output buffer registration
+// ---------------------------------------------------------------------------
+void AllGatherIntoTensor::register_output_buffer(void* ptr, size_t size) {
+  impl_->register_output_buffer(ptr, size);
+}
+
+void AllGatherIntoTensor::deregister_output_buffer(void* ptr) {
+  impl_->deregister_output_buffer(ptr);
+}
+
+bool AllGatherIntoTensor::is_output_registered(void* ptr) const {
+  return impl_->is_output_registered(ptr);
+}
+
+void AllGatherIntoTensor::resetFlags() { impl_->resetFlags(); }
+
+}  // namespace collective
+}  // namespace mori

--- a/src/collective/core/allgather_into_tensor.cpp
+++ b/src/collective/core/allgather_into_tensor.cpp
@@ -22,6 +22,7 @@
 
 #include "mori/collective/allgather/allgather_into_tensor.hpp"
 
+#include <cstdio>
 #include <stdexcept>
 
 namespace mori {
@@ -80,21 +81,66 @@ size_t bytes_to_u32_count(size_t sendcount, DataType dtype) {
 AllGatherIntoTensor::AllGatherIntoTensor(int my_pe, int npes,
                                          size_t input_buffer_size,
                                          size_t output_buffer_size,
-                                         bool copy_output_to_user)
+                                         bool copy_output_to_user,
+                                         bool auto_register)
     : my_pe_(my_pe),
       npes_(npes),
+      auto_register_(auto_register),
       impl_(std::make_unique<AllgatherSdma<uint32_t>>(
           my_pe, npes, input_buffer_size, output_buffer_size, copy_output_to_user)) {}
 
 AllGatherIntoTensor::AllGatherIntoTensor(int my_pe, int npes,
                                          size_t transit_buffer_size,
-                                         bool copy_output_to_user)
+                                         bool copy_output_to_user,
+                                         bool auto_register)
     : my_pe_(my_pe),
       npes_(npes),
+      auto_register_(auto_register),
       impl_(std::make_unique<AllgatherSdma<uint32_t>>(
           my_pe, npes, transit_buffer_size, copy_output_to_user)) {}
 
 AllGatherIntoTensor::~AllGatherIntoTensor() = default;
+
+// ---------------------------------------------------------------------------
+// maybe_auto_register
+// ---------------------------------------------------------------------------
+//
+// Idempotent best-effort registration of ``recvbuff`` with mori's symmetric
+// memory.  Registration is collective: every rank must call
+// ShmemSymmetricRegister with matching size at the same time.  This method
+// is invoked from inside ``operator()`` / ``start_async``, the natural
+// allgather barrier point — all ranks reach it together, so the collective
+// is well-formed.
+//
+// Discipline expected from the caller:
+//   * The *sequence* of recv buffers passed across allgather calls must
+//     match across ranks (their VAs differ, their order does not).  ZeRO-3
+//     parameter prefetching satisfies this naturally.
+//   * Recv buffers must remain live until shmem_finalize().  We never
+//     deregister, so freeing a buffer and reallocating into the same VA
+//     would silently use a stale IPC mapping.  ZeRO-3's prefetch pool
+//     reuses the same buffers across steps so this is fine in practice.
+//
+// On registration failure we log once and leave the buffer unregistered;
+// the underlying AllgatherSdma falls back to its transit-buffer path,
+// which is still correct, just one hipMemcpyAsync slower.
+void AllGatherIntoTensor::maybe_auto_register(void* recvbuff, size_t output_bytes) {
+  if (!auto_register_ || recvbuff == nullptr) return;
+  if (impl_->is_output_registered(recvbuff)) return;
+  try {
+    impl_->register_output_buffer(recvbuff, output_bytes);
+  } catch (const std::exception& e) {
+    static thread_local bool warned = false;
+    if (!warned) {
+      fprintf(stderr,
+              "[mori] AllGatherIntoTensor PE %d: auto-register failed (%s); "
+              "falling back to transit-buffer path for this and future calls\n",
+              my_pe_, e.what());
+      warned = true;
+    }
+    auto_register_ = false;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // ncclAllGather-style synchronous entry point
@@ -103,6 +149,8 @@ bool AllGatherIntoTensor::operator()(const void* sendbuff, void* recvbuff,
                                      size_t sendcount, DataType dtype,
                                      hipStream_t stream) {
   size_t u32_count = bytes_to_u32_count(sendcount, dtype);
+  size_t output_bytes = sendcount * SizeOf(dtype) * static_cast<size_t>(npes_);
+  maybe_auto_register(recvbuff, output_bytes);
   // The const_cast is safe: AllgatherSdma::operator() doesn't write through
   // the input pointer; we drop const only to reuse the existing entry point
   // (NCCL has the same situation: ncclAllGather declares sendbuff const but
@@ -119,6 +167,8 @@ bool AllGatherIntoTensor::start_async(const void* sendbuff, void* recvbuff,
                                       size_t sendcount, DataType dtype,
                                       hipStream_t stream) {
   size_t u32_count = bytes_to_u32_count(sendcount, dtype);
+  size_t output_bytes = sendcount * SizeOf(dtype) * static_cast<size_t>(npes_);
+  maybe_auto_register(recvbuff, output_bytes);
   auto* in = reinterpret_cast<uint32_t*>(const_cast<void*>(sendbuff));
   auto* out = reinterpret_cast<uint32_t*>(recvbuff);
   return impl_->start_async(in, out, u32_count, stream);

--- a/src/collective/core/allgather_into_tensor.cpp
+++ b/src/collective/core/allgather_into_tensor.cpp
@@ -78,26 +78,22 @@ size_t bytes_to_u32_count(size_t sendcount, DataType dtype) {
 // ---------------------------------------------------------------------------
 // Constructors / destructor
 // ---------------------------------------------------------------------------
-AllGatherIntoTensor::AllGatherIntoTensor(int my_pe, int npes,
-                                         size_t input_buffer_size,
-                                         size_t output_buffer_size,
-                                         bool copy_output_to_user,
+AllGatherIntoTensor::AllGatherIntoTensor(int my_pe, int npes, size_t input_buffer_size,
+                                         size_t output_buffer_size, bool copy_output_to_user,
                                          bool auto_register)
     : my_pe_(my_pe),
       npes_(npes),
       auto_register_(auto_register),
-      impl_(std::make_unique<AllgatherSdma<uint32_t>>(
-          my_pe, npes, input_buffer_size, output_buffer_size, copy_output_to_user)) {}
+      impl_(std::make_unique<AllgatherSdma<uint32_t>>(my_pe, npes, input_buffer_size,
+                                                      output_buffer_size, copy_output_to_user)) {}
 
-AllGatherIntoTensor::AllGatherIntoTensor(int my_pe, int npes,
-                                         size_t transit_buffer_size,
-                                         bool copy_output_to_user,
-                                         bool auto_register)
+AllGatherIntoTensor::AllGatherIntoTensor(int my_pe, int npes, size_t transit_buffer_size,
+                                         bool copy_output_to_user, bool auto_register)
     : my_pe_(my_pe),
       npes_(npes),
       auto_register_(auto_register),
-      impl_(std::make_unique<AllgatherSdma<uint32_t>>(
-          my_pe, npes, transit_buffer_size, copy_output_to_user)) {}
+      impl_(std::make_unique<AllgatherSdma<uint32_t>>(my_pe, npes, transit_buffer_size,
+                                                      copy_output_to_user)) {}
 
 AllGatherIntoTensor::~AllGatherIntoTensor() = default;
 
@@ -145,9 +141,8 @@ void AllGatherIntoTensor::maybe_auto_register(void* recvbuff, size_t output_byte
 // ---------------------------------------------------------------------------
 // ncclAllGather-style synchronous entry point
 // ---------------------------------------------------------------------------
-bool AllGatherIntoTensor::operator()(const void* sendbuff, void* recvbuff,
-                                     size_t sendcount, DataType dtype,
-                                     hipStream_t stream) {
+bool AllGatherIntoTensor::operator()(const void* sendbuff, void* recvbuff, size_t sendcount,
+                                     DataType dtype, hipStream_t stream) {
   size_t u32_count = bytes_to_u32_count(sendcount, dtype);
   size_t output_bytes = sendcount * SizeOf(dtype) * static_cast<size_t>(npes_);
   maybe_auto_register(recvbuff, output_bytes);
@@ -163,9 +158,8 @@ bool AllGatherIntoTensor::operator()(const void* sendbuff, void* recvbuff,
 // ---------------------------------------------------------------------------
 // Async two-phase API
 // ---------------------------------------------------------------------------
-bool AllGatherIntoTensor::start_async(const void* sendbuff, void* recvbuff,
-                                      size_t sendcount, DataType dtype,
-                                      hipStream_t stream) {
+bool AllGatherIntoTensor::start_async(const void* sendbuff, void* recvbuff, size_t sendcount,
+                                      DataType dtype, hipStream_t stream) {
   size_t u32_count = bytes_to_u32_count(sendcount, dtype);
   size_t output_bytes = sendcount * SizeOf(dtype) * static_cast<size_t>(npes_);
   maybe_auto_register(recvbuff, output_bytes);
@@ -174,13 +168,9 @@ bool AllGatherIntoTensor::start_async(const void* sendbuff, void* recvbuff,
   return impl_->start_async(in, out, u32_count, stream);
 }
 
-double AllGatherIntoTensor::wait_async(hipStream_t stream) {
-  return impl_->wait_async(stream);
-}
+double AllGatherIntoTensor::wait_async(hipStream_t stream) { return impl_->wait_async(stream); }
 
-bool AllGatherIntoTensor::is_async_in_progress() const {
-  return impl_->is_async_in_progress();
-}
+bool AllGatherIntoTensor::is_async_in_progress() const { return impl_->is_async_in_progress(); }
 
 void AllGatherIntoTensor::cancel_async() { impl_->cancel_async(); }
 

--- a/src/pybind/pybind_ccl.cpp
+++ b/src/pybind/pybind_ccl.cpp
@@ -26,6 +26,7 @@
 #include <pybind11/stl.h>
 
 #include "mori/collective/all2all/oneshot_all2all_sdma_class.hpp"
+#include "mori/collective/allgather/allgather_into_tensor.hpp"
 #include "mori/collective/allgather/oneshot_allgather_sdma_class.hpp"
 #include "mori/collective/allreduce/twoshot_allreduce_sdma_class.hpp"
 #include "src/pybind/mori.hpp"
@@ -206,6 +207,92 @@ void RegisterMoriCcl(pybind11::module_& m) {
       .def(
           "is_output_registered",
           [](mori::collective::AllgatherSdma<uint32_t>& self, uintptr_t ptr) -> bool {
+            return self.is_output_registered(reinterpret_cast<void*>(ptr));
+          },
+          py::arg("ptr"), "Check whether an output buffer is registered for direct SDMA writes");
+
+  // =========================================================================
+  // AllGatherIntoTensor (NCCL/RCCL-style dispatcher over AllgatherSdma<uint32_t>)
+  // =========================================================================
+  py::enum_<mori::collective::DataType>(m, "DataType")
+      .value("Int8", mori::collective::DataType::kInt8)
+      .value("Uint8", mori::collective::DataType::kUint8)
+      .value("Int16", mori::collective::DataType::kInt16)
+      .value("Uint16", mori::collective::DataType::kUint16)
+      .value("Int32", mori::collective::DataType::kInt32)
+      .value("Uint32", mori::collective::DataType::kUint32)
+      .value("Int64", mori::collective::DataType::kInt64)
+      .value("Uint64", mori::collective::DataType::kUint64)
+      .value("Float16", mori::collective::DataType::kFloat16)
+      .value("BFloat16", mori::collective::DataType::kBFloat16)
+      .value("Float32", mori::collective::DataType::kFloat32)
+      .value("Float64", mori::collective::DataType::kFloat64);
+  m.def("size_of", &mori::collective::SizeOf, py::arg("dtype"),
+        "Return element size in bytes for a mori_cpp.DataType value");
+
+  py::class_<mori::collective::AllGatherIntoTensor>(m, "AllGatherIntoTensor")
+      .def(py::init<int, int, size_t, size_t, bool>(), py::arg("my_pe"), py::arg("npes"),
+           py::arg("input_buffer_size"), py::arg("output_buffer_size"),
+           py::arg("copy_output_to_user") = true,
+           "Construct with separate input/output transit buffer sizes (bytes)")
+      .def(py::init<int, int, size_t, bool>(), py::arg("my_pe"), py::arg("npes"),
+           py::arg("transit_buffer_size") = 512 * 1024 * 1024,
+           py::arg("copy_output_to_user") = true,
+           "Construct with one combined transit buffer size (split 50/50 input/output)")
+      .def_property_readonly("my_pe", &mori::collective::AllGatherIntoTensor::my_pe)
+      .def_property_readonly("npes", &mori::collective::AllGatherIntoTensor::npes)
+      .def(
+          "__call__",
+          [](mori::collective::AllGatherIntoTensor& self, uintptr_t input_ptr,
+             uintptr_t output_ptr, size_t count, mori::collective::DataType dtype,
+             int64_t stream) -> bool {
+            return self(reinterpret_cast<const void*>(input_ptr),
+                        reinterpret_cast<void*>(output_ptr), count, dtype,
+                        reinterpret_cast<hipStream_t>(stream));
+          },
+          py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"), py::arg("dtype"),
+          py::arg("stream") = 0,
+          "ncclAllGather-style synchronous launch: every rank contributes "
+          "`count` elements of `dtype` from `input_ptr`, output of size "
+          "`count * npes` lands at `output_ptr` on every rank.")
+      .def(
+          "start_async",
+          [](mori::collective::AllGatherIntoTensor& self, uintptr_t input_ptr,
+             uintptr_t output_ptr, size_t count, mori::collective::DataType dtype,
+             int64_t stream) -> bool {
+            return self.start_async(reinterpret_cast<const void*>(input_ptr),
+                                    reinterpret_cast<void*>(output_ptr), count, dtype,
+                                    reinterpret_cast<hipStream_t>(stream));
+          },
+          py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"), py::arg("dtype"),
+          py::arg("stream") = 0,
+          "Two-phase async PUT (pair with wait_async)")
+      .def(
+          "wait_async",
+          [](mori::collective::AllGatherIntoTensor& self, int64_t stream) -> double {
+            return self.wait_async(reinterpret_cast<hipStream_t>(stream));
+          },
+          py::arg("stream") = 0,
+          "Two-phase async WAIT; returns elapsed seconds for the operation")
+      .def("is_async_in_progress", &mori::collective::AllGatherIntoTensor::is_async_in_progress)
+      .def("cancel_async", &mori::collective::AllGatherIntoTensor::cancel_async)
+      .def("reset_flags", &mori::collective::AllGatherIntoTensor::resetFlags)
+      .def(
+          "register_output_buffer",
+          [](mori::collective::AllGatherIntoTensor& self, uintptr_t ptr, size_t size) {
+            self.register_output_buffer(reinterpret_cast<void*>(ptr), size);
+          },
+          py::arg("ptr"), py::arg("size"),
+          "Register a GPU buffer as direct SDMA output target (collective)")
+      .def(
+          "deregister_output_buffer",
+          [](mori::collective::AllGatherIntoTensor& self, uintptr_t ptr) {
+            self.deregister_output_buffer(reinterpret_cast<void*>(ptr));
+          },
+          py::arg("ptr"), "Deregister a previously registered output buffer (collective)")
+      .def(
+          "is_output_registered",
+          [](mori::collective::AllGatherIntoTensor& self, uintptr_t ptr) -> bool {
             return self.is_output_registered(reinterpret_cast<void*>(ptr));
           },
           py::arg("ptr"), "Check whether an output buffer is registered for direct SDMA writes");

--- a/src/pybind/pybind_ccl.cpp
+++ b/src/pybind/pybind_ccl.cpp
@@ -241,8 +241,7 @@ void RegisterMoriCcl(pybind11::module_& m) {
            "Construct with one combined transit buffer size (split 50/50 input/output)")
       .def_property_readonly("my_pe", &mori::collective::AllGatherIntoTensor::my_pe)
       .def_property_readonly("npes", &mori::collective::AllGatherIntoTensor::npes)
-      .def_property("auto_register",
-                    &mori::collective::AllGatherIntoTensor::auto_register,
+      .def_property("auto_register", &mori::collective::AllGatherIntoTensor::auto_register,
                     &mori::collective::AllGatherIntoTensor::set_auto_register,
                     "Whether the class lazily registers recv buffers on first sight "
                     "to enable the zero-copy direct-write path. Requires the recv "
@@ -252,9 +251,8 @@ void RegisterMoriCcl(pybind11::module_& m) {
                     "incoherence. Default is False.")
       .def(
           "__call__",
-          [](mori::collective::AllGatherIntoTensor& self, uintptr_t input_ptr,
-             uintptr_t output_ptr, size_t count, mori::collective::DataType dtype,
-             int64_t stream) -> bool {
+          [](mori::collective::AllGatherIntoTensor& self, uintptr_t input_ptr, uintptr_t output_ptr,
+             size_t count, mori::collective::DataType dtype, int64_t stream) -> bool {
             return self(reinterpret_cast<const void*>(input_ptr),
                         reinterpret_cast<void*>(output_ptr), count, dtype,
                         reinterpret_cast<hipStream_t>(stream));
@@ -266,23 +264,20 @@ void RegisterMoriCcl(pybind11::module_& m) {
           "`count * npes` lands at `output_ptr` on every rank.")
       .def(
           "start_async",
-          [](mori::collective::AllGatherIntoTensor& self, uintptr_t input_ptr,
-             uintptr_t output_ptr, size_t count, mori::collective::DataType dtype,
-             int64_t stream) -> bool {
+          [](mori::collective::AllGatherIntoTensor& self, uintptr_t input_ptr, uintptr_t output_ptr,
+             size_t count, mori::collective::DataType dtype, int64_t stream) -> bool {
             return self.start_async(reinterpret_cast<const void*>(input_ptr),
                                     reinterpret_cast<void*>(output_ptr), count, dtype,
                                     reinterpret_cast<hipStream_t>(stream));
           },
           py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"), py::arg("dtype"),
-          py::arg("stream") = 0,
-          "Two-phase async PUT (pair with wait_async)")
+          py::arg("stream") = 0, "Two-phase async PUT (pair with wait_async)")
       .def(
           "wait_async",
           [](mori::collective::AllGatherIntoTensor& self, int64_t stream) -> double {
             return self.wait_async(reinterpret_cast<hipStream_t>(stream));
           },
-          py::arg("stream") = 0,
-          "Two-phase async WAIT; returns elapsed seconds for the operation")
+          py::arg("stream") = 0, "Two-phase async WAIT; returns elapsed seconds for the operation")
       .def("is_async_in_progress", &mori::collective::AllGatherIntoTensor::is_async_in_progress)
       .def("cancel_async", &mori::collective::AllGatherIntoTensor::cancel_async)
       .def("reset_flags", &mori::collective::AllGatherIntoTensor::resetFlags)

--- a/src/pybind/pybind_ccl.cpp
+++ b/src/pybind/pybind_ccl.cpp
@@ -231,16 +231,25 @@ void RegisterMoriCcl(pybind11::module_& m) {
         "Return element size in bytes for a mori_cpp.DataType value");
 
   py::class_<mori::collective::AllGatherIntoTensor>(m, "AllGatherIntoTensor")
-      .def(py::init<int, int, size_t, size_t, bool>(), py::arg("my_pe"), py::arg("npes"),
+      .def(py::init<int, int, size_t, size_t, bool, bool>(), py::arg("my_pe"), py::arg("npes"),
            py::arg("input_buffer_size"), py::arg("output_buffer_size"),
-           py::arg("copy_output_to_user") = true,
+           py::arg("copy_output_to_user") = true, py::arg("auto_register") = false,
            "Construct with separate input/output transit buffer sizes (bytes)")
-      .def(py::init<int, int, size_t, bool>(), py::arg("my_pe"), py::arg("npes"),
+      .def(py::init<int, int, size_t, bool, bool>(), py::arg("my_pe"), py::arg("npes"),
            py::arg("transit_buffer_size") = 512 * 1024 * 1024,
-           py::arg("copy_output_to_user") = true,
+           py::arg("copy_output_to_user") = true, py::arg("auto_register") = false,
            "Construct with one combined transit buffer size (split 50/50 input/output)")
       .def_property_readonly("my_pe", &mori::collective::AllGatherIntoTensor::my_pe)
       .def_property_readonly("npes", &mori::collective::AllGatherIntoTensor::npes)
+      .def_property("auto_register",
+                    &mori::collective::AllGatherIntoTensor::auto_register,
+                    &mori::collective::AllGatherIntoTensor::set_auto_register,
+                    "Whether the class lazily registers recv buffers on first sight "
+                    "to enable the zero-copy direct-write path. Requires the recv "
+                    "buffer to be allocated as uncached device memory (e.g. via "
+                    "mori.shmem.shmem_malloc); cached PyTorch tensors will read back "
+                    "stale (all-zero) data due to GPU L2 cache vs SDMA copy-engine "
+                    "incoherence. Default is False.")
       .def(
           "__call__",
           [](mori::collective::AllGatherIntoTensor& self, uintptr_t input_ptr,

--- a/tests/python/ccl/bench_allgather_into_tensor.py
+++ b/tests/python/ccl/bench_allgather_into_tensor.py
@@ -89,8 +89,15 @@ def _stats(times_ms, *, bytes_per_call):
     return mean, p50, p99, bw
 
 
-def _worker(rank: int, world_size: int, port: int, sizes_bytes, dtype: torch.dtype,
-            warmup: int, iters: int):
+def _worker(
+    rank: int,
+    world_size: int,
+    port: int,
+    sizes_bytes,
+    dtype: torch.dtype,
+    warmup: int,
+    iters: int,
+):
     with TorchDistContext(rank=rank, world_size=world_size, master_port=port):
         shmem.shmem_torch_process_group_init("default")
         device = torch.device(f"cuda:{rank}")
@@ -101,7 +108,8 @@ def _worker(rank: int, world_size: int, port: int, sizes_bytes, dtype: torch.dty
         # round up to 4-byte alignment (SDMA kernel walks uint32 lanes)
         max_per_rank_bytes = (max_per_rank_bytes + 3) & ~0x3
         ag_mori = AllGatherIntoTensor(
-            my_pe=rank, npes=world_size,
+            my_pe=rank,
+            npes=world_size,
             input_buffer_size=max_per_rank_bytes + 4096,
             output_buffer_size=(max_per_rank_bytes + 4096) * world_size,
             copy_output_to_user=True,
@@ -110,18 +118,24 @@ def _worker(rank: int, world_size: int, port: int, sizes_bytes, dtype: torch.dty
         stream = torch.cuda.current_stream()
 
         if rank == 0:
-            print(f"=== bench_allgather_into_tensor "
-                  f"world_size={world_size}  dtype={dtype}  "
-                  f"iters={iters} (warmup={warmup}) ===")
-            print(f"{'output MB':>10}  {'variant':22}"
-                  f"{'mean ms':>10}{'p50 ms':>10}{'p99 ms':>10}{'GB/s':>10}")
+            print(
+                f"=== bench_allgather_into_tensor "
+                f"world_size={world_size}  dtype={dtype}  "
+                f"iters={iters} (warmup={warmup}) ==="
+            )
+            print(
+                f"{'output MB':>10}  {'variant':22}"
+                f"{'mean ms':>10}{'p50 ms':>10}{'p99 ms':>10}{'GB/s':>10}"
+            )
             print("-" * 72)
 
         for total_bytes in sizes_bytes:
             # Free any cached PyTorch tensors from the previous iteration
             # so big sizes don't compound the caching-allocator footprint.
             torch.cuda.empty_cache()
-            per_rank_bytes = (total_bytes // world_size) // dtype.itemsize * dtype.itemsize
+            per_rank_bytes = (
+                (total_bytes // world_size) // dtype.itemsize * dtype.itemsize
+            )
             if per_rank_bytes < 4 or (per_rank_bytes % 4) != 0:
                 continue
             per_rank_numel = per_rank_bytes // dtype.itemsize
@@ -130,13 +144,20 @@ def _worker(rank: int, world_size: int, port: int, sizes_bytes, dtype: torch.dty
             inp = torch.randn(per_rank_numel, device=device).to(dtype).contiguous()
             out_flat = torch.empty(total_numel, dtype=dtype, device=device)
             # list-form: N independent allocations (the case that costs N memcpys)
-            out_list = [torch.empty(per_rank_numel, dtype=dtype, device=device)
-                        for _ in range(world_size)]
+            out_list = [
+                torch.empty(per_rank_numel, dtype=dtype, device=device)
+                for _ in range(world_size)
+            ]
 
             def call_mori_into():
                 # AllGatherIntoTensor: 1 SDMA kernel + 1 D2D memcpy total.
-                ag_mori(inp.data_ptr(), out_flat.data_ptr(),
-                        per_rank_numel, mori_dtype, stream.cuda_stream)
+                ag_mori(
+                    inp.data_ptr(),
+                    out_flat.data_ptr(),
+                    per_rank_numel,
+                    mori_dtype,
+                    stream.cuda_stream,
+                )
 
             def call_mori_list():
                 # Same SDMA kernel, but emulate the all_gather (list) API:
@@ -145,11 +166,16 @@ def _worker(rank: int, world_size: int, port: int, sizes_bytes, dtype: torch.dty
                 # allocated user tensors with N hipMemcpyAsync copies — this
                 # is the cost a hypothetical mori ``AllGather`` (list form)
                 # wrapper would have to pay every call.
-                ag_mori(inp.data_ptr(), out_flat.data_ptr(),
-                        per_rank_numel, mori_dtype, stream.cuda_stream)
+                ag_mori(
+                    inp.data_ptr(),
+                    out_flat.data_ptr(),
+                    per_rank_numel,
+                    mori_dtype,
+                    stream.cuda_stream,
+                )
                 for i in range(world_size):
                     out_list[i].copy_(
-                        out_flat[i * per_rank_numel:(i + 1) * per_rank_numel],
+                        out_flat[i * per_rank_numel : (i + 1) * per_rank_numel],
                         non_blocking=True,
                     )
 
@@ -160,11 +186,16 @@ def _worker(rank: int, world_size: int, port: int, sizes_bytes, dtype: torch.dty
             cat_target = torch.empty(total_numel, dtype=dtype, device=device)
 
             def call_mori_list_then_cat():
-                ag_mori(inp.data_ptr(), out_flat.data_ptr(),
-                        per_rank_numel, mori_dtype, stream.cuda_stream)
+                ag_mori(
+                    inp.data_ptr(),
+                    out_flat.data_ptr(),
+                    per_rank_numel,
+                    mori_dtype,
+                    stream.cuda_stream,
+                )
                 for i in range(world_size):
                     out_list[i].copy_(
-                        out_flat[i * per_rank_numel:(i + 1) * per_rank_numel],
+                        out_flat[i * per_rank_numel : (i + 1) * per_rank_numel],
                         non_blocking=True,
                     )
                 torch.cat(out_list, dim=0, out=cat_target)
@@ -185,39 +216,49 @@ def _worker(rank: int, world_size: int, port: int, sizes_bytes, dtype: torch.dty
 
             # Correctness checks: every variant must reproduce the
             # full contiguous result byte-for-byte.
-            out_flat.zero_(); call_mori_into(); torch.cuda.synchronize()
+            out_flat.zero_()
+            call_mori_into()
+            torch.cuda.synchronize()
             if not torch.equal(out_flat, ref):
                 raise AssertionError(f"rank {rank} mori AG_into_tensor mismatch")
 
-            for t in out_list: t.zero_()
-            call_mori_list(); torch.cuda.synchronize()
+            for t in out_list:
+                t.zero_()
+            call_mori_list()
+            torch.cuda.synchronize()
             for i in range(world_size):
-                slice_ref = ref[i * per_rank_numel:(i + 1) * per_rank_numel]
+                slice_ref = ref[i * per_rank_numel : (i + 1) * per_rank_numel]
                 if not torch.equal(out_list[i], slice_ref):
                     raise AssertionError(f"rank {rank} mori AG_list slot {i} mismatch")
 
-            cat_target.zero_(); call_mori_list_then_cat(); torch.cuda.synchronize()
+            cat_target.zero_()
+            call_mori_list_then_cat()
+            torch.cuda.synchronize()
             if not torch.equal(cat_target, ref):
                 raise AssertionError(f"rank {rank} mori AG_list+cat final mismatch")
 
-            t_mori_into     = _bench_loop(call_mori_into,           warmup=warmup, iters=iters)
-            t_mori_list     = _bench_loop(call_mori_list,           warmup=warmup, iters=iters)
-            t_mori_list_cat = _bench_loop(call_mori_list_then_cat,  warmup=warmup, iters=iters)
+            t_mori_into = _bench_loop(call_mori_into, warmup=warmup, iters=iters)
+            t_mori_list = _bench_loop(call_mori_list, warmup=warmup, iters=iters)
+            t_mori_list_cat = _bench_loop(
+                call_mori_list_then_cat, warmup=warmup, iters=iters
+            )
 
             if rank == 0:
                 mb = total_numel * dtype.itemsize / 1e6
                 bytes_per = total_numel * dtype.itemsize
-                for label, ts in (("mori AG_into_tensor",      t_mori_into),
-                                  ("mori AG_list (1+N)",       t_mori_list),
-                                  ("mori AG_list+cat (1+N+1)", t_mori_list_cat)):
+                for label, ts in (
+                    ("mori AG_into_tensor", t_mori_into),
+                    ("mori AG_list (1+N)", t_mori_list),
+                    ("mori AG_list+cat (1+N+1)", t_mori_list_cat),
+                ):
                     m, p50, p99, bw = _stats(ts, bytes_per_call=bytes_per)
-                    print(f"{mb:>10.2f}  {label:26}"
-                          f"{m:>10.3f}{p50:>10.3f}{p99:>10.3f}{bw:>10.2f}")
+                    print(
+                        f"{mb:>10.2f}  {label:26}"
+                        f"{m:>10.3f}{p50:>10.3f}{p99:>10.3f}{bw:>10.2f}"
+                    )
                 print()
 
         torch.cuda.synchronize()
-        dist.barrier()
-        del ag_mori
         dist.barrier()
         shmem.shmem_finalize()
 
@@ -228,10 +269,13 @@ def main():
     p.add_argument("--dtype", type=str, default="bfloat16")
     p.add_argument("--iters", type=int, default=100)
     p.add_argument("--warmup", type=int, default=20)
-    p.add_argument("--sizes-mb", type=str,
-                   default="1,4,10,40,100",
-                   help="Comma-separated list of total output sizes in MB "
-                        "(matches DS prefetch_bucket_size range).")
+    p.add_argument(
+        "--sizes-mb",
+        type=str,
+        default="1,4,10,40,100",
+        help="Comma-separated list of total output sizes in MB "
+        "(matches DS prefetch_bucket_size range).",
+    )
     args = p.parse_args()
 
     if args.world_size is None:
@@ -246,7 +290,8 @@ def main():
     torch.multiprocessing.spawn(
         _worker,
         args=(args.world_size, port, sizes_bytes, dtype, args.warmup, args.iters),
-        nprocs=args.world_size, join=True,
+        nprocs=args.world_size,
+        join=True,
     )
 
 

--- a/tests/python/ccl/bench_allgather_into_tensor.py
+++ b/tests/python/ccl/bench_allgather_into_tensor.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""DeepSpeed-style benchmark for mori SDMA all_gather_into_tensor.
+
+Measures end-to-end per-call latency and throughput for three variants
+of the same allgather, using the contiguous-output pattern that ZeRO-3
+prefetch buckets actually use (i.e. a single ``torch.empty`` of size
+``world_size * per_rank_numel``):
+
+  1. ``mori_cpp.AllGatherIntoTensor``  - 1 SDMA kernel + 1 D2D memcpy
+  2. ``dist.all_gather_into_tensor``   - RCCL into a single contig tensor
+  3. ``dist.all_gather``               - RCCL into a list of N separate tensors
+                                        (forces N D2D copies internally)
+
+Run with the same shapes DeepSpeed uses for ZeRO-3 fetch buckets
+(``stage3_prefetch_bucket_size`` ranges 1MB..100MB in practice).
+
+Example:
+    python3 -m tests.python.ccl.bench_allgather_into_tensor \\
+        --world-size 8 --dtype bfloat16 --iters 200 \\
+        --sizes-mb 0.5,1,4,10,40,100
+"""
+
+import argparse
+import os
+import statistics
+
+import torch
+import torch.distributed as dist
+
+import mori.shmem as shmem
+from mori.ccl import AllGatherIntoTensor, DataType
+
+from tests.python.utils import TorchDistContext, get_free_port
+
+
+_TORCH_TO_MORI = {
+    torch.bfloat16: DataType.BFloat16,
+    torch.float16: DataType.Float16,
+    torch.float32: DataType.Float32,
+}
+
+
+def _bench_loop(launch_fn, *, warmup: int, iters: int):
+    """Time ``launch_fn`` ``iters`` times on the current CUDA stream.
+
+    Uses CUDA events on each iteration so the timer captures actual
+    GPU-side execution (kernel + memcpy + RCCL collective), not host
+    queue latency.
+    """
+    for _ in range(warmup):
+        launch_fn()
+    torch.cuda.synchronize()
+    starts = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
+    ends = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
+    for i in range(iters):
+        starts[i].record()
+        launch_fn()
+        ends[i].record()
+    torch.cuda.synchronize()
+    return [s.elapsed_time(e) for s, e in zip(starts, ends)]
+
+
+def _stats(times_ms, *, bytes_per_call):
+    mean = statistics.mean(times_ms)
+    p50 = statistics.median(times_ms)
+    p99 = sorted(times_ms)[max(0, int(0.99 * len(times_ms)) - 1)]
+    bw = bytes_per_call / (mean / 1000.0) / 1e9
+    return mean, p50, p99, bw
+
+
+def _worker(rank: int, world_size: int, port: int, sizes_bytes, dtype: torch.dtype,
+            warmup: int, iters: int):
+    with TorchDistContext(rank=rank, world_size=world_size, master_port=port):
+        shmem.shmem_torch_process_group_init("default")
+        device = torch.device(f"cuda:{rank}")
+        torch.cuda.set_device(device)
+
+        max_bytes = max(sizes_bytes)
+        max_per_rank_bytes = max_bytes // world_size  # per-rank shard
+        # round up to 4-byte alignment (SDMA kernel walks uint32 lanes)
+        max_per_rank_bytes = (max_per_rank_bytes + 3) & ~0x3
+        ag_mori = AllGatherIntoTensor(
+            my_pe=rank, npes=world_size,
+            input_buffer_size=max_per_rank_bytes + 4096,
+            output_buffer_size=(max_per_rank_bytes + 4096) * world_size,
+            copy_output_to_user=True,
+        )
+        mori_dtype = _TORCH_TO_MORI[dtype]
+        stream = torch.cuda.current_stream()
+
+        if rank == 0:
+            print(f"=== bench_allgather_into_tensor "
+                  f"world_size={world_size}  dtype={dtype}  "
+                  f"iters={iters} (warmup={warmup}) ===")
+            print(f"{'output MB':>10}  {'variant':22}"
+                  f"{'mean ms':>10}{'p50 ms':>10}{'p99 ms':>10}{'GB/s':>10}")
+            print("-" * 72)
+
+        for total_bytes in sizes_bytes:
+            # Free any cached PyTorch tensors from the previous iteration
+            # so big sizes don't compound the caching-allocator footprint.
+            torch.cuda.empty_cache()
+            per_rank_bytes = (total_bytes // world_size) // dtype.itemsize * dtype.itemsize
+            if per_rank_bytes < 4 or (per_rank_bytes % 4) != 0:
+                continue
+            per_rank_numel = per_rank_bytes // dtype.itemsize
+            total_numel = per_rank_numel * world_size
+
+            inp = torch.randn(per_rank_numel, device=device).to(dtype).contiguous()
+            out_flat = torch.empty(total_numel, dtype=dtype, device=device)
+            # list-form: N independent allocations (the case that costs N memcpys)
+            out_list = [torch.empty(per_rank_numel, dtype=dtype, device=device)
+                        for _ in range(world_size)]
+
+            def call_mori_into():
+                # AllGatherIntoTensor: 1 SDMA kernel + 1 D2D memcpy total.
+                ag_mori(inp.data_ptr(), out_flat.data_ptr(),
+                        per_rank_numel, mori_dtype, stream.cuda_stream)
+
+            def call_mori_list():
+                # Same SDMA kernel, but emulate the all_gather (list) API:
+                # after the kernel writes the gathered shards into the flat
+                # transit/staging buffer, scatter them out into N separately
+                # allocated user tensors with N hipMemcpyAsync copies — this
+                # is the cost a hypothetical mori ``AllGather`` (list form)
+                # wrapper would have to pay every call.
+                ag_mori(inp.data_ptr(), out_flat.data_ptr(),
+                        per_rank_numel, mori_dtype, stream.cuda_stream)
+                for i in range(world_size):
+                    out_list[i].copy_(
+                        out_flat[i * per_rank_numel:(i + 1) * per_rank_numel],
+                        non_blocking=True,
+                    )
+
+            # End-to-end equivalent of "list-form allgather + the consumer
+            # actually wanting a contiguous tensor" — i.e. what DS / GEMM
+            # would need.  Pays N scatter copies + one final torch.cat
+            # (another ~world_size_bytes worth of D2D copy traffic).
+            cat_target = torch.empty(total_numel, dtype=dtype, device=device)
+
+            def call_mori_list_then_cat():
+                ag_mori(inp.data_ptr(), out_flat.data_ptr(),
+                        per_rank_numel, mori_dtype, stream.cuda_stream)
+                for i in range(world_size):
+                    out_list[i].copy_(
+                        out_flat[i * per_rank_numel:(i + 1) * per_rank_numel],
+                        non_blocking=True,
+                    )
+                torch.cat(out_list, dim=0, out=cat_target)
+
+            def call_rccl_into():
+                dist.all_gather_into_tensor(out_flat, inp)
+
+            def call_rccl_list():
+                dist.all_gather(out_list, inp)
+
+            # Sanity check: every mori variant must agree byte-for-byte
+            # with the RCCL reference on the very first call.
+            torch.cuda.synchronize()
+            dist.barrier()
+            call_rccl_into()
+            torch.cuda.synchronize()
+            ref = out_flat.clone()
+
+            # Correctness checks: every variant must reproduce the
+            # full contiguous result byte-for-byte.
+            out_flat.zero_(); call_mori_into(); torch.cuda.synchronize()
+            if not torch.equal(out_flat, ref):
+                raise AssertionError(f"rank {rank} mori AG_into_tensor mismatch")
+
+            for t in out_list: t.zero_()
+            call_mori_list(); torch.cuda.synchronize()
+            for i in range(world_size):
+                slice_ref = ref[i * per_rank_numel:(i + 1) * per_rank_numel]
+                if not torch.equal(out_list[i], slice_ref):
+                    raise AssertionError(f"rank {rank} mori AG_list slot {i} mismatch")
+
+            cat_target.zero_(); call_mori_list_then_cat(); torch.cuda.synchronize()
+            if not torch.equal(cat_target, ref):
+                raise AssertionError(f"rank {rank} mori AG_list+cat final mismatch")
+
+            t_mori_into     = _bench_loop(call_mori_into,           warmup=warmup, iters=iters)
+            t_mori_list     = _bench_loop(call_mori_list,           warmup=warmup, iters=iters)
+            t_mori_list_cat = _bench_loop(call_mori_list_then_cat,  warmup=warmup, iters=iters)
+
+            if rank == 0:
+                mb = total_numel * dtype.itemsize / 1e6
+                bytes_per = total_numel * dtype.itemsize
+                for label, ts in (("mori AG_into_tensor",      t_mori_into),
+                                  ("mori AG_list (1+N)",       t_mori_list),
+                                  ("mori AG_list+cat (1+N+1)", t_mori_list_cat)):
+                    m, p50, p99, bw = _stats(ts, bytes_per_call=bytes_per)
+                    print(f"{mb:>10.2f}  {label:26}"
+                          f"{m:>10.3f}{p50:>10.3f}{p99:>10.3f}{bw:>10.2f}")
+                print()
+
+        torch.cuda.synchronize()
+        dist.barrier()
+        del ag_mori
+        dist.barrier()
+        shmem.shmem_finalize()
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--world-size", type=int, default=None)
+    p.add_argument("--dtype", type=str, default="bfloat16")
+    p.add_argument("--iters", type=int, default=100)
+    p.add_argument("--warmup", type=int, default=20)
+    p.add_argument("--sizes-mb", type=str,
+                   default="1,4,10,40,100",
+                   help="Comma-separated list of total output sizes in MB "
+                        "(matches DS prefetch_bucket_size range).")
+    args = p.parse_args()
+
+    if args.world_size is None:
+        args.world_size = torch.cuda.device_count()
+    assert args.world_size >= 2
+
+    sizes_bytes = [int(float(s) * 1024 * 1024) for s in args.sizes_mb.split(",")]
+    dtype = getattr(torch, args.dtype)
+
+    os.environ.setdefault("MORI_ENABLE_SDMA", "1")
+    port = get_free_port()
+    torch.multiprocessing.spawn(
+        _worker,
+        args=(args.world_size, port, sizes_bytes, dtype, args.warmup, args.iters),
+        nprocs=args.world_size, join=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/ccl/test_allgather_into_tensor.py
+++ b/tests/python/ccl/test_allgather_into_tensor.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+Unit test for mori::collective::AllGatherIntoTensor (the NCCL/RCCL-style
+C++ dispatcher exposed as ``mori.ccl.AllGatherIntoTensor``).
+
+For each supported dtype we
+
+  1. compute the reference output via ``torch.distributed.all_gather_into_tensor``
+  2. run the mori SDMA path (synchronous and async two-phase)
+  3. assert exact equality with the reference (no tolerance — allgather is
+     a pure data move, no arithmetic).
+
+A small smoke test of the alignment-error path is also exercised
+(int8 with an odd count must raise from C++ because the SDMA kernel
+walks the buffer in uint32 lanes).
+"""
+
+import os
+import traceback
+
+import numpy as np
+import torch
+import torch.distributed as dist
+
+import mori.shmem as shmem
+from mori.ccl import AllGatherIntoTensor, DataType, size_of
+
+from tests.python.utils import TorchDistContext, get_free_port
+
+
+# torch.dtype -> mori_cpp.DataType.
+_TORCH_TO_MORI = {
+    torch.uint8: DataType.Uint8,
+    torch.int8: DataType.Int8,
+    torch.int16: DataType.Int16,
+    torch.int32: DataType.Int32,
+    torch.int64: DataType.Int64,
+    torch.float16: DataType.Float16,
+    torch.bfloat16: DataType.BFloat16,
+    torch.float32: DataType.Float32,
+    torch.float64: DataType.Float64,
+}
+
+
+def _make_input(dtype: torch.dtype, numel: int, rank: int, device) -> torch.Tensor:
+    """Rank-distinct, dtype-friendly input tensor.
+
+    Values must be exactly representable in every dtype we test (the
+    correctness check is bit-exact), so we stick to small-magnitude
+    integers that round-trip through fp16/bf16 without loss.
+    """
+    base = (rank + 1) * 17  # arbitrary, small, dtype-safe
+    if dtype in (torch.float16, torch.bfloat16, torch.float32, torch.float64):
+        ramp = torch.arange(numel, dtype=torch.int32) % 64
+        t = (ramp + base).to(dtype=dtype)
+    else:
+        info = torch.iinfo(dtype) if dtype != torch.uint8 else None
+        ramp = torch.arange(numel, dtype=torch.int64) % 64
+        t = (ramp + base) % (256 if dtype in (torch.uint8, torch.int8) else 1024)
+        t = t.to(dtype=dtype)
+        # int8 / uint8 may have wrapped; that's fine — the reference uses the
+        # same input so equality still holds.
+    return t.contiguous().to(device=device)
+
+
+def _run_one(handle: AllGatherIntoTensor, dtype: torch.dtype, numel: int,
+             rank: int, world_size: int, device, async_mode: bool):
+    """Run a single (dtype, mode) round and assert against torch reference."""
+    mori_dtype = _TORCH_TO_MORI[dtype]
+
+    inp = _make_input(dtype, numel, rank, device)
+    out_mori = torch.empty(numel * world_size, dtype=dtype, device=device)
+    out_ref = torch.empty(numel * world_size, dtype=dtype, device=device)
+
+    # Reference path — RCCL via torch.distributed.
+    dist.all_gather_into_tensor(out_ref, inp)
+
+    # Mori SDMA path on the current compute stream, then make the verifying
+    # code path wait on the same stream (mirrors what DeepSpeed does).
+    stream = torch.cuda.current_stream()
+    if async_mode:
+        ok = handle.start_async(inp.data_ptr(), out_mori.data_ptr(),
+                                numel, mori_dtype, stream.cuda_stream)
+        assert ok, f"start_async failed for dtype={dtype}, async={async_mode}"
+        elapsed = handle.wait_async(stream.cuda_stream)
+        assert elapsed >= 0, f"wait_async failed for dtype={dtype}, async={async_mode}"
+    else:
+        ok = handle(inp.data_ptr(), out_mori.data_ptr(), numel, mori_dtype,
+                    stream.cuda_stream)
+        assert ok, f"sync call failed for dtype={dtype}, async={async_mode}"
+    stream.synchronize()
+
+    if not torch.equal(out_mori, out_ref):
+        # Surface a useful diff so the test message is debuggable.
+        diff = (out_mori != out_ref).nonzero(as_tuple=False).flatten()[:8].tolist()
+        raise AssertionError(
+            f"mori AllGatherIntoTensor mismatch for dtype={dtype} "
+            f"async={async_mode}: first mismatching positions={diff} "
+            f"got={out_mori[diff].tolist()} ref={out_ref[diff].tolist()}"
+        )
+
+
+def _check_alignment_error(handle: AllGatherIntoTensor, device):
+    """Per-rank byte length must be a multiple of 4; otherwise C++ raises."""
+    inp = torch.zeros(3, dtype=torch.int8, device=device)         # 3 bytes
+    out = torch.zeros(3 * 8, dtype=torch.int8, device=device)
+    raised = False
+    try:
+        handle(inp.data_ptr(), out.data_ptr(), 3, DataType.Int8, 0)
+    except RuntimeError:
+        raised = True
+    assert raised, "Expected RuntimeError for non-uint32-aligned input bytes"
+
+
+def _worker(rank: int, world_size: int, port: int, numel: int,
+            dtypes: list, async_modes: list, auto_register: bool):
+    """Body executed in each spawned process."""
+    with TorchDistContext(rank=rank, world_size=world_size, master_port=port):
+        shmem.shmem_torch_process_group_init("default")
+
+        device = torch.device(f"cuda:{rank}")
+        torch.cuda.set_device(device)
+
+        # Size the transit buffers to the largest dtype × numel we'll see.
+        max_dtype_bytes = max(t.itemsize for t in dtypes)
+        # Pad up so shape changes don't trigger reallocation inside mori.
+        per_rank_bytes = numel * max_dtype_bytes + 4096
+        handle = AllGatherIntoTensor(
+            my_pe=rank,
+            npes=world_size,
+            input_buffer_size=per_rank_bytes,
+            output_buffer_size=per_rank_bytes * world_size,
+            copy_output_to_user=True,
+            auto_register=auto_register,
+        )
+        if rank == 0:
+            print(f"  auto_register={auto_register}")
+
+        try:
+            for dtype in dtypes:
+                # Skip dtypes whose total per-rank byte count isn't 4-byte
+                # aligned: the SDMA kernel walks uint32 lanes and the C++
+                # entry rejects them on purpose.
+                if (numel * dtype.itemsize) % 4 != 0:
+                    continue
+                for async_mode in async_modes:
+                    _run_one(handle, dtype, numel, rank, world_size, device,
+                             async_mode)
+                    if rank == 0:
+                        print(f"  ok dtype={dtype}, async={async_mode}, "
+                              f"numel={numel}")
+
+            _check_alignment_error(handle, device)
+            if rank == 0:
+                print("  ok alignment-error path")
+
+            torch.cuda.synchronize()
+            dist.barrier()
+            if rank == 0:
+                print("test_allgather_into_tensor: PASSED")
+        finally:
+            torch.cuda.synchronize()
+            dist.barrier()
+            del handle
+            dist.barrier()
+            shmem.shmem_finalize()
+
+
+def test_allgather_into_tensor(numel: int = 1024, world_size: int = None,
+                               dtypes=None, async_modes=None,
+                               auto_register: bool = False):
+    """Pytest-friendly entry point.
+
+    Defaults to a small problem (numel=1024) and the local visible GPU
+    count so the test fits a CI box; tweak via CLI for perf sweeps.
+
+    ``auto_register`` defaults to False to match the C++ default — direct
+    SDMA writes into a registered user buffer only produce correct values
+    when the buffer is uncached device memory.  PyTorch's caching
+    allocator is cached, so the test allocates output via ``torch.empty``
+    and would otherwise read stale (all-zero) data from L2.  Pass True
+    only when ``out_mori`` is allocated through ``mori.shmem.shmem_malloc``
+    (or another uncached allocator).
+    """
+    if world_size is None:
+        world_size = torch.cuda.device_count()
+    assert world_size >= 2, (
+        f"AllGatherIntoTensor needs >=2 GPUs, got {world_size}"
+    )
+    if dtypes is None:
+        dtypes = [
+            torch.uint8, torch.int8,
+            torch.int16,
+            torch.int32,
+            torch.float16, torch.bfloat16,
+            torch.float32, torch.float64,
+            torch.int64,
+        ]
+    if async_modes is None:
+        async_modes = [False, True]
+
+    os.environ.setdefault("MORI_ENABLE_SDMA", "1")
+    port = get_free_port()
+    torch.multiprocessing.spawn(
+        _worker,
+        args=(world_size, port, numel, dtypes, async_modes, auto_register),
+        nprocs=world_size,
+        join=True,
+    )
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Unit test for mori::collective::AllGatherIntoTensor",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--numel", type=int, default=1024,
+                        help="Per-rank element count")
+    parser.add_argument("--world-size", type=int, default=None,
+                        help="Number of ranks (default: torch.cuda.device_count())")
+    parser.add_argument("--dtype", type=str, default=None,
+                        help="Restrict to a single torch dtype, e.g. bfloat16")
+    parser.add_argument("--auto-register", action="store_true",
+                        help="Enable experimental zero-copy direct-write path "
+                             "(requires uncached recv buffer; cached PyTorch "
+                             "tensors will read back zeros).")
+    args = parser.parse_args()
+
+    if args.dtype is not None:
+        from tests.python.utils import string_to_dtype
+        dtypes = [string_to_dtype(args.dtype)]
+    else:
+        dtypes = None
+
+    try:
+        test_allgather_into_tensor(numel=args.numel, world_size=args.world_size,
+                                   dtypes=dtypes,
+                                   auto_register=args.auto_register)
+    except Exception:
+        traceback.print_exc()
+        raise SystemExit(1)

--- a/tests/python/ccl/test_allgather_into_tensor.py
+++ b/tests/python/ccl/test_allgather_into_tensor.py
@@ -39,12 +39,11 @@ walks the buffer in uint32 lanes).
 import os
 import traceback
 
-import numpy as np
 import torch
 import torch.distributed as dist
 
 import mori.shmem as shmem
-from mori.ccl import AllGatherIntoTensor, DataType, size_of
+from mori.ccl import AllGatherIntoTensor, DataType
 
 from tests.python.utils import TorchDistContext, get_free_port
 
@@ -75,7 +74,6 @@ def _make_input(dtype: torch.dtype, numel: int, rank: int, device) -> torch.Tens
         ramp = torch.arange(numel, dtype=torch.int32) % 64
         t = (ramp + base).to(dtype=dtype)
     else:
-        info = torch.iinfo(dtype) if dtype != torch.uint8 else None
         ramp = torch.arange(numel, dtype=torch.int64) % 64
         t = (ramp + base) % (256 if dtype in (torch.uint8, torch.int8) else 1024)
         t = t.to(dtype=dtype)
@@ -84,8 +82,15 @@ def _make_input(dtype: torch.dtype, numel: int, rank: int, device) -> torch.Tens
     return t.contiguous().to(device=device)
 
 
-def _run_one(handle: AllGatherIntoTensor, dtype: torch.dtype, numel: int,
-             rank: int, world_size: int, device, async_mode: bool):
+def _run_one(
+    handle: AllGatherIntoTensor,
+    dtype: torch.dtype,
+    numel: int,
+    rank: int,
+    world_size: int,
+    device,
+    async_mode: bool,
+):
     """Run a single (dtype, mode) round and assert against torch reference."""
     mori_dtype = _TORCH_TO_MORI[dtype]
 
@@ -100,14 +105,16 @@ def _run_one(handle: AllGatherIntoTensor, dtype: torch.dtype, numel: int,
     # code path wait on the same stream (mirrors what DeepSpeed does).
     stream = torch.cuda.current_stream()
     if async_mode:
-        ok = handle.start_async(inp.data_ptr(), out_mori.data_ptr(),
-                                numel, mori_dtype, stream.cuda_stream)
+        ok = handle.start_async(
+            inp.data_ptr(), out_mori.data_ptr(), numel, mori_dtype, stream.cuda_stream
+        )
         assert ok, f"start_async failed for dtype={dtype}, async={async_mode}"
         elapsed = handle.wait_async(stream.cuda_stream)
         assert elapsed >= 0, f"wait_async failed for dtype={dtype}, async={async_mode}"
     else:
-        ok = handle(inp.data_ptr(), out_mori.data_ptr(), numel, mori_dtype,
-                    stream.cuda_stream)
+        ok = handle(
+            inp.data_ptr(), out_mori.data_ptr(), numel, mori_dtype, stream.cuda_stream
+        )
         assert ok, f"sync call failed for dtype={dtype}, async={async_mode}"
     stream.synchronize()
 
@@ -123,7 +130,7 @@ def _run_one(handle: AllGatherIntoTensor, dtype: torch.dtype, numel: int,
 
 def _check_alignment_error(handle: AllGatherIntoTensor, device):
     """Per-rank byte length must be a multiple of 4; otherwise C++ raises."""
-    inp = torch.zeros(3, dtype=torch.int8, device=device)         # 3 bytes
+    inp = torch.zeros(3, dtype=torch.int8, device=device)  # 3 bytes
     out = torch.zeros(3 * 8, dtype=torch.int8, device=device)
     raised = False
     try:
@@ -133,8 +140,15 @@ def _check_alignment_error(handle: AllGatherIntoTensor, device):
     assert raised, "Expected RuntimeError for non-uint32-aligned input bytes"
 
 
-def _worker(rank: int, world_size: int, port: int, numel: int,
-            dtypes: list, async_modes: list, auto_register: bool):
+def _worker(
+    rank: int,
+    world_size: int,
+    port: int,
+    numel: int,
+    dtypes: list,
+    async_modes: list,
+    auto_register: bool,
+):
     """Body executed in each spawned process."""
     with TorchDistContext(rank=rank, world_size=world_size, master_port=port):
         shmem.shmem_torch_process_group_init("default")
@@ -165,11 +179,11 @@ def _worker(rank: int, world_size: int, port: int, numel: int,
                 if (numel * dtype.itemsize) % 4 != 0:
                     continue
                 for async_mode in async_modes:
-                    _run_one(handle, dtype, numel, rank, world_size, device,
-                             async_mode)
+                    _run_one(handle, dtype, numel, rank, world_size, device, async_mode)
                     if rank == 0:
-                        print(f"  ok dtype={dtype}, async={async_mode}, "
-                              f"numel={numel}")
+                        print(
+                            f"  ok dtype={dtype}, async={async_mode}, " f"numel={numel}"
+                        )
 
             _check_alignment_error(handle, device)
             if rank == 0:
@@ -187,9 +201,13 @@ def _worker(rank: int, world_size: int, port: int, numel: int,
             shmem.shmem_finalize()
 
 
-def test_allgather_into_tensor(numel: int = 1024, world_size: int = None,
-                               dtypes=None, async_modes=None,
-                               auto_register: bool = False):
+def test_allgather_into_tensor(
+    numel: int = 1024,
+    world_size: int = None,
+    dtypes=None,
+    async_modes=None,
+    auto_register: bool = False,
+):
     """Pytest-friendly entry point.
 
     Defaults to a small problem (numel=1024) and the local visible GPU
@@ -205,16 +223,17 @@ def test_allgather_into_tensor(numel: int = 1024, world_size: int = None,
     """
     if world_size is None:
         world_size = torch.cuda.device_count()
-    assert world_size >= 2, (
-        f"AllGatherIntoTensor needs >=2 GPUs, got {world_size}"
-    )
+    assert world_size >= 2, f"AllGatherIntoTensor needs >=2 GPUs, got {world_size}"
     if dtypes is None:
         dtypes = [
-            torch.uint8, torch.int8,
+            torch.uint8,
+            torch.int8,
             torch.int16,
             torch.int32,
-            torch.float16, torch.bfloat16,
-            torch.float32, torch.float64,
+            torch.float16,
+            torch.bfloat16,
+            torch.float32,
+            torch.float64,
             torch.int64,
         ]
     if async_modes is None:
@@ -237,28 +256,44 @@ if __name__ == "__main__":
         description="Unit test for mori::collective::AllGatherIntoTensor",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("--numel", type=int, default=1024,
-                        help="Per-rank element count")
-    parser.add_argument("--world-size", type=int, default=None,
-                        help="Number of ranks (default: torch.cuda.device_count())")
-    parser.add_argument("--dtype", type=str, default=None,
-                        help="Restrict to a single torch dtype, e.g. bfloat16")
-    parser.add_argument("--auto-register", action="store_true",
-                        help="Enable experimental zero-copy direct-write path "
-                             "(requires uncached recv buffer; cached PyTorch "
-                             "tensors will read back zeros).")
+    parser.add_argument(
+        "--numel", type=int, default=1024, help="Per-rank element count"
+    )
+    parser.add_argument(
+        "--world-size",
+        type=int,
+        default=None,
+        help="Number of ranks (default: torch.cuda.device_count())",
+    )
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default=None,
+        help="Restrict to a single torch dtype, e.g. bfloat16",
+    )
+    parser.add_argument(
+        "--auto-register",
+        action="store_true",
+        help="Enable experimental zero-copy direct-write path "
+        "(requires uncached recv buffer; cached PyTorch "
+        "tensors will read back zeros).",
+    )
     args = parser.parse_args()
 
     if args.dtype is not None:
         from tests.python.utils import string_to_dtype
+
         dtypes = [string_to_dtype(args.dtype)]
     else:
         dtypes = None
 
     try:
-        test_allgather_into_tensor(numel=args.numel, world_size=args.world_size,
-                                   dtypes=dtypes,
-                                   auto_register=args.auto_register)
+        test_allgather_into_tensor(
+            numel=args.numel,
+            world_size=args.world_size,
+            dtypes=dtypes,
+            auto_register=args.auto_register,
+        )
     except Exception:
         traceback.print_exc()
         raise SystemExit(1)


### PR DESCRIPTION
## Summary
cc @wuyl1 
Adds `mori::collective::AllGatherIntoTensor`, an `ncclAllGather` /
`torch.distributed.all_gather_into_tensor` style entry point on top of
the existing `AllgatherSdma` SDMA kernel:

```cpp
bool operator()(const void* sendbuff, void* recvbuff,
                size_t sendcount, DataType dtype, hipStream_t stream);
```

It owns one instance of `AllgatherSdma<uint32_t>` and dispatches by
`DataType` to a uint32 byte count, so the SDMA kernel itself is
unchanged. Two-phase async (`start_async` / `wait_async`),
output-buffer registration and `reset_flags` mirror `AllgatherSdma`'s
surface area. This is the API DeepSpeed calls into (companion PR).

## What's added

- `include/mori/collective/allgather/allgather_into_tensor.hpp` —
  class + `DataType` enum (Int8..Float64 / Float16 / BFloat16) +
  `SizeOf`.
- `src/collective/core/allgather_into_tensor.cpp` — implementation.
- `src/pybind/pybind_ccl.cpp` — `mori_cpp.AllGatherIntoTensor`,
  `mori_cpp.DataType`, `mori_cpp.size_of`.
- `python/mori/ccl/__init__.py` — re-exports the above.
  `AllgatherSdma` still exposed; legacy callers unaffected.
- `tests/python/ccl/test_allgather_into_tensor.py` — 8-rank
  correctness UT vs. `torch.distributed.all_gather_into_tensor`,
  every dtype × {sync, async} + alignment-error path.
- `tests/python/ccl/bench_allgather_into_tensor.py` — DS-style
  microbench (numbers below).

## `auto_register` defaults to `false`

Direct SDMA writes bypass GPU L2; PyTorch's caching allocator hands
out cached memory, so direct-write into PyTorch buffers leaves the
consuming kernel reading stale data through L2. The transit-buffer +
`hipMemcpyAsync` path is byte-exact against RCCL and is the correct
default until callers can supply uncached memory (e.g.
`mori.shmem.shmem_malloc`). The flag is documented inline.

## Benchmark — ZeRO-3 fetch-bucket pattern

8× MI300X, intra-node, bf16, 100 iters / 30 warmup, contiguous outputs.

Comparing three same-output-shape variants on the **mori SDMA path**:

- `AG_into_tensor`        — 1 SDMA kernel + 1 D2D memcpy (this PR)
- `AG_list (1+N)`         — kernel + N scatter copies into N independent tensors
- `AG_list+cat (1+N+1)`   — above + final `torch.cat` to recover a contiguous tensor

| total out | AG_into_tensor (ms) | AG_list 1+N (ms) | AG_list+cat 1+N+1 (ms) | speedup vs list | speedup vs list+cat |
|----------:|--------------------:|-----------------:|-----------------------:|----------------:|--------------------:|
|    1 MB   |               0.030 |            0.115 |                  0.129 |          3.83×  |              4.30×  |
|    4 MB   |               0.032 |            0.114 |                  0.128 |          3.56×  |              4.00×  |
|   16 MB   |               0.071 |            0.118 |                  0.128 |          1.66×  |              1.80×  |
|   64 MB   |               0.224 |            0.263 |                  0.293 |          1.17×  |              1.31×  |
|  256 MB   |               0.867 |            1.008 |                  1.177 |          1.16×  |              1.36×  |
|    1 GB   |               3.417 |            3.951 |                  4.650 |          1.16×  |              1.36×  |
|    4 GB   |              13.672 |           15.821 |                 18.012 |          1.16×  |              1.32×  |
|    8 GB   |              27.378 |           32.060 |                 36.849 |          1.17×  |              1.35×  |

≤16 MB is launch-overhead bound (collapses N packets into one);
≥64 MB is bandwidth bound at ~314 GB/s vs ~270 GB/s for the list path.



## Test plan

- [x] UT: byte-exact vs `torch.distributed.all_gather_into_tensor`,
      every dtype × {sync, async}, plus alignment-error path.
- [x] `cmake --build build -j8` clean (42/42).
- [x] DeepSpeed end-to-end (companion PR): GPT-7B ZeRO-3, 100 steps,
      bit-identical loss, throughput within 0.1% of legacy
      `AllgatherSdma`.
