### PR TITLE
test(async_ll): probe SDMA path via MORI_ENABLE_SDMA in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE: rocm/mori:ci_rocm723
-  BASE_IMAGE: rocm/pytorch:rocm7.2.3_ubuntu24.04_py3.12_pytorch_release_2.10.0
+  IMAGE: rocm/mori:ci_rocm722
+  BASE_IMAGE: rocm/pytorch:rocm7.2.2_ubuntu24.04_py3.12_pytorch_release_2.10.0
   CONTAINER: mori_ci_${{ github.run_id }}
   CT: docker
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE: rocm/mori:ci
-  BASE_IMAGE: rocm/pytorch:rocm7.2.1_ubuntu24.04_py3.12_pytorch_release_2.8.0
+  IMAGE: rocm/mori:ci_rocm723
+  BASE_IMAGE: rocm/pytorch:rocm7.2.3_ubuntu24.04_py3.12_pytorch_release_2.10.0
   CONTAINER: mori_ci_${{ github.run_id }}
   CT: docker
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
       - name: MORI-EP (async_ll)
         run: |
           $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE && timeout 300 pytest tests/python/ops/test_dispatch_combine_async_ll.py -v
+            cd $GITHUB_WORKSPACE && MORI_ENABLE_SDMA=1 timeout 300 pytest tests/python/ops/test_dispatch_combine_async_ll.py -v
           "
 
       - name: MORI-EP bench

--- a/tests/python/ops/test_dispatch_combine_async_ll.py
+++ b/tests/python/ops/test_dispatch_combine_async_ll.py
@@ -131,7 +131,7 @@ def _test_dispatch_combine(
     num_token_override=None,
     check_results=True,
 ):
-    os.environ["MORI_DISABLE_P2P"] = "1"
+    os.environ["MORI_ENABLE_SDMA"] = "1"
     try:
         config = _make_asyncll_config(
             rank=rank,
@@ -155,7 +155,7 @@ def _test_dispatch_combine(
             check_results=check_results,
         )
     finally:
-        os.environ.pop("MORI_DISABLE_P2P", None)
+        os.environ.pop("MORI_ENABLE_SDMA", None)
 
 
 def _test_dispatch_combine_multi_iteration(
@@ -172,7 +172,7 @@ def _test_dispatch_combine_multi_iteration(
     quant_type="none",
     routing="round_robin",
 ):
-    os.environ["MORI_DISABLE_P2P"] = "1"
+    os.environ["MORI_ENABLE_SDMA"] = "1"
     try:
         config = _make_asyncll_config(
             rank=rank,
@@ -195,7 +195,7 @@ def _test_dispatch_combine_multi_iteration(
             )
             test_case.run_test_once(op, test_data)
     finally:
-        os.environ.pop("MORI_DISABLE_P2P", None)
+        os.environ.pop("MORI_ENABLE_SDMA", None)
 
 
 @pytest.mark.parametrize("world_size", (8,))


### PR DESCRIPTION
## Summary

Switches `tests/python/ops/test_dispatch_combine_async_ll.py` from `MORI_DISABLE_P2P=1` to `MORI_ENABLE_SDMA=1` so the async_ll kernel runs over the **intra-node SDMA** transport instead of the RDMA / IBGDA path.

This is a probe PR — the goal is to see whether CI can run the async_ll kernel end-to-end over SDMA on the current hardware/setup.

## Why

The previous setting (`MORI_DISABLE_P2P=1`) gates `Context::InitializePossibleTransports` so same-host peers fall through to the RDMA branch. With `MORI_ENABLE_SDMA=1` (and P2P NOT disabled), `context.cpp` instead picks `TransportType::SDMA` for same-host peers and exercises the SDMA signal-pointer exchange in `symmetric_memory.cpp`.

## Test plan

- [ ] CI runs `tests/python/ops/test_dispatch_combine_async_ll.py` and reports pass/fail under SDMA