### PR TITLE
feat(io): fall back RDMA backend to XGMI when no RDMA device is present

### DIFF
--- a/src/io/engine.cpp
+++ b/src/io/engine.cpp
@@ -26,6 +26,8 @@
 
 #include <cctype>
 #include <cstdlib>
+#include <stdexcept>
+#include <string>
 #include <utility>
 
 #include "mori/io/env.hpp"
@@ -73,6 +75,11 @@ std::string QueryDeviceBusId(int deviceId) {
     c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
   }
   return result;
+}
+
+bool IsAutoXgmiEnabled() {
+  const char* v = std::getenv("MORI_DISABLE_AUTO_XGMI");
+  return v != nullptr && v[0] == '0';
 }
 
 }  // namespace
@@ -163,6 +170,42 @@ void IOEngine::CreateBackend(BackendType type, const BackendConfig& beConfig) {
   }
 
   if (type == BackendType::RDMA) {
+    if (!RdmaBackend::HasActiveDevices()) {
+      if (!IsAutoXgmiEnabled()) {
+        throw std::runtime_error(
+            "no active RDMA device on this host; "
+            "set MORI_DISABLE_AUTO_XGMI=0 to enable XGMI-only fallback");
+      }
+
+      if (!SupportsXgmiBackendByP2P()) {
+        throw std::runtime_error(
+            "no active RDMA device and no usable GPU P2P; cannot create any backend");
+      }
+
+      desc.port = internal::kXgmiOnlyFallbackPlaceholderPort;
+      this->config.port = internal::kXgmiOnlyFallbackPlaceholderPort;
+
+      if (backends.find(BackendType::XGMI) != backends.end()) {
+        InvalidateRouteCache();
+        return;
+      }
+
+      MORI_IO_WARN("No active RDMA device; falling back to XGMI-only mode (port={})",
+                   internal::kXgmiOnlyFallbackPlaceholderPort);
+
+      XgmiBackendConfig xgmiConfig{};
+      auto backend = std::make_unique<XgmiBackend>(desc.key, config, xgmiConfig);
+      backends.insert({BackendType::XGMI, std::move(backend)});
+      InvalidateRouteCache();
+      return;
+    }
+
+    if (config.port == internal::kXgmiOnlyFallbackPlaceholderPort) {
+      throw std::runtime_error(
+          "IOEngineConfig.port=" + std::to_string(internal::kXgmiOnlyFallbackPlaceholderPort) +
+          " is reserved as XGMI-only fallback sentinel");
+    }
+
     auto backend = std::make_unique<RdmaBackend>(desc.key, config,
                                                  static_cast<const RdmaBackendConfig&>(beConfig));
 
@@ -174,6 +217,10 @@ void IOEngine::CreateBackend(BackendType type, const BackendConfig& beConfig) {
         assert(false && "Failed to retrieve bound port after RDMA backend init");
       } else {
         uint16_t bound_port = bound_port_opt.value();
+        if (bound_port == internal::kXgmiOnlyFallbackPlaceholderPort) {
+          throw std::runtime_error("RDMA control-plane bound to sentinel port " +
+                                   std::to_string(bound_port));
+        }
         desc.port = bound_port;
         this->config.port = bound_port;
         MORI_IO_INFO("IOEngine key {} bound ephemeral port {}", desc.key, bound_port);
@@ -234,9 +281,8 @@ bool IOEngine::SupportsXgmiBackendByP2P() const {
 }
 
 void IOEngine::EnsureXgmiBackendCreatedIfSupported() {
-  const char* disableAutoXgmi = std::getenv("MORI_DISABLE_AUTO_XGMI");
-  // Default: do not auto-create XGMI. Set MORI_DISABLE_AUTO_XGMI=0 to enable.
-  if (disableAutoXgmi == nullptr || disableAutoXgmi[0] != '0') {
+  if (!IsAutoXgmiEnabled()) {
+    const char* disableAutoXgmi = std::getenv("MORI_DISABLE_AUTO_XGMI");
     if (disableAutoXgmi != nullptr && disableAutoXgmi[0] != '\0' && disableAutoXgmi[0] != '0') {
       MORI_IO_INFO("Auto XGMI creation is disabled by MORI_DISABLE_AUTO_XGMI");
     }
@@ -333,11 +379,8 @@ Backend* IOEngine::SelectBackend(const MemoryDesc& local, const MemoryDesc& remo
 
   if (auto cachedType = QueryRouteCache(routeKey); cachedType.has_value()) {
     auto cachedBackend = backends.find(cachedType.value());
-    if (cachedBackend != backends.end()) {
-      if (cachedType.value() != BackendType::XGMI ||
-          cachedBackend->second->CanHandle(local, remote)) {
-        return cachedBackend->second.get();
-      }
+    if (cachedBackend != backends.end() && cachedBackend->second->CanHandle(local, remote)) {
+      return cachedBackend->second.get();
     }
   }
 
@@ -350,14 +393,13 @@ Backend* IOEngine::SelectBackend(const MemoryDesc& local, const MemoryDesc& remo
   }
 
   auto rdmaIt = backends.find(BackendType::RDMA);
-  if (rdmaIt != backends.end()) {
+  if (rdmaIt != backends.end() && rdmaIt->second->CanHandle(local, remote)) {
     UpdateRouteCache(routeKey, BackendType::RDMA);
     return rdmaIt->second.get();
   }
 
-  BackendType fallbackType = backends.begin()->first;
-  UpdateRouteCache(routeKey, fallbackType);
-  return backends.begin()->second.get();
+  // No backend can handle this pair (e.g. cross-node under XGMI-only fallback).
+  return nullptr;
 }
 
 void IOEngine::InvalidateRouteCache() {

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <limits>
+#include <memory>
 #include <shared_mutex>
 #include <stdexcept>
 #include <string>
@@ -147,7 +148,9 @@ RdmaManager::RdmaManager(const RdmaBackendConfig cfg, application::RdmaContext* 
     : config(cfg), ctx(ctx) {
   application::RdmaDeviceList devices = ctx->GetRdmaDeviceList();
   availDevices = GetActiveDevicePortList(devices);
-  assert(availDevices.size() > 0);
+  if (availDevices.empty()) {
+    throw std::runtime_error("RdmaManager: no active RDMA device/port found");
+  }
 
   deviceCtxs.resize(availDevices.size(), nullptr);
   topo.reset(new application::TopoSystem());
@@ -780,6 +783,13 @@ void ControlPlaneServer::DeregisterRemoteEngine(const EngineDesc& rdesc) {
   engines.erase(rdesc.key);
 }
 
+std::optional<int> ControlPlaneServer::TryGetRemoteEnginePort(const EngineKey& ekey) const {
+  std::lock_guard<std::mutex> lock(mu);
+  auto it = engines.find(ekey);
+  if (it == engines.end()) return std::nullopt;
+  return it->second.port;
+}
+
 void ControlPlaneServer::BuildRdmaConn(EngineKey ekey, TopoKeyPair topo) {
   application::TCPEndpointHandle tcph;
   {
@@ -1013,6 +1023,11 @@ bool RdmaBackendSession::Alive() const { return true; }
 /* ----------------------------------------------------------------------------------------------
  */
 
+bool RdmaBackend::HasActiveDevices() {
+  application::RdmaContext ctx(application::RdmaBackendType::IBVerbs);
+  return !GetActiveDevicePortList(ctx.GetRdmaDeviceList()).empty();
+}
+
 RdmaBackend::RdmaBackend(EngineKey k, const IOEngineConfig& engConfig,
                          const RdmaBackendConfig& beConfig)
     : myEngKey(k), config(beConfig) {
@@ -1020,9 +1035,9 @@ RdmaBackend::RdmaBackend(EngineKey k, const IOEngineConfig& engConfig,
                 mori::env::detail::ParseBool);
   ValidateRdmaNotificationConfig(config);
 
-  application::RdmaContext* ctx =
-      new application::RdmaContext(application::RdmaBackendType::IBVerbs);
-  rdma.reset(new mori::io::RdmaManager(config, ctx));
+  auto rdmaCtx = std::make_unique<application::RdmaContext>(application::RdmaBackendType::IBVerbs);
+  rdma.reset(new mori::io::RdmaManager(config, rdmaCtx.get()));
+  (void)rdmaCtx.release();
 
   notif.reset(new NotifManager(rdma.get(), config));
   notif->Start();
@@ -1063,6 +1078,12 @@ void RdmaBackend::RegisterMemory(MemoryDesc& desc) { server->RegisterMemory(desc
 void RdmaBackend::DeregisterMemory(const MemoryDesc& desc) {
   server->DeregisterMemory(desc);
   InvalidateSessionsForMemory(desc.id);
+}
+
+bool RdmaBackend::CanHandle(const MemoryDesc& local, const MemoryDesc& remote) const {
+  (void)local;
+  auto rport = server->TryGetRemoteEnginePort(remote.engineKey);
+  return rport.has_value() && rport.value() != internal::kXgmiOnlyFallbackPlaceholderPort;
 }
 
 void RdmaBackend::ReadWrite(const MemoryDesc& localDest, size_t localOffset,

--- a/src/io/rdma/backend_impl.hpp
+++ b/src/io/rdma/backend_impl.hpp
@@ -42,6 +42,15 @@
 
 namespace mori {
 namespace io {
+
+namespace internal {
+
+// Placeholder written into engine_desc.port when an RDMA backend request is
+// rerouted to XGMI-only mode because this host has no active RDMA device.
+inline constexpr uint16_t kXgmiOnlyFallbackPlaceholderPort = 1;
+
+}  // namespace internal
+
 /* ---------------------------------------------------------------------------------------------- */
 /*                                           RdmaManager                                          */
 /* ---------------------------------------------------------------------------------------------- */
@@ -196,6 +205,7 @@ class ControlPlaneServer {
   // Remote engine meta management
   void RegisterRemoteEngine(const EngineDesc&);
   void DeregisterRemoteEngine(const EngineDesc&);
+  std::optional<int> TryGetRemoteEnginePort(const EngineKey&) const;
 
   // Endpoint management
   void BuildRdmaConn(EngineKey, TopoKeyPair);
@@ -268,24 +278,28 @@ class RdmaBackend : public Backend {
   RdmaBackend(EngineKey, const IOEngineConfig&, const RdmaBackendConfig&);
   ~RdmaBackend();
 
+  static bool HasActiveDevices();
+
   std::optional<uint16_t> GetListenPort() const {
     if (!server) return std::nullopt;
     return server->GetListenPort();
   }
 
-  void RegisterRemoteEngine(const EngineDesc&);
-  void DeregisterRemoteEngine(const EngineDesc&);
-  void RegisterMemory(MemoryDesc& desc);
-  void DeregisterMemory(const MemoryDesc& desc);
+  void RegisterRemoteEngine(const EngineDesc&) override;
+  void DeregisterRemoteEngine(const EngineDesc&) override;
+  void RegisterMemory(MemoryDesc& desc) override;
+  void DeregisterMemory(const MemoryDesc& desc) override;
   void ReadWrite(const MemoryDesc& localDest, size_t localOffset, const MemoryDesc& remoteSrc,
                  size_t remoteOffset, size_t size, TransferStatus* status, TransferUniqueId id,
-                 bool isRead);
+                 bool isRead) override;
   void BatchReadWrite(const MemoryDesc& localDest, const SizeVec& localOffsets,
                       const MemoryDesc& remoteSrc, const SizeVec& remoteOffsets,
                       const SizeVec& sizes, TransferStatus* status, TransferUniqueId id,
-                      bool isRead);
-  BackendSession* CreateSession(const MemoryDesc& local, const MemoryDesc& remote);
-  bool PopInboundTransferStatus(EngineKey remote, TransferUniqueId id, TransferStatus* status);
+                      bool isRead) override;
+  BackendSession* CreateSession(const MemoryDesc& local, const MemoryDesc& remote) override;
+  bool PopInboundTransferStatus(EngineKey remote, TransferUniqueId id,
+                                TransferStatus* status) override;
+  bool CanHandle(const MemoryDesc& local, const MemoryDesc& remote) const override;
 
  private:
   void CreateSession(const MemoryDesc& local, const MemoryDesc& remote, RdmaBackendSession& sess);

--- a/tests/cpp/io/test_engine.cpp
+++ b/tests/cpp/io/test_engine.cpp
@@ -44,11 +44,14 @@
 
 #include "mori/application/utils/check.hpp"
 #include "mori/io/io.hpp"
+#include "src/io/rdma/backend_impl.hpp"
 #include "src/io/rdma/common.hpp"
 
 using namespace mori::io;
 
 namespace {
+
+constexpr const char* kNoRdmaDeviceFilter = "__mori_no_such_device_for_test__";
 
 struct TestSkip : public std::runtime_error {
   using std::runtime_error::runtime_error;
@@ -168,6 +171,10 @@ int GetFreePort() {
 }
 
 ConnectedEnginePair CreateConnectedRdmaPair(const std::string& prefix, bool enableNotification) {
+  if (!RdmaBackend::HasActiveDevices()) {
+    throw TestSkip("requires at least one active RDMA device");
+  }
+
   IOEngineConfig cfg;
   cfg.host = "127.0.0.1";
   cfg.port = GetFreePort();
@@ -261,6 +268,10 @@ void CaseWrIdNamespaceHelpers() {
 }
 
 void CaseRdmaNotificationRejectsZeroNotifPerQp() {
+  if (!RdmaBackend::HasActiveDevices()) {
+    throw TestSkip("requires at least one active RDMA device");
+  }
+
   IOEngineConfig cfg;
   cfg.host = "127.0.0.1";
   cfg.port = 0;
@@ -279,6 +290,286 @@ void CaseRdmaNotificationRejectsZeroNotifPerQp() {
             "zero notifPerQp failure should mention notifPerQp");
   }
   Require(threw, "notification-enabled RDMA backend should reject notifPerQp == 0");
+}
+
+void CaseRdmaBackendHasActiveDevicesReturnsFalseWhenNoDevice() {
+  ScopedEnvVar noRdma("MORI_RDMA_DEVICES", kNoRdmaDeviceFilter);
+  Require(!RdmaBackend::HasActiveDevices(),
+          "RdmaBackend::HasActiveDevices() should return false when MORI_RDMA_DEVICES filters "
+          "out all devices");
+}
+
+void CaseRdmaManagerThrowsWhenNoActiveDevices() {
+  ScopedEnvVar noRdma("MORI_RDMA_DEVICES", kNoRdmaDeviceFilter);
+  auto ctx =
+      std::make_unique<mori::application::RdmaContext>(mori::application::RdmaBackendType::IBVerbs);
+  RdmaBackendConfig cfg{};
+
+  bool threw = false;
+  try {
+    RdmaManager mgr(cfg, ctx.get());
+    (void)ctx.release();
+    (void)mgr;
+  } catch (const std::runtime_error&) {
+    threw = true;
+  }
+
+  Require(threw, "RdmaManager ctor must throw when no active RDMA device is available");
+}
+
+void CaseCreateBackendRdmaThrowsByDefaultWhenNoRdmaDevice() {
+  ScopedEnvVar noRdma("MORI_RDMA_DEVICES", kNoRdmaDeviceFilter);
+  ScopedEnvVar gate("MORI_DISABLE_AUTO_XGMI", "1");
+
+  IOEngineConfig cfg{};
+  cfg.host = "127.0.0.1";
+  cfg.port = 0;
+  IOEngine engine("test_default_no_rdma_fallback", cfg);
+
+  RdmaBackendConfig rdmaCfg{};
+  bool threw = false;
+  std::string what;
+  try {
+    engine.CreateBackend(BackendType::RDMA, rdmaCfg);
+  } catch (const std::runtime_error& e) {
+    threw = true;
+    what = e.what();
+  }
+
+  Require(threw,
+          "CreateBackend(RDMA) must throw when no RDMA device is available and fallback is not "
+          "explicitly enabled");
+  Require(what.find("MORI_DISABLE_AUTO_XGMI=0") != std::string::npos,
+          "no-RDMA error should mention MORI_DISABLE_AUTO_XGMI=0; got: " + what);
+}
+
+void CaseCreateBackendRdmaFallsBackToXgmiWhenOptedIn() {
+  if (GetGpuCount() < 1) throw TestSkip("requires at least one GPU");
+
+  ScopedEnvVar noRdma("MORI_RDMA_DEVICES", kNoRdmaDeviceFilter);
+  ScopedEnvVar gate("MORI_DISABLE_AUTO_XGMI", "0");
+
+  IOEngineConfig cfg{};
+  cfg.host = "127.0.0.1";
+  cfg.port = 0;
+  IOEngine engine("test_rdma_fallback_to_xgmi", cfg);
+
+  RdmaBackendConfig rdmaCfg{};
+  engine.CreateBackend(BackendType::RDMA, rdmaCfg);
+
+  EngineDesc desc = engine.GetEngineDesc();
+  Require(desc.port == internal::kXgmiOnlyFallbackPlaceholderPort,
+          "XGMI-only fallback should set engine_desc.port to sentinel; got " +
+              std::to_string(desc.port));
+
+  engine.CreateBackend(BackendType::RDMA, rdmaCfg);
+  desc = engine.GetEngineDesc();
+  Require(desc.port == internal::kXgmiOnlyFallbackPlaceholderPort,
+          "repeated fallback should keep engine_desc.port at sentinel; got " +
+              std::to_string(desc.port));
+}
+
+void CaseCreateBackendRdmaThrowsWhenOptedInButNoXgmi() {
+  if (GetGpuCount() != 0) {
+    throw TestSkip("requires a no-GPU host to deterministically exercise no-XGMI fallback failure");
+  }
+
+  ScopedEnvVar noRdma("MORI_RDMA_DEVICES", kNoRdmaDeviceFilter);
+  ScopedEnvVar gate("MORI_DISABLE_AUTO_XGMI", "0");
+
+  IOEngineConfig cfg{};
+  cfg.host = "127.0.0.1";
+  cfg.port = 0;
+  IOEngine engine("test_no_rdma_no_xgmi", cfg);
+
+  RdmaBackendConfig rdmaCfg{};
+  bool threw = false;
+  std::string what;
+  try {
+    engine.CreateBackend(BackendType::RDMA, rdmaCfg);
+  } catch (const std::runtime_error& e) {
+    threw = true;
+    what = e.what();
+  }
+
+  Require(threw, "CreateBackend(RDMA) must throw when neither RDMA nor XGMI is usable");
+  Require(what.find("XGMI") != std::string::npos || what.find("GPU P2P") != std::string::npos,
+          "no-XGMI error should mention XGMI/GPU P2P; got: " + what);
+}
+
+void CaseExplicitXgmiThenRdmaWithoutOptInStillThrows() {
+  if (GetGpuCount() < 1) throw TestSkip("requires at least one GPU");
+
+  ScopedEnvVar noRdma("MORI_RDMA_DEVICES", kNoRdmaDeviceFilter);
+  ScopedEnvVar gate("MORI_DISABLE_AUTO_XGMI", "1");
+
+  IOEngineConfig cfg{};
+  cfg.host = "127.0.0.1";
+  cfg.port = 0;
+  IOEngine engine("test_explicit_xgmi_then_rdma_no_optin", cfg);
+
+  XgmiBackendConfig xgmiCfg{};
+  engine.CreateBackend(BackendType::XGMI, xgmiCfg);
+
+  RdmaBackendConfig rdmaCfg{};
+  bool threw = false;
+  std::string what;
+  try {
+    engine.CreateBackend(BackendType::RDMA, rdmaCfg);
+  } catch (const std::runtime_error& e) {
+    threw = true;
+    what = e.what();
+  }
+
+  Require(threw, "explicit XGMI must not bypass the RDMA fallback env gate");
+  Require(what.find("MORI_DISABLE_AUTO_XGMI=0") != std::string::npos,
+          "env-gate error should remain actionable; got: " + what);
+}
+
+void CaseExplicitXgmiThenRdmaWithOptInRefreshesPort() {
+  if (GetGpuCount() < 1) throw TestSkip("requires at least one GPU");
+
+  ScopedEnvVar noRdma("MORI_RDMA_DEVICES", kNoRdmaDeviceFilter);
+  ScopedEnvVar gate("MORI_DISABLE_AUTO_XGMI", "0");
+
+  IOEngineConfig cfg{};
+  cfg.host = "127.0.0.1";
+  cfg.port = 0;
+  IOEngine engine("test_explicit_xgmi_then_rdma_optin", cfg);
+
+  XgmiBackendConfig xgmiCfg{};
+  engine.CreateBackend(BackendType::XGMI, xgmiCfg);
+
+  RdmaBackendConfig rdmaCfg{};
+  engine.CreateBackend(BackendType::RDMA, rdmaCfg);
+
+  EngineDesc desc = engine.GetEngineDesc();
+  Require(desc.port == internal::kXgmiOnlyFallbackPlaceholderPort,
+          "opted-in RDMA fallback should refresh desc.port to sentinel after explicit XGMI; got " +
+              std::to_string(desc.port));
+}
+
+void CaseRdmaBackendRefusesSentinelPortConfig() {
+  if (!RdmaBackend::HasActiveDevices()) {
+    throw TestSkip("requires at least one active RDMA device");
+  }
+
+  ScopedEnvVar gate("MORI_DISABLE_AUTO_XGMI", "1");
+  IOEngineConfig cfg{};
+  cfg.host = "127.0.0.1";
+  cfg.port = internal::kXgmiOnlyFallbackPlaceholderPort;
+  IOEngine engine("test_rdma_sentinel_port_refused", cfg);
+
+  RdmaBackendConfig rdmaCfg{};
+  bool threw = false;
+  std::string what;
+  try {
+    engine.CreateBackend(BackendType::RDMA, rdmaCfg);
+  } catch (const std::runtime_error& e) {
+    threw = true;
+    what = e.what();
+  }
+
+  Require(threw, "real RDMA backend must refuse the XGMI-only sentinel port");
+  Require(what.find("sentinel") != std::string::npos || what.find("reserved") != std::string::npos,
+          "sentinel port error should explain that the port is reserved; got: " + what);
+}
+
+void CaseSelectBackendReturnsNullForCrossNodeUnderXgmiOnly() {
+  if (GetGpuCount() < 1) throw TestSkip("requires at least one GPU");
+
+  ScopedEnvVar noRdma("MORI_RDMA_DEVICES", kNoRdmaDeviceFilter);
+  ScopedEnvVar gate("MORI_DISABLE_AUTO_XGMI", "0");
+
+  IOEngineConfig cfg{};
+  cfg.host = "127.0.0.1";
+  cfg.port = 0;
+  IOEngine engine("test_xgmi_only_cross_node", cfg);
+
+  RdmaBackendConfig rdmaCfg{};
+  engine.CreateBackend(BackendType::RDMA, rdmaCfg);
+
+  EngineDesc fakeRemote{};
+  fakeRemote.key = "fake_cross_node_remote";
+  fakeRemote.nodeId = "different-node";
+  fakeRemote.hostname = "different-host";
+  fakeRemote.host = "127.0.0.1";
+  fakeRemote.port = internal::kXgmiOnlyFallbackPlaceholderPort;
+  fakeRemote.pid = 0;
+  engine.RegisterRemoteEngine(fakeRemote);
+
+  auto local = RegisterGpuMemory(&engine, 4096, 0);
+  MemoryDesc remote{};
+  remote.engineKey = fakeRemote.key;
+  remote.id = 999;
+  remote.deviceId = 0;
+  remote.deviceBusId = local.desc.deviceBusId;
+  remote.data = local.desc.data;
+  remote.size = local.desc.size;
+  remote.loc = MemoryLocationType::GPU;
+
+  TransferStatus status;
+  TransferUniqueId uid = engine.AllocateTransferUniqueId();
+  engine.Write(local.desc, 0, remote, 0, 16, &status, uid);
+
+  Require(status.Code() == StatusCode::ERR_BAD_STATE,
+          "cross-node transfer under XGMI-only fallback should return ERR_BAD_STATE; got " +
+              std::to_string(status.CodeUint32()) + ", msg='" + status.Message() + "'");
+  Require(status.Message().find("No available backend") != std::string::npos,
+          "cross-node transfer under XGMI-only fallback should be rejected by route layer; got: " +
+              status.Message());
+}
+
+void CaseRdmaBackendCanHandleRejectsSentinelPortRemote() {
+  if (!RdmaBackend::HasActiveDevices()) {
+    throw TestSkip("requires at least one active RDMA device");
+  }
+
+  ScopedEnvVar gate("MORI_DISABLE_AUTO_XGMI", "1");
+  IOEngineConfig cfg{};
+  cfg.host = "127.0.0.1";
+  cfg.port = 0;
+  IOEngine engine("test_rdma_rejects_sentinel_remote", cfg);
+
+  RdmaBackendConfig rdmaCfg{};
+  engine.CreateBackend(BackendType::RDMA, rdmaCfg);
+
+  EngineDesc fakeRemote{};
+  fakeRemote.key = "remote_xgmi_only";
+  fakeRemote.nodeId = "remote-node";
+  fakeRemote.hostname = "remote-host";
+  fakeRemote.host = "10.255.255.255";
+  fakeRemote.port = internal::kXgmiOnlyFallbackPlaceholderPort;
+  fakeRemote.pid = 0;
+  engine.RegisterRemoteEngine(fakeRemote);
+
+  int localValue = 0;
+  int remoteValue = 0;
+  MemoryDesc local{};
+  local.engineKey = engine.GetEngineDesc().key;
+  local.id = 1;
+  local.deviceId = -1;
+  local.data = reinterpret_cast<uintptr_t>(&localValue);
+  local.size = sizeof(localValue);
+  local.loc = MemoryLocationType::CPU;
+
+  MemoryDesc remote{};
+  remote.engineKey = fakeRemote.key;
+  remote.id = 2;
+  remote.deviceId = -1;
+  remote.data = reinterpret_cast<uintptr_t>(&remoteValue);
+  remote.size = sizeof(remoteValue);
+  remote.loc = MemoryLocationType::CPU;
+
+  TransferStatus status;
+  TransferUniqueId uid = engine.AllocateTransferUniqueId();
+  engine.Write(local, 0, remote, 0, sizeof(localValue), &status, uid);
+
+  Require(status.Code() == StatusCode::ERR_BAD_STATE,
+          "RDMA backend must reject sentinel-port remote before Connect; got " +
+              std::to_string(status.CodeUint32()) + ", msg='" + status.Message() + "'");
+  Require(status.Message().find("No available backend") != std::string::npos,
+          "sentinel-port remote should be rejected by route layer; got: " + status.Message());
 }
 
 void CaseRdmaTransferBasic() {
@@ -778,6 +1069,24 @@ int main(int argc, char* argv[]) {
       {"submission_ledger_basic", CaseSubmissionLedgerBasic},
       {"wr_id_namespace_helpers", CaseWrIdNamespaceHelpers},
       {"rdma_notification_rejects_zero_notif_per_qp", CaseRdmaNotificationRejectsZeroNotifPerQp},
+      {"rdma_backend_has_active_devices_returns_false_when_no_device",
+       CaseRdmaBackendHasActiveDevicesReturnsFalseWhenNoDevice},
+      {"rdma_manager_throws_when_no_active_devices", CaseRdmaManagerThrowsWhenNoActiveDevices},
+      {"create_backend_rdma_throws_by_default_when_no_rdma_device",
+       CaseCreateBackendRdmaThrowsByDefaultWhenNoRdmaDevice},
+      {"create_backend_rdma_falls_back_to_xgmi_when_opted_in",
+       CaseCreateBackendRdmaFallsBackToXgmiWhenOptedIn},
+      {"create_backend_rdma_throws_when_opted_in_but_no_xgmi",
+       CaseCreateBackendRdmaThrowsWhenOptedInButNoXgmi},
+      {"explicit_xgmi_then_rdma_without_opt_in_still_throws",
+       CaseExplicitXgmiThenRdmaWithoutOptInStillThrows},
+      {"explicit_xgmi_then_rdma_with_opt_in_refreshes_port",
+       CaseExplicitXgmiThenRdmaWithOptInRefreshesPort},
+      {"rdma_backend_refuses_sentinel_port_config", CaseRdmaBackendRefusesSentinelPortConfig},
+      {"select_backend_returns_null_for_cross_node_under_xgmi_only",
+       CaseSelectBackendReturnsNullForCrossNodeUnderXgmiOnly},
+      {"rdma_backend_can_handle_rejects_sentinel_port_remote",
+       CaseRdmaBackendCanHandleRejectsSentinelPortRemote},
       {"rdma_transfer_basic", CaseRdmaTransferBasic},
       {"rdma_notification_disabled_behavior", CaseRdmaNotificationDisabledBehavior},
       {"rdma_notification_env_override_disables", CaseRdmaNotificationEnvOverrideDisables},


### PR DESCRIPTION
## Summary

Make `IOEngine::CreateBackend(BackendType::RDMA, ...)` behave gracefully on hosts without an active RDMA NIC. Previously the call would hit `assert(availDevices.size() > 0)` deep inside `RdmaManager` and `SIGABRT` —
which prevents SGLang's mori PD-disaggregation path ([sgl-project/sglang#25094](https://github.com/sgl-project/sglang/pull/25094)) from running on single-node setups even when XGMI/Infinity Fabric is available between local GPUs.

This PR is the mori-side counterpart: when no RDMA device exists and the operator opts in via `MORI_DISABLE_AUTO_XGMI=0`, `CreateBackend(RDMA)` is transparently rerouted to create an `XgmiBackend` instead. SGLang's existing `engine.create_backend(BackendType.RDMA, rdma_cfg)` keeps working unchanged on no-RDMA hosts.

### Behavior

| Scenario                                                              | New behavior                                                                                                |
| --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
| Has RDMA device                                                       | Unchanged (creates `RdmaBackend`; `EnsureXgmiBackendCreatedIfSupported()` still runs)                       |
| No RDMA device, default env (`MORI_DISABLE_AUTO_XGMI` unset / not `0`)| `throw std::runtime_error("...; set MORI_DISABLE_AUTO_XGMI=0 to enable XGMI-only fallback")` (no SIGABRT)   |
| No RDMA device, opt-in (`MORI_DISABLE_AUTO_XGMI=0`), GPU P2P available| Reroutes to `XgmiBackend`, `engine_desc.port = 1` (sentinel); one-line `WARN` log                           |
| No RDMA device, opt-in, no GPU P2P                                    | `throw std::runtime_error("...no usable GPU P2P; cannot create any backend")` — startup fail-fast           |

### Implementation notes

- `RdmaManager` ctor: `assert` → `throw std::runtime_error` (assert is compiled out in Release, masking failures).
- `RdmaBackend` ctor: wrap `RdmaContext*` in `unique_ptr` to avoid leak on the new throw path.
- `RdmaBackend::CanHandle()`: rejects sentinel-port remotes — otherwise a peer's `BuildRdmaConn → Connect` hits `SYSCALL_RETURN_ZERO` and `exit(-1)`s the whole peer process.
- `IOEngine::SelectBackend()`: every routing path now checks `CanHandle()`; the previous "first backend wins" tail-fallback is replaced with `return nullptr`, so unhandled transfers surface `ERR_BAD_STATE` via the existing `SELECT_BACKEND_AND_RETURN_IF_NONE` macro.
- Sentinel port `1`: must be `> 0` (SGLang asserts `port > 0`); unbindable by non-root, easy to spot in netstat. Defensive checks reject `config.port == 1` and any RDMA ephemeral bind that lands on `1`.

## Test plan

New `Case*` tests in `tests/cpp/io/test_engine.cpp`, registered in the `cases` list. Use `MORI_RDMA_DEVICES="__mori_no_such_device_for_test__"` to deterministically simulate "no RDMA":

- [x] `rdma_backend_has_active_devices_returns_false_when_no_device`
- [x] `rdma_manager_throws_when_no_active_devices`
- [x] `create_backend_rdma_throws_by_default_when_no_rdma_device`
- [x] `create_backend_rdma_falls_back_to_xgmi_when_opted_in`
- [x] `create_backend_rdma_throws_when_opted_in_but_no_xgmi` (no-GPU only)
- [x] `explicit_xgmi_then_rdma_without_opt_in_still_throws`
- [x] `explicit_xgmi_then_rdma_with_opt_in_refreshes_port`
- [x] `rdma_backend_refuses_sentinel_port_config`
- [x] `select_backend_returns_null_for_cross_node_under_xgmi_only`
- [x] `rdma_backend_can_handle_rejects_sentinel_port_remote`

Existing RDMA tests guarded by `if (!RdmaBackend::HasActiveDevices()) throw TestSkip(...)` so the `assert → throw` change does not break test_engine on no-RDMA CI.