### PR TITLE
fix(sdma): All2allSdma completion flags not reset between calls

### DIFF
--- a/src/collective/core/oneshot_all2all_sdma_class.cpp
+++ b/src/collective/core/oneshot_all2all_sdma_class.cpp
@@ -158,7 +158,7 @@ bool All2allSdma<T>::start_async(T* input, T* output, size_t total_count, hipStr
     // copy_input_to_transit(input, total_count * npes_, stream);
 
     // Step 2: Reset flags
-    // resetFlags();
+    resetFlags();
 
     // Step 3: Execute All2All kernel (PUT operation)
     printf("PE %d: Launching async PUT kernel...\n", myPe_);
@@ -277,7 +277,7 @@ void All2allSdma<T>::cancel_async() {
     async_start_time_ = 0.0;
 
     // Reset flags
-    // resetFlags();
+    resetFlags();
   }
 }
 
@@ -419,7 +419,7 @@ double All2allSdma<T>::operator()(T* input, T* output, size_t total_count, hipSt
     // copy_input_to_transit(input, total_count * npes_, stream);
 
     // Step 2: Reset flags
-    // resetFlags();
+    resetFlags();
 
     // Step 3: Execute All2All kernel
     int block_size = 256;

--- a/tests/python/ccl/test_all2all.py
+++ b/tests/python/ccl/test_all2all.py
@@ -94,27 +94,31 @@ def _test_all2all(rank, world_size, port, elems, iterations, warmup):
             elems_per_pe * npes, dtype=torch.uint32, device=device
         )
 
-        # Prepare data: PE i sends value (i+1)*1000 + j to PE j
+        # Input is refreshed each iteration with an iter-dependent value so that
+        # stale flags (the flag-reset bug) produce detectably wrong output on call 2+.
+        # Pattern: PE i sends (i+1)*1000 + dest_pe + iter*100000 to PE dest_pe.
         input_data_cpu = np.zeros(elems_per_pe * npes, dtype=np.uint32)
-        for dest_pe in range(npes):
-            value = (my_pe + 1) * 1000 + dest_pe
-            input_data_cpu[dest_pe * elems_per_pe : (dest_pe + 1) * elems_per_pe] = (
-                value
-            )
 
-        # Copy to GPU
-        input_tensor.copy_(torch.from_numpy(input_data_cpu))
+        def refresh_input(iter_idx):
+            for dest_pe in range(npes):
+                value = (my_pe + 1) * 1000 + dest_pe + iter_idx * 100000
+                input_data_cpu[dest_pe * elems_per_pe : (dest_pe + 1) * elems_per_pe] = value
+            input_tensor.copy_(torch.from_numpy(input_data_cpu))
+
+        def verify_output(iter_idx):
+            output_data_cpu = output_tensor.cpu().numpy()
+            ok = True
+            for src_pe in range(npes):
+                chunk = output_data_cpu[src_pe * elems_per_pe : (src_pe + 1) * elems_per_pe]
+                expected = (src_pe + 1) * 1000 + my_pe + iter_idx * 100000
+                if not np.all(chunk == expected):
+                    print(f"PE {rank}: iter {iter_idx} chunk from PE {src_pe} FAILED! "
+                          f"expected={expected} got unique={np.unique(chunk)[:5]}")
+                    ok = False
+            return ok
 
         if rank == 0:
-            print(
-                f"PE {rank}: Prepared input data with pattern: (src_pe+1)*1000 + dest_pe"
-            )
-            print(
-                f"  Sending to PE 0: {input_tensor[0].item()} (expected: {(my_pe+1)*1000 + 0})"
-            )
-            print(
-                f"  Sending to PE 1: {input_tensor[elems_per_pe].item()} (expected: {(my_pe+1)*1000 + 1})"
-            )
+            print(f"PE {rank}: Input refreshed each iteration — pattern: (src+1)*1000 + dest + iter*100000")
 
         # Create CUDA stream for all2all operations (similar to test_allgather.py)
         stream = torch.cuda.Stream(device=device)
@@ -134,6 +138,10 @@ def _test_all2all(rank, world_size, port, elems, iterations, warmup):
             all2all_end = torch.cuda.Event(enable_timing=True)
 
             for iter_idx in range(total_iters):
+                # Refresh input with iter-dependent values to catch stale-flag bug
+                refresh_input(iter_idx)
+                dist.barrier()
+
                 # Record start time
                 all2all_start.record(stream)
 
@@ -150,6 +158,12 @@ def _test_all2all(rank, world_size, port, elems, iterations, warmup):
                     print(
                         f"PE {rank}: All2All operation failed at iteration {iter_idx}"
                     )
+                    break
+
+                # Per-iteration correctness check
+                if not verify_output(iter_idx):
+                    success = False
+                    print(f"PE {rank}: Correctness check failed at iteration {iter_idx}")
                     break
 
                 # Calculate execution time
@@ -252,7 +266,7 @@ def _test_all2all(rank, world_size, port, elems, iterations, warmup):
                 chunk = output_data_cpu[
                     src_pe * elems_per_pe : (src_pe + 1) * elems_per_pe
                 ]
-                expected_value = (src_pe + 1) * 1000 + my_pe
+                expected_value = (src_pe + 1) * 1000 + my_pe + (total_iters - 1) * 100000
 
                 if not np.all(chunk == expected_value):
                     print(f"PE {rank}: Chunk from PE {src_pe} verification FAILED!")
@@ -293,7 +307,7 @@ def _test_all2all(rank, world_size, port, elems, iterations, warmup):
                     transit_buffer_chunk = transit_chunk[
                         src_pe * elems_per_pe : (src_pe + 1) * elems_per_pe
                     ]
-                    expected_value = (src_pe + 1) * 1000 + my_pe
+                    expected_value = (src_pe + 1) * 1000 + my_pe + (total_iters - 1) * 100000
                     if np.all(transit_buffer_chunk == expected_value):
                         if rank == 0:
                             print(

--- a/tests/python/ccl/test_all2all.py
+++ b/tests/python/ccl/test_all2all.py
@@ -33,7 +33,7 @@ from mori.ccl import All2allSdma
 from tests.python.utils import TorchDistContext, get_free_port
 
 
-def _test_all2all(rank, world_size, port, elems, iterations, warmup):
+def _test_all2all(rank, world_size, port, elems, iterations, warmup, use_async=False):
     """Worker function for each process"""
 
     with TorchDistContext(rank=rank, world_size=world_size, master_port=port):
@@ -96,12 +96,12 @@ def _test_all2all(rank, world_size, port, elems, iterations, warmup):
 
         # Input is refreshed each iteration with an iter-dependent value so that
         # stale flags (the flag-reset bug) produce detectably wrong output on call 2+.
-        # Pattern: PE i sends (i+1)*1000 + dest_pe + iter*100000 to PE dest_pe.
+        # Pattern: PE i sends iter*100000 + (i+1)*1000 + dest_pe to PE dest_pe.
         input_data_cpu = np.zeros(elems_per_pe * npes, dtype=np.uint32)
 
         def refresh_input(iter_idx):
             for dest_pe in range(npes):
-                value = (my_pe + 1) * 1000 + dest_pe + iter_idx * 100000
+                value = iter_idx * 100000 + (my_pe + 1) * 1000 + dest_pe
                 input_data_cpu[dest_pe * elems_per_pe : (dest_pe + 1) * elems_per_pe] = value
             input_tensor.copy_(torch.from_numpy(input_data_cpu))
 
@@ -110,7 +110,7 @@ def _test_all2all(rank, world_size, port, elems, iterations, warmup):
             ok = True
             for src_pe in range(npes):
                 chunk = output_data_cpu[src_pe * elems_per_pe : (src_pe + 1) * elems_per_pe]
-                expected = (src_pe + 1) * 1000 + my_pe + iter_idx * 100000
+                expected = iter_idx * 100000 + (src_pe + 1) * 1000 + my_pe
                 if not np.all(chunk == expected):
                     print(f"PE {rank}: iter {iter_idx} chunk from PE {src_pe} FAILED! "
                           f"expected={expected} got unique={np.unique(chunk)[:5]}")
@@ -118,7 +118,7 @@ def _test_all2all(rank, world_size, port, elems, iterations, warmup):
             return ok
 
         if rank == 0:
-            print(f"PE {rank}: Input refreshed each iteration — pattern: (src+1)*1000 + dest + iter*100000")
+            print(f"PE {rank}: Input refreshed each iteration — pattern: iter*100000 + (src+1)*1000 + dest")
 
         # Create CUDA stream for all2all operations (similar to test_allgather.py)
         stream = torch.cuda.Stream(device=device)
@@ -129,7 +129,6 @@ def _test_all2all(rank, world_size, port, elems, iterations, warmup):
         # Execute All2All multiple times
         exec_times = []
         total_iters = warmup + iterations
-        use_async = False  # Use async mode to match C++ test
 
         if not use_async:
             # Synchronous mode (single SDMA queue) - add timing and stream
@@ -195,6 +194,8 @@ def _test_all2all(rank, world_size, port, elems, iterations, warmup):
                     stage = "Warmup" if iter_idx < warmup else "Measurement"
                     print(f"\n--- {stage} Iteration {iter_idx + 1} ---")
 
+                # Refresh input with iter-dependent values to catch stale-flag bug
+                refresh_input(iter_idx)
                 dist.barrier()
 
                 # Start async operation using context manager style (like test_allgather.py)
@@ -216,6 +217,12 @@ def _test_all2all(rank, world_size, port, elems, iterations, warmup):
 
                 # Synchronize stream to ensure completion (like test_allgather.py)
                 stream.synchronize()
+
+                # Per-iteration correctness check
+                if not verify_output(iter_idx):
+                    success = False
+                    print(f"PE {rank}: Correctness check failed at iteration {iter_idx}")
+                    break
 
                 # Collect times after warmup
                 if iter_idx >= warmup:
@@ -266,7 +273,7 @@ def _test_all2all(rank, world_size, port, elems, iterations, warmup):
                 chunk = output_data_cpu[
                     src_pe * elems_per_pe : (src_pe + 1) * elems_per_pe
                 ]
-                expected_value = (src_pe + 1) * 1000 + my_pe + (total_iters - 1) * 100000
+                expected_value = (total_iters - 1) * 100000 + (src_pe + 1) * 1000 + my_pe
 
                 if not np.all(chunk == expected_value):
                     print(f"PE {rank}: Chunk from PE {src_pe} verification FAILED!")
@@ -307,7 +314,7 @@ def _test_all2all(rank, world_size, port, elems, iterations, warmup):
                     transit_buffer_chunk = transit_chunk[
                         src_pe * elems_per_pe : (src_pe + 1) * elems_per_pe
                     ]
-                    expected_value = (src_pe + 1) * 1000 + my_pe + (total_iters - 1) * 100000
+                    expected_value = (total_iters - 1) * 100000 + (src_pe + 1) * 1000 + my_pe
                     if np.all(transit_buffer_chunk == expected_value):
                         if rank == 0:
                             print(
@@ -374,13 +381,13 @@ def _test_all2all(rank, world_size, port, elems, iterations, warmup):
             raise AssertionError(f"PE {rank}: All2All verification failed")
 
 
-def test_all2all(elems=67108864, world_size=8, iterations=10, warmup=10):
+def test_all2all(elems=67108864, world_size=8, iterations=10, warmup=10, use_async=False):
     """Run All2All SDMA test"""
     os.environ.setdefault("MORI_ENABLE_SDMA", "1")
     port = get_free_port()
     torch.multiprocessing.spawn(
         _test_all2all,
-        args=(world_size, port, elems, iterations, warmup),
+        args=(world_size, port, elems, iterations, warmup, use_async),
         nprocs=world_size,
         join=True,
     )
@@ -402,6 +409,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "--enable-sdma", type=int, default=1, choices=[0, 1], help="Enable SDMA"
     )
+    parser.add_argument(
+        "--async", dest="use_async", action="store_true", help="Use async mode (start_async + wait_async)"
+    )
     args = parser.parse_args()
     os.environ["MORI_ENABLE_SDMA"] = str(args.enable_sdma)
 
@@ -410,6 +420,7 @@ if __name__ == "__main__":
     print(f"  World size: {args.world_size}")
     print(f"  Iterations: {args.iterations}")
     print(f"  Warmup: {args.warmup}")
+    print(f"  Mode: {'async' if args.use_async else 'sync'}")
     print("-" * 60)
 
-    test_all2all(args.elems, args.world_size, args.iterations, args.warmup)
+    test_all2all(args.elems, args.world_size, args.iterations, args.warmup, args.use_async)


### PR DESCRIPTION
## Motivation

`resetFlags()` was commented out in `All2allSdma::start_async()`, `All2allSdma::operator()`, and `All2allSdma::cancel_async()` since the initial SDMA commit. Without resetting, completion flags remain set to 1 after the first call, causing all subsequent calls to return immediately with stale output.

The original test used fixed input values across iterations, so stale output from call 1 matched the expected values for call 2+, masking the bug entirely.

## Technical Details

Uncomment `resetFlags()` in the three call sites in `src/collective/core/oneshot_all2all_sdma_class.cpp`.

The test is also updated to use iter-dependent input values so the bug is reliably reproducible on call 2+, and async mode is covered via a new `--async` CLI flag.

## Test Plan

- Sync mode, no fix → FAIL (stale flags produce wrong output on iteration 2+)
- Sync mode, fix applied → PASS
- Async mode, fix applied → PASS

## Test Result

Tested on AMD MI355X (8 GPUs), `rocm/primus:v26.2`, 1M elements, 10 iterations — all 8 PEs passed in both sync and async modes.