### PR TITLE
refactor(ccl): migrate collective kernels from AOT to JIT compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,6 @@ jobs:
             cd $GITHUB_WORKSPACE
             MORI_ENABLE_SDMA=1 timeout 300 python -m tests.python.ccl.test_allgather --world-size 8 --elems 1024 --iterations 1 --warmup 0
             MORI_ENABLE_SDMA=1 timeout 300 python -m tests.python.ccl.test_all2all --world-size 8 --elems 1024 --iterations 1 --warmup 0
-            MORI_ENABLE_SDMA=1 timeout 300 python -m tests.python.ccl.test_allreduce --world-size 8 --elems 1024 --iterations 1 --warmup 0
           "
 
       - name: MORI-EP async kernel bench (intranode)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,11 +232,11 @@ jobs:
 
       - name: MORI-CCL collectives
         run: |
-          $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE -e MORI_ENABLE_SDMA=1 $CONTAINER bash -c "
+          $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
             cd $GITHUB_WORKSPACE
-            timeout 300 python -m tests.python.ccl.test_allgather --world-size 8 --elems 1024 --iterations 1 --warmup 0
-            timeout 300 python -m tests.python.ccl.test_all2all --world-size 8 --elems 1024 --iterations 1 --warmup 0
-            timeout 300 python -m tests.python.ccl.test_allreduce --world-size 8 --elems 1024 --iterations 1 --warmup 0
+            MORI_ENABLE_SDMA=1 timeout 300 python -m tests.python.ccl.test_allgather --world-size 8 --elems 1024 --iterations 1 --warmup 0
+            MORI_ENABLE_SDMA=1 timeout 300 python -m tests.python.ccl.test_all2all --world-size 8 --elems 1024 --iterations 1 --warmup 0
+            MORI_ENABLE_SDMA=1 timeout 300 python -m tests.python.ccl.test_allreduce --world-size 8 --elems 1024 --iterations 1 --warmup 0
           "
 
       - name: MORI-EP async kernel bench (intranode)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,15 @@ jobs:
             timeout 600 pytest tests/python/shmem/test_api.py -v
           "
 
+      - name: MORI-CCL collectives
+        run: |
+          $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE -e MORI_ENABLE_SDMA=1 $CONTAINER bash -c "
+            cd $GITHUB_WORKSPACE
+            timeout 300 python -m tests.python.ccl.test_allgather --world-size 8 --elems 1024 --iterations 1 --warmup 0
+            timeout 300 python -m tests.python.ccl.test_all2all --world-size 8 --elems 1024 --iterations 1 --warmup 0
+            timeout 300 python -m tests.python.ccl.test_allreduce --world-size 8 --elems 1024 --iterations 1 --warmup 0
+          "
+
       - name: MORI-EP async kernel bench (intranode)
         run: |
           $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "

--- a/include/mori/collective/all2all/oneshot_all2all_sdma_async_kernel.hpp
+++ b/include/mori/collective/all2all/oneshot_all2all_sdma_async_kernel.hpp
@@ -33,11 +33,11 @@ namespace collective {
 // One-shot all-reduce: single phase.
 // Every GPU reads the full buffer from all peers, accumulates locally, and writes the result.
 template <typename T>
-__global__ void OneShotAll2allSdmaAsyncPutKernel(int myPe, int npes, T* input,
-                                                 const application::SymmMemObjPtr srcMemObj,
-                                                 const application::SymmMemObjPtr dstMemObj,
-                                                 const application::SymmMemObjPtr flagsMemObj,
-                                                 size_t elementCount) {
+__device__ void OneShotAll2allSdmaAsyncPutKernel_body(int myPe, int npes, T* input,
+                                                      const application::SymmMemObjPtr srcMemObj,
+                                                      const application::SymmMemObjPtr dstMemObj,
+                                                      const application::SymmMemObjPtr flagsMemObj,
+                                                      size_t elementCount) {
   if (elementCount == 0 || npes <= 0) {
     return;
   }
@@ -83,9 +83,19 @@ __global__ void OneShotAll2allSdmaAsyncPutKernel(int myPe, int npes, T* input,
   }
 }
 
-__global__ void OneShotAll2allSdmaAsyncWaitKernel(int myPe, int npes,
-                                                  const application::SymmMemObjPtr dstMemObj,
-                                                  const application::SymmMemObjPtr flagsMemObj) {
+template <typename T>
+__global__ void OneShotAll2allSdmaAsyncPutKernel(int myPe, int npes, T* input,
+                                                 const application::SymmMemObjPtr srcMemObj,
+                                                 const application::SymmMemObjPtr dstMemObj,
+                                                 const application::SymmMemObjPtr flagsMemObj,
+                                                 size_t elementCount) {
+  OneShotAll2allSdmaAsyncPutKernel_body<T>(myPe, npes, input, srcMemObj, dstMemObj, flagsMemObj,
+                                           elementCount);
+}
+
+__device__ void OneShotAll2allSdmaAsyncWaitKernel_body(
+    int myPe, int npes, const application::SymmMemObjPtr dstMemObj,
+    const application::SymmMemObjPtr flagsMemObj) {
   int flag_val = 1;
   uint64_t* __restrict__ flags = reinterpret_cast<uint64_t*>(flagsMemObj->localPtr);
 
@@ -122,6 +132,12 @@ __global__ void OneShotAll2allSdmaAsyncWaitKernel(int myPe, int npes,
   if (threadLinearId < npes) {
     flags[threadLinearId] = 0;
   }
+}
+
+__global__ void OneShotAll2allSdmaAsyncWaitKernel(int myPe, int npes,
+                                                  const application::SymmMemObjPtr dstMemObj,
+                                                  const application::SymmMemObjPtr flagsMemObj) {
+  OneShotAll2allSdmaAsyncWaitKernel_body(myPe, npes, dstMemObj, flagsMemObj);
 }
 }  // namespace collective
 }  // namespace mori

--- a/include/mori/collective/all2all/oneshot_all2all_sdma_class.hpp
+++ b/include/mori/collective/all2all/oneshot_all2all_sdma_class.hpp
@@ -31,6 +31,7 @@
 
 // Include necessary headers
 #include "mori/application/application.hpp"
+#include "mori/collective/ccl_kernel_args.hpp"
 #include "mori/collective/collective_pub.hpp"
 #include "mori/collective/core/wall_time.hpp"
 #include "mori/shmem/shmem.hpp"
@@ -72,6 +73,9 @@ class All2allSdma {
   // Copy mode flag: if true, copy output_transit_buffer to user output buffer
   // if false, user should directly use output_transit_buffer
   bool copy_output_to_user_;
+
+  // Reusable args struct for JIT kernel launch from Python
+  CclAll2allArgs<T> jit_args_;
 
   // Disable copy constructor and assignment operator
   All2allSdma(const All2allSdma&) = delete;
@@ -143,6 +147,18 @@ class All2allSdma {
    */
   void cancel_async();
   // =======================================================
+
+  // JIT launch support: prepare args struct and return pointer.
+  // Python calls prepare_*, then launches the kernel via JIT, then calls finish_*.
+
+  int64_t prepare_sync(T* input, T* output, size_t total_count, hipStream_t stream);
+  double finish_sync(T* output, size_t total_count, hipStream_t stream);
+
+  int64_t prepare_async_start(T* input, T* output, size_t total_count, hipStream_t stream);
+  void after_async_start();
+
+  int64_t prepare_async_wait(hipStream_t stream);
+  double finish_async_wait(hipStream_t stream);
 
   /**
    * @brief Executes synchronous All2All SDMA operation

--- a/include/mori/collective/all2all/oneshot_all2all_sdma_class.hpp
+++ b/include/mori/collective/all2all/oneshot_all2all_sdma_class.hpp
@@ -74,7 +74,7 @@ class All2allSdma {
   // if false, user should directly use output_transit_buffer
   bool copy_output_to_user_;
 
-  // Reusable args struct for JIT kernel launch from Python
+  // Not reentrant: previous launch must complete before next prepare_*.
   CclAll2allArgs<T> jit_args_;
 
   // Disable copy constructor and assignment operator

--- a/include/mori/collective/all2all/oneshot_all2all_sdma_kernel.hpp
+++ b/include/mori/collective/all2all/oneshot_all2all_sdma_kernel.hpp
@@ -31,7 +31,7 @@
 namespace mori {
 namespace collective {
 template <typename T>
-__global__ void OneShotAll2allSdmaKernel(
+__device__ void OneShotAll2allSdmaKernel_body(
     int myPe, int npes, T* input,
     const application::SymmMemObjPtr inputTransitMemObj,   // Changed to input transit buffer
     const application::SymmMemObjPtr outputTransitMemObj,  // Output transit buffer
@@ -136,6 +136,16 @@ __global__ void OneShotAll2allSdmaKernel(
         }
     }
 #endif
+}
+
+template <typename T>
+__global__ void OneShotAll2allSdmaKernel(int myPe, int npes, T* input,
+                                         const application::SymmMemObjPtr inputTransitMemObj,
+                                         const application::SymmMemObjPtr outputTransitMemObj,
+                                         const application::SymmMemObjPtr flagsMemObj,
+                                         size_t elementCount) {
+  OneShotAll2allSdmaKernel_body<T>(myPe, npes, input, inputTransitMemObj, outputTransitMemObj,
+                                   flagsMemObj, elementCount);
 }
 
 }  // namespace collective

--- a/include/mori/collective/allgather/oneshot_allgather_sdma_class.hpp
+++ b/include/mori/collective/allgather/oneshot_allgather_sdma_class.hpp
@@ -32,6 +32,7 @@
 
 // Include necessary headers
 #include "mori/application/application.hpp"
+#include "mori/collective/ccl_kernel_args.hpp"
 #include "mori/collective/collective_pub.hpp"
 #include "mori/collective/core/wall_time.hpp"
 #include "mori/shmem/shmem.hpp"
@@ -88,6 +89,9 @@ class AllgatherSdma {
 
   // Range lookup helper: returns {SymmMemObjPtr, offset_from_base} or {invalid, 0}.
   std::pair<application::SymmMemObjPtr, size_t> find_registered(void* ptr) const;
+
+  // Reusable args struct for JIT kernel launch from Python
+  CclAllgatherArgs<T> jit_args_;
 
   // Disable copy constructor and assignment operator
   AllgatherSdma(const AllgatherSdma&) = delete;
@@ -231,6 +235,13 @@ class AllgatherSdma {
    * @brief Resets flags (sets to 0)
    */
   void resetFlags();
+
+  int64_t prepare_sync(T* input, T* output, size_t total_count, hipStream_t stream);
+  double finish_sync(T* output, size_t total_count, hipStream_t stream);
+  int64_t prepare_async_start(T* input, T* output, size_t total_count, hipStream_t stream);
+  void after_async_start();
+  int64_t prepare_async_wait(hipStream_t stream);
+  double finish_async_wait(hipStream_t stream);
 };
 
 }  // namespace collective

--- a/include/mori/collective/allgather/oneshot_allgather_sdma_class.hpp
+++ b/include/mori/collective/allgather/oneshot_allgather_sdma_class.hpp
@@ -90,7 +90,7 @@ class AllgatherSdma {
   // Range lookup helper: returns {SymmMemObjPtr, offset_from_base} or {invalid, 0}.
   std::pair<application::SymmMemObjPtr, size_t> find_registered(void* ptr) const;
 
-  // Reusable args struct for JIT kernel launch from Python
+  // Not reentrant: previous launch must complete before next prepare_*.
   CclAllgatherArgs<T> jit_args_;
 
   // Disable copy constructor and assignment operator

--- a/include/mori/collective/allgather/oneshot_sdma_async_kernel.hpp
+++ b/include/mori/collective/allgather/oneshot_sdma_async_kernel.hpp
@@ -32,11 +32,10 @@ namespace mori {
 namespace collective {
 
 template <typename T>
-__global__ void OneShotAllGatherSdmaAsyncPutKernel(int myPe, int npes, T* input,
-                                                   const application::SymmMemObjPtr srcMemObj,
-                                                   const application::SymmMemObjPtr dstMemObj,
-                                                   const application::SymmMemObjPtr flagsMemObj,
-                                                   size_t elementCount, size_t dstBaseOffset = 0) {
+__device__ void OneShotAllGatherSdmaAsyncPutKernel_body(
+    int myPe, int npes, T* input, const application::SymmMemObjPtr srcMemObj,
+    const application::SymmMemObjPtr dstMemObj, const application::SymmMemObjPtr flagsMemObj,
+    size_t elementCount, size_t dstBaseOffset = 0) {
   if (elementCount == 0 || npes <= 0) {
     return;
   }
@@ -83,10 +82,19 @@ __global__ void OneShotAllGatherSdmaAsyncPutKernel(int myPe, int npes, T* input,
   }
 }
 
-__global__ void OneShotAllGatherSdmaAsyncWaitKernel(int myPe, int npes,
-                                                    const application::SymmMemObjPtr dstMemObj,
-                                                    const application::SymmMemObjPtr flagsMemObj,
-                                                    uint64_t flagVal = 1) {
+template <typename T>
+__global__ void OneShotAllGatherSdmaAsyncPutKernel(int myPe, int npes, T* input,
+                                                   const application::SymmMemObjPtr srcMemObj,
+                                                   const application::SymmMemObjPtr dstMemObj,
+                                                   const application::SymmMemObjPtr flagsMemObj,
+                                                   size_t elementCount, size_t dstBaseOffset = 0) {
+  OneShotAllGatherSdmaAsyncPutKernel_body<T>(myPe, npes, input, srcMemObj, dstMemObj, flagsMemObj,
+                                             elementCount, dstBaseOffset);
+}
+
+__device__ void OneShotAllGatherSdmaAsyncWaitKernel_body(
+    int myPe, int npes, const application::SymmMemObjPtr dstMemObj,
+    const application::SymmMemObjPtr flagsMemObj, uint64_t flagVal = 1) {
   uint64_t* __restrict__ flags = reinterpret_cast<uint64_t*>(flagsMemObj->localPtr);
 
   const size_t threadLinearId =
@@ -121,6 +129,13 @@ __global__ void OneShotAllGatherSdmaAsyncWaitKernel(int myPe, int npes,
   }
 
   // Monotonic generation flags; no reset needed.
+}
+
+__global__ void OneShotAllGatherSdmaAsyncWaitKernel(int myPe, int npes,
+                                                    const application::SymmMemObjPtr dstMemObj,
+                                                    const application::SymmMemObjPtr flagsMemObj,
+                                                    uint64_t flagVal = 1) {
+  OneShotAllGatherSdmaAsyncWaitKernel_body(myPe, npes, dstMemObj, flagsMemObj, flagVal);
 }
 }  // namespace collective
 }  // namespace mori

--- a/include/mori/collective/allgather/oneshot_sdma_kernel.hpp
+++ b/include/mori/collective/allgather/oneshot_sdma_kernel.hpp
@@ -31,12 +31,12 @@
 namespace mori {
 namespace collective {
 template <typename T>
-__global__ void OneShotAllGatherSdmaKernel(int myPe, int npes, T* input,
-                                           const application::SymmMemObjPtr srcMemObj,
-                                           const application::SymmMemObjPtr dstMemObj,
-                                           const application::SymmMemObjPtr flagsMemObj,
-                                           size_t elementCount, size_t dstBaseOffset = 0,
-                                           uint64_t flagVal = 1) {
+__device__ void OneShotAllGatherSdmaKernel_body(int myPe, int npes, T* input,
+                                                const application::SymmMemObjPtr srcMemObj,
+                                                const application::SymmMemObjPtr dstMemObj,
+                                                const application::SymmMemObjPtr flagsMemObj,
+                                                size_t elementCount, size_t dstBaseOffset = 0,
+                                                uint64_t flagVal = 1) {
   if (elementCount == 0 || npes <= 0) {
     return;
   }
@@ -109,6 +109,17 @@ __global__ void OneShotAllGatherSdmaKernel(int myPe, int npes, T* input,
   }
 
   // Monotonic generation flags; no reset needed.
+}
+
+template <typename T>
+__global__ void OneShotAllGatherSdmaKernel(int myPe, int npes, T* input,
+                                           const application::SymmMemObjPtr srcMemObj,
+                                           const application::SymmMemObjPtr dstMemObj,
+                                           const application::SymmMemObjPtr flagsMemObj,
+                                           size_t elementCount, size_t dstBaseOffset = 0,
+                                           uint64_t flagVal = 1) {
+  OneShotAllGatherSdmaKernel_body<T>(myPe, npes, input, srcMemObj, dstMemObj, flagsMemObj,
+                                     elementCount, dstBaseOffset, flagVal);
 }
 }  // namespace collective
 }  // namespace mori

--- a/include/mori/collective/allreduce/twoshot_allreduce_sdma_class.hpp
+++ b/include/mori/collective/allreduce/twoshot_allreduce_sdma_class.hpp
@@ -27,8 +27,10 @@
 
 #include <cstdint>
 #include <memory>
+#include <tuple>
 
 #include "mori/application/application.hpp"
+#include "mori/collective/ccl_kernel_args.hpp"
 #include "mori/collective/collective_pub.hpp"
 #include "mori/collective/core/wall_time.hpp"
 #include "mori/shmem/shmem.hpp"
@@ -36,7 +38,17 @@
 namespace mori {
 namespace collective {
 
-struct CrossPeBarrier;
+struct alignas(128) CrossPeBarrier {
+  alignas(128) uint32_t flag;
+};
+
+inline int getDeviceMaxBlocks() {
+  int dev = 0;
+  (void)hipGetDevice(&dev);
+  hipDeviceProp_t prop;
+  (void)hipGetDeviceProperties(&prop, dev);
+  return (prop.multiProcessorCount > 0) ? prop.multiProcessorCount : 80;
+}
 
 template <typename T>
 class AllreduceSdma {
@@ -92,6 +104,7 @@ class AllreduceSdma {
 
   void copy_input_to_transit(T* input, size_t total_count, hipStream_t stream);
   void copy_output_to_user(T* output, size_t total_count, hipStream_t stream);
+  void fill_jit_args_(const T* input, size_t total_count);
 
  public:
   /**
@@ -160,6 +173,26 @@ class AllreduceSdma {
   }
 
   void resetFlags();
+
+  // JIT launch support: Python calls prepare_* to get args pointer,
+  // launches the kernel via HipModule, then calls finish_*.
+  CclAllreduceArgs<T> jit_args_;
+
+  int64_t prepare_reduce_scatter(const T* input, T* output, size_t total_count, hipStream_t stream);
+  std::tuple<int, int> get_reduce_scatter_grid(size_t total_count) const;
+  int64_t prepare_allgather(size_t total_count, hipStream_t stream);
+  double finish_sync(T* output, size_t total_count, hipStream_t stream);
+
+  int64_t prepare_async_reduce_scatter(const T* input, T* output, size_t total_count,
+                                       hipStream_t stream);
+  int64_t prepare_async_allgather_put(size_t total_count, hipStream_t stream);
+  void after_async_start();
+
+  int64_t prepare_async_wait(hipStream_t stream);
+  double finish_async_wait(hipStream_t stream);
+
+  int max_blocks() const { return max_blocks_; }
+  int npes() const { return npes_; }
 };
 
 }  // namespace collective

--- a/include/mori/collective/allreduce/twoshot_allreduce_sdma_class.hpp
+++ b/include/mori/collective/allreduce/twoshot_allreduce_sdma_class.hpp
@@ -176,6 +176,7 @@ class AllreduceSdma {
 
   // JIT launch support: Python calls prepare_* to get args pointer,
   // launches the kernel via HipModule, then calls finish_*.
+  // Not reentrant: previous launch must complete before next prepare_*.
   CclAllreduceArgs<T> jit_args_;
 
   int64_t prepare_reduce_scatter(const T* input, T* output, size_t total_count, hipStream_t stream);

--- a/include/mori/collective/allreduce/twoshot_allreduce_sdma_class.hpp
+++ b/include/mori/collective/allreduce/twoshot_allreduce_sdma_class.hpp
@@ -181,7 +181,8 @@ class AllreduceSdma {
   int64_t prepare_reduce_scatter(const T* input, T* output, size_t total_count, hipStream_t stream);
   std::tuple<int, int> get_reduce_scatter_grid(size_t total_count) const;
   int64_t prepare_allgather(size_t total_count, hipStream_t stream);
-  double finish_sync(T* output, size_t total_count, hipStream_t stream);
+  double finish_sync(T* output, size_t total_count, hipStream_t stream,
+                     bool force_copy_output_to_user = false);
 
   int64_t prepare_async_reduce_scatter(const T* input, T* output, size_t total_count,
                                        hipStream_t stream);

--- a/include/mori/collective/allreduce/twoshot_sdma_async_kernel.hpp
+++ b/include/mori/collective/allreduce/twoshot_sdma_async_kernel.hpp
@@ -46,9 +46,9 @@ namespace collective {
 //   slot npes-1: PE (npes-1)'s shard_j
 // ============================================================
 template <typename T>
-__global__ void ReduceScatterSdmaPutKernel(int myPe, int npes, T* input,
-                                           const application::SymmMemObjPtr dstMemObj,
-                                           size_t elementCountPerRank) {
+__device__ void ReduceScatterSdmaPutKernel_body(int myPe, int npes, T* input,
+                                                const application::SymmMemObjPtr dstMemObj,
+                                                size_t elementCountPerRank) {
   const size_t bytesPerElement = sizeof(T);
   const size_t bytesPerPeer = elementCountPerRank * bytesPerElement;
   const int numQueues = dstMemObj->sdmaNumQueue;
@@ -82,6 +82,13 @@ __global__ void ReduceScatterSdmaPutKernel(int myPe, int npes, T* input,
   }
 }
 
+template <typename T>
+__global__ void ReduceScatterSdmaPutKernel(int myPe, int npes, T* input,
+                                           const application::SymmMemObjPtr dstMemObj,
+                                           size_t elementCountPerRank) {
+  ReduceScatterSdmaPutKernel_body<T>(myPe, npes, input, dstMemObj, elementCountPerRank);
+}
+
 // ============================================================
 // AllGather async PUT kernel
 //
@@ -90,10 +97,11 @@ __global__ void ReduceScatterSdmaPutKernel(int myPe, int npes, T* input,
 // Paired with AllGatherAsyncWaitKernel below.
 // ============================================================
 template <typename T>
-__global__ void AllGatherAsyncPutKernel(int myPe, int npes,
-                                        const application::SymmMemObjPtr dstMemObj,
-                                        const application::SymmMemObjPtr flagsMemObj,
-                                        CrossPeBarrier* __restrict__ barrier, size_t elementCount) {
+__device__ void AllGatherAsyncPutKernel_body(int myPe, int npes,
+                                             const application::SymmMemObjPtr dstMemObj,
+                                             const application::SymmMemObjPtr flagsMemObj,
+                                             CrossPeBarrier* __restrict__ barrier,
+                                             size_t elementCount) {
   if (elementCount == 0 || npes <= 0) return;
 
   using P = typename packed_t<T>::P;
@@ -144,6 +152,14 @@ __global__ void AllGatherAsyncPutKernel(int myPe, int npes,
   }
 }
 
+template <typename T>
+__global__ void AllGatherAsyncPutKernel(int myPe, int npes,
+                                        const application::SymmMemObjPtr dstMemObj,
+                                        const application::SymmMemObjPtr flagsMemObj,
+                                        CrossPeBarrier* __restrict__ barrier, size_t elementCount) {
+  AllGatherAsyncPutKernel_body<T>(myPe, npes, dstMemObj, flagsMemObj, barrier, elementCount);
+}
+
 // ============================================================
 // AllGather async WAIT kernel
 //
@@ -151,10 +167,10 @@ __global__ void AllGatherAsyncPutKernel(int myPe, int npes,
 // Uses AMO_SET + generation counter (< flag_val comparison).
 // Paired with AllGatherAsyncPutKernel above.
 // ============================================================
-__global__ void AllGatherAsyncWaitKernel(int myPe, int npes,
-                                         const application::SymmMemObjPtr flagsMemObj,
-                                         CrossPeBarrier* __restrict__ barrier,
-                                         size_t elementCount) {
+__device__ void AllGatherAsyncWaitKernel_body(int myPe, int npes,
+                                              const application::SymmMemObjPtr flagsMemObj,
+                                              CrossPeBarrier* __restrict__ barrier,
+                                              size_t elementCount) {
   uint64_t* __restrict__ flags = reinterpret_cast<uint64_t*>(flagsMemObj->localPtr);
 
   // Read the generation token set by AllGatherAsyncPutKernel
@@ -184,6 +200,13 @@ __global__ void AllGatherAsyncWaitKernel(int myPe, int npes,
   __syncthreads();
 }
 
+__global__ void AllGatherAsyncWaitKernel(int myPe, int npes,
+                                         const application::SymmMemObjPtr flagsMemObj,
+                                         CrossPeBarrier* __restrict__ barrier,
+                                         size_t elementCount) {
+  AllGatherAsyncWaitKernel_body(myPe, npes, flagsMemObj, barrier, elementCount);
+}
+
 // ============================================================
 // Phase 2: Local reduce kernel for reduce-scatter
 //
@@ -204,8 +227,9 @@ __device__ __forceinline__ __half reduce_add(__half a, __half b) {
 #endif
 
 template <typename T>
-__global__ void ReduceScatterLocalReduceKernel(T* gathered, const T* input,
-                                               size_t elementCountPerRank, int myPe, int npes) {
+__device__ void ReduceScatterLocalReduceKernel_body(T* gathered, const T* input,
+                                                    size_t elementCountPerRank, int myPe,
+                                                    int npes) {
   const size_t threadLinearId =
       static_cast<size_t>(blockIdx.x) * static_cast<size_t>(blockDim.x) + threadIdx.x;
   const size_t threadsPerGrid = static_cast<size_t>(blockDim.x) * static_cast<size_t>(gridDim.x);
@@ -239,6 +263,12 @@ __global__ void ReduceScatterLocalReduceKernel(T* gathered, const T* input,
 #endif
 }
 
+template <typename T>
+__global__ void ReduceScatterLocalReduceKernel(T* gathered, const T* input,
+                                               size_t elementCountPerRank, int myPe, int npes) {
+  ReduceScatterLocalReduceKernel_body<T>(gathered, input, elementCountPerRank, myPe, npes);
+}
+
 // ============================================================
 // Phase 1+2 (P2P variant): ReduceScatter via P2P memory reads
 //
@@ -250,10 +280,10 @@ __global__ void ReduceScatterLocalReduceKernel(T* gathered, const T* input,
 // Result: reduced shard written to dstMemObj->localPtr at slot myPe
 // ============================================================
 template <typename T>
-__global__ void ReduceScatterP2pKernel(int myPe, int npes,
-                                       const application::SymmMemObjPtr srcMemObj,
-                                       const application::SymmMemObjPtr dstMemObj,
-                                       size_t elementCount) {
+__device__ void ReduceScatterP2pKernel_body(int myPe, int npes,
+                                            const application::SymmMemObjPtr srcMemObj,
+                                            const application::SymmMemObjPtr dstMemObj,
+                                            size_t elementCount) {
   if (elementCount == 0 || npes <= 0) {
     return;
   }
@@ -299,6 +329,14 @@ __global__ void ReduceScatterP2pKernel(int myPe, int npes,
 #endif
 }
 
+template <typename T>
+__global__ void ReduceScatterP2pKernel(int myPe, int npes,
+                                       const application::SymmMemObjPtr srcMemObj,
+                                       const application::SymmMemObjPtr dstMemObj,
+                                       size_t elementCount) {
+  ReduceScatterP2pKernel_body<T>(myPe, npes, srcMemObj, dstMemObj, elementCount);
+}
+
 // ============================================================
 // Phase 3: AllGather SDMA PUT kernel for reduced shards
 //
@@ -307,9 +345,9 @@ __global__ void ReduceScatterP2pKernel(int myPe, int npes,
 // Uses multi-queue SDMA for bandwidth.
 // ============================================================
 template <typename T>
-__global__ void AllGatherReducedSdmaPutKernel(int myPe, int npes,
-                                              const application::SymmMemObjPtr dstMemObj,
-                                              size_t elementCountPerRank) {
+__device__ void AllGatherReducedSdmaPutKernel_body(int myPe, int npes,
+                                                   const application::SymmMemObjPtr dstMemObj,
+                                                   size_t elementCountPerRank) {
   const size_t bytesPerElement = sizeof(T);
   const size_t bytesPerPeer = elementCountPerRank * bytesPerElement;
   const int numQueues = dstMemObj->sdmaNumQueue;
@@ -342,6 +380,13 @@ __global__ void AllGatherReducedSdmaPutKernel(int myPe, int npes,
   }
 }
 
+template <typename T>
+__global__ void AllGatherReducedSdmaPutKernel(int myPe, int npes,
+                                              const application::SymmMemObjPtr dstMemObj,
+                                              size_t elementCountPerRank) {
+  AllGatherReducedSdmaPutKernel_body<T>(myPe, npes, dstMemObj, elementCountPerRank);
+}
+
 // ============================================================
 // Fused kernel: ReduceScatter + AllGather PUT in one launch.
 //
@@ -353,11 +398,12 @@ __global__ void AllGatherReducedSdmaPutKernel(int myPe, int npes,
 // Requirement: gridDim.x <= multiProcessorCount (co-resident blocks).
 // ============================================================
 template <typename T>
-__global__ void ReduceScatterAllGatherFusedKernel(int myPe, int npes, const T* __restrict__ input,
-                                                  const application::SymmMemObjPtr dstMemObj,
-                                                  const application::SymmMemObjPtr flagsMemObj,
-                                                  CrossPeBarrier* __restrict__ barrier,
-                                                  size_t elementCount) {
+__device__ void ReduceScatterAllGatherFusedKernel_body(int myPe, int npes,
+                                                       const T* __restrict__ input,
+                                                       const application::SymmMemObjPtr dstMemObj,
+                                                       const application::SymmMemObjPtr flagsMemObj,
+                                                       CrossPeBarrier* __restrict__ barrier,
+                                                       size_t elementCount) {
   if (elementCount == 0 || npes <= 0) return;
 
   using P = typename packed_t<T>::P;
@@ -482,6 +528,16 @@ __global__ void ReduceScatterAllGatherFusedKernel(int myPe, int npes, const T* _
     asm volatile("buffer_wbl2" ::: "memory");
   }
 #endif
+}
+
+template <typename T>
+__global__ void ReduceScatterAllGatherFusedKernel(int myPe, int npes, const T* __restrict__ input,
+                                                  const application::SymmMemObjPtr dstMemObj,
+                                                  const application::SymmMemObjPtr flagsMemObj,
+                                                  CrossPeBarrier* __restrict__ barrier,
+                                                  size_t elementCount) {
+  ReduceScatterAllGatherFusedKernel_body<T>(myPe, npes, input, dstMemObj, flagsMemObj, barrier,
+                                            elementCount);
 }
 
 }  // namespace collective

--- a/include/mori/collective/allreduce/twoshot_sdma_kernel.hpp
+++ b/include/mori/collective/allreduce/twoshot_sdma_kernel.hpp
@@ -65,10 +65,11 @@ inline int getDeviceMaxBlocks() {
 // This replaces the previous hipStreamSynchronize — no host blocking needed.
 // ============================================================================
 template <typename T>
-__global__ void ReduceScatterKernel(int myPe, int npes, const application::SymmMemObjPtr srcMemObj,
-                                    const application::SymmMemObjPtr dstMemObj,
-                                    const application::SymmMemObjPtr barrierObj,
-                                    size_t elementCount) {
+__device__ void ReduceScatterKernel_body(int myPe, int npes,
+                                         const application::SymmMemObjPtr srcMemObj,
+                                         const application::SymmMemObjPtr dstMemObj,
+                                         const application::SymmMemObjPtr barrierObj,
+                                         size_t elementCount) {
   if (elementCount == 0 || npes <= 0) {
     return;
   }
@@ -130,6 +131,14 @@ __global__ void ReduceScatterKernel(int myPe, int npes, const application::SymmM
   }
 }
 
+template <typename T>
+__global__ void ReduceScatterKernel(int myPe, int npes, const application::SymmMemObjPtr srcMemObj,
+                                    const application::SymmMemObjPtr dstMemObj,
+                                    const application::SymmMemObjPtr barrierObj,
+                                    size_t elementCount) {
+  ReduceScatterKernel_body<T>(myPe, npes, srcMemObj, dstMemObj, barrierObj, elementCount);
+}
+
 // ============================================================================
 // SdmaReduceScatterKernel — SDMA scatter + local reduce in ONE kernel
 //
@@ -148,10 +157,11 @@ __global__ void ReduceScatterKernel(int myPe, int npes, const application::SymmM
 // Requirement: gridDim.x <= multiProcessorCount (co-resident blocks).
 // ============================================================================
 template <typename T>
-__global__ void SdmaReduceScatterKernel(int myPe, int npes, const T* __restrict__ input,
-                                        const application::SymmMemObjPtr dstMemObj,
-                                        const application::SymmMemObjPtr flagsMemObj,
-                                        CrossPeBarrier* __restrict__ barrier, size_t elementCount) {
+__device__ void SdmaReduceScatterKernel_body(int myPe, int npes, const T* __restrict__ input,
+                                             const application::SymmMemObjPtr dstMemObj,
+                                             const application::SymmMemObjPtr flagsMemObj,
+                                             CrossPeBarrier* __restrict__ barrier,
+                                             size_t elementCount) {
   if (elementCount == 0 || npes <= 0) return;
 
   using P = typename packed_t<T>::P;
@@ -283,6 +293,14 @@ __global__ void SdmaReduceScatterKernel(int myPe, int npes, const T* __restrict_
 #endif
 }
 
+template <typename T>
+__global__ void SdmaReduceScatterKernel(int myPe, int npes, const T* __restrict__ input,
+                                        const application::SymmMemObjPtr dstMemObj,
+                                        const application::SymmMemObjPtr flagsMemObj,
+                                        CrossPeBarrier* __restrict__ barrier, size_t elementCount) {
+  SdmaReduceScatterKernel_body<T>(myPe, npes, input, dstMemObj, flagsMemObj, barrier, elementCount);
+}
+
 // ============================================================================
 // AllGatherSdmaKernel — AllGather via SDMA
 //
@@ -290,9 +308,11 @@ __global__ void SdmaReduceScatterKernel(int myPe, int npes, const T* __restrict_
 // to every rank via SDMA put, then waits for all peers to finish.
 // ============================================================================
 template <typename T>
-__global__ void AllGatherSdmaKernel(int myPe, int npes, const application::SymmMemObjPtr dstMemObj,
-                                    const application::SymmMemObjPtr flagsMemObj,
-                                    CrossPeBarrier* __restrict__ barrier, size_t elementCount) {
+__device__ void AllGatherSdmaKernel_body(int myPe, int npes,
+                                         const application::SymmMemObjPtr dstMemObj,
+                                         const application::SymmMemObjPtr flagsMemObj,
+                                         CrossPeBarrier* __restrict__ barrier,
+                                         size_t elementCount) {
   if (elementCount == 0 || npes <= 0) {
     return;
   }
@@ -372,6 +392,13 @@ __global__ void AllGatherSdmaKernel(int myPe, int npes, const application::SymmM
   }
 
   // Flags are monotonic generation tokens (AMO_SET), so no reset is needed.
+}
+
+template <typename T>
+__global__ void AllGatherSdmaKernel(int myPe, int npes, const application::SymmMemObjPtr dstMemObj,
+                                    const application::SymmMemObjPtr flagsMemObj,
+                                    CrossPeBarrier* __restrict__ barrier, size_t elementCount) {
+  AllGatherSdmaKernel_body<T>(myPe, npes, dstMemObj, flagsMemObj, barrier, elementCount);
 }
 
 }  // namespace collective

--- a/include/mori/collective/ccl_kernel_args.hpp
+++ b/include/mori/collective/ccl_kernel_args.hpp
@@ -21,19 +21,50 @@
 // SOFTWARE.
 #pragma once
 
-#include <pybind11/pybind11.h>
+#include <cstddef>
+#include <cstdint>
+
+#include "mori/application/application_device_types.hpp"
 
 namespace mori {
-void RegisterMoriOps(pybind11::module_& m);
-void RegisterMoriShmem(pybind11::module_& m);
-void RegisterMoriIo(pybind11::module_& m);
-#ifdef MORI_BUILD_COLLECTIVE
-void RegisterMoriCcl(pybind11::module_& m);
-#endif
-#ifdef BUILD_XLA_FFI_OPS
-void RegisterXLAFFIOps(pybind11::module_& m);
-#endif
-#ifdef MORI_BUILD_UMBP
-void RegisterMoriUmbp(pybind11::module_& m);
-#endif
+namespace collective {
+
+struct CrossPeBarrier;
+
+template <typename T>
+struct CclAll2allArgs {
+  int myPe;
+  int npes;
+  T* input;
+  application::SymmMemObjPtr inputTransitMemObj;
+  application::SymmMemObjPtr outputTransitMemObj;
+  application::SymmMemObjPtr flagsMemObj;
+  size_t elementCount;
+};
+
+template <typename T>
+struct CclAllgatherArgs {
+  int myPe;
+  int npes;
+  T* input;
+  application::SymmMemObjPtr srcMemObj;
+  application::SymmMemObjPtr dstMemObj;
+  application::SymmMemObjPtr flagsMemObj;
+  size_t elementCount;
+  size_t dstBaseOffset;
+  uint64_t flagVal;
+};
+
+template <typename T>
+struct CclAllreduceArgs {
+  int myPe;
+  int npes;
+  const T* input;
+  application::SymmMemObjPtr dstMemObj;
+  application::SymmMemObjPtr flagsMemObj;
+  CrossPeBarrier* barrier;
+  size_t elementCount;
+};
+
+}  // namespace collective
 }  // namespace mori

--- a/python/mori/ccl/__init__.py
+++ b/python/mori/ccl/__init__.py
@@ -20,27 +20,36 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from .collective import All2allSdma
-from .collective import AllgatherSdma
-from .collective import AllreduceSdma
+try:
+    from .collective import All2allSdma
+    from .collective import AllgatherSdma
+    from .collective import AllreduceSdma
 
-# NCCL/RCCL-style C++ AllGather-into-tensor dispatcher.  The class and its
-# DataType enum are implemented entirely in C++ (see
-# ``include/mori/collective/allgather/allgather_into_tensor.hpp`` and
-# ``src/collective/core/allgather_into_tensor.cpp``); we only re-export the
-# pybind11 symbols here so callers can do
-# ``from mori.ccl import AllGatherIntoTensor, DataType``.
-from mori import cpp as _mori_cpp
+    # NCCL/RCCL-style C++ AllGather-into-tensor dispatcher.  The class and its
+    # DataType enum are implemented entirely in C++ (see
+    # ``include/mori/collective/allgather/allgather_into_tensor.hpp`` and
+    # ``src/collective/core/allgather_into_tensor.cpp``); we only re-export the
+    # pybind11 symbols here so callers can do
+    # ``from mori.ccl import AllGatherIntoTensor, DataType``.
+    from mori import cpp as _mori_cpp
 
-AllGatherIntoTensor = _mori_cpp.AllGatherIntoTensor
-DataType = _mori_cpp.DataType
-size_of = _mori_cpp.size_of
+    AllGatherIntoTensor = _mori_cpp.AllGatherIntoTensor
+    DataType = _mori_cpp.DataType
+    size_of = _mori_cpp.size_of
 
-__all__ = [
-    "All2allSdma",
-    "AllgatherSdma",
-    "AllreduceSdma",
-    "AllGatherIntoTensor",
-    "DataType",
-    "size_of",
-]
+    __all__ = [
+        "All2allSdma",
+        "AllgatherSdma",
+        "AllreduceSdma",
+        "AllGatherIntoTensor",
+        "DataType",
+        "size_of",
+    ]
+except (ImportError, AttributeError):
+    __all__ = []
+
+    def __getattr__(name: str):
+        raise ImportError(
+            f"mori.ccl.{name} is not available. "
+            "Rebuild mori with -DBUILD_COLLECTIVE=ON to enable collective ops."
+        )

--- a/python/mori/ccl/__init__.py
+++ b/python/mori/ccl/__init__.py
@@ -46,10 +46,11 @@ try:
         "size_of",
     ]
 except (ImportError, AttributeError):
-    __all__ = []
+    __all__ = [
+        "All2allSdma",
+        "AllgatherSdma",
+        "AllreduceSdma",
+    ]
 
     def __getattr__(name: str):
-        raise ImportError(
-            f"mori.ccl.{name} is not available. "
-            "Rebuild mori with -DBUILD_COLLECTIVE=ON to enable collective ops."
-        )
+        raise ImportError(f"mori.ccl.{name} is not available — not yet ported to JIT.")

--- a/python/mori/ccl/collective.py
+++ b/python/mori/ccl/collective.py
@@ -373,7 +373,14 @@ class AllreduceSdma:
                 my_pe, npes, 512 * 1024 * 1024, copy_output_to_user
             )
 
-    def __call__(self, input_data, output_data, count: int, stream=None) -> bool:
+    def _run_sync(
+        self,
+        input_data,
+        output_data,
+        count: int,
+        stream=None,
+        force_copy_output: bool = False,
+    ) -> bool:
         s = _stream_to_int(stream)
         sfx = self._type_suffix
         # Step 1: ReduceScatter
@@ -390,11 +397,14 @@ class AllreduceSdma:
             (1,), (512,), 0, s, args
         )
         # Sync + copy output
-        self._handle.finish_sync(output_data.data_ptr(), count, s)
+        self._handle.finish_sync(output_data.data_ptr(), count, s, force_copy_output)
         return True
 
+    def __call__(self, input_data, output_data, count: int, stream=None) -> bool:
+        return self._run_sync(input_data, output_data, count, stream)
+
     def allreduce_inplace(self, data, count: int, stream=None) -> bool:
-        return self(data, data, count, stream)
+        return self._run_sync(data, data, count, stream, force_copy_output=True)
 
     def start_async(self, input_data, output_data, count: int, stream=None) -> bool:
         s = _stream_to_int(stream)

--- a/python/mori/ccl/collective.py
+++ b/python/mori/ccl/collective.py
@@ -21,20 +21,45 @@
 # SOFTWARE.
 
 import os
+import time
 
 import torch
 from mori import cpp as mori_cpp
 from typing import Optional
 
 
-def _require_sdma_env(class_name: str) -> None:
-    """Fail fast if MORI_ENABLE_SDMA is not enabled.
+# ---------------------------------------------------------------------------
+# JIT compilation for CCL kernels
+# ---------------------------------------------------------------------------
+_ccl_hip_module = None
 
-    Without it, SymmMemManager::Malloc falls back to cached hipMalloc instead
-    of hipExtMallocWithFlags(hipDeviceMallocUncached), and the SDMA kernel
-    NULL-faults on first use ("Memory access fault by GPU node-X on address
-    (nil)") with no actionable error.
-    """
+
+def _ensure_ccl_jit():
+    """JIT compile ccl_kernels.hip and load the HipModule (once)."""
+    global _ccl_hip_module
+    if _ccl_hip_module is not None:
+        return
+    from mori.jit.core import compile_genco
+    from mori.ops._jit_loader import _compiled_hsaco, load_hip_module
+
+    if "ccl_kernels" not in _compiled_hsaco:
+        _compiled_hsaco["ccl_kernels"] = compile_genco(
+            "ccl_kernels", source_dir="src/collective/kernels"
+        )
+    _ccl_hip_module = load_hip_module("ccl_kernels", init_shmem=True)
+
+
+def _get_ccl_func(name: str):
+    """Get a kernel function from the JIT-compiled CCL module."""
+    return _ccl_hip_module.get_function(name)
+
+
+# ---------------------------------------------------------------------------
+# Helpers (unchanged from original)
+# ---------------------------------------------------------------------------
+
+
+def _require_sdma_env(class_name: str) -> None:
     raw = os.environ.get("MORI_ENABLE_SDMA", "").strip().lower()
     if raw in ("", "0", "false", "no", "off"):
         raise RuntimeError(
@@ -48,15 +73,12 @@ _TORCH_DTYPE_TO_NUMPY = {
     torch.uint32: "<u4",
     torch.int32: "<i4",
     torch.float16: "<f2",
-    # torch.as_tensor() cannot materialize bf16 from a raw "void" CUDA array
-    # interface view, so expose it as uint16 and reinterpret via .view().
     torch.bfloat16: "<u2",
     torch.float32: "<f4",
 }
 
 
 def _stream_to_int(stream) -> int:
-    """Convert a torch.cuda.Stream (or None / int) to an integer handle."""
     if stream is None:
         return 0
     if isinstance(stream, int):
@@ -65,9 +87,6 @@ def _stream_to_int(stream) -> int:
 
 
 class _GpuBufferView:
-    """Lightweight wrapper that exposes __cuda_array_interface__ so
-    ``torch.as_tensor`` can wrap a raw GPU pointer without a copy."""
-
     def __init__(self, ptr: int, shape: tuple, typestr: str):
         self.__cuda_array_interface__ = {
             "shape": shape,
@@ -78,7 +97,6 @@ class _GpuBufferView:
 
 
 def _ptr_to_tensor(ptr: int, size_bytes: int, dtype=torch.uint32, device=None):
-    """Wrap a raw GPU pointer as a 1-D torch CUDA tensor (zero-copy view)."""
     elem_size = torch.tensor([], dtype=dtype).element_size()
     num_elements = size_bytes // elem_size
     typestr = _TORCH_DTYPE_TO_NUMPY.get(dtype, "<u4")
@@ -92,7 +110,6 @@ def _ptr_to_tensor(ptr: int, size_bytes: int, dtype=torch.uint32, device=None):
 
 
 def _normalize_cuda_device(device):
-    """Resolve a CUDA tensor/device spec into a torch.device."""
     if device is None:
         return None
     if isinstance(device, torch.Tensor):
@@ -103,35 +120,28 @@ def _normalize_cuda_device(device):
         device = torch.device(device)
     elif not isinstance(device, torch.device):
         raise TypeError("device must be a CUDA tensor, torch.device, int, str, or None")
-
     if device.type != "cuda":
         raise ValueError("device must refer to a CUDA device")
     return device
 
 
 def _resolve_transit_view_args(dtype, device, fallback_dtype):
-    """Support both the new dtype= API and legacy device= calls."""
     if device is None and dtype is not None and not isinstance(dtype, torch.dtype):
         device = dtype
         dtype = None
-
     if isinstance(device, torch.Tensor) and dtype is None:
         dtype = device.dtype
-
     if dtype is None:
         dtype = fallback_dtype
-
     return dtype, _normalize_cuda_device(device)
 
 
-def _cpp_all2all_factory(entity_name: str):
-    """Factory function to get C++ entities from mori_cpp module"""
-    return getattr(mori_cpp, entity_name)
+# ---------------------------------------------------------------------------
+# All2allSdma
+# ---------------------------------------------------------------------------
 
 
 class All2allSdma:
-    """Python wrapper for All2allSdma C++ class"""
-
     def __init__(
         self,
         my_pe: int,
@@ -142,9 +152,10 @@ class All2allSdma:
         copy_output_to_user: bool = True,
     ):
         _require_sdma_env("All2allSdma")
+        _ensure_ccl_jit()
         self.my_pe = my_pe
         self.npes = npes
-        handle_class = _cpp_all2all_factory("All2allSdmaHandle")
+        handle_class = getattr(mori_cpp, "All2allSdmaHandle")
 
         if input_buffer_size is not None and output_buffer_size is not None:
             self._handle = handle_class(
@@ -160,28 +171,35 @@ class All2allSdma:
             )
 
     def __call__(self, input_data, output_data, count: int, stream=None) -> float:
-        """Execute All2All SDMA operation.
-
-        Args:
-            input_data: Input CUDA tensor (1D, GPU memory)
-            output_data: Output CUDA tensor (1D, GPU memory)
-            count: Number of elements per PE
-            stream: Optional torch.cuda.Stream / int / None
-
-        Returns:
-            Execution time in seconds
-        """
-        return self._handle(
-            input_data.data_ptr(), output_data.data_ptr(), count, _stream_to_int(stream)
+        s = _stream_to_int(stream)
+        t0 = time.perf_counter()
+        args = self._handle.prepare_sync(
+            input_data.data_ptr(), output_data.data_ptr(), count, s
         )
+        _get_ccl_func("OneShotAll2allSdmaKernel_u32").launch_struct(
+            (1,), (64,), 0, s, args
+        )
+        self._handle.finish_sync(output_data.data_ptr(), count, s)
+        return time.perf_counter() - t0
 
     def start_async(self, input_data, output_data, count: int, stream=None) -> bool:
-        return self._handle.start_async(
-            input_data.data_ptr(), output_data.data_ptr(), count, _stream_to_int(stream)
+        s = _stream_to_int(stream)
+        args = self._handle.prepare_async_start(
+            input_data.data_ptr(), output_data.data_ptr(), count, s
         )
+        _get_ccl_func("OneShotAll2allSdmaAsyncPutKernel_u32").launch_struct(
+            (1,), (64,), 0, s, args
+        )
+        self._handle.after_async_start()
+        return True
 
     def wait_async(self, stream=None) -> float:
-        return self._handle.wait_async(_stream_to_int(stream))
+        s = _stream_to_int(stream)
+        args = self._handle.prepare_async_wait(s)
+        _get_ccl_func("OneShotAll2allSdmaAsyncWaitKernel_u32").launch_struct(
+            (1,), (512,), 0, s, args
+        )
+        return self._handle.finish_async_wait(s)
 
     def is_async_in_progress(self) -> bool:
         return self._handle.is_async_in_progress()
@@ -193,24 +211,17 @@ class All2allSdma:
         self._handle.reset_flags()
 
     def get_output_transit_buffer(self, dtype=None, device=None):
-        """Get output transit buffer as a PyTorch CUDA tensor (zero-copy view).
-
-        Args:
-            dtype: torch.dtype for the returned tensor view.
-            device: Optional CUDA tensor/device for legacy compatibility.
-        """
         dtype, device = _resolve_transit_view_args(dtype, device, torch.uint32)
         ptr, size_bytes = self._handle.get_output_transit_buffer()
         return _ptr_to_tensor(ptr, size_bytes, dtype, device)
 
 
-def _cpp_allgather_factory(entity_name: str):
-    return getattr(mori_cpp, entity_name)
+# ---------------------------------------------------------------------------
+# AllgatherSdma
+# ---------------------------------------------------------------------------
 
 
 class AllgatherSdma:
-    """Python wrapper for AllgatherSdma C++ class"""
-
     def __init__(
         self,
         my_pe: int,
@@ -221,9 +232,10 @@ class AllgatherSdma:
         copy_output_to_user: bool = True,
     ):
         _require_sdma_env("AllgatherSdma")
+        _ensure_ccl_jit()
         self.my_pe = my_pe
         self.npes = npes
-        handle_class = _cpp_allgather_factory("AllgatherSdmaHandle")
+        handle_class = getattr(mori_cpp, "AllgatherSdmaHandle")
 
         if input_buffer_size is not None and output_buffer_size is not None:
             self._handle = handle_class(
@@ -239,33 +251,38 @@ class AllgatherSdma:
             )
 
     def __call__(self, input_data, output_data, count: int, stream=None) -> bool:
-        """Execute Allgather SDMA operation.
-
-        ``count`` is in *elements* of the tensor dtype; the wrapper converts
-        to a uint32-equivalent count so the SDMA kernel copies the right
-        number of bytes.
-        """
         byte_count = count * input_data.element_size()
         u32_count = (byte_count + 3) // 4
-        return self._handle(
-            input_data.data_ptr(),
-            output_data.data_ptr(),
-            u32_count,
-            _stream_to_int(stream),
+        s = _stream_to_int(stream)
+        args = self._handle.prepare_sync(
+            input_data.data_ptr(), output_data.data_ptr(), u32_count, s
         )
+        _get_ccl_func("OneShotAllGatherSdmaKernel_u32").launch_struct(
+            (1,), (512,), 0, s, args
+        )
+        self._handle.finish_sync(output_data.data_ptr(), u32_count, s)
+        return True
 
     def start_async(self, input_data, output_data, count: int, stream=None) -> bool:
         byte_count = count * input_data.element_size()
         u32_count = (byte_count + 3) // 4
-        return self._handle.start_async(
-            input_data.data_ptr(),
-            output_data.data_ptr(),
-            u32_count,
-            _stream_to_int(stream),
+        s = _stream_to_int(stream)
+        args = self._handle.prepare_async_start(
+            input_data.data_ptr(), output_data.data_ptr(), u32_count, s
         )
+        _get_ccl_func("OneShotAllGatherSdmaAsyncPutKernel_u32").launch_struct(
+            (1,), (512,), 0, s, args
+        )
+        self._handle.after_async_start()
+        return True
 
     def wait_async(self, stream=None) -> float:
-        return self._handle.wait_async(_stream_to_int(stream))
+        s = _stream_to_int(stream)
+        args = self._handle.prepare_async_wait(s)
+        _get_ccl_func("OneShotAllGatherSdmaAsyncWaitKernel_u32").launch_struct(
+            (1,), (64,), 0, s, args
+        )
+        return self._handle.finish_async_wait(s)
 
     def is_async_in_progress(self) -> bool:
         return self._handle.is_async_in_progress()
@@ -277,49 +294,44 @@ class AllgatherSdma:
         self._handle.reset_flags()
 
     def get_output_transit_buffer(self, dtype=None, device=None):
-        """Get output transit buffer as a PyTorch CUDA tensor (zero-copy view)."""
         dtype, device = _resolve_transit_view_args(dtype, device, torch.uint32)
         ptr, size_bytes = self._handle.get_output_transit_buffer()
         return _ptr_to_tensor(ptr, size_bytes, dtype, device)
 
     def register_output_buffer(self, tensor):
-        """Register a CUDA tensor as direct SDMA output target (collective)."""
         self._handle.register_output_buffer(
             tensor.data_ptr(), tensor.numel() * tensor.element_size()
         )
 
     def deregister_output_buffer(self, tensor):
-        """Deregister a previously registered output buffer (collective)."""
         self._handle.deregister_output_buffer(tensor.data_ptr())
 
     def is_output_registered(self, tensor) -> bool:
-        """Check whether an output tensor is registered."""
         return self._handle.is_output_registered(tensor.data_ptr())
 
 
-def _cpp_allreduce_factory(entity_name: str):
-    return getattr(mori_cpp, entity_name)
+# ---------------------------------------------------------------------------
+# AllreduceSdma
+# ---------------------------------------------------------------------------
+
+_DTYPE_TO_SUFFIX = {
+    torch.uint32: "u32",
+    torch.int32: "i32",
+    torch.float32: "f32",
+    torch.float16: "f16",
+    torch.bfloat16: "bf16",
+}
+
+_HANDLE_MAP = {
+    torch.uint32: "AllreduceSdmaHandle",
+    torch.int32: "AllreduceSdmaHandleInt32",
+    torch.float32: "AllreduceSdmaHandleFp32",
+    torch.float16: "AllreduceSdmaHandleFp16",
+    torch.bfloat16: "AllreduceSdmaHandleBf16",
+}
 
 
 class AllreduceSdma:
-    """Python wrapper for AllreduceSdma C++ class.
-
-    Performs AllReduce in two stages:
-      Stage 1: ReduceScatter -- each rank reduces its shard across all peers
-      Stage 2: AllGather -- broadcast reduced shards to all peers via SDMA
-
-    Supported dtypes: torch.uint32, torch.int32, torch.float32, torch.float16,
-    torch.bfloat16
-    """
-
-    _HANDLE_MAP = {
-        torch.uint32: "AllreduceSdmaHandle",
-        torch.int32: "AllreduceSdmaHandleInt32",
-        torch.float32: "AllreduceSdmaHandleFp32",
-        torch.float16: "AllreduceSdmaHandleFp16",
-        torch.bfloat16: "AllreduceSdmaHandleBf16",
-    }
-
     def __init__(
         self,
         my_pe: int,
@@ -332,17 +344,21 @@ class AllreduceSdma:
         mode: str = "eager",
     ):
         _require_sdma_env("AllreduceSdma")
+        _ensure_ccl_jit()
         self.my_pe = my_pe
         self.npes = npes
         self.dtype = dtype
         self.mode = mode
-
-        handle_name = self._HANDLE_MAP.get(dtype)
-        if handle_name is None:
+        self._type_suffix = _DTYPE_TO_SUFFIX.get(dtype)
+        if self._type_suffix is None:
             raise ValueError(
-                f"Unsupported dtype {dtype}. Supported: {list(self._HANDLE_MAP.keys())}"
+                f"Unsupported dtype {dtype}. Supported: {list(_DTYPE_TO_SUFFIX.keys())}"
             )
-        handle_class = _cpp_allreduce_factory(handle_name)
+
+        handle_name = _HANDLE_MAP.get(dtype)
+        if handle_name is None:
+            raise ValueError(f"Unsupported dtype {dtype}")
+        handle_class = getattr(mori_cpp, handle_name)
 
         if input_buffer_size is not None and output_buffer_size is not None:
             self._handle = handle_class(
@@ -358,24 +374,55 @@ class AllreduceSdma:
             )
 
     def __call__(self, input_data, output_data, count: int, stream=None) -> bool:
-        """Execute out-of-place AllReduce SDMA operation."""
-        return self._handle(
-            input_data.data_ptr(), output_data.data_ptr(), count, _stream_to_int(stream)
+        s = _stream_to_int(stream)
+        sfx = self._type_suffix
+        # Step 1: ReduceScatter
+        args = self._handle.prepare_reduce_scatter(
+            input_data.data_ptr(), output_data.data_ptr(), count, s
         )
+        blocks, threads = self._handle.get_reduce_scatter_grid(count)
+        _get_ccl_func(f"SdmaReduceScatterKernel_{sfx}").launch_struct(
+            (blocks,), (threads,), 0, s, args
+        )
+        # Step 2: AllGather
+        args = self._handle.prepare_allgather(count, s)
+        _get_ccl_func(f"AllGatherSdmaKernel_{sfx}").launch_struct(
+            (1,), (512,), 0, s, args
+        )
+        # Sync + copy output
+        self._handle.finish_sync(output_data.data_ptr(), count, s)
+        return True
 
     def allreduce_inplace(self, data, count: int, stream=None) -> bool:
-        """Execute in-place AllReduce SDMA operation (result overwrites input)."""
-        return self._handle.allreduce_inplace(
-            data.data_ptr(), count, _stream_to_int(stream)
-        )
+        return self(data, data, count, stream)
 
     def start_async(self, input_data, output_data, count: int, stream=None) -> bool:
-        return self._handle.start_async(
-            input_data.data_ptr(), output_data.data_ptr(), count, _stream_to_int(stream)
+        s = _stream_to_int(stream)
+        sfx = self._type_suffix
+        # ReduceScatter
+        args = self._handle.prepare_async_reduce_scatter(
+            input_data.data_ptr(), output_data.data_ptr(), count, s
         )
+        blocks, threads = self._handle.get_reduce_scatter_grid(count)
+        _get_ccl_func(f"SdmaReduceScatterKernel_{sfx}").launch_struct(
+            (blocks,), (threads,), 0, s, args
+        )
+        # AllGather PUT
+        args = self._handle.prepare_async_allgather_put(count, s)
+        _get_ccl_func(f"AllGatherAsyncPutKernel_{sfx}").launch_struct(
+            (1,), (512,), 0, s, args
+        )
+        self._handle.after_async_start()
+        return True
 
     def wait_async(self, stream=None) -> float:
-        return self._handle.wait_async(_stream_to_int(stream))
+        s = _stream_to_int(stream)
+        sfx = self._type_suffix
+        args = self._handle.prepare_async_wait(s)
+        _get_ccl_func(f"AllGatherAsyncWaitKernel_{sfx}").launch_struct(
+            (1,), (64,), 0, s, args
+        )
+        return self._handle.finish_async_wait(s)
 
     def is_async_in_progress(self) -> bool:
         return self._handle.is_async_in_progress()
@@ -387,12 +434,6 @@ class AllreduceSdma:
         self._handle.reset_flags()
 
     def get_output_transit_buffer(self, dtype=None, device=None):
-        """Get output transit buffer as a PyTorch CUDA tensor (zero-copy view).
-
-        Args:
-            dtype: torch.dtype for the view. Defaults to self.dtype.
-            device: Optional CUDA tensor/device for legacy compatibility.
-        """
         dtype, device = _resolve_transit_view_args(dtype, device, self.dtype)
         ptr, size_bytes = self._handle.get_output_transit_buffer()
         return _ptr_to_tensor(ptr, size_bytes, dtype, device)

--- a/python/mori/jit/__init__.py
+++ b/python/mori/jit/__init__.py
@@ -68,18 +68,25 @@ def precompile():
         ("scatter_gather", "src/io/kernels"),
     ]
 
+    # CCL kernels
+    ccl_kernels = [
+        ("ccl_kernels", "src/collective/kernels"),
+    ]
+
     def _compile_bc():
         return "shmem bitcode", ensure_bitcode()
 
     def _compile_genco(name, source_dir="src/ops/kernels"):
         return name, compile_genco(name, source_dir=source_dir)
 
-    total_tasks = len(all_kernels) + len(io_kernels) + 1
+    total_tasks = len(all_kernels) + len(io_kernels) + len(ccl_kernels) + 1
     with ThreadPoolExecutor(max_workers=total_tasks) as pool:
         futures = [pool.submit(_compile_bc)]
         for name in all_kernels:
             futures.append(pool.submit(_compile_genco, name))
         for name, src_dir in io_kernels:
+            futures.append(pool.submit(_compile_genco, name, src_dir))
+        for name, src_dir in ccl_kernels:
             futures.append(pool.submit(_compile_genco, name, src_dir))
 
         for future in as_completed(futures):

--- a/setup.py
+++ b/setup.py
@@ -253,6 +253,10 @@ def _copy_jit_sources(root_dir: Path) -> None:
     if io_kernels_src.is_dir():
         _copytree(io_kernels_src, jit_dir / "src" / "io" / "kernels")
 
+    ccl_kernels_src = root_dir / "src" / "collective" / "kernels"
+    if ccl_kernels_src.is_dir():
+        _copytree(ccl_kernels_src, jit_dir / "src" / "collective" / "kernels")
+
     shmem_dst = jit_dir / "src" / "shmem"
     shmem_dst.mkdir(parents=True, exist_ok=True)
     for name in ["shmem_device_api_wrapper.cpp"]:
@@ -435,11 +439,12 @@ class CMakeBuild(build_ext):
                 build_dir / "src/io/libmori_io.so",
                 root_dir / "python/mori/libmori_io.so",
             ),
-            (
-                build_dir / "src/collective/libmori_collective.so",
-                root_dir / "python/mori/libmori_collective.so",
-            ),
         ]
+        collective_so = build_dir / "src/collective/libmori_collective.so"
+        if collective_so.exists():
+            files_to_copy.append(
+                (collective_so, root_dir / "python/mori/libmori_collective.so")
+            )
         for src_path, dst_path in files_to_copy:
             shutil.copyfile(src_path, dst_path)
 
@@ -531,11 +536,12 @@ mori_package_data = [
     "libmori_ops.so",
     "libmori_io.so",
     "libmori_application.so",
-    "libmori_collective.so",
+    "libmori_collective.so",  # optional: only present when BUILD_COLLECTIVE=ON
     "spdk_proxy",
     "umbp_master",
     "_jit-sources/include/**/*.hpp",
     "_jit-sources/include/**/*.h",
+    "_jit-sources/include/**/*.cuh",
     "_jit-sources/src/**/*.hip",
     "_jit-sources/src/**/*.hpp",
     "_jit-sources/src/**/*.cpp",

--- a/src/collective/CMakeLists.txt
+++ b/src/collective/CMakeLists.txt
@@ -5,13 +5,6 @@ set(COLLECTIVE_SOURCES
     # Note: intra_node_executor is header-only template class
 )
 
-if(WITH_MPI)
-  find_package(MPI REQUIRED)
-  list(APPEND COLLECTIVE_SOURCES core/topology_detector.cpp
-       core/allreduce_manager.cpp inter_node/executors/ring_1d_executor.cpp
-       inter_node/executors/one_shot_executor.cpp)
-endif()
-
 add_library(mori_collective SHARED ${COLLECTIVE_SOURCES})
 
 if(USE_ROCM)
@@ -20,15 +13,47 @@ if(USE_ROCM)
                             __HIP_PLATFORM_HCC__=1 MORI_SHMEM_NO_STATIC_INIT)
 endif()
 
-# Host-only: kernels are JIT-compiled from ccl_kernels.hip at runtime. No
+# Host-only: SDMA kernels are JIT-compiled from ccl_kernels.hip at runtime. No
 # hip::device (no -x hip, no --hip-link) — avoids atexit/glibc compat issues.
 target_link_libraries(
   mori_collective
   PUBLIC mori_shmem mori_application mori_logging
   PRIVATE hip::host)
 
+# Inter-node MPI executors contain AOT device code (<<<>>> launches) and require
+# hip::device. Built as a separate object library so the core SDMA path stays
+# host-only.
 if(WITH_MPI)
-  target_link_libraries(mori_collective PUBLIC MPI::MPI_CXX)
+  find_package(MPI REQUIRED)
+  add_library(
+    mori_collective_internode OBJECT
+    core/topology_detector.cpp core/allreduce_manager.cpp
+    inter_node/executors/ring_1d_executor.cpp
+    inter_node/executors/one_shot_executor.cpp)
+  target_include_directories(mori_collective_internode
+                             PUBLIC ${CMAKE_SOURCE_DIR}/include)
+  target_link_libraries(mori_collective_internode PUBLIC MPI::MPI_CXX hip::host
+                                                         hip::device)
+  if(USE_ROCM)
+    target_compile_definitions(
+      mori_collective_internode
+      PRIVATE __HIP_PLATFORM_AMD__=1 USE_ROCM=1 HIPBLAS_V2
+              __HIP_PLATFORM_HCC__=1 MORI_SHMEM_NO_STATIC_INIT
+              MORI_SHMEM_ENABLE_WEAK_GLOBAL_GPU_STATES)
+    target_compile_options(
+      mori_collective_internode
+      PRIVATE $<$<COMPILE_LANGUAGE:HIP>:
+              --offload-arch=native
+              -fgpu-flush-denormals-to-zero
+              -fno-offload-uniform-block
+              -mllvm
+              --amdgpu-kernarg-preload-count=16
+              -fno-gpu-rdc
+              -Wno-unused-result
+              >)
+  endif()
+  target_link_libraries(mori_collective PRIVATE mori_collective_internode
+                                                MPI::MPI_CXX)
 endif()
 
 target_include_directories(mori_collective PUBLIC ${CMAKE_SOURCE_DIR}/include)

--- a/src/collective/CMakeLists.txt
+++ b/src/collective/CMakeLists.txt
@@ -14,36 +14,18 @@ endif()
 
 add_library(mori_collective SHARED ${COLLECTIVE_SOURCES})
 
-# HIP compile options (extracted from aiter, PyTorch dependencies removed)
 if(USE_ROCM)
-  # NO_STATIC_INIT: skip auto barrier launcher from shmem.hpp.
-  # ENABLE_WEAK_GLOBAL_GPU_STATES collective HIP TUs need weak globalGpuStates +
-  # RegisterGpuStatesAddrProvider; EP JIT must not set this (uses
-  # MORI_DEFINE_GPU_STATES). See include/mori/shmem/shmem.hpp "Policy: EP vs
-  # SDMA CCL".
   target_compile_definitions(
-    mori_collective
-    PRIVATE __HIP_PLATFORM_AMD__=1 USE_ROCM=1 HIPBLAS_V2 __HIP_PLATFORM_HCC__=1
-            MORI_SHMEM_NO_STATIC_INIT MORI_SHMEM_ENABLE_WEAK_GLOBAL_GPU_STATES)
-
-  # HIP-specific compile options
-  target_compile_options(
-    mori_collective
-    PRIVATE $<$<COMPILE_LANGUAGE:HIP>:
-            --offload-arch=native
-            -fgpu-flush-denormals-to-zero
-            -fno-offload-uniform-block
-            -mllvm
-            --amdgpu-kernarg-preload-count=16
-            -fno-gpu-rdc
-            -Wno-unused-result
-            >)
+    mori_collective PRIVATE __HIP_PLATFORM_AMD__=1 USE_ROCM=1 HIPBLAS_V2
+                            __HIP_PLATFORM_HCC__=1 MORI_SHMEM_NO_STATIC_INIT)
 endif()
 
+# Host-only: kernels are JIT-compiled from ccl_kernels.hip at runtime. No
+# hip::device (no -x hip, no --hip-link) — avoids atexit/glibc compat issues.
 target_link_libraries(
   mori_collective
   PUBLIC mori_shmem mori_application mori_logging
-  PRIVATE hip::host hip::device)
+  PRIVATE hip::host)
 
 if(WITH_MPI)
   target_link_libraries(mori_collective PUBLIC MPI::MPI_CXX)

--- a/src/collective/core/oneshot_all2all_sdma_class.cpp
+++ b/src/collective/core/oneshot_all2all_sdma_class.cpp
@@ -26,8 +26,6 @@
 #include <cstring>
 #include <stdexcept>
 
-#include "mori/collective/all2all/oneshot_all2all_sdma_async_kernel.hpp"
-#include "mori/collective/all2all/oneshot_all2all_sdma_kernel.hpp"
 #include "mori/shmem/shmem.hpp"
 
 namespace mori {
@@ -138,129 +136,20 @@ All2allSdma<T>::~All2allSdma() {
 
 template <typename T>
 bool All2allSdma<T>::start_async(T* input, T* output, size_t total_count, hipStream_t stream) {
-  // Check if another async operation is in progress
-  bool expected = false;
-  if (!async_in_progress_.compare_exchange_strong(expected, true)) {
-    printf("PE %d: Another async operation is already in progress\n", myPe_);
-    return false;
-  }
-
-  // Save parameters for async operation
-  async_input_ = input;
-  async_output_ = output;
-  async_total_count_ = total_count;
-  async_stream_ = stream;
-  async_start_time_ = CollectiveWallTime();
-
-  try {
-    // Step 1: Copy input data to input transit buffer
-    printf("PE %d: Starting async All2All (PUT phase)\n", myPe_);
-    // copy_input_to_transit(input, total_count * npes_, stream);
-
-    // Step 2: Reset flags
-    // resetFlags();
-
-    // Step 3: Execute All2All kernel (PUT operation)
-    printf("PE %d: Launching async PUT kernel...\n", myPe_);
-
-    int block_size = 256;
-    int grid_size = (total_count * npes_ + block_size - 1) / block_size;
-    if (grid_size < 1) grid_size = 1;
-    if (grid_size > 65535) grid_size = 65535;
-
-    printf("  Grid size: %d, Block size: %d\n", grid_size, block_size);
-
-    // Launch the kernel - this runs asynchronously
-    OneShotAll2allSdmaAsyncPutKernel<T>
-        <<<1, 64, 0, stream>>>(myPe_, npes_, input, input_transit_buffer_obj_,
-                               output_transit_buffer_obj_, flagsObj_, total_count);
-
-    hipError_t kernel_err = hipGetLastError();
-    if (kernel_err != hipSuccess) {
-      printf("PE %d: Async kernel launch failed: %s\n", myPe_, hipGetErrorString(kernel_err));
-      throw std::runtime_error("Kernel launch failed");
-    }
-
-    printf("PE %d: Async PUT operation started successfully\n", myPe_);
-    return true;
-
-  } catch (const std::exception& e) {
-    printf("PE %d: Failed to start async operation: %s\n", myPe_, e.what());
-    async_in_progress_ = false;
-    return false;
-  }
+  // Kernel launch moved to Python JIT path.
+  // Use prepare_async_start / after_async_start instead.
+  throw std::runtime_error(
+      "All2allSdma::start_async() is deprecated; use Python JIT launch path "
+      "(prepare_async_start + after_async_start)");
 }
 
 template <typename T>
 double All2allSdma<T>::wait_async(hipStream_t stream) {
-  if (!async_in_progress_) {
-    printf("PE %d: No async operation in progress\n", myPe_);
-    return -1.0;
-  }
-
-  try {
-    printf("PE %d: Waiting for async All2All completion (WAIT phase)\n", myPe_);
-
-    // Use provided stream or the one from start_async
-    hipStream_t wait_stream = (stream != nullptr) ? stream : async_stream_;
-
-    OneShotAll2allSdmaAsyncWaitKernel<<<1, 512, 0, wait_stream>>>(
-        myPe_, npes_, output_transit_buffer_obj_, flagsObj_);
-
-    // Step 1: Synchronize to ensure PUT kernel is completed
-    printf("PE %d: Synchronizing to ensure PUT kernel completion\n", myPe_);
-
-    if (wait_stream != nullptr) {
-      hipError_t err = hipStreamSynchronize(wait_stream);
-      if (err != hipSuccess) {
-        printf("PE %d: Stream synchronization failed: %s\n", myPe_, hipGetErrorString(err));
-        throw std::runtime_error("Stream synchronization failed");
-      }
-    } else {
-      hipError_t err = hipDeviceSynchronize();
-      if (err != hipSuccess) {
-        printf("PE %d: Device synchronization failed: %s\n", myPe_, hipGetErrorString(err));
-        throw std::runtime_error("Device synchronization failed");
-      }
-    }
-
-    // Step 2: Copy from output transit buffer to user output buffer (if enabled)
-    if (copy_output_to_user_) {
-      printf("PE %d: Copying results to user output buffer\n", myPe_);
-      copy_output_to_user(async_output_, async_total_count_, wait_stream);
-    } else {
-      printf("PE %d: Skipping copy to user output buffer (using output_transit_buffer directly)\n",
-             myPe_);
-    }
-
-    // Final synchronization
-    if (wait_stream != nullptr) {
-      (void)hipStreamSynchronize(wait_stream);
-    } else {
-      (void)hipDeviceSynchronize();
-    }
-
-    // Calculate total execution time
-    double end_time = CollectiveWallTime();
-    double duration = end_time - async_start_time_;
-
-    printf("PE %d: Async All2All completed in %.6f seconds\n", myPe_, duration);
-
-    // Reset async state
-    async_in_progress_ = false;
-    async_input_ = nullptr;
-    async_output_ = nullptr;
-    async_total_count_ = 0;
-    async_stream_ = nullptr;
-    async_start_time_ = 0.0;
-
-    return duration;
-
-  } catch (const std::exception& e) {
-    printf("PE %d: Async wait failed: %s\n", myPe_, e.what());
-    cancel_async();
-    return -1.0;
-  }
+  // Kernel launch moved to Python JIT path.
+  // Use prepare_async_wait / finish_async_wait instead.
+  throw std::runtime_error(
+      "All2allSdma::wait_async() is deprecated; use Python JIT launch path "
+      "(prepare_async_wait + finish_async_wait)");
 }
 
 template <typename T>
@@ -400,83 +289,135 @@ void All2allSdma<T>::copy_output_to_user(T* output, size_t total_count, hipStrea
   }
 }
 
-// operator() implementation (modified to check async status)
+// operator() — kernel launch moved to Python JIT path
 template <typename T>
 double All2allSdma<T>::operator()(T* input, T* output, size_t total_count, hipStream_t stream) {
-  // Check if async operation is in progress
+  // Kernel launch moved to Python JIT path.
+  // Use prepare_sync / finish_sync instead.
+  throw std::runtime_error(
+      "All2allSdma::operator() is deprecated; use Python JIT launch path "
+      "(prepare_sync + finish_sync)");
+}
+
+// ================ JIT launch support ================
+
+template <typename T>
+int64_t All2allSdma<T>::prepare_sync(T* input, T* output, size_t total_count, hipStream_t stream) {
   if (async_in_progress_) {
-    printf("PE %d: Cannot execute sync operation while async is in progress\n", myPe_);
-    printf("  Call cancel_async() first or wait for async to complete\n");
-    return -1.0;
+    throw std::runtime_error("Cannot execute sync operation while async is in progress");
+  }
+  jit_args_.myPe = myPe_;
+  jit_args_.npes = npes_;
+  jit_args_.input = input;
+  jit_args_.inputTransitMemObj = input_transit_buffer_obj_;
+  jit_args_.outputTransitMemObj = output_transit_buffer_obj_;
+  jit_args_.flagsMemObj = flagsObj_;
+  jit_args_.elementCount = total_count;
+  return reinterpret_cast<int64_t>(&jit_args_);
+}
+
+template <typename T>
+double All2allSdma<T>::finish_sync(T* output, size_t total_count, hipStream_t stream) {
+  hipError_t err;
+  if (stream != nullptr) {
+    err = hipStreamSynchronize(stream);
+  } else {
+    err = hipDeviceSynchronize();
+  }
+  if (err != hipSuccess) {
+    throw std::runtime_error("Synchronization failed");
+  }
+  if (copy_output_to_user_) {
+    copy_output_to_user(output, total_count, stream);
+  }
+  if (stream != nullptr) {
+    (void)hipStreamSynchronize(stream);
+  } else {
+    (void)hipDeviceSynchronize();
+  }
+  return 0.0;
+}
+
+template <typename T>
+int64_t All2allSdma<T>::prepare_async_start(T* input, T* output, size_t total_count,
+                                            hipStream_t stream) {
+  bool expected = false;
+  if (!async_in_progress_.compare_exchange_strong(expected, true)) {
+    throw std::runtime_error("Another async operation is already in progress");
+  }
+  async_input_ = input;
+  async_output_ = output;
+  async_total_count_ = total_count;
+  async_stream_ = stream;
+  async_start_time_ = CollectiveWallTime();
+
+  jit_args_.myPe = myPe_;
+  jit_args_.npes = npes_;
+  jit_args_.input = input;
+  jit_args_.inputTransitMemObj = input_transit_buffer_obj_;
+  jit_args_.outputTransitMemObj = output_transit_buffer_obj_;
+  jit_args_.flagsMemObj = flagsObj_;
+  jit_args_.elementCount = total_count;
+  return reinterpret_cast<int64_t>(&jit_args_);
+}
+
+template <typename T>
+void All2allSdma<T>::after_async_start() {
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess) {
+    async_in_progress_ = false;
+    throw std::runtime_error("Async kernel launch failed");
+  }
+}
+
+template <typename T>
+int64_t All2allSdma<T>::prepare_async_wait(hipStream_t stream) {
+  if (!async_in_progress_) {
+    throw std::runtime_error("No async operation in progress");
+  }
+  jit_args_.myPe = myPe_;
+  jit_args_.npes = npes_;
+  jit_args_.input = nullptr;
+  jit_args_.inputTransitMemObj = {};
+  jit_args_.outputTransitMemObj = output_transit_buffer_obj_;
+  jit_args_.flagsMemObj = flagsObj_;
+  jit_args_.elementCount = 0;
+  return reinterpret_cast<int64_t>(&jit_args_);
+}
+
+template <typename T>
+double All2allSdma<T>::finish_async_wait(hipStream_t stream) {
+  hipStream_t wait_stream = (stream != nullptr) ? stream : async_stream_;
+  hipError_t err;
+  if (wait_stream != nullptr) {
+    err = hipStreamSynchronize(wait_stream);
+  } else {
+    err = hipDeviceSynchronize();
+  }
+  if (err != hipSuccess) {
+    throw std::runtime_error("Synchronization failed");
   }
 
-  // Execute All2All operation
-  double start = CollectiveWallTime();
-
-  hipError_t sync_err = hipSuccess;
-  try {
-    // Step 1: Copy input data to input transit buffer
-    // copy_input_to_transit(input, total_count * npes_, stream);
-
-    // Step 2: Reset flags
-    // resetFlags();
-
-    // Step 3: Execute All2All kernel
-    int block_size = 256;
-    int grid_size = (total_count * npes_ + block_size - 1) / block_size;
-    if (grid_size < 1) grid_size = 1;
-    if (grid_size > 65535) grid_size = 65535;
-
-    OneShotAll2allSdmaKernel<T>
-        <<<1, 64, 0, stream>>>(myPe_, npes_, input, input_transit_buffer_obj_,
-                               output_transit_buffer_obj_, flagsObj_, total_count);
-
-    sync_err = hipGetLastError();
-    if (sync_err != hipSuccess) {
-      fprintf(stderr, "PE %d: Kernel launch failed: %s\n", myPe_, hipGetErrorString(sync_err));
-      throw std::runtime_error("Kernel launch failed");
-    }
-
-    // Synchronize GPU to ensure kernel completion
-    if (stream != nullptr) {
-      sync_err = hipStreamSynchronize(stream);
-    } else {
-      sync_err = hipDeviceSynchronize();
-    }
-
-    if (sync_err != hipSuccess) {
-      fprintf(stderr, "PE %d: Failed to synchronize: %s\n", myPe_, hipGetErrorString(sync_err));
-      throw std::runtime_error("Synchronization failed");
-    }
-
-    // Step 4: Copy from output transit buffer to user output buffer (if enabled)
-    if (copy_output_to_user_) {
-      copy_output_to_user(output, total_count, stream);
-    }
-
-    // Final synchronization
-    if (stream != nullptr) {
-      sync_err = hipStreamSynchronize(stream);
-    } else {
-      sync_err = hipDeviceSynchronize();
-    }
-
-    if (sync_err != hipSuccess) {
-      fprintf(stderr, "PE %d: Final synchronization failed: %s\n", myPe_,
-              hipGetErrorString(sync_err));
-      throw std::runtime_error("Final synchronization failed");
-    }
-
-  } catch (const std::exception& e) {
-    fprintf(stderr, "PE %d: All2All operation failed: %s\n", myPe_, e.what());
-    return -1.0;
+  if (copy_output_to_user_) {
+    copy_output_to_user(async_output_, async_total_count_, wait_stream);
+  }
+  if (wait_stream != nullptr) {
+    (void)hipStreamSynchronize(wait_stream);
+  } else {
+    (void)hipDeviceSynchronize();
   }
 
-  double end = CollectiveWallTime();
-  double duration = end - start;
-
+  double duration = CollectiveWallTime() - async_start_time_;
+  async_in_progress_ = false;
+  async_input_ = nullptr;
+  async_output_ = nullptr;
+  async_total_count_ = 0;
+  async_stream_ = nullptr;
+  async_start_time_ = 0.0;
   return duration;
 }
+
+// ================ END: JIT launch support ================
 
 // resetFlags implementation (unchanged)
 template <typename T>

--- a/src/collective/core/oneshot_allgather_sdma_class.cpp
+++ b/src/collective/core/oneshot_allgather_sdma_class.cpp
@@ -450,7 +450,7 @@ int64_t AllgatherSdma<T>::prepare_async_start(T* input, T* output, size_t total_
   jit_args_.flagsMemObj = flagsObj_;
   jit_args_.elementCount = total_count;
   jit_args_.dstBaseOffset = direct ? byteOffset : 0;
-  jit_args_.flagVal = 0;
+  jit_args_.flagVal = async_flag_token_;
 
   return (int64_t)&jit_args_;
 }

--- a/src/collective/core/oneshot_allgather_sdma_class.cpp
+++ b/src/collective/core/oneshot_allgather_sdma_class.cpp
@@ -26,8 +26,6 @@
 #include <cstring>
 #include <stdexcept>
 
-#include "mori/collective/allgather/oneshot_sdma_async_kernel.hpp"
-#include "mori/collective/allgather/oneshot_sdma_kernel.hpp"
 #include "mori/shmem/shmem.hpp"
 
 namespace mori {
@@ -198,40 +196,12 @@ bool AllgatherSdma<T>::start_async(T* input, T* output, size_t total_count, hipS
     return false;
   }
 
-  // Save parameters for async operation
-  async_input_ = input;
-  async_output_ = output;
-  async_total_count_ = total_count;
-  async_stream_ = stream;
-  async_start_time_ = CollectiveWallTime();
-  async_flag_token_ = call_seq_.fetch_add(1, std::memory_order_relaxed) + 1;
-
-  try {
-    auto [regObj, byteOffset] = find_registered(output);
-    bool direct = regObj.IsValid();
-    auto& dst_obj = direct ? regObj : output_transit_buffer_obj_;
-    async_dst_obj_ = dst_obj;
-
-    OneShotAllGatherSdmaAsyncPutKernel<T>
-        <<<1, 512, 0, stream>>>(myPe_, npes_, input, input_transit_buffer_obj_, dst_obj, flagsObj_,
-                                total_count, direct ? byteOffset : 0);
-
-    hipError_t kernel_err = hipGetLastError();
-    if (kernel_err != hipSuccess) {
-      fprintf(stderr, "PE %d: Async kernel launch failed: %s\n", myPe_,
-              hipGetErrorString(kernel_err));
-      throw std::runtime_error("Kernel launch failed");
-    }
-
-    return true;
-
-  } catch (const std::exception& e) {
-    printf("PE %d: Failed to start async operation: %s\n", myPe_, e.what());
-    async_in_progress_ = false;
-    async_dst_obj_ = {};
-    async_flag_token_ = 0;
-    return false;
-  }
+  (void)input;
+  (void)output;
+  (void)total_count;
+  (void)stream;
+  async_in_progress_ = false;
+  throw std::runtime_error("Use Python JIT launch path");
 }
 
 template <typename T>
@@ -241,59 +211,8 @@ double AllgatherSdma<T>::wait_async(hipStream_t stream) {
     return -1.0;
   }
 
-  try {
-    hipStream_t wait_stream = (stream != nullptr) ? stream : async_stream_;
-
-    OneShotAllGatherSdmaAsyncWaitKernel<<<1, 64, 0, wait_stream>>>(
-        myPe_, npes_, async_dst_obj_.IsValid() ? async_dst_obj_ : output_transit_buffer_obj_,
-        flagsObj_, async_flag_token_);
-
-    if (wait_stream != nullptr) {
-      hipError_t err = hipStreamSynchronize(wait_stream);
-      if (err != hipSuccess) {
-        fprintf(stderr, "PE %d: Stream synchronization failed: %s\n", myPe_,
-                hipGetErrorString(err));
-        throw std::runtime_error("Stream synchronization failed");
-      }
-    } else {
-      hipError_t err = hipDeviceSynchronize();
-      if (err != hipSuccess) {
-        fprintf(stderr, "PE %d: Device synchronization failed: %s\n", myPe_,
-                hipGetErrorString(err));
-        throw std::runtime_error("Device synchronization failed");
-      }
-    }
-
-    bool direct = find_registered(async_output_).first.IsValid();
-    if (!direct && copy_output_to_user_) {
-      copy_output_to_user(async_output_, async_total_count_, wait_stream);
-    }
-
-    if (wait_stream != nullptr) {
-      (void)hipStreamSynchronize(wait_stream);
-    } else {
-      (void)hipDeviceSynchronize();
-    }
-
-    double end_time = CollectiveWallTime();
-    double duration = end_time - async_start_time_;
-
-    async_in_progress_ = false;
-    async_input_ = nullptr;
-    async_output_ = nullptr;
-    async_total_count_ = 0;
-    async_stream_ = nullptr;
-    async_dst_obj_ = {};
-    async_start_time_ = 0.0;
-    async_flag_token_ = 0;
-
-    return duration;
-
-  } catch (const std::exception& e) {
-    printf("PE %d: Async wait failed: %s\n", myPe_, e.what());
-    cancel_async();
-    return -1.0;
-  }
+  (void)stream;
+  throw std::runtime_error("Use Python JIT launch path");
 }
 
 template <typename T>
@@ -444,33 +363,171 @@ bool AllgatherSdma<T>::operator()(T* input, T* output, size_t total_count, hipSt
     return false;
   }
 
-  try {
-    uint64_t flag_token = call_seq_.fetch_add(1, std::memory_order_relaxed) + 1;
-    auto [regObj, byteOffset] = find_registered(output);
-    bool direct = regObj.IsValid();
-    auto& dst_obj = direct ? regObj : output_transit_buffer_obj_;
+  (void)input;
+  (void)output;
+  (void)total_count;
+  (void)stream;
+  throw std::runtime_error("Use Python JIT launch path");
+}
 
-    OneShotAllGatherSdmaKernel<T>
-        <<<1, 512, 0, stream>>>(myPe_, npes_, input, input_transit_buffer_obj_, dst_obj, flagsObj_,
-                                total_count, direct ? byteOffset : 0, flag_token);
+// ================ JIT prepare/finish methods ================
 
-    hipError_t err = hipGetLastError();
+template <typename T>
+int64_t AllgatherSdma<T>::prepare_sync(T* input, T* output, size_t total_count,
+                                       hipStream_t stream) {
+  (void)stream;
+  uint64_t flag_token = call_seq_.fetch_add(1, std::memory_order_relaxed) + 1;
+  auto [regObj, byteOffset] = find_registered(output);
+  bool direct = regObj.IsValid();
+
+  jit_args_.myPe = myPe_;
+  jit_args_.npes = npes_;
+  jit_args_.input = input;
+  jit_args_.srcMemObj = input_transit_buffer_obj_;
+  jit_args_.dstMemObj = direct ? regObj : output_transit_buffer_obj_;
+  jit_args_.flagsMemObj = flagsObj_;
+  jit_args_.elementCount = total_count;
+  jit_args_.dstBaseOffset = direct ? byteOffset : 0;
+  jit_args_.flagVal = flag_token;
+
+  return (int64_t)&jit_args_;
+}
+
+template <typename T>
+double AllgatherSdma<T>::finish_sync(T* output, size_t total_count, hipStream_t stream) {
+  if (stream != nullptr) {
+    hipError_t err = hipStreamSynchronize(stream);
     if (err != hipSuccess) {
-      fprintf(stderr, "PE %d: Kernel launch failed: %s\n", myPe_, hipGetErrorString(err));
-      return false;
+      fprintf(stderr, "PE %d: Stream synchronization failed: %s\n", myPe_, hipGetErrorString(err));
+      throw std::runtime_error("Stream synchronization failed");
     }
-
-    if (!direct && copy_output_to_user_) {
-      copy_output_to_user(output, total_count, stream);
+  } else {
+    hipError_t err = hipDeviceSynchronize();
+    if (err != hipSuccess) {
+      fprintf(stderr, "PE %d: Device synchronization failed: %s\n", myPe_, hipGetErrorString(err));
+      throw std::runtime_error("Device synchronization failed");
     }
-
-  } catch (const std::exception& e) {
-    fprintf(stderr, "PE %d: Allgather operation failed: %s\n", myPe_, e.what());
-    return false;
   }
 
-  return true;
+  bool direct = find_registered(output).first.IsValid();
+  if (!direct && copy_output_to_user_) {
+    copy_output_to_user(output, total_count, stream);
+    if (stream != nullptr) {
+      (void)hipStreamSynchronize(stream);
+    } else {
+      (void)hipDeviceSynchronize();
+    }
+  }
+
+  return 0.0;
 }
+
+template <typename T>
+int64_t AllgatherSdma<T>::prepare_async_start(T* input, T* output, size_t total_count,
+                                              hipStream_t stream) {
+  bool expected = false;
+  if (!async_in_progress_.compare_exchange_strong(expected, true)) {
+    throw std::runtime_error("Another async operation is already in progress");
+  }
+
+  async_input_ = input;
+  async_output_ = output;
+  async_total_count_ = total_count;
+  async_stream_ = stream;
+  async_start_time_ = CollectiveWallTime();
+  async_flag_token_ = call_seq_.fetch_add(1, std::memory_order_relaxed) + 1;
+
+  auto [regObj, byteOffset] = find_registered(output);
+  bool direct = regObj.IsValid();
+  auto& dst_obj = direct ? regObj : output_transit_buffer_obj_;
+  async_dst_obj_ = dst_obj;
+
+  jit_args_.myPe = myPe_;
+  jit_args_.npes = npes_;
+  jit_args_.input = input;
+  jit_args_.srcMemObj = input_transit_buffer_obj_;
+  jit_args_.dstMemObj = dst_obj;
+  jit_args_.flagsMemObj = flagsObj_;
+  jit_args_.elementCount = total_count;
+  jit_args_.dstBaseOffset = direct ? byteOffset : 0;
+  jit_args_.flagVal = 0;
+
+  return (int64_t)&jit_args_;
+}
+
+template <typename T>
+void AllgatherSdma<T>::after_async_start() {}
+
+template <typename T>
+int64_t AllgatherSdma<T>::prepare_async_wait(hipStream_t stream) {
+  if (!async_in_progress_) {
+    throw std::runtime_error("No async operation in progress");
+  }
+  (void)stream;
+
+  jit_args_.myPe = myPe_;
+  jit_args_.npes = npes_;
+  jit_args_.input = nullptr;
+  jit_args_.srcMemObj = {};
+  jit_args_.dstMemObj = async_dst_obj_.IsValid() ? async_dst_obj_ : output_transit_buffer_obj_;
+  jit_args_.flagsMemObj = flagsObj_;
+  jit_args_.elementCount = 0;
+  jit_args_.dstBaseOffset = 0;
+  jit_args_.flagVal = async_flag_token_;
+
+  return (int64_t)&jit_args_;
+}
+
+template <typename T>
+double AllgatherSdma<T>::finish_async_wait(hipStream_t stream) {
+  if (!async_in_progress_) {
+    throw std::runtime_error("No async operation in progress");
+  }
+
+  hipStream_t wait_stream = (stream != nullptr) ? stream : async_stream_;
+
+  if (wait_stream != nullptr) {
+    hipError_t err = hipStreamSynchronize(wait_stream);
+    if (err != hipSuccess) {
+      fprintf(stderr, "PE %d: Stream synchronization failed: %s\n", myPe_, hipGetErrorString(err));
+      cancel_async();
+      throw std::runtime_error("Stream synchronization failed");
+    }
+  } else {
+    hipError_t err = hipDeviceSynchronize();
+    if (err != hipSuccess) {
+      fprintf(stderr, "PE %d: Device synchronization failed: %s\n", myPe_, hipGetErrorString(err));
+      cancel_async();
+      throw std::runtime_error("Device synchronization failed");
+    }
+  }
+
+  bool direct = find_registered(async_output_).first.IsValid();
+  if (!direct && copy_output_to_user_) {
+    copy_output_to_user(async_output_, async_total_count_, wait_stream);
+    if (wait_stream != nullptr) {
+      (void)hipStreamSynchronize(wait_stream);
+    } else {
+      (void)hipDeviceSynchronize();
+    }
+  }
+
+  double end_time = CollectiveWallTime();
+  double duration = end_time - async_start_time_;
+
+  async_in_progress_ = false;
+  async_input_ = nullptr;
+  async_output_ = nullptr;
+  async_total_count_ = 0;
+  async_stream_ = nullptr;
+  async_dst_obj_ = {};
+  async_start_time_ = 0.0;
+  async_flag_token_ = 0;
+
+  return duration;
+}
+
+// ================ END: JIT prepare/finish methods ================
 
 // resetFlags implementation (unchanged)
 template <typename T>

--- a/src/collective/core/twoshot_allreduce_sdma_class.cpp
+++ b/src/collective/core/twoshot_allreduce_sdma_class.cpp
@@ -310,8 +310,9 @@ int64_t AllreduceSdma<T>::prepare_allgather(size_t total_count, hipStream_t /*st
 }
 
 template <typename T>
-double AllreduceSdma<T>::finish_sync(T* output, size_t total_count, hipStream_t stream) {
-  if (copy_output_to_user_) {
+double AllreduceSdma<T>::finish_sync(T* output, size_t total_count, hipStream_t stream,
+                                     bool force_copy_output_to_user) {
+  if (copy_output_to_user_ || force_copy_output_to_user) {
     copy_output_to_user(output, total_count, stream);
   }
   return 0.0;

--- a/src/collective/core/twoshot_allreduce_sdma_class.cpp
+++ b/src/collective/core/twoshot_allreduce_sdma_class.cpp
@@ -312,8 +312,6 @@ int64_t AllreduceSdma<T>::prepare_allgather(size_t total_count, hipStream_t /*st
 template <typename T>
 double AllreduceSdma<T>::finish_sync(T* output, size_t total_count, hipStream_t stream,
                                      bool force_copy_output_to_user) {
-  hipError_t err = stream ? hipStreamSynchronize(stream) : hipDeviceSynchronize();
-  if (err != hipSuccess) throw std::runtime_error("Synchronization failed in finish_sync");
   if (copy_output_to_user_ || force_copy_output_to_user) {
     copy_output_to_user(output, total_count, stream);
   }

--- a/src/collective/core/twoshot_allreduce_sdma_class.cpp
+++ b/src/collective/core/twoshot_allreduce_sdma_class.cpp
@@ -30,8 +30,6 @@
 #include <cstring>
 #include <stdexcept>
 
-#include "mori/collective/allreduce/twoshot_sdma_async_kernel.hpp"
-#include "mori/collective/allreduce/twoshot_sdma_kernel.hpp"
 #include "mori/shmem/shmem.hpp"
 
 namespace mori {
@@ -215,156 +213,28 @@ void AllreduceSdma<T>::copy_output_to_user(T* output, size_t total_count, hipStr
 // ---------------------------------------------------------------------------
 template <typename T>
 bool AllreduceSdma<T>::operator()(T* input, T* output, size_t total_count, hipStream_t stream) {
-  try {
-    // Step 1: SdmaReduceScatter — SDMA scatter + local reduce
-    constexpr int pack_size = packed_t<T>::P::size;
-    int threads = 512;
-    int packedPerRank = static_cast<int>(((total_count / npes_ + pack_size - 1) / pack_size));
-    int blocks = std::min(max_blocks_, (packedPerRank + threads - 1) / threads);
-    if (blocks < 1) blocks = 1;
-
-    SdmaReduceScatterKernel<T><<<blocks, threads, 0, stream>>>(
-        myPe_, npes_, input, output_transit_buffer_obj_, flagsObj_, barrierPtr_, total_count);
-
-    hipError_t err = hipGetLastError();
-    if (err != hipSuccess) {
-      fprintf(stderr, "PE %d: SdmaReduceScatter launch failed: %s\n", myPe_,
-              hipGetErrorString(err));
-      return false;
-    }
-
-    // Step 2: AllGather via SDMA
-    AllGatherSdmaKernel<T><<<1, 512, 0, stream>>>(myPe_, npes_, output_transit_buffer_obj_,
-                                                  flagsObj_, barrierPtr_, total_count);
-
-    err = hipGetLastError();
-    if (err != hipSuccess) {
-      fprintf(stderr, "PE %d: AllGather launch failed: %s\n", myPe_, hipGetErrorString(err));
-      return false;
-    }
-
-    // Step 3: Copy result to user buffer
-    if (copy_output_to_user_) {
-      copy_output_to_user(output, total_count, stream);
-    }
-
-  } catch (const std::exception& e) {
-    fprintf(stderr, "PE %d: AllReduce failed: %s\n", myPe_, e.what());
-    return false;
-  }
-  return true;
+  (void)input;
+  (void)output;
+  (void)total_count;
+  (void)stream;
+  throw std::runtime_error("AllreduceSdma::operator() removed — use Python JIT launch path");
 }
 
 // ================ Async API Implementations ================
 
 template <typename T>
 bool AllreduceSdma<T>::start_async(T* input, T* output, size_t total_count, hipStream_t stream) {
-  bool expected = false;
-  if (!async_in_progress_.compare_exchange_strong(expected, true)) {
-    printf("PE %d: Another async operation is already in progress\n", myPe_);
-    return false;
-  }
-
-  async_input_ = input;
-  async_output_ = output;
-  async_total_count_ = total_count;
-  async_stream_ = stream;
-  async_start_time_ = CollectiveWallTime();
-
-  try {
-    size_t elementCountPerRank = total_count / npes_;
-    size_t required_output_size = elementCountPerRank * npes_ * dtype_size_;
-    if (!ensure_buffer_size(output_transit_buffer_, output_transit_buffer_ptr_,
-                            output_transit_buffer_size_, output_transit_buffer_obj_,
-                            required_output_size, "output transit buffer")) {
-      async_in_progress_ = false;
-      return false;
-    }
-
-    // Step 1: SdmaReduceScatter — same as operator()
-    constexpr int pack_size = packed_t<T>::P::size;
-    int threads = 512;
-    int packedPerRank = static_cast<int>(((total_count / npes_ + pack_size - 1) / pack_size));
-    int blocks = std::min(max_blocks_, (packedPerRank + threads - 1) / threads);
-    if (blocks < 1) blocks = 1;
-
-    SdmaReduceScatterKernel<T><<<blocks, threads, 0, stream>>>(
-        myPe_, npes_, input, output_transit_buffer_obj_, flagsObj_, barrierPtr_, total_count);
-
-    // Step 2: AllGather PUT only — sends data, returns immediately
-    // The wait is deferred to wait_async so the user can run GEMM on CU
-    AllGatherAsyncPutKernel<T><<<1, 512, 0, stream>>>(myPe_, npes_, output_transit_buffer_obj_,
-                                                      flagsObj_, barrierPtr_, total_count);
-
-    hipError_t kernel_err = hipGetLastError();
-    if (kernel_err != hipSuccess) {
-      fprintf(stderr, "PE %d: Async kernel launch failed: %s\n", myPe_,
-              hipGetErrorString(kernel_err));
-      throw std::runtime_error("Kernel launch failed");
-    }
-
-    return true;
-
-  } catch (const std::exception& e) {
-    fprintf(stderr, "PE %d: Failed to start async operation: %s\n", myPe_, e.what());
-    async_in_progress_ = false;
-    return false;
-  }
+  (void)input;
+  (void)output;
+  (void)total_count;
+  (void)stream;
+  throw std::runtime_error("AllreduceSdma::start_async removed — use Python JIT launch path");
 }
 
 template <typename T>
 double AllreduceSdma<T>::wait_async(hipStream_t stream) {
-  if (!async_in_progress_) {
-    printf("PE %d: No async operation in progress\n", myPe_);
-    return -1.0;
-  }
-
-  try {
-    hipStream_t wait_stream = (stream != nullptr) ? stream : async_stream_;
-
-    // Wait for AllGather SDMA transfers to complete + invalidate L2
-    AllGatherAsyncWaitKernel<<<1, 64, 0, wait_stream>>>(myPe_, npes_, flagsObj_, barrierPtr_,
-                                                        async_total_count_);
-
-    // Copy result to user buffer (if enabled)
-    if (copy_output_to_user_) {
-      copy_output_to_user(async_output_, async_total_count_, wait_stream);
-    }
-
-    // Single synchronization at the end
-    if (wait_stream != nullptr) {
-      hipError_t err = hipStreamSynchronize(wait_stream);
-      if (err != hipSuccess) {
-        fprintf(stderr, "PE %d: Stream synchronization failed: %s\n", myPe_,
-                hipGetErrorString(err));
-        throw std::runtime_error("Stream synchronization failed");
-      }
-    } else {
-      hipError_t err = hipDeviceSynchronize();
-      if (err != hipSuccess) {
-        fprintf(stderr, "PE %d: Device synchronization failed: %s\n", myPe_,
-                hipGetErrorString(err));
-        throw std::runtime_error("Device synchronization failed");
-      }
-    }
-
-    double end_time = CollectiveWallTime();
-    double duration = end_time - async_start_time_;
-
-    async_in_progress_ = false;
-    async_input_ = nullptr;
-    async_output_ = nullptr;
-    async_total_count_ = 0;
-    async_stream_ = nullptr;
-    async_start_time_ = 0.0;
-
-    return duration;
-
-  } catch (const std::exception& e) {
-    fprintf(stderr, "PE %d: Async wait failed: %s\n", myPe_, e.what());
-    cancel_async();
-    return -1.0;
-  }
+  (void)stream;
+  throw std::runtime_error("AllreduceSdma::wait_async removed — use Python JIT launch path");
 }
 
 template <typename T>
@@ -382,15 +252,12 @@ void AllreduceSdma<T>::cancel_async() {
 
 // ================ END: Async API Implementations ================
 
-// allreduce_inplace implementation
+// allreduce_inplace — removed; use prepare/finish JIT path
 // ---------------------------------------------------------------------------
 template <typename T>
-bool AllreduceSdma<T>::allreduce_inplace(T* data, size_t total_count, hipStream_t stream) {
-  bool saved = copy_output_to_user_;
-  copy_output_to_user_ = true;
-  bool ok = (*this)(data, data, total_count, stream);
-  copy_output_to_user_ = saved;
-  return ok;
+bool AllreduceSdma<T>::allreduce_inplace(T* /*data*/, size_t /*total_count*/,
+                                         hipStream_t /*stream*/) {
+  throw std::runtime_error("AllreduceSdma::allreduce_inplace removed — use Python JIT launch path");
 }
 
 // ---------------------------------------------------------------------------
@@ -399,6 +266,125 @@ void AllreduceSdma<T>::resetFlags() {
   if (flags_) {
     memset(flags_.get(), 0, npes_ * sizeof(uint64_t));
   }
+}
+
+// ---------------------------------------------------------------------------
+// JIT launch helpers
+// ---------------------------------------------------------------------------
+template <typename T>
+void AllreduceSdma<T>::fill_jit_args_(const T* input, size_t total_count) {
+  jit_args_.myPe = myPe_;
+  jit_args_.npes = npes_;
+  jit_args_.input = input;
+  jit_args_.dstMemObj = output_transit_buffer_obj_;
+  jit_args_.flagsMemObj = flagsObj_;
+  jit_args_.barrier = barrierPtr_;
+  jit_args_.elementCount = total_count;
+}
+
+template <typename T>
+int64_t AllreduceSdma<T>::prepare_reduce_scatter(const T* input, T* output, size_t total_count,
+                                                 hipStream_t stream) {
+  if (async_in_progress_) throw std::runtime_error("Async operation in progress");
+  (void)output;
+  (void)stream;
+  fill_jit_args_(input, total_count);
+  return reinterpret_cast<int64_t>(&jit_args_);
+}
+
+template <typename T>
+std::tuple<int, int> AllreduceSdma<T>::get_reduce_scatter_grid(size_t total_count) const {
+  constexpr size_t pack_size = 16 / sizeof(T);
+  size_t packedPerRank = (total_count / npes_ + pack_size - 1) / pack_size;
+  int threads = 512;
+  int blocks = std::min(max_blocks_, static_cast<int>((packedPerRank + threads - 1) / threads));
+  if (blocks < 1) blocks = 1;
+  return {blocks, threads};
+}
+
+template <typename T>
+int64_t AllreduceSdma<T>::prepare_allgather(size_t total_count, hipStream_t /*stream*/) {
+  jit_args_.input = nullptr;
+  jit_args_.elementCount = total_count;
+  return reinterpret_cast<int64_t>(&jit_args_);
+}
+
+template <typename T>
+double AllreduceSdma<T>::finish_sync(T* output, size_t total_count, hipStream_t stream) {
+  if (copy_output_to_user_) {
+    copy_output_to_user(output, total_count, stream);
+  }
+  return 0.0;
+}
+
+template <typename T>
+int64_t AllreduceSdma<T>::prepare_async_reduce_scatter(const T* input, T* output,
+                                                       size_t total_count, hipStream_t stream) {
+  bool expected = false;
+  if (!async_in_progress_.compare_exchange_strong(expected, true))
+    throw std::runtime_error("Another async operation is already in progress");
+
+  async_input_ = const_cast<T*>(input);
+  async_output_ = output;
+  async_total_count_ = total_count;
+  async_stream_ = stream;
+  async_start_time_ = CollectiveWallTime();
+
+  size_t required = (total_count / npes_) * npes_ * dtype_size_;
+  if (!ensure_buffer_size(output_transit_buffer_, output_transit_buffer_ptr_,
+                          output_transit_buffer_size_, output_transit_buffer_obj_, required,
+                          "output transit buffer")) {
+    async_in_progress_ = false;
+    throw std::runtime_error("Buffer allocation failed");
+  }
+
+  fill_jit_args_(input, total_count);
+  return reinterpret_cast<int64_t>(&jit_args_);
+}
+
+template <typename T>
+int64_t AllreduceSdma<T>::prepare_async_allgather_put(size_t total_count, hipStream_t /*stream*/) {
+  jit_args_.input = nullptr;
+  jit_args_.elementCount = total_count;
+  return reinterpret_cast<int64_t>(&jit_args_);
+}
+
+template <typename T>
+void AllreduceSdma<T>::after_async_start() {
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess) {
+    async_in_progress_ = false;
+    throw std::runtime_error("Async kernel launch failed");
+  }
+}
+
+template <typename T>
+int64_t AllreduceSdma<T>::prepare_async_wait(hipStream_t stream) {
+  if (!async_in_progress_) throw std::runtime_error("No async operation in progress");
+  (void)stream;
+  jit_args_.input = nullptr;
+  jit_args_.elementCount = async_total_count_;
+  return reinterpret_cast<int64_t>(&jit_args_);
+}
+
+template <typename T>
+double AllreduceSdma<T>::finish_async_wait(hipStream_t stream) {
+  hipStream_t ws = (stream != nullptr) ? stream : async_stream_;
+  hipError_t err = ws ? hipStreamSynchronize(ws) : hipDeviceSynchronize();
+  if (err != hipSuccess) throw std::runtime_error("Synchronization failed");
+
+  if (copy_output_to_user_) {
+    copy_output_to_user(async_output_, async_total_count_, ws);
+  }
+
+  double duration = CollectiveWallTime() - async_start_time_;
+  async_in_progress_ = false;
+  async_input_ = nullptr;
+  async_output_ = nullptr;
+  async_total_count_ = 0;
+  async_stream_ = nullptr;
+  async_start_time_ = 0.0;
+  return duration;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/collective/core/twoshot_allreduce_sdma_class.cpp
+++ b/src/collective/core/twoshot_allreduce_sdma_class.cpp
@@ -312,6 +312,8 @@ int64_t AllreduceSdma<T>::prepare_allgather(size_t total_count, hipStream_t /*st
 template <typename T>
 double AllreduceSdma<T>::finish_sync(T* output, size_t total_count, hipStream_t stream,
                                      bool force_copy_output_to_user) {
+  hipError_t err = stream ? hipStreamSynchronize(stream) : hipDeviceSynchronize();
+  if (err != hipSuccess) throw std::runtime_error("Synchronization failed in finish_sync");
   if (copy_output_to_user_ || force_copy_output_to_user) {
     copy_output_to_user(output, total_count, stream);
   }

--- a/src/collective/kernels/ccl_kernels.hip
+++ b/src/collective/kernels/ccl_kernels.hip
@@ -163,9 +163,6 @@ CCL_ALLREDUCE_ALL_TYPES(CCL_WRAP_ALLREDUCE_RS, SdmaReduceScatterKernel)
 // --- AllGatherSdmaKernel ---
 CCL_ALLREDUCE_ALL_TYPES(CCL_WRAP_ALLREDUCE_AG, AllGatherSdmaKernel)
 
-// --- ReduceScatterAllGatherFusedKernel ---
-CCL_ALLREDUCE_ALL_TYPES(CCL_WRAP_ALLREDUCE_RS, ReduceScatterAllGatherFusedKernel)
-
 // --- ReduceScatterSdmaPutKernel (async scatter, no wait/reduce) ---
 CCL_ALLREDUCE_ALL_TYPES(CCL_WRAP_ALLREDUCE_RS_PUT, ReduceScatterSdmaPutKernel)
 

--- a/src/collective/kernels/ccl_kernels.hip
+++ b/src/collective/kernels/ccl_kernels.hip
@@ -1,0 +1,182 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// CCL collective kernels — JIT compiled via hipcc --genco
+
+#include <hip/hip_bfloat16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+
+#define MORI_SHMEM_NO_STATIC_INIT
+#include "mori/shmem/shmem.hpp"
+
+#include "mori/collective/all2all/oneshot_all2all_sdma_async_kernel.hpp"
+#include "mori/collective/all2all/oneshot_all2all_sdma_kernel.hpp"
+#include "mori/collective/allgather/oneshot_sdma_async_kernel.hpp"
+#include "mori/collective/allgather/oneshot_sdma_kernel.hpp"
+#include "mori/collective/allreduce/twoshot_sdma_async_kernel.hpp"
+#include "mori/collective/allreduce/twoshot_sdma_kernel.hpp"
+
+#include "mori/collective/ccl_kernel_args.hpp"
+
+// Each .hsaco needs its own globalGpuStates, initialized via ShmemModuleInit.
+namespace mori {
+namespace shmem {
+__device__ __attribute__((visibility("default"))) GpuStates globalGpuStates;
+}  // namespace shmem
+}  // namespace mori
+
+using namespace mori::collective;
+
+// ============================================================================
+// Wrapper macros
+// ============================================================================
+
+// All2all: (myPe, npes, input, inputTransitMemObj, outputTransitMemObj,
+//           flagsMemObj, elementCount)
+#define CCL_WRAP_ALL2ALL(kernel, suffix, T)                                  \
+  extern "C" __global__ void kernel##_##suffix(CclAll2allArgs<T> args) {    \
+    kernel##_body<T>(args.myPe, args.npes, args.input, args.inputTransitMemObj, \
+                     args.outputTransitMemObj, args.flagsMemObj, args.elementCount); \
+  }
+
+// AllGather sync: all fields including dstBaseOffset and flagVal
+#define CCL_WRAP_ALLGATHER(kernel, suffix, T)                                \
+  extern "C" __global__ void kernel##_##suffix(CclAllgatherArgs<T> args) {  \
+    kernel##_body<T>(args.myPe, args.npes, args.input, args.srcMemObj,      \
+                     args.dstMemObj, args.flagsMemObj, args.elementCount,   \
+                     args.dstBaseOffset, args.flagVal);                     \
+  }
+
+// AllGather async put: no flagVal parameter
+#define CCL_WRAP_ALLGATHER_ASYNC_PUT(kernel, suffix, T)                      \
+  extern "C" __global__ void kernel##_##suffix(CclAllgatherArgs<T> args) {  \
+    kernel##_body<T>(args.myPe, args.npes, args.input, args.srcMemObj,      \
+                     args.dstMemObj, args.flagsMemObj, args.elementCount,   \
+                     args.dstBaseOffset);                                   \
+  }
+
+// AllReduce reduce-scatter / fused: (myPe, npes, input, dstMemObj,
+//                                    flagsMemObj, barrier, elementCount)
+#define CCL_WRAP_ALLREDUCE_RS(kernel, suffix, T)                              \
+  extern "C" __global__ void kernel##_##suffix(CclAllreduceArgs<T> args) {   \
+    kernel##_body<T>(args.myPe, args.npes, args.input, args.dstMemObj,       \
+                     args.flagsMemObj, args.barrier, args.elementCount);     \
+  }
+
+// AllReduce allgather / async-put: (myPe, npes, dstMemObj, flagsMemObj,
+//                                   barrier, elementCount)
+#define CCL_WRAP_ALLREDUCE_AG(kernel, suffix, T)                              \
+  extern "C" __global__ void kernel##_##suffix(CclAllreduceArgs<T> args) {   \
+    kernel##_body<T>(args.myPe, args.npes, args.dstMemObj, args.flagsMemObj, \
+                     args.barrier, args.elementCount);                       \
+  }
+
+// AllReduce async wait (non-template): (myPe, npes, flagsMemObj, barrier,
+//                                       elementCount)
+#define CCL_WRAP_ALLREDUCE_AG_WAIT(kernel, suffix, T)                         \
+  extern "C" __global__ void kernel##_##suffix(CclAllreduceArgs<T> args) {   \
+    kernel##_body(args.myPe, args.npes, args.flagsMemObj, args.barrier,      \
+                  args.elementCount);                                        \
+  }
+
+// Async RS SDMA put: (myPe, npes, input, dstMemObj, elementCount)
+#define CCL_WRAP_ALLREDUCE_RS_PUT(kernel, suffix, T)                          \
+  extern "C" __global__ void kernel##_##suffix(CclAllreduceArgs<T> args) {   \
+    kernel##_body<T>(args.myPe, args.npes, const_cast<T*>(args.input),       \
+                     args.dstMemObj, args.elementCount);                     \
+  }
+
+// Async RS local reduce: (gathered, input, elementCount, myPe, npes)
+#define CCL_WRAP_ALLREDUCE_LOCAL_REDUCE(kernel, suffix, T)                    \
+  extern "C" __global__ void kernel##_##suffix(CclAllreduceArgs<T> args) {   \
+    kernel##_body<T>(reinterpret_cast<T*>(args.dstMemObj->localPtr),          \
+                     args.input, args.elementCount, args.myPe, args.npes);  \
+  }
+
+// Async AG reduced SDMA put: (myPe, npes, dstMemObj, elementCount)
+#define CCL_WRAP_ALLREDUCE_AG_REDUCED_PUT(kernel, suffix, T)                  \
+  extern "C" __global__ void kernel##_##suffix(CclAllreduceArgs<T> args) {   \
+    kernel##_body<T>(args.myPe, args.npes, args.dstMemObj, args.elementCount); \
+  }
+
+// Expand a WRAP macro across all allreduce types.
+#define CCL_ALLREDUCE_ALL_TYPES(WRAP_MACRO, kernel) \
+  WRAP_MACRO(kernel, u32, uint32_t)                 \
+  WRAP_MACRO(kernel, i32, int32_t)                  \
+  WRAP_MACRO(kernel, f32, float)                    \
+  WRAP_MACRO(kernel, f16, __half)                   \
+  WRAP_MACRO(kernel, bf16, hip_bfloat16)
+
+// ============================================================================
+// All2all instantiations (uint32_t)
+// ============================================================================
+
+CCL_WRAP_ALL2ALL(OneShotAll2allSdmaKernel, u32, uint32_t)
+CCL_WRAP_ALL2ALL(OneShotAll2allSdmaAsyncPutKernel, u32, uint32_t)
+
+extern "C" __global__ void OneShotAll2allSdmaAsyncWaitKernel_u32(
+    CclAll2allArgs<uint32_t> args) {
+  OneShotAll2allSdmaAsyncWaitKernel_body(args.myPe, args.npes,
+                                         args.outputTransitMemObj, args.flagsMemObj);
+}
+
+// ============================================================================
+// AllGather instantiations (uint32_t)
+// ============================================================================
+
+CCL_WRAP_ALLGATHER(OneShotAllGatherSdmaKernel, u32, uint32_t)
+CCL_WRAP_ALLGATHER_ASYNC_PUT(OneShotAllGatherSdmaAsyncPutKernel, u32, uint32_t)
+
+extern "C" __global__ void OneShotAllGatherSdmaAsyncWaitKernel_u32(
+    CclAllgatherArgs<uint32_t> args) {
+  OneShotAllGatherSdmaAsyncWaitKernel_body(args.myPe, args.npes, args.dstMemObj,
+                                           args.flagsMemObj, args.flagVal);
+}
+
+// ============================================================================
+// AllReduce instantiations (uint32_t, int32_t, float, __half, hip_bfloat16)
+// ============================================================================
+
+// --- SdmaReduceScatterKernel ---
+CCL_ALLREDUCE_ALL_TYPES(CCL_WRAP_ALLREDUCE_RS, SdmaReduceScatterKernel)
+
+// --- AllGatherSdmaKernel ---
+CCL_ALLREDUCE_ALL_TYPES(CCL_WRAP_ALLREDUCE_AG, AllGatherSdmaKernel)
+
+// --- ReduceScatterAllGatherFusedKernel ---
+CCL_ALLREDUCE_ALL_TYPES(CCL_WRAP_ALLREDUCE_RS, ReduceScatterAllGatherFusedKernel)
+
+// --- ReduceScatterSdmaPutKernel (async scatter, no wait/reduce) ---
+CCL_ALLREDUCE_ALL_TYPES(CCL_WRAP_ALLREDUCE_RS_PUT, ReduceScatterSdmaPutKernel)
+
+// --- ReduceScatterLocalReduceKernel (local reduce after async scatter) ---
+CCL_ALLREDUCE_ALL_TYPES(CCL_WRAP_ALLREDUCE_LOCAL_REDUCE, ReduceScatterLocalReduceKernel)
+
+// --- AllGatherReducedSdmaPutKernel (SDMA put of reduced shard) ---
+CCL_ALLREDUCE_ALL_TYPES(CCL_WRAP_ALLREDUCE_AG_REDUCED_PUT, AllGatherReducedSdmaPutKernel)
+
+// --- AllGatherAsyncPutKernel ---
+CCL_ALLREDUCE_ALL_TYPES(CCL_WRAP_ALLREDUCE_AG, AllGatherAsyncPutKernel)
+
+// --- AllGatherAsyncWaitKernel (non-template) ---
+CCL_ALLREDUCE_ALL_TYPES(CCL_WRAP_ALLREDUCE_AG_WAIT, AllGatherAsyncWaitKernel)

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -36,8 +36,10 @@ if(NOT _pybind11_result EQUAL 0)
 endif()
 message(STATUS "pybind11 include dir: ${PYBIND11_INCLUDE_DIR}")
 
-set(MORI_PYBIND_SOURCES mori.cpp pybind_ops.cpp pybind_shmem.cpp pybind_io.cpp
-                        pybind_ccl.cpp)
+set(MORI_PYBIND_SOURCES mori.cpp pybind_ops.cpp pybind_shmem.cpp pybind_io.cpp)
+if(BUILD_COLLECTIVE)
+  list(APPEND MORI_PYBIND_SOURCES pybind_ccl.cpp)
+endif()
 if(BUILD_UMBP)
   list(APPEND MORI_PYBIND_SOURCES pybind_umbp.cpp)
 endif()
@@ -52,8 +54,11 @@ target_include_directories(
   mori_pybinds PUBLIC ${PYTHON_INCLUDE_DIRS} ${PYBIND11_INCLUDE_DIR}
                       ${CMAKE_BINARY_DIR}/generated/include)
 target_link_directories(mori_pybinds PRIVATE /opt/rocm/lib)
-target_link_libraries(mori_pybinds mori_ops mori_shmem mori_io mori_collective
-                      hip::host)
+target_link_libraries(mori_pybinds mori_ops mori_shmem mori_io hip::host)
+if(BUILD_COLLECTIVE)
+  target_link_libraries(mori_pybinds mori_collective)
+  target_compile_definitions(mori_pybinds PRIVATE MORI_BUILD_COLLECTIVE)
+endif()
 
 if(BUILD_UMBP)
   target_link_libraries(mori_pybinds umbp_core)

--- a/src/pybind/mori.cpp
+++ b/src/pybind/mori.cpp
@@ -33,7 +33,9 @@ PYBIND11_MODULE(libmori_pybinds, m) {
   mori::RegisterMoriOps(m);
   mori::RegisterMoriShmem(m);
   mori::RegisterMoriIo(m);
+#ifdef MORI_BUILD_COLLECTIVE
   mori::RegisterMoriCcl(m);
+#endif
 #ifdef BUILD_XLA_FFI_OPS
   mori::RegisterXLAFFIOps(m);
 #endif

--- a/src/pybind/pybind_ccl.cpp
+++ b/src/pybind/pybind_ccl.cpp
@@ -45,37 +45,65 @@ void BindAllreduceHandle(py::module_& m, const char* python_name) {
       .def(py::init<int, int, size_t, bool, bool>(), py::arg("my_pe"), py::arg("npes"),
            py::arg("transit_buffer_size") = 512 * 1024 * 1024,
            py::arg("copy_output_to_user") = true, py::arg("use_graph_mode") = false)
+      // JIT sync path (two-shot: reduce-scatter kernel, then allgather kernel)
       .def(
-          "__call__",
-          [](Handle& self, uintptr_t input_ptr, uintptr_t output_ptr, size_t count,
-             int64_t stream) -> bool {
-            return self(reinterpret_cast<T*>(input_ptr), reinterpret_cast<T*>(output_ptr), count,
-                        reinterpret_cast<hipStream_t>(stream));
+          "prepare_reduce_scatter",
+          [](Handle& self, uintptr_t input, uintptr_t output, size_t count,
+             int64_t stream) -> int64_t {
+            return self.prepare_reduce_scatter(reinterpret_cast<const T*>(input),
+                                               reinterpret_cast<T*>(output), count,
+                                               reinterpret_cast<hipStream_t>(stream));
           },
-          py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"), py::arg("stream") = 0)
+          py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"), py::arg("stream"))
       .def(
-          "allreduce_inplace",
-          [](Handle& self, uintptr_t data_ptr, size_t count, int64_t stream) -> bool {
-            return self.allreduce_inplace(reinterpret_cast<T*>(data_ptr), count,
-                                          reinterpret_cast<hipStream_t>(stream));
+          "get_reduce_scatter_grid",
+          [](Handle& self, size_t count) -> py::tuple {
+            auto [blocks, threads] = self.get_reduce_scatter_grid(count);
+            return py::make_tuple(blocks, threads);
           },
-          py::arg("data_ptr"), py::arg("count"), py::arg("stream") = 0,
-          "Execute in-place AllReduce SDMA operation")
+          py::arg("count"))
       .def(
-          "start_async",
-          [](Handle& self, uintptr_t input_ptr, uintptr_t output_ptr, size_t count,
-             int64_t stream) -> bool {
-            return self.start_async(reinterpret_cast<T*>(input_ptr),
-                                    reinterpret_cast<T*>(output_ptr), count,
+          "prepare_allgather",
+          [](Handle& self, size_t count, int64_t stream) -> int64_t {
+            return self.prepare_allgather(count, reinterpret_cast<hipStream_t>(stream));
+          },
+          py::arg("count"), py::arg("stream"))
+      .def(
+          "finish_sync",
+          [](Handle& self, uintptr_t output, size_t count, int64_t stream) -> double {
+            return self.finish_sync(reinterpret_cast<T*>(output), count,
                                     reinterpret_cast<hipStream_t>(stream));
           },
-          py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"), py::arg("stream") = 0)
+          py::arg("output_ptr"), py::arg("count"), py::arg("stream"))
+      // JIT async path
       .def(
-          "wait_async",
-          [](Handle& self, int64_t stream) -> double {
-            return self.wait_async(reinterpret_cast<hipStream_t>(stream));
+          "prepare_async_reduce_scatter",
+          [](Handle& self, uintptr_t input, uintptr_t output, size_t count,
+             int64_t stream) -> int64_t {
+            return self.prepare_async_reduce_scatter(reinterpret_cast<const T*>(input),
+                                                     reinterpret_cast<T*>(output), count,
+                                                     reinterpret_cast<hipStream_t>(stream));
           },
-          py::arg("stream") = 0)
+          py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"), py::arg("stream"))
+      .def(
+          "prepare_async_allgather_put",
+          [](Handle& self, size_t count, int64_t stream) -> int64_t {
+            return self.prepare_async_allgather_put(count, reinterpret_cast<hipStream_t>(stream));
+          },
+          py::arg("count"), py::arg("stream"))
+      .def("after_async_start", &Handle::after_async_start)
+      .def(
+          "prepare_async_wait",
+          [](Handle& self, int64_t stream) -> int64_t {
+            return self.prepare_async_wait(reinterpret_cast<hipStream_t>(stream));
+          },
+          py::arg("stream"))
+      .def(
+          "finish_async_wait",
+          [](Handle& self, int64_t stream) -> double {
+            return self.finish_async_wait(reinterpret_cast<hipStream_t>(stream));
+          },
+          py::arg("stream"))
       .def("is_async_in_progress", &Handle::is_async_in_progress)
       .def("cancel_async", &Handle::cancel_async)
       .def("reset_flags", &Handle::resetFlags)
@@ -87,16 +115,19 @@ void BindAllreduceHandle(py::module_& m, const char* python_name) {
             if (ptr == nullptr) throw std::runtime_error("Output transit buffer is null");
             return py::make_tuple(reinterpret_cast<uintptr_t>(ptr), size);
           },
-          "Return (ptr, size_bytes) of the output transit buffer");
+          "Return (ptr, size_bytes) of the output transit buffer")
+      .def("max_blocks", &Handle::max_blocks)
+      .def("npes", &Handle::npes);
 }
 }  // namespace
 
 namespace mori {
 void RegisterMoriCcl(pybind11::module_& m) {
   // =========================================================================
-  // All2allSdma (uint32_t)
+  // All2allSdma (uint32_t) — JIT launch path
   // =========================================================================
-  py::class_<mori::collective::All2allSdma<uint32_t>>(m, "All2allSdmaHandle")
+  using All2allU32 = mori::collective::All2allSdma<uint32_t>;
+  py::class_<All2allU32>(m, "All2allSdmaHandle")
       .def(py::init<int, int, size_t, size_t, bool>(), py::arg("my_pe"), py::arg("npes"),
            py::arg("input_buffer_size"), py::arg("output_buffer_size"),
            py::arg("copy_output_to_user") = true)
@@ -104,38 +135,49 @@ void RegisterMoriCcl(pybind11::module_& m) {
            py::arg("transit_buffer_size") = 512 * 1024 * 1024,
            py::arg("copy_output_to_user") = true)
       .def(
-          "__call__",
-          [](mori::collective::All2allSdma<uint32_t>& self, uintptr_t input_ptr,
-             uintptr_t output_ptr, size_t count, int64_t stream) -> double {
-            return self(reinterpret_cast<uint32_t*>(input_ptr),
-                        reinterpret_cast<uint32_t*>(output_ptr), count,
-                        reinterpret_cast<hipStream_t>(stream));
+          "prepare_sync",
+          [](All2allU32& self, uintptr_t input, uintptr_t output, size_t count,
+             int64_t stream) -> int64_t {
+            return self.prepare_sync(reinterpret_cast<uint32_t*>(input),
+                                     reinterpret_cast<uint32_t*>(output), count,
+                                     reinterpret_cast<hipStream_t>(stream));
           },
-          py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"), py::arg("stream") = 0,
-          "Execute All2all SDMA operation (raw GPU pointers)")
+          py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"), py::arg("stream"))
       .def(
-          "start_async",
-          [](mori::collective::All2allSdma<uint32_t>& self, uintptr_t input_ptr,
-             uintptr_t output_ptr, size_t count, int64_t stream) -> bool {
-            return self.start_async(reinterpret_cast<uint32_t*>(input_ptr),
-                                    reinterpret_cast<uint32_t*>(output_ptr), count,
+          "finish_sync",
+          [](All2allU32& self, uintptr_t output, size_t count, int64_t stream) -> double {
+            return self.finish_sync(reinterpret_cast<uint32_t*>(output), count,
                                     reinterpret_cast<hipStream_t>(stream));
           },
-          py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"), py::arg("stream") = 0,
-          "Start asynchronous All2all SDMA operation (PUT phase)")
+          py::arg("output_ptr"), py::arg("count"), py::arg("stream"))
       .def(
-          "wait_async",
-          [](mori::collective::All2allSdma<uint32_t>& self, int64_t stream) -> double {
-            return self.wait_async(reinterpret_cast<hipStream_t>(stream));
+          "prepare_async_start",
+          [](All2allU32& self, uintptr_t input, uintptr_t output, size_t count,
+             int64_t stream) -> int64_t {
+            return self.prepare_async_start(reinterpret_cast<uint32_t*>(input),
+                                            reinterpret_cast<uint32_t*>(output), count,
+                                            reinterpret_cast<hipStream_t>(stream));
           },
-          py::arg("stream") = 0,
-          "Wait for asynchronous All2all SDMA operation to complete (WAIT phase)")
-      .def("is_async_in_progress", &mori::collective::All2allSdma<uint32_t>::is_async_in_progress)
-      .def("cancel_async", &mori::collective::All2allSdma<uint32_t>::cancel_async)
-      .def("reset_flags", &mori::collective::All2allSdma<uint32_t>::resetFlags)
+          py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"), py::arg("stream"))
+      .def("after_async_start", &All2allU32::after_async_start)
+      .def(
+          "prepare_async_wait",
+          [](All2allU32& self, int64_t stream) -> int64_t {
+            return self.prepare_async_wait(reinterpret_cast<hipStream_t>(stream));
+          },
+          py::arg("stream"))
+      .def(
+          "finish_async_wait",
+          [](All2allU32& self, int64_t stream) -> double {
+            return self.finish_async_wait(reinterpret_cast<hipStream_t>(stream));
+          },
+          py::arg("stream"))
+      .def("is_async_in_progress", &All2allU32::is_async_in_progress)
+      .def("cancel_async", &All2allU32::cancel_async)
+      .def("reset_flags", &All2allU32::resetFlags)
       .def(
           "get_output_transit_buffer",
-          [](mori::collective::All2allSdma<uint32_t>& self) -> py::tuple {
+          [](All2allU32& self) -> py::tuple {
             void* ptr = self.getOutputTransitBuffer();
             size_t size = self.getOutputTransitBufferSize();
             if (ptr == nullptr) throw std::runtime_error("Output transit buffer is null");
@@ -144,9 +186,10 @@ void RegisterMoriCcl(pybind11::module_& m) {
           "Return (ptr, size_bytes) of the output transit buffer");
 
   // =========================================================================
-  // AllgatherSdma (uint32_t)
+  // AllgatherSdma (uint32_t) — JIT launch path
   // =========================================================================
-  py::class_<mori::collective::AllgatherSdma<uint32_t>>(m, "AllgatherSdmaHandle")
+  using AllgatherU32 = mori::collective::AllgatherSdma<uint32_t>;
+  py::class_<AllgatherU32>(m, "AllgatherSdmaHandle")
       .def(py::init<int, int, size_t, size_t, bool>(), py::arg("my_pe"), py::arg("npes"),
            py::arg("input_buffer_size"), py::arg("output_buffer_size"),
            py::arg("copy_output_to_user") = true)
@@ -154,37 +197,49 @@ void RegisterMoriCcl(pybind11::module_& m) {
            py::arg("transit_buffer_size") = 512 * 1024 * 1024,
            py::arg("copy_output_to_user") = true)
       .def(
-          "__call__",
-          [](mori::collective::AllgatherSdma<uint32_t>& self, uintptr_t input_ptr,
-             uintptr_t output_ptr, size_t count, int64_t stream) -> bool {
-            return self(reinterpret_cast<uint32_t*>(input_ptr),
-                        reinterpret_cast<uint32_t*>(output_ptr), count,
-                        reinterpret_cast<hipStream_t>(stream));
+          "prepare_sync",
+          [](AllgatherU32& self, uintptr_t input, uintptr_t output, size_t count,
+             int64_t stream) -> int64_t {
+            return self.prepare_sync(reinterpret_cast<uint32_t*>(input),
+                                     reinterpret_cast<uint32_t*>(output), count,
+                                     reinterpret_cast<hipStream_t>(stream));
           },
-          py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"), py::arg("stream") = 0,
-          "Execute Allgather SDMA operation (raw GPU pointers)")
+          py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"), py::arg("stream"))
       .def(
-          "start_async",
-          [](mori::collective::AllgatherSdma<uint32_t>& self, uintptr_t input_ptr,
-             uintptr_t output_ptr, size_t count, int64_t stream) -> bool {
-            return self.start_async(reinterpret_cast<uint32_t*>(input_ptr),
-                                    reinterpret_cast<uint32_t*>(output_ptr), count,
+          "finish_sync",
+          [](AllgatherU32& self, uintptr_t output, size_t count, int64_t stream) -> double {
+            return self.finish_sync(reinterpret_cast<uint32_t*>(output), count,
                                     reinterpret_cast<hipStream_t>(stream));
           },
-          py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"), py::arg("stream") = 0,
-          "Start asynchronous Allgather SDMA operation (PUT phase)")
+          py::arg("output_ptr"), py::arg("count"), py::arg("stream"))
       .def(
-          "wait_async",
-          [](mori::collective::AllgatherSdma<uint32_t>& self, int64_t stream) -> double {
-            return self.wait_async(reinterpret_cast<hipStream_t>(stream));
+          "prepare_async_start",
+          [](AllgatherU32& self, uintptr_t input, uintptr_t output, size_t count,
+             int64_t stream) -> int64_t {
+            return self.prepare_async_start(reinterpret_cast<uint32_t*>(input),
+                                            reinterpret_cast<uint32_t*>(output), count,
+                                            reinterpret_cast<hipStream_t>(stream));
           },
-          py::arg("stream") = 0, "Wait for asynchronous Allgather SDMA operation to complete")
-      .def("is_async_in_progress", &mori::collective::AllgatherSdma<uint32_t>::is_async_in_progress)
-      .def("cancel_async", &mori::collective::AllgatherSdma<uint32_t>::cancel_async)
-      .def("reset_flags", &mori::collective::AllgatherSdma<uint32_t>::resetFlags)
+          py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"), py::arg("stream"))
+      .def("after_async_start", &AllgatherU32::after_async_start)
+      .def(
+          "prepare_async_wait",
+          [](AllgatherU32& self, int64_t stream) -> int64_t {
+            return self.prepare_async_wait(reinterpret_cast<hipStream_t>(stream));
+          },
+          py::arg("stream"))
+      .def(
+          "finish_async_wait",
+          [](AllgatherU32& self, int64_t stream) -> double {
+            return self.finish_async_wait(reinterpret_cast<hipStream_t>(stream));
+          },
+          py::arg("stream"))
+      .def("is_async_in_progress", &AllgatherU32::is_async_in_progress)
+      .def("cancel_async", &AllgatherU32::cancel_async)
+      .def("reset_flags", &AllgatherU32::resetFlags)
       .def(
           "get_output_transit_buffer",
-          [](mori::collective::AllgatherSdma<uint32_t>& self) -> py::tuple {
+          [](AllgatherU32& self) -> py::tuple {
             void* ptr = self.getOutputTransitBuffer();
             size_t size = self.getOutputTransitBufferSize();
             if (ptr == nullptr) throw std::runtime_error("Output transit buffer is null");
@@ -193,26 +248,26 @@ void RegisterMoriCcl(pybind11::module_& m) {
           "Return (ptr, size_bytes) of the output transit buffer")
       .def(
           "register_output_buffer",
-          [](mori::collective::AllgatherSdma<uint32_t>& self, uintptr_t ptr, size_t size) {
+          [](AllgatherU32& self, uintptr_t ptr, size_t size) {
             self.register_output_buffer(reinterpret_cast<void*>(ptr), size);
           },
           py::arg("ptr"), py::arg("size"),
           "Register a GPU buffer as direct SDMA output target (collective)")
       .def(
           "deregister_output_buffer",
-          [](mori::collective::AllgatherSdma<uint32_t>& self, uintptr_t ptr) {
+          [](AllgatherU32& self, uintptr_t ptr) {
             self.deregister_output_buffer(reinterpret_cast<void*>(ptr));
           },
           py::arg("ptr"), "Deregister a previously registered output buffer (collective)")
       .def(
           "is_output_registered",
-          [](mori::collective::AllgatherSdma<uint32_t>& self, uintptr_t ptr) -> bool {
+          [](AllgatherU32& self, uintptr_t ptr) -> bool {
             return self.is_output_registered(reinterpret_cast<void*>(ptr));
           },
           py::arg("ptr"), "Check whether an output buffer is registered for direct SDMA writes");
 
   // =========================================================================
-  // AllGatherIntoTensor (NCCL/RCCL-style dispatcher over AllgatherSdma<uint32_t>)
+  // DataType enum and size_of
   // =========================================================================
   py::enum_<mori::collective::DataType>(m, "DataType")
       .value("Int8", mori::collective::DataType::kInt8)
@@ -230,77 +285,16 @@ void RegisterMoriCcl(pybind11::module_& m) {
   m.def("size_of", &mori::collective::SizeOf, py::arg("dtype"),
         "Return element size in bytes for a mori_cpp.DataType value");
 
-  py::class_<mori::collective::AllGatherIntoTensor>(m, "AllGatherIntoTensor")
-      .def(py::init<int, int, size_t, size_t, bool, bool>(), py::arg("my_pe"), py::arg("npes"),
-           py::arg("input_buffer_size"), py::arg("output_buffer_size"),
-           py::arg("copy_output_to_user") = true, py::arg("auto_register") = false,
-           "Construct with separate input/output transit buffer sizes (bytes)")
-      .def(py::init<int, int, size_t, bool, bool>(), py::arg("my_pe"), py::arg("npes"),
-           py::arg("transit_buffer_size") = 512 * 1024 * 1024,
-           py::arg("copy_output_to_user") = true, py::arg("auto_register") = false,
-           "Construct with one combined transit buffer size (split 50/50 input/output)")
-      .def_property_readonly("my_pe", &mori::collective::AllGatherIntoTensor::my_pe)
-      .def_property_readonly("npes", &mori::collective::AllGatherIntoTensor::npes)
-      .def_property("auto_register", &mori::collective::AllGatherIntoTensor::auto_register,
-                    &mori::collective::AllGatherIntoTensor::set_auto_register,
-                    "Whether the class lazily registers recv buffers on first sight "
-                    "to enable the zero-copy direct-write path. Requires the recv "
-                    "buffer to be allocated as uncached device memory (e.g. via "
-                    "mori.shmem.shmem_malloc); cached PyTorch tensors will read back "
-                    "stale (all-zero) data due to GPU L2 cache vs SDMA copy-engine "
-                    "incoherence. Default is False.")
-      .def(
-          "__call__",
-          [](mori::collective::AllGatherIntoTensor& self, uintptr_t input_ptr, uintptr_t output_ptr,
-             size_t count, mori::collective::DataType dtype, int64_t stream) -> bool {
-            return self(reinterpret_cast<const void*>(input_ptr),
-                        reinterpret_cast<void*>(output_ptr), count, dtype,
-                        reinterpret_cast<hipStream_t>(stream));
-          },
-          py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"), py::arg("dtype"),
-          py::arg("stream") = 0,
-          "ncclAllGather-style synchronous launch: every rank contributes "
-          "`count` elements of `dtype` from `input_ptr`, output of size "
-          "`count * npes` lands at `output_ptr` on every rank.")
-      .def(
-          "start_async",
-          [](mori::collective::AllGatherIntoTensor& self, uintptr_t input_ptr, uintptr_t output_ptr,
-             size_t count, mori::collective::DataType dtype, int64_t stream) -> bool {
-            return self.start_async(reinterpret_cast<const void*>(input_ptr),
-                                    reinterpret_cast<void*>(output_ptr), count, dtype,
-                                    reinterpret_cast<hipStream_t>(stream));
-          },
-          py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"), py::arg("dtype"),
-          py::arg("stream") = 0, "Two-phase async PUT (pair with wait_async)")
-      .def(
-          "wait_async",
-          [](mori::collective::AllGatherIntoTensor& self, int64_t stream) -> double {
-            return self.wait_async(reinterpret_cast<hipStream_t>(stream));
-          },
-          py::arg("stream") = 0, "Two-phase async WAIT; returns elapsed seconds for the operation")
-      .def("is_async_in_progress", &mori::collective::AllGatherIntoTensor::is_async_in_progress)
-      .def("cancel_async", &mori::collective::AllGatherIntoTensor::cancel_async)
-      .def("reset_flags", &mori::collective::AllGatherIntoTensor::resetFlags)
-      .def(
-          "register_output_buffer",
-          [](mori::collective::AllGatherIntoTensor& self, uintptr_t ptr, size_t size) {
-            self.register_output_buffer(reinterpret_cast<void*>(ptr), size);
-          },
-          py::arg("ptr"), py::arg("size"),
-          "Register a GPU buffer as direct SDMA output target (collective)")
-      .def(
-          "deregister_output_buffer",
-          [](mori::collective::AllGatherIntoTensor& self, uintptr_t ptr) {
-            self.deregister_output_buffer(reinterpret_cast<void*>(ptr));
-          },
-          py::arg("ptr"), "Deregister a previously registered output buffer (collective)")
-      .def(
-          "is_output_registered",
-          [](mori::collective::AllGatherIntoTensor& self, uintptr_t ptr) -> bool {
-            return self.is_output_registered(reinterpret_cast<void*>(ptr));
-          },
-          py::arg("ptr"), "Check whether an output buffer is registered for direct SDMA writes");
+  // =========================================================================
+  // AllGatherIntoTensor — REMOVED
+  // The underlying AllgatherSdma<uint32_t>::operator() now throws; this
+  // wrapper needs the Python JIT launch path to be ported before it can be
+  // re-enabled.
+  // =========================================================================
 
+  // =========================================================================
+  // AllreduceSdma — JIT launch path (typed instantiations)
+  // =========================================================================
   BindAllreduceHandle<uint32_t>(m, "AllreduceSdmaHandle");
   BindAllreduceHandle<int32_t>(m, "AllreduceSdmaHandleInt32");
   BindAllreduceHandle<float>(m, "AllreduceSdmaHandleFp32");

--- a/src/pybind/pybind_ccl.cpp
+++ b/src/pybind/pybind_ccl.cpp
@@ -70,11 +70,14 @@ void BindAllreduceHandle(py::module_& m, const char* python_name) {
           py::arg("count"), py::arg("stream"))
       .def(
           "finish_sync",
-          [](Handle& self, uintptr_t output, size_t count, int64_t stream) -> double {
+          [](Handle& self, uintptr_t output, size_t count, int64_t stream,
+             bool force_copy_output_to_user) -> double {
             return self.finish_sync(reinterpret_cast<T*>(output), count,
-                                    reinterpret_cast<hipStream_t>(stream));
+                                    reinterpret_cast<hipStream_t>(stream),
+                                    force_copy_output_to_user);
           },
-          py::arg("output_ptr"), py::arg("count"), py::arg("stream"))
+          py::arg("output_ptr"), py::arg("count"), py::arg("stream"),
+          py::arg("force_copy_output_to_user") = false)
       // JIT async path
       .def(
           "prepare_async_reduce_scatter",


### PR DESCRIPTION
## Summary
Migrate CCL (collective) kernel compilation from build-time AOT (`-x hip` / `--hip-link`) to runtime JIT (`hipcc --genco`), consistent with the EP kernel architecture.
### Motivation
- **Fix `undefined symbol: atexit`** on glibc >= 2.34 (TheRock toolchain). AOT HIP compilation generates device registration code that references `atexit`, which newer glibc no longer exports as a dynamic symbol.
- **Architecture consistency**: all mori kernels (EP + CCL) now use the same JIT path — `.hip` → `hipcc --genco` → `.hsaco` → `HipModule` → `launch_struct`.
- **Clean wheel**: `libmori_collective.so` is now pure host C++ (no `--hip-link`, no device code embedded).
- **Runtime arch detection**: no build-time `--offload-arch` baked into the .so.
### Changes
- Split all CCL `__global__` kernels into `__device__ _body` + `__global__` wrapper in headers (backward compatible)
- Add `src/collective/kernels/ccl_kernels.hip` as JIT compilation unit with `extern "C"` entry points
- Add `CclAll2allArgs` / `CclAllgatherArgs` / `CclAllreduceArgs` POD args structs
- Refactor C++ host classes: remove `<<<>>>`, add `prepare_*/finish_*` methods for Python-side launch
- Rewrite `python/mori/ccl/collective.py` to use `compile_genco` + `HipModule` + `launch_struct`
- Remove `hip::device` from collective CMakeLists (host-only build)
- Add `ccl_kernels` to `MORI_PRECOMPILE` path
- Package `.cuh` files in wheel JIT sources
### Behavioral equivalence
All kernel names, grid/block sizes, launch order, and sync patterns are identical to the original AOT path. No runtime behavior change.
## Test plan
- [x] `pip install .` builds without `-x hip` or `--hip-link` for collective
- [x] `nm -D libmori_collective.so | grep "U atexit"` — no undefined atexit
- [x] `import mori.ops` / `import mori.ccl` — both work
- [x] `MORI_PRECOMPILE=1 python -c "import mori"` — ccl_kernels compiled and cached
- [x] `test_allgather --world-size 8 --elems 1048576` — passed
- [x] `test_all2all --world-size 8 --elems 1048576` — passed
- [x] AllReduce test