### PR TITLE
ci: use next patch version for nightly dev builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,10 +46,11 @@ jobs:
       - name: Build wheels
         run: |
           BASE_VER=$(git describe --tags --abbrev=0 | sed 's/^v//')
+          NEXT_VER=$(echo "$BASE_VER" | awk -F. '{$NF=$NF+1; print}' OFS=.)
           DATE=$(date +%Y%m%d)
           SHA=$(git rev-parse --short HEAD)
-          GH_VERSION="${BASE_VER}.dev${DATE}+${SHA}"
-          PYPI_VERSION="${BASE_VER}.dev${DATE}"
+          GH_VERSION="${NEXT_VER}.dev${DATE}+${SHA}"
+          PYPI_VERSION="${NEXT_VER}.dev${DATE}"
 
           $CT run --rm --network=host \
             -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE -w $GITHUB_WORKSPACE \


### PR DESCRIPTION
## Summary

- Nightly version bumped from `1.1.1.dev*` to `1.1.2.dev*`
- `1.1.1` is already released, nightly should be the next version's dev build
- Automatic: derives from latest git tag and increments patch number

Made with [Cursor](https://cursor.com)