### PR TITLE
docs: add PyPI nightly install and conflict warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,10 +218,17 @@ pip install amd_mori
 #### Nightly (pre-built, tested daily)
 
 ```bash
+# From PyPI
+pip install --pre amd-mori-nightly
+
+# Or from GitHub Pages
 pip install --no-index --force-reinstall --find-links https://rocm.github.io/mori/nightly/latest/ amd_mori
 ```
 
 Browse all nightly builds: https://rocm.github.io/mori/nightly/
+
+> **Note**: `amd-mori` and `amd-mori-nightly` both provide the `mori` Python module.
+> Do not install both at the same time — uninstall one before installing the other.
 
 #### From source
 


### PR DESCRIPTION
## Summary

- Add `pip install --pre amd-mori-nightly` as primary nightly install method
- Keep GitHub Pages install as alternative
- Add warning: do not install amd-mori and amd-mori-nightly simultaneously

Made with [Cursor](https://cursor.com)