### PR TITLE
fix: use compiled spdlog with hidden visibility to prevent symbol collision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,13 +152,18 @@ set(SPDLOG_BUILD_BENCH
     CACHE BOOL "" FORCE)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 add_subdirectory(3rdparty/spdlog)
-# Hide spdlog symbols from other libraries to avoid symbol conflicts
-target_compile_options(spdlog PRIVATE -fvisibility=hidden
-                                      -fvisibility-inlines-hidden)
+# Hide spdlog symbols to avoid cross-library symbol collisions. Both rocroller
+# (via hipblaslt/TE) and MORI statically link spdlog; if both export spdlog
+# symbols, MORI's spdlog calls can be interposed by rocroller's copy, causing
+# heap corruption (free(): invalid size). Using the compiled spdlog library (not
+# header-only) with hidden visibility ensures spdlog symbols stay internal to
+# MORI's .so files.
+set_target_properties(spdlog PROPERTIES CXX_VISIBILITY_PRESET hidden
+                                        VISIBILITY_INLINES_HIDDEN ON)
 
 add_library(mori_logging INTERFACE)
 target_include_directories(mori_logging INTERFACE include)
-target_link_libraries(mori_logging INTERFACE spdlog::spdlog_header_only)
+target_link_libraries(mori_logging INTERFACE spdlog::spdlog)
 
 if(ENABLE_PROFILER)
   find_package(


### PR DESCRIPTION
## Summary
- Switch spdlog from header-only (`spdlog::spdlog_header_only`) to compiled static library (`spdlog::spdlog`) with `CXX_VISIBILITY_PRESET=hidden` and `VISIBILITY_INLINES_HIDDEN=ON`, preventing spdlog symbols from leaking into MORI's dynamic symbol table.
## Problem
When TransformerEngine is imported before MORI shmem init, the process crashes with `free(): invalid size` (SIGABRT).
**Root cause:** Both MORI and rocroller (loaded transitively via `libtransformer_engine.so` → `libhipblaslt.so` → `librocroller.so`) statically link spdlog. TE loads its core library with `ctypes.RTLD_GLOBAL`, which promotes rocroller's spdlog symbols into the global namespace. MORI's spdlog calls (e.g. `registry::initialize_logger`) are then interposed by rocroller's copy, and cross-library object lifetime mismatch causes heap corruption.
GDB backtrace confirms the interposition:
`#11 spdlog::details::registry::initialize_logger() ← from libmori_application.so #10 spdlog::sinks::ansicolor_sink::set_formatter() ← from librocroller.so (!) #7 spdlog::details::full_formatter::~full_formatter() ← from librocroller.so #6 free() → SIGABRT`

## Fix
| Before | After |
|--------|-------|
| `target_compile_options(spdlog PRIVATE -fvisibility=hidden ...)` | `set_target_properties(spdlog PROPERTIES CXX_VISIBILITY_PRESET hidden VISIBILITY_INLINES_HIDDEN ON)` |
| `spdlog::spdlog_header_only` | `spdlog::spdlog` |

With compiled mode, spdlog is built into `libspdlog.a` with hidden visibility. When linked into MORI's `.so` files, the spdlog symbols are present but hidden from the dynamic symbol table — they cannot be interposed by rocroller's copy.

## Test plan
- [x] TE container: `mori-only` → PASS
- [x] TE container: `mori-then-te` → PASS
- [x] TE container: `te-then-mori` → PASS (was CRASH)
- [ ] JAX container: `BUILD_XLA_FFI_OPS=ON pip install -e .` → PASS
- [ ] JAX container: AOT `.hsaco` kernel generation → PASS
