### PR TITLE
ci: preserve nightly/ dir when deploying docs to gh-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,4 +69,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./html
+          keep_files: true
           commit_message: 'docs: deploy documentation'


### PR DESCRIPTION
## Summary

- Fix: docs deployment was wiping nightly wheel directory on gh-pages
- Add `keep_files: true` to `peaceiris/actions-gh-pages` in docs.yml

Made with [Cursor](https://cursor.com)