### PR TITLE
docs: add PyPI and nightly install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,12 +207,30 @@ cd mori && docker build -t rocm/mori:dev -f docker/Dockerfile.dev .
 
 ### Install
 
+MoRI can be installed in three ways: from PyPI (stable), nightly pre-built wheels (latest dev), or from source.
+
+#### From PyPI (stable release)
+
+```bash
+pip install amd_mori
+```
+
+#### Nightly (pre-built, tested daily)
+
+```bash
+pip install --no-index --force-reinstall --find-links https://rocm.github.io/mori/nightly/latest/ amd_mori
+```
+
+Browse all nightly builds: https://rocm.github.io/mori/nightly/
+
+#### From source
+
 ```bash
 # NOTE: for venv build, add --no-build-isolation at the end
 cd mori && pip install .
 ```
 
-That's it. No hipcc needed at install time — host code compiles with a standard
+No hipcc needed at install time — host code compiles with a standard
 C++ compiler. GPU kernels are JIT-compiled on first use and cached to
 `~/.mori/jit/`. If a GPU is detected during install, kernel precompilation
 starts automatically in the background.
@@ -225,7 +243,7 @@ MORI_PRECOMPILE=1 python -c "import mori"
 ### Verify installation
 
 ```bash
-python -c "import mori; print('OK')"
+python -c "import mori; print(mori.__version__)"
 ```
 
 ## Testing


### PR DESCRIPTION
## Summary

- Add PyPI install command (`pip install amd_mori`)
- Add nightly wheel install command with gh-pages link
- Update verify step to print `mori.__version__`

Made with [Cursor](https://cursor.com)