### PR TITLE
fix(ep): copy device counters to host before dereferencing

### DIFF
--- a/src/pybind/pybind_ops.cpp
+++ b/src/pybind/pybind_ops.cpp
@@ -209,10 +209,13 @@ void PyLaunchLocalExpertCount(const mori::moe::EpDispatchCombineConfig& config, 
 }
 
 py::tuple GetDispatchSrcTokenId(mori::moe::EpDispatchCombineHandle& handle) {
+  mori::moe::index_t recvNum = 0;
+  HIP_RUNTIME_CHECK(
+      hipMemcpy(&recvNum, handle.totalRecvTokenNum, sizeof(recvNum), hipMemcpyDeviceToHost));
   return py::make_tuple(
       reinterpret_cast<int64_t>(
           handle.dispTokIdToSrcTokIdMemObj->template GetAs<mori::moe::index_t*>()),
-      static_cast<int64_t>(*handle.totalRecvTokenNum));
+      static_cast<int64_t>(recvNum));
 }
 
 py::tuple GetDispatchSenderTokenIdxMap(mori::moe::EpDispatchCombineHandle& handle) {
@@ -222,8 +225,11 @@ py::tuple GetDispatchSenderTokenIdxMap(mori::moe::EpDispatchCombineHandle& handl
 }
 
 py::tuple GetDispatchReceiverTokenIdxMap(mori::moe::EpDispatchCombineHandle& handle) {
+  mori::moe::index_t counter = 0;
+  HIP_RUNTIME_CHECK(
+      hipMemcpy(&counter, handle.localPeTokenCounter, sizeof(counter), hipMemcpyDeviceToHost));
   return py::make_tuple(reinterpret_cast<int64_t>(handle.dispReceiverIdxMap),
-                        static_cast<int64_t>(*handle.localPeTokenCounter));
+                        static_cast<int64_t>(counter));
 }
 
 py::tuple GetRegisteredCombineInputBuffer(mori::moe::EpDispatchCombineHandle& handle,

--- a/tests/python/ops/test_dispatch_combine_intranode.py
+++ b/tests/python/ops/test_dispatch_combine_intranode.py
@@ -57,7 +57,7 @@ def _make_intranode_config(
         num_experts_per_rank=num_experts_per_rank,
         num_experts_per_token=num_experts_per_token,
         max_token_type_size=4,
-        block_num=256,
+        block_num=64,
         warp_num_per_block=4,
         use_external_inp_buf=use_external_inp_buf,
         kernel_type=mori.ops.EpDispatchCombineKernelType.IntraNode,


### PR DESCRIPTION
## Summary
- `GetDispatchSrcTokenId` and `GetDispatchReceiverTokenIdxMap` were dereferencing device pointers (`handle.totalRecvTokenNum`, `handle.localPeTokenCounter`) directly on the host, which is undefined behavior on HIP/ROCm.
- Use `hipMemcpy` D2H to safely read these counters before passing them to Python.
- Also reduce `block_num` from 256 to 64 in the intranode dispatch/combine test config.

## Test plan
- [ ] `pytest tests/python/ops/test_dispatch_combine_intranode.py`
- [ ] Verify `GetDispatchSrcTokenId` / `GetDispatchReceiverTokenIdxMap` return correct counts under multi-rank runs