### PR TITLE
fix(tool): reorder DSCP mapping before scheduling in env_setup.sh

### DIFF
--- a/tools/env_setup.sh
+++ b/tools/env_setup.sh
@@ -64,14 +64,15 @@ reset_qos() {
 setup_pfc() {
     sudo nicctl update qos --classification-type dscp                          || { die "set classification-type failed"; return 1; }
     sudo nicctl update port --all --pause-type pfc --rx-pause enable --tx-pause enable || { die "set pause failed"; return 1; }
-    # Define scheduling FIRST so subsequent dscp-to-priority calls can target
-    # priorities 0/3/6 (nicctl rejects DSCP -> priority N if priority N has
-    # no scheduling configured yet). Priority 6 = control/CNP lane: DWRR=0 +
-    # 10Gbps strict rate-limit (matches the AMD Pollara reference recipe; bare
-    # dwrr=0/rate-limit=0 is rejected as "Invalid input").
-    sudo nicctl update qos scheduling --priority 0,3,6 --dwrr 10,90,0 --rate-limit 0,0,10 || { die "set scheduling failed"; return 1; }
+    # DSCP-to-priority mapping MUST be done before scheduling — the firmware
+    # rejects scheduling updates for priorities that have no DSCP entries yet
+    # (nicctl returns "Invalid input" for priority N if N has no DSCP mapping).
     sudo nicctl update qos dscp-to-priority --dscp 26 --priority 3             || { die "map DSCP 26 -> priority 3 failed"; return 1; }
     sudo nicctl update qos dscp-to-priority --dscp 48 --priority 6             || { die "map DSCP 48 -> priority 6 failed"; return 1; }
+    # Priority 6 = control/CNP lane: DWRR=0 + 10Gbps strict rate-limit
+    # (matches the AMD Pollara reference recipe; bare dwrr=0/rate-limit=0
+    # is rejected as "Invalid input").
+    sudo nicctl update qos scheduling --priority 0,3,6 --dwrr 10,90,0 --rate-limit 0,0,10 || { die "set scheduling failed"; return 1; }
     sudo nicctl update qos pfc --priority 3 --no-drop enable                   || { die "enable PFC no-drop on priority 3 failed"; return 1; }
     sudo nicctl update port --all --admin-state up                             || { die "set admin-state up failed"; return 1; }
     log_ok "PFC / DSCP / scheduling configured"


### PR DESCRIPTION
The firmware rejects scheduling updates for priorities that have no DSCP entries yet (nicctl returns "Invalid input").  Move the two dscp-to-priority calls before the scheduling call so that priorities 3 and 6 exist when the scheduling command references them.