### PR TITLE
io: SQ flow control rework — diagnostics, SqController, session lifecycle

### DIFF
--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -29,6 +29,7 @@
 #include <shared_mutex>
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
 
 #include "mori/io/env.hpp"
 #include "mori/io/logging.hpp"
@@ -137,6 +138,73 @@ static CqeFailureAdvice DescribeCqeFailure(ibv_wc_status status, CqeFailureOrigi
       break;
   }
   return advice;
+}
+
+static bool IsTerminalCqeStatus(ibv_wc_status status) {
+  switch (status) {
+    case IBV_WC_RETRY_EXC_ERR:
+    case IBV_WC_RNR_RETRY_EXC_ERR:
+    case IBV_WC_LOC_QP_OP_ERR:
+    case IBV_WC_REM_ACCESS_ERR:
+    case IBV_WC_REM_INV_REQ_ERR:
+    case IBV_WC_FATAL_ERR:
+      return true;
+    default:
+      return false;
+  }
+}
+
+static void ReleaseSqCredit(const EpPair& ep, int wrCount) {
+  if (wrCount <= 0) return;
+  if (ep.sq) {
+    ep.sq->Release(wrCount);
+  } else if (ep.sqDepth) {
+    ep.sqDepth->fetch_sub(wrCount, std::memory_order_relaxed);
+  }
+}
+
+static bool EpDegraded(const EpPair& ep) {
+  if (ep.sq) return ep.sq->IsDegraded();
+  return ep.degraded && ep.degraded->load(std::memory_order_relaxed);
+}
+
+static void MarkEpDegraded(const EpPair& ep, SqDegradeReason reason) {
+  if (ep.sq) {
+    ep.sq->MarkDegraded(reason);
+  } else if (ep.degraded) {
+    ep.degraded->store(true, std::memory_order_relaxed);
+  }
+}
+
+static void FailUniqueSubmissionMetas(const std::vector<SubmissionRecord>& records,
+                                      const std::string& message) {
+  std::unordered_set<CqCallbackMeta*> seen;
+  for (const auto& record : records) {
+    if (!record.meta || !seen.insert(record.meta.get()).second) continue;
+    if (record.batchSize > 0) {
+      (void)record.meta->finishedBatchSize.fetch_add(static_cast<uint32_t>(record.batchSize),
+                                                     std::memory_order_relaxed);
+    }
+    record.meta->diagnostics.MarkRootCause();
+    LogAsyncTransferFailureIfNeeded(&record.meta->diagnostics,
+                                    static_cast<uint32_t>(StatusCode::ERR_RDMA_OP), message);
+    TransferStatus* statusPtr = record.meta->status;
+    if (statusPtr != nullptr) {
+      statusPtr->Update(StatusCode::ERR_RDMA_OP, message);
+      record.meta->status = nullptr;
+    }
+  }
+}
+
+static void ExtractAndFailOrphanedRecords(const EpPair& ep, const std::string& message) {
+  if (!ep.ledger) return;
+  std::vector<SubmissionRecord> orphaned;
+  ep.ledger->ExtractOrphanedRecords(&orphaned);
+  if (!orphaned.empty()) {
+    MORI_IO_WARN("ProcessOneCqe: failing {} orphaned record(s) on endpoint qpn={}", orphaned.size(),
+                 ep.local.handle.qpn);
+    FailUniqueSubmissionMetas(orphaned, message);
+  }
 }
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -256,12 +324,28 @@ void RdmaManager::DeregisterRemoteMemory(EngineKey ekey, int remRdmaDevId, Memor
 /* ------------------------------------- Endpoint Management ------------------------------------ */
 int RdmaManager::CountEndpoint(EngineKey engine, TopoKeyPair key) {
   std::shared_lock<std::shared_mutex> lock(mu);
-  return remotes[engine].rTable[key].size();
+  auto remoteIt = remotes.find(engine);
+  if (remoteIt == remotes.end()) return 0;
+  auto routeIt = remoteIt->second.rTable.find(key);
+  if (routeIt == remoteIt->second.rTable.end()) return 0;
+  int count = 0;
+  for (const auto& ep : routeIt->second) {
+    if (!ep.sq || !ep.sq->IsTerminalDegraded()) count++;
+  }
+  return count;
 }
 
 EpPairVec RdmaManager::GetAllEndpoint(EngineKey engine, TopoKeyPair key) {
   std::shared_lock<std::shared_mutex> lock(mu);
-  return remotes[engine].rTable[key];
+  EpPairVec healthy;
+  auto remoteIt = remotes.find(engine);
+  if (remoteIt == remotes.end()) return healthy;
+  auto routeIt = remoteIt->second.rTable.find(key);
+  if (routeIt == remoteIt->second.rTable.end()) return healthy;
+  for (const auto& ep : routeIt->second) {
+    if (!ep.sq || !ep.sq->IsTerminalDegraded()) healthy.push_back(ep);
+  }
+  return healthy;
 }
 
 application::RdmaEndpointConfig RdmaManager::GetRdmaEndpointConfig(int devId) {
@@ -354,22 +438,25 @@ EndpointId RdmaManager::ConnectEndpoint(EngineKey remoteKey, int devId,
   deviceCtxs[devId]->ConnectEndpoint(local.handle, remote);
   RemoteEngineMeta& meta = remotes[remoteKey];
   auto epConfig = GetRdmaEndpointConfig(devId);
-  EpPair ep{weight,
+  EndpointId id = nextEndpointId_.fetch_add(1);
+  const int maxSqDepth = static_cast<int>(epConfig.maxMsgsNum);
+  EpPair ep{id,
+            weight,
             devId,
             rdevId,
             remoteKey,
             local,
             remote,
-            std::make_shared<std::atomic<int>>(0),
-            static_cast<int>(epConfig.maxMsgsNum),
-            std::make_shared<std::atomic<bool>>(false),
+            std::make_shared<SqController>(maxSqDepth, GetSqResumeWatermarkWrForDepth(maxSqDepth)),
+            nullptr,
+            maxSqDepth,
+            nullptr,
             std::make_shared<SubmissionLedger>(config.notifPerQp),
             config.qpPerTransfer,
             config.numWorkerThreads,
             std::make_shared<SqCqeDiagnostics>()};
   meta.rTable[topoKey].push_back(ep);
 
-  EndpointId id = nextEndpointId_.fetch_add(1);
   auto rt = std::make_shared<EndpointRuntime>(id, ep);
   endpointsById_[id] = rt;
   return id;
@@ -518,39 +605,34 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
           }
         }
 
-        int mergedBatchSize = 0;
-        int releasedWr = 0;
-        auto meta = ep.ledger ? ep.ledger->ReleaseByCqe(wc[i].wr_id, ep.sqDepth.get(),
-                                                        &mergedBatchSize, &releasedWr)
-                              : nullptr;
-        RecordSqBatchReleaseWr(ep, releasedWr);
-        if (meta) {
-          (void)meta->finishedBatchSize.fetch_add(mergedBatchSize);
-          if (isFlush) {
-            meta->diagnostics.MarkFlushCascade();
-          } else {
-            meta->diagnostics.MarkRootCause();
-          }
-          LogAsyncTransferFailureIfNeeded(&meta->diagnostics,
-                                          static_cast<uint32_t>(StatusCode::ERR_RDMA_OP),
-                                          failureAdvice.ComposeStatusMessage());
-          TransferStatus* statusPtr = meta->status;
-          if (statusPtr != nullptr) {
-            statusPtr->Update(StatusCode::ERR_RDMA_OP, failureAdvice.ComposeStatusMessage());
-            meta->status = nullptr;
-          }
-          if (ep.degraded && ep.degraded->load(std::memory_order_relaxed) && ep.ledger) {
-            const int orphanedReleased = ep.ledger->ReleaseOrphanedByRecovery(ep.sqDepth.get());
-            ep.degraded->store(false, std::memory_order_relaxed);
-            MORI_IO_WARN(
-                "ProcessOneCqe: recovered degraded EP eid={} qpn={} by releasing {} orphaned WRs",
-                rt->id, ep.local.handle.qpn, orphanedReleased);
+        SubmissionRecord record;
+        const bool hasRecord = ep.ledger ? ep.ledger->ReleaseByCqe(wc[i].wr_id, &record) : false;
+        if (hasRecord) {
+          ReleaseSqCredit(ep, record.postedWr);
+          RecordSqBatchReleaseWr(ep, record.postedWr);
+          auto meta = record.meta;
+          if (meta) {
+            (void)meta->finishedBatchSize.fetch_add(static_cast<uint32_t>(record.batchSize),
+                                                    std::memory_order_relaxed);
+            if (isFlush) {
+              meta->diagnostics.MarkFlushCascade();
+            } else {
+              meta->diagnostics.MarkRootCause();
+            }
+            LogAsyncTransferFailureIfNeeded(&meta->diagnostics,
+                                            static_cast<uint32_t>(StatusCode::ERR_RDMA_OP),
+                                            failureAdvice.ComposeStatusMessage());
+            TransferStatus* statusPtr = meta->status;
+            if (statusPtr != nullptr) {
+              statusPtr->Update(StatusCode::ERR_RDMA_OP, failureAdvice.ComposeStatusMessage());
+              meta->status = nullptr;
+            }
           }
         } else if (IsNotifSendWrId(wc[i].wr_id)) {
-          if (ep.sqDepth) ep.sqDepth->fetch_sub(1, std::memory_order_relaxed);
+          ReleaseSqCredit(ep, 1);
           if (!isFlush) {
             MORI_IO_WARN(
-                "ProcessOneCqe: failed notification SEND CQE, transfer_id={}, released 1 sqDepth",
+                "ProcessOneCqe: failed notification SEND CQE, transfer_id={}, released 1 SQ credit",
                 ExtractTransferIdFromWrId(wc[i].wr_id));
           }
         } else if (wc[i].wr_id < config.notifPerQp) {
@@ -562,9 +644,17 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
           if (!isFlush) {
             MORI_IO_WARN(
                 "ProcessOneCqe: failed CQE wr_id={} in ledger range but no record found, "
-                "sqDepth may be stale",
+                "SQ credit may be stale",
                 wc[i].wr_id);
           }
+        }
+        if (!isFlush && IsTerminalCqeStatus(wc[i].status)) {
+          std::unique_lock<std::shared_mutex> recoveryGuard;
+          if (ep.sq) recoveryGuard = ep.sq->AcquireRecoveryGuard();
+          MarkEpDegraded(ep, SqDegradeReason::FatalCqe);
+          ExtractAndFailOrphanedRecords(ep, failureAdvice.ComposeStatusMessage());
+        } else if (EpDegraded(ep) && ep.ledger && ep.ledger->HasOrphaned()) {
+          ExtractAndFailOrphanedRecords(ep, failureAdvice.ComposeStatusMessage());
         }
         continue;
       }
@@ -610,30 +700,34 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
         if (!IsNotifSendWrId(wc[i].wr_id)) {
           MORI_IO_WARN(
               "ProcessOneCqe: unexpected SEND completion with non-notification wr_id {}; "
-              "releasing 1 sqDepth under current SEND invariant",
+              "releasing 1 SQ credit under current SEND invariant",
               wc[i].wr_id);
         }
-        if (ep.sqDepth) ep.sqDepth->fetch_sub(1, std::memory_order_relaxed);
+        ReleaseSqCredit(ep, 1);
       } else {
         // Batch path: wr_id carries a recordId from the SubmissionLedger.
         uint64_t recordId = wc[i].wr_id;
-        int mergedBatchSize = 0;
-        int releasedWr = 0;
-        auto meta = ep.ledger ? ep.ledger->ReleaseByCqe(recordId, ep.sqDepth.get(),
-                                                        &mergedBatchSize, &releasedWr)
-                              : nullptr;
-        RecordSqBatchReleaseWr(ep, releasedWr);
-        if (meta) {
-          uint32_t finishedBefore = meta->finishedBatchSize.fetch_add(mergedBatchSize);
-          TransferStatus* statusPtr = meta->status;
-          if (statusPtr != nullptr && (finishedBefore + mergedBatchSize) == meta->totalBatchSize) {
-            statusPtr->Update(StatusCode::SUCCESS, ibv_wc_status_str(wc[i].status));
+        SubmissionRecord record;
+        const bool hasRecord = ep.ledger ? ep.ledger->ReleaseByCqe(recordId, &record) : false;
+        if (hasRecord) {
+          ReleaseSqCredit(ep, record.postedWr);
+          RecordSqBatchReleaseWr(ep, record.postedWr);
+          auto meta = record.meta;
+          if (meta) {
+            uint32_t finishedBefore = meta->finishedBatchSize.fetch_add(
+                static_cast<uint32_t>(record.batchSize), std::memory_order_relaxed);
+            TransferStatus* statusPtr = meta->status;
+            if (statusPtr != nullptr &&
+                (finishedBefore + static_cast<uint32_t>(record.batchSize)) ==
+                    static_cast<uint32_t>(meta->totalBatchSize)) {
+              statusPtr->Update(StatusCode::SUCCESS, ibv_wc_status_str(wc[i].status));
+            }
+            MORI_IO_TRACE("ProcessOneCqe: batch CQE for task {} total={} finished={} cur={}",
+                          meta->id, meta->totalBatchSize, finishedBefore, record.batchSize);
           }
-          MORI_IO_TRACE("ProcessOneCqe: batch CQE for task {} total={} finished={} cur={}",
-                        meta->id, meta->totalBatchSize, finishedBefore, mergedBatchSize);
         } else {
           MORI_IO_WARN(
-              "ProcessOneCqe: no ledger record for wr_id {} (recordId {}); sqDepth may be stale",
+              "ProcessOneCqe: no ledger record for wr_id {} (recordId {}); SQ credit may be stale",
               wc[i].wr_id, recordId);
         }
       }
@@ -1014,7 +1108,12 @@ void RdmaBackendSession::BatchReadWrite(const SizeVec& localOffsets, const SizeV
   }
 }
 
-bool RdmaBackendSession::Alive() const { return true; }
+bool RdmaBackendSession::Alive() const {
+  for (const auto& ep : eps) {
+    if (ep.sq && ep.sq->IsTerminalDegraded()) return false;
+  }
+  return true;
+}
 
 /* ----------------------------------------------------------------------------------------------
  */
@@ -1078,7 +1177,7 @@ void RdmaBackend::ReadWrite(const MemoryDesc& localDest, size_t localOffset,
                             const MemoryDesc& remoteSrc, size_t remoteOffset, size_t size,
                             TransferStatus* status, TransferUniqueId id, bool isRead) {
   MORI_IO_FUNCTION_TIMER;
-  RdmaBackendSession* sess = GetOrCreateSessionCached(localDest, remoteSrc);
+  auto sess = GetOrCreateSessionCached(localDest, remoteSrc);
   sess->ReadWrite(localOffset, remoteOffset, size, status, id, isRead);
 }
 
@@ -1095,7 +1194,7 @@ void RdmaBackend::BatchReadWrite(const MemoryDesc& localDest, const SizeVec& loc
     return;
   }
 
-  RdmaBackendSession* sess = GetOrCreateSessionCached(localDest, remoteSrc);
+  auto sess = GetOrCreateSessionCached(localDest, remoteSrc);
   sess->BatchReadWrite(localOffsets, remoteOffsets, sizes, status, id, isRead);
 }
 
@@ -1119,7 +1218,7 @@ void RdmaBackend::CreateSession(const MemoryDesc& local, const MemoryDesc& remot
     server->BuildRdmaConn(ekey, kp);
   }
   EpPairVec eps = rdma->GetAllEndpoint(ekey, kp);
-  assert(!eps.empty());
+  assert(static_cast<int>(eps.size()) >= config.qpPerTransfer);
 
   EpPairVec epSet = {eps.begin(), eps.begin() + config.qpPerTransfer};
 
@@ -1147,32 +1246,44 @@ bool RdmaBackend::PopInboundTransferStatus(EngineKey remote, TransferUniqueId id
   return notif->PopInboundTransferStatus(remote, id, status);
 }
 
-RdmaBackendSession* RdmaBackend::GetOrCreateSessionCached(const MemoryDesc& local,
-                                                          const MemoryDesc& remote) {
+std::shared_ptr<RdmaBackendSession> RdmaBackend::GetOrCreateSessionCached(
+    const MemoryDesc& local, const MemoryDesc& remote) {
   SessionCacheKey key{remote.engineKey, local.id, remote.id};
   {
     std::lock_guard<std::mutex> lock(sessionCacheMu);
+    InvalidateUnhealthySessionsLocked();
     auto it = sessionCache.find(key);
     if (it != sessionCache.end()) {
-      return it->second.get();
+      return it->second;
     }
   }
   // create outside lock (CreateSession may allocate / block); then insert
-  auto newSess = std::make_unique<RdmaBackendSession>();
+  auto newSess = std::make_shared<RdmaBackendSession>();
   CreateSession(local, remote, *newSess);
   std::lock_guard<std::mutex> lock(sessionCacheMu);
+  InvalidateUnhealthySessionsLocked();
   auto it = sessionCache.find(key);
   if (it != sessionCache.end()) {
-    return it->second.get();
+    return it->second;
   }
   auto [emplacedIt, inserted] = sessionCache.emplace(key, std::move(newSess));
-  return emplacedIt->second.get();
+  return emplacedIt->second;
 }
 
 void RdmaBackend::InvalidateSessionsForMemory(MemoryUniqueId id) {
   std::lock_guard<std::mutex> lock(sessionCacheMu);
   for (auto it = sessionCache.begin(); it != sessionCache.end();) {
     if (it->first.localMemId == id || it->first.remoteMemId == id) {
+      it = sessionCache.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+void RdmaBackend::InvalidateUnhealthySessionsLocked() {
+  for (auto it = sessionCache.begin(); it != sessionCache.end();) {
+    if (!it->second || !it->second->Alive()) {
       it = sessionCache.erase(it);
     } else {
       ++it;

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -1212,13 +1212,24 @@ void RdmaBackend::CreateSession(const MemoryDesc& local, const MemoryDesc& remot
 
   EngineKey ekey = remote.engineKey;
 
-  // Create a pair of endpoint if none
-  int epNum = rdma->CountEndpoint(ekey, kp);
-  for (int i = 0; i < (config.qpPerTransfer - epNum); i++) {
-    server->BuildRdmaConn(ekey, kp);
+  if (config.qpPerTransfer <= 0) {
+    throw std::runtime_error("RDMA CreateSession requires qpPerTransfer > 0");
   }
-  EpPairVec eps = rdma->GetAllEndpoint(ekey, kp);
-  assert(static_cast<int>(eps.size()) >= config.qpPerTransfer);
+
+  EpPairVec eps;
+  const int maxAttempts = std::max(2, config.qpPerTransfer * 2);
+  for (int attempt = 0; attempt < maxAttempts; ++attempt) {
+    eps = rdma->GetAllEndpoint(ekey, kp);
+    const int missing = config.qpPerTransfer - static_cast<int>(eps.size());
+    if (missing <= 0) break;
+    for (int i = 0; i < missing; ++i) {
+      server->BuildRdmaConn(ekey, kp);
+    }
+  }
+  eps = rdma->GetAllEndpoint(ekey, kp);
+  if (static_cast<int>(eps.size()) < config.qpPerTransfer) {
+    throw std::runtime_error("RDMA CreateSession could not allocate enough healthy endpoints");
+  }
 
   EpPairVec epSet = {eps.begin(), eps.begin() + config.qpPerTransfer};
 

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -168,7 +168,7 @@ static bool EpDegraded(const EpPair& ep) {
   return ep.degraded && ep.degraded->load(std::memory_order_relaxed);
 }
 
-static void MarkEpDegraded(const EpPair& ep, SqDegradeReason reason) {
+static void MarkEpDegradedFromCqe(const EpPair& ep, SqDegradeReason reason) {
   if (ep.sq) {
     ep.sq->MarkDegraded(reason);
   } else if (ep.degraded) {
@@ -176,8 +176,8 @@ static void MarkEpDegraded(const EpPair& ep, SqDegradeReason reason) {
   }
 }
 
-static void FailUniqueSubmissionMetas(const std::vector<SubmissionRecord>& records,
-                                      const std::string& message) {
+static void FailUniqueSubmissionMetasFromCqe(const std::vector<SubmissionRecord>& records,
+                                             const std::string& message) {
   std::unordered_set<CqCallbackMeta*> seen;
   for (const auto& record : records) {
     if (!record.meta || !seen.insert(record.meta.get()).second) continue;
@@ -196,14 +196,14 @@ static void FailUniqueSubmissionMetas(const std::vector<SubmissionRecord>& recor
   }
 }
 
-static void ExtractAndFailOrphanedRecords(const EpPair& ep, const std::string& message) {
+static void ExtractAndFailOrphanedRecordsFromCqe(const EpPair& ep, const std::string& message) {
   if (!ep.ledger) return;
   std::vector<SubmissionRecord> orphaned;
   ep.ledger->ExtractOrphanedRecords(&orphaned);
   if (!orphaned.empty()) {
     MORI_IO_WARN("ProcessOneCqe: failing {} orphaned record(s) on endpoint qpn={}", orphaned.size(),
                  ep.local.handle.qpn);
-    FailUniqueSubmissionMetas(orphaned, message);
+    FailUniqueSubmissionMetasFromCqe(orphaned, message);
   }
 }
 
@@ -440,21 +440,20 @@ EndpointId RdmaManager::ConnectEndpoint(EngineKey remoteKey, int devId,
   auto epConfig = GetRdmaEndpointConfig(devId);
   EndpointId id = nextEndpointId_.fetch_add(1);
   const int maxSqDepth = static_cast<int>(epConfig.maxMsgsNum);
-  EpPair ep{id,
-            weight,
-            devId,
-            rdevId,
-            remoteKey,
-            local,
-            remote,
-            std::make_shared<SqController>(maxSqDepth, GetSqResumeWatermarkWrForDepth(maxSqDepth)),
-            nullptr,
-            maxSqDepth,
-            nullptr,
-            std::make_shared<SubmissionLedger>(config.notifPerQp),
-            config.qpPerTransfer,
-            config.numWorkerThreads,
-            std::make_shared<SqCqeDiagnostics>()};
+  EpPair ep{};
+  ep.endpointId = id;
+  ep.weight = weight;
+  ep.ldevId = devId;
+  ep.rdevId = rdevId;
+  ep.remoteEngineKey = remoteKey;
+  ep.local = local;
+  ep.remote = remote;
+  ep.sq = std::make_shared<SqController>(maxSqDepth, GetSqResumeWatermarkWrForDepth(maxSqDepth));
+  ep.maxSqDepth = maxSqDepth;
+  ep.ledger = std::make_shared<SubmissionLedger>(config.notifPerQp);
+  ep.qpPerTransfer = config.qpPerTransfer;
+  ep.numWorkerThreads = config.numWorkerThreads;
+  ep.sqCqeDiagnostics = std::make_shared<SqCqeDiagnostics>();
   meta.rTable[topoKey].push_back(ep);
 
   auto rt = std::make_shared<EndpointRuntime>(id, ep);
@@ -651,10 +650,10 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
         if (!isFlush && IsTerminalCqeStatus(wc[i].status)) {
           std::unique_lock<std::shared_mutex> recoveryGuard;
           if (ep.sq) recoveryGuard = ep.sq->AcquireRecoveryGuard();
-          MarkEpDegraded(ep, SqDegradeReason::FatalCqe);
-          ExtractAndFailOrphanedRecords(ep, failureAdvice.ComposeStatusMessage());
+          MarkEpDegradedFromCqe(ep, SqDegradeReason::FatalCqe);
+          ExtractAndFailOrphanedRecordsFromCqe(ep, failureAdvice.ComposeStatusMessage());
         } else if (EpDegraded(ep) && ep.ledger && ep.ledger->HasOrphaned()) {
-          ExtractAndFailOrphanedRecords(ep, failureAdvice.ComposeStatusMessage());
+          ExtractAndFailOrphanedRecordsFromCqe(ep, failureAdvice.ComposeStatusMessage());
         }
         continue;
       }
@@ -1228,7 +1227,17 @@ void RdmaBackend::CreateSession(const MemoryDesc& local, const MemoryDesc& remot
   }
   eps = rdma->GetAllEndpoint(ekey, kp);
   if (static_cast<int>(eps.size()) < config.qpPerTransfer) {
-    throw std::runtime_error("RDMA CreateSession could not allocate enough healthy endpoints");
+    std::string message =
+        "RDMA CreateSession could not allocate enough healthy endpoints: remoteEngine=" + ekey +
+        ", localTopo=(" + std::to_string(localKey.deviceId) + "," +
+        std::to_string(static_cast<uint32_t>(localKey.loc)) + "), remoteTopo=(" +
+        std::to_string(remoteKey.deviceId) + "," +
+        std::to_string(static_cast<uint32_t>(remoteKey.loc)) +
+        "), requestedQpPerTransfer=" + std::to_string(config.qpPerTransfer) +
+        ", healthyEndpointCount=" + std::to_string(eps.size()) +
+        ", attempts=" + std::to_string(maxAttempts);
+    MORI_IO_ERROR("{}", message);
+    throw std::runtime_error(std::move(message));
   }
 
   EpPairVec epSet = {eps.begin(), eps.begin() + config.qpPerTransfer};

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -363,7 +363,10 @@ EndpointId RdmaManager::ConnectEndpoint(EngineKey remoteKey, int devId,
             std::make_shared<std::atomic<int>>(0),
             static_cast<int>(epConfig.maxMsgsNum),
             std::make_shared<std::atomic<bool>>(false),
-            std::make_shared<SubmissionLedger>(config.notifPerQp)};
+            std::make_shared<SubmissionLedger>(config.notifPerQp),
+            config.qpPerTransfer,
+            config.numWorkerThreads,
+            std::make_shared<SqCqeDiagnostics>()};
   meta.rTable[topoKey].push_back(ep);
 
   EndpointId id = nextEndpointId_.fetch_add(1);
@@ -469,6 +472,7 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
   const EpPair& ep = rt->ep;
   ibv_cq* cq = ep.local.ibvHandle.cq;
   FlushDrainStats flushDrain;
+  RecordSqPollAttempt(ep);
 
   // Resolve notif context once before the CQ drain loop.
   QpNotifContext* notifCtxPtr = nullptr;
@@ -483,6 +487,7 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
   int n = 0;
 
   while ((n = ibv_poll_cq(cq, batchSize, wc)) > 0) {
+    RecordSqPollCqes(ep, n);
     for (int i = 0; i < n; ++i) {
       if (wc[i].status != IBV_WC_SUCCESS) {
         const bool isFlush = (wc[i].status == IBV_WC_WR_FLUSH_ERR);
@@ -514,9 +519,11 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
         }
 
         int mergedBatchSize = 0;
-        auto meta = ep.ledger
-                        ? ep.ledger->ReleaseByCqe(wc[i].wr_id, ep.sqDepth.get(), &mergedBatchSize)
-                        : nullptr;
+        int releasedWr = 0;
+        auto meta = ep.ledger ? ep.ledger->ReleaseByCqe(wc[i].wr_id, ep.sqDepth.get(),
+                                                        &mergedBatchSize, &releasedWr)
+                              : nullptr;
+        RecordSqBatchReleaseWr(ep, releasedWr);
         if (meta) {
           (void)meta->finishedBatchSize.fetch_add(mergedBatchSize);
           if (isFlush) {
@@ -611,9 +618,11 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
         // Batch path: wr_id carries a recordId from the SubmissionLedger.
         uint64_t recordId = wc[i].wr_id;
         int mergedBatchSize = 0;
-        auto meta = ep.ledger
-                        ? ep.ledger->ReleaseByCqe(recordId, ep.sqDepth.get(), &mergedBatchSize)
-                        : nullptr;
+        int releasedWr = 0;
+        auto meta = ep.ledger ? ep.ledger->ReleaseByCqe(recordId, ep.sqDepth.get(),
+                                                        &mergedBatchSize, &releasedWr)
+                              : nullptr;
+        RecordSqBatchReleaseWr(ep, releasedWr);
         if (meta) {
           uint32_t finishedBefore = meta->finishedBatchSize.fetch_add(mergedBatchSize);
           TransferStatus* statusPtr = meta->status;

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -156,24 +156,18 @@ static bool IsTerminalCqeStatus(ibv_wc_status status) {
 
 static void ReleaseSqCredit(const EpPair& ep, int wrCount) {
   if (wrCount <= 0) return;
-  if (ep.sq) {
-    ep.sq->Release(wrCount);
-  } else if (ep.sqDepth) {
-    ep.sqDepth->fetch_sub(wrCount, std::memory_order_relaxed);
-  }
+  assert(ep.sq != nullptr);
+  ep.sq->Release(wrCount);
 }
 
 static bool EpDegraded(const EpPair& ep) {
-  if (ep.sq) return ep.sq->IsDegraded();
-  return ep.degraded && ep.degraded->load(std::memory_order_relaxed);
+  assert(ep.sq != nullptr);
+  return ep.sq->IsDegraded();
 }
 
 static void MarkEpDegradedFromCqe(const EpPair& ep, SqDegradeReason reason) {
-  if (ep.sq) {
-    ep.sq->MarkDegraded(reason);
-  } else if (ep.degraded) {
-    ep.degraded->store(true, std::memory_order_relaxed);
-  }
+  assert(ep.sq != nullptr);
+  ep.sq->MarkDegraded(reason);
 }
 
 static void FailUniqueSubmissionMetasFromCqe(const std::vector<SubmissionRecord>& records,
@@ -330,7 +324,8 @@ int RdmaManager::CountEndpoint(EngineKey engine, TopoKeyPair key) {
   if (routeIt == remoteIt->second.rTable.end()) return 0;
   int count = 0;
   for (const auto& ep : routeIt->second) {
-    if (!ep.sq || !ep.sq->IsTerminalDegraded()) count++;
+    assert(ep.sq != nullptr);
+    if (!ep.sq->IsTerminalDegraded()) count++;
   }
   return count;
 }
@@ -343,7 +338,8 @@ EpPairVec RdmaManager::GetAllEndpoint(EngineKey engine, TopoKeyPair key) {
   auto routeIt = remoteIt->second.rTable.find(key);
   if (routeIt == remoteIt->second.rTable.end()) return healthy;
   for (const auto& ep : routeIt->second) {
-    if (!ep.sq || !ep.sq->IsTerminalDegraded()) healthy.push_back(ep);
+    assert(ep.sq != nullptr);
+    if (!ep.sq->IsTerminalDegraded()) healthy.push_back(ep);
   }
   return healthy;
 }

--- a/src/io/rdma/backend_impl.hpp
+++ b/src/io/rdma/backend_impl.hpp
@@ -312,8 +312,10 @@ class RdmaBackend : public Backend {
       return seed;
     }
   };
-  RdmaBackendSession* GetOrCreateSessionCached(const MemoryDesc& local, const MemoryDesc& remote);
+  std::shared_ptr<RdmaBackendSession> GetOrCreateSessionCached(const MemoryDesc& local,
+                                                               const MemoryDesc& remote);
   void InvalidateSessionsForMemory(MemoryUniqueId id);
+  void InvalidateUnhealthySessionsLocked();
 
  private:
   EngineKey myEngKey;
@@ -323,7 +325,7 @@ class RdmaBackend : public Backend {
   std::unique_ptr<ControlPlaneServer> server{nullptr};
   std::unique_ptr<Executor> executor{nullptr};
   // session cache
-  std::unordered_map<SessionCacheKey, std::unique_ptr<RdmaBackendSession>, SessionCacheKeyHash>
+  std::unordered_map<SessionCacheKey, std::shared_ptr<RdmaBackendSession>, SessionCacheKeyHash>
       sessionCache;
   std::mutex sessionCacheMu;
 };

--- a/src/io/rdma/common.cpp
+++ b/src/io/rdma/common.cpp
@@ -627,7 +627,7 @@ static bool RecheckSqBeforePost(const EpPair& ep, int reservedWrCount, int epId,
   return true;
 }
 
-static void MarkEpDegraded(const EpPair& ep, SqDegradeReason reason) {
+static void MarkEpDegradedFromSubmitFailure(const EpPair& ep, SqDegradeReason reason) {
   if (ep.sq) {
     ep.sq->MarkDegraded(reason);
   } else if (ep.degraded) {
@@ -635,8 +635,8 @@ static void MarkEpDegraded(const EpPair& ep, SqDegradeReason reason) {
   }
 }
 
-static void FailUniqueSubmissionMetas(const std::vector<SubmissionRecord>& records,
-                                      const std::string& message) {
+static void FailUniqueSubmissionMetasFromSubmitFailure(const std::vector<SubmissionRecord>& records,
+                                                       const std::string& message) {
   std::unordered_set<CqCallbackMeta*> seen;
   for (const auto& record : records) {
     if (!record.meta || !seen.insert(record.meta.get()).second) continue;
@@ -652,12 +652,13 @@ static void FailUniqueSubmissionMetas(const std::vector<SubmissionRecord>& recor
   }
 }
 
-static void ExtractAndFailOrphanedRecords(const EpPair& ep, const std::string& message) {
+static void ExtractAndFailOrphanedRecordsFromSubmitFailure(const EpPair& ep,
+                                                           const std::string& message) {
   if (!ep.ledger) return;
   std::vector<SubmissionRecord> orphaned;
   ep.ledger->ExtractOrphanedRecords(&orphaned);
   if (!orphaned.empty()) {
-    FailUniqueSubmissionMetas(orphaned, message);
+    FailUniqueSubmissionMetasFromSubmitFailure(orphaned, message);
   }
 }
 
@@ -679,7 +680,7 @@ void MovePendingUnsignaledToOrphanedForEndpoint(
 
   std::unique_lock<std::shared_mutex> recoveryGuard;
   if (eps[epId].sq) recoveryGuard = eps[epId].sq->AcquireRecoveryGuard();
-  MarkEpDegraded(eps[epId], SqDegradeReason::PartialPostOrphaned);
+  MarkEpDegradedFromSubmitFailure(eps[epId], SqDegradeReason::PartialPostOrphaned);
 
   MORI_IO_WARN(
       "{}: moving pending unsignaled WRs on ep {} (wrCount={}, mergedReq={}) to orphaned and "
@@ -687,7 +688,7 @@ void MovePendingUnsignaledToOrphanedForEndpoint(
       context != nullptr ? context : "RDMA submit failure", epId, wrCount, mergedReq);
   if (eps[epId].ledger) {
     eps[epId].ledger->InsertOrphaned(wrCount, callbackMeta, static_cast<int>(mergedReq));
-    ExtractAndFailOrphanedRecords(eps[epId], message);
+    ExtractAndFailOrphanedRecordsFromSubmitFailure(eps[epId], message);
   } else {
     MORI_IO_WARN(
         "EP {} has pending unsignaled WRs but no submission ledger; SQ credit may remain stale "

--- a/src/io/rdma/common.cpp
+++ b/src/io/rdma/common.cpp
@@ -674,13 +674,15 @@ void MovePendingUnsignaledToOrphanedForEndpoint(
 
   const int wrCount = epWrsSinceSignal[epId];
   const size_t mergedReq = epMergedSinceSignal[epId];
+  // Close admission before dropping the caller's shared submit guard. The
+  // unique recovery guard below then waits for already-admitted posters to drain.
+  MarkEpDegradedFromSubmitFailure(eps[epId], SqDegradeReason::PartialPostOrphaned);
   if (heldSubmitGuard != nullptr && heldSubmitGuard->owns_lock()) {
     heldSubmitGuard->unlock();
   }
 
   std::unique_lock<std::shared_mutex> recoveryGuard;
   if (eps[epId].sq) recoveryGuard = eps[epId].sq->AcquireRecoveryGuard();
-  MarkEpDegradedFromSubmitFailure(eps[epId], SqDegradeReason::PartialPostOrphaned);
 
   MORI_IO_WARN(
       "{}: moving pending unsignaled WRs on ep {} (wrCount={}, mergedReq={}) to orphaned and "

--- a/src/io/rdma/common.cpp
+++ b/src/io/rdma/common.cpp
@@ -27,7 +27,6 @@
 #include <cstdlib>
 #include <limits>
 #include <numeric>
-#include <thread>
 #include <unordered_set>
 #include <utility>
 
@@ -54,7 +53,7 @@ static int GetSqBackoffTimeoutUs() {
   return kBackoffTimeoutUs;
 }
 
-static int GetSqSignalIntervalWr() {
+int GetSqSignalIntervalWr() {
   static const int kSignalIntervalWr = []() {
     int v = 0;
     const char* raw = std::getenv("MORI_IO_SQ_SIGNAL_INTERVAL_WR");
@@ -120,6 +119,21 @@ static void SetReserveResult(ReserveResult* result, SqReserveFailureKind kind, i
   result->backoffCount = backoffCount;
 }
 
+static void SetAdmissionResult(AdmissionResult* result, AdmissionFailureKind kind, int depth,
+                               int queuedDepth, int requested, int requiredFree,
+                               int effectiveResumeWatermarkWr, int maxDepth, uint64_t epoch) {
+  if (result == nullptr) return;
+  result->kind = kind;
+  result->snapshot.depth = depth;
+  result->snapshot.queuedDepth = queuedDepth;
+  result->snapshot.effectiveLoad = std::max(0, depth) + std::max(0, queuedDepth);
+  result->snapshot.maxDepth = maxDepth;
+  result->snapshot.requested = requested;
+  result->snapshot.requiredFree = requiredFree;
+  result->snapshot.effectiveResumeWatermarkWr = effectiveResumeWatermarkWr;
+  result->snapshot.epoch = epoch;
+}
+
 SqController::SqController(int maxDepth, int resumeWatermark)
     : maxDepth_(std::max(0, maxDepth)),
       resumeWatermark_(maxDepth_ > 0 ? std::max(0, std::min(resumeWatermark, maxDepth_))
@@ -172,7 +186,7 @@ bool SqController::Reserve(int wrCount, ReserveOptions opts, ReserveResult* resu
     }
 
     std::unique_lock<std::mutex> lock(mu_);
-    const uint64_t observedEpoch = epoch_;
+    const uint64_t observedEpoch = epoch_.load(std::memory_order_relaxed);
     auto waitPred = [&]() -> bool {
       if (degraded_.load(std::memory_order_relaxed)) return true;
       int depth = depth_.load(std::memory_order_relaxed);
@@ -183,7 +197,7 @@ bool SqController::Reserve(int wrCount, ReserveOptions opts, ReserveResult* resu
         requiredFree = std::max(requiredFree, resumeWatermark_);
       }
       if (freeSlots >= requiredFree) return true;
-      return epoch_ != observedEpoch;
+      return epoch_.load(std::memory_order_relaxed) != observedEpoch;
     };
     if (!cv_.wait_until(lock, deadline, waitPred)) {
       SetReserveResult(result, SqReserveFailureKind::Timeout, Depth(), wrCount, maxDepth_, backoff);
@@ -221,6 +235,82 @@ void SqController::Release(int wrCount) {
   NotifyStateChangedLocked();
 }
 
+bool SqController::TryAcquireAdmission(int admissionWr, int requiredFree, AdmissionResult* result) {
+  const int requested = admissionWr;
+  if (admissionWr <= 0 || maxDepth_ <= 0) {
+    SetAdmissionResult(result, AdmissionFailureKind::None, Depth(), QueuedDepth(), requested,
+                       requiredFree, std::min(resumeWatermark_, maxDepth_), maxDepth_,
+                       epoch_.load(std::memory_order_relaxed));
+    return true;
+  }
+  if (admissionWr > maxDepth_) {
+    SetAdmissionResult(result, AdmissionFailureKind::ExceedsCapacity, Depth(), QueuedDepth(),
+                       requested, requiredFree, std::min(resumeWatermark_, maxDepth_), maxDepth_,
+                       epoch_.load(std::memory_order_relaxed));
+    return false;
+  }
+
+  int effectiveRequiredFree = requiredFree > 0 ? requiredFree : admissionWr;
+  if (effectiveRequiredFree > maxDepth_) effectiveRequiredFree = maxDepth_;
+  const int effectiveResumeWatermark = std::min(resumeWatermark_, maxDepth_);
+
+  while (true) {
+    if (IsDegraded()) {
+      SetAdmissionResult(result,
+                         IsTerminalDegraded() ? AdmissionFailureKind::TerminalDegraded
+                                              : AdmissionFailureKind::Degraded,
+                         Depth(), QueuedDepth(), requested, effectiveRequiredFree,
+                         effectiveResumeWatermark, maxDepth_,
+                         epoch_.load(std::memory_order_relaxed));
+      return false;
+    }
+
+    int depth = depth_.load(std::memory_order_relaxed);
+    if (depth < 0) depth = 0;
+    int queued = queuedDepth_.load(std::memory_order_relaxed);
+    if (queued < 0) queued = 0;
+    const int effectiveLoad = depth + queued;
+    const int freeSlots = std::max(0, maxDepth_ - effectiveLoad);
+    if (freeSlots < effectiveRequiredFree) {
+      SetAdmissionResult(result, AdmissionFailureKind::NoCapacity, depth, queued, requested,
+                         effectiveRequiredFree, effectiveResumeWatermark, maxDepth_,
+                         epoch_.load(std::memory_order_relaxed));
+      return false;
+    }
+
+    int expected = queued;
+    if (queuedDepth_.compare_exchange_weak(expected, queued + admissionWr,
+                                           std::memory_order_relaxed)) {
+      SetAdmissionResult(result, AdmissionFailureKind::None, depth, queued + admissionWr, requested,
+                         effectiveRequiredFree, effectiveResumeWatermark, maxDepth_,
+                         epoch_.load(std::memory_order_relaxed));
+      return true;
+    }
+  }
+}
+
+void SqController::ReleaseAdmission(int admissionWr) {
+  if (admissionWr <= 0) return;
+  int cur = queuedDepth_.load(std::memory_order_relaxed);
+  while (true) {
+    const int next = std::max(0, cur - admissionWr);
+    if (queuedDepth_.compare_exchange_weak(cur, next, std::memory_order_relaxed)) break;
+  }
+  std::lock_guard<std::mutex> lock(mu_);
+  NotifyStateChangedLocked();
+}
+
+bool SqController::WaitForAdmissionChange(std::chrono::steady_clock::time_point deadline,
+                                          uint64_t observedEpoch) {
+  std::unique_lock<std::mutex> lock(mu_);
+  auto pred = [&]() {
+    return degraded_.load(std::memory_order_relaxed) ||
+           epoch_.load(std::memory_order_relaxed) != observedEpoch;
+  };
+  if (pred()) return true;
+  return cv_.wait_until(lock, deadline, pred);
+}
+
 bool SqController::MarkDegraded(SqDegradeReason reason) {
   bool changed = false;
   {
@@ -252,6 +342,14 @@ std::unique_lock<std::shared_mutex> SqController::AcquireRecoveryGuard() {
 
 int SqController::Depth() const { return depth_.load(std::memory_order_relaxed); }
 
+int SqController::QueuedDepth() const { return queuedDepth_.load(std::memory_order_relaxed); }
+
+int SqController::EffectiveDepth() const {
+  return std::max(0, Depth()) + std::max(0, QueuedDepth());
+}
+
+int SqController::FreeAdmissionSlots() const { return std::max(0, maxDepth_ - EffectiveDepth()); }
+
 int SqController::MaxDepth() const { return maxDepth_; }
 
 bool SqController::IsDegraded() const { return degraded_.load(std::memory_order_relaxed); }
@@ -261,7 +359,7 @@ bool SqController::IsTerminalDegraded() const {
 }
 
 void SqController::NotifyStateChangedLocked() {
-  epoch_++;
+  epoch_.fetch_add(1, std::memory_order_relaxed);
   cv_.notify_all();
 }
 
@@ -284,23 +382,23 @@ void RecordSqBatchReleaseWr(const EpPair& ep, int wrCount) {
 }
 
 static int EpSqDepth(const EpPair& ep) {
-  if (ep.sq) return ep.sq->Depth();
-  return ep.sqDepth ? ep.sqDepth->load(std::memory_order_relaxed) : -1;
+  assert(ep.sq != nullptr);
+  return ep.sq->Depth();
 }
 
 static int EpMaxSqDepth(const EpPair& ep) {
-  if (ep.sq) return ep.sq->MaxDepth();
-  return ep.maxSqDepth;
+  assert(ep.sq != nullptr);
+  return ep.sq->MaxDepth();
 }
 
 static bool EpIsDegraded(const EpPair& ep) {
-  if (ep.sq) return ep.sq->IsDegraded();
-  return ep.degraded && ep.degraded->load(std::memory_order_relaxed);
+  assert(ep.sq != nullptr);
+  return ep.sq->IsDegraded();
 }
 
 static bool EpIsTerminalDegraded(const EpPair& ep) {
-  if (ep.sq) return ep.sq->IsTerminalDegraded();
-  return false;
+  assert(ep.sq != nullptr);
+  return ep.sq->IsTerminalDegraded();
 }
 
 static void SetSqReserveFailureKind(SqReserveFailureKind* out, SqReserveFailureKind kind) {
@@ -323,7 +421,7 @@ static std::string FormatDiagnosticTimeAge(int64_t nowUs, int64_t timestampUs) {
   return std::to_string(std::max<int64_t>(0, nowUs - timestampUs)) + "us_ago";
 }
 
-static std::string BuildSqCqeDiagnosticHint(const EpPair& ep) {
+std::string BuildSqCqeDiagnosticHint(const EpPair& ep) {
   if (!ep.sqCqeDiagnostics) return "SQ/CQE diagnostics unavailable.";
 
   const int64_t nowUs = SteadyClockNowUs();
@@ -481,158 +579,72 @@ static bool TryReserveSqDepth(const EpPair& ep, int wrCount, int epId, const cha
                               std::string* errMsg, SqReserveFailureKind* failureKind = nullptr) {
   if (wrCount <= 0) return true;
   const int kBackoffTimeoutUs = GetSqBackoffTimeoutUs();
-  if (ep.sq) {
-    ReserveOptions opts;
-    opts.timeoutUs = kBackoffTimeoutUs;
-    ReserveResult result;
-    if (ep.sq->Reserve(wrCount, opts, &result)) return true;
+  assert(ep.sq != nullptr);
+  ReserveOptions opts;
+  opts.timeoutUs = kBackoffTimeoutUs;
+  ReserveResult result;
+  if (ep.sq->Reserve(wrCount, opts, &result)) return true;
 
-    SetSqReserveFailureKind(failureKind, result.kind);
-    if (result.kind == SqReserveFailureKind::TerminalDegraded ||
-        result.kind == SqReserveFailureKind::Degraded) {
-      if (errMsg) {
-        *errMsg = EpIsTerminalDegraded(ep) ? "EP is terminal degraded, rejecting new submissions"
-                                           : "EP is degraded, rejecting new submissions";
-      }
-      return false;
+  SetSqReserveFailureKind(failureKind, result.kind);
+  if (result.kind == SqReserveFailureKind::TerminalDegraded ||
+      result.kind == SqReserveFailureKind::Degraded) {
+    if (errMsg) {
+      *errMsg = EpIsTerminalDegraded(ep) ? "EP is terminal degraded, rejecting new submissions"
+                                         : "EP is degraded, rejecting new submissions";
     }
-    if (result.kind == SqReserveFailureKind::ExceedsCapacity) {
-      MORI_IO_WARN("SQ request exceeds capacity ({}): ep={} requested={} max={}", opTag, epId,
-                   wrCount, result.maxDepth);
-      if (errMsg) {
-        *errMsg = "SQ request exceeds capacity (" + std::string(opTag) +
-                  "): ep=" + std::to_string(epId) + " requested=" + std::to_string(wrCount) +
-                  " max=" + std::to_string(result.maxDepth);
-      }
-      return false;
-    }
-    if (result.kind == SqReserveFailureKind::Timeout) {
-      MORI_IO_WARN(
-          "SQ full timeout ({}): ep={} depth={} requested={} max={} after {} us (backoff={})",
-          opTag, epId, result.depth, wrCount, result.maxDepth, kBackoffTimeoutUs,
-          result.backoffCount);
-      if (errMsg) {
-        *errMsg = "SQ full (" + std::string(opTag) + "): ep=" + std::to_string(epId) +
-                  " depth=" + std::to_string(result.depth) +
-                  " requested=" + std::to_string(wrCount) +
-                  " max=" + std::to_string(result.maxDepth);
-      }
-      return false;
-    }
-    if (errMsg) *errMsg = "SQ reserve failed";
     return false;
   }
-
-  if (!ep.sqDepth) return true;
-  if (EpIsDegraded(ep)) {
-    SetSqReserveFailureKind(failureKind, SqReserveFailureKind::Degraded);
-    if (errMsg) *errMsg = "EP is degraded, rejecting new submissions";
-    return false;
-  }
-  const int maxSqDepth = EpMaxSqDepth(ep);
-  if (wrCount > maxSqDepth) {
-    SetSqReserveFailureKind(failureKind, SqReserveFailureKind::ExceedsCapacity);
+  if (result.kind == SqReserveFailureKind::ExceedsCapacity) {
     MORI_IO_WARN("SQ request exceeds capacity ({}): ep={} requested={} max={}", opTag, epId,
-                 wrCount, maxSqDepth);
+                 wrCount, result.maxDepth);
     if (errMsg) {
       *errMsg = "SQ request exceeds capacity (" + std::string(opTag) +
                 "): ep=" + std::to_string(epId) + " requested=" + std::to_string(wrCount) +
-                " max=" + std::to_string(maxSqDepth);
+                " max=" + std::to_string(result.maxDepth);
     }
     return false;
   }
-  const auto deadline =
-      std::chrono::steady_clock::now() + std::chrono::microseconds(kBackoffTimeoutUs);
-  int backoff = 0;
-  int cur = ep.sqDepth->load(std::memory_order_relaxed);
-  if (cur < 0) cur = 0;  // defensive: clamp stale negative depth
-  while (true) {
-    // Re-check degraded state while waiting to avoid accepting new submissions
-    // after another thread has marked this EP as degraded.
-    if (EpIsDegraded(ep)) {
-      SetSqReserveFailureKind(failureKind, SqReserveFailureKind::Degraded);
-      if (errMsg) *errMsg = "EP is degraded, rejecting new submissions";
-      return false;
+  if (result.kind == SqReserveFailureKind::Timeout) {
+    MORI_IO_WARN(
+        "SQ full timeout ({}): ep={} depth={} requested={} max={} after {} us (backoff={})", opTag,
+        epId, result.depth, wrCount, result.maxDepth, kBackoffTimeoutUs, result.backoffCount);
+    if (errMsg) {
+      *errMsg = "SQ full (" + std::string(opTag) + "): ep=" + std::to_string(epId) +
+                " depth=" + std::to_string(result.depth) + " requested=" + std::to_string(wrCount) +
+                " max=" + std::to_string(result.maxDepth);
     }
-    if (cur + wrCount > maxSqDepth) {
-      if (std::chrono::steady_clock::now() >= deadline) {
-        SetSqReserveFailureKind(failureKind, SqReserveFailureKind::Timeout);
-        MORI_IO_WARN(
-            "SQ full timeout ({}): ep={} depth={} requested={} max={} after {} us (backoff={})",
-            opTag, epId, cur, wrCount, maxSqDepth, kBackoffTimeoutUs, backoff);
-        if (errMsg) {
-          *errMsg = "SQ full (" + std::string(opTag) + "): ep=" + std::to_string(epId) +
-                    " depth=" + std::to_string(cur) + " requested=" + std::to_string(wrCount) +
-                    " max=" + std::to_string(maxSqDepth);
-        }
-        return false;
-      }
-      // Phased backoff: short polite yields, then tiny sleeps to reduce CPU burn.
-      if (backoff < 16) {
-        std::this_thread::yield();
-      } else {
-        std::this_thread::sleep_for(std::chrono::microseconds(2));
-      }
-      backoff++;
-      cur = ep.sqDepth->load(std::memory_order_relaxed);
-      continue;
-    }
-    if (ep.sqDepth->compare_exchange_weak(cur, cur + wrCount, std::memory_order_relaxed))
-      return true;
-    if (backoff < 16) {
-      std::this_thread::yield();
-    } else {
-      std::this_thread::sleep_for(std::chrono::microseconds(2));
-    }
-    backoff++;
+    return false;
   }
+  if (errMsg) *errMsg = "SQ reserve failed";
+  return false;
 }
 
 static void ReleaseSqDepth(const EpPair& ep, int wrCount) {
   if (wrCount <= 0) return;
-  if (ep.sq) {
-    ep.sq->Release(wrCount);
-    return;
-  }
-  if (!ep.sqDepth) return;
-  ep.sqDepth->fetch_sub(wrCount, std::memory_order_relaxed);
+  assert(ep.sq != nullptr);
+  ep.sq->Release(wrCount);
 }
 
 static bool RecheckSqBeforePost(const EpPair& ep, int reservedWrCount, int epId, const char* opTag,
                                 std::string* errMsg, SqReserveFailureKind* failureKind = nullptr) {
   if (reservedWrCount <= 0) return true;
-  if (ep.sq) {
-    ReserveResult result;
-    if (ep.sq->RecheckBeforePost(reservedWrCount, &result)) return true;
-    SetSqReserveFailureKind(failureKind, result.kind);
-    if (errMsg) {
-      *errMsg =
-          "EP is " +
-          std::string(result.kind == SqReserveFailureKind::TerminalDegraded ? "terminal degraded"
-                                                                            : "degraded") +
-          ", rejecting reserved " + std::string(opTag) +
-          " submission on ep=" + std::to_string(epId);
-    }
-    return false;
+  assert(ep.sq != nullptr);
+  ReserveResult result;
+  if (ep.sq->RecheckBeforePost(reservedWrCount, &result)) return true;
+  SetSqReserveFailureKind(failureKind, result.kind);
+  if (errMsg) {
+    *errMsg =
+        "EP is " +
+        std::string(result.kind == SqReserveFailureKind::TerminalDegraded ? "terminal degraded"
+                                                                          : "degraded") +
+        ", rejecting reserved " + std::string(opTag) + " submission on ep=" + std::to_string(epId);
   }
-  if (EpIsDegraded(ep)) {
-    ReleaseSqDepth(ep, reservedWrCount);
-    SetSqReserveFailureKind(failureKind, SqReserveFailureKind::Degraded);
-    if (errMsg) {
-      *errMsg = "EP is degraded, rejecting reserved " + std::string(opTag) +
-                " submission on ep=" + std::to_string(epId);
-    }
-    return false;
-  }
-  return true;
+  return false;
 }
 
 static void MarkEpDegradedFromSubmitFailure(const EpPair& ep, SqDegradeReason reason) {
-  if (ep.sq) {
-    ep.sq->MarkDegraded(reason);
-  } else if (ep.degraded) {
-    ep.degraded->store(true, std::memory_order_relaxed);
-  }
+  assert(ep.sq != nullptr);
+  ep.sq->MarkDegraded(reason);
 }
 
 static void FailUniqueSubmissionMetasFromSubmitFailure(const std::vector<SubmissionRecord>& records,
@@ -770,6 +782,69 @@ RdmaOpRet RdmaNotifyTransfer(const EpPairVec& eps, TransferStatus* status, Trans
   return {StatusCode::IN_PROGRESS, ""};
 }
 
+int EstimateMergedWrCount(const SizeVec& localOffsets, const SizeVec& remoteOffsets,
+                          const SizeVec& sizes, uint32_t maxSge) {
+  if ((localOffsets.size() != remoteOffsets.size()) || (sizes.size() != remoteOffsets.size())) {
+    return static_cast<int>(sizes.size());
+  }
+
+  const size_t batchSize = sizes.size();
+  if (batchSize == 0) return 0;
+
+  std::vector<size_t> indices(batchSize);
+  std::iota(indices.begin(), indices.end(), 0);
+  if (!std::is_sorted(remoteOffsets.begin(), remoteOffsets.end())) {
+    std::sort(indices.begin(), indices.end(),
+              [&](size_t a, size_t b) { return remoteOffsets[a] < remoteOffsets[b]; });
+  }
+
+  const uint32_t effectiveMaxSge = std::max(maxSge, 1u);
+  bool hasCurrent = false;
+  uint64_t currentRemoteAddr = 0;
+  uint64_t currentRemoteLength = 0;
+  uint64_t lastSgeLocalAddr = 0;
+  uint64_t lastSgeLength = 0;
+  uint32_t currentSgeCount = 0;
+  int wrCount = 0;
+
+  auto startNewWr = [&](uint64_t remoteAddr, uint64_t localAddr, uint64_t len) {
+    hasCurrent = true;
+    wrCount++;
+    currentRemoteAddr = remoteAddr;
+    currentRemoteLength = len;
+    lastSgeLocalAddr = localAddr;
+    lastSgeLength = len;
+    currentSgeCount = 1;
+  };
+
+  for (size_t i = 0; i < batchSize; ++i) {
+    const size_t idx = indices[i];
+    const uint64_t currentLocalAddr = static_cast<uint64_t>(localOffsets[idx]);
+    const uint64_t remoteAddr = static_cast<uint64_t>(remoteOffsets[idx]);
+    const uint64_t len = static_cast<uint64_t>(sizes[idx]);
+
+    bool merged = false;
+    if (hasCurrent && currentRemoteAddr + currentRemoteLength == remoteAddr) {
+      if (lastSgeLocalAddr + lastSgeLength == currentLocalAddr &&
+          lastSgeLength + len <= std::numeric_limits<uint32_t>::max()) {
+        lastSgeLength += len;
+        currentRemoteLength += len;
+        merged = true;
+      } else if (currentSgeCount < effectiveMaxSge && len <= std::numeric_limits<uint32_t>::max()) {
+        currentSgeCount++;
+        lastSgeLocalAddr = currentLocalAddr;
+        lastSgeLength = len;
+        currentRemoteLength += len;
+        merged = true;
+      }
+    }
+    if (!merged) {
+      startNewWr(remoteAddr, currentLocalAddr, len);
+    }
+  }
+  return wrCount;
+}
+
 RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemoryRegion& local,
                              const SizeVec& localOffsets,
                              const application::RdmaMemoryRegion& remote,
@@ -885,7 +960,7 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
   int minMaxSqDepth = std::numeric_limits<int>::max();
   for (size_t epId = 0; epId < epNum; ++epId) {
     const int maxSqDepth = EpMaxSqDepth(eps[epId]);
-    if ((eps[epId].sq || eps[epId].sqDepth) && maxSqDepth > 0) {
+    if (eps[epId].sq && maxSqDepth > 0) {
       minMaxSqDepth = std::min(minMaxSqDepth, maxSqDepth);
     }
   }
@@ -972,8 +1047,7 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
     bool signalIntervalReached =
         effectiveSignalIntervalWr > 0 && epWrsSinceSignal[epId] >= effectiveSignalIntervalWr;
     const int epMaxSqDepth = EpMaxSqDepth(eps[epId]);
-    bool sqNearFull = (eps[epId].sq || eps[epId].sqDepth) && epMaxSqDepth > 0 &&
-                      (epWrsSinceSignal[epId] >= epMaxSqDepth);
+    bool sqNearFull = eps[epId].sq && epMaxSqDepth > 0 && (epWrsSinceSignal[epId] >= epMaxSqDepth);
     bool needSignal = isLastBatchForEp || signalIntervalReached || sqNearFull;
 
     struct ibv_send_wr& last = mergedWrs[end - 1].wr;

--- a/src/io/rdma/common.cpp
+++ b/src/io/rdma/common.cpp
@@ -21,6 +21,7 @@
 // SOFTWARE.
 #include "src/io/rdma/common.hpp"
 
+#include <algorithm>
 #include <cerrno>
 #include <chrono>
 #include <cstdlib>
@@ -51,9 +52,58 @@ static int GetSqBackoffTimeoutUs() {
   static const int kBackoffTimeoutUs = []() {
     int v = 10000;
     env::Override("MORI_IO_SQ_BACKOFF_TIMEOUT_US", v, mori::env::detail::ParsePositiveInt);
+    const char* raw = std::getenv("MORI_IO_SQ_BACKOFF_TIMEOUT_US");
+    MORI_IO_INFO("MORI_IO_SQ_BACKOFF_TIMEOUT_US raw={} effective={} us",
+                 raw != nullptr ? raw : "<unset>", v);
     return v;
   }();
   return kBackoffTimeoutUs;
+}
+
+static int GetSqSignalIntervalWr() {
+  static const int kSignalIntervalWr = []() {
+    int v = 0;
+    const char* raw = std::getenv("MORI_IO_SQ_SIGNAL_INTERVAL_WR");
+    if (raw != nullptr && raw[0] != '\0') {
+      errno = 0;
+      char* end = nullptr;
+      long parsed = std::strtol(raw, &end, 10);
+      if (end != raw && *end == '\0' && errno == 0 && parsed >= 0 &&
+          parsed <= std::numeric_limits<int>::max()) {
+        v = static_cast<int>(parsed);
+      } else {
+        MORI_IO_WARN("Ignore invalid env MORI_IO_SQ_SIGNAL_INTERVAL_WR={}", raw);
+      }
+    }
+    MORI_IO_INFO("MORI_IO_SQ_SIGNAL_INTERVAL_WR raw={} configured={} WR",
+                 raw != nullptr ? raw : "<unset>", v);
+    return v;
+  }();
+  return kSignalIntervalWr;
+}
+
+static int64_t SteadyClockNowUs() {
+  return std::chrono::duration_cast<std::chrono::microseconds>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+}
+
+void RecordSqPollAttempt(const EpPair& ep) {
+  if (!ep.sqCqeDiagnostics) return;
+  ep.sqCqeDiagnostics->lastPollAttemptTimeUs.store(SteadyClockNowUs(), std::memory_order_relaxed);
+}
+
+void RecordSqPollCqes(const EpPair& ep, int cqeCount) {
+  if (!ep.sqCqeDiagnostics || cqeCount <= 0) return;
+  ep.sqCqeDiagnostics->lastNonEmptyCqeTimeUs.store(SteadyClockNowUs(), std::memory_order_relaxed);
+  ep.sqCqeDiagnostics->recentCqeCount.fetch_add(static_cast<uint64_t>(cqeCount),
+                                                std::memory_order_relaxed);
+}
+
+void RecordSqBatchReleaseWr(const EpPair& ep, int wrCount) {
+  if (!ep.sqCqeDiagnostics || wrCount <= 0) return;
+  ep.sqCqeDiagnostics->recentBatchReleaseWr.fetch_add(static_cast<uint64_t>(wrCount),
+                                                      std::memory_order_relaxed);
 }
 
 static void SetSqReserveFailureKind(SqReserveFailureKind* out, SqReserveFailureKind kind) {
@@ -71,7 +121,37 @@ static std::string BuildNotifyHint() {
          "MORI_IO_ENABLE_NOTIFICATION=0 if inbound notification is not required";
 }
 
-static std::string BuildSqDepthHint(const EpPair& ep, size_t qpCount, int effectivePostBatchSize,
+static std::string FormatDiagnosticTimeAge(int64_t nowUs, int64_t timestampUs) {
+  if (timestampUs <= 0) return "never";
+  return std::to_string(std::max<int64_t>(0, nowUs - timestampUs)) + "us_ago";
+}
+
+static std::string BuildSqCqeDiagnosticHint(const EpPair& ep) {
+  if (!ep.sqCqeDiagnostics) return "SQ/CQE diagnostics unavailable.";
+
+  const int64_t nowUs = SteadyClockNowUs();
+  const int64_t lastPollAttempt =
+      ep.sqCqeDiagnostics->lastPollAttemptTimeUs.load(std::memory_order_relaxed);
+  const int64_t lastNonEmptyCqe =
+      ep.sqCqeDiagnostics->lastNonEmptyCqeTimeUs.load(std::memory_order_relaxed);
+  const uint64_t recentCqeCount =
+      ep.sqCqeDiagnostics->recentCqeCount.exchange(0, std::memory_order_relaxed);
+  const uint64_t recentBatchReleaseWr =
+      ep.sqCqeDiagnostics->recentBatchReleaseWr.exchange(0, std::memory_order_relaxed);
+  const size_t recordCount = ep.ledger ? ep.ledger->RecordCount() : 0;
+  const int sqDepth = ep.sqDepth ? ep.sqDepth->load(std::memory_order_relaxed) : -1;
+
+  return "SQ/CQE diagnostics since previous SQ-full timeout: lastPollAttemptTime=" +
+         FormatDiagnosticTimeAge(nowUs, lastPollAttempt) +
+         ", lastNonEmptyCqeTime=" + FormatDiagnosticTimeAge(nowUs, lastNonEmptyCqe) +
+         ", recentCqeCount=" + std::to_string(recentCqeCount) +
+         ", recentBatchReleaseWr=" + std::to_string(recentBatchReleaseWr) +
+         ", ledgerRecordCount=" + std::to_string(recordCount) +
+         ", currentSqDepth=" + std::to_string(sqDepth) + ".";
+}
+
+static std::string BuildSqDepthHint(const EpPair& ep, size_t workerLocalQpCount,
+                                    int effectivePostBatchSize, int effectiveSignalIntervalWr,
                                     PostSendOpKind opKind, SqReserveFailureKind failureKind) {
   if (failureKind == SqReserveFailureKind::Degraded) return {};
 
@@ -87,6 +167,9 @@ static std::string BuildSqDepthHint(const EpPair& ep, size_t qpCount, int effect
       hint = "try increasing MORI_IO_QP_MAX_SEND_WR";
     }
     hint += ", and " + BuildNotifyHint() + ".";
+    if (failureKind == SqReserveFailureKind::Timeout) {
+      hint += " " + BuildSqCqeDiagnosticHint(ep);
+    }
     return hint;
   }
 
@@ -105,11 +188,23 @@ static std::string BuildSqDepthHint(const EpPair& ep, size_t qpCount, int effect
     hint += ", reducing RdmaBackendConfig::postBatchSize (current effective value " +
             std::to_string(effectivePostBatchSize) + ")";
   }
-  if (qpCount > 0) {
-    hint += ", or increasing RdmaBackendConfig::qpPerTransfer (current transfer uses " +
-            std::to_string(qpCount) + " QP(s)) if additional QPs are available";
+  if (workerLocalQpCount > 0) {
+    const int sessionQpPerTransfer =
+        ep.qpPerTransfer > 0 ? ep.qpPerTransfer : static_cast<int>(workerLocalQpCount);
+    const int numWorkerThreads = ep.numWorkerThreads > 0 ? ep.numWorkerThreads : 0;
+    hint +=
+        ", or increasing RdmaBackendConfig::qpPerTransfer only if additional QPs are "
+        "actually used by workers";
+    hint += " (worker-local QP count for this call=" + std::to_string(workerLocalQpCount) +
+            ", session qpPerTransfer=" + std::to_string(sessionQpPerTransfer) +
+            ", numWorkerThreads=" + std::to_string(numWorkerThreads) + ")";
   }
   hint += ". Current per-QP send WR limit is " + std::to_string(ep.maxSqDepth) + ".";
+  hint += " MORI_IO_SQ_SIGNAL_INTERVAL_WR configured=" + std::to_string(GetSqSignalIntervalWr()) +
+          ", effective=" + std::to_string(effectiveSignalIntervalWr) + " WR.";
+  if (failureKind == SqReserveFailureKind::Timeout) {
+    hint += " " + BuildSqCqeDiagnosticHint(ep);
+  }
   return hint;
 }
 
@@ -268,8 +363,8 @@ RdmaOpRet RdmaNotifyTransfer(const EpPairVec& eps, TransferStatus* status, Trans
   for (size_t i = 0; i < eps.size(); i++) {
     SqReserveFailureKind reserveFailure = SqReserveFailureKind::None;
     if (!TryReserveSqDepth(eps[i], 1, i, "notify", &reserveErr, &reserveFailure)) {
-      AppendHint(&reserveErr, BuildSqDepthHint(eps[i], eps.size(), -1, PostSendOpKind::Notification,
-                                               reserveFailure));
+      AppendHint(&reserveErr, BuildSqDepthHint(eps[i], eps.size(), -1, 0,
+                                               PostSendOpKind::Notification, reserveFailure));
       for (int j = 0; j < reserved; ++j) ReleaseSqDepth(eps[j], 1);
       return {StatusCode::ERR_RDMA_OP, reserveErr};
     }
@@ -422,21 +517,32 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
   size_t mergedWrCount = mergedWrs.size();
   size_t epNum = eps.size();
   size_t epBatchSize = (mergedWrCount + epNum - 1) / epNum;
+  int minMaxSqDepth = std::numeric_limits<int>::max();
+  for (size_t epId = 0; epId < epNum; ++epId) {
+    if (eps[epId].sqDepth && eps[epId].maxSqDepth > 0) {
+      minMaxSqDepth = std::min(minMaxSqDepth, eps[epId].maxSqDepth);
+    }
+  }
 
   if (postBatchSize == -1) {
     postBatchSize = (epBatchSize > static_cast<size_t>(std::numeric_limits<int>::max()))
                         ? std::numeric_limits<int>::max()
                         : static_cast<int>(epBatchSize);
   }
-  {
-    int minMaxSqDepth = std::numeric_limits<int>::max();
-    for (size_t epId = 0; epId < epNum; ++epId) {
-      if (eps[epId].sqDepth && eps[epId].maxSqDepth > 0) {
-        minMaxSqDepth = std::min(minMaxSqDepth, eps[epId].maxSqDepth);
-      }
+  if (minMaxSqDepth != std::numeric_limits<int>::max() && postBatchSize > minMaxSqDepth) {
+    postBatchSize = minMaxSqDepth;
+  }
+
+  int effectiveSignalIntervalWr = 0;
+  const int configuredSignalIntervalWr = GetSqSignalIntervalWr();
+  if (configuredSignalIntervalWr > 0) {
+    effectiveSignalIntervalWr = configuredSignalIntervalWr;
+    if (minMaxSqDepth != std::numeric_limits<int>::max()) {
+      effectiveSignalIntervalWr = std::min(effectiveSignalIntervalWr, minMaxSqDepth);
     }
-    if (minMaxSqDepth != std::numeric_limits<int>::max() && postBatchSize > minMaxSqDepth)
-      postBatchSize = minMaxSqDepth;
+    if (effectiveSignalIntervalWr > 0 && postBatchSize > effectiveSignalIntervalWr) {
+      postBatchSize = effectiveSignalIntervalWr;
+    }
   }
   if (postBatchSize <= 0) postBatchSize = 1;
   int numPostBatch = (mergedWrCount + postBatchSize - 1) / postBatchSize;
@@ -458,8 +564,9 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
     std::string reserveErr;
     SqReserveFailureKind reserveFailure = SqReserveFailureKind::None;
     if (!TryReserveSqDepth(eps[epId], batchWrNum, epId, "batch", &reserveErr, &reserveFailure)) {
-      AppendHint(&reserveErr, BuildSqDepthHint(eps[epId], epNum, postBatchSize,
-                                               PostSendOpKind::BatchData, reserveFailure));
+      AppendHint(&reserveErr,
+                 BuildSqDepthHint(eps[epId], epNum, postBatchSize, effectiveSignalIntervalWr,
+                                  PostSendOpKind::BatchData, reserveFailure));
       return {StatusCode::ERR_RDMA_OP, reserveErr};
     }
 
@@ -475,8 +582,10 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
     epMergedSinceSignal[epId] += mergedReqSize;
 
     bool isLastBatchForEp = ((i + epNum) >= numPostBatch);
+    bool signalIntervalReached =
+        effectiveSignalIntervalWr > 0 && epWrsSinceSignal[epId] >= effectiveSignalIntervalWr;
     bool sqNearFull = eps[epId].sqDepth && (epWrsSinceSignal[epId] >= eps[epId].maxSqDepth);
-    bool needSignal = isLastBatchForEp || sqNearFull;
+    bool needSignal = isLastBatchForEp || signalIntervalReached || sqNearFull;
 
     struct ibv_send_wr& last = mergedWrs[end - 1].wr;
     uint64_t recordId = 0;

--- a/src/io/rdma/common.cpp
+++ b/src/io/rdma/common.cpp
@@ -28,6 +28,7 @@
 #include <limits>
 #include <numeric>
 #include <thread>
+#include <unordered_set>
 #include <utility>
 
 #include "mori/io/env.hpp"
@@ -35,13 +36,6 @@
 
 namespace mori {
 namespace io {
-
-enum class SqReserveFailureKind : uint8_t {
-  None = 0,
-  Degraded,
-  ExceedsCapacity,
-  Timeout,
-};
 
 enum class PostSendOpKind : uint8_t {
   BatchData = 0,
@@ -82,10 +76,193 @@ static int GetSqSignalIntervalWr() {
   return kSignalIntervalWr;
 }
 
+int GetSqResumeWatermarkWrForDepth(int maxDepth) {
+  static const int kResumeWatermarkWr = []() {
+    int v = 0;
+    const char* raw = std::getenv("MORI_IO_SQ_RESUME_WATERMARK_WR");
+    if (raw != nullptr && raw[0] != '\0') {
+      errno = 0;
+      char* end = nullptr;
+      long parsed = std::strtol(raw, &end, 10);
+      if (end != raw && *end == '\0' && errno == 0 && parsed >= 0 &&
+          parsed <= std::numeric_limits<int>::max()) {
+        v = static_cast<int>(parsed);
+      } else {
+        MORI_IO_WARN("Ignore invalid env MORI_IO_SQ_RESUME_WATERMARK_WR={}", raw);
+      }
+    }
+    MORI_IO_INFO("MORI_IO_SQ_RESUME_WATERMARK_WR raw={} configured={} WR",
+                 raw != nullptr ? raw : "<unset>", v);
+    return v;
+  }();
+  if (maxDepth > 0) return std::min(kResumeWatermarkWr, maxDepth);
+  return kResumeWatermarkWr;
+}
+
 static int64_t SteadyClockNowUs() {
   return std::chrono::duration_cast<std::chrono::microseconds>(
              std::chrono::steady_clock::now().time_since_epoch())
       .count();
+}
+
+static bool IsTerminalDegradeReason(SqDegradeReason reason) {
+  return reason == SqDegradeReason::PartialPostOrphaned || reason == SqDegradeReason::FatalCqe ||
+         reason == SqDegradeReason::EndpointTeardown;
+}
+
+static void SetReserveResult(ReserveResult* result, SqReserveFailureKind kind, int depth,
+                             int requested, int maxDepth, int backoffCount) {
+  if (result == nullptr) return;
+  result->kind = kind;
+  result->depth = depth;
+  result->requested = requested;
+  result->maxDepth = maxDepth;
+  result->backoffCount = backoffCount;
+}
+
+SqController::SqController(int maxDepth, int resumeWatermark)
+    : maxDepth_(std::max(0, maxDepth)),
+      resumeWatermark_(maxDepth_ > 0 ? std::max(0, std::min(resumeWatermark, maxDepth_))
+                                     : std::max(0, resumeWatermark)) {}
+
+bool SqController::Reserve(int wrCount, ReserveOptions opts, ReserveResult* result) {
+  SetReserveResult(result, SqReserveFailureKind::None, Depth(), wrCount, maxDepth_, 0);
+  if (wrCount <= 0 || maxDepth_ <= 0) return true;
+  if (wrCount > maxDepth_) {
+    SetReserveResult(result, SqReserveFailureKind::ExceedsCapacity, Depth(), wrCount, maxDepth_, 0);
+    return false;
+  }
+
+  const int timeoutUs = opts.timeoutUs > 0 ? opts.timeoutUs : GetSqBackoffTimeoutUs();
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::microseconds(timeoutUs);
+  int backoff = 0;
+  bool pressureSeen = false;
+
+  while (true) {
+    if (IsDegraded()) {
+      SetReserveResult(result,
+                       IsTerminalDegraded() ? SqReserveFailureKind::TerminalDegraded
+                                            : SqReserveFailureKind::Degraded,
+                       Depth(), wrCount, maxDepth_, backoff);
+      return false;
+    }
+
+    int cur = depth_.load(std::memory_order_relaxed);
+    if (cur < 0) cur = 0;
+    const int freeSlots = std::max(0, maxDepth_ - cur);
+    int requiredFree = wrCount;
+    if (pressureSeen && resumeWatermark_ > 0) {
+      requiredFree = std::max(requiredFree, resumeWatermark_);
+    }
+    if (freeSlots >= requiredFree) {
+      int expected = cur;
+      if (depth_.compare_exchange_weak(expected, cur + wrCount, std::memory_order_relaxed)) {
+        SetReserveResult(result, SqReserveFailureKind::None, cur + wrCount, wrCount, maxDepth_,
+                         backoff);
+        return true;
+      }
+      backoff++;
+      continue;
+    }
+
+    pressureSeen = true;
+    if (std::chrono::steady_clock::now() >= deadline) {
+      SetReserveResult(result, SqReserveFailureKind::Timeout, cur, wrCount, maxDepth_, backoff);
+      return false;
+    }
+
+    std::unique_lock<std::mutex> lock(mu_);
+    const uint64_t observedEpoch = epoch_;
+    auto waitPred = [&]() -> bool {
+      if (degraded_.load(std::memory_order_relaxed)) return true;
+      int depth = depth_.load(std::memory_order_relaxed);
+      if (depth < 0) depth = 0;
+      const int freeSlots = std::max(0, maxDepth_ - depth);
+      int requiredFree = wrCount;
+      if (pressureSeen && resumeWatermark_ > 0) {
+        requiredFree = std::max(requiredFree, resumeWatermark_);
+      }
+      if (freeSlots >= requiredFree) return true;
+      return epoch_ != observedEpoch;
+    };
+    if (!cv_.wait_until(lock, deadline, waitPred)) {
+      SetReserveResult(result, SqReserveFailureKind::Timeout, Depth(), wrCount, maxDepth_, backoff);
+      return false;
+    }
+    backoff++;
+  }
+}
+
+bool SqController::RecheckBeforePost(int reservedWrCount, ReserveResult* result) {
+  if (!IsDegraded()) {
+    SetReserveResult(result, SqReserveFailureKind::None, Depth(), reservedWrCount, maxDepth_, 0);
+    return true;
+  }
+  Release(reservedWrCount);
+  SetReserveResult(result,
+                   IsTerminalDegraded() ? SqReserveFailureKind::TerminalDegraded
+                                        : SqReserveFailureKind::Degraded,
+                   Depth(), reservedWrCount, maxDepth_, 0);
+  return false;
+}
+
+void SqController::ReleaseInternal(int wrCount) {
+  if (wrCount <= 0) return;
+  int cur = depth_.load(std::memory_order_relaxed);
+  while (true) {
+    const int next = std::max(0, cur - wrCount);
+    if (depth_.compare_exchange_weak(cur, next, std::memory_order_relaxed)) break;
+  }
+}
+
+void SqController::Release(int wrCount) {
+  ReleaseInternal(wrCount);
+  std::lock_guard<std::mutex> lock(mu_);
+  NotifyStateChangedLocked();
+}
+
+bool SqController::MarkDegraded(SqDegradeReason reason) {
+  bool changed = false;
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    const bool wasDegraded = degraded_.exchange(true, std::memory_order_relaxed);
+    changed = !wasDegraded;
+    if (IsTerminalDegradeReason(reason)) {
+      const bool wasTerminal = terminalDegraded_.exchange(true, std::memory_order_relaxed);
+      changed = changed || !wasTerminal;
+    }
+    NotifyStateChangedLocked();
+  }
+  return changed;
+}
+
+void SqController::ReleaseDrainedOrphaned(int wrCount) {
+  ReleaseInternal(wrCount);
+  std::lock_guard<std::mutex> lock(mu_);
+  NotifyStateChangedLocked();
+}
+
+std::shared_lock<std::shared_mutex> SqController::AcquireSubmitGuard() {
+  return std::shared_lock<std::shared_mutex>(submitMu_);
+}
+
+std::unique_lock<std::shared_mutex> SqController::AcquireRecoveryGuard() {
+  return std::unique_lock<std::shared_mutex>(submitMu_);
+}
+
+int SqController::Depth() const { return depth_.load(std::memory_order_relaxed); }
+
+int SqController::MaxDepth() const { return maxDepth_; }
+
+bool SqController::IsDegraded() const { return degraded_.load(std::memory_order_relaxed); }
+
+bool SqController::IsTerminalDegraded() const {
+  return terminalDegraded_.load(std::memory_order_relaxed);
+}
+
+void SqController::NotifyStateChangedLocked() {
+  epoch_++;
+  cv_.notify_all();
 }
 
 void RecordSqPollAttempt(const EpPair& ep) {
@@ -104,6 +281,26 @@ void RecordSqBatchReleaseWr(const EpPair& ep, int wrCount) {
   if (!ep.sqCqeDiagnostics || wrCount <= 0) return;
   ep.sqCqeDiagnostics->recentBatchReleaseWr.fetch_add(static_cast<uint64_t>(wrCount),
                                                       std::memory_order_relaxed);
+}
+
+static int EpSqDepth(const EpPair& ep) {
+  if (ep.sq) return ep.sq->Depth();
+  return ep.sqDepth ? ep.sqDepth->load(std::memory_order_relaxed) : -1;
+}
+
+static int EpMaxSqDepth(const EpPair& ep) {
+  if (ep.sq) return ep.sq->MaxDepth();
+  return ep.maxSqDepth;
+}
+
+static bool EpIsDegraded(const EpPair& ep) {
+  if (ep.sq) return ep.sq->IsDegraded();
+  return ep.degraded && ep.degraded->load(std::memory_order_relaxed);
+}
+
+static bool EpIsTerminalDegraded(const EpPair& ep) {
+  if (ep.sq) return ep.sq->IsTerminalDegraded();
+  return false;
 }
 
 static void SetSqReserveFailureKind(SqReserveFailureKind* out, SqReserveFailureKind kind) {
@@ -139,7 +336,7 @@ static std::string BuildSqCqeDiagnosticHint(const EpPair& ep) {
   const uint64_t recentBatchReleaseWr =
       ep.sqCqeDiagnostics->recentBatchReleaseWr.exchange(0, std::memory_order_relaxed);
   const size_t recordCount = ep.ledger ? ep.ledger->RecordCount() : 0;
-  const int sqDepth = ep.sqDepth ? ep.sqDepth->load(std::memory_order_relaxed) : -1;
+  const int sqDepth = EpSqDepth(ep);
 
   return "SQ/CQE diagnostics since previous SQ-full timeout: lastPollAttemptTime=" +
          FormatDiagnosticTimeAge(nowUs, lastPollAttempt) +
@@ -153,7 +350,9 @@ static std::string BuildSqCqeDiagnosticHint(const EpPair& ep) {
 static std::string BuildSqDepthHint(const EpPair& ep, size_t workerLocalQpCount,
                                     int effectivePostBatchSize, int effectiveSignalIntervalWr,
                                     PostSendOpKind opKind, SqReserveFailureKind failureKind) {
-  if (failureKind == SqReserveFailureKind::Degraded) return {};
+  if (failureKind == SqReserveFailureKind::Degraded ||
+      failureKind == SqReserveFailureKind::TerminalDegraded)
+    return {};
 
   if (opKind == PostSendOpKind::Notification) {
     std::string hint;
@@ -199,7 +398,7 @@ static std::string BuildSqDepthHint(const EpPair& ep, size_t workerLocalQpCount,
             ", session qpPerTransfer=" + std::to_string(sessionQpPerTransfer) +
             ", numWorkerThreads=" + std::to_string(numWorkerThreads) + ")";
   }
-  hint += ". Current per-QP send WR limit is " + std::to_string(ep.maxSqDepth) + ".";
+  hint += ". Current per-QP send WR limit is " + std::to_string(EpMaxSqDepth(ep)) + ".";
   hint += " MORI_IO_SQ_SIGNAL_INTERVAL_WR configured=" + std::to_string(GetSqSignalIntervalWr()) +
           ", effective=" + std::to_string(effectiveSignalIntervalWr) + " WR.";
   if (failureKind == SqReserveFailureKind::Timeout) {
@@ -280,24 +479,68 @@ uint64_t MakeNotifSendWrId(TransferUniqueId id) {
 // across threads, so relaxed atomics are sufficient for correctness.
 static bool TryReserveSqDepth(const EpPair& ep, int wrCount, int epId, const char* opTag,
                               std::string* errMsg, SqReserveFailureKind* failureKind = nullptr) {
-  if (wrCount <= 0 || !ep.sqDepth) return true;
-  if (ep.degraded && ep.degraded->load(std::memory_order_relaxed)) {
+  if (wrCount <= 0) return true;
+  const int kBackoffTimeoutUs = GetSqBackoffTimeoutUs();
+  if (ep.sq) {
+    ReserveOptions opts;
+    opts.timeoutUs = kBackoffTimeoutUs;
+    ReserveResult result;
+    if (ep.sq->Reserve(wrCount, opts, &result)) return true;
+
+    SetSqReserveFailureKind(failureKind, result.kind);
+    if (result.kind == SqReserveFailureKind::TerminalDegraded ||
+        result.kind == SqReserveFailureKind::Degraded) {
+      if (errMsg) {
+        *errMsg = EpIsTerminalDegraded(ep) ? "EP is terminal degraded, rejecting new submissions"
+                                           : "EP is degraded, rejecting new submissions";
+      }
+      return false;
+    }
+    if (result.kind == SqReserveFailureKind::ExceedsCapacity) {
+      MORI_IO_WARN("SQ request exceeds capacity ({}): ep={} requested={} max={}", opTag, epId,
+                   wrCount, result.maxDepth);
+      if (errMsg) {
+        *errMsg = "SQ request exceeds capacity (" + std::string(opTag) +
+                  "): ep=" + std::to_string(epId) + " requested=" + std::to_string(wrCount) +
+                  " max=" + std::to_string(result.maxDepth);
+      }
+      return false;
+    }
+    if (result.kind == SqReserveFailureKind::Timeout) {
+      MORI_IO_WARN(
+          "SQ full timeout ({}): ep={} depth={} requested={} max={} after {} us (backoff={})",
+          opTag, epId, result.depth, wrCount, result.maxDepth, kBackoffTimeoutUs,
+          result.backoffCount);
+      if (errMsg) {
+        *errMsg = "SQ full (" + std::string(opTag) + "): ep=" + std::to_string(epId) +
+                  " depth=" + std::to_string(result.depth) +
+                  " requested=" + std::to_string(wrCount) +
+                  " max=" + std::to_string(result.maxDepth);
+      }
+      return false;
+    }
+    if (errMsg) *errMsg = "SQ reserve failed";
+    return false;
+  }
+
+  if (!ep.sqDepth) return true;
+  if (EpIsDegraded(ep)) {
     SetSqReserveFailureKind(failureKind, SqReserveFailureKind::Degraded);
     if (errMsg) *errMsg = "EP is degraded, rejecting new submissions";
     return false;
   }
-  if (wrCount > ep.maxSqDepth) {
+  const int maxSqDepth = EpMaxSqDepth(ep);
+  if (wrCount > maxSqDepth) {
     SetSqReserveFailureKind(failureKind, SqReserveFailureKind::ExceedsCapacity);
     MORI_IO_WARN("SQ request exceeds capacity ({}): ep={} requested={} max={}", opTag, epId,
-                 wrCount, ep.maxSqDepth);
+                 wrCount, maxSqDepth);
     if (errMsg) {
       *errMsg = "SQ request exceeds capacity (" + std::string(opTag) +
                 "): ep=" + std::to_string(epId) + " requested=" + std::to_string(wrCount) +
-                " max=" + std::to_string(ep.maxSqDepth);
+                " max=" + std::to_string(maxSqDepth);
     }
     return false;
   }
-  const int kBackoffTimeoutUs = GetSqBackoffTimeoutUs();
   const auto deadline =
       std::chrono::steady_clock::now() + std::chrono::microseconds(kBackoffTimeoutUs);
   int backoff = 0;
@@ -306,21 +549,21 @@ static bool TryReserveSqDepth(const EpPair& ep, int wrCount, int epId, const cha
   while (true) {
     // Re-check degraded state while waiting to avoid accepting new submissions
     // after another thread has marked this EP as degraded.
-    if (ep.degraded && ep.degraded->load(std::memory_order_relaxed)) {
+    if (EpIsDegraded(ep)) {
       SetSqReserveFailureKind(failureKind, SqReserveFailureKind::Degraded);
       if (errMsg) *errMsg = "EP is degraded, rejecting new submissions";
       return false;
     }
-    if (cur + wrCount > ep.maxSqDepth) {
+    if (cur + wrCount > maxSqDepth) {
       if (std::chrono::steady_clock::now() >= deadline) {
         SetSqReserveFailureKind(failureKind, SqReserveFailureKind::Timeout);
         MORI_IO_WARN(
             "SQ full timeout ({}): ep={} depth={} requested={} max={} after {} us (backoff={})",
-            opTag, epId, cur, wrCount, ep.maxSqDepth, kBackoffTimeoutUs, backoff);
+            opTag, epId, cur, wrCount, maxSqDepth, kBackoffTimeoutUs, backoff);
         if (errMsg) {
           *errMsg = "SQ full (" + std::string(opTag) + "): ep=" + std::to_string(epId) +
                     " depth=" + std::to_string(cur) + " requested=" + std::to_string(wrCount) +
-                    " max=" + std::to_string(ep.maxSqDepth);
+                    " max=" + std::to_string(maxSqDepth);
         }
         return false;
       }
@@ -346,8 +589,114 @@ static bool TryReserveSqDepth(const EpPair& ep, int wrCount, int epId, const cha
 }
 
 static void ReleaseSqDepth(const EpPair& ep, int wrCount) {
-  if (wrCount <= 0 || !ep.sqDepth) return;
+  if (wrCount <= 0) return;
+  if (ep.sq) {
+    ep.sq->Release(wrCount);
+    return;
+  }
+  if (!ep.sqDepth) return;
   ep.sqDepth->fetch_sub(wrCount, std::memory_order_relaxed);
+}
+
+static bool RecheckSqBeforePost(const EpPair& ep, int reservedWrCount, int epId, const char* opTag,
+                                std::string* errMsg, SqReserveFailureKind* failureKind = nullptr) {
+  if (reservedWrCount <= 0) return true;
+  if (ep.sq) {
+    ReserveResult result;
+    if (ep.sq->RecheckBeforePost(reservedWrCount, &result)) return true;
+    SetSqReserveFailureKind(failureKind, result.kind);
+    if (errMsg) {
+      *errMsg =
+          "EP is " +
+          std::string(result.kind == SqReserveFailureKind::TerminalDegraded ? "terminal degraded"
+                                                                            : "degraded") +
+          ", rejecting reserved " + std::string(opTag) +
+          " submission on ep=" + std::to_string(epId);
+    }
+    return false;
+  }
+  if (EpIsDegraded(ep)) {
+    ReleaseSqDepth(ep, reservedWrCount);
+    SetSqReserveFailureKind(failureKind, SqReserveFailureKind::Degraded);
+    if (errMsg) {
+      *errMsg = "EP is degraded, rejecting reserved " + std::string(opTag) +
+                " submission on ep=" + std::to_string(epId);
+    }
+    return false;
+  }
+  return true;
+}
+
+static void MarkEpDegraded(const EpPair& ep, SqDegradeReason reason) {
+  if (ep.sq) {
+    ep.sq->MarkDegraded(reason);
+  } else if (ep.degraded) {
+    ep.degraded->store(true, std::memory_order_relaxed);
+  }
+}
+
+static void FailUniqueSubmissionMetas(const std::vector<SubmissionRecord>& records,
+                                      const std::string& message) {
+  std::unordered_set<CqCallbackMeta*> seen;
+  for (const auto& record : records) {
+    if (!record.meta || !seen.insert(record.meta.get()).second) continue;
+    if (record.batchSize > 0) {
+      (void)record.meta->finishedBatchSize.fetch_add(static_cast<uint32_t>(record.batchSize),
+                                                     std::memory_order_relaxed);
+    }
+    TransferStatus* statusPtr = record.meta->status;
+    if (statusPtr != nullptr) {
+      statusPtr->Update(StatusCode::ERR_RDMA_OP, message);
+      record.meta->status = nullptr;
+    }
+  }
+}
+
+static void ExtractAndFailOrphanedRecords(const EpPair& ep, const std::string& message) {
+  if (!ep.ledger) return;
+  std::vector<SubmissionRecord> orphaned;
+  ep.ledger->ExtractOrphanedRecords(&orphaned);
+  if (!orphaned.empty()) {
+    FailUniqueSubmissionMetas(orphaned, message);
+  }
+}
+
+void MovePendingUnsignaledToOrphanedForEndpoint(
+    const EpPairVec& eps, size_t epId, std::vector<int>& epWrsSinceSignal,
+    std::vector<size_t>& epMergedSinceSignal, const std::shared_ptr<CqCallbackMeta>& callbackMeta,
+    const std::string& message, const char* context,
+    std::shared_lock<std::shared_mutex>* heldSubmitGuard) {
+  if (epId >= eps.size() || epId >= epWrsSinceSignal.size() || epId >= epMergedSinceSignal.size()) {
+    return;
+  }
+  if (epWrsSinceSignal[epId] <= 0) return;
+
+  const int wrCount = epWrsSinceSignal[epId];
+  const size_t mergedReq = epMergedSinceSignal[epId];
+  if (heldSubmitGuard != nullptr && heldSubmitGuard->owns_lock()) {
+    heldSubmitGuard->unlock();
+  }
+
+  std::unique_lock<std::shared_mutex> recoveryGuard;
+  if (eps[epId].sq) recoveryGuard = eps[epId].sq->AcquireRecoveryGuard();
+  MarkEpDegraded(eps[epId], SqDegradeReason::PartialPostOrphaned);
+
+  MORI_IO_WARN(
+      "{}: moving pending unsignaled WRs on ep {} (wrCount={}, mergedReq={}) to orphaned and "
+      "marking terminal degraded",
+      context != nullptr ? context : "RDMA submit failure", epId, wrCount, mergedReq);
+  if (eps[epId].ledger) {
+    eps[epId].ledger->InsertOrphaned(wrCount, callbackMeta, static_cast<int>(mergedReq));
+    ExtractAndFailOrphanedRecords(eps[epId], message);
+  } else {
+    MORI_IO_WARN(
+        "EP {} has pending unsignaled WRs but no submission ledger; SQ credit may remain stale "
+        "until endpoint restart",
+        epId);
+  }
+
+  epWrsSinceSignal[epId] = 0;
+  epMergedSinceSignal[epId] = 0;
 }
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -372,6 +721,19 @@ RdmaOpRet RdmaNotifyTransfer(const EpPairVec& eps, TransferStatus* status, Trans
   }
 
   for (size_t i = 0; i < eps.size(); i++) {
+    std::shared_lock<std::shared_mutex> submitGuard;
+    if (eps[i].sq) submitGuard = eps[i].sq->AcquireSubmitGuard();
+    SqReserveFailureKind recheckFailure = SqReserveFailureKind::None;
+    if (!RecheckSqBeforePost(eps[i], 1, static_cast<int>(i), "notify", &reserveErr,
+                             &recheckFailure)) {
+      AppendHint(&reserveErr, BuildSqDepthHint(eps[i], eps.size(), -1, 0,
+                                               PostSendOpKind::Notification, recheckFailure));
+      for (int j = static_cast<int>(i) + 1; j < static_cast<int>(eps.size()); ++j) {
+        ReleaseSqDepth(eps[j], 1);
+      }
+      return {StatusCode::ERR_RDMA_OP, reserveErr};
+    }
+
     const application::RdmaEndpoint& ep = eps[i].local;
     NotifMessage msg{id, static_cast<int>(i), static_cast<int>(eps.size())};
 
@@ -519,8 +881,9 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
   size_t epBatchSize = (mergedWrCount + epNum - 1) / epNum;
   int minMaxSqDepth = std::numeric_limits<int>::max();
   for (size_t epId = 0; epId < epNum; ++epId) {
-    if (eps[epId].sqDepth && eps[epId].maxSqDepth > 0) {
-      minMaxSqDepth = std::min(minMaxSqDepth, eps[epId].maxSqDepth);
+    const int maxSqDepth = EpMaxSqDepth(eps[epId]);
+    if ((eps[epId].sq || eps[epId].sqDepth) && maxSqDepth > 0) {
+      minMaxSqDepth = std::min(minMaxSqDepth, maxSqDepth);
     }
   }
 
@@ -567,6 +930,27 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
       AppendHint(&reserveErr,
                  BuildSqDepthHint(eps[epId], epNum, postBatchSize, effectiveSignalIntervalWr,
                                   PostSendOpKind::BatchData, reserveFailure));
+      for (size_t pendingEpId = 0; pendingEpId < epNum; ++pendingEpId) {
+        MovePendingUnsignaledToOrphanedForEndpoint(eps, pendingEpId, epWrsSinceSignal,
+                                                   epMergedSinceSignal, callbackMeta, reserveErr,
+                                                   "TryReserveSqDepth failed");
+      }
+      return {StatusCode::ERR_RDMA_OP, reserveErr};
+    }
+
+    std::shared_lock<std::shared_mutex> submitGuard;
+    if (eps[epId].sq) submitGuard = eps[epId].sq->AcquireSubmitGuard();
+    SqReserveFailureKind recheckFailure = SqReserveFailureKind::None;
+    if (!RecheckSqBeforePost(eps[epId], batchWrNum, epId, "batch", &reserveErr, &recheckFailure)) {
+      AppendHint(&reserveErr,
+                 BuildSqDepthHint(eps[epId], epNum, postBatchSize, effectiveSignalIntervalWr,
+                                  PostSendOpKind::BatchData, recheckFailure));
+      for (size_t pendingEpId = 0; pendingEpId < epNum; ++pendingEpId) {
+        MovePendingUnsignaledToOrphanedForEndpoint(
+            eps, pendingEpId, epWrsSinceSignal, epMergedSinceSignal, callbackMeta, reserveErr,
+            "RecheckBeforePost failed",
+            static_cast<int>(pendingEpId) == epId ? &submitGuard : nullptr);
+      }
       return {StatusCode::ERR_RDMA_OP, reserveErr};
     }
 
@@ -584,7 +968,9 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
     bool isLastBatchForEp = ((i + epNum) >= numPostBatch);
     bool signalIntervalReached =
         effectiveSignalIntervalWr > 0 && epWrsSinceSignal[epId] >= effectiveSignalIntervalWr;
-    bool sqNearFull = eps[epId].sqDepth && (epWrsSinceSignal[epId] >= eps[epId].maxSqDepth);
+    const int epMaxSqDepth = EpMaxSqDepth(eps[epId]);
+    bool sqNearFull = (eps[epId].sq || eps[epId].sqDepth) && epMaxSqDepth > 0 &&
+                      (epWrsSinceSignal[epId] >= epMaxSqDepth);
     bool needSignal = isLastBatchForEp || signalIntervalReached || sqNearFull;
 
     struct ibv_send_wr& last = mergedWrs[end - 1].wr;
@@ -634,47 +1020,9 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
         // Signaled WR was posted; CQ path (ledger->ReleaseByCqe) owns the release.
         // The record inserted above remains in Posted state — nothing to do here.
       } else if (needSignal) {
-        // Signaled WR itself was NOT posted; remove the record we just inserted
-        // and release whatever was actually posted (tracked via unpostedCount above).
-        int dummy = 0;
-        eps[epId].ledger->ReleaseByCqe(recordId, nullptr, &dummy);
-      }
-
-      if (postedCount > 0 && (!needSignal || !lastWasPosted)) {
-        MORI_IO_WARN(
-            "ibv_post_send partially posted {} / {} WRs without a posted signaled tail; "
-            "marking EP {} as degraded until recovery",
-            postedCount, batchWrNum, epId);
-        if (eps[epId].degraded) {
-          eps[epId].degraded->store(true, std::memory_order_relaxed);
-        }
-        // Ledger record for ALL orphaned posted WRs (including prior unsignaled batches
-        // on this EP): sqDepth held by ledger until recovery.
-        if (eps[epId].ledger) {
-          eps[epId].ledger->InsertOrphaned(epWrsSinceSignal[epId], callbackMeta,
-                                           static_cast<int>(epMergedSinceSignal[epId]));
-        }
-      }
-
-      for (size_t otherEpId = 0; otherEpId < epNum; ++otherEpId) {
-        if (static_cast<int>(otherEpId) == epId) continue;
-        if (epWrsSinceSignal[otherEpId] <= 0) continue;
-        MORI_IO_WARN(
-            "ibv_post_send failed on ep {}: moving pending unsignaled WRs on ep {} "
-            "(wrCount={}, mergedReq={}) to orphaned and marking degraded",
-            epId, otherEpId, epWrsSinceSignal[otherEpId], epMergedSinceSignal[otherEpId]);
-        if (eps[otherEpId].degraded) {
-          eps[otherEpId].degraded->store(true, std::memory_order_relaxed);
-        }
-        if (eps[otherEpId].ledger) {
-          eps[otherEpId].ledger->InsertOrphaned(epWrsSinceSignal[otherEpId], callbackMeta,
-                                                static_cast<int>(epMergedSinceSignal[otherEpId]));
-        } else {
-          MORI_IO_WARN(
-              "EP {} has pending unsignaled WRs but no submission ledger; "
-              "sqDepth may remain stale until endpoint restart",
-              otherEpId);
-        }
+        // Signaled WR itself was NOT posted; remove the tentative record.
+        SubmissionRecord canceled;
+        (void)eps[epId].ledger->CancelTentative(recordId, &canceled);
       }
 
       std::string message = "ibv_post_send failed with " + std::to_string(ret) + ": " +
@@ -682,6 +1030,20 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
                             std::to_string(batchWrNum) + " WRs)";
       AppendHint(&message, BuildPostSendFailureHint(ret, eps[epId], epNum, postBatchSize, badWr,
                                                     PostSendOpKind::BatchData));
+
+      if (epWrsSinceSignal[epId] > 0 && (!needSignal || !lastWasPosted)) {
+        MovePendingUnsignaledToOrphanedForEndpoint(eps, epId, epWrsSinceSignal, epMergedSinceSignal,
+                                                   callbackMeta, message, "ibv_post_send failed",
+                                                   &submitGuard);
+      }
+
+      for (size_t otherEpId = 0; otherEpId < epNum; ++otherEpId) {
+        if (static_cast<int>(otherEpId) == epId) continue;
+        MovePendingUnsignaledToOrphanedForEndpoint(eps, otherEpId, epWrsSinceSignal,
+                                                   epMergedSinceSignal, callbackMeta, message,
+                                                   "ibv_post_send failed");
+      }
+
       return {StatusCode::ERR_RDMA_OP, std::move(message)};
     }
 

--- a/src/io/rdma/common.cpp
+++ b/src/io/rdma/common.cpp
@@ -1018,7 +1018,7 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
       const bool lastWasPosted = (postedCount == batchWrNum);
       if (needSignal && lastWasPosted) {
         // Signaled WR was posted; CQ path (ledger->ReleaseByCqe) owns the release.
-        // The record inserted above remains in Posted state — nothing to do here.
+        (void)eps[epId].ledger->MarkPosted(recordId);
       } else if (needSignal) {
         // Signaled WR itself was NOT posted; remove the tentative record.
         SubmissionRecord canceled;
@@ -1048,6 +1048,7 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
     }
 
     if (needSignal) {
+      (void)eps[epId].ledger->MarkPosted(recordId);
       epWrsSinceSignal[epId] = 0;
       epMergedSinceSignal[epId] = 0;
     }

--- a/src/io/rdma/common.hpp
+++ b/src/io/rdma/common.hpp
@@ -285,6 +285,8 @@ using EpPairVec = std::vector<EpPair>;
 void RecordSqPollAttempt(const EpPair& ep);
 void RecordSqPollCqes(const EpPair& ep, int cqeCount);
 void RecordSqBatchReleaseWr(const EpPair& ep, int wrCount);
+// The vector membership is not modified, but endpoint controller/ledger/status
+// state is mutated through EpPair's shared ownership fields.
 void MovePendingUnsignaledToOrphanedForEndpoint(
     const EpPairVec& eps, size_t epId, std::vector<int>& epWrsSinceSignal,
     std::vector<size_t>& epMergedSinceSignal, const std::shared_ptr<CqCallbackMeta>& callbackMeta,

--- a/src/io/rdma/common.hpp
+++ b/src/io/rdma/common.hpp
@@ -214,8 +214,9 @@ using EndpointId = uint64_t;
 // SubmissionLedger tracks per-EP WR completions. SQ credit is released by
 // SqController after callers inspect the returned SubmissionRecord.
 enum class SubmissionState : uint8_t {
-  Posted,    // submitted, awaiting CQE
-  Orphaned,  // partial post without signaled tail; awaits recovery
+  Tentative,  // inserted before ibv_post_send confirms the signaled tail was posted
+  Posted,     // submitted, awaiting CQE
+  Orphaned,   // partial post without signaled tail; awaits recovery
 };
 
 struct SubmissionRecord {
@@ -240,6 +241,9 @@ class SubmissionLedger {
 
   // CQE path: find record by recordId, return it, and erase it.
   bool ReleaseByCqe(uint64_t recordId, SubmissionRecord* outRecord);
+
+  // Post path: a tentative signaled record has a posted tail and must await CQE.
+  bool MarkPosted(uint64_t recordId);
 
   // Post failure path: erase a tentative signaled record whose tail was not posted.
   bool CancelTentative(uint64_t recordId, SubmissionRecord* outRecord);

--- a/src/io/rdma/common.hpp
+++ b/src/io/rdma/common.hpp
@@ -22,12 +22,15 @@
 #pragma once
 
 #include <atomic>
+#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <unordered_map>
+#include <vector>
 
 #include "mori/io/common.hpp"
 #include "mori/io/enum.hpp"
@@ -145,7 +148,71 @@ struct SqCqeDiagnostics {
   std::atomic<uint64_t> recentBatchReleaseWr{0};
 };
 
-// SubmissionLedger: tracks per-EP WR submissions and enables precise sqDepth release.
+enum class SqReserveFailureKind : uint8_t {
+  None = 0,
+  Degraded,
+  TerminalDegraded,
+  ExceedsCapacity,
+  Timeout,
+};
+
+enum class SqDegradeReason : uint8_t {
+  None = 0,
+  PartialPostOrphaned,
+  FatalCqe,
+  EndpointTeardown,
+};
+
+struct ReserveOptions {
+  int timeoutUs{0};
+};
+
+struct ReserveResult {
+  SqReserveFailureKind kind{SqReserveFailureKind::None};
+  int depth{0};
+  int requested{0};
+  int maxDepth{0};
+  int backoffCount{0};
+};
+
+class SqController {
+ public:
+  SqController(int maxDepth, int resumeWatermark);
+
+  bool Reserve(int wrCount, ReserveOptions opts, ReserveResult* result);
+  bool RecheckBeforePost(int reservedWrCount, ReserveResult* result);
+  void Release(int wrCount);
+  bool MarkDegraded(SqDegradeReason reason);
+  void ReleaseDrainedOrphaned(int wrCount);
+  std::shared_lock<std::shared_mutex> AcquireSubmitGuard();
+  std::unique_lock<std::shared_mutex> AcquireRecoveryGuard();
+
+  int Depth() const;
+  int MaxDepth() const;
+  bool IsDegraded() const;
+  bool IsTerminalDegraded() const;
+
+ private:
+  void ReleaseInternal(int wrCount);
+  void NotifyStateChangedLocked();
+
+  std::atomic<int> depth_{0};
+  int maxDepth_{0};
+  int resumeWatermark_{0};
+  std::atomic<bool> degraded_{false};
+  std::atomic<bool> terminalDegraded_{false};
+  std::shared_mutex submitMu_;
+  std::mutex mu_;
+  std::condition_variable cv_;
+  uint64_t epoch_{0};
+};
+
+int GetSqResumeWatermarkWrForDepth(int maxDepth);
+
+using EndpointId = uint64_t;
+
+// SubmissionLedger tracks per-EP WR completions. SQ credit is released by
+// SqController after callers inspect the returned SubmissionRecord.
 enum class SubmissionState : uint8_t {
   Posted,    // submitted, awaiting CQE
   Orphaned,  // partial post without signaled tail; awaits recovery
@@ -169,15 +236,16 @@ class SubmissionLedger {
                   int batchSize);
 
   // Insert an Orphaned record (partial post, no signaled tail).
-  void InsertOrphaned(int postedWr, std::shared_ptr<CqCallbackMeta> meta, int batchSize);
+  uint64_t InsertOrphaned(int postedWr, std::shared_ptr<CqCallbackMeta> meta, int batchSize);
 
-  // CQE path: find record by recordId, release sqDepth, return CqCallbackMeta.
-  // Returns nullptr if record not found.
-  std::shared_ptr<CqCallbackMeta> ReleaseByCqe(uint64_t recordId, std::atomic<int>* sqDepth,
-                                               int* outBatchSize, int* outPostedWr = nullptr);
+  // CQE path: find record by recordId, return it, and erase it.
+  bool ReleaseByCqe(uint64_t recordId, SubmissionRecord* outRecord);
 
-  // Recovery path: release only Orphaned records and keep Posted records.
-  int ReleaseOrphanedByRecovery(std::atomic<int>* sqDepth);
+  // Post failure path: erase a tentative signaled record whose tail was not posted.
+  bool CancelTentative(uint64_t recordId, SubmissionRecord* outRecord);
+
+  // Terminal degraded path: extract Orphaned records and keep Posted records.
+  void ExtractOrphanedRecords(std::vector<SubmissionRecord>* outRecords);
 
   bool HasOrphaned() const;
   size_t RecordCount() const;
@@ -189,16 +257,18 @@ class SubmissionLedger {
 };
 
 struct EpPair {
-  int weight;
-  int ldevId;
-  int rdevId;
+  EndpointId endpointId{0};
+  int weight{0};
+  int ldevId{0};
+  int rdevId{0};
   EngineKey remoteEngineKey;
   application::RdmaEndpoint local;
   application::RdmaEndpointHandle remote;
-  // Shared across EpPair copies that refer to the same QP.
+  // Shared across EpPair copies that refer to the same QP. sq is the Phase 2
+  // owner; sqDepth/degraded remain only for legacy/fallback EpPair instances.
+  std::shared_ptr<SqController> sq;
   std::shared_ptr<std::atomic<int>> sqDepth;
   int maxSqDepth{0};
-  // Degraded flag — set on partial post without signaled tail.
   std::shared_ptr<std::atomic<bool>> degraded;
   std::shared_ptr<SubmissionLedger> ledger;
   int qpPerTransfer{0};
@@ -206,11 +276,16 @@ struct EpPair {
   std::shared_ptr<SqCqeDiagnostics> sqCqeDiagnostics;
 };
 
+using EpPairVec = std::vector<EpPair>;
+
 void RecordSqPollAttempt(const EpPair& ep);
 void RecordSqPollCqes(const EpPair& ep, int cqeCount);
 void RecordSqBatchReleaseWr(const EpPair& ep, int wrCount);
-
-using EndpointId = uint64_t;
+void MovePendingUnsignaledToOrphanedForEndpoint(
+    const EpPairVec& eps, size_t epId, std::vector<int>& epWrsSinceSignal,
+    std::vector<size_t>& epMergedSinceSignal, const std::shared_ptr<CqCallbackMeta>& callbackMeta,
+    const std::string& message, const char* context,
+    std::shared_lock<std::shared_mutex>* heldSubmitGuard = nullptr);
 
 struct EndpointRuntime {
   EndpointRuntime() = default;
@@ -220,7 +295,6 @@ struct EndpointRuntime {
   EpPair ep;
 };
 
-using EpPairVec = std::vector<EpPair>;
 using RouteTable = std::unordered_map<TopoKeyPair, EpPairVec>;
 using MemoryTable = std::unordered_map<MemoryKey, application::RdmaMemoryRegion>;
 

--- a/src/io/rdma/common.hpp
+++ b/src/io/rdma/common.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -137,6 +138,13 @@ struct CqCallbackMeta {
   internal::IoCallDiagnostics diagnostics{};
 };
 
+struct SqCqeDiagnostics {
+  std::atomic<int64_t> lastPollAttemptTimeUs{0};
+  std::atomic<int64_t> lastNonEmptyCqeTimeUs{0};
+  std::atomic<uint64_t> recentCqeCount{0};
+  std::atomic<uint64_t> recentBatchReleaseWr{0};
+};
+
 // SubmissionLedger: tracks per-EP WR submissions and enables precise sqDepth release.
 enum class SubmissionState : uint8_t {
   Posted,    // submitted, awaiting CQE
@@ -166,12 +174,13 @@ class SubmissionLedger {
   // CQE path: find record by recordId, release sqDepth, return CqCallbackMeta.
   // Returns nullptr if record not found.
   std::shared_ptr<CqCallbackMeta> ReleaseByCqe(uint64_t recordId, std::atomic<int>* sqDepth,
-                                               int* outBatchSize);
+                                               int* outBatchSize, int* outPostedWr = nullptr);
 
   // Recovery path: release only Orphaned records and keep Posted records.
   int ReleaseOrphanedByRecovery(std::atomic<int>* sqDepth);
 
   bool HasOrphaned() const;
+  size_t RecordCount() const;
 
  private:
   mutable std::mutex mu_;
@@ -192,7 +201,14 @@ struct EpPair {
   // Degraded flag — set on partial post without signaled tail.
   std::shared_ptr<std::atomic<bool>> degraded;
   std::shared_ptr<SubmissionLedger> ledger;
+  int qpPerTransfer{0};
+  int numWorkerThreads{0};
+  std::shared_ptr<SqCqeDiagnostics> sqCqeDiagnostics;
 };
+
+void RecordSqPollAttempt(const EpPair& ep);
+void RecordSqPollCqes(const EpPair& ep, int cqeCount);
+void RecordSqBatchReleaseWr(const EpPair& ep, int wrCount);
 
 using EndpointId = uint64_t;
 

--- a/src/io/rdma/common.hpp
+++ b/src/io/rdma/common.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
@@ -29,6 +30,7 @@
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -146,6 +148,11 @@ struct SqCqeDiagnostics {
   std::atomic<int64_t> lastNonEmptyCqeTimeUs{0};
   std::atomic<uint64_t> recentCqeCount{0};
   std::atomic<uint64_t> recentBatchReleaseWr{0};
+  std::atomic<uint64_t> executorAdmissionWaitCount{0};
+  std::atomic<uint64_t> executorAdmissionWaitUs{0};
+  std::atomic<uint64_t> executorAdmissionTimeoutCount{0};
+  std::atomic<uint64_t> leastLoadedSelectionCount{0};
+  std::atomic<int> queuedWrHighWatermark{0};
 };
 
 enum class SqReserveFailureKind : uint8_t {
@@ -175,6 +182,30 @@ struct ReserveResult {
   int backoffCount{0};
 };
 
+enum class AdmissionFailureKind : uint8_t {
+  None = 0,
+  NoCapacity,
+  Degraded,
+  TerminalDegraded,
+  ExceedsCapacity,
+};
+
+struct AdmissionSnapshot {
+  int depth{0};
+  int queuedDepth{0};
+  int effectiveLoad{0};
+  int maxDepth{0};
+  int requested{0};
+  int requiredFree{0};
+  int effectiveResumeWatermarkWr{0};
+  uint64_t epoch{0};
+};
+
+struct AdmissionResult {
+  AdmissionFailureKind kind{AdmissionFailureKind::None};
+  AdmissionSnapshot snapshot{};
+};
+
 class SqController {
  public:
   SqController(int maxDepth, int resumeWatermark);
@@ -182,12 +213,19 @@ class SqController {
   bool Reserve(int wrCount, ReserveOptions opts, ReserveResult* result);
   bool RecheckBeforePost(int reservedWrCount, ReserveResult* result);
   void Release(int wrCount);
+  bool TryAcquireAdmission(int admissionWr, int requiredFree, AdmissionResult* result);
+  void ReleaseAdmission(int admissionWr);
+  bool WaitForAdmissionChange(std::chrono::steady_clock::time_point deadline,
+                              uint64_t observedEpoch);
   bool MarkDegraded(SqDegradeReason reason);
   void ReleaseDrainedOrphaned(int wrCount);
   std::shared_lock<std::shared_mutex> AcquireSubmitGuard();
   std::unique_lock<std::shared_mutex> AcquireRecoveryGuard();
 
   int Depth() const;
+  int QueuedDepth() const;
+  int EffectiveDepth() const;
+  int FreeAdmissionSlots() const;
   int MaxDepth() const;
   bool IsDegraded() const;
   bool IsTerminalDegraded() const;
@@ -197,6 +235,7 @@ class SqController {
   void NotifyStateChangedLocked();
 
   std::atomic<int> depth_{0};
+  std::atomic<int> queuedDepth_{0};
   int maxDepth_{0};
   int resumeWatermark_{0};
   std::atomic<bool> degraded_{false};
@@ -204,10 +243,11 @@ class SqController {
   std::shared_mutex submitMu_;
   std::mutex mu_;
   std::condition_variable cv_;
-  uint64_t epoch_{0};
+  std::atomic<uint64_t> epoch_{0};
 };
 
 int GetSqResumeWatermarkWrForDepth(int maxDepth);
+int GetSqSignalIntervalWr();
 
 using EndpointId = uint64_t;
 
@@ -268,12 +308,9 @@ struct EpPair {
   EngineKey remoteEngineKey;
   application::RdmaEndpoint local;
   application::RdmaEndpointHandle remote;
-  // Shared across EpPair copies that refer to the same QP. sq is the Phase 2
-  // owner; sqDepth/degraded remain only for legacy/fallback EpPair instances.
+  // Shared across EpPair copies that refer to the same QP.
   std::shared_ptr<SqController> sq;
-  std::shared_ptr<std::atomic<int>> sqDepth;
   int maxSqDepth{0};
-  std::shared_ptr<std::atomic<bool>> degraded;
   std::shared_ptr<SubmissionLedger> ledger;
   int qpPerTransfer{0};
   int numWorkerThreads{0};
@@ -285,6 +322,7 @@ using EpPairVec = std::vector<EpPair>;
 void RecordSqPollAttempt(const EpPair& ep);
 void RecordSqPollCqes(const EpPair& ep, int cqeCount);
 void RecordSqBatchReleaseWr(const EpPair& ep, int wrCount);
+std::string BuildSqCqeDiagnosticHint(const EpPair& ep);
 // The vector membership is not modified, but endpoint controller/ledger/status
 // state is mutated through EpPair's shared ownership fields.
 void MovePendingUnsignaledToOrphanedForEndpoint(
@@ -321,6 +359,9 @@ struct RdmaOpRet {
 };
 
 RdmaOpRet RdmaNotifyTransfer(const EpPairVec& eps, TransferStatus* status, TransferUniqueId id);
+
+int EstimateMergedWrCount(const SizeVec& localOffsets, const SizeVec& remoteOffsets,
+                          const SizeVec& sizes, uint32_t maxSge);
 
 RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemoryRegion& local,
                              const SizeVec& localOffsets,

--- a/src/io/rdma/executor.cpp
+++ b/src/io/rdma/executor.cpp
@@ -24,13 +24,570 @@
 #include <pthread.h>
 #include <sched.h>
 
+#include <algorithm>
+#include <cctype>
+#include <cerrno>
+#include <chrono>
+#include <cstdlib>
 #include <cstring>
+#include <deque>
 #include <future>
+#include <limits>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
 
 #include "mori/io/logging.hpp"
+#include "mori/utils/env_utils.hpp"
 
 namespace mori {
 namespace io {
+
+AdmissionToken::AdmissionToken(std::shared_ptr<SqController> sq_, int wr)
+    : sq(std::move(sq_)), estimatedWr(wr), active(sq != nullptr && wr > 0) {}
+
+AdmissionToken::AdmissionToken(AdmissionToken&& rhs) noexcept
+    : sq(std::move(rhs.sq)), estimatedWr(rhs.estimatedWr), active(rhs.active) {
+  rhs.estimatedWr = 0;
+  rhs.active = false;
+}
+
+AdmissionToken& AdmissionToken::operator=(AdmissionToken&& rhs) noexcept {
+  if (this == &rhs) return *this;
+  Release();
+  sq = std::move(rhs.sq);
+  estimatedWr = rhs.estimatedWr;
+  active = rhs.active;
+  rhs.estimatedWr = 0;
+  rhs.active = false;
+  return *this;
+}
+
+AdmissionToken::~AdmissionToken() { Release(); }
+
+void AdmissionToken::Release() {
+  if (!active) return;
+  if (sq) sq->ReleaseAdmission(estimatedWr);
+  active = false;
+  estimatedWr = 0;
+  sq.reset();
+}
+
+namespace {
+
+enum class ExecutorSplitPolicy {
+  Static,
+  LeastLoaded,
+  Capacity,
+};
+
+struct ExecutorAdmissionConfig {
+  bool enabled{false};
+  ExecutorSplitPolicy policy{ExecutorSplitPolicy::Static};
+  int timeoutUs{1000000};
+  int resumeWatermarkWr{2048};
+  int waitSliceUs{100};
+  int admissionChunkWr{0};
+  int maxChunksPerCall{0};
+};
+
+struct AdmissionCandidate {
+  int epId{-1};
+  int workerId{-1};
+  std::shared_ptr<SqController> sq;
+  int depth{0};
+  int queuedDepth{0};
+  int effectiveLoad{0};
+  int maxDepth{0};
+  int effectiveFree{0};
+};
+
+struct AcquiredAdmission {
+  bool ok{false};
+  RdmaOpRet error;
+  int epId{-1};
+  int workerId{-1};
+  int begin{-1};
+  int end{-1};
+  int admissionWr{0};
+  AdmissionToken token;
+};
+
+struct AdmissionWaitStats {
+  uint64_t waitCount{0};
+  uint64_t waitUs{0};
+};
+
+std::optional<int> ParseNonNegativeInt(const char* raw) {
+  errno = 0;
+  char* end = nullptr;
+  long parsed = std::strtol(raw, &end, 10);
+  if (end == raw || *end != '\0' || errno != 0 || parsed < 0 ||
+      parsed > std::numeric_limits<int>::max()) {
+    return std::nullopt;
+  }
+  return static_cast<int>(parsed);
+}
+
+int GetNonNegativeEnv(const char* name, int fallback) {
+  const char* raw = mori::env::Get(name);
+  if (raw == nullptr || raw[0] == '\0') return fallback;
+  auto parsed = ParseNonNegativeInt(raw);
+  if (!parsed.has_value()) {
+    MORI_IO_WARN("Ignore invalid env {}={}", name, raw);
+    return fallback;
+  }
+  return *parsed;
+}
+
+bool GetBoolEnv(const char* name, bool fallback) {
+  const char* raw = mori::env::Get(name);
+  if (raw == nullptr || raw[0] == '\0') return fallback;
+  auto parsed = mori::env::detail::ParseBool(raw);
+  if (!parsed.has_value()) {
+    MORI_IO_WARN("Ignore invalid env {}={}", name, raw);
+    return fallback;
+  }
+  return *parsed;
+}
+
+ExecutorSplitPolicy GetSplitPolicyEnv() {
+  const char* raw = mori::env::Get("MORI_IO_SQ_SPLIT_POLICY");
+  if (raw == nullptr || raw[0] == '\0') return ExecutorSplitPolicy::Static;
+  std::string value(raw);
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  if (value == "static") return ExecutorSplitPolicy::Static;
+  if (value == "least_loaded") return ExecutorSplitPolicy::LeastLoaded;
+  if (value == "capacity") {
+    if (GetBoolEnv("MORI_IO_SQ_ENABLE_EXPERIMENTAL_CAPACITY", false)) {
+      return ExecutorSplitPolicy::Capacity;
+    }
+    MORI_IO_WARN(
+        "MORI_IO_SQ_SPLIT_POLICY=capacity requires "
+        "MORI_IO_SQ_ENABLE_EXPERIMENTAL_CAPACITY=1; falling back to static");
+    return ExecutorSplitPolicy::Static;
+  }
+  MORI_IO_WARN("Ignore invalid env MORI_IO_SQ_SPLIT_POLICY={}", raw);
+  return ExecutorSplitPolicy::Static;
+}
+
+const char* SplitPolicyName(ExecutorSplitPolicy policy) {
+  switch (policy) {
+    case ExecutorSplitPolicy::Static:
+      return "static";
+    case ExecutorSplitPolicy::LeastLoaded:
+      return "least_loaded";
+    case ExecutorSplitPolicy::Capacity:
+      return "capacity";
+  }
+  return "unknown";
+}
+
+ExecutorAdmissionConfig LoadAdmissionConfig() {
+  ExecutorAdmissionConfig cfg;
+  cfg.enabled = GetBoolEnv("MORI_IO_SQ_EXECUTOR_ADMISSION", false);
+  cfg.policy = GetSplitPolicyEnv();
+  cfg.timeoutUs = GetNonNegativeEnv("MORI_IO_SQ_ADMISSION_TIMEOUT_US", 1000000);
+  cfg.resumeWatermarkWr = GetNonNegativeEnv("MORI_IO_SQ_ADMISSION_RESUME_WATERMARK_WR", 2048);
+  cfg.waitSliceUs = std::max(1, GetNonNegativeEnv("MORI_IO_SQ_ADMISSION_WAIT_SLICE_US", 100));
+  cfg.admissionChunkWr = GetNonNegativeEnv("MORI_IO_SQ_ADMISSION_CHUNK_WR", 0);
+  cfg.maxChunksPerCall = GetNonNegativeEnv("MORI_IO_SQ_ADMISSION_MAX_CHUNKS_PER_CALL", 0);
+  return cfg;
+}
+
+const ExecutorAdmissionConfig& GetCachedAdmissionConfig() {
+  static const ExecutorAdmissionConfig kConfig = LoadAdmissionConfig();
+  return kConfig;
+}
+
+int ActiveQpCount(const ExecutorReq& req, int numWorker) {
+  return std::min(static_cast<int>(req.eps.size()), numWorker);
+}
+
+void RecordAdmissionWait(const EpPair& ep, uint64_t waitUs) {
+  if (!ep.sqCqeDiagnostics) return;
+  ep.sqCqeDiagnostics->executorAdmissionWaitCount.fetch_add(1, std::memory_order_relaxed);
+  ep.sqCqeDiagnostics->executorAdmissionWaitUs.fetch_add(waitUs, std::memory_order_relaxed);
+}
+
+void RecordAdmissionTimeout(const EpPair& ep) {
+  if (!ep.sqCqeDiagnostics) return;
+  ep.sqCqeDiagnostics->executorAdmissionTimeoutCount.fetch_add(1, std::memory_order_relaxed);
+}
+
+void RecordLeastLoadedSelection(const EpPair& ep) {
+  if (!ep.sqCqeDiagnostics) return;
+  ep.sqCqeDiagnostics->leastLoadedSelectionCount.fetch_add(1, std::memory_order_relaxed);
+}
+
+void RecordQueuedWrHighWatermark(const EpPair& ep, int queuedDepth) {
+  if (!ep.sqCqeDiagnostics) return;
+  int cur = ep.sqCqeDiagnostics->queuedWrHighWatermark.load(std::memory_order_relaxed);
+  while (queuedDepth > cur && !ep.sqCqeDiagnostics->queuedWrHighWatermark.compare_exchange_weak(
+                                  cur, queuedDepth, std::memory_order_relaxed)) {
+  }
+}
+
+void WarnMaxChunksCappedOnce(int configured, int activeQps, int effective) {
+  static std::atomic<bool> warned{false};
+  if (warned.exchange(true, std::memory_order_relaxed)) return;
+  MORI_IO_WARN(
+      "MORI_IO_SQ_ADMISSION_MAX_CHUNKS_PER_CALL={} is above the current cap activeQps*2={} "
+      "(activeQps={}); using effective maxOutstandingChunks={}",
+      configured, activeQps * 2, activeQps, effective);
+}
+
+int ComputeAdmissionChunkBudgetWr(const ExecutorReq& req, int epId,
+                                  const ExecutorAdmissionConfig& cfg) {
+  assert(epId >= 0 && epId < static_cast<int>(req.eps.size()));
+  const EpPair& ep = req.eps[epId];
+  assert(ep.sq != nullptr);
+  int budget = ep.sq->MaxDepth();
+  if (budget <= 0) budget = 1;
+
+  if (req.postBatchSize > 0) {
+    budget = std::min(budget, req.postBatchSize);
+  } else if (req.postBatchSize == 0) {
+    budget = std::min(budget, 1);
+  }
+
+  const int signalIntervalWr = GetSqSignalIntervalWr();
+  if (signalIntervalWr > 0) budget = std::min(budget, signalIntervalWr);
+  if (cfg.admissionChunkWr > 0) budget = std::min(budget, cfg.admissionChunkWr);
+  return std::max(1, budget);
+}
+
+int ComputeMinAdmissionChunkBudgetWr(const ExecutorReq& req, int activeQps,
+                                     const ExecutorAdmissionConfig& cfg) {
+  int budget = std::numeric_limits<int>::max();
+  for (int epId = 0; epId < activeQps; ++epId) {
+    budget = std::min(budget, ComputeAdmissionChunkBudgetWr(req, epId, cfg));
+  }
+  return budget == std::numeric_limits<int>::max() ? 1 : std::max(1, budget);
+}
+
+int EstimateWrForRange(const ExecutorReq& req, int begin, int end, int epId) {
+  if (end <= begin) return 0;
+  assert(epId >= 0 && epId < static_cast<int>(req.eps.size()));
+  const uint32_t maxSge = std::max(req.eps[epId].local.handle.maxSge, 1u);
+  SizeVec localOffsets(req.localOffsets.begin() + begin, req.localOffsets.begin() + end);
+  SizeVec remoteOffsets(req.remoteOffsets.begin() + begin, req.remoteOffsets.begin() + end);
+  SizeVec sizes(req.sizes.begin() + begin, req.sizes.begin() + end);
+  const int estimated = EstimateMergedWrCount(localOffsets, remoteOffsets, sizes, maxSge);
+  return std::max(1, estimated);
+}
+
+std::vector<AdmissionCandidate> BuildHealthyCandidates(const ExecutorReq& req, int numWorker,
+                                                       ExecutorSplitPolicy policy) {
+  const int activeQps = ActiveQpCount(req, numWorker);
+  std::vector<AdmissionCandidate> candidates;
+  candidates.reserve(activeQps);
+  for (int epId = 0; epId < activeQps; ++epId) {
+    const EpPair& ep = req.eps[epId];
+    assert(ep.sq != nullptr);
+    if (ep.sq->IsDegraded()) continue;
+    AdmissionCandidate candidate;
+    candidate.epId = epId;
+    candidate.workerId = epId;
+    candidate.sq = ep.sq;
+    candidate.depth = ep.sq->Depth();
+    candidate.queuedDepth = ep.sq->QueuedDepth();
+    candidate.effectiveLoad = candidate.depth + candidate.queuedDepth;
+    candidate.maxDepth = ep.sq->MaxDepth();
+    candidate.effectiveFree = std::max(0, candidate.maxDepth - candidate.effectiveLoad);
+    candidates.push_back(std::move(candidate));
+  }
+
+  if (policy == ExecutorSplitPolicy::Capacity) {
+    std::sort(candidates.begin(), candidates.end(), [](const auto& lhs, const auto& rhs) {
+      if (lhs.effectiveFree != rhs.effectiveFree) return lhs.effectiveFree > rhs.effectiveFree;
+      if (lhs.effectiveLoad != rhs.effectiveLoad) return lhs.effectiveLoad < rhs.effectiveLoad;
+      return lhs.epId < rhs.epId;
+    });
+  } else {
+    std::sort(candidates.begin(), candidates.end(), [](const auto& lhs, const auto& rhs) {
+      if (lhs.effectiveLoad != rhs.effectiveLoad) return lhs.effectiveLoad < rhs.effectiveLoad;
+      return lhs.epId < rhs.epId;
+    });
+  }
+  return candidates;
+}
+
+std::vector<AdmissionCandidate> BuildStaticCandidate(const ExecutorReq& req, int epId) {
+  assert(epId >= 0 && epId < static_cast<int>(req.eps.size()));
+  const EpPair& ep = req.eps[epId];
+  assert(ep.sq != nullptr);
+  if (ep.sq->IsDegraded()) return {};
+  AdmissionCandidate candidate;
+  candidate.epId = epId;
+  candidate.workerId = epId;
+  candidate.sq = ep.sq;
+  candidate.depth = ep.sq->Depth();
+  candidate.queuedDepth = ep.sq->QueuedDepth();
+  candidate.effectiveLoad = candidate.depth + candidate.queuedDepth;
+  candidate.maxDepth = ep.sq->MaxDepth();
+  candidate.effectiveFree = std::max(0, candidate.maxDepth - candidate.effectiveLoad);
+  return {std::move(candidate)};
+}
+
+int ComputeRequiredFree(const AdmissionCandidate& candidate, int admissionWr, bool pressureSeen,
+                        int chunkBudgetWr, const ExecutorAdmissionConfig& cfg) {
+  int requiredFree = admissionWr;
+  const int watermarkCap = std::min(candidate.maxDepth, chunkBudgetWr);
+  const int effectiveWatermark = std::max(0, std::min(cfg.resumeWatermarkWr, watermarkCap));
+  if (pressureSeen && effectiveWatermark > 0) {
+    requiredFree = std::max(requiredFree, effectiveWatermark);
+  }
+  return std::max(1, std::min(requiredFree, candidate.maxDepth));
+}
+
+std::string FormatAdmissionQps(const ExecutorReq& req, int activeQps) {
+  std::ostringstream os;
+  os << "[";
+  for (int epId = 0; epId < activeQps; ++epId) {
+    if (epId > 0) os << ", ";
+    const EpPair& ep = req.eps[epId];
+    if (!ep.sq) {
+      os << "{ep=" << epId << " sq=null}";
+      continue;
+    }
+    const int depth = ep.sq->Depth();
+    const int queued = ep.sq->QueuedDepth();
+    const int queuedHwm =
+        ep.sqCqeDiagnostics
+            ? ep.sqCqeDiagnostics->queuedWrHighWatermark.load(std::memory_order_relaxed)
+            : 0;
+    os << "{ep=" << epId << " depth=" << depth << " queued=" << queued << " load=" << depth + queued
+       << " max=" << ep.sq->MaxDepth() << " queuedHwm=" << queuedHwm
+       << " degraded=" << (ep.sq->IsDegraded() ? 1 : 0) << "}";
+  }
+  os << "]";
+  return os.str();
+}
+
+RdmaOpRet BuildAdmissionTimeoutRet(const ExecutorReq& req, int activeQps,
+                                   const ExecutorAdmissionConfig& cfg, int requestedWr,
+                                   int requiredFree, int chunkBudgetWr,
+                                   const AdmissionWaitStats& stats, int diagnosticEpId) {
+  int effectiveResumeWatermarkWr = 0;
+  if (diagnosticEpId >= 0 && diagnosticEpId < activeQps && req.eps[diagnosticEpId].sq) {
+    const int watermarkCap = std::min(req.eps[diagnosticEpId].sq->MaxDepth(), chunkBudgetWr);
+    effectiveResumeWatermarkWr = std::max(0, std::min(cfg.resumeWatermarkWr, watermarkCap));
+  }
+  std::string message =
+      "SQ admission timeout: requestedWr=" + std::to_string(requestedWr) +
+      " activeQps=" + std::to_string(activeQps) + " timeoutUs=" + std::to_string(cfg.timeoutUs) +
+      " policy=" + SplitPolicyName(cfg.policy) +
+      " resumeWatermarkWr=" + std::to_string(cfg.resumeWatermarkWr) +
+      " effectiveResumeWatermarkWr=" + std::to_string(effectiveResumeWatermarkWr) +
+      " requiredFree=" + std::to_string(requiredFree) +
+      " admissionChunkBudgetWr=" + std::to_string(chunkBudgetWr) +
+      " waitCount=" + std::to_string(stats.waitCount) + " waitUs=" + std::to_string(stats.waitUs) +
+      " qps=" + FormatAdmissionQps(req, activeQps);
+  if (diagnosticEpId >= 0 && diagnosticEpId < activeQps) {
+    message += " diagnosticEp=" + std::to_string(diagnosticEpId) + ". ";
+    message += BuildSqCqeDiagnosticHint(req.eps[diagnosticEpId]);
+  }
+  return {StatusCode::ERR_RDMA_OP, std::move(message)};
+}
+
+AcquiredAdmission TryAcquireAdmissionForCandidates(const ExecutorReq& req, int begin, int end,
+                                                   int admissionWr, std::optional<int> fixedEpId,
+                                                   const ExecutorAdmissionConfig& cfg,
+                                                   int numWorker,
+                                                   std::chrono::steady_clock::time_point deadline) {
+  AdmissionWaitStats stats;
+  bool pressureSeen = false;
+  int lastRequiredFree = admissionWr;
+  int lastChunkBudgetWr = 1;
+  const int activeQps = ActiveQpCount(req, numWorker);
+
+  while (true) {
+    AdmissionResult bestFailure;
+    AdmissionCandidate bestFailedCandidate;
+    bool hasBestFailure = false;
+    std::vector<AdmissionCandidate> candidates =
+        fixedEpId.has_value() ? BuildStaticCandidate(req, *fixedEpId)
+                              : BuildHealthyCandidates(req, numWorker, cfg.policy);
+    if (candidates.empty()) {
+      return {
+          false,
+          {StatusCode::ERR_RDMA_OP, "SQ admission failed: no healthy active endpoint for policy " +
+                                        std::string(SplitPolicyName(cfg.policy))},
+          -1,
+          -1,
+          begin,
+          end,
+          admissionWr,
+          AdmissionToken{}};
+    }
+
+    for (const auto& candidate : candidates) {
+      const int chunkBudgetWr = ComputeAdmissionChunkBudgetWr(req, candidate.epId, cfg);
+      const int requiredFree =
+          ComputeRequiredFree(candidate, admissionWr, pressureSeen, chunkBudgetWr, cfg);
+      lastRequiredFree = requiredFree;
+      lastChunkBudgetWr = chunkBudgetWr;
+      AdmissionResult result;
+      if (candidate.sq->TryAcquireAdmission(admissionWr, requiredFree, &result)) {
+        RecordQueuedWrHighWatermark(req.eps[candidate.epId], candidate.sq->QueuedDepth());
+        if (cfg.policy == ExecutorSplitPolicy::LeastLoaded ||
+            cfg.policy == ExecutorSplitPolicy::Capacity) {
+          RecordLeastLoadedSelection(req.eps[candidate.epId]);
+        }
+        AcquiredAdmission acquired;
+        acquired.ok = true;
+        acquired.epId = candidate.epId;
+        acquired.workerId = candidate.workerId;
+        acquired.begin = begin;
+        acquired.end = end;
+        acquired.admissionWr = admissionWr;
+        acquired.token = AdmissionToken(candidate.sq, admissionWr);
+        return acquired;
+      }
+
+      if (!hasBestFailure || result.snapshot.effectiveLoad < bestFailure.snapshot.effectiveLoad) {
+        hasBestFailure = true;
+        bestFailure = result;
+        bestFailedCandidate = candidate;
+      }
+    }
+
+    pressureSeen = true;
+    const auto now = std::chrono::steady_clock::now();
+    if (now >= deadline) {
+      if (hasBestFailure) RecordAdmissionTimeout(req.eps[bestFailedCandidate.epId]);
+      return {false,
+              BuildAdmissionTimeoutRet(req, activeQps, cfg, admissionWr, lastRequiredFree,
+                                       lastChunkBudgetWr, stats,
+                                       hasBestFailure ? bestFailedCandidate.epId : -1),
+              -1,
+              -1,
+              begin,
+              end,
+              admissionWr,
+              AdmissionToken{}};
+    }
+
+    const auto sliceDeadline = std::min(deadline, now + std::chrono::microseconds(cfg.waitSliceUs));
+    const auto waitStart = std::chrono::steady_clock::now();
+    if (hasBestFailure) {
+      bestFailedCandidate.sq->WaitForAdmissionChange(sliceDeadline, bestFailure.snapshot.epoch);
+      const auto waitedUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                                std::chrono::steady_clock::now() - waitStart)
+                                .count();
+      stats.waitCount++;
+      stats.waitUs += static_cast<uint64_t>(std::max<int64_t>(0, waitedUs));
+      RecordAdmissionWait(req.eps[bestFailedCandidate.epId],
+                          static_cast<uint64_t>(std::max<int64_t>(0, waitedUs)));
+    } else {
+      std::this_thread::sleep_until(sliceDeadline);
+    }
+  }
+}
+
+AcquiredAdmission TryAcquireCapacityAdmission(const ExecutorReq& req, int begin, int total,
+                                              const ExecutorAdmissionConfig& cfg, int numWorker,
+                                              std::chrono::steady_clock::time_point deadline) {
+  AdmissionWaitStats stats;
+  bool pressureSeen = false;
+  int lastRequestedWr = 1;
+  int lastRequiredFree = 1;
+  int lastChunkBudgetWr = 1;
+  const int activeQps = ActiveQpCount(req, numWorker);
+
+  while (true) {
+    AdmissionResult bestFailure;
+    AdmissionCandidate bestFailedCandidate;
+    bool hasBestFailure = false;
+    auto candidates = BuildHealthyCandidates(req, numWorker, ExecutorSplitPolicy::Capacity);
+    if (candidates.empty()) {
+      return {false,
+              {StatusCode::ERR_RDMA_OP,
+               "SQ admission failed: no healthy active endpoint for policy capacity"},
+              -1,
+              -1,
+              begin,
+              begin,
+              0,
+              AdmissionToken{}};
+    }
+
+    for (const auto& candidate : candidates) {
+      const int chunkBudgetWr = ComputeAdmissionChunkBudgetWr(req, candidate.epId, cfg);
+      int requestBudget = std::min(total - begin, chunkBudgetWr);
+      if (candidate.effectiveFree > 0) {
+        requestBudget = std::min(requestBudget, candidate.effectiveFree);
+      }
+      if (requestBudget <= 0) requestBudget = std::min(total - begin, chunkBudgetWr);
+      requestBudget = std::max(1, requestBudget);
+      const int end = std::min(total, begin + requestBudget);
+      const int admissionWr = EstimateWrForRange(req, begin, end, candidate.epId);
+      const int requiredFree =
+          ComputeRequiredFree(candidate, admissionWr, pressureSeen, chunkBudgetWr, cfg);
+      lastRequestedWr = admissionWr;
+      lastRequiredFree = requiredFree;
+      lastChunkBudgetWr = chunkBudgetWr;
+
+      AdmissionResult result;
+      if (candidate.sq->TryAcquireAdmission(admissionWr, requiredFree, &result)) {
+        RecordQueuedWrHighWatermark(req.eps[candidate.epId], candidate.sq->QueuedDepth());
+        RecordLeastLoadedSelection(req.eps[candidate.epId]);
+        AcquiredAdmission acquired;
+        acquired.ok = true;
+        acquired.epId = candidate.epId;
+        acquired.workerId = candidate.workerId;
+        acquired.begin = begin;
+        acquired.end = end;
+        acquired.admissionWr = admissionWr;
+        acquired.token = AdmissionToken(candidate.sq, admissionWr);
+        return acquired;
+      }
+
+      if (!hasBestFailure || result.snapshot.effectiveLoad < bestFailure.snapshot.effectiveLoad) {
+        hasBestFailure = true;
+        bestFailure = result;
+        bestFailedCandidate = candidate;
+      }
+    }
+
+    pressureSeen = true;
+    const auto now = std::chrono::steady_clock::now();
+    if (now >= deadline) {
+      if (hasBestFailure) RecordAdmissionTimeout(req.eps[bestFailedCandidate.epId]);
+      return {false,
+              BuildAdmissionTimeoutRet(req, activeQps, cfg, lastRequestedWr, lastRequiredFree,
+                                       lastChunkBudgetWr, stats,
+                                       hasBestFailure ? bestFailedCandidate.epId : -1),
+              -1,
+              -1,
+              begin,
+              begin,
+              lastRequestedWr,
+              AdmissionToken{}};
+    }
+
+    const auto sliceDeadline = std::min(deadline, now + std::chrono::microseconds(cfg.waitSliceUs));
+    const auto waitStart = std::chrono::steady_clock::now();
+    if (hasBestFailure) {
+      bestFailedCandidate.sq->WaitForAdmissionChange(sliceDeadline, bestFailure.snapshot.epoch);
+      const auto waitedUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                                std::chrono::steady_clock::now() - waitStart)
+                                .count();
+      stats.waitCount++;
+      stats.waitUs += static_cast<uint64_t>(std::max<int64_t>(0, waitedUs));
+      RecordAdmissionWait(req.eps[bestFailedCandidate.epId],
+                          static_cast<uint64_t>(std::max<int64_t>(0, waitedUs)));
+    } else {
+      std::this_thread::sleep_until(sliceDeadline);
+    }
+  }
+}
+
+}  // namespace
 
 /* ---------------------------------------------------------------------------------------------- */
 /*                                   MultithreadExecutor::Worker                                  */
@@ -46,12 +603,21 @@ void MultithreadExecutor::Worker::Start() {
 }
 
 void MultithreadExecutor::Worker::Shutdown() {
+  std::queue<Task> abandoned;
   {
     std::lock_guard<std::mutex> lock(mu);
-    if (!running.load()) return;
     running.store(false);
+    std::swap(abandoned, q);
     cond.notify_all();
   }
+
+  while (!abandoned.empty()) {
+    Task task = std::move(abandoned.front());
+    abandoned.pop();
+    task.admissionToken.Release();
+    task.ret.set_value({StatusCode::ERR_BAD_STATE, "executor shutdown"});
+  }
+
   if (thd.joinable()) thd.join();
 }
 
@@ -79,13 +645,13 @@ void MultithreadExecutor::Worker::MainLoop() {
 
   MORI_IO_INFO("worker {} enter main loop, running on core {}", workerId, sched_getcpu());
 
-  Task task{nullptr, 0, 0, 0};
   while (true) {
+    Task task;
     {
       std::unique_lock<std::mutex> lock(mu);
       cond.wait(lock, [this]() { return !q.empty() || !running.load(); });
 
-      if (!running.load()) {
+      if (q.empty() && !running.load()) {
         MORI_IO_INFO("worker {} shutdown", workerId);
         break;
       }
@@ -102,6 +668,7 @@ void MultithreadExecutor::Worker::MainLoop() {
     RdmaOpRet ret = mori::io::RdmaBatchReadWrite(
         {task.req->eps[task.epId]}, task.req->local, tLoclOffsets, task.req->remote, tRemoteOffsets,
         tSizes, task.req->callbackMeta, task.req->id, task.req->isRead, task.req->postBatchSize);
+    task.admissionToken.Release();
     task.ret.set_value(ret);
     MORI_IO_TRACE("Worker {} execute task {} begin {} end {} ret code {}", workerId, task.req->id,
                   task.begin, task.end, static_cast<uint32_t>(ret.code));
@@ -110,17 +677,21 @@ void MultithreadExecutor::Worker::MainLoop() {
 
 void MultithreadExecutor::Worker::Submit(Task&& task) {
   MORI_IO_FUNCTION_TIMER;
+  const TransferUniqueId taskId = task.req != nullptr ? task.req->id : 0;
+  const int taskBegin = task.begin;
+  const int taskEnd = task.end;
   {
     std::lock_guard<std::mutex> lock(mu);
     if (!running.load()) {
+      task.admissionToken.Release();
       task.ret.set_value({StatusCode::ERR_BAD_STATE, "worker not started yet"});
       return;
     }
     q.push(std::move(task));
     cond.notify_all();
   }
-  MORI_IO_TRACE("Submit to worker {} task {} begin {} end {}", workerId, task.req->id, task.begin,
-                task.end);
+  MORI_IO_TRACE("Submit to worker {} task {} begin {} end {}", workerId, taskId, taskBegin,
+                taskEnd);
 }
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -162,6 +733,11 @@ std::vector<MultithreadExecutor::WorkSplit> MultithreadExecutor::SplitWork(const
 RdmaOpRet MultithreadExecutor::RdmaBatchReadWrite(const ExecutorReq& req) {
   MORI_IO_FUNCTION_TIMER;
 
+  const ExecutorAdmissionConfig& admissionCfg = GetCachedAdmissionConfig();
+  if (admissionCfg.enabled) {
+    return RdmaBatchReadWriteWithAdmission(req);
+  }
+
   auto splits = SplitWork(req);
   int numSplits = splits.size();
   std::vector<std::future<RdmaOpRet>> futs;
@@ -191,6 +767,208 @@ RdmaOpRet MultithreadExecutor::RdmaBatchReadWrite(const ExecutorReq& req) {
   }
 
   MORI_IO_TRACE("MultithreadExecutor submit request for RdmaBatchReadWrite done");
+  return {StatusCode::IN_PROGRESS, ""};
+}
+
+RdmaOpRet MultithreadExecutor::RdmaBatchReadWriteWithAdmission(const ExecutorReq& req) {
+  MORI_IO_FUNCTION_TIMER;
+
+  // Admission may split one user batch into multiple sub-chunks. Each sub-chunk
+  // invokes RdmaBatchReadWrite with the same callbackMeta, whose totalBatchSize
+  // remains the original request size. On a later admission/worker failure this
+  // call returns an error and backend_impl updates TransferStatus to ERR_*.
+  // TransferStatus::Update ignores subsequent updates once failed, so late CQE
+  // SUCCESS from already-posted earlier chunks cannot overwrite the error; those
+  // chunks still drain SQ credit through the normal ledger/CQE path.
+  const ExecutorAdmissionConfig& cfg = GetCachedAdmissionConfig();
+  const int totalBatchSize = static_cast<int>(req.sizes.size());
+  if (totalBatchSize == 0) return {StatusCode::SUCCESS, ""};
+  const int activeQps = ActiveQpCount(req, numWorker);
+  if (activeQps <= 0) return {StatusCode::ERR_INVALID_ARGS, "no active RDMA endpoints"};
+
+  int maxOutstandingChunks = cfg.maxChunksPerCall > 0 ? cfg.maxChunksPerCall : activeQps;
+  const int maxOutstandingCap = activeQps * 2;
+  if (cfg.maxChunksPerCall > maxOutstandingCap) {
+    WarnMaxChunksCappedOnce(cfg.maxChunksPerCall, activeQps, maxOutstandingCap);
+  }
+  maxOutstandingChunks = std::max(1, std::min(maxOutstandingChunks, maxOutstandingCap));
+  // The admission timeout is scoped to the whole user batch, not each chunk, so
+  // later chunks share the original call's remaining wait budget.
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::microseconds(cfg.timeoutUs);
+
+  std::deque<std::future<RdmaOpRet>> futs;
+  bool hasFail = false;
+  RdmaOpRet failedRet;
+
+  auto drainOne = [&]() {
+    RdmaOpRet ret = futs.front().get();
+    futs.pop_front();
+    if (ret.Failed()) {
+      hasFail = true;
+      failedRet = ret;
+    }
+  };
+
+  auto drainAll = [&]() {
+    while (!futs.empty()) drainOne();
+  };
+
+  auto submitAcquired = [&](AcquiredAdmission&& acquired) {
+    Task task{&req, acquired.epId, acquired.begin, acquired.end, std::move(acquired.token)};
+    futs.push_back(task.ret.get_future());
+    pool[acquired.workerId]->Submit(std::move(task));
+  };
+
+  auto drainForPipelineLimit = [&]() -> bool {
+    while (static_cast<int>(futs.size()) >= maxOutstandingChunks) {
+      drainOne();
+      if (hasFail) {
+        drainAll();
+        return false;
+      }
+    }
+    return true;
+  };
+
+  if (cfg.policy == ExecutorSplitPolicy::Static) {
+    auto splits = SplitWork(req);
+    std::vector<int> nextBegin;
+    std::vector<bool> pressureSeen;
+    nextBegin.reserve(splits.size());
+    for (const auto& split : splits) {
+      nextBegin.push_back(split.begin);
+      pressureSeen.push_back(false);
+    }
+
+    AdmissionWaitStats staticWaitStats;
+    bool hasRemaining = true;
+    while (hasRemaining) {
+      hasRemaining = false;
+      bool admittedAny = false;
+      AdmissionResult bestFailure;
+      AdmissionCandidate bestFailedCandidate;
+      bool hasBestFailure = false;
+      int lastAdmissionWr = 1;
+      int lastRequiredFree = 1;
+      int lastChunkBudgetWr = 1;
+
+      for (size_t splitIdx = 0; splitIdx < splits.size(); ++splitIdx) {
+        const WorkSplit& split = splits[splitIdx];
+        int begin = nextBegin[splitIdx];
+        if (begin >= split.end) continue;
+        hasRemaining = true;
+        if (!drainForPipelineLimit()) return failedRet;
+
+        auto candidates = BuildStaticCandidate(req, split.epId);
+        if (candidates.empty()) {
+          drainAll();
+          return {StatusCode::ERR_RDMA_OP,
+                  "SQ admission failed: static target ep=" + std::to_string(split.epId) +
+                      " is degraded or unavailable"};
+        }
+        const AdmissionCandidate& candidate = candidates.front();
+        const int chunkBudgetWr = ComputeAdmissionChunkBudgetWr(req, split.epId, cfg);
+        const int end = std::min(split.end, begin + chunkBudgetWr);
+        const int admissionWr = EstimateWrForRange(req, begin, end, split.epId);
+        const int requiredFree =
+            ComputeRequiredFree(candidate, admissionWr, pressureSeen[splitIdx], chunkBudgetWr, cfg);
+        lastAdmissionWr = admissionWr;
+        lastRequiredFree = requiredFree;
+        lastChunkBudgetWr = chunkBudgetWr;
+
+        AdmissionResult result;
+        if (candidate.sq->TryAcquireAdmission(admissionWr, requiredFree, &result)) {
+          AcquiredAdmission acquired;
+          acquired.ok = true;
+          acquired.epId = split.epId;
+          acquired.workerId = split.workerId;
+          acquired.begin = begin;
+          acquired.end = end;
+          acquired.admissionWr = admissionWr;
+          acquired.token = AdmissionToken(candidate.sq, admissionWr);
+          RecordQueuedWrHighWatermark(req.eps[split.epId], candidate.sq->QueuedDepth());
+          submitAcquired(std::move(acquired));
+          nextBegin[splitIdx] = end;
+          pressureSeen[splitIdx] = false;
+          admittedAny = true;
+          continue;
+        }
+
+        pressureSeen[splitIdx] = true;
+        if (!hasBestFailure || result.snapshot.effectiveLoad < bestFailure.snapshot.effectiveLoad) {
+          hasBestFailure = true;
+          bestFailure = result;
+          bestFailedCandidate = candidate;
+        }
+      }
+
+      if (!hasRemaining || admittedAny) continue;
+
+      const auto now = std::chrono::steady_clock::now();
+      if (now >= deadline) {
+        if (hasBestFailure) RecordAdmissionTimeout(req.eps[bestFailedCandidate.epId]);
+        drainAll();
+        return hasFail
+                   ? failedRet
+                   : BuildAdmissionTimeoutRet(req, activeQps, cfg, lastAdmissionWr,
+                                              lastRequiredFree, lastChunkBudgetWr, staticWaitStats,
+                                              hasBestFailure ? bestFailedCandidate.epId : -1);
+      }
+
+      if (!hasBestFailure) {
+        std::this_thread::sleep_until(
+            std::min(deadline, now + std::chrono::microseconds(cfg.waitSliceUs)));
+        continue;
+      }
+
+      const auto sliceDeadline =
+          std::min(deadline, now + std::chrono::microseconds(cfg.waitSliceUs));
+      const auto waitStart = std::chrono::steady_clock::now();
+      bestFailedCandidate.sq->WaitForAdmissionChange(sliceDeadline, bestFailure.snapshot.epoch);
+      const auto waitedUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                                std::chrono::steady_clock::now() - waitStart)
+                                .count();
+      staticWaitStats.waitCount++;
+      staticWaitStats.waitUs += static_cast<uint64_t>(std::max<int64_t>(0, waitedUs));
+      RecordAdmissionWait(req.eps[bestFailedCandidate.epId],
+                          static_cast<uint64_t>(std::max<int64_t>(0, waitedUs)));
+    }
+  } else if (cfg.policy == ExecutorSplitPolicy::LeastLoaded) {
+    const int chunkBudgetWr = ComputeMinAdmissionChunkBudgetWr(req, activeQps, cfg);
+    int begin = 0;
+    while (begin < totalBatchSize) {
+      if (!drainForPipelineLimit()) return failedRet;
+      const int end = std::min(totalBatchSize, begin + chunkBudgetWr);
+      // Endpoint maxSge is assumed uniform across a session, matching the
+      // verbs post path, so ep0 is a stable estimator before final QP choice.
+      const int admissionWr = EstimateWrForRange(req, begin, end, 0);
+      AcquiredAdmission acquired = TryAcquireAdmissionForCandidates(
+          req, begin, end, admissionWr, std::nullopt, cfg, numWorker, deadline);
+      if (!acquired.ok) {
+        drainAll();
+        return hasFail ? failedRet : acquired.error;
+      }
+      submitAcquired(std::move(acquired));
+      begin = end;
+    }
+  } else {
+    int begin = 0;
+    while (begin < totalBatchSize) {
+      if (!drainForPipelineLimit()) return failedRet;
+      AcquiredAdmission acquired =
+          TryAcquireCapacityAdmission(req, begin, totalBatchSize, cfg, numWorker, deadline);
+      if (!acquired.ok) {
+        drainAll();
+        return hasFail ? failedRet : acquired.error;
+      }
+      begin = acquired.end;
+      submitAcquired(std::move(acquired));
+    }
+  }
+
+  drainAll();
+  if (hasFail) return failedRet;
+  MORI_IO_TRACE("MultithreadExecutor admission submit request for RdmaBatchReadWrite done");
   return {StatusCode::IN_PROGRESS, ""};
 }
 

--- a/src/io/rdma/executor.cpp
+++ b/src/io/rdma/executor.cpp
@@ -135,7 +135,7 @@ MultithreadExecutor::MultithreadExecutor(int n) : numWorker(n) {
 
 MultithreadExecutor::~MultithreadExecutor() { Shutdown(); }
 
-std::vector<std::pair<int, int>> MultithreadExecutor::SplitWork(const ExecutorReq& req) {
+std::vector<MultithreadExecutor::WorkSplit> MultithreadExecutor::SplitWork(const ExecutorReq& req) {
   int numEps = req.eps.size();
   int totalBatchSize = req.sizes.size();
 
@@ -143,12 +143,16 @@ std::vector<std::pair<int, int>> MultithreadExecutor::SplitWork(const ExecutorRe
 
   int numActiveWorkers = std::min(numEps, numWorker);
   int perWorkerBatchSize = (totalBatchSize + numActiveWorkers - 1) / numActiveWorkers;
+  int startWorker = totalBatchSize < numActiveWorkers
+                        ? static_cast<int>(req.id % static_cast<TransferUniqueId>(numActiveWorkers))
+                        : 0;
 
-  std::vector<std::pair<int, int>> splits;
+  std::vector<WorkSplit> splits;
   for (int i = 0; i < numActiveWorkers; i++) {
     int begin = i * perWorkerBatchSize;
     int end = std::min(begin + perWorkerBatchSize, totalBatchSize);
-    splits.push_back({begin, end});
+    int workerId = totalBatchSize < numActiveWorkers ? (startWorker + i) % numActiveWorkers : i;
+    splits.push_back({workerId, workerId, begin, end});
     if (end >= totalBatchSize) break;
   }
 
@@ -163,9 +167,9 @@ RdmaOpRet MultithreadExecutor::RdmaBatchReadWrite(const ExecutorReq& req) {
   std::vector<std::future<RdmaOpRet>> futs;
 
   for (int i = 0; i < numSplits; i++) {
-    Task task{&req, i, splits[i].first, splits[i].second};
+    Task task{&req, splits[i].epId, splits[i].begin, splits[i].end};
     futs.push_back(std::move(task.ret.get_future()));
-    pool[i]->Submit(std::move(task));
+    pool[splits[i].workerId]->Submit(std::move(task));
   }
 
   bool hasFail = false;

--- a/src/io/rdma/executor.hpp
+++ b/src/io/rdma/executor.hpp
@@ -87,7 +87,14 @@ class MultithreadExecutor : public Executor {
         : req(req_), epId(epId_), begin(begin_), end(end_) {}
   };
 
-  std::vector<std::pair<int, int>> SplitWork(const ExecutorReq& req);
+  struct WorkSplit {
+    int workerId{-1};
+    int epId{-1};
+    int begin{-1};
+    int end{-1};
+  };
+
+  std::vector<WorkSplit> SplitWork(const ExecutorReq& req);
 
   class Worker {
    public:

--- a/src/io/rdma/executor.hpp
+++ b/src/io/rdma/executor.hpp
@@ -21,11 +21,16 @@
 // SOFTWARE.
 #pragma once
 
+#include <atomic>
+#include <chrono>
 #include <condition_variable>
+#include <deque>
 #include <future>
 #include <memory>
 #include <mutex>
 #include <queue>
+#include <thread>
+#include <utility>
 
 #include "mori/application/transport/rdma/rdma.hpp"
 #include "mori/io/common.hpp"
@@ -37,6 +42,22 @@ namespace io {
 /* ---------------------------------------------------------------------------------------------- */
 /*                                         Data Structures                                        */
 /* ---------------------------------------------------------------------------------------------- */
+struct AdmissionToken {
+  std::shared_ptr<SqController> sq;
+  int estimatedWr{0};
+  bool active{false};
+
+  AdmissionToken() = default;
+  AdmissionToken(std::shared_ptr<SqController> sq_, int wr);
+  AdmissionToken(const AdmissionToken&) = delete;
+  AdmissionToken& operator=(const AdmissionToken&) = delete;
+  AdmissionToken(AdmissionToken&& rhs) noexcept;
+  AdmissionToken& operator=(AdmissionToken&& rhs) noexcept;
+  ~AdmissionToken();
+
+  void Release();
+};
+
 struct ExecutorReq {
   const EpPairVec& eps;
   const application::RdmaMemoryRegion& local;
@@ -77,14 +98,18 @@ class MultithreadExecutor : public Executor {
 
  private:
   struct Task {
-    const ExecutorReq* req;
+    const ExecutorReq* req{nullptr};
     int epId{-1};
     int begin{-1};
     int end{-1};
+    AdmissionToken admissionToken;
     std::promise<RdmaOpRet> ret;
 
+    Task() = default;
     Task(const ExecutorReq* req_, int epId_, int begin_, int end_)
         : req(req_), epId(epId_), begin(begin_), end(end_) {}
+    Task(const ExecutorReq* req_, int epId_, int begin_, int end_, AdmissionToken token)
+        : req(req_), epId(epId_), begin(begin_), end(end_), admissionToken(std::move(token)) {}
   };
 
   struct WorkSplit {
@@ -92,9 +117,13 @@ class MultithreadExecutor : public Executor {
     int epId{-1};
     int begin{-1};
     int end{-1};
+    int admissionWr{0};
   };
 
   std::vector<WorkSplit> SplitWork(const ExecutorReq& req);
+  RdmaOpRet RdmaBatchReadWriteWithAdmission(const ExecutorReq& req);
+
+  friend void TestWorkerShutdownDrainsTokensAndPromisesForTest();
 
   class Worker {
    public:
@@ -107,6 +136,8 @@ class MultithreadExecutor : public Executor {
     void Submit(Task&&);
 
    private:
+    friend void TestWorkerShutdownDrainsTokensAndPromisesForTest();
+
     int workerId{-1};
     std::atomic<bool> running{false};
     mutable std::mutex mu;

--- a/src/io/rdma/ledger.cpp
+++ b/src/io/rdma/ledger.cpp
@@ -29,7 +29,7 @@ uint64_t SubmissionLedger::Insert(int postedWr, bool hasSignaledTail,
   std::lock_guard<std::mutex> lock(mu_);
   uint64_t id = nextId_++;
   records_[id] = SubmissionRecord{
-      id, postedWr, hasSignaledTail, SubmissionState::Posted, std::move(meta), batchSize};
+      id, postedWr, hasSignaledTail, SubmissionState::Tentative, std::move(meta), batchSize};
   return id;
 }
 
@@ -51,10 +51,20 @@ bool SubmissionLedger::ReleaseByCqe(uint64_t recordId, SubmissionRecord* outReco
   return true;
 }
 
+bool SubmissionLedger::MarkPosted(uint64_t recordId) {
+  std::lock_guard<std::mutex> lock(mu_);
+  auto it = records_.find(recordId);
+  if (it == records_.end()) return false;
+  if (it->second.state != SubmissionState::Tentative || !it->second.hasSignaledTail) return false;
+  it->second.state = SubmissionState::Posted;
+  return true;
+}
+
 bool SubmissionLedger::CancelTentative(uint64_t recordId, SubmissionRecord* outRecord) {
   std::lock_guard<std::mutex> lock(mu_);
   auto it = records_.find(recordId);
   if (it == records_.end()) return false;
+  if (it->second.state != SubmissionState::Tentative || !it->second.hasSignaledTail) return false;
   if (outRecord != nullptr) *outRecord = std::move(it->second);
   records_.erase(it);
   return true;

--- a/src/io/rdma/ledger.cpp
+++ b/src/io/rdma/ledger.cpp
@@ -33,49 +33,45 @@ uint64_t SubmissionLedger::Insert(int postedWr, bool hasSignaledTail,
   return id;
 }
 
-void SubmissionLedger::InsertOrphaned(int postedWr, std::shared_ptr<CqCallbackMeta> meta,
-                                      int batchSize) {
+uint64_t SubmissionLedger::InsertOrphaned(int postedWr, std::shared_ptr<CqCallbackMeta> meta,
+                                          int batchSize) {
   std::lock_guard<std::mutex> lock(mu_);
   uint64_t id = nextId_++;
   records_[id] =
       SubmissionRecord{id, postedWr, false, SubmissionState::Orphaned, std::move(meta), batchSize};
+  return id;
 }
 
-std::shared_ptr<CqCallbackMeta> SubmissionLedger::ReleaseByCqe(uint64_t recordId,
-                                                               std::atomic<int>* sqDepth,
-                                                               int* outBatchSize,
-                                                               int* outPostedWr) {
+bool SubmissionLedger::ReleaseByCqe(uint64_t recordId, SubmissionRecord* outRecord) {
   std::lock_guard<std::mutex> lock(mu_);
-  if (outBatchSize) *outBatchSize = 0;
-  if (outPostedWr) *outPostedWr = 0;
   auto it = records_.find(recordId);
-  if (it == records_.end()) return nullptr;
-  SubmissionRecord& rec = it->second;
-  if (sqDepth && rec.postedWr > 0) sqDepth->fetch_sub(rec.postedWr, std::memory_order_relaxed);
-  if (outBatchSize) *outBatchSize = rec.batchSize;
-  if (outPostedWr) *outPostedWr = rec.postedWr;
-  auto meta = std::move(rec.meta);
+  if (it == records_.end()) return false;
+  if (outRecord != nullptr) *outRecord = std::move(it->second);
   records_.erase(it);
-  return meta;
+  return true;
 }
 
-int SubmissionLedger::ReleaseOrphanedByRecovery(std::atomic<int>* sqDepth) {
+bool SubmissionLedger::CancelTentative(uint64_t recordId, SubmissionRecord* outRecord) {
   std::lock_guard<std::mutex> lock(mu_);
-  int total = 0;
-  // Only erase Orphaned records.  Posted records still have signaled WRs whose
-  // CQEs may arrive later; they must remain so ReleaseByCqe() can update the
-  // corresponding TransferStatus and release sqDepth normally.
+  auto it = records_.find(recordId);
+  if (it == records_.end()) return false;
+  if (outRecord != nullptr) *outRecord = std::move(it->second);
+  records_.erase(it);
+  return true;
+}
+
+void SubmissionLedger::ExtractOrphanedRecords(std::vector<SubmissionRecord>* outRecords) {
+  std::lock_guard<std::mutex> lock(mu_);
+  if (outRecords != nullptr) outRecords->clear();
   auto it = records_.begin();
   while (it != records_.end()) {
     if (it->second.state == SubmissionState::Orphaned) {
-      total += it->second.postedWr;
+      if (outRecords != nullptr) outRecords->push_back(std::move(it->second));
       it = records_.erase(it);
     } else {
       ++it;
     }
   }
-  if (sqDepth && total > 0) sqDepth->fetch_sub(total, std::memory_order_relaxed);
-  return total;
 }
 
 bool SubmissionLedger::HasOrphaned() const {

--- a/src/io/rdma/ledger.cpp
+++ b/src/io/rdma/ledger.cpp
@@ -43,13 +43,17 @@ void SubmissionLedger::InsertOrphaned(int postedWr, std::shared_ptr<CqCallbackMe
 
 std::shared_ptr<CqCallbackMeta> SubmissionLedger::ReleaseByCqe(uint64_t recordId,
                                                                std::atomic<int>* sqDepth,
-                                                               int* outBatchSize) {
+                                                               int* outBatchSize,
+                                                               int* outPostedWr) {
   std::lock_guard<std::mutex> lock(mu_);
+  if (outBatchSize) *outBatchSize = 0;
+  if (outPostedWr) *outPostedWr = 0;
   auto it = records_.find(recordId);
   if (it == records_.end()) return nullptr;
   SubmissionRecord& rec = it->second;
   if (sqDepth && rec.postedWr > 0) sqDepth->fetch_sub(rec.postedWr, std::memory_order_relaxed);
   if (outBatchSize) *outBatchSize = rec.batchSize;
+  if (outPostedWr) *outPostedWr = rec.postedWr;
   auto meta = std::move(rec.meta);
   records_.erase(it);
   return meta;
@@ -80,6 +84,11 @@ bool SubmissionLedger::HasOrphaned() const {
     if (rec.state == SubmissionState::Orphaned) return true;
   }
   return false;
+}
+
+size_t SubmissionLedger::RecordCount() const {
+  std::lock_guard<std::mutex> lock(mu_);
+  return records_.size();
 }
 
 }  // namespace io

--- a/tests/cpp/io/test_engine.cpp
+++ b/tests/cpp/io/test_engine.cpp
@@ -30,6 +30,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cctype>
 #include <chrono>
 #include <cstdio>
@@ -44,6 +45,7 @@
 
 #include "mori/application/utils/check.hpp"
 #include "mori/io/io.hpp"
+#include "src/io/rdma/backend_impl.hpp"
 #include "src/io/rdma/common.hpp"
 
 using namespace mori::io;
@@ -207,36 +209,206 @@ RegisteredGpuMem RegisterGpuMemory(IOEngine* engine, size_t sizeBytes, int devic
 void CaseSubmissionLedgerBasic() {
   constexpr uint32_t kNotifPerQp = 16;
   SubmissionLedger ledger(kNotifPerQp);
-  std::atomic<int> sqDepth{5};
   TransferStatus status;
   auto meta = std::make_shared<CqCallbackMeta>(&status, 101, 8);
   const uint64_t id = ledger.Insert(3, true, meta, 8);
   Require(id == kNotifPerQp, "first ledger record id should start at notifPerQp boundary");
-  int batchSize = 0;
-  auto releasedMeta = ledger.ReleaseByCqe(id, &sqDepth, &batchSize);
-  Require(releasedMeta != nullptr, "ledger release meta should not be null");
-  Require(releasedMeta->id == 101, "unexpected transfer id from ledger release");
-  Require(batchSize == 8, "unexpected batch size from ledger release");
-  Require(sqDepth.load(std::memory_order_relaxed) == 2, "unexpected sq depth after release");
+  SubmissionRecord released;
+  Require(ledger.ReleaseByCqe(id, &released), "ledger release should find posted record");
+  Require(released.meta != nullptr, "ledger release meta should not be null");
+  Require(released.meta->id == 101, "unexpected transfer id from ledger release");
+  Require(released.batchSize == 8, "unexpected batch size from ledger release");
+  Require(released.postedWr == 3, "unexpected posted WR count from ledger release");
 
   SubmissionLedger ledger2(kNotifPerQp);
-  std::atomic<int> sqDepth2{12};
   auto meta2 = std::make_shared<CqCallbackMeta>(&status, 202, 16);
   uint64_t postedId = ledger2.Insert(4, true, meta2, 10);
   Require(postedId == kNotifPerQp, "posted record id should respect notifPerQp offset");
-  ledger2.InsertOrphaned(3, meta2, 6);
+  uint64_t orphanedId = ledger2.InsertOrphaned(3, meta2, 6);
+  Require(orphanedId == kNotifPerQp + 1, "orphaned record id should follow posted id");
   Require(ledger2.HasOrphaned(), "expected orphaned record in ledger");
-  int recovered = ledger2.ReleaseOrphanedByRecovery(&sqDepth2);
-  // Only Orphaned record (3 WRs) should be released; Posted record (4 WRs) preserved.
-  Require(recovered == 3, "unexpected recovered wr count (should only release orphaned)");
-  Require(sqDepth2.load(std::memory_order_relaxed) == 9, "unexpected sq depth after recovery");
+  std::vector<SubmissionRecord> orphaned;
+  ledger2.ExtractOrphanedRecords(&orphaned);
+  Require(orphaned.size() == 1, "expected one orphaned record");
+  Require(orphaned[0].postedWr == 3, "unexpected orphaned WR count");
+  Require(orphaned[0].meta == meta2, "orphaned record should preserve callback meta");
   Require(!ledger2.HasOrphaned(), "orphaned records should be drained");
   // The Posted record should still be present and retrievable via ReleaseByCqe.
-  int postedBatch = 0;
-  auto postedMeta = ledger2.ReleaseByCqe(postedId, &sqDepth2, &postedBatch);
-  Require(postedMeta != nullptr, "posted record should survive recovery");
-  Require(postedBatch == 10, "posted record batch size mismatch");
-  Require(sqDepth2.load(std::memory_order_relaxed) == 5, "sq depth after posted CQE release");
+  SubmissionRecord posted;
+  Require(ledger2.ReleaseByCqe(postedId, &posted), "posted record should survive recovery");
+  Require(posted.meta != nullptr, "posted record meta should not be null");
+  Require(posted.batchSize == 10, "posted record batch size mismatch");
+  Require(posted.postedWr == 4, "posted record WR count mismatch");
+
+  SubmissionLedger ledger3(kNotifPerQp);
+  uint64_t tentativeId = ledger3.Insert(2, true, meta2, 2);
+  SubmissionRecord tentative;
+  Require(ledger3.CancelTentative(tentativeId, &tentative), "tentative cancel should find record");
+  Require(tentative.postedWr == 2, "tentative cancel should return record contents");
+  Require(!ledger3.ReleaseByCqe(tentativeId, nullptr), "canceled record should be erased");
+}
+
+void CaseSqControllerReserveReleaseWait() {
+  SqController sq(4, 0);
+  ReserveOptions opts;
+  opts.timeoutUs = 200000;
+  ReserveResult result;
+  Require(sq.Reserve(4, opts, &result), "initial reserve should fill SQ");
+  Require(sq.Depth() == 4, "unexpected depth after initial reserve");
+
+  std::atomic<bool> waiterDone{false};
+  std::atomic<bool> waiterOk{false};
+  std::thread waiter([&]() {
+    ReserveResult waitResult;
+    waiterOk.store(sq.Reserve(1, opts, &waitResult), std::memory_order_release);
+    waiterDone.store(true, std::memory_order_release);
+  });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  Require(!waiterDone.load(std::memory_order_acquire), "waiter should block while SQ is full");
+  sq.Release(4);
+  waiter.join();
+  Require(waiterOk.load(std::memory_order_acquire), "waiter should reserve after release");
+  Require(sq.Depth() == 1, "waiter reserve should hold one credit");
+  sq.Release(1);
+  Require(sq.Depth() == 0, "release should drain controller depth");
+
+  SqController watermarked(4, 2);
+  Require(watermarked.Reserve(4, opts, &result), "watermark initial reserve should fill SQ");
+  waiterDone.store(false, std::memory_order_release);
+  waiterOk.store(false, std::memory_order_release);
+  std::thread watermarkWaiter([&]() {
+    ReserveResult waitResult;
+    waiterOk.store(watermarked.Reserve(1, opts, &waitResult), std::memory_order_release);
+    waiterDone.store(true, std::memory_order_release);
+  });
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  watermarked.Release(1);
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  Require(!waiterDone.load(std::memory_order_acquire),
+          "waiter should respect resume watermark after pressure");
+  watermarked.Release(1);
+  watermarkWaiter.join();
+  Require(waiterOk.load(std::memory_order_acquire),
+          "waiter should reserve after resume watermark is available");
+  Require(watermarked.Depth() == 3,
+          "watermark waiter should reserve one credit after two releases");
+  watermarked.Release(3);
+}
+
+void CaseSqControllerTerminalDegraded() {
+  SqController sq(4, 2);
+  ReserveOptions opts;
+  opts.timeoutUs = 200000;
+  ReserveResult result;
+  Require(sq.Reserve(4, opts, &result), "initial reserve should fill SQ");
+
+  std::atomic<bool> waiterDone{false};
+  std::atomic<bool> waiterOk{true};
+  std::atomic<SqReserveFailureKind> waiterKind{SqReserveFailureKind::None};
+  std::thread waiter([&]() {
+    ReserveResult waitResult;
+    waiterOk.store(sq.Reserve(1, opts, &waitResult), std::memory_order_release);
+    waiterKind.store(waitResult.kind, std::memory_order_release);
+    waiterDone.store(true, std::memory_order_release);
+  });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  sq.MarkDegraded(SqDegradeReason::PartialPostOrphaned);
+  waiter.join();
+  Require(waiterDone.load(std::memory_order_acquire), "waiter should wake on degraded");
+  Require(!waiterOk.load(std::memory_order_acquire), "waiter should not reserve degraded SQ");
+  Require(waiterKind.load(std::memory_order_acquire) == SqReserveFailureKind::TerminalDegraded,
+          "waiter should fail with terminal degraded");
+  Require(sq.IsTerminalDegraded(), "partial-post orphaned should be terminal degraded");
+  Require(sq.Depth() == 4, "mark degraded should not release outstanding credits");
+  sq.ReleaseDrainedOrphaned(4);
+  Require(sq.Depth() == 0, "drained orphaned release should fix diagnostic depth");
+  Require(sq.IsTerminalDegraded(), "drained orphaned release must not restore admission");
+  Require(!sq.Reserve(1, opts, &result), "terminal degraded controller should reject reserve");
+}
+
+void CaseSqControllerRecheckRollsBack() {
+  SqController sq(8, 0);
+  ReserveOptions opts;
+  opts.timeoutUs = 10000;
+  ReserveResult result;
+  Require(sq.Reserve(3, opts, &result), "reserve before recheck should succeed");
+  sq.MarkDegraded(SqDegradeReason::FatalCqe);
+  Require(!sq.RecheckBeforePost(3, &result), "recheck should fail after terminal degraded");
+  Require(result.kind == SqReserveFailureKind::TerminalDegraded,
+          "recheck should report terminal degraded");
+  Require(sq.Depth() == 0, "failed recheck should roll back reserved credits");
+}
+
+void RunPendingUnsignaledOrphaningCase(const char* context, int epCount) {
+  constexpr uint32_t kNotifPerQp = 16;
+  TransferStatus status;
+  status.SetCode(StatusCode::IN_PROGRESS);
+  auto meta = std::make_shared<CqCallbackMeta>(&status, 303, epCount * 3);
+
+  EpPairVec eps;
+  eps.reserve(epCount);
+
+  ReserveOptions opts;
+  opts.timeoutUs = 10000;
+  ReserveResult result;
+  std::vector<int> epWrsSinceSignal;
+  std::vector<size_t> epMergedSinceSignal;
+  epWrsSinceSignal.reserve(epCount);
+  epMergedSinceSignal.reserve(epCount);
+
+  for (int i = 0; i < epCount; ++i) {
+    EpPair ep{};
+    ep.sq = std::make_shared<SqController>(8, 0);
+    ep.ledger = std::make_shared<SubmissionLedger>(kNotifPerQp);
+    Require(ep.sq->Reserve(2, opts, &result), "simulated unsignaled reserve should succeed");
+    eps.push_back(ep);
+    epWrsSinceSignal.push_back(2);
+    epMergedSinceSignal.push_back(3);
+  }
+
+  for (int i = 0; i < epCount; ++i) {
+    MovePendingUnsignaledToOrphanedForEndpoint(eps, static_cast<size_t>(i), epWrsSinceSignal,
+                                               epMergedSinceSignal, meta,
+                                               std::string("simulated ") + context, context);
+  }
+
+  for (int i = 0; i < epCount; ++i) {
+    Require(epWrsSinceSignal[i] == 0, "pending WR counter should be cleared after orphaning");
+    Require(epMergedSinceSignal[i] == 0,
+            "pending merged counter should be cleared after orphaning");
+    Require(eps[i].sq->IsTerminalDegraded(),
+            "pending unsignaled orphan should terminal degrade SQ");
+    Require(eps[i].sq->Depth() == 2, "orphaned WR credits should remain held until proven drained");
+    Require(eps[i].ledger->RecordCount() == 0, "orphaned records should be extracted for failure");
+    eps[i].sq->ReleaseDrainedOrphaned(2);
+    Require(eps[i].sq->Depth() == 0, "drained orphaned release should clear held credits");
+  }
+
+  Require(
+      meta->finishedBatchSize.load(std::memory_order_relaxed) == static_cast<uint32_t>(epCount * 3),
+      "orphaned meta should be counted as finished by failure path");
+  Require(status.Failed(), "orphaned meta should fail transfer status");
+}
+
+void CasePendingUnsignaledRecheckFailureOrphans() {
+  RunPendingUnsignaledOrphaningCase("RecheckBeforePost failed", 1);
+}
+
+void CasePendingUnsignaledReserveFailureOrphans() {
+  RunPendingUnsignaledOrphaningCase("TryReserveSqDepth failed", 2);
+}
+
+void CaseRdmaBackendSessionAliveChecksTerminalSq() {
+  RdmaBackendConfig cfg{};
+  mori::application::RdmaMemoryRegion mr{};
+  EpPair ep{};
+  ep.sq = std::make_shared<SqController>(8, 0);
+  RdmaBackendSession sess(cfg, mr, mr, EpPairVec{ep}, nullptr);
+  Require(sess.Alive(), "session should be alive before terminal degrade");
+  ep.sq->MarkDegraded(SqDegradeReason::PartialPostOrphaned);
+  Require(!sess.Alive(), "session should be dead after terminal degraded endpoint");
 }
 
 void CaseWrIdNamespaceHelpers() {
@@ -776,6 +948,12 @@ int main(int argc, char* argv[]) {
   SetLogLevel("info");
   std::vector<TestCase> cases = {
       {"submission_ledger_basic", CaseSubmissionLedgerBasic},
+      {"sq_controller_reserve_release_wait", CaseSqControllerReserveReleaseWait},
+      {"sq_controller_terminal_degraded", CaseSqControllerTerminalDegraded},
+      {"sq_controller_recheck_rolls_back", CaseSqControllerRecheckRollsBack},
+      {"pending_unsignaled_recheck_failure_orphans", CasePendingUnsignaledRecheckFailureOrphans},
+      {"pending_unsignaled_reserve_failure_orphans", CasePendingUnsignaledReserveFailureOrphans},
+      {"rdma_session_alive_checks_terminal_sq", CaseRdmaBackendSessionAliveChecksTerminalSq},
       {"wr_id_namespace_helpers", CaseWrIdNamespaceHelpers},
       {"rdma_notification_rejects_zero_notif_per_qp", CaseRdmaNotificationRejectsZeroNotifPerQp},
       {"rdma_transfer_basic", CaseRdmaTransferBasic},

--- a/tests/cpp/io/test_engine.cpp
+++ b/tests/cpp/io/test_engine.cpp
@@ -213,6 +213,7 @@ void CaseSubmissionLedgerBasic() {
   auto meta = std::make_shared<CqCallbackMeta>(&status, 101, 8);
   const uint64_t id = ledger.Insert(3, true, meta, 8);
   Require(id == kNotifPerQp, "first ledger record id should start at notifPerQp boundary");
+  Require(ledger.MarkPosted(id), "ledger mark posted should accept tentative signaled record");
   SubmissionRecord released;
   Require(ledger.ReleaseByCqe(id, &released), "ledger release should find posted record");
   Require(released.meta != nullptr, "ledger release meta should not be null");
@@ -224,8 +225,12 @@ void CaseSubmissionLedgerBasic() {
   auto meta2 = std::make_shared<CqCallbackMeta>(&status, 202, 16);
   uint64_t postedId = ledger2.Insert(4, true, meta2, 10);
   Require(postedId == kNotifPerQp, "posted record id should respect notifPerQp offset");
+  Require(ledger2.MarkPosted(postedId), "posted record should be markable after tail post");
   uint64_t orphanedId = ledger2.InsertOrphaned(3, meta2, 6);
   Require(orphanedId == kNotifPerQp + 1, "orphaned record id should follow posted id");
+  Require(!ledger2.MarkPosted(orphanedId), "orphaned record should not be markable as posted");
+  Require(!ledger2.CancelTentative(orphanedId, nullptr),
+          "orphaned record should not be cancelable as tentative");
   Require(ledger2.HasOrphaned(), "expected orphaned record in ledger");
   std::vector<SubmissionRecord> orphaned;
   ledger2.ExtractOrphanedRecords(&orphaned);
@@ -246,6 +251,16 @@ void CaseSubmissionLedgerBasic() {
   Require(ledger3.CancelTentative(tentativeId, &tentative), "tentative cancel should find record");
   Require(tentative.postedWr == 2, "tentative cancel should return record contents");
   Require(!ledger3.ReleaseByCqe(tentativeId, nullptr), "canceled record should be erased");
+
+  SubmissionLedger ledger4(kNotifPerQp);
+  uint64_t postedTentativeId = ledger4.Insert(5, true, meta2, 5);
+  Require(ledger4.MarkPosted(postedTentativeId), "posted tentative should transition to posted");
+  Require(!ledger4.CancelTentative(postedTentativeId, nullptr),
+          "posted record should not be cancelable as tentative");
+  SubmissionRecord stillPosted;
+  Require(ledger4.ReleaseByCqe(postedTentativeId, &stillPosted),
+          "posted record should remain after failed tentative cancel");
+  Require(stillPosted.postedWr == 5, "posted record contents should be preserved");
 }
 
 void CaseSqControllerReserveReleaseWait() {

--- a/tests/cpp/io/test_engine.cpp
+++ b/tests/cpp/io/test_engine.cpp
@@ -442,6 +442,54 @@ void CasePendingUnsignaledReserveFailureOrphans() {
   RunPendingUnsignaledOrphaningCase("TryReserveSqDepth failed", 2);
 }
 
+void CasePendingUnsignaledOrphaningClosesAdmissionBeforeRecoveryGuard() {
+  constexpr uint32_t kNotifPerQp = 16;
+  TransferStatus status;
+  status.SetCode(StatusCode::IN_PROGRESS);
+  auto meta = std::make_shared<CqCallbackMeta>(&status, 404, 3);
+
+  EpPair ep{};
+  ep.sq = std::make_shared<SqController>(8, 0);
+  ep.ledger = std::make_shared<SubmissionLedger>(kNotifPerQp);
+
+  ReserveOptions opts;
+  opts.timeoutUs = 10000;
+  ReserveResult result;
+  Require(ep.sq->Reserve(2, opts, &result), "simulated unsignaled reserve should succeed");
+
+  EpPairVec eps{ep};
+  std::vector<int> epWrsSinceSignal{2};
+  std::vector<size_t> epMergedSinceSignal{3};
+  std::shared_lock<std::shared_mutex> recoveryBlocker = ep.sq->AcquireSubmitGuard();
+  std::atomic<bool> helperStarted{false};
+  std::atomic<bool> helperDone{false};
+
+  std::thread helper([&]() {
+    std::shared_lock<std::shared_mutex> heldSubmitGuard = eps[0].sq->AcquireSubmitGuard();
+    helperStarted.store(true, std::memory_order_release);
+    MovePendingUnsignaledToOrphanedForEndpoint(eps, 0, epWrsSinceSignal, epMergedSinceSignal, meta,
+                                               "blocked recovery", "admission-close test",
+                                               &heldSubmitGuard);
+    helperDone.store(true, std::memory_order_release);
+  });
+
+  Require(WaitUntil([&]() { return helperStarted.load(std::memory_order_acquire); },
+                    std::chrono::seconds(1)),
+          "helper thread should acquire submit guard");
+  Require(WaitUntil([&]() { return ep.sq->IsTerminalDegraded(); }, std::chrono::seconds(1)),
+          "helper should close admission before recovery guard drains");
+  Require(!helperDone.load(std::memory_order_acquire),
+          "helper should wait for recovery guard while admission is closed");
+  Require(!ep.sq->Reserve(1, opts, &result), "reserve should fail after admission is closed");
+
+  recoveryBlocker.unlock();
+  helper.join();
+  Require(helperDone.load(std::memory_order_acquire), "helper should finish after recovery drains");
+  Require(status.Failed(), "orphaned meta should fail after recovery drains");
+  ep.sq->ReleaseDrainedOrphaned(2);
+  Require(ep.sq->Depth() == 0, "drained orphaned release should clear held credits");
+}
+
 void CaseRdmaBackendSessionAliveChecksTerminalSq() {
   RdmaBackendConfig cfg{};
   mori::application::RdmaMemoryRegion mr{};
@@ -995,6 +1043,8 @@ int main(int argc, char* argv[]) {
       {"sq_controller_recheck_rolls_back", CaseSqControllerRecheckRollsBack},
       {"pending_unsignaled_recheck_failure_orphans", CasePendingUnsignaledRecheckFailureOrphans},
       {"pending_unsignaled_reserve_failure_orphans", CasePendingUnsignaledReserveFailureOrphans},
+      {"pending_unsignaled_orphaning_closes_admission_before_recovery",
+       CasePendingUnsignaledOrphaningClosesAdmissionBeforeRecoveryGuard},
       {"rdma_session_alive_checks_terminal_sq", CaseRdmaBackendSessionAliveChecksTerminalSq},
       {"wr_id_namespace_helpers", CaseWrIdNamespaceHelpers},
       {"rdma_notification_rejects_zero_notif_per_qp", CaseRdmaNotificationRejectsZeroNotifPerQp},

--- a/tests/cpp/io/test_engine.cpp
+++ b/tests/cpp/io/test_engine.cpp
@@ -36,6 +36,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <functional>
+#include <future>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -62,6 +63,16 @@ struct TestFailure : public std::runtime_error {
 
 void Require(bool cond, const std::string& msg) {
   if (!cond) throw TestFailure(msg);
+}
+
+template <typename Predicate>
+bool WaitUntil(Predicate pred, std::chrono::milliseconds timeout) {
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (pred()) return true;
+    std::this_thread::yield();
+  }
+  return pred();
 }
 
 class ScopedEnvVar {
@@ -273,14 +284,20 @@ void CaseSqControllerReserveReleaseWait() {
 
   std::atomic<bool> waiterDone{false};
   std::atomic<bool> waiterOk{false};
+  std::promise<void> waiterStartedPromise;
+  std::future<void> waiterStarted = waiterStartedPromise.get_future();
   std::thread waiter([&]() {
+    waiterStartedPromise.set_value();
     ReserveResult waitResult;
     waiterOk.store(sq.Reserve(1, opts, &waitResult), std::memory_order_release);
     waiterDone.store(true, std::memory_order_release);
   });
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  Require(!waiterDone.load(std::memory_order_acquire), "waiter should block while SQ is full");
+  Require(waiterStarted.wait_for(std::chrono::seconds(1)) == std::future_status::ready,
+          "waiter thread should start before release");
+  Require(!WaitUntil([&]() { return waiterDone.load(std::memory_order_acquire); },
+                     std::chrono::milliseconds(20)),
+          "waiter should block while SQ is full");
   sq.Release(4);
   waiter.join();
   Require(waiterOk.load(std::memory_order_acquire), "waiter should reserve after release");
@@ -292,15 +309,19 @@ void CaseSqControllerReserveReleaseWait() {
   Require(watermarked.Reserve(4, opts, &result), "watermark initial reserve should fill SQ");
   waiterDone.store(false, std::memory_order_release);
   waiterOk.store(false, std::memory_order_release);
+  std::promise<void> watermarkWaiterStartedPromise;
+  std::future<void> watermarkWaiterStarted = watermarkWaiterStartedPromise.get_future();
   std::thread watermarkWaiter([&]() {
+    watermarkWaiterStartedPromise.set_value();
     ReserveResult waitResult;
     waiterOk.store(watermarked.Reserve(1, opts, &waitResult), std::memory_order_release);
     waiterDone.store(true, std::memory_order_release);
   });
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  Require(watermarkWaiterStarted.wait_for(std::chrono::seconds(1)) == std::future_status::ready,
+          "watermark waiter thread should start before release");
   watermarked.Release(1);
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  Require(!waiterDone.load(std::memory_order_acquire),
+  Require(!WaitUntil([&]() { return waiterDone.load(std::memory_order_acquire); },
+                     std::chrono::milliseconds(20)),
           "waiter should respect resume watermark after pressure");
   watermarked.Release(1);
   watermarkWaiter.join();
@@ -321,17 +342,23 @@ void CaseSqControllerTerminalDegraded() {
   std::atomic<bool> waiterDone{false};
   std::atomic<bool> waiterOk{true};
   std::atomic<SqReserveFailureKind> waiterKind{SqReserveFailureKind::None};
+  std::promise<void> waiterStartedPromise;
+  std::future<void> waiterStarted = waiterStartedPromise.get_future();
   std::thread waiter([&]() {
+    waiterStartedPromise.set_value();
     ReserveResult waitResult;
     waiterOk.store(sq.Reserve(1, opts, &waitResult), std::memory_order_release);
     waiterKind.store(waitResult.kind, std::memory_order_release);
     waiterDone.store(true, std::memory_order_release);
   });
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  Require(waiterStarted.wait_for(std::chrono::seconds(1)) == std::future_status::ready,
+          "degraded waiter thread should start before mark degraded");
   sq.MarkDegraded(SqDegradeReason::PartialPostOrphaned);
+  Require(WaitUntil([&]() { return waiterDone.load(std::memory_order_acquire); },
+                    std::chrono::seconds(1)),
+          "waiter should wake on degraded");
   waiter.join();
-  Require(waiterDone.load(std::memory_order_acquire), "waiter should wake on degraded");
   Require(!waiterOk.load(std::memory_order_acquire), "waiter should not reserve degraded SQ");
   Require(waiterKind.load(std::memory_order_acquire) == SqReserveFailureKind::TerminalDegraded,
           "waiter should fail with terminal degraded");

--- a/tests/cpp/io/test_engine.cpp
+++ b/tests/cpp/io/test_engine.cpp
@@ -48,8 +48,15 @@
 #include "mori/io/io.hpp"
 #include "src/io/rdma/backend_impl.hpp"
 #include "src/io/rdma/common.hpp"
+#include "src/io/rdma/executor.hpp"
 
 using namespace mori::io;
+
+namespace mori {
+namespace io {
+void TestWorkerShutdownDrainsTokensAndPromisesForTest();
+}  // namespace io
+}  // namespace mori
 
 namespace {
 
@@ -381,6 +388,97 @@ void CaseSqControllerRecheckRollsBack() {
   Require(result.kind == SqReserveFailureKind::TerminalDegraded,
           "recheck should report terminal degraded");
   Require(sq.Depth() == 0, "failed recheck should roll back reserved credits");
+}
+
+void CaseSqControllerAdmissionCounters() {
+  SqController sq(4, 2);
+  AdmissionResult result;
+  Require(sq.TryAcquireAdmission(2, 2, &result), "initial admission should succeed");
+  Require(sq.QueuedDepth() == 2, "admission should increment queued depth");
+  Require(sq.EffectiveDepth() == 2, "effective depth should include queued depth");
+  Require(sq.FreeAdmissionSlots() == 2, "free admission slots should reflect queued depth");
+  Require(result.snapshot.queuedDepth == 2, "admission result should report queued depth");
+
+  Require(!sq.TryAcquireAdmission(3, 3, &result),
+          "admission should fail when effective SQ is full");
+  Require(result.kind == AdmissionFailureKind::NoCapacity,
+          "full admission should report no capacity");
+  const uint64_t observedEpoch = result.snapshot.epoch;
+
+  std::atomic<bool> waiterDone{false};
+  std::thread waiter([&]() {
+    waiterDone.store(sq.WaitForAdmissionChange(
+                         std::chrono::steady_clock::now() + std::chrono::seconds(1), observedEpoch),
+                     std::memory_order_release);
+  });
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  sq.ReleaseAdmission(2);
+  waiter.join();
+  Require(waiterDone.load(std::memory_order_acquire), "admission waiter should wake on release");
+  Require(sq.QueuedDepth() == 0, "admission release should decrement queued depth");
+
+  ReserveOptions opts;
+  opts.timeoutUs = 10000;
+  ReserveResult reserveResult;
+  Require(sq.Reserve(1, opts, &reserveResult), "hard reserve should still work");
+  Require(sq.TryAcquireAdmission(2, 2, &result), "admission should account with hard depth");
+  Require(sq.EffectiveDepth() == 3, "effective depth should be hard plus queued depth");
+  sq.ReleaseAdmission(2);
+  sq.Release(1);
+}
+
+void CaseSqControllerAdmissionDegraded() {
+  SqController sq(4, 0);
+  sq.MarkDegraded(SqDegradeReason::FatalCqe);
+  AdmissionResult result;
+  Require(!sq.TryAcquireAdmission(1, 1, &result), "degraded SQ should reject admission");
+  Require(result.kind == AdmissionFailureKind::TerminalDegraded,
+          "fatal degraded SQ should report terminal degraded admission failure");
+}
+
+void CaseSqControllerAdmissionMarkDegradedWakes() {
+  SqController sq(1, 0);
+  AdmissionResult result;
+  Require(sq.TryAcquireAdmission(1, 1, &result), "initial admission should fill soft slots");
+  Require(!sq.TryAcquireAdmission(1, 1, &result), "second admission should observe pressure");
+  const uint64_t observedEpoch = result.snapshot.epoch;
+
+  std::atomic<bool> waiterDone{false};
+  std::thread waiter([&]() {
+    waiterDone.store(sq.WaitForAdmissionChange(
+                         std::chrono::steady_clock::now() + std::chrono::seconds(1), observedEpoch),
+                     std::memory_order_release);
+  });
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  sq.MarkDegraded(SqDegradeReason::FatalCqe);
+  waiter.join();
+
+  Require(waiterDone.load(std::memory_order_acquire), "MarkDegraded should wake admission waiters");
+  sq.ReleaseAdmission(1);
+}
+
+void CaseAdmissionTokenMoveReleasesOnce() {
+  auto sq = std::make_shared<SqController>(8, 0);
+  AdmissionResult result;
+  Require(sq->TryAcquireAdmission(3, 3, &result), "token test admission should succeed");
+  {
+    AdmissionToken token(sq, 3);
+    AdmissionToken moved(std::move(token));
+    AdmissionToken assigned;
+    assigned = std::move(moved);
+    Require(sq->QueuedDepth() == 3, "moving token must not release admission early");
+  }
+  Require(sq->QueuedDepth() == 0, "moved token should release exactly once on destruction");
+
+  Require(sq->TryAcquireAdmission(2, 2, &result), "manual release admission should succeed");
+  AdmissionToken token(sq, 2);
+  token.Release();
+  token.Release();
+  Require(sq->QueuedDepth() == 0, "manual token release should be idempotent");
+}
+
+void CaseWorkerShutdownDrainsTokensAndPromises() {
+  mori::io::TestWorkerShutdownDrainsTokensAndPromisesForTest();
 }
 
 void RunPendingUnsignaledOrphaningCase(const char* context, int epCount) {
@@ -1029,6 +1127,48 @@ struct TestCase {
 
 }  // namespace
 
+namespace mori {
+namespace io {
+
+void TestWorkerShutdownDrainsTokensAndPromisesForTest() {
+  auto check = [](bool cond, const std::string& msg) {
+    if (!cond) throw std::runtime_error(msg);
+  };
+
+  MultithreadExecutor::Worker worker(0);
+  worker.running.store(true, std::memory_order_release);
+
+  auto sq = std::make_shared<SqController>(8, 0);
+  AdmissionResult result;
+  std::vector<std::future<RdmaOpRet>> futures;
+
+  {
+    std::lock_guard<std::mutex> lock(worker.mu);
+    for (int i = 0; i < 3; ++i) {
+      check(sq->TryAcquireAdmission(1, 1, &result),
+            "test setup should acquire worker shutdown admission token");
+      MultithreadExecutor::Task task{nullptr, 0, 0, 0, AdmissionToken(sq, 1)};
+      futures.push_back(task.ret.get_future());
+      worker.q.push(std::move(task));
+    }
+  }
+
+  check(sq->QueuedDepth() == 3, "queued test tasks should hold admission tokens");
+  worker.Shutdown();
+  check(sq->QueuedDepth() == 0, "shutdown should release queued task admission tokens");
+
+  for (auto& fut : futures) {
+    check(fut.wait_for(std::chrono::seconds(1)) == std::future_status::ready,
+          "shutdown should complete queued task promise");
+    RdmaOpRet ret = fut.get();
+    check(ret.code == StatusCode::ERR_BAD_STATE, "shutdown should return ERR_BAD_STATE");
+    check(ret.message == "executor shutdown", "shutdown should use executor shutdown message");
+  }
+}
+
+}  // namespace io
+}  // namespace mori
+
 int main(int argc, char* argv[]) {
   // Subprocess entry point for hidden-device importer
   if (argc >= 3 && std::string(argv[1]) == "--hidden-device-importer") {
@@ -1041,6 +1181,11 @@ int main(int argc, char* argv[]) {
       {"sq_controller_reserve_release_wait", CaseSqControllerReserveReleaseWait},
       {"sq_controller_terminal_degraded", CaseSqControllerTerminalDegraded},
       {"sq_controller_recheck_rolls_back", CaseSqControllerRecheckRollsBack},
+      {"sq_controller_admission_counters", CaseSqControllerAdmissionCounters},
+      {"sq_controller_admission_degraded", CaseSqControllerAdmissionDegraded},
+      {"sq_controller_admission_mark_degraded_wakes", CaseSqControllerAdmissionMarkDegradedWakes},
+      {"admission_token_move_releases_once", CaseAdmissionTokenMoveReleasesOnce},
+      {"worker_shutdown_drains_tokens_and_promises", CaseWorkerShutdownDrainsTokensAndPromises},
       {"pending_unsignaled_recheck_failure_orphans", CasePendingUnsignaledRecheckFailureOrphans},
       {"pending_unsignaled_reserve_failure_orphans", CasePendingUnsignaledReserveFailureOrphans},
       {"pending_unsignaled_orphaning_closes_admission_before_recovery",


### PR DESCRIPTION
## Summary

- **Phase 1A — diagnostics (4df7bbb3)**: rewrite `SQ full` hint to print worker-local QP / session `qpPerTransfer` / `numWorkerThreads` separately, and add five per-EP CQE diagnostic counters (`lastPollAttemptTime` / `lastNonEmptyCqeTime` / `recentCqeCount` / `recentBatchReleaseWr` / ledger `RecordCount`) into the timeout hint so operators can triage CQ-poll stall vs slow drain vs submission burst from a single error line. Adds optional `MORI_IO_SQ_SIGNAL_INTERVAL_WR` (default 0 = off) for in-call signal cadence, and a `SplitWork` small-batch round-robin that no longer pins single-entry transfers to worker 0 / global ep[0].
- **Phase 2 — SqController + ledger boundary + session lifecycle (ee445121)**: introduce per-EP `SqController` as the single owner of SQ credits / waiters / degraded state, with CAS + epoch-protected `condition_variable` wait and `MORI_IO_SQ_RESUME_WATERMARK_WR` hysteresis. `SubmissionLedger` no longer mutates `sqDepth`; new `CancelTentative` and `ExtractOrphanedRecords` return full records so callers can do exactly-once meta failure convergence. All four failure paths (`TryReserveSqDepth` fail, `RecheckBeforePost` fail, `ibv_post_send` fail, fatal CQE) converge through one helper `MovePendingUnsignaledToOrphanedForEndpoint` that releases any held submit guard, takes unique recovery guard, marks endpoint terminal degraded, inserts an orphaned record, and fails unique metas. Fatal CQE white list: `IBV_WC_RETRY_EXC_ERR / RNR / LOC_QP_OP_ERR / REM_ACCESS_ERR / REM_INV_REQ_ERR / FATAL_ERR`; `IBV_WC_WR_FLUSH_ERR` stays as flush cascade only. `RdmaBackendSession::Alive()` reflects any endpoint terminal degraded; `sessionCache` holds `shared_ptr` and invalidates unhealthy entries on cache hit/miss; `RdmaManager::CountEndpoint` / `GetAllEndpoint` filter out terminal-degraded `EpPair` so new sessions only consume healthy endpoints (`BuildRdmaConn` refills `qpPerTransfer` if needed).
- **Phase 3 — executor admission gate + dynamic per-QP load balancing (8d81a916)**: move backpressure from worker-thread retry loops up to the user thread. `SqController` grows a soft `queuedDepth_` (admitted but not yet posted) plus `TryAcquireAdmission` / `ReleaseAdmission` / `WaitForAdmissionChange` so the executor reserves SQ slots *before* submitting work to a worker; under sustained SQ pressure callers block on the admission cv instead of failing on a worker-thread reserve timeout. New move-only RAII `AdmissionToken` is owned by each `Task` — even on worker shutdown the queued tasks release their admission and complete with `ERR_BAD_STATE`. `MultithreadExecutor::RdmaBatchReadWriteWithAdmission` is the new dispatcher when `MORI_IO_SQ_EXECUTOR_ADMISSION=1`; falls back to the legacy `SplitWork` path when disabled (default). Three split policies via `MORI_IO_SQ_SPLIT_POLICY={static,least_loaded,capacity}`: `static` keeps the Phase 1A round-robin; `least_loaded` picks the active QP with the lowest `Depth + QueuedDepth` (skipping degraded QPs); `capacity` (gated behind `MORI_IO_SQ_ENABLE_EXPERIMENTAL_CAPACITY=1`) splits a large batch by per-QP free slots. Admission-side WR estimation reuses a new `EstimateMergedWrCount` helper (SGL merging aware) shared with the worker post path. Five new counters in `SqCqeDiagnostics` (`executorAdmissionWaitCount` / `executorAdmissionWaitUs` / `executorAdmissionTimeoutCount` / `leastLoadedSelectionCount` / `queuedWrHighWatermark`) appear in the SQ-full timeout hint so operators can confirm the gate is actively backpressuring upstream callers.

## Behavior summary

- **Phase 1A + 2 only** (default deploy of this PR): worker-thread cv-wait gated by `MORI_IO_SQ_BACKOFF_TIMEOUT_US`, exactly-once orphan convergence, terminal-degraded `EpPair` filtering, `shared_ptr` session cache with unhealthy invalidation. SQ-full pressure still surfaces as user-visible errors when the backoff window closes.
- **Phase 3 enabled (opt-in: `MORI_IO_SQ_EXECUTOR_ADMISSION=1`)**: user thread blocks in the admission gate until the chosen QP has effective free slots; sustained pressure produces tail latency rather than errors (errors only when the admission deadline expires).

## New env vars (defaults are safe — Phase 3 is opt-in)

| Env var | Default | Phase | Purpose |
|---|---|---|---|
| `MORI_IO_SQ_BACKOFF_TIMEOUT_US` | `10000` (10 ms) | 1A | worker-thread reserve timeout |
| `MORI_IO_SQ_SIGNAL_INTERVAL_WR` | `0` (off) | 1A | optional periodic signaled-WR cadence |
| `MORI_IO_SQ_RESUME_WATERMARK_WR` | `0` (off) | 2 | hysteresis for waking SQ-credit waiters |
| `MORI_IO_SQ_EXECUTOR_ADMISSION` | `false` | 3 | enable user-thread admission gate |
| `MORI_IO_SQ_ADMISSION_TIMEOUT_US` | `1000000` (1 s) | 3 | user-thread admission deadline |
| `MORI_IO_SQ_ADMISSION_RESUME_WATERMARK_WR` | `2048` | 3 | hysteresis for waking admission waiters |
| `MORI_IO_SQ_ADMISSION_WAIT_SLICE_US` | `100` | 3 | inner cv slice for diagnostic accounting |
| `MORI_IO_SQ_ADMISSION_CHUNK_WR` | `0` (auto) | 3 | per-chunk admission size cap |
| `MORI_IO_SQ_ADMISSION_MAX_CHUNKS_PER_CALL` | `0` (= `activeQps`) | 3 | per-call pipeline depth cap |
| `MORI_IO_SQ_SPLIT_POLICY` | `static` | 3 | `static` / `least_loaded` / `capacity` |
| `MORI_IO_SQ_ENABLE_EXPERIMENTAL_CAPACITY` | `false` | 3 | gate the experimental `capacity` policy |

## Test plan

- [x] `tests/cpp/io/test_engine` (24/24 passing locally):
  - `submission_ledger_basic` (extended for `ReleaseByCqe` / `CancelTentative` / `ExtractOrphanedRecords`)
  - `sq_controller_reserve_release_wait` (CV wakeup + resume watermark hysteresis)
  - `sq_controller_terminal_degraded` (waiter wakes on degrade; `ReleaseDrainedOrphaned` does not restore admission)
  - `sq_controller_recheck_rolls_back` (`RecheckBeforePost` rollback after degrade)
  - `sq_controller_admission_counters` (admission acquire/release/`WaitForAdmissionChange`, hard + soft credit interaction)
  - `sq_controller_admission_degraded` (terminal-degraded SQ rejects admission)
  - `sq_controller_admission_mark_degraded_wakes` (`MarkDegraded` wakes admission waiters)
  - `admission_token_move_releases_once` (move-only token RAII + idempotent `Release()`)
  - `worker_shutdown_drains_tokens_and_promises` (worker shutdown releases queued tokens and completes promises with `ERR_BAD_STATE`)
  - `pending_unsignaled_recheck_failure_orphans` (1-EP helper path)
  - `pending_unsignaled_reserve_failure_orphans` (2-EP helper path, multi-meta accumulation)
  - `pending_unsignaled_orphaning_closes_admission_before_recovery` (admission closed before recovery guard)
  - `rdma_session_alive_checks_terminal_sq`
- [ ] Multi-node DSR1 8k1k disagg `conc=1024/2048/4096` regression, two configurations on the same workload:
  - **Phase 1A+2 baseline** (admission off): `MORI_IO_SQ_BACKOFF_TIMEOUT_US=5000000`, expect SQ-full timeout count to drop ~10× and the per-EP diagnostic counters in the timeout hint to classify residual stalls.
  - **Phase 3 enabled**: `MORI_IO_SQ_EXECUTOR_ADMISSION=1 MORI_IO_SQ_ADMISSION_TIMEOUT_US=2000000 MORI_IO_SQ_BACKOFF_TIMEOUT_US=1000000`, expect SQ-full errors to approach 0 with `executorAdmissionWaitCount > 0` confirming the gate is actively backpressuring upstream.
- [ ] `MORI_IO_SQ_SPLIT_POLICY=least_loaded` A/B vs `static` at `4QP/4Worker conc=4096` — track per-QP `Depth` distribution stddev and `leastLoadedSelectionCount`.
- [ ] Optional `MORI_IO_SQ_SIGNAL_INTERVAL_WR=64/128/256` cadence matrix once the `backoff=1s, interval=0` baseline is captured.
- [ ] Submission-guard throughput regression at `4QP/4Worker conc=4096` vs. baseline (no exclusive-guard fallback enabled).

## Follow-ups (separate PRs)

- 4-class partial-post mock tests (no WR posted, signaled-tail-posted, fatal-CQE → terminal-degraded → endpoint rebuild).
- End-to-end mock for `Alive()=false → InvalidateUnhealthySessions → fresh session`, plus `shared_ptr` lifetime test under in-flight transfer + terminal degrade.
- `RouteTable` GC for terminal-degraded `EpPair` (use_count-guarded).
- `RdmaManager::Search` GPU-branch fall-through fix (separate narrower change).
- `least_loaded` / `capacity` policy benchmark under non-uniform NIC link speeds (e.g., one slow rank in an 8-rank × 8-NIC node).
- Flip-the-default PR for `MORI_IO_SQ_EXECUTOR_ADMISSION=1` + `MORI_IO_SQ_SPLIT_POLICY=least_loaded` once production validation is captured.
