### PR TITLE
feat(jit): enable hip kernel debug info

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ python -c "import mori; print('OK')"
 ```bash
 cd /path/to/mori
 export PYTHONPATH=/path/to/mori:$PYTHONPATH
+python -c "import mori; print(mori.__file__)"
 
 # Test correctness (8 GPUs)
 pytest tests/python/ops/test_dispatch_combine_intranode.py -q

--- a/python/mori/jit/config.py
+++ b/python/mori/jit/config.py
@@ -264,6 +264,12 @@ def is_profiler_enabled() -> bool:
     return val.lower() in ("1", "true", "yes", "on")
 
 
+def is_debuginfo_enabled() -> bool:
+    """Return True if MORI_DEBUG_INFO is set to a truthy value."""
+    val = os.environ.get("MORI_DEBUG_INFO", "")
+    return val.lower() in ("1", "true", "yes", "on")
+
+
 def detect_build_config() -> BuildConfig:
     """Auto-detect the full build config (cached after first call)."""
     global _cached_config

--- a/python/mori/jit/core.py
+++ b/python/mori/jit/core.py
@@ -40,6 +40,7 @@ from mori.jit.config import (
     detect_nic_type,
     find_mpi_include,
     get_mori_source_root,
+    is_debuginfo_enabled,
     is_profiler_enabled,
 )
 
@@ -176,6 +177,11 @@ def _profiler_defines() -> list[str]:
     return ["-DENABLE_PROFILER"] if is_profiler_enabled() else []
 
 
+def _debuginfo_flags() -> list[str]:
+    """Return hipcc debug flags if MORI_DEBUG_INFO is enabled."""
+    return ["-g", "-ggdb"] if is_debuginfo_enabled() else []
+
+
 def _ensure_generated_include(mori_root: Path) -> Path:
     """Run generate_profiler_bindings.py into the JIT cache and return the include root.
 
@@ -295,6 +301,7 @@ def _hipcc_genco(
         f"--offload-arch={cfg.arch}",
         "-std=c++17",
         "-O2",
+        *_debuginfo_flags(),
         "-D__HIP_PLATFORM_AMD__",
         "-DHIP_ENABLE_WARP_SYNC_BUILTINS",
         *_nic_defines(),


### PR DESCRIPTION
## Motivation

  Enable debugging of JIT-compiled kernels by adding debug symbol generation support. When troubleshooting kernel issues, developers need to inspect assembly with source-level debug info.

## Technical Details

  Add MORI_DEBUG_INFO environment variable to control hipcc debug flags in JIT compilation:

  - config.py: add is_debuginfo_enabled() to detect MORI_DEBUG_INFO env var
  - core.py: add _debuginfo_flags() returning ["-g", "-ggdb"] when enabled, integrate into _hipcc_genco()

  When MORI_DEBUG_INFO=1, hipcc jit compiles with -g -ggdb flags alongside -O2.

## Test Plan

MORI_PRECOMPILE=1 MORI_DEBUG_INFO=1 python -c "import mori"

## Test Result

- [x] The mori jit kernel pre-compilation test has been verified.