### PR TITLE
feat(EP): decouple fp8_blockwise combine scale_dim from user config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,10 @@ jobs:
           $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
             cd $GITHUB_WORKSPACE
             timeout 120 python3 tests/python/ops/bench_dispatch_combine.py
+            timeout 120 python3 tests/python/ops/bench_dispatch_combine.py \
+              --cmd bench --dtype bf16 --quant-type fp8_blockwise \
+              --zero-copy 0 --max-tokens 128 \
+              --force-scale-active 1 --report-scale-stats 1
           "
 
       - name: MORI-IO

--- a/include/mori/ops/dispatch_combine/dispatch_combine.hpp
+++ b/include/mori/ops/dispatch_combine/dispatch_combine.hpp
@@ -234,6 +234,8 @@ class EpDispatchCombineHandle {
   void LaunchReset(hipStream_t = 0);
 
   index_t GetCurRankNumToken() const { return curRankNumToken; }
+  int Fp8BlockwiseCombineScaleDim() const { return fp8BlockwiseCombineScaleDim; }
+  int Fp8BlockwiseCombineScaleTypeSize() const { return fp8BlockwiseCombineScaleTypeSize; }
 
   mori::application::SymmMemObjPtr GetShmemDispatchOutTokMemObj() const {
     if (config.kernelType == KernelType::IntraNode)
@@ -284,6 +286,8 @@ class EpDispatchCombineHandle {
  public:
   // Config
   EpDispatchCombineConfig config;
+  int fp8BlockwiseCombineScaleDim{0};
+  int fp8BlockwiseCombineScaleTypeSize{0};
   // Routed expert indices for tokens
   index_t* tokenIndices{nullptr};
 
@@ -385,6 +389,7 @@ template <typename T>
 struct EpDispatchCombineArgs {
   using data_type = T;
   EpDispatchCombineConfig config;
+  int fp8BlockwiseCombineScaleDim{0};
   int rdmaBlockNum{-1};
   index_t curRankNumToken{0};
   index_t* tokenIndices{nullptr};
@@ -447,6 +452,7 @@ struct EpDispatchCombineArgs {
 // Used by Python-side kernel launch where the type is erased.
 struct EpDispatchCombineArgsRaw {
   EpDispatchCombineConfig config;
+  int fp8BlockwiseCombineScaleDim{0};
   int rdmaBlockNum{-1};
   index_t curRankNumToken{0};
   index_t* tokenIndices{nullptr};

--- a/include/mori/utils/env_utils.hpp
+++ b/include/mori/utils/env_utils.hpp
@@ -102,5 +102,14 @@ inline bool IsEnvVarEnabled(const char* varName) {
   return parsed.value_or(true);
 }
 
+/// Read a positive int env var. Returns `defaultValue` when unset, empty, or
+/// not parseable as a positive int.
+inline int GetPositiveIntOr(const char* varName, int defaultValue) {
+  const char* val = Get(varName);
+  if (val == nullptr || val[0] == '\0') return defaultValue;
+  auto parsed = detail::ParsePositiveInt(val);
+  return parsed.value_or(defaultValue);
+}
+
 }  // namespace env
 }  // namespace mori

--- a/python/mori/ops/dispatch_combine.py
+++ b/python/mori/ops/dispatch_combine.py
@@ -79,6 +79,9 @@ class EpDispatchCombineConfig:
             operation.
         hidden_dim: Hidden dimension of each token embedding.
         scale_dim: Number of scale values stored per token for quantized paths.
+            Describes caller-provided dispatch scales (e.g. FP4 input).
+            ``quant_type="fp8_blockwise"`` combine uses its own internal
+            scale_dim driven by ``MORI_FP8_COMBINE_SCALE_DIM`` (default 56).
         scale_type_size: Size in bytes of each scale element.
         max_token_type_size: Maximum size in bytes for the token element type.
         max_num_inp_token_per_rank: Maximum number of input tokens each rank
@@ -226,6 +229,13 @@ class EpDispatchCombineOp:
         self._handle = handle_class(self._cpp_config)
         self._hip_module = _load_hip_modules(config.kernel_type)
         self._handle_info = mori_cpp.get_handle_info(self._handle)
+
+        self._fp8_blockwise_combine_scale_dim = self._handle_info[
+            "fp8_blockwise_combine_scale_dim"
+        ]
+        self._fp8_blockwise_combine_scale_type_size = self._handle_info[
+            "fp8_blockwise_combine_scale_type_size"
+        ]
 
         self._dispatch_out_ptrs = mori_cpp.get_dispatch_output_ptrs(self._handle, True)
         self._combine_out_ptrs = mori_cpp.get_combine_output_ptrs(self._handle, True)
@@ -754,8 +764,10 @@ class EpDispatchCombineOp:
                     "Fp8BlockwiseQuant currently requires --zero-copy 0 "
                     "(useExternalInpBuffer=True). P2P read path not yet implemented."
                 )
-            if self.config.scale_dim <= 0:
-                raise ValueError("Fp8BlockwiseQuant requires scale_dim > 0")
+            if self._fp8_blockwise_combine_scale_dim <= 0:
+                raise ValueError(
+                    "Fp8BlockwiseQuant requires internal combine scale_dim > 0"
+                )
 
         if kt == EpDispatchCombineKernelType.InterNode.value:
             self._launch(
@@ -802,12 +814,8 @@ class EpDispatchCombineOp:
             if quant_type == EpDispatchCombineQuantType.Fp8BlockwiseQuant:
                 # Mirror of the AccumNum=8 + VecBytes=8 specialization gating in
                 # LaunchCombine() / launch.cpp. Keep in sync.
-                if self.config.scale_dim > 0:
-                    block_elems = (
-                        hidden_dim + self.config.scale_dim - 1
-                    ) // self.config.scale_dim
-                else:
-                    block_elems = 0
+                fp8_scale_dim = self._fp8_blockwise_combine_scale_dim
+                block_elems = (hidden_dim + fp8_scale_dim - 1) // fp8_scale_dim
                 base_vec8_top8_eligible = (
                     weight_ptr == 0
                     and (hidden_dim % 512) == 0

--- a/src/ops/dispatch_combine/dispatch_combine.cpp
+++ b/src/ops/dispatch_combine/dispatch_combine.cpp
@@ -41,6 +41,10 @@ using namespace mori::shmem;
 
 static constexpr int32_t EP_CONFIG_I32_VERSION = 1;
 
+// 56 → block_elems = 7168/56 = 128, matching the AccumNum=8 + VecBytes=8 dequant specialization.
+static constexpr int kDefaultFp8BlockwiseScaleDim = 56;
+static constexpr const char* kFp8BlockwiseScaleDimEnv = "MORI_FP8_COMBINE_SCALE_DIM";
+
 std::vector<int32_t> EpDispatchCombineConfig::ToPackedI32Array() const {
   return {
       EP_CONFIG_I32_VERSION,
@@ -111,6 +115,17 @@ EpDispatchCombineHandle::EpDispatchCombineHandle(EpDispatchCombineConfig config_
     MORI_OPS_INFO("numQpPerPe {} larger than shmem numQpPerPe {}, set to {}", config.numQpPerPe,
                   shmemNumQpPerPe, shmemNumQpPerPe);
   }
+
+  if (config.quantType == QuantType::Fp8BlockwiseQuant) {
+    fp8BlockwiseCombineScaleDim =
+        env::GetPositiveIntOr(kFp8BlockwiseScaleDimEnv, kDefaultFp8BlockwiseScaleDim);
+    fp8BlockwiseCombineScaleTypeSize = static_cast<int>(sizeof(float));
+    if (config.rank == 0) {
+      MORI_OPS_INFO("Fp8BlockwiseQuant combine scale_dim={} (override via {})",
+                    fp8BlockwiseCombineScaleDim, kFp8BlockwiseScaleDimEnv);
+    }
+  }
+
   config.enableSdma = env::IsEnvVarEnabled("MORI_ENABLE_SDMA");
   MORI_OPS_INFO("EpDispatchCombine SDMA {} (currently only effective for AsyncLL kernel type)",
                 config.enableSdma ? "enabled" : "disabled");
@@ -169,7 +184,9 @@ void EpDispatchCombineHandle::InitializeShmemBuf() {
   if (config.kernelType == KernelType::IntraNode &&
       config.quantType == QuantType::Fp8BlockwiseQuant) {
     size_t blockwiseScaleBytes =
-        (config.scaleDim > 0) ? static_cast<size_t>(config.scaleDim) * sizeof(float) : 0;
+        (fp8BlockwiseCombineScaleDim > 0)
+            ? static_cast<size_t>(fp8BlockwiseCombineScaleDim) * fp8BlockwiseCombineScaleTypeSize
+            : 0;
     maxStagingSize = static_cast<size_t>(config.MaxNumTokensToRecv()) *
                      (config.HiddenBytes(config.maxTokenTypeSize) + config.IndexBytes() +
                       config.WeightBytes() + config.SrcTokenIdBytes() + blockwiseScaleBytes);
@@ -214,14 +231,22 @@ void EpDispatchCombineHandle::InitializeShmemBuf() {
   shmemCombineOutWeightsMemObj =
       ShmemMallocAndReturnMemObjPtr(maxWeightSize, hipDeviceMallocUncached);
 
-  if ((config.scaleDim > 0) &&
-      ((config.scaleTypeSize > 0) || config.quantType == QuantType::Fp8BlockwiseQuant)) {
-    size_t scaleElemSizeForAlloc =
-        (config.quantType == QuantType::Fp8BlockwiseQuant) ? sizeof(float) : config.scaleTypeSize;
-    size_t maxScaleSize =
-        static_cast<size_t>(config.MaxNumTokensToRecv()) * config.scaleDim * scaleElemSizeForAlloc;
-    shmemInpScalesMemObj = ShmemMallocAndReturnMemObjPtr(maxScaleSize, hipDeviceMallocUncached);
-    shmemOutScalesMemObj = ShmemMallocAndReturnMemObjPtr(maxScaleSize, hipDeviceMallocUncached);
+  size_t userScaleSize = 0;
+  if (config.scaleDim > 0 && config.scaleTypeSize > 0) {
+    userScaleSize =
+        static_cast<size_t>(config.MaxNumTokensToRecv()) * config.scaleDim * config.scaleTypeSize;
+  }
+  size_t fp8BlockwiseScaleSize = 0;
+  if (config.quantType == QuantType::Fp8BlockwiseQuant && fp8BlockwiseCombineScaleDim > 0) {
+    fp8BlockwiseScaleSize = static_cast<size_t>(config.MaxNumTokensToRecv()) *
+                            fp8BlockwiseCombineScaleDim * fp8BlockwiseCombineScaleTypeSize;
+  }
+  size_t inpScaleSize = std::max(userScaleSize, fp8BlockwiseScaleSize);
+  if (inpScaleSize > 0) {
+    shmemInpScalesMemObj = ShmemMallocAndReturnMemObjPtr(inpScaleSize, hipDeviceMallocUncached);
+  }
+  if (userScaleSize > 0) {
+    shmemOutScalesMemObj = ShmemMallocAndReturnMemObjPtr(userScaleSize, hipDeviceMallocUncached);
   }
 
   size_t maxIndicesSize = config.MaxNumTokensToRecv() * config.numExpertPerToken * sizeof(index_t);
@@ -422,6 +447,7 @@ EpDispatchCombineArgsRaw GetEpDispatchCombineArgsRaw(const EpDispatchCombineHand
                                                      int rdmaBlockNum) {
   EpDispatchCombineArgsRaw args;
   args.config = handle.config;
+  args.fp8BlockwiseCombineScaleDim = handle.fp8BlockwiseCombineScaleDim;
   args.rdmaBlockNum = rdmaBlockNum;
   args.curRankNumToken = handle.curRankNumToken;
   args.tokenIndices = handle.tokenIndices;

--- a/src/ops/dispatch_combine/intranode.hpp
+++ b/src/ops/dispatch_combine/intranode.hpp
@@ -266,7 +266,8 @@ __device__ __forceinline__ void EpCombineIntraNodeKernel_body(EpDispatchCombineA
   const size_t weightBytes =
       (UseWeights && args.weightsBuf != nullptr) ? config.numExpertPerToken * sizeof(float) : 0;
   const size_t scaleBytes =
-      UseFp8BlockwiseQuant ? static_cast<size_t>(config.scaleDim) * sizeof(float) : 0;
+      UseFp8BlockwiseQuant ? static_cast<size_t>(args.fp8BlockwiseCombineScaleDim) * sizeof(float)
+                           : 0;
   const size_t combXferBytes = hiddenBytes + scaleBytes + weightBytes;
 
   if constexpr (EnableStdMoE) {
@@ -279,8 +280,9 @@ __device__ __forceinline__ void EpCombineIntraNodeKernel_body(EpDispatchCombineA
         if constexpr (UseFp8BlockwiseQuant) {
           core::WarpQuantizeToFp8Blockwise<core::CombineInternalFp8>(
               args.intraNodeTokBufs.combineInp->template GetAs<TokT*>() + i * hiddenDim,
-              args.shmemInpScalesMemObj->template GetAs<float*>() + i * config.scaleDim,
-              args.inpTokenBuf + i * hiddenDim, hiddenDim, config.scaleDim);
+              args.shmemInpScalesMemObj->template GetAs<float*>() +
+                  i * args.fp8BlockwiseCombineScaleDim,
+              args.inpTokenBuf + i * hiddenDim, hiddenDim, args.fp8BlockwiseCombineScaleDim);
         } else if constexpr (!std::is_same_v<T, TokT> &&
                              std::is_same_v<TokT, core::CombineInternalFp8>) {
           core::WarpCastBf16ToCombineInternalFp8<T>(
@@ -314,7 +316,7 @@ __device__ __forceinline__ void EpCombineIntraNodeKernel_body(EpDispatchCombineA
         core::WarpQuantizeToFp8Blockwise<core::CombineInternalFp8>(
             reinterpret_cast<core::CombineInternalFp8*>(destStagingPtr),
             reinterpret_cast<float*>(destStagingPtr + hiddenBytes),
-            args.inpTokenBuf + tokenIdx * hiddenDim, hiddenDim, config.scaleDim);
+            args.inpTokenBuf + tokenIdx * hiddenDim, hiddenDim, args.fp8BlockwiseCombineScaleDim);
       } else if constexpr (!std::is_same_v<T, TokT> &&
                            std::is_same_v<TokT, core::CombineInternalFp8>) {
         core::WarpCastBf16ToCombineInternalFp8<T>(reinterpret_cast<TokT*>(destStagingPtr),
@@ -353,7 +355,7 @@ __device__ __forceinline__ void EpCombineIntraNodeKernel_body(EpDispatchCombineA
         core::WarpQuantizeToFp8Blockwise<core::CombineInternalFp8>(
             reinterpret_cast<core::CombineInternalFp8*>(destStagingPtr),
             reinterpret_cast<float*>(destStagingPtr + hiddenBytes),
-            args.inpTokenBuf + tokenIdx * hiddenDim, hiddenDim, config.scaleDim);
+            args.inpTokenBuf + tokenIdx * hiddenDim, hiddenDim, args.fp8BlockwiseCombineScaleDim);
       } else if constexpr (!std::is_same_v<T, TokT> &&
                            std::is_same_v<TokT, core::CombineInternalFp8>) {
         core::WarpCastBf16ToCombineInternalFp8<T>(reinterpret_cast<TokT*>(destStagingPtr),
@@ -423,7 +425,7 @@ __device__ __forceinline__ void EpCombineIntraNodeKernel_body(EpDispatchCombineA
           }
           if constexpr (UseFp8BlockwiseQuant) {
             float* scalePtr = args.shmemInpScalesMemObj->template GetAs<float*>(destPe) +
-                              destLocalTokId * config.scaleDim;
+                              destLocalTokId * args.fp8BlockwiseCombineScaleDim;
             srcScalePtrs[j] = (scalePtr[0] < 0.0f) ? scalePtr : nullptr;
           }
         } else {
@@ -508,12 +510,12 @@ __device__ __forceinline__ void EpCombineIntraNodeKernel_body(EpDispatchCombineA
           core::WarpAccumFp8DequantFull<T, core::CombineInternalFp8>(
               outPtr, reinterpret_cast<const core::CombineInternalFp8* const*>(srcPtrs),
               reinterpret_cast<const float* const*>(srcScalePtrs), validAccumCount, hiddenDim,
-              config.scaleDim);
+              args.fp8BlockwiseCombineScaleDim);
         } else {
           core::WarpAccumFp8DequantSegment<T, core::CombineInternalFp8>(
               outPtr, reinterpret_cast<const core::CombineInternalFp8* const*>(srcPtrs),
               reinterpret_cast<const float* const*>(srcScalePtrs), validAccumCount, hiddenDimOffset,
-              hiddenDimSize, hiddenDim, config.scaleDim);
+              hiddenDimSize, hiddenDim, args.fp8BlockwiseCombineScaleDim);
         }
       }
     } else if constexpr (!std::is_same_v<T, TokT> &&

--- a/src/ops/dispatch_combine/launch.cpp
+++ b/src/ops/dispatch_combine/launch.cpp
@@ -507,16 +507,14 @@ void LaunchCombine(EpDispatchCombineHandle& handle, void* input, void* weights, 
               "Fp8BlockwiseQuant currently requires --zero-copy 0 "
               "(useExternalInpBuffer=true)");
         }
-        if (args.config.scaleDim <= 0) {
-          throw std::runtime_error("Fp8BlockwiseQuant requires scaleDim > 0");
+        const int fp8ScaleDim = args.fp8BlockwiseCombineScaleDim;
+        if (fp8ScaleDim <= 0) {
+          throw std::runtime_error("Fp8BlockwiseQuant requires internal combine scaleDim > 0");
         }
         // Pick the AccumNum=8 + VecBytes=8 specialization when (no weights, hidden_dim % 512 == 0,
         // top-k == 8, EP > 4) and block_elems matches a registered symbol. Keep in sync with the
         // Python launch path in dispatch_combine.py.
-        const int block_elems =
-            (args.config.scaleDim > 0)
-                ? ((args.config.hiddenDim + args.config.scaleDim - 1) / args.config.scaleDim)
-                : 0;
+        const int block_elems = (args.config.hiddenDim + fp8ScaleDim - 1) / fp8ScaleDim;
         const bool baseVec8Top8Eligible = !hasWeights && (args.config.hiddenDim % 512 == 0) &&
                                           args.config.numExpertPerToken == 8 &&
                                           args.config.worldSize > 4;

--- a/src/pybind/pybind_ops.cpp
+++ b/src/pybind/pybind_ops.cpp
@@ -97,9 +97,10 @@ int64_t PrepareAndBuildArgs(mori::moe::EpDispatchCombineHandle& handle, int64_t 
 py::tuple GetDispatchOutputPtrs(mori::moe::EpDispatchCombineHandle& handle, bool has_scales) {
   int64_t out_ptr = reinterpret_cast<int64_t>(handle.GetShmemDispatchOutTokMemObj()->Get());
   int64_t outW_ptr = reinterpret_cast<int64_t>(handle.shmemDispatchOutWeightsMemObj->Get());
-  int64_t outS_ptr = (has_scales && handle.config.scaleDim > 0)
-                         ? reinterpret_cast<int64_t>(handle.shmemOutScalesMemObj->Get())
-                         : 0;
+  int64_t outS_ptr =
+      (has_scales && handle.config.scaleDim > 0 && handle.shmemOutScalesMemObj.IsValid())
+          ? reinterpret_cast<int64_t>(handle.shmemOutScalesMemObj->Get())
+          : 0;
   int64_t outI_ptr = reinterpret_cast<int64_t>(handle.shmemOutIndicesMemObj->Get());
   int64_t total_ptr = reinterpret_cast<int64_t>(handle.totalRecvTokenNum);
   return py::make_tuple(out_ptr, outW_ptr, outS_ptr, outI_ptr, total_ptr);
@@ -120,6 +121,8 @@ py::dict GetHandleInfo(mori::moe::EpDispatchCombineHandle& handle) {
   info["hidden_dim"] = handle.config.hiddenDim;
   info["scale_dim"] = handle.config.scaleDim;
   info["scale_type_size"] = handle.config.scaleTypeSize;
+  info["fp8_blockwise_combine_scale_dim"] = handle.Fp8BlockwiseCombineScaleDim();
+  info["fp8_blockwise_combine_scale_type_size"] = handle.Fp8BlockwiseCombineScaleTypeSize();
   info["max_token_type_size"] = handle.config.maxTokenTypeSize;
   info["max_num_inp_token_per_rank"] = handle.config.maxNumInpTokenPerRank;
   info["num_expert_per_rank"] = handle.config.numExpertPerRank;

--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -1392,9 +1392,9 @@ if __name__ == "__main__":
         type=int,
         default=32,
         help=(
-            "Number of scale blocks per token for blockwise quant "
-            "(only used when --quant-type fp8_blockwise; default: 32). "
-            "Block size in elements is hidden_dim / scale_dim."
+            "Number of caller-provided dispatch scale values per token "
+            "(default: 32). fp8_blockwise combine ignores this and uses "
+            "MORI_FP8_COMBINE_SCALE_DIM for its internal scale layout."
         ),
     )
     parser.add_argument(

--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -51,6 +51,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
         input_shift=0.0,
         force_scale_active=False,
         report_scale_stats=False,
+        combine_scale_dim=None,
     ):
         super().__init__(config)
         self.combine_data_type = (
@@ -69,6 +70,10 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
         self.input_shift = float(input_shift)
         self.force_scale_active = bool(force_scale_active)
         self.report_scale_stats = bool(report_scale_stats)
+        # For fp8_blockwise the kernel quantizes by its own internal
+        # scale_dim; sentinel placement and scale-stat reporting must use
+        # the same value or they describe a different block partition.
+        self.combine_scale_dim = combine_scale_dim
         # Avoid printing the same scale-stats block more than once when
         # gen_test_data is called multiple times in the same run.
         self._scale_stats_reported = False
@@ -82,6 +87,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
             input_scale=self.input_scale,
             input_shift=self.input_shift,
             force_scale_active=self.force_scale_active,
+            combine_scale_dim=self.combine_scale_dim,
         )
         self.config.hidden_dim = saved
 
@@ -102,13 +108,14 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
             _,
             _,
         ) = test_data
+        stats_scale_dim = self.combine_scale_dim or self.config.scale_dim
         per_rank, aggregate = compute_scale_active_stats(
-            all_rank_input, scale_dim=self.config.scale_dim
+            all_rank_input, scale_dim=stats_scale_dim
         )
         if self.config.rank == 0:
             print(
                 format_scale_stats_report(
-                    per_rank, aggregate, scale_dim=self.config.scale_dim
+                    per_rank, aggregate, scale_dim=stats_scale_dim
                 )
             )
 
@@ -937,6 +944,14 @@ def _bench_dispatch_combine(
     with TorchDistContext(rank=rank, world_size=world_size, master_port=port):
         mori.shmem.shmem_torch_process_group_init("default")
         op = mori.ops.EpDispatchCombineOp(config)
+        # For fp8_blockwise, plumb the kernel-internal scale_dim into the
+        # benchmark so force_scale_active sentinels and report_scale_stats
+        # match the partition the kernel actually quantizes.
+        bench_combine_scale_dim = (
+            op._fp8_blockwise_combine_scale_dim
+            if quant_type == "fp8_blockwise"
+            else None
+        )
         benchmark = EpDispatchCombineBenchmark(
             config,
             combine_data_type=combine_data_type,
@@ -947,6 +962,7 @@ def _bench_dispatch_combine(
             input_shift=input_shift,
             force_scale_active=force_scale_active,
             report_scale_stats=report_scale_stats,
+            combine_scale_dim=bench_combine_scale_dim,
         )
 
         (

--- a/tests/python/ops/dispatch_combine_test_utils.py
+++ b/tests/python/ops/dispatch_combine_test_utils.py
@@ -371,6 +371,7 @@ class EpDispatchCombineTestCase:
         input_scale=1.0,
         input_shift=0.0,
         force_scale_active=False,
+        combine_scale_dim=None,
     ):
         """Generate test data."""
         if num_token_override is not None:
@@ -466,10 +467,15 @@ class EpDispatchCombineTestCase:
 
         # Pre-compute the device-side block partition so force_scale_active
         # writes a sentinel into the same block layout the kernel uses.
+        # For fp8_blockwise the caller should pass `combine_scale_dim` from
+        # op._fp8_blockwise_combine_scale_dim; otherwise we fall back to the
+        # user-config scale_dim (FP4 / non-blockwise paths).
+        partition_scale_dim = (
+            combine_scale_dim if combine_scale_dim else self.config.scale_dim
+        )
         block_elems = (
-            (self.config.hidden_dim + self.config.scale_dim - 1)
-            // self.config.scale_dim
-            if self.config.scale_dim > 0
+            (self.config.hidden_dim + partition_scale_dim - 1) // partition_scale_dim
+            if partition_scale_dim > 0
             else self.config.hidden_dim
         )
 

--- a/tests/python/ops/test_dispatch_combine_intranode.py
+++ b/tests/python/ops/test_dispatch_combine_intranode.py
@@ -140,8 +140,8 @@ def test_dispatch_combine(
             pytest.skip("fp8_blockwise only supports bfloat16 input")
         if not use_external_inp_buf:
             pytest.skip("fp8_blockwise requires use_external_inp_buf=True")
-        if scale_dim <= 0:
-            pytest.skip("fp8_blockwise requires scale_dim > 0")
+        # fp8_blockwise combine ignores scale_dim/scale_type_size (driven by
+        # MORI_FP8_COMBINE_SCALE_DIM internally).
 
     for i in range(world_size):
         torch_dist_process_manager.task_queue.put(


### PR DESCRIPTION
## Summary

- Add a dedicated `fp8BlockwiseCombineScaleDim` on `EpDispatchCombineHandle`, plumbed through `EpDispatchCombineArgs<T>` / `ArgsRaw` to the kernel. Driven by a new env var `MORI_FP8_COMBINE_SCALE_DIM` (default `56`, matching `block_elems = 7168 / 56 = 128` for the `AccumNum=8 + VecBytes=8` dequant specialization).
- `EpDispatchCombineConfig.scaleDim` / `scaleTypeSize` keep their original semantics (caller-provided dispatch scales, e.g. FP4 input). fp8_blockwise combine no longer consults them.
- `shmemOutScalesMemObj` is allocated only when the caller provides user scales; `shmemInpScalesMemObj` is sized as `max(userScaleSize, fp8BlockwiseScaleSize)`. Pybind `get_dispatch_output_ptrs` guards with `IsValid()`.
- Python `EpDispatchCombineOp` reads the effective fp8 combine `scale_dim` from `handle_info` into a private attribute; `self.config.scale_dim` is no longer mutated by op construction.

## Test plan

Verified on MI300X, EP=8, `hidden_dim=7168`, `max-tokens=4096`, `zero-copy=0`:

- [x] `pytest tests/python/ops/test_dispatch_combine_intranode.py::test_dispatch_combine -k "fp8_blockwise and data_type0 and True"` — **16/16 pass**
- [x] Sanity: `MORI_FP8_COMBINE_SCALE_DIM=112` correctly drives the internal combine scale_dim to 112 while `config.scaleDim` (user value) stays untouched.
- [x] `bench_dispatch_combine.py --cmd bench --quant-type fp8_blockwise`: combine ~910 us (~19.5% faster than bf16 no-quant baseline ~1131 us), matching PR #311.
- [x] Same combine latency irrespective of caller-supplied `--scale-dim` ∈ {0, 32, 56}.
