### PR TITLE
perf(ep): optimize dispatch intranode kernel perf in cases with small tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       - name: MORI-EP (intranode)
         run: |
           $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE && timeout 300 pytest tests/python/ops/test_dispatch_combine_intranode.py -v
+            cd $GITHUB_WORKSPACE && timeout 420 pytest tests/python/ops/test_dispatch_combine_intranode.py -v
           "
 
       - name: MORI-EP (internode_v1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       - name: MORI-EP (intranode)
         run: |
           $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE && timeout 420 pytest tests/python/ops/test_dispatch_combine_intranode.py -v
+            cd $GITHUB_WORKSPACE && timeout 360 pytest tests/python/ops/test_dispatch_combine_intranode.py -v
           "
 
       - name: MORI-EP (internode_v1)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -306,7 +306,7 @@ jobs:
       - name: MORI-EP (intranode)
         run: |
           $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE && timeout 420 pytest tests/python/ops/test_dispatch_combine_intranode.py -v
+            cd $GITHUB_WORKSPACE && timeout 360 pytest tests/python/ops/test_dispatch_combine_intranode.py -v
           "
 
       - name: MORI-EP (internode_v1)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -306,7 +306,7 @@ jobs:
       - name: MORI-EP (intranode)
         run: |
           $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE && timeout 300 pytest tests/python/ops/test_dispatch_combine_intranode.py -v
+            cd $GITHUB_WORKSPACE && timeout 420 pytest tests/python/ops/test_dispatch_combine_intranode.py -v
           "
 
       - name: MORI-EP (internode_v1)

--- a/include/mori/ops/dispatch_combine/dispatch_combine.hpp
+++ b/include/mori/ops/dispatch_combine/dispatch_combine.hpp
@@ -45,7 +45,14 @@
 namespace mori {
 namespace moe {
 
-enum KernelType { IntraNode = 0, InterNode = 1, InterNodeV1 = 2, InterNodeV1LL = 3, AsyncLL = 4 };
+enum KernelType {
+  IntraNode = 0,
+  InterNode = 1,
+  InterNodeV1 = 2,
+  InterNodeV1LL = 3,
+  AsyncLL = 4,
+  IntraNodeLL = 5
+};
 enum class QuantType { None = 0, Fp8DirectCast = 1, Fp8BlockwiseQuant = 2 };
 
 inline const char* HipDataTypeToString(hipDataType dtype) {

--- a/include/mori/ops/dispatch_combine/dispatch_combine.hpp
+++ b/include/mori/ops/dispatch_combine/dispatch_combine.hpp
@@ -245,7 +245,7 @@ class EpDispatchCombineHandle {
   int Fp8BlockwiseCombineScaleTypeSize() const { return fp8BlockwiseCombineScaleTypeSize; }
 
   mori::application::SymmMemObjPtr GetShmemDispatchOutTokMemObj() const {
-    if (config.kernelType == KernelType::IntraNode)
+    if (config.kernelType == KernelType::IntraNode || config.kernelType == KernelType::IntraNodeLL)
       return std::get<ShmemBufsIntraNode>(shmemTokBufs).dispatchOut;
     if (config.kernelType == KernelType::InterNodeV1 ||
         config.kernelType == KernelType::InterNodeV1LL)
@@ -253,7 +253,7 @@ class EpDispatchCombineHandle {
     return std::get<ShmemBufsInterNode>(shmemTokBufs).dispatchOut;
   }
   mori::application::SymmMemObjPtr GetShmemCombineOutTokMemObj() const {
-    if (config.kernelType == KernelType::IntraNode)
+    if (config.kernelType == KernelType::IntraNode || config.kernelType == KernelType::IntraNodeLL)
       return std::get<ShmemBufsIntraNode>(shmemTokBufs).combineOut;
     if (config.kernelType == KernelType::InterNodeV1 ||
         config.kernelType == KernelType::InterNodeV1LL)
@@ -261,7 +261,7 @@ class EpDispatchCombineHandle {
     return std::get<ShmemBufsInterNode>(shmemTokBufs).combineOut;
   }
   mori::application::SymmMemObjPtr GetShmemCombineInpTokMemObj() const {
-    if (config.kernelType == KernelType::IntraNode)
+    if (config.kernelType == KernelType::IntraNode || config.kernelType == KernelType::IntraNodeLL)
       return std::get<ShmemBufsIntraNode>(shmemTokBufs).combineInp;
     if (config.kernelType == KernelType::InterNodeV1 ||
         config.kernelType == KernelType::InterNodeV1LL)

--- a/python/mori/ops/dispatch_combine.py
+++ b/python/mori/ops/dispatch_combine.py
@@ -763,9 +763,12 @@ class EpDispatchCombineOp:
         shared_mem = self._combine_shared_mem(actual_wpb)
 
         if quant_type == EpDispatchCombineQuantType.Fp8BlockwiseQuant:
-            if kt != EpDispatchCombineKernelType.IntraNode.value:
+            if kt not in (
+                EpDispatchCombineKernelType.IntraNode.value,
+                EpDispatchCombineKernelType.IntraNodeLL.value,
+            ):
                 raise ValueError(
-                    "Fp8BlockwiseQuant currently only supports IntraNode combine"
+                    "Fp8BlockwiseQuant currently only supports IntraNode/IntraNodeLL combine"
                 )
             if sfx != "bf16":
                 raise ValueError(f"Fp8BlockwiseQuant only supports bf16, got {sfx}")
@@ -1379,6 +1382,7 @@ class EpDispatchCombineOp:
 
         if self.config.kernel_type.value in (
             EpDispatchCombineKernelType.IntraNode.value,
+            EpDispatchCombineKernelType.IntraNodeLL.value,
             EpDispatchCombineKernelType.InterNodeV1.value,
             EpDispatchCombineKernelType.InterNodeV1LL.value,
             EpDispatchCombineKernelType.AsyncLL.value,

--- a/python/mori/ops/dispatch_combine.py
+++ b/python/mori/ops/dispatch_combine.py
@@ -139,6 +139,7 @@ def _cpp_dispatch_combine_factory(entity_name, allow_missing=False):
 # ---------------------------------------------------------------------------
 _KERNEL_TYPE_TO_HIP = {
     EpDispatchCombineKernelType.IntraNode: "ep_intranode",
+    EpDispatchCombineKernelType.IntraNodeLL: "ep_intranode",
     EpDispatchCombineKernelType.InterNode: "ep_internode",
     EpDispatchCombineKernelType.InterNodeV1: "ep_internode_v1",
     EpDispatchCombineKernelType.InterNodeV1LL: "ep_internode_v1ll",
@@ -573,6 +574,15 @@ class EpDispatchCombineOp:
                 stream,
                 args_ptr,
             )
+        elif kt == EpDispatchCombineKernelType.IntraNodeLL.value:
+            self._launch(
+                f"EpDispatchIntraNodeLLKernel_{sfx}",
+                grid,
+                block,
+                shared_mem,
+                stream,
+                args_ptr,
+            )
         elif kt == EpDispatchCombineKernelType.AsyncLL.value:
             mp = self._handle_info["multi_processor_count"]
             mp_aligned = mp // self.config.world_size * self.config.world_size
@@ -810,7 +820,10 @@ class EpDispatchCombineOp:
                 stream,
                 args_ptr,
             )
-        elif kt == EpDispatchCombineKernelType.IntraNode.value:
+        elif kt in (
+            EpDispatchCombineKernelType.IntraNode.value,
+            EpDispatchCombineKernelType.IntraNodeLL.value,
+        ):
             if quant_type == EpDispatchCombineQuantType.Fp8BlockwiseQuant:
                 # Mirror of the AccumNum=8 + VecBytes=8 specialization gating in
                 # LaunchCombine() / launch.cpp. Keep in sync.

--- a/python/mori/ops/tuning_config.py
+++ b/python/mori/ops/tuning_config.py
@@ -76,7 +76,7 @@ CONFIG_STR_TO_DTYPE: dict[str, torch.dtype] = {r[1]: r[0] for r in _DTYPE_REGIST
 CONFIG_STR_TO_SHORT_NAME: dict[str, str] = {r[1]: r[2] for r in _DTYPE_REGISTRY}
 
 _KERNEL_TYPE_NAMES = frozenset(
-    {"IntraNode", "InterNode", "InterNodeV1", "InterNodeV1LL", "AsyncLL"}
+    {"IntraNode", "InterNode", "InterNodeV1", "InterNodeV1LL", "AsyncLL", "IntraNodeLL"}
 )
 
 _QUANT_TYPE_CONFIG_STRS = {"none", "fp8_direct_cast", "fp8_blockwise"}

--- a/python/mori/ops/tuning_configs/gfx950_mi355x_IntraNodeLL_ep8_dispatch.json
+++ b/python/mori/ops/tuning_configs/gfx950_mi355x_IntraNodeLL_ep8_dispatch.json
@@ -1,0 +1,40 @@
+{
+  "version": "1.0",
+  "gpu_arch": "gfx950",
+  "gpu_model": "mi355x",
+  "kernel_type": "IntraNode",
+  "ep_size": 8,
+  "phase": "dispatch",
+  "rules": [
+    {
+      "dtype": "bf16",
+      "num_tokens": 1,
+      "hidden_dim": 7168,
+      "block_num": 4,
+      "rdma_block_num": 0,
+      "warp_per_block": 4,
+      "bandwidth_gbps": 2.56,
+      "latency_us": 27.7
+    },
+    {
+      "dtype": "bf16",
+      "num_tokens": 32,
+      "hidden_dim": 7168,
+      "block_num": 32,
+      "rdma_block_num": 0,
+      "warp_per_block": 16,
+      "bandwidth_gbps": 79.9,
+      "latency_us": 30.9
+    },
+    {
+      "dtype": "bf16",
+      "num_tokens": 64,
+      "hidden_dim": 7168,
+      "block_num": 64,
+      "rdma_block_num": 0,
+      "warp_per_block": 16,
+      "bandwidth_gbps": 145.95,
+      "latency_us": 34.3
+    }
+  ]
+}

--- a/python/mori/ops/tuning_configs/gfx950_mi355x_IntraNodeLL_ep8_dispatch.json
+++ b/python/mori/ops/tuning_configs/gfx950_mi355x_IntraNodeLL_ep8_dispatch.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "gpu_arch": "gfx950",
   "gpu_model": "mi355x",
-  "kernel_type": "IntraNode",
+  "kernel_type": "IntraNodeLL",
   "ep_size": 8,
   "phase": "dispatch",
   "rules": [

--- a/src/ops/dispatch_combine/convert.hpp
+++ b/src/ops/dispatch_combine/convert.hpp
@@ -184,7 +184,8 @@ template <typename T>
 __device__ inline void InvokeConvertDispatchOutput(const EpDispatchCombineArgs<T>& args, int myPe) {
   ConvertDispatchOutputArgs convArgs{};
   convArgs.config = args.config;
-  if (args.config.kernelType == KernelType::IntraNode) {
+  if (args.config.kernelType == KernelType::IntraNode ||
+      args.config.kernelType == KernelType::IntraNodeLL) {
     convArgs.dispatchOutX = args.intraNodeTokBufs.dispatchOut->template GetAs<T*>(myPe);
   } else if (args.config.kernelType == KernelType::InterNodeV1 ||
              args.config.kernelType == KernelType::InterNodeV1LL) {
@@ -218,7 +219,8 @@ __device__ inline void InvokeConvertCombineInput(const EpDispatchCombineArgs<T>&
   convArgs.combineInput = nullptr;
   convArgs.dispTokToEpSlotMap = args.dispTokToEpSlotMap;
   convArgs.packedRecvCount = args.standardPackedRecvCount;
-  if (args.config.kernelType == KernelType::IntraNode) {
+  if (args.config.kernelType == KernelType::IntraNode ||
+      args.config.kernelType == KernelType::IntraNodeLL) {
     convArgs.shmemCombineInpTokMemObj = args.intraNodeTokBufs.combineInp;
   } else if (args.config.kernelType == KernelType::InterNodeV1 ||
              args.config.kernelType == KernelType::InterNodeV1LL) {

--- a/src/ops/dispatch_combine/dispatch_combine.cpp
+++ b/src/ops/dispatch_combine/dispatch_combine.cpp
@@ -198,7 +198,7 @@ void EpDispatchCombineHandle::InitializeShmemBuf() {
                       config.WeightBytes() + config.SrcTokenIdBytes() + blockwiseScaleBytes);
   }
 
-  if (config.kernelType == KernelType::IntraNode) {
+  if (config.kernelType == KernelType::IntraNode || config.kernelType == KernelType::IntraNodeLL) {
     auto& bufs = shmemTokBufs.emplace<ShmemBufsIntraNode>();
     bufs.combineInp = ShmemMallocAndReturnMemObjPtr(maxStagingSize, hipDeviceMallocUncached);
     bufs.dispatchOut = ShmemMallocAndReturnMemObjPtr(dispatchOutSize, hipDeviceMallocUncached);
@@ -271,7 +271,7 @@ void EpDispatchCombineHandle::InitializeShmemBuf() {
 }
 
 void EpDispatchCombineHandle::FinalizeShmemBuf() {
-  if (config.kernelType == KernelType::IntraNode) {
+  if (config.kernelType == KernelType::IntraNode || config.kernelType == KernelType::IntraNodeLL) {
     auto& bufs = std::get<ShmemBufsIntraNode>(shmemTokBufs);
     ShmemFree(bufs.dispatchOut->localPtr);
     ShmemFree(bufs.combineInp->localPtr);
@@ -463,7 +463,8 @@ EpDispatchCombineArgsRaw GetEpDispatchCombineArgsRaw(const EpDispatchCombineHand
   args.scalesBuf = handle.scalesBuf;
   args.destPeTokenCounter = handle.destPeTokenCounter;
   args.localPeTokenCounter = handle.localPeTokenCounter;
-  if (handle.config.kernelType == KernelType::IntraNode) {
+  if (handle.config.kernelType == KernelType::IntraNode ||
+      handle.config.kernelType == KernelType::IntraNodeLL) {
     args.intraNodeTokBufs = std::get<ShmemBufsIntraNode>(handle.shmemTokBufs);
   } else if (handle.config.kernelType == KernelType::InterNodeV1 ||
              handle.config.kernelType == KernelType::InterNodeV1LL) {

--- a/src/ops/dispatch_combine/intranode.hpp
+++ b/src/ops/dispatch_combine/intranode.hpp
@@ -241,7 +241,7 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   const bool hasScales = args.scalesBuf && (config.scaleDim > 0) && (config.scaleTypeSize > 0);
 
   // Warp-group coordination: 4 warps per group
-  constexpr int kWarpsPerGroup = 4;
+  constexpr int kWarpsPerGroup = 2;
   constexpr int kMaxWarpGroups = 8;
 
   __shared__ uint64_t groupData[kMaxWarpGroups];  // (iteration+1, destTokId)
@@ -252,17 +252,19 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   int warpGroupId = globalWarpId / kWarpsPerGroup;
   int warpGroupNum = globalWarpNum / kWarpsPerGroup;
 
-  // Clear shared memory
+  // clear shared memory
   if (inGroupWarpId == 0 && laneId == 0) {
     groupData[warpGroupIdInBlock] = 0;
-    groupCounters[warpGroupIdInBlock] = 0;
+    groupCounters[warpGroupIdInBlock] = kWarpsPerGroup - 1;
   }
-  __threadfence_block();
+  __syncthreads();
 
   // Hidden dim split for each warp in group
   size_t dimPerWarp = (hiddenDim + kWarpsPerGroup - 1) / kWarpsPerGroup;
-  size_t myDimOffset = (size_t)inGroupWarpId * dimPerWarp;
-  size_t myDimChunk = (myDimOffset < hiddenDim) ? min(hiddenDim - myDimOffset, dimPerWarp) : 0;
+  size_t warpDimOffset = (size_t)inGroupWarpId * dimPerWarp;
+  size_t warpDimChunk =
+      (warpDimOffset < hiddenDim) ? min(hiddenDim - warpDimOffset, dimPerWarp) : 0;
+  assert(warpDimChunk > 0 && "warpDimChunk must be > 0 for warpgroups to be useful");
 
   IF_ENABLE_PROFILER(
       INTRANODE_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
@@ -279,7 +281,7 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
       index_t destPe = destExpert / config.numExpertPerRank;
       index_t destTokId = 0;
 
-      // ALL 4 warps do dedup independently (same input = same result)
+      // ALL warps in warp-group do dedup independently (same input = same result)
       assert(config.numExpertPerToken < warpSize);
       int condition = 0;
       if (laneId < (i % config.numExpertPerToken)) {
@@ -294,7 +296,7 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
         continue;
       }
 
-      // Warp 0: atomic allocation + notify via shared memory
+      // Header Warp: atomic allocation + notify via shared memory
       if (inGroupWarpId == 0) {
         if (laneId == 0) {
           // Atomic allocation
@@ -306,15 +308,14 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
           args.dispTokIdToSrcTokIdMemObj->template GetAs<index_t*>(destPe)[destTokId] =
               FlatTokenIndex(config, myPe, srcTokId);
 
-          // Wait for previous round to be consumed (use atomicAdd for shared memory)
-          while (atomicAdd(&groupCounters[warpGroupIdInBlock], 0) != 0) {
+          // Wait for all consumers done (counter == N-1), then set to 0
+          while (atomicCAS(&groupCounters[warpGroupIdInBlock], kWarpsPerGroup - 1, 0) !=
+                 kWarpsPerGroup - 1) {
           }
 
           // Write to shared mem: use (i+1) to avoid confusion with initial value 0
-          // Use atomicExch for shared memory (workgroup scope)
           atomicExch((unsigned long long*)&groupData[warpGroupIdInBlock],
                      ((uint64_t)(i + 1) << 32) | (uint32_t)destTokId);
-          atomicExch(&groupCounters[warpGroupIdInBlock], 3);
         }
         destTokId = __shfl(destTokId, 0);
 
@@ -330,28 +331,30 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
               args.tokenIndices[srcTokId * config.numExpertPerToken + laneId];
         }
       } else {
-        // Warps 1-3: spin wait for iteration match, then consume
-        // Use atomicAdd for shared memory atomic load (workgroup scope)
-        uint64_t val;
-        do {
-          val = atomicAdd((unsigned long long*)&groupData[warpGroupIdInBlock], 0ULL);
-        } while ((val >> 32) != (uint32_t)(i + 1));
-        destTokId = (index_t)(val & 0xFFFFFFFF);
-
+        // Normal Warps: spin wait for iteration match, then consume
+        // Only lane 0 spins, then broadcast to other lanes
         if (laneId == 0) {
-          atomicSub(&groupCounters[warpGroupIdInBlock], 1);
+          uint64_t val;
+          do {
+            __builtin_amdgcn_s_sleep(4);
+            val = __hip_atomic_load(
+                reinterpret_cast<unsigned long long*>(&groupData[warpGroupIdInBlock]),
+                __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_WORKGROUP);
+          } while ((val >> 32) != (uint32_t)(i + 1));
+          atomicAdd(&groupCounters[warpGroupIdInBlock], 1);
+          destTokId = (index_t)(val & 0xFFFFFFFF);
         }
+
+        destTokId = __shfl(destTokId, 0);
       }
 
-      // All 4 warps: copy their portion of token data
+      // All warps in warpgroup: copy their portion of token data
       size_t srcTokOffset = srcTokId * hiddenDim;
       size_t destTokOffset = destTokId * hiddenDim;
 
-      if (myDimChunk > 0) {
-        core::WarpCopy<T, 2>(args.intraNodeTokBufs.dispatchOut->template GetAs<T*>(destPe) +
-                                 destTokOffset + myDimOffset,
-                             args.inpTokenBuf + srcTokOffset + myDimOffset, myDimChunk);
-      }
+      core::WarpCopy<T, 2>(args.intraNodeTokBufs.dispatchOut->template GetAs<T*>(destPe) +
+                               destTokOffset + warpDimOffset,
+                           args.inpTokenBuf + srcTokOffset + warpDimOffset, warpDimChunk);
 
       // Write scales: split across 4 warps
       if (hasScales) {
@@ -361,16 +364,15 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
         size_t myScaleChunk =
             (myScaleOffset < scaleSize) ? min(scaleSize - myScaleOffset, scalePerWarp) : 0;
 
-        if (myScaleChunk > 0) {
-          size_t destScaleOffset = (size_t)destTokId * scaleSize;
-          size_t srcScaleOffset = (size_t)srcTokId * scaleSize;
-          core::WarpCopy(args.shmemOutScalesMemObj->template GetAs<uint8_t*>(destPe) +
-                             destScaleOffset + myScaleOffset,
-                         args.scalesBuf + srcScaleOffset + myScaleOffset, myScaleChunk);
-        }
+        size_t destScaleOffset = (size_t)destTokId * scaleSize;
+        size_t srcScaleOffset = (size_t)srcTokId * scaleSize;
+        core::WarpCopy(args.shmemOutScalesMemObj->template GetAs<uint8_t*>(destPe) +
+                           destScaleOffset + myScaleOffset,
+                       args.scalesBuf + srcScaleOffset + myScaleOffset, myScaleChunk);
       }
     }
   }
+
   __syncthreads();
   if (thdId == 0) atomicAdd(args.dispatchGridBarrier, 1);
 

--- a/src/ops/dispatch_combine/intranode.hpp
+++ b/src/ops/dispatch_combine/intranode.hpp
@@ -80,9 +80,6 @@ inline __device__ void CrossDeviceBarrierIntraNodeKernel(EpDispatchCombineArgs<T
 /*                                    EpDispatchIntraNodeKernel                                   */
 /* ---------------------------------------------------------------------------------------------- */
 
-#define ENABLE_DISPATCH_WARPGROUP
-
-#if !defined(ENABLE_DISPATCH_WARPGROUP)
 template <typename T, bool EnableStdMoE = false>
 __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   const EpDispatchCombineConfig& config = args.config;
@@ -219,9 +216,9 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   }
 #endif
 }
-#else
+
 template <typename T, bool EnableStdMoE = false>
-__device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
+__device__ void EpDispatchIntraNodeLLKernel_body(EpDispatchCombineArgs<T> args) {
   const EpDispatchCombineConfig& config = args.config;
 
   int thdId = threadIdx.x;
@@ -423,11 +420,9 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   }
 #endif
 }
-#endif
 
-template <typename T, bool EnableStdMoE = false, int block_threads = 512, int grid_blocks = 1>
-__global__ void __launch_bounds__(block_threads, grid_blocks)
-    EpDispatchIntraNodeKernel(EpDispatchCombineArgs<T> args) {
+template <typename T, bool EnableStdMoE = false>
+__global__ void EpDispatchIntraNodeKernel(EpDispatchCombineArgs<T> args) {
   EpDispatchIntraNodeKernel_body<T, EnableStdMoE>(args);
 }
 

--- a/src/ops/dispatch_combine/intranode.hpp
+++ b/src/ops/dispatch_combine/intranode.hpp
@@ -79,6 +79,8 @@ inline __device__ void CrossDeviceBarrierIntraNodeKernel(EpDispatchCombineArgs<T
 /* ---------------------------------------------------------------------------------------------- */
 /*                                    EpDispatchIntraNodeKernel                                   */
 /* ---------------------------------------------------------------------------------------------- */
+
+/*
 template <typename T, bool EnableStdMoE = false>
 __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   const EpDispatchCombineConfig& config = args.config;
@@ -217,9 +219,207 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   }
 #endif
 }
+*/
 
-template <typename T, bool EnableStdMoE = false, int threads = 512, int blocks = 1>
-__global__ void __launch_bounds__(threads, blocks)
+template <typename T, bool EnableStdMoE = false>
+__device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
+  const EpDispatchCombineConfig& config = args.config;
+
+  int thdId = threadIdx.x;
+  int thdNum = blockDim.x;
+
+  int laneId = threadIdx.x & (warpSize - 1);
+  int warpId = thdId / warpSize;
+  int warpNum = blockDim.x / warpSize;
+
+  int globalWarpId = blockIdx.x * warpNum + warpId;
+  int globalWarpNum = gridDim.x * warpNum;
+
+  int myPe = config.rank;
+  int npes = config.worldSize;
+  size_t hiddenDim = config.HiddenDimSz();
+  const bool hasScales = args.scalesBuf && (config.scaleDim > 0) && (config.scaleTypeSize > 0);
+
+  // Warp-group coordination: 4 warps per group
+  constexpr int kWarpsPerGroup = 4;
+  constexpr int kMaxWarpGroups = 8;
+
+  __shared__ uint64_t groupData[kMaxWarpGroups];  // (iteration+1, destTokId)
+  __shared__ int groupCounters[kMaxWarpGroups];   // consume counter
+
+  int warpGroupIdInBlock = warpId / kWarpsPerGroup;
+  int inGroupWarpId = warpId % kWarpsPerGroup;  // 0-3
+  int warpGroupId = globalWarpId / kWarpsPerGroup;
+  int warpGroupNum = globalWarpNum / kWarpsPerGroup;
+
+  // Clear shared memory
+  if (inGroupWarpId == 0 && laneId == 0) {
+    groupData[warpGroupIdInBlock] = 0;
+    groupCounters[warpGroupIdInBlock] = 0;
+  }
+  __threadfence_block();
+
+  // Hidden dim split for each warp in group
+  size_t dimPerWarp = (hiddenDim + kWarpsPerGroup - 1) / kWarpsPerGroup;
+  size_t myDimOffset = (size_t)inGroupWarpId * dimPerWarp;
+  size_t myDimChunk = (myDimOffset < hiddenDim) ? min(hiddenDim - myDimOffset, dimPerWarp) : 0;
+
+  IF_ENABLE_PROFILER(
+      INTRANODE_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
+  MORI_TRACE_SEQ(seq, profiler);
+  MORI_TRACE_NEXT(seq, Slot::DispatchSendTokens);
+
+  if (args.tokenIndices && args.inpTokenBuf) {
+    // Phase1: send token
+    // Each warp-group (4 warps) processes one token-expert pair
+    for (int i = warpGroupId; i < args.curRankNumToken * config.numExpertPerToken;
+         i += warpGroupNum) {
+      index_t srcTokId = i / config.numExpertPerToken;
+      index_t destExpert = args.tokenIndices[i];
+      index_t destPe = destExpert / config.numExpertPerRank;
+      index_t destTokId = 0;
+
+      // ALL 4 warps do dedup independently (same input = same result)
+      assert(config.numExpertPerToken < warpSize);
+      int condition = 0;
+      if (laneId < (i % config.numExpertPerToken)) {
+        condition = destPe == (args.tokenIndices[srcTokId * config.numExpertPerToken + laneId] /
+                               config.numExpertPerRank);
+      }
+      if (__any(condition)) {
+        // All 4 warps skip together, only warp 0 writes the skip marker
+        if (inGroupWarpId == 0 && laneId == 0) {
+          args.dispDestTokIdMap[i] = FlatTokenIndex(config, config.worldSize, 0);
+        }
+        continue;
+      }
+
+      // Warp 0: atomic allocation + notify via shared memory
+      if (inGroupWarpId == 0) {
+        if (laneId == 0) {
+          // Atomic allocation
+          destTokId = atomicAdd(args.dispTokOffsetMemObj->template GetAs<index_t*>(destPe), 1);
+          assert(destTokId < config.MaxNumTokensToRecv() &&
+                 "Total recv token overflow: increase maxTotalRecvTokens");
+          atomicAdd(args.destPeTokenCounter + destPe, 1);
+          args.dispDestTokIdMap[i] = FlatTokenIndex(config, destPe, destTokId);
+          args.dispTokIdToSrcTokIdMemObj->template GetAs<index_t*>(destPe)[destTokId] =
+              FlatTokenIndex(config, myPe, srcTokId);
+
+          // Wait for previous round to be consumed (use atomicAdd for shared memory)
+          while (atomicAdd(&groupCounters[warpGroupIdInBlock], 0) != 0) {
+          }
+
+          // Write to shared mem: use (i+1) to avoid confusion with initial value 0
+          // Use atomicExch for shared memory (workgroup scope)
+          atomicExch((unsigned long long*)&groupData[warpGroupIdInBlock],
+                     ((uint64_t)(i + 1) << 32) | (uint32_t)destTokId);
+          atomicExch(&groupCounters[warpGroupIdInBlock], 3);
+        }
+        destTokId = __shfl(destTokId, 0);
+
+        // Write weights and indices: only warp 0 writes
+        if (laneId < config.numExpertPerToken) {
+          if (args.weightsBuf) {
+            args.shmemDispatchOutWeightsMemObj->template GetAs<float*>(
+                destPe)[destTokId * config.numExpertPerToken + laneId] =
+                args.weightsBuf[srcTokId * config.numExpertPerToken + laneId];
+          }
+          args.shmemOutIndicesMemObj->template GetAs<index_t*>(
+              destPe)[destTokId * config.numExpertPerToken + laneId] =
+              args.tokenIndices[srcTokId * config.numExpertPerToken + laneId];
+        }
+      } else {
+        // Warps 1-3: spin wait for iteration match, then consume
+        // Use atomicAdd for shared memory atomic load (workgroup scope)
+        uint64_t val;
+        do {
+          val = atomicAdd((unsigned long long*)&groupData[warpGroupIdInBlock], 0ULL);
+        } while ((val >> 32) != (uint32_t)(i + 1));
+        destTokId = (index_t)(val & 0xFFFFFFFF);
+
+        if (laneId == 0) {
+          atomicSub(&groupCounters[warpGroupIdInBlock], 1);
+        }
+      }
+
+      // All 4 warps: copy their portion of token data
+      size_t srcTokOffset = srcTokId * hiddenDim;
+      size_t destTokOffset = destTokId * hiddenDim;
+
+      if (myDimChunk > 0) {
+        core::WarpCopy<T, 2>(args.intraNodeTokBufs.dispatchOut->template GetAs<T*>(destPe) +
+                                 destTokOffset + myDimOffset,
+                             args.inpTokenBuf + srcTokOffset + myDimOffset, myDimChunk);
+      }
+
+      // Write scales: split across 4 warps
+      if (hasScales) {
+        size_t scaleSize = config.scaleDim * config.scaleTypeSize;
+        size_t scalePerWarp = (scaleSize + kWarpsPerGroup - 1) / kWarpsPerGroup;
+        size_t myScaleOffset = (size_t)inGroupWarpId * scalePerWarp;
+        size_t myScaleChunk =
+            (myScaleOffset < scaleSize) ? min(scaleSize - myScaleOffset, scalePerWarp) : 0;
+
+        if (myScaleChunk > 0) {
+          size_t destScaleOffset = (size_t)destTokId * scaleSize;
+          size_t srcScaleOffset = (size_t)srcTokId * scaleSize;
+          core::WarpCopy(args.shmemOutScalesMemObj->template GetAs<uint8_t*>(destPe) +
+                             destScaleOffset + myScaleOffset,
+                         args.scalesBuf + srcScaleOffset + myScaleOffset, myScaleChunk);
+        }
+      }
+    }
+  }
+  __syncthreads();
+  if (thdId == 0) atomicAdd(args.dispatchGridBarrier, 1);
+
+  // Send token num & token to expert mapping to other ranks
+  MORI_TRACE_NEXT(seq, Slot::DispatchNotifyPeer);
+  if (globalWarpId == 0) {
+    for (int destPe = laneId; destPe < npes; destPe += warpSize) {
+      // Wait until all tokens are sent
+      shmem::ShmemUint32WaitUntilEquals(args.dispatchGridBarrier, gridDim.x);
+      __hip_atomic_store(args.dispatchGridBarrier, 0u, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+
+      // Add 1 so that when token number == 0, receiver side still know the signal is sent
+      index_t numTokenSignal = core::AtomicLoadRelaxed(args.destPeTokenCounter + destPe) + 1;
+      index_t* signal = args.recvTokenNumMemObj->template GetAs<index_t*>(destPe) + myPe;
+      shmem::ShmemInt32WaitUntilEquals(signal, 0);
+      core::AtomicStoreRelaxedSystem(signal, numTokenSignal);
+    }
+  }
+
+  // Phase 2: recv token
+  // Each warp wait until sender finished by waiting token number signal
+  MORI_TRACE_NEXT(seq, Slot::DispatchWaitPeerToken);
+  index_t* recvTokenNums = args.recvTokenNumMemObj->template GetAs<index_t*>();
+  if (globalWarpId == 0) {
+    for (int destPe = laneId; destPe < npes; destPe += warpSize) {
+      index_t* signal = recvTokenNums + destPe;
+      index_t recvTokenNum = shmem::ShmemInt32WaitUntilGreaterThan(signal, 0) - 1;
+      core::AtomicStoreRelaxedSystem(signal, 0);
+      atomicAdd(args.totalRecvTokenNum, recvTokenNum);
+
+      // reset local counter
+      args.destPeTokenCounter[destPe] = 0;
+    }
+
+    // reset counter
+    if (laneId == 0) {
+      args.dispTokOffsetMemObj->template GetAs<index_t*>()[0] = 0;
+    }
+  }
+
+#ifdef ENABLE_STANDARD_MOE_ADAPT
+  if constexpr (EnableStdMoE) {
+    InvokeConvertDispatchOutput<T>(args, myPe);
+  }
+#endif
+}
+
+template <typename T, bool EnableStdMoE = false, int block_threads = 512, int grid_blocks = 1>
+__global__ void __launch_bounds__(block_threads, grid_blocks)
     EpDispatchIntraNodeKernel(EpDispatchCombineArgs<T> args) {
   EpDispatchIntraNodeKernel_body<T, EnableStdMoE>(args);
 }

--- a/src/ops/dispatch_combine/intranode.hpp
+++ b/src/ops/dispatch_combine/intranode.hpp
@@ -260,7 +260,9 @@ __device__ void EpDispatchIntraNodeLLKernel_body(EpDispatchCombineArgs<T> args) 
   size_t warpDimOffset = (size_t)inGroupWarpId * dimPerWarp;
   size_t warpDimChunk =
       (warpDimOffset < hiddenDim) ? min(hiddenDim - warpDimOffset, dimPerWarp) : 0;
-  assert(warpDimChunk > 0 && "warpDimChunk must be > 0 for warpgroups to be useful");
+  assert(!(warpNum % kWarpsPerGroup) && warpDimChunk > 0 &&
+         "total num of warps must be divisible by the num of warpgroups,
+         warpDimChunk must be > 0 for warpgroups to be useful");
 
   IF_ENABLE_PROFILER(
       INTRANODE_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));

--- a/src/ops/dispatch_combine/intranode.hpp
+++ b/src/ops/dispatch_combine/intranode.hpp
@@ -165,8 +165,8 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
       size_t srcTokOffset = srcTokId * hiddenDim;
       size_t destTokOffset = destTokId * hiddenDim;
 
-      core::WarpCopy(args.intraNodeTokBufs.dispatchOut->template GetAs<T*>(destPe) + destTokOffset,
-                     args.inpTokenBuf + srcTokOffset, hiddenDim);
+      core::WarpCopy<T, 2>(args.intraNodeTokBufs.dispatchOut->template GetAs<T*>(destPe) + destTokOffset,
+                           args.inpTokenBuf + srcTokOffset, hiddenDim);
     }
   }
   __syncthreads();
@@ -216,8 +216,9 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
 #endif
 }
 
-template <typename T, bool EnableStdMoE = false>
-__global__ void EpDispatchIntraNodeKernel(EpDispatchCombineArgs<T> args) {
+template <typename T, bool EnableStdMoE = false, int threads = 512, int blocks = 1>
+__global__ void __launch_bounds__(threads, blocks)
+    EpDispatchIntraNodeKernel(EpDispatchCombineArgs<T> args) {
   EpDispatchIntraNodeKernel_body<T, EnableStdMoE>(args);
 }
 

--- a/src/ops/dispatch_combine/intranode.hpp
+++ b/src/ops/dispatch_combine/intranode.hpp
@@ -260,9 +260,9 @@ __device__ void EpDispatchIntraNodeLLKernel_body(EpDispatchCombineArgs<T> args) 
   size_t warpDimOffset = (size_t)inGroupWarpId * dimPerWarp;
   size_t warpDimChunk =
       (warpDimOffset < hiddenDim) ? min(hiddenDim - warpDimOffset, dimPerWarp) : 0;
-  assert(!(warpNum % kWarpsPerGroup) && warpDimChunk > 0 &&
-         "total num of warps must be divisible by the num of warpgroups,
-         warpDimChunk must be > 0 for warpgroups to be useful");
+  assert((warpNum % kWarpsPerGroup == 0) && (warpDimChunk > 0) &&
+         "total num of warps must be divisible by the num of warpgroups, "
+         "warpDimChunk must be > 0 for warpgroups to be useful");
 
   IF_ENABLE_PROFILER(
       INTRANODE_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));

--- a/src/ops/dispatch_combine/intranode.hpp
+++ b/src/ops/dispatch_combine/intranode.hpp
@@ -96,6 +96,7 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   int myPe = config.rank;
   int npes = config.worldSize;
   size_t hiddenDim = config.HiddenDimSz();
+  const bool hasScales = args.scalesBuf && (config.scaleDim > 0) && (config.scaleTypeSize > 0);
 
   IF_ENABLE_PROFILER(
       INTRANODE_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
@@ -141,6 +142,13 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
       }
       destTokId = __shfl(destTokId, 0);
 
+      size_t srcTokOffset = srcTokId * hiddenDim;
+      size_t destTokOffset = destTokId * hiddenDim;
+
+      core::WarpCopy<T, 2>(
+          args.intraNodeTokBufs.dispatchOut->template GetAs<T*>(destPe) + destTokOffset,
+          args.inpTokenBuf + srcTokOffset, hiddenDim);
+
       // Write weights and indices
       if (laneId < config.numExpertPerToken) {
         if (args.weightsBuf) {
@@ -154,19 +162,13 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
       }
 
       // Write scales
-      if (args.scalesBuf && (config.scaleDim > 0) && (config.scaleTypeSize > 0)) {
+      if (hasScales) {
         size_t destScaleOffset = (size_t)destTokId * config.scaleDim * config.scaleTypeSize;
         size_t srcScaleOffset = (size_t)srcTokId * config.scaleDim * config.scaleTypeSize;
         core::WarpCopy(
             args.shmemOutScalesMemObj->template GetAs<uint8_t*>(destPe) + destScaleOffset,
             args.scalesBuf + srcScaleOffset, config.scaleDim * config.scaleTypeSize);
       }
-
-      size_t srcTokOffset = srcTokId * hiddenDim;
-      size_t destTokOffset = destTokId * hiddenDim;
-
-      core::WarpCopy<T, 2>(args.intraNodeTokBufs.dispatchOut->template GetAs<T*>(destPe) + destTokOffset,
-                           args.inpTokenBuf + srcTokOffset, hiddenDim);
     }
   }
   __syncthreads();

--- a/src/ops/dispatch_combine/intranode.hpp
+++ b/src/ops/dispatch_combine/intranode.hpp
@@ -80,7 +80,9 @@ inline __device__ void CrossDeviceBarrierIntraNodeKernel(EpDispatchCombineArgs<T
 /*                                    EpDispatchIntraNodeKernel                                   */
 /* ---------------------------------------------------------------------------------------------- */
 
-/*
+#define ENABLE_DISPATCH_WARPGROUP
+
+#if !defined(ENABLE_DISPATCH_WARPGROUP)
 template <typename T, bool EnableStdMoE = false>
 __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   const EpDispatchCombineConfig& config = args.config;
@@ -98,7 +100,6 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   int myPe = config.rank;
   int npes = config.worldSize;
   size_t hiddenDim = config.HiddenDimSz();
-  const bool hasScales = args.scalesBuf && (config.scaleDim > 0) && (config.scaleTypeSize > 0);
 
   IF_ENABLE_PROFILER(
       INTRANODE_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
@@ -144,13 +145,6 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
       }
       destTokId = __shfl(destTokId, 0);
 
-      size_t srcTokOffset = srcTokId * hiddenDim;
-      size_t destTokOffset = destTokId * hiddenDim;
-
-      core::WarpCopy<T, 2>(
-          args.intraNodeTokBufs.dispatchOut->template GetAs<T*>(destPe) + destTokOffset,
-          args.inpTokenBuf + srcTokOffset, hiddenDim);
-
       // Write weights and indices
       if (laneId < config.numExpertPerToken) {
         if (args.weightsBuf) {
@@ -164,13 +158,19 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
       }
 
       // Write scales
-      if (hasScales) {
+      if (args.scalesBuf && (config.scaleDim > 0) && (config.scaleTypeSize > 0)) {
         size_t destScaleOffset = (size_t)destTokId * config.scaleDim * config.scaleTypeSize;
         size_t srcScaleOffset = (size_t)srcTokId * config.scaleDim * config.scaleTypeSize;
         core::WarpCopy(
             args.shmemOutScalesMemObj->template GetAs<uint8_t*>(destPe) + destScaleOffset,
             args.scalesBuf + srcScaleOffset, config.scaleDim * config.scaleTypeSize);
       }
+
+      size_t srcTokOffset = srcTokId * hiddenDim;
+      size_t destTokOffset = destTokId * hiddenDim;
+
+      core::WarpCopy(args.intraNodeTokBufs.dispatchOut->template GetAs<T*>(destPe) + destTokOffset,
+                     args.inpTokenBuf + srcTokOffset, hiddenDim);
     }
   }
   __syncthreads();
@@ -219,8 +219,7 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   }
 #endif
 }
-*/
-
+#else
 template <typename T, bool EnableStdMoE = false>
 __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   const EpDispatchCombineConfig& config = args.config;
@@ -240,7 +239,7 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   size_t hiddenDim = config.HiddenDimSz();
   const bool hasScales = args.scalesBuf && (config.scaleDim > 0) && (config.scaleTypeSize > 0);
 
-  // Warp-group coordination: 4 warps per group
+  // Warp-group coordination: 2 warps per group
   constexpr int kWarpsPerGroup = 2;
   constexpr int kMaxWarpGroups = 8;
 
@@ -248,7 +247,7 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   __shared__ int groupCounters[kMaxWarpGroups];   // consume counter
 
   int warpGroupIdInBlock = warpId / kWarpsPerGroup;
-  int inGroupWarpId = warpId % kWarpsPerGroup;  // 0-3
+  int inGroupWarpId = warpId % kWarpsPerGroup;
   int warpGroupId = globalWarpId / kWarpsPerGroup;
   int warpGroupNum = globalWarpNum / kWarpsPerGroup;
 
@@ -281,6 +280,9 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
       index_t destPe = destExpert / config.numExpertPerRank;
       index_t destTokId = 0;
 
+      // prefetch remote addr
+      auto dispTokOffset = args.dispTokOffsetMemObj->template GetAs<index_t*>(destPe);
+
       // ALL warps in warp-group do dedup independently (same input = same result)
       assert(config.numExpertPerToken < warpSize);
       int condition = 0;
@@ -296,26 +298,30 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
         continue;
       }
 
+      // prefetch remote addr
+      auto dispatchOut = args.intraNodeTokBufs.dispatchOut->template GetAs<T*>(destPe);
+
       // Header Warp: atomic allocation + notify via shared memory
       if (inGroupWarpId == 0) {
         if (laneId == 0) {
           // Atomic allocation
-          destTokId = atomicAdd(args.dispTokOffsetMemObj->template GetAs<index_t*>(destPe), 1);
+          destTokId = atomicAdd(dispTokOffset, 1);
           assert(destTokId < config.MaxNumTokensToRecv() &&
                  "Total recv token overflow: increase maxTotalRecvTokens");
-          atomicAdd(args.destPeTokenCounter + destPe, 1);
-          args.dispDestTokIdMap[i] = FlatTokenIndex(config, destPe, destTokId);
-          args.dispTokIdToSrcTokIdMemObj->template GetAs<index_t*>(destPe)[destTokId] =
-              FlatTokenIndex(config, myPe, srcTokId);
 
           // Wait for all consumers done (counter == N-1), then set to 0
           while (atomicCAS(&groupCounters[warpGroupIdInBlock], kWarpsPerGroup - 1, 0) !=
                  kWarpsPerGroup - 1) {
           }
-
           // Write to shared mem: use (i+1) to avoid confusion with initial value 0
-          atomicExch((unsigned long long*)&groupData[warpGroupIdInBlock],
-                     ((uint64_t)(i + 1) << 32) | (uint32_t)destTokId);
+          __hip_atomic_store((unsigned long long*)&groupData[warpGroupIdInBlock],
+                             ((uint64_t)(i + 1) << 32) | (uint32_t)destTokId, __ATOMIC_RELAXED,
+                             __HIP_MEMORY_SCOPE_WORKGROUP);
+
+          atomicAdd(args.destPeTokenCounter + destPe, 1);
+          args.dispDestTokIdMap[i] = FlatTokenIndex(config, destPe, destTokId);
+          args.dispTokIdToSrcTokIdMemObj->template GetAs<index_t*>(destPe)[destTokId] =
+              FlatTokenIndex(config, myPe, srcTokId);
         }
         destTokId = __shfl(destTokId, 0);
 
@@ -336,10 +342,9 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
         if (laneId == 0) {
           uint64_t val;
           do {
-            __builtin_amdgcn_s_sleep(4);
             val = __hip_atomic_load(
                 reinterpret_cast<unsigned long long*>(&groupData[warpGroupIdInBlock]),
-                __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_WORKGROUP);
+                __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_WORKGROUP);
           } while ((val >> 32) != (uint32_t)(i + 1));
           atomicAdd(&groupCounters[warpGroupIdInBlock], 1);
           destTokId = (index_t)(val & 0xFFFFFFFF);
@@ -352,8 +357,7 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
       size_t srcTokOffset = srcTokId * hiddenDim;
       size_t destTokOffset = destTokId * hiddenDim;
 
-      core::WarpCopy<T, 2>(args.intraNodeTokBufs.dispatchOut->template GetAs<T*>(destPe) +
-                               destTokOffset + warpDimOffset,
+      core::WarpCopy<T, 2>(dispatchOut + destTokOffset + warpDimOffset,
                            args.inpTokenBuf + srcTokOffset + warpDimOffset, warpDimChunk);
 
       // Write scales: split across 4 warps
@@ -419,6 +423,7 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   }
 #endif
 }
+#endif
 
 template <typename T, bool EnableStdMoE = false, int block_threads = 512, int grid_blocks = 1>
 __global__ void __launch_bounds__(block_threads, grid_blocks)

--- a/src/ops/kernels/ep_intranode.hip
+++ b/src/ops/kernels/ep_intranode.hip
@@ -6,6 +6,9 @@ MORI_DEFINE_GPU_STATES
 WRAP_ALL_TYPES_BOOL(EpDispatchIntraNodeKernel, , false)
 WRAP_ALL_TYPES_BOOL(EpDispatchIntraNodeKernel, _stdmoe, true)
 
+// Dispatch Low Lantency (SMALL TOKEN)
+WRAP_ALL_TYPES_BOOL(EpDispatchIntraNodeLLKernel, , false)
+
 // Combine
 WRAP_ALL_TYPES_BOOL3(EpCombineIntraNodeKernel, _p2p, true, false, false)
 WRAP_ALL_TYPES_BOOL3(EpCombineIntraNodeKernel, _nop2p, false, false, false)

--- a/src/ops/kernels/ep_intranode.hip
+++ b/src/ops/kernels/ep_intranode.hip
@@ -8,6 +8,7 @@ WRAP_ALL_TYPES_BOOL(EpDispatchIntraNodeKernel, _stdmoe, true)
 
 // Dispatch Low Lantency (SMALL TOKEN)
 WRAP_ALL_TYPES_BOOL(EpDispatchIntraNodeLLKernel, , false)
+WRAP_ALL_TYPES_BOOL(EpDispatchIntraNodeLLKernel, _stdmoe, false)
 
 // Combine
 WRAP_ALL_TYPES_BOOL3(EpCombineIntraNodeKernel, _p2p, true, false, false)

--- a/src/ops/kernels/ep_intranode.hip
+++ b/src/ops/kernels/ep_intranode.hip
@@ -8,7 +8,7 @@ WRAP_ALL_TYPES_BOOL(EpDispatchIntraNodeKernel, _stdmoe, true)
 
 // Dispatch Low Lantency (SMALL TOKEN)
 WRAP_ALL_TYPES_BOOL(EpDispatchIntraNodeLLKernel, , false)
-WRAP_ALL_TYPES_BOOL(EpDispatchIntraNodeLLKernel, _stdmoe, false)
+WRAP_ALL_TYPES_BOOL(EpDispatchIntraNodeLLKernel, _stdmoe, true)
 
 // Combine
 WRAP_ALL_TYPES_BOOL3(EpCombineIntraNodeKernel, _p2p, true, false, false)

--- a/src/pybind/pybind_ops.cpp
+++ b/src/pybind/pybind_ops.cpp
@@ -305,6 +305,7 @@ namespace mori {
 void RegisterMoriOps(py::module_& m) {
   pybind11::enum_<mori::moe::KernelType>(m, "EpDispatchCombineKernelType")
       .value("IntraNode", mori::moe::KernelType::IntraNode)
+      .value("IntraNodeLL", mori::moe::KernelType::IntraNodeLL)
       .value("InterNode", mori::moe::KernelType::InterNode)
       .value("InterNodeV1", mori::moe::KernelType::InterNodeV1)
       .value("InterNodeV1LL", mori::moe::KernelType::InterNodeV1LL)

--- a/tests/python/ops/test_dispatch_combine_intranode.py
+++ b/tests/python/ops/test_dispatch_combine_intranode.py
@@ -45,6 +45,7 @@ def _make_intranode_config(
     scale_type_size=1,
     max_total_recv_tokens=0,
     quant_type="none",
+    kernel_type=mori.ops.EpDispatchCombineKernelType.IntraNode,
 ):
     return mori.ops.EpDispatchCombineConfig(
         data_type=data_type,
@@ -60,7 +61,7 @@ def _make_intranode_config(
         block_num=64,
         warp_num_per_block=4,
         use_external_inp_buf=use_external_inp_buf,
-        kernel_type=mori.ops.EpDispatchCombineKernelType.IntraNode,
+        kernel_type=kernel_type,
         max_total_recv_tokens=max_total_recv_tokens,
         quant_type=quant_type,
     )
@@ -96,6 +97,48 @@ def _test_dispatch_combine(
         scale_type_size=scale_type_size,
         quant_type=quant_type,
         max_total_recv_tokens=max_total_recv_tokens,
+        kernel_type=mori.ops.EpDispatchCombineKernelType.IntraNode,
+    )
+    run_ep_dispatch_combine_test(
+        config,
+        EpDispatchCombineTestCase,
+        use_max_token_num=use_max_token_num,
+        routing=routing,
+        check_results=check_results,
+    )
+
+
+def _test_dispatch_combine_ll(
+    rank,
+    world_size,
+    data_type,
+    hidden_dim,
+    max_num_inp_token_per_rank,
+    num_experts_per_rank,
+    num_experts_per_token,
+    use_external_inp_buf,
+    scale_dim=0,
+    scale_type_size=1,
+    quant_type="none",
+    max_total_recv_tokens=0,
+    routing=None,
+    use_max_token_num=False,
+    check_results=True,
+):
+    config = _make_intranode_config(
+        rank=rank,
+        world_size=world_size,
+        data_type=data_type,
+        hidden_dim=hidden_dim,
+        max_num_inp_token_per_rank=max_num_inp_token_per_rank,
+        num_experts_per_rank=num_experts_per_rank,
+        num_experts_per_token=num_experts_per_token,
+        use_external_inp_buf=use_external_inp_buf,
+        scale_dim=scale_dim,
+        scale_type_size=scale_type_size,
+        quant_type=quant_type,
+        max_total_recv_tokens=max_total_recv_tokens,
+        kernel_type=mori.ops.EpDispatchCombineKernelType.IntraNodeLL,
     )
     run_ep_dispatch_combine_test(
         config,
@@ -147,6 +190,64 @@ def test_dispatch_combine(
         torch_dist_process_manager.task_queue.put(
             (
                 _test_dispatch_combine,
+                [
+                    world_size,
+                    data_type,
+                    hidden_dim,
+                    max_num_inp_token_per_rank,
+                    num_experts_per_rank,
+                    num_experts_per_token,
+                    use_external_inp_buf,
+                    scale_dim,
+                    scale_type_size,
+                    quant_type,
+                ],
+            )
+        )
+
+    assert_worker_results(torch_dist_process_manager, world_size)
+
+
+@pytest.mark.parametrize("world_size", (8,))
+@pytest.mark.parametrize("data_type", _all_data_types())
+@pytest.mark.parametrize("hidden_dim", (7168, 4096))
+@pytest.mark.parametrize("scale_dim", (0, 32))
+@pytest.mark.parametrize("scale_type_size", (1, 4))
+@pytest.mark.parametrize("max_num_inp_token_per_rank", (1, 64))
+@pytest.mark.parametrize("num_experts_per_rank", (32,))
+@pytest.mark.parametrize("num_experts_per_token", (8,))
+@pytest.mark.parametrize("use_external_inp_buf", (True, False))
+@pytest.mark.parametrize("quant_type", ("none", "fp8_direct_cast", "fp8_blockwise"))
+def test_dispatch_combine_ll(
+    torch_dist_process_manager,
+    world_size,
+    data_type,
+    hidden_dim,
+    scale_dim,
+    scale_type_size,
+    max_num_inp_token_per_rank,
+    num_experts_per_rank,
+    num_experts_per_token,
+    use_external_inp_buf,
+    quant_type,
+):
+    # fp8_direct_cast is not supported in zero-copy mode (use_external_inp_buf=False)
+    if quant_type == "fp8_direct_cast" and not use_external_inp_buf:
+        pytest.skip("fp8_direct_cast is not supported in zero-copy mode")
+    if quant_type == "fp8_direct_cast" and data_type is not torch.bfloat16:
+        pytest.skip("fp8_direct_cast is only supported for bfloat16 data type")
+    if quant_type == "fp8_blockwise":
+        if data_type is not torch.bfloat16:
+            pytest.skip("fp8_blockwise only supports bfloat16 input")
+        if not use_external_inp_buf:
+            pytest.skip("fp8_blockwise requires use_external_inp_buf=True")
+        # fp8_blockwise combine ignores scale_dim/scale_type_size (driven by
+        # MORI_FP8_COMBINE_SCALE_DIM internally).
+
+    for i in range(world_size):
+        torch_dist_process_manager.task_queue.put(
+            (
+                _test_dispatch_combine_ll,
                 [
                     world_size,
                     data_type,


### PR DESCRIPTION
This PR introduces a warp-group optimization to the IntraNode dispatch kernel (`src/ops/dispatch_combine/intranode.hpp`), enabling multiple warps to cooperatively process each token-expert pair for improved memory bandwidth utilization within small token condition.

 ### Usage

  To use the IntraNodeLL kernel, specify `kernel_type=IntraNodeLL` when creating the config:

  ```python
  import mori
  import torch

  config = mori.ops.EpDispatchCombineConfig(
      data_type=torch.bfloat16,
      rank=rank,
      world_size=8,
      hidden_dim=7168,
      max_num_inp_token_per_rank=64,
      num_experts_per_rank=32,
      num_experts_per_token=8,
      block_num=64,
      warp_num_per_block=4,
      use_external_inp_buf=True,
      kernel_type=mori.ops.EpDispatchCombineKernelType.IntraNodeLL,
  )

  op = mori.ops.EpDispatchCombineOp(config)

  # Dispatch and combine work the same as IntraNode
  dispatch_output, ... = op.dispatch(input_tensor, weights, indices, ...)
  combine_output, ... = op.combine(combine_input, weights, ...)
  ```

### Dispatch Latency  (MI355X, TOPK8, EP8, BF16)

| block_num | topk | max_token | Baseline(us) | Current(us) | Speedup |
|-----------|------|-----------|----------|------------|---------|
| 4        | 8    | 1        |    18.6      |    15.8        |   +15.08%      |
| 32        | 8    | 32       |    23.8      |   19.16          |   +19.4%      |
| 64        | 8    | 64       |    28.12      |     24.04       |   +14.6%      |

### Test Plan

- [x] test_dispatch_combine_ll passes for quant_type=none
- [x] test_dispatch_combine_ll passes for quant_type=fp8_direct_cast
- [x] test_dispatch_combine_ll passes for quant_type=fp8_blockwise