### PR TITLE
Adding missing include for anvil.cpp and fixing SIOF issue

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -140,3 +140,30 @@ add_shmem_example(ibverbs_test SOURCES application/ibverbs_test.cpp)
 
 add_executable(test_vmm_mpi_write utils/test_vmm_mpi_write.cpp)
 target_link_libraries(test_vmm_mpi_write mori_application hip::host hip::device)
+
+# ============================================================================
+# Static-link SIOF reproducer for mori_shmem's GpuStatesAddrProvider registry
+# ============================================================================
+add_library(mori_shmem_for_siof_static STATIC
+            ${CMAKE_SOURCE_DIR}/src/shmem/init.cpp
+            ${CMAKE_SOURCE_DIR}/src/shmem/runtime.cpp
+            ${CMAKE_SOURCE_DIR}/src/shmem/memory.cpp)
+target_include_directories(mori_shmem_for_siof_static
+                           PUBLIC ${CMAKE_SOURCE_DIR}/include
+                                  ${CMAKE_SOURCE_DIR})
+target_link_libraries(mori_shmem_for_siof_static
+                      PUBLIC mori_application mori_logging ibverbs hip::host)
+
+add_executable(static_link_siof_test shmem/static_link_siof_test.cpp)
+
+# Test source is HIP — shmem.hpp's static_init block is gated on
+# __HIPCC__ / __HIP__ / __CUDACC__ and emits the `_s_gpuStatesRegistrar`
+# only when compiled as device code.
+set_source_files_properties(shmem/static_link_siof_test.cpp
+                            PROPERTIES LANGUAGE HIP)
+
+target_link_libraries(static_link_siof_test
+                      -Wl,--whole-archive
+                      mori_shmem_for_siof_static
+                      -Wl,--no-whole-archive
+                      hip::host)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -144,26 +144,25 @@ target_link_libraries(test_vmm_mpi_write mori_application hip::host hip::device)
 # ============================================================================
 # Static-link SIOF reproducer for mori_shmem's GpuStatesAddrProvider registry
 # ============================================================================
-add_library(mori_shmem_for_siof_static STATIC
-            ${CMAKE_SOURCE_DIR}/src/shmem/init.cpp
-            ${CMAKE_SOURCE_DIR}/src/shmem/runtime.cpp
-            ${CMAKE_SOURCE_DIR}/src/shmem/memory.cpp)
-target_include_directories(mori_shmem_for_siof_static
-                           PUBLIC ${CMAKE_SOURCE_DIR}/include
-                                  ${CMAKE_SOURCE_DIR})
+add_library(
+  mori_shmem_for_siof_static STATIC
+  ${CMAKE_SOURCE_DIR}/src/shmem/init.cpp
+  ${CMAKE_SOURCE_DIR}/src/shmem/runtime.cpp
+  ${CMAKE_SOURCE_DIR}/src/shmem/memory.cpp)
+target_include_directories(
+  mori_shmem_for_siof_static PUBLIC ${CMAKE_SOURCE_DIR}/include
+                                    ${CMAKE_SOURCE_DIR})
 target_link_libraries(mori_shmem_for_siof_static
                       PUBLIC mori_application mori_logging ibverbs hip::host)
 
 add_executable(static_link_siof_test shmem/static_link_siof_test.cpp)
 
-# Test source is HIP — shmem.hpp's static_init block is gated on
-# __HIPCC__ / __HIP__ / __CUDACC__ and emits the `_s_gpuStatesRegistrar`
-# only when compiled as device code.
-set_source_files_properties(shmem/static_link_siof_test.cpp
-                            PROPERTIES LANGUAGE HIP)
+# Test source is HIP — shmem.hpp's static_init block is gated on __HIPCC__ /
+# __HIP__ / __CUDACC__ and emits the `_s_gpuStatesRegistrar` only when compiled
+# as device code.
+set_source_files_properties(shmem/static_link_siof_test.cpp PROPERTIES LANGUAGE
+                                                                       HIP)
 
-target_link_libraries(static_link_siof_test
-                      -Wl,--whole-archive
-                      mori_shmem_for_siof_static
-                      -Wl,--no-whole-archive
-                      hip::host)
+target_link_libraries(
+  static_link_siof_test -Wl,--whole-archive mori_shmem_for_siof_static
+  -Wl,--no-whole-archive hip::host)

--- a/examples/shmem/static_link_siof_test.cpp
+++ b/examples/shmem/static_link_siof_test.cpp
@@ -41,7 +41,7 @@
 // `src/shmem/runtime.cpp`. Always safe to call; returns 0 if no consumer has
 // registered yet.
 namespace mori::shmem {
-  size_t GetGpuStatesAddrProviderCount();
+size_t GetGpuStatesAddrProviderCount();
 }
 
 int main(int /*argc*/, char* /*argv*/[]) {
@@ -49,8 +49,7 @@ int main(int /*argc*/, char* /*argv*/[]) {
 
   // Address of the registrar emitted in *this* TU. Printing it confirms the
   // static-init block was compiled (i.e. the file was processed as HIP).
-  fprintf(stderr,
-          "[SIOF-TEST] this TU's _s_gpuStatesRegistrar = %p (ctor should have run)\n",
+  fprintf(stderr, "[SIOF-TEST] this TU's _s_gpuStatesRegistrar = %p (ctor should have run)\n",
           static_cast<const void*>(&mori::shmem::_static_init::_s_gpuStatesRegistrar));
 
   const size_t count = mori::shmem::GetGpuStatesAddrProviderCount();
@@ -75,8 +74,7 @@ int main(int /*argc*/, char* /*argv*/[]) {
     return 1;
   }
 
-  fprintf(stderr,
-          "\n[SIOF-TEST] PASS: registry contains %zu provider(s); SIOF not present.\n",
+  fprintf(stderr, "\n[SIOF-TEST] PASS: registry contains %zu provider(s); SIOF not present.\n",
           count);
   return 0;
 }

--- a/examples/shmem/static_link_siof_test.cpp
+++ b/examples/shmem/static_link_siof_test.cpp
@@ -1,0 +1,82 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// ============================================================================
+// Static-link SIOF reproducer for mori_shmem's GpuStatesAddrProvider registry.
+// ============================================================================
+
+#include <cstdio>
+#include <cstdlib>
+
+// Pulls in `__device__ globalGpuStates`, `_getGpuStatesAddr`, and
+// `_s_gpuStatesRegistrar` from the static-init block at shmem.hpp:62-76.
+// Must be compiled as HIP (the static-init block is gated on __HIPCC__ /
+// __HIP__ / __CUDACC__) — see the LANGUAGE HIP property on this source file
+// in examples/CMakeLists.txt.
+#include "mori/shmem/shmem.hpp"
+
+// Diagnostic accessor for the GpuStates addr-provider registry. Used by
+// examples/shmem/static_link_siof_test.cpp to detect a Static Initialization
+// Order Fiasco between user-TU `_s_gpuStatesRegistrar` ctors (emitted by
+// `mori/shmem/shmem.hpp`) and the registry's own backing storage in
+// `src/shmem/runtime.cpp`. Always safe to call; returns 0 if no consumer has
+// registered yet.
+namespace mori::shmem {
+  size_t GetGpuStatesAddrProviderCount();
+}
+
+int main(int /*argc*/, char* /*argv*/[]) {
+  fprintf(stderr, "[SIOF-TEST] static_link_siof_test starting\n");
+
+  // Address of the registrar emitted in *this* TU. Printing it confirms the
+  // static-init block was compiled (i.e. the file was processed as HIP).
+  fprintf(stderr,
+          "[SIOF-TEST] this TU's _s_gpuStatesRegistrar = %p (ctor should have run)\n",
+          static_cast<const void*>(&mori::shmem::_static_init::_s_gpuStatesRegistrar));
+
+  const size_t count = mori::shmem::GetGpuStatesAddrProviderCount();
+  fprintf(stderr, "[SIOF-TEST] GpuStatesAddrProvider registry size = %zu\n", count);
+
+  if (count == 0) {
+    fprintf(stderr, "\n");
+    fprintf(stderr, "[SIOF-TEST] FAIL: registry is empty.\n");
+    fprintf(stderr, "\n");
+    fprintf(stderr,
+            "  This TU's `_s_gpuStatesRegistrar` ctor either did not run, or ran\n"
+            "  BEFORE the registry's std::vector ctor in runtime.cpp and its push\n"
+            "  was silently erased — the classic Static Initialization Order Fiasco.\n"
+            "\n"
+            "  Downstream symptom: `CopyGpuStatesToDevice` iterates an empty list,\n"
+            "  never populates device-side `globalGpuStates`, and the first kernel\n"
+            "  that dereferences its fields faults with GPU illegal memory access.\n"
+            "\n"
+            "  Fix: wrap the registry in a Meyer's singleton in src/shmem/runtime.cpp\n"
+            "  (`GpuStatesProviders()` function-local static). See the header comment\n"
+            "  of this file for the full chain.\n");
+    return 1;
+  }
+
+  fprintf(stderr,
+          "\n[SIOF-TEST] PASS: registry contains %zu provider(s); SIOF not present.\n",
+          count);
+  return 0;
+}

--- a/src/application/transport/sdma/anvil.cpp
+++ b/src/application/transport/sdma/anvil.cpp
@@ -29,9 +29,9 @@
 
 #include "mori/application/transport/sdma/anvil.hpp"
 
+#include <cstring>
 #include <fstream>
 #include <iostream>
-
 namespace anvil {
 
 auto checkHsaError = [](hsa_status_t s, const char* msg, const char* file, int line) {

--- a/src/shmem/runtime.cpp
+++ b/src/shmem/runtime.cpp
@@ -50,14 +50,14 @@ using GpuStatesAddrProvider = void* (*)();
 static std::vector<GpuStatesAddrProvider> s_gpuStatesAddrProviders;
 #endif
 namespace {
-  std::vector<GpuStatesAddrProvider>& GpuStatesProviders() {
+std::vector<GpuStatesAddrProvider>& GpuStatesProviders() {
 #if USE_SINGLETON
-    static std::vector<GpuStatesAddrProvider> instance;   // initialized on first use
-    return instance;
+  static std::vector<GpuStatesAddrProvider> instance;  // initialized on first use
+  return instance;
 #else
-    return s_gpuStatesAddrProviders;
+  return s_gpuStatesAddrProviders;
 #endif
-  }
+}
 }  // namespace
 
 using BarrierLauncher = void (*)(hipStream_t);

--- a/src/shmem/runtime.cpp
+++ b/src/shmem/runtime.cpp
@@ -122,7 +122,6 @@ void FinalizeRuntime(ShmemStates* states) {
     ms.barrierFunc = nullptr;
   }
   states->gpuStates = {};
-  GpuStatesProviders().clear();
 }
 
 /* ---------------------------------------------------------------------------------------------- */

--- a/src/shmem/runtime.cpp
+++ b/src/shmem/runtime.cpp
@@ -43,20 +43,11 @@ namespace shmem {
 
 using GpuStatesAddrProvider = void* (*)();
 
-// Use Meyer's singleton for the GpuStatesAddrProvider registry
-#define USE_SINGLETON 1
-
-#if !USE_SINGLETON
-static std::vector<GpuStatesAddrProvider> s_gpuStatesAddrProviders;
-#endif
 namespace {
+// Meyer's singleton: initialized on first use, avoiding static-init order fiasco
 std::vector<GpuStatesAddrProvider>& GpuStatesProviders() {
-#if USE_SINGLETON
-  static std::vector<GpuStatesAddrProvider> instance;  // initialized on first use
+  static std::vector<GpuStatesAddrProvider> instance;
   return instance;
-#else
-  return s_gpuStatesAddrProviders;
-#endif
 }
 }  // namespace
 

--- a/src/shmem/runtime.cpp
+++ b/src/shmem/runtime.cpp
@@ -42,18 +42,27 @@ namespace shmem {
 /* ---------------------------------------------------------------------------------------------- */
 
 using GpuStatesAddrProvider = void* (*)();
-// One entry per RegisterGpuStatesAddrProvider (e.g. multiple HIP TUs + modules).
-// Single-pointer storage would drop earlier registrations. See shmem.hpp policy.
-static std::vector<GpuStatesAddrProvider> s_gpuStatesAddrProviders;
+
+// static std::vector<GpuStatesAddrProvider> s_gpuStatesAddrProviders;
+
+namespace {
+  std::vector<GpuStatesAddrProvider>& GpuStatesProviders() {
+    static std::vector<GpuStatesAddrProvider> instance;   // initialized on first use
+    return instance;
+    // return s_gpuStatesAddrProviders;
+  }
+}  // namespace
 
 using BarrierLauncher = void (*)(hipStream_t);
 static BarrierLauncher s_staticBarrierLauncher = nullptr;
 
 void RegisterGpuStatesAddrProvider(GpuStatesAddrProvider provider) {
-  s_gpuStatesAddrProviders.push_back(provider);
+  GpuStatesProviders().push_back(provider);
 }
 
 void RegisterBarrierLauncher(BarrierLauncher launcher) { s_staticBarrierLauncher = launcher; }
+
+size_t GetGpuStatesAddrProviderCount() { return GpuStatesProviders().size(); }
 
 int LoadShmemModule(const char* hsaco_path) {
   ShmemStates* states = ShmemStatesSingleton::GetInstance();
@@ -94,7 +103,7 @@ void CopyGpuStatesToDevice(ShmemStates* states) {
         hipMemcpy(ms.gpuStatesPtr, gpuStates, sizeof(GpuStates), hipMemcpyHostToDevice));
   }
 
-  for (auto& provider : s_gpuStatesAddrProviders) {
+  for (auto& provider : GpuStatesProviders()) {
     void* staticAddr = provider();
     if (staticAddr != nullptr) {
       MORI_SHMEM_TRACE("Copying GpuStates to static globalGpuStates ({:p})", staticAddr);
@@ -115,6 +124,7 @@ void FinalizeRuntime(ShmemStates* states) {
     ms.barrierFunc = nullptr;
   }
   states->gpuStates = {};
+  GpuStatesProviders().clear();
 }
 
 /* ---------------------------------------------------------------------------------------------- */

--- a/src/shmem/runtime.cpp
+++ b/src/shmem/runtime.cpp
@@ -43,13 +43,20 @@ namespace shmem {
 
 using GpuStatesAddrProvider = void* (*)();
 
-// static std::vector<GpuStatesAddrProvider> s_gpuStatesAddrProviders;
+// Use Meyer's singleton for the GpuStatesAddrProvider registry
+#define USE_SINGLETON 1
 
+#if !USE_SINGLETON
+static std::vector<GpuStatesAddrProvider> s_gpuStatesAddrProviders;
+#endif
 namespace {
   std::vector<GpuStatesAddrProvider>& GpuStatesProviders() {
+#if USE_SINGLETON
     static std::vector<GpuStatesAddrProvider> instance;   // initialized on first use
     return instance;
-    // return s_gpuStatesAddrProviders;
+#else
+    return s_gpuStatesAddrProviders;
+#endif
   }
 }  // namespace
 


### PR DESCRIPTION
### shmem: fix Static Initialization Order Fiasco in `GpuStatesAddrProvider` registry

The point is, `RegisterGpuStatesAddrProvider(GpuStatesAddrProvider provider)`
function maybe called **before** the constructor of 
`static std::vector<GpuStatesAddrProvider> s_gpuStatesAddrProviders`
is run. As a result, `s_gpuStatesAddrProviders` remains empty which leads to crashes at runtime.


The PR:
1. **Fixes the SIOF** by wrapping the registry in a Meyer's singleton
   (function-local `static`).
2. **Adds a diagnostic getter** `GetGpuStatesAddrProviderCount()` exposing
   the live registry size.
3. **Adds a deterministic regression test** (`static_link_siof_test`) that
   reproduces the static-link layout in isolation and fails fast at
   `main()` if a future change reintroduces a registry susceptible to SIOF.
4. Adds a missing include for anvil.cpp (when built with a host compiler, **cstring** include is missing):
```
external/roc_mori/src/application/transport/sdma/anvil.cpp:119:3: error: use of undeclared identifier 'memset'; did you mean 'wmemset'?
  119 |   memset(&m_SystemProperties, 0, sizeof(m_SystemProperties));
      |   ^~~~~~
      |   wmemset
```

## Why the SIOF was hard to spot

It only manifests under **static linking** of `runtime.cpp` into the same
link unit as the consumer TUs. The shipped `libmori_shmem.so` build hides
the bug because:

- `libmori_shmem.so` is loaded via `DT_NEEDED`, so its `.init_array`
  (which contains the registry's vector ctor) is fully processed
  **before** the executable's own `.init_array` (which contains the
  registrar ctors) runs.
- ELF lazy resolution + the dynamic linker's strict load-order semantics
  effectively impose `vector ctor → registrar ctor` ordering.

The bug shows up when:

- The XLA/Bazel build pulls `runtime.cpp` into a `cc_binary` with
  `linkstatic=True`, or
- `runtime.cpp` is compiled into an intermediate `cc_library` that is
  later embedded as a static archive in a downstream `.so` whose own
  `.init_array` interleaves the registrar ctors.

Both link layouts can reproduce the kernel-side illegal access; both are
fixed here in one place at the source of the registry.