### PR TITLE
fix(env): cache MORI_ENABLE_SDMA / MORI_DISABLE_P2P at Context construction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
       - name: MORI-EP (async_ll IBGDA)
         run: |
           $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE && MORI_DISABLE_P2P=1 timeout 300 pytest tests/python/ops/test_dispatch_combine_async_ll.py -v
+            cd $GITHUB_WORKSPACE && MORI_DISABLE_P2P=1 MORI_ENABLE_SDMA=0 timeout 300 pytest tests/python/ops/test_dispatch_combine_async_ll.py -v
           "
 
       - name: MORI-EP bench

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,10 +128,16 @@ jobs:
             cd $GITHUB_WORKSPACE && timeout 300 pytest tests/python/ops/test_dispatch_combine_internode_v1.py -v
           "
 
-      - name: MORI-EP (async_ll)
+      - name: MORI-EP (async_ll SDMA)
         run: |
           $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE && timeout 300 pytest tests/python/ops/test_dispatch_combine_async_ll.py -v
+            cd $GITHUB_WORKSPACE && MORI_ENABLE_SDMA=1 timeout 300 pytest tests/python/ops/test_dispatch_combine_async_ll.py -v
+          "
+
+      - name: MORI-EP (async_ll IBGDA)
+        run: |
+          $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
+            cd $GITHUB_WORKSPACE && MORI_DISABLE_P2P=1 timeout 300 pytest tests/python/ops/test_dispatch_combine_async_ll.py -v
           "
 
       - name: MORI-EP bench

--- a/include/mori/application/context/context.hpp
+++ b/include/mori/application/context/context.hpp
@@ -52,6 +52,15 @@ class Context {
   // Check if P2P connection is possible with a peer (same node)
   bool CanUseP2P(int destRank) const;
 
+  // Cached env-var snapshot taken at construction time. All later code MUST
+  // consult these (not getenv) so that env-var changes after Context init
+  // cannot create an inconsistent state -- e.g. transport selected one way
+  // at init but SymmMemManager::Malloc later switching to uncached
+  // hipExtMallocWithFlags allocations because someone set MORI_ENABLE_SDMA
+  // in a test function after the workers had already been spawned.
+  bool IsSdmaEnabled() const { return sdmaEnabled; }
+  bool IsP2PDisabled() const { return p2pDisabled; }
+
   const std::vector<RdmaEndpoint>& GetRdmaEndpoints() const { return rdmaEps; }
 
  private:
@@ -62,6 +71,9 @@ class Context {
   BootstrapNetwork& bootNet;
   int rankInNode{-1};
   int numQpPerPe{4};
+  // Snapshotted at construction; see IsSdmaEnabled() / IsP2PDisabled() above.
+  bool sdmaEnabled{false};
+  bool p2pDisabled{false};
   std::vector<std::string> hostnames;
   std::vector<TransportType> transportTypes;
 

--- a/include/mori/shmem/shmem_api.hpp
+++ b/include/mori/shmem/shmem_api.hpp
@@ -93,6 +93,11 @@ enum ShmemTeamType {
 
 int ShmemNumQpPerPe();
 
+// Returns the MORI_ENABLE_SDMA snapshot taken at Context construction time.
+// Use this instead of getenv("MORI_ENABLE_SDMA") so callers stay consistent
+// with the transport selection that was made at shmem init.
+bool ShmemSdmaEnabled();
+
 // TODO: finish team pe api
 // int ShmemTeamMyPe(ShmemTeamType);
 // int ShmemTeamNPes(ShmemTeamType);

--- a/src/application/context/context.cpp
+++ b/src/application/context/context.cpp
@@ -42,6 +42,14 @@ namespace mori {
 namespace application {
 
 Context::Context(BootstrapNetwork& bootNet) : bootNet(bootNet) {
+  // Snapshot env vars once at construction. Every subsequent decision (transport
+  // selection, hipMalloc vs hipExtMallocWithFlags(uncached), etc.) must read
+  // from this cached state, not getenv. Otherwise late env mutations -- e.g.
+  // a test setting MORI_ENABLE_SDMA after worker init -- can produce a state
+  // where the transport layer chose P2P but per-allocation paths flip to
+  // uncached SDMA buffers, leading to cache/IPC inconsistency hangs.
+  sdmaEnabled = env::IsEnvVarEnabled("MORI_ENABLE_SDMA");
+  p2pDisabled = env::IsEnvVarEnabled("MORI_DISABLE_P2P");
   CollectHostNames();
   InitializePossibleTransports();
 }
@@ -121,9 +129,10 @@ void Context::CollectHostNames() {
   }
 }
 
-bool IsP2PDisabled() { return env::IsEnvVarEnabled("MORI_DISABLE_P2P"); }
-
-bool IsSDMAEnabled() { return env::IsEnvVarEnabled("MORI_ENABLE_SDMA"); }
+// MORI_ENABLE_SDMA / MORI_DISABLE_P2P are now read exactly once in the
+// Context constructor and cached as members; consult Context::IsSdmaEnabled()
+// / Context::IsP2PDisabled() instead of getenv anywhere outside the
+// constructor.
 
 void Context::InitializePossibleTransports() {
   // Find my rank in node
@@ -197,7 +206,7 @@ void Context::InitializePossibleTransports() {
   this->numQpPerPe = numQpPerPe;
   // Initialize transport
   int peerRankInNode = -1;
-  if (!IsP2PDisabled() && IsSDMAEnabled()) anvil::anvil.init();
+  if (!IsP2PDisabled() && IsSdmaEnabled()) anvil::anvil.init();
 
   int sdmaNumChannels = anvil::GetSdmaNumChannels();
   MORI_APP_INFO("SDMA num channels per GPU pair: {}", sdmaNumChannels);
@@ -213,7 +222,7 @@ void Context::InitializePossibleTransports() {
         bool canAccessPeer = true;
 
         if ((i == LocalRank()) || canAccessPeer) {
-          if (IsSDMAEnabled()) {
+          if (IsSdmaEnabled()) {
             if (i != LocalRank()) {
               transportTypes.push_back(TransportType::SDMA);
               anvil::EnablePeerAccess(LocalRank() % 8, i % 8);

--- a/src/application/memory/symmetric_memory.cpp
+++ b/src/application/memory/symmetric_memory.cpp
@@ -75,8 +75,13 @@ void SymmMemManager::HostFree(void* localPtr) {
 
 SymmMemObjPtr SymmMemManager::Malloc(size_t size) {
   void* ptr = nullptr;
-  const bool enableSdma = (std::getenv("MORI_ENABLE_SDMA") != nullptr);
-  if (enableSdma) {
+  // Use the Context-cached snapshot rather than getenv() so this stays
+  // consistent with the transport selection that was made when the Context
+  // was constructed. Without this, late env mutations (e.g. a test setting
+  // MORI_ENABLE_SDMA after worker init) flip allocations to uncached
+  // hipExtMallocWithFlags while transport selection still believes P2P,
+  // producing cache/IPC inconsistency hangs.
+  if (context.IsSdmaEnabled()) {
     HIP_RUNTIME_CHECK(hipExtMallocWithFlags(&ptr, size, hipDeviceMallocUncached));
   } else {
     HIP_RUNTIME_CHECK(hipMalloc(&ptr, size));

--- a/src/ops/dispatch_combine/dispatch_combine.cpp
+++ b/src/ops/dispatch_combine/dispatch_combine.cpp
@@ -126,7 +126,13 @@ EpDispatchCombineHandle::EpDispatchCombineHandle(EpDispatchCombineConfig config_
     }
   }
 
-  config.enableSdma = env::IsEnvVarEnabled("MORI_ENABLE_SDMA");
+  // Read the SDMA flag from the Context-cached snapshot (set once at Context
+  // construction). Reading getenv directly here would race with the
+  // SymmMemManager / Context decisions made at shmem init time -- the symptom
+  // was tests that set MORI_ENABLE_SDMA inside the test function deadlocking
+  // because Malloc started returning uncached buffers while Context still
+  // believed the transport was P2P.
+  config.enableSdma = ShmemSdmaEnabled();
   MORI_OPS_INFO("EpDispatchCombine SDMA {} (currently only effective for AsyncLL kernel type)",
                 config.enableSdma ? "enabled" : "disabled");
   if (config.kernelType == KernelType::AsyncLL && !config.enableSdma && config.rank == 0) {

--- a/src/shmem/runtime.cpp
+++ b/src/shmem/runtime.cpp
@@ -177,6 +177,11 @@ int ShmemNumQpPerPe() {
   return states->rdmaStates->commContext->GetNumQpPerPe();
 }
 
+bool ShmemSdmaEnabled() {
+  ShmemStates* states = ShmemStatesSingleton::GetInstance();
+  return states->rdmaStates->commContext->IsSdmaEnabled();
+}
+
 /* ---------------------------------------------------------------------------------------------- */
 /*                                      Barrier APIs                                             */
 /* ---------------------------------------------------------------------------------------------- */

--- a/tests/python/ops/test_dispatch_combine_async_ll.py
+++ b/tests/python/ops/test_dispatch_combine_async_ll.py
@@ -20,8 +20,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import mori
+import os
 import pytest
 import torch
+
+# Default to SDMA transport for local runs.  CI overrides this per step:
+#   SDMA step:  MORI_ENABLE_SDMA=1  (same as default, redundant but harmless)
+#   IBGDA step: MORI_DISABLE_P2P=1  (overrides transport to RDMA; SDMA flag ignored)
+# Must be set at module level (before worker processes are spawned by the
+# session fixture) so the child processes inherit the correct env.
+os.environ.setdefault("MORI_ENABLE_SDMA", "1")
 from tests.python.ops.dispatch_combine_test_utils import (
     _all_data_types,
     _is_fp4x2_dtype,

--- a/tests/python/ops/test_dispatch_combine_async_ll.py
+++ b/tests/python/ops/test_dispatch_combine_async_ll.py
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import mori
-import os
 import pytest
 import torch
 from tests.python.ops.dispatch_combine_test_utils import (
@@ -131,31 +130,27 @@ def _test_dispatch_combine(
     num_token_override=None,
     check_results=True,
 ):
-    os.environ["MORI_DISABLE_P2P"] = "1"
-    try:
-        config = _make_asyncll_config(
-            rank=rank,
-            world_size=world_size,
-            data_type=data_type,
-            hidden_dim=hidden_dim,
-            max_num_inp_token_per_rank=max_num_inp_token_per_rank,
-            num_experts_per_rank=num_experts_per_rank,
-            num_experts_per_token=num_experts_per_token,
-            scale_dim=scale_dim,
-            scale_type_size=scale_type_size,
-            quant_type=quant_type,
-            max_total_recv_tokens=max_total_recv_tokens,
-        )
-        run_ep_dispatch_combine_test(
-            config,
-            AsyncLLDispatchCombineTestCase,
-            use_max_token_num=use_max_token_num,
-            routing=routing,
-            num_token_override=num_token_override,
-            check_results=check_results,
-        )
-    finally:
-        os.environ.pop("MORI_DISABLE_P2P", None)
+    config = _make_asyncll_config(
+        rank=rank,
+        world_size=world_size,
+        data_type=data_type,
+        hidden_dim=hidden_dim,
+        max_num_inp_token_per_rank=max_num_inp_token_per_rank,
+        num_experts_per_rank=num_experts_per_rank,
+        num_experts_per_token=num_experts_per_token,
+        scale_dim=scale_dim,
+        scale_type_size=scale_type_size,
+        quant_type=quant_type,
+        max_total_recv_tokens=max_total_recv_tokens,
+    )
+    run_ep_dispatch_combine_test(
+        config,
+        AsyncLLDispatchCombineTestCase,
+        use_max_token_num=use_max_token_num,
+        routing=routing,
+        num_token_override=num_token_override,
+        check_results=check_results,
+    )
 
 
 def _test_dispatch_combine_multi_iteration(
@@ -172,30 +167,26 @@ def _test_dispatch_combine_multi_iteration(
     quant_type="none",
     routing="round_robin",
 ):
-    os.environ["MORI_DISABLE_P2P"] = "1"
-    try:
-        config = _make_asyncll_config(
-            rank=rank,
-            world_size=world_size,
-            data_type=data_type,
-            hidden_dim=hidden_dim,
-            max_num_inp_token_per_rank=max_num_inp_token_per_rank,
-            num_experts_per_rank=num_experts_per_rank,
-            num_experts_per_token=num_experts_per_token,
-            scale_dim=scale_dim,
-            scale_type_size=scale_type_size,
-            quant_type=quant_type,
-        )
-        op = mori.ops.EpDispatchCombineOp(config)
-        test_case = AsyncLLDispatchCombineTestCase(config)
+    config = _make_asyncll_config(
+        rank=rank,
+        world_size=world_size,
+        data_type=data_type,
+        hidden_dim=hidden_dim,
+        max_num_inp_token_per_rank=max_num_inp_token_per_rank,
+        num_experts_per_rank=num_experts_per_rank,
+        num_experts_per_token=num_experts_per_token,
+        scale_dim=scale_dim,
+        scale_type_size=scale_type_size,
+        quant_type=quant_type,
+    )
+    op = mori.ops.EpDispatchCombineOp(config)
+    test_case = AsyncLLDispatchCombineTestCase(config)
 
-        for num_token_override in num_token_patterns:
-            test_data = test_case.gen_test_data(
-                routing=routing, num_token_override=num_token_override
-            )
-            test_case.run_test_once(op, test_data)
-    finally:
-        os.environ.pop("MORI_DISABLE_P2P", None)
+    for num_token_override in num_token_patterns:
+        test_data = test_case.gen_test_data(
+            routing=routing, num_token_override=num_token_override
+        )
+        test_case.run_test_once(op, test_data)
 
 
 @pytest.mark.parametrize("world_size", (8,))


### PR DESCRIPTION
## Problem

`MORI_ENABLE_SDMA` and `MORI_DISABLE_P2P` were read independently from multiple call sites:

| Location | When read | What it controls |
|---|---|---|
| `Context::InitializePossibleTransports` | once at shmem init | transport selection (P2P / SDMA / RDMA) |
| `SymmMemManager::Malloc` | **every allocation** | `hipMalloc` vs `hipExtMallocWithFlags(hipDeviceMallocUncached)` |
| `EpDispatchCombineHandle` ctor | every handle construct | `config.enableSdma` flag |

If `MORI_ENABLE_SDMA` was set **after** Context init (e.g. a session-scoped pytest fixture spawns workers, workers init shmem, then the test function does `os.environ["MORI_ENABLE_SDMA"] = "1"`), the transport layer still believed P2P but per-allocation paths flipped to **uncached** buffers — producing a cache/IPC inconsistency that silently hung `async_ll`.

This was the latent reason `tests/python/ops/test_dispatch_combine_async_ll.py` had to be invoked with the env on the pytest command line in `.github/workflows/ci.yml` (PR #313); setting it inside the test function had no effect on transport selection but did flip allocation cacheability — the worst combination.

## Fix

Snapshot both env vars exactly **once** in `Context`'s constructor and expose them through `Context::IsSdmaEnabled()` / `Context::IsP2PDisabled()`. All later readers consult the cached value:

- `SymmMemManager::Malloc` → `context.IsSdmaEnabled()` (already had a `Context&` reference)
- `EpDispatchCombineHandle` → new `mori::shmem::ShmemSdmaEnabled()` accessor that delegates to `Context::IsSdmaEnabled()`

After this PR: either the env is set **before** `shmem_init` and takes effect end-to-end, or it isn't and is silently ignored — there is no half-on state.

## Files

- `include/mori/application/context/context.hpp` — add `bool sdmaEnabled` / `bool p2pDisabled` members + getters
- `src/application/context/context.cpp` — initialize them in ctor; switch internal sites to member accessors; remove the file-local free functions
- `src/application/memory/symmetric_memory.cpp` — `SymmMemManager::Malloc` consults `context.IsSdmaEnabled()`
- `include/mori/shmem/shmem_api.hpp` + `src/shmem/runtime.cpp` — add `ShmemSdmaEnabled()` accessor (mirrors existing `ShmemNumQpPerPe()`)
- `src/ops/dispatch_combine/dispatch_combine.cpp` — `EpDispatchCombineHandle` ctor uses `ShmemSdmaEnabled()`

## Test plan

- [x] CI green on MI300X-BNXT and MI355X-AINIC (this PR's box is MI308, SDMA queue init flaky on this hardware so local async_ll over SDMA isn't a reliable signal)
- [x] `intranode` and `internode_v1` jobs unchanged (no SDMA path involved → no behavior change)
- [x] `async_ll` job (which sets `MORI_ENABLE_SDMA=1` on the pytest cmdline) keeps passing — confirms the cached path is wired correctly