### PR TITLE
feat(mori-io): add sync transfer wait API

### DIFF
--- a/include/mori/io/common.hpp
+++ b/include/mori/io/common.hpp
@@ -23,6 +23,8 @@
 
 #include <array>
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <functional>
 #include <msgpack.hpp>
 #include <mutex>
@@ -116,6 +118,10 @@ struct TransferStatus {
  public:
   TransferStatus() = default;
   ~TransferStatus() = default;
+  TransferStatus(const TransferStatus&) = delete;
+  TransferStatus& operator=(const TransferStatus&) = delete;
+  TransferStatus(TransferStatus&&) = delete;
+  TransferStatus& operator=(TransferStatus&&) = delete;
 
   StatusCode Code() { return CodeWithProgress(); }
   uint32_t CodeUint32() { return static_cast<uint32_t>(Code()); }
@@ -126,12 +132,15 @@ struct TransferStatus {
   }
 
   void Update(enum StatusCode val, const std::string& message) {
-    std::lock_guard<std::mutex> lock(msgMu);
-    StatusCode current = code.load(std::memory_order_relaxed);
-    if (current > StatusCode::ERR_BEGIN) return;
+    {
+      std::lock_guard<std::mutex> lock(msgMu);
+      StatusCode current = code.load(std::memory_order_relaxed);
+      if (current > StatusCode::ERR_BEGIN) return;
 
-    msg = message;
-    code.store(val, std::memory_order_release);
+      msg = message;
+      code.store(val, std::memory_order_release);
+    }
+    cv_.notify_all();
   }
 
   bool Init() { return Code() == StatusCode::INIT; }
@@ -139,20 +148,56 @@ struct TransferStatus {
   bool Succeeded() { return Code() == StatusCode::SUCCESS; }
   bool Failed() { return Code() > StatusCode::ERR_BEGIN; }
 
-  void SetCode(enum StatusCode val) { code.store(val, std::memory_order_release); }
+  void SetCode(enum StatusCode val) {
+    {
+      std::lock_guard<std::mutex> lock(msgMu);
+      code.store(val, std::memory_order_release);
+    }
+    if (val != StatusCode::INIT && val != StatusCode::IN_PROGRESS) {
+      cv_.notify_all();
+    }
+  }
   void SetMessage(const std::string& val) {
     std::lock_guard<std::mutex> lock(msgMu);
     msg = val;
   }
 
-  void Wait() {
+  void Wait() { (void)WaitFor(-1); }
+
+  // timeoutMs < 0 waits indefinitely, timeoutMs == 0 polls once, timeoutMs > 0
+  // waits up to the requested deadline. The returned code may still be
+  // IN_PROGRESS when a bounded wait times out.
+  StatusCode WaitFor(int timeoutMs = -1) {
+    StatusCode current = code.load(std::memory_order_acquire);
+    if (current != StatusCode::IN_PROGRESS) return current;
+
     PollProgress();
-    if (waitCallback) {
-      waitCallback();
-      return;
+    if (timeoutMs == 0) {
+      return code.load(std::memory_order_acquire);
     }
-    while (InProgress()) {
+
+    if (timeoutMs < 0) {
+      if (waitCallback) {
+        waitCallback();
+        return code.load(std::memory_order_acquire);
+      }
+
+      std::unique_lock<std::mutex> lock(msgMu);
+      cv_.wait(lock,
+               [&] { return code.load(std::memory_order_acquire) != StatusCode::IN_PROGRESS; });
+      return code.load(std::memory_order_acquire);
     }
+
+    std::unique_lock<std::mutex> lock(msgMu);
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeoutMs);
+    while (code.load(std::memory_order_acquire) == StatusCode::IN_PROGRESS) {
+      if (std::chrono::steady_clock::now() >= deadline) break;
+      cv_.wait_until(lock, deadline);
+      lock.unlock();
+      PollProgress();
+      lock.lock();
+    }
+    return code.load(std::memory_order_acquire);
   }
 
   void SetWaitCallback(std::function<void()> cb) { waitCallback = std::move(cb); }
@@ -174,6 +219,7 @@ struct TransferStatus {
   std::string msg;
   std::function<void()> waitCallback;
   std::function<void()> progressCallback;
+  std::condition_variable cv_;
 };
 
 using SizeVec = std::vector<size_t>;

--- a/include/mori/io/engine.hpp
+++ b/include/mori/io/engine.hpp
@@ -104,6 +104,8 @@ class IOEngine {
                   TransferUniqueIdVec& ids);
   // Take the transfer status of an inbound op
   bool PopInboundTransferStatus(EngineKey remote, TransferUniqueId id, TransferStatus* status);
+  // Wait for all statuses with failure-wins precedence. Empty input succeeds.
+  StatusCode WaitAll(const std::vector<TransferStatus*>& statuses, int timeoutMs = -1);
 
   std::optional<IOEngineSession> CreateSession(const MemoryDesc& local, const MemoryDesc& remote);
   void LoadScatterGatherModule(const std::string& hsacoPath);

--- a/python/mori/io/engine.py
+++ b/python/mori/io/engine.py
@@ -213,3 +213,6 @@ class IOEngine:
         if found:
             return transfer_status
         return None
+
+    def wait_all(self, statuses, timeout_ms: int = -1) -> "mori_cpp.StatusCode":
+        return self._engine.WaitAll(statuses, timeout_ms)

--- a/src/io/engine.cpp
+++ b/src/io/engine.cpp
@@ -25,7 +25,9 @@
 #include <unistd.h>
 
 #include <cctype>
+#include <chrono>
 #include <cstdlib>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -554,6 +556,61 @@ bool IOEngine::PopInboundTransferStatus(EngineKey remote, TransferUniqueId id,
     if (popped) return true;
   }
   return false;
+}
+
+StatusCode IOEngine::WaitAll(const std::vector<TransferStatus*>& statuses, int timeoutMs) {
+  if (statuses.empty()) return StatusCode::SUCCESS;
+
+  if (timeoutMs == 0) {
+    bool anyInProgress = false;
+    for (TransferStatus* status : statuses) {
+      if (status == nullptr) continue;
+      StatusCode rc = status->WaitFor(0);
+      if (rc == StatusCode::IN_PROGRESS) {
+        anyInProgress = true;
+        continue;
+      }
+      if (rc != StatusCode::SUCCESS) return rc;
+    }
+    return anyInProgress ? StatusCode::IN_PROGRESS : StatusCode::SUCCESS;
+  }
+
+  if (timeoutMs < 0) {
+    StatusCode firstError = StatusCode::SUCCESS;
+    for (TransferStatus* status : statuses) {
+      if (status == nullptr) continue;
+      StatusCode rc = status->WaitFor(-1);
+      if (rc != StatusCode::SUCCESS && firstError == StatusCode::SUCCESS) {
+        firstError = rc;
+      }
+    }
+    return firstError;
+  }
+
+  using Clock = std::chrono::steady_clock;
+  const auto deadline = Clock::now() + std::chrono::milliseconds(timeoutMs);
+  StatusCode firstError = StatusCode::SUCCESS;
+  for (TransferStatus* status : statuses) {
+    if (status == nullptr) continue;
+
+    const auto now = Clock::now();
+    if (now >= deadline) {
+      return firstError != StatusCode::SUCCESS ? firstError : StatusCode::IN_PROGRESS;
+    }
+
+    const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now);
+    const int remainingMs = remaining.count() > std::numeric_limits<int>::max()
+                                ? std::numeric_limits<int>::max()
+                                : static_cast<int>(remaining.count());
+    StatusCode rc = status->WaitFor(remainingMs);
+    if (rc == StatusCode::IN_PROGRESS) {
+      return firstError != StatusCode::SUCCESS ? firstError : StatusCode::IN_PROGRESS;
+    }
+    if (rc != StatusCode::SUCCESS && firstError == StatusCode::SUCCESS) {
+      firstError = rc;
+    }
+  }
+  return firstError;
 }
 
 }  // namespace io

--- a/src/pybind/pybind_io.cpp
+++ b/src/pybind/pybind_io.cpp
@@ -99,7 +99,9 @@ void RegisterMoriIo(pybind11::module_& m) {
       .def("Failed", &mori::io::TransferStatus::Failed)
       .def("SetCode", &mori::io::TransferStatus::SetCode)
       .def("SetMessage", &mori::io::TransferStatus::SetMessage)
-      .def("Wait", &mori::io ::TransferStatus::Wait);
+      .def("Wait", &mori::io::TransferStatus::Wait, py::call_guard<py::gil_scoped_release>())
+      .def("WaitFor", &mori::io::TransferStatus::WaitFor, py::arg("timeout_ms") = -1,
+           py::call_guard<py::gil_scoped_release>());
 
   py::class_<mori::io::EngineDesc>(m, "EngineDesc")
       .def_readonly("key", &mori::io::EngineDesc::key)
@@ -180,6 +182,8 @@ void RegisterMoriIo(pybind11::module_& m) {
       .def("BatchWrite", &mori::io::IOEngine::BatchWrite, py::call_guard<py::gil_scoped_release>())
       .def("CreateSession", &mori::io::IOEngine::CreateSession)
       .def("PopInboundTransferStatus", &mori::io::IOEngine::PopInboundTransferStatus,
+           py::call_guard<py::gil_scoped_release>())
+      .def("WaitAll", &mori::io::IOEngine::WaitAll, py::arg("statuses"), py::arg("timeout_ms") = -1,
            py::call_guard<py::gil_scoped_release>())
       .def("LoadScatterGatherModule", &mori::io::IOEngine::LoadScatterGatherModule);
 }

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -19,6 +19,13 @@ if(BUILD_IO)
   target_include_directories(test_engine PUBLIC ${CMAKE_SOURCE_DIR})
   target_link_libraries(test_engine mori_application mori_io)
 
+  add_executable(test_transfer_wait io/test_transfer_wait.cpp)
+
+  target_include_directories(test_transfer_wait
+                             PUBLIC ${CMAKE_SOURCE_DIR}/include)
+  target_include_directories(test_transfer_wait PUBLIC ${CMAKE_SOURCE_DIR})
+  target_link_libraries(test_transfer_wait mori_application mori_io)
+
   add_executable(test_topology application/test_topology.cpp)
 
   target_include_directories(test_topology PUBLIC ${CMAKE_SOURCE_DIR}/include)

--- a/tests/cpp/io/test_transfer_wait.cpp
+++ b/tests/cpp/io/test_transfer_wait.cpp
@@ -1,0 +1,420 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "mori/io/io.hpp"
+
+using namespace mori::io;
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+struct TestFailure : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
+void Require(bool cond, const std::string& msg) {
+  if (!cond) throw TestFailure(msg);
+}
+
+int64_t ElapsedMs(Clock::time_point start) {
+  return std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() - start).count();
+}
+
+std::unique_ptr<IOEngine> MakeEngine(const std::string& key) {
+  IOEngineConfig cfg;
+  cfg.host = "127.0.0.1";
+  cfg.port = 0;
+  return std::make_unique<IOEngine>(key, cfg);
+}
+
+std::thread DelayedUpdate(TransferStatus* status, int delayMs, StatusCode code,
+                          std::string msg = "") {
+  return std::thread([status, delayMs, code, msg = std::move(msg)] {
+    std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
+    status->Update(code, msg);
+  });
+}
+
+void SetInProgress(TransferStatus* status) { status->SetCode(StatusCode::IN_PROGRESS); }
+
+template <size_t N>
+std::vector<TransferStatus*> Ptrs(std::array<TransferStatus, N>* statuses) {
+  std::vector<TransferStatus*> ptrs;
+  ptrs.reserve(N);
+  for (TransferStatus& status : *statuses) ptrs.push_back(&status);
+  return ptrs;
+}
+
+void CaseWaitForFastPathSuccess() {
+  TransferStatus status;
+  status.SetCode(StatusCode::SUCCESS);
+  auto start = Clock::now();
+  StatusCode rc = status.WaitFor(-1);
+  Require(rc == StatusCode::SUCCESS, "WaitFor(-1) should return preset success");
+  Require(ElapsedMs(start) < 50, "WaitFor fast-path success took too long");
+}
+
+void CaseWaitForFastPathFailure() {
+  TransferStatus status;
+  status.SetCode(StatusCode::ERR_RDMA_OP);
+  StatusCode rc = status.WaitFor(-1);
+  Require(rc == StatusCode::ERR_RDMA_OP, "WaitFor(-1) should return preset failure");
+}
+
+void CaseWaitForZeroIsPollOnly() {
+  TransferStatus status;
+  SetInProgress(&status);
+  std::atomic<bool> callbackCalled{false};
+  status.SetWaitCallback([&] {
+    callbackCalled.store(true, std::memory_order_release);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    status.SetCode(StatusCode::SUCCESS);
+  });
+
+  auto start = Clock::now();
+  StatusCode rc = status.WaitFor(0);
+  int64_t elapsed = ElapsedMs(start);
+  Require(rc == StatusCode::IN_PROGRESS, "WaitFor(0) should not wait for completion");
+  Require(!callbackCalled.load(std::memory_order_acquire), "WaitFor(0) must not call waitCallback");
+  Require(elapsed < 50, "WaitFor(0) took too long");
+}
+
+void CaseWaitForZeroPollsProgressCallback() {
+  TransferStatus status;
+  SetInProgress(&status);
+  status.SetProgressCallback([&] { status.SetCode(StatusCode::SUCCESS); });
+  StatusCode rc = status.WaitFor(0);
+  Require(rc == StatusCode::SUCCESS, "WaitFor(0) should run progressCallback once");
+}
+
+void CaseWaitForBoundedIgnoresCallback() {
+  TransferStatus status;
+  SetInProgress(&status);
+  std::atomic<bool> callbackCalled{false};
+  status.SetWaitCallback([&] {
+    callbackCalled.store(true, std::memory_order_release);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    status.SetCode(StatusCode::SUCCESS);
+  });
+
+  auto start = Clock::now();
+  StatusCode rc = status.WaitFor(30);
+  int64_t elapsed = ElapsedMs(start);
+  Require(rc == StatusCode::IN_PROGRESS, "bounded WaitFor should time out");
+  Require(!callbackCalled.load(std::memory_order_acquire),
+          "bounded WaitFor must not call waitCallback");
+  Require(elapsed >= 20 && elapsed < 250, "bounded WaitFor did not respect timeout");
+}
+
+void CaseWaitForUnboundedHonoursCallback() {
+  TransferStatus status;
+  SetInProgress(&status);
+  std::atomic<bool> callbackCalled{false};
+  status.SetWaitCallback([&] {
+    callbackCalled.store(true, std::memory_order_release);
+    status.SetCode(StatusCode::SUCCESS);
+  });
+
+  StatusCode rc = status.WaitFor(-1);
+  Require(callbackCalled.load(std::memory_order_acquire),
+          "unbounded WaitFor should call waitCallback");
+  Require(rc == StatusCode::SUCCESS, "unbounded WaitFor should return callback result");
+}
+
+void CaseWaitForBlockingSuccess() {
+  TransferStatus status;
+  SetInProgress(&status);
+  std::thread updater = DelayedUpdate(&status, 10, StatusCode::SUCCESS);
+  StatusCode rc = status.WaitFor(-1);
+  updater.join();
+  Require(rc == StatusCode::SUCCESS, "WaitFor(-1) should wake on Update(SUCCESS)");
+}
+
+void CaseWaitForTimeoutNoUpdate() {
+  TransferStatus status;
+  SetInProgress(&status);
+  auto start = Clock::now();
+  StatusCode rc = status.WaitFor(30);
+  int64_t elapsed = ElapsedMs(start);
+  Require(rc == StatusCode::IN_PROGRESS, "WaitFor should return IN_PROGRESS on timeout");
+  Require(elapsed >= 20 && elapsed < 250, "WaitFor timeout duration out of range");
+}
+
+void CaseWaitForTimeoutThenUpdate() {
+  TransferStatus status;
+  SetInProgress(&status);
+  Require(status.WaitFor(10) == StatusCode::IN_PROGRESS, "first bounded WaitFor should time out");
+  status.Update(StatusCode::SUCCESS, "");
+  Require(status.WaitFor(-1) == StatusCode::SUCCESS, "second WaitFor should observe later success");
+}
+
+void CaseWaitForMultipleWaiters() {
+  TransferStatus status;
+  SetInProgress(&status);
+  std::array<StatusCode, 2> results{StatusCode::INIT, StatusCode::INIT};
+  std::thread waiter0([&] { results[0] = status.WaitFor(-1); });
+  std::thread waiter1([&] { results[1] = status.WaitFor(-1); });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  status.Update(StatusCode::SUCCESS, "");
+  waiter0.join();
+  waiter1.join();
+  Require(results[0] == StatusCode::SUCCESS && results[1] == StatusCode::SUCCESS,
+          "notify_all should wake every waiter");
+}
+
+void CaseWaitForRedundantUpdates() {
+  TransferStatus status;
+  SetInProgress(&status);
+  std::atomic<bool> done{false};
+  StatusCode result = StatusCode::INIT;
+  std::thread waiter([&] {
+    result = status.WaitFor(-1);
+    done.store(true, std::memory_order_release);
+  });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  status.Update(StatusCode::IN_PROGRESS, "msg-1");
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  bool returnedAfterFirstUpdate = done.load(std::memory_order_acquire);
+  status.Update(StatusCode::IN_PROGRESS, "msg-2");
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  bool returnedAfterSecondUpdate = done.load(std::memory_order_acquire);
+  status.Update(StatusCode::SUCCESS, "");
+  waiter.join();
+
+  Require(!returnedAfterFirstUpdate && !returnedAfterSecondUpdate,
+          "redundant IN_PROGRESS updates must not complete WaitFor");
+  Require(result == StatusCode::SUCCESS, "WaitFor should complete on terminal update");
+}
+
+void CaseSetCodeSuccessNotifies() {
+  TransferStatus status;
+  SetInProgress(&status);
+  StatusCode result = StatusCode::INIT;
+  std::thread waiter([&] { result = status.WaitFor(-1); });
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  status.SetCode(StatusCode::SUCCESS);
+  waiter.join();
+  Require(result == StatusCode::SUCCESS, "SetCode(SUCCESS) should wake WaitFor");
+}
+
+void CaseSetCodeInProgressDoesNotNotify() {
+  TransferStatus status;
+  SetInProgress(&status);
+  std::atomic<bool> done{false};
+  StatusCode result = StatusCode::INIT;
+  std::thread waiter([&] {
+    result = status.WaitFor(-1);
+    done.store(true, std::memory_order_release);
+  });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  status.SetCode(StatusCode::IN_PROGRESS);
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  bool returnedAfterInProgress = done.load(std::memory_order_acquire);
+  status.SetCode(StatusCode::SUCCESS);
+  waiter.join();
+
+  Require(!returnedAfterInProgress, "SetCode(IN_PROGRESS) must not wake WaitFor as terminal");
+  Require(result == StatusCode::SUCCESS, "WaitFor should still complete on later success");
+}
+
+void CaseWaitAllEmpty() {
+  auto engine = MakeEngine("wait_all_empty");
+  std::vector<TransferStatus*> statuses;
+  Require(engine->WaitAll(statuses) == StatusCode::SUCCESS, "WaitAll({}) should succeed");
+}
+
+void CaseWaitAllZeroTimeoutPollOnly() {
+  auto engine = MakeEngine("wait_all_zero_poll");
+  std::array<TransferStatus, 4> statuses;
+  for (TransferStatus& status : statuses) SetInProgress(&status);
+  auto ptrs = Ptrs(&statuses);
+
+  auto start = Clock::now();
+  StatusCode rc = engine->WaitAll(ptrs, 0);
+  int64_t elapsed = ElapsedMs(start);
+  Require(rc == StatusCode::IN_PROGRESS, "WaitAll(0) should report in-progress statuses");
+  Require(elapsed < 50, "WaitAll(0) should not wait");
+}
+
+void CaseWaitAllZeroTimeoutFailureWins() {
+  auto engine = MakeEngine("wait_all_zero_failure");
+  TransferStatus success;
+  TransferStatus inProgress;
+  TransferStatus failed;
+  success.SetCode(StatusCode::SUCCESS);
+  SetInProgress(&inProgress);
+  failed.SetCode(StatusCode::ERR_RDMA_OP);
+  std::vector<TransferStatus*> statuses{&success, &inProgress, &failed};
+
+  StatusCode rc = engine->WaitAll(statuses, 0);
+  Require(rc == StatusCode::ERR_RDMA_OP,
+          "WaitAll(0) should scan past IN_PROGRESS and return failure");
+}
+
+void CaseWaitAllAllSuccess() {
+  auto engine = MakeEngine("wait_all_success");
+  std::array<TransferStatus, 4> statuses;
+  for (TransferStatus& status : statuses) SetInProgress(&status);
+  auto ptrs = Ptrs(&statuses);
+
+  std::vector<std::thread> updaters;
+  for (size_t i = 0; i < statuses.size(); ++i) {
+    updaters.push_back(
+        DelayedUpdate(&statuses[i], static_cast<int>((i + 1) * 5), StatusCode::SUCCESS));
+  }
+  StatusCode rc = engine->WaitAll(ptrs, -1);
+  for (std::thread& updater : updaters) updater.join();
+  Require(rc == StatusCode::SUCCESS, "WaitAll should succeed when every status succeeds");
+}
+
+void CaseWaitAllOneFailure() {
+  auto engine = MakeEngine("wait_all_failure");
+  std::array<TransferStatus, 3> statuses;
+  for (TransferStatus& status : statuses) SetInProgress(&status);
+  auto ptrs = Ptrs(&statuses);
+
+  std::thread success0 = DelayedUpdate(&statuses[0], 20, StatusCode::SUCCESS);
+  std::thread failure = DelayedUpdate(&statuses[1], 10, StatusCode::ERR_GPU_OP, "gpu failure");
+  std::thread success2 = DelayedUpdate(&statuses[2], 30, StatusCode::SUCCESS);
+  StatusCode rc = engine->WaitAll(ptrs, -1);
+  success0.join();
+  failure.join();
+  success2.join();
+
+  Require(rc == StatusCode::ERR_GPU_OP, "WaitAll should return first observed failure");
+  Require(!statuses[0].InProgress() && !statuses[1].InProgress() && !statuses[2].InProgress(),
+          "unbounded WaitAll should wait for every status to become terminal");
+}
+
+void CaseWaitAllTimeout() {
+  auto engine = MakeEngine("wait_all_timeout");
+  TransferStatus neverDone;
+  SetInProgress(&neverDone);
+  std::vector<TransferStatus*> statuses{&neverDone};
+  StatusCode rc = engine->WaitAll(statuses, 20);
+  Require(rc == StatusCode::IN_PROGRESS, "WaitAll should return IN_PROGRESS on timeout");
+}
+
+void CaseWaitAllBudget() {
+  {
+    auto engine = MakeEngine("wait_all_budget_success");
+    std::array<TransferStatus, 4> statuses;
+    for (TransferStatus& status : statuses) SetInProgress(&status);
+    auto ptrs = Ptrs(&statuses);
+    std::vector<std::thread> updaters;
+    for (size_t i = 0; i < statuses.size(); ++i) {
+      updaters.push_back(
+          DelayedUpdate(&statuses[i], static_cast<int>((i + 1) * 15), StatusCode::SUCCESS));
+    }
+    StatusCode rc = engine->WaitAll(ptrs, 120);
+    for (std::thread& updater : updaters) updater.join();
+    Require(rc == StatusCode::SUCCESS, "WaitAll should share enough budget across statuses");
+  }
+
+  {
+    auto engine = MakeEngine("wait_all_budget_timeout");
+    std::array<TransferStatus, 4> statuses;
+    for (TransferStatus& status : statuses) SetInProgress(&status);
+    auto ptrs = Ptrs(&statuses);
+    std::vector<std::thread> updaters;
+    for (size_t i = 0; i < statuses.size(); ++i) {
+      updaters.push_back(
+          DelayedUpdate(&statuses[i], static_cast<int>((i + 1) * 30), StatusCode::SUCCESS));
+    }
+    StatusCode rc = engine->WaitAll(ptrs, 50);
+    for (std::thread& updater : updaters) updater.join();
+    Require(rc == StatusCode::IN_PROGRESS,
+            "WaitAll should stop when shared timeout budget is exhausted");
+  }
+}
+
+void CaseWaitAllBoundedFailureBeatsTimeout() {
+  auto engine = MakeEngine("wait_all_failure_beats_timeout");
+  TransferStatus failed;
+  TransferStatus neverDone;
+  SetInProgress(&failed);
+  SetInProgress(&neverDone);
+  std::vector<TransferStatus*> statuses{&failed, &neverDone};
+
+  std::thread failure = DelayedUpdate(&failed, 10, StatusCode::ERR_RDMA_OP, "rdma failure");
+  StatusCode rc = engine->WaitAll(statuses, 50);
+  failure.join();
+  Require(rc == StatusCode::ERR_RDMA_OP, "recorded failure should beat a later timeout in WaitAll");
+}
+
+struct TestCase {
+  const char* name;
+  std::function<void()> run;
+};
+
+}  // namespace
+
+int main() {
+  std::vector<TestCase> cases = {
+      {"WaitForFastPathSuccess", CaseWaitForFastPathSuccess},
+      {"WaitForFastPathFailure", CaseWaitForFastPathFailure},
+      {"WaitForZeroIsPollOnly", CaseWaitForZeroIsPollOnly},
+      {"WaitForZeroPollsProgressCallback", CaseWaitForZeroPollsProgressCallback},
+      {"WaitForBoundedIgnoresCallback", CaseWaitForBoundedIgnoresCallback},
+      {"WaitForUnboundedHonoursCallback", CaseWaitForUnboundedHonoursCallback},
+      {"WaitForBlockingSuccess", CaseWaitForBlockingSuccess},
+      {"WaitForTimeoutNoUpdate", CaseWaitForTimeoutNoUpdate},
+      {"WaitForTimeoutThenUpdate", CaseWaitForTimeoutThenUpdate},
+      {"WaitForMultipleWaiters", CaseWaitForMultipleWaiters},
+      {"WaitForRedundantUpdates", CaseWaitForRedundantUpdates},
+      {"SetCodeSuccessNotifies", CaseSetCodeSuccessNotifies},
+      {"SetCodeInProgressDoesNotNotify", CaseSetCodeInProgressDoesNotNotify},
+      {"WaitAllEmpty", CaseWaitAllEmpty},
+      {"WaitAllZeroTimeoutPollOnly", CaseWaitAllZeroTimeoutPollOnly},
+      {"WaitAllZeroTimeoutFailureWins", CaseWaitAllZeroTimeoutFailureWins},
+      {"WaitAllAllSuccess", CaseWaitAllAllSuccess},
+      {"WaitAllOneFailure", CaseWaitAllOneFailure},
+      {"WaitAllTimeout", CaseWaitAllTimeout},
+      {"WaitAllBudget", CaseWaitAllBudget},
+      {"WaitAllBoundedFailureBeatsTimeout", CaseWaitAllBoundedFailureBeatsTimeout},
+  };
+
+  for (const TestCase& test : cases) {
+    try {
+      test.run();
+      std::cout << "[PASS] " << test.name << "\n";
+    } catch (const std::exception& e) {
+      std::cerr << "[FAIL] " << test.name << ": " << e.what() << "\n";
+      return 1;
+    }
+  }
+  return 0;
+}

--- a/tests/python/io/test_transfer_wait.py
+++ b/tests/python/io/test_transfer_wait.py
@@ -1,0 +1,99 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import threading
+import time
+
+from mori.cpp import TransferStatus
+from mori.io import IOEngine, IOEngineConfig, StatusCode
+
+
+def make_status_in_progress():
+    status = TransferStatus()
+    status.SetCode(StatusCode.IN_PROGRESS)
+    return status
+
+
+def test_wait_for_blocks_and_releases_gil():
+    status = make_status_in_progress()
+
+    def updater():
+        time.sleep(0.05)
+        status.Update(StatusCode.SUCCESS, "")
+
+    other_thread_ran = []
+
+    def sibling():
+        time.sleep(0.01)
+        other_thread_ran.append(time.perf_counter())
+
+    updater_thread = threading.Thread(target=updater)
+    sibling_thread = threading.Thread(target=sibling)
+    updater_thread.start()
+    sibling_thread.start()
+
+    start = time.perf_counter()
+    rc = status.WaitFor(timeout_ms=500)
+    elapsed = time.perf_counter() - start
+
+    updater_thread.join()
+    sibling_thread.join()
+
+    assert rc == StatusCode.SUCCESS
+    assert 0.03 < elapsed < 0.30
+    assert len(other_thread_ran) == 1
+
+
+def test_wait_all_wrapper_success():
+    engine = IOEngine("py_wait_all_success", IOEngineConfig(host="127.0.0.1", port=0))
+    statuses = [make_status_in_progress() for _ in range(3)]
+
+    def complete(status, delay):
+        time.sleep(delay)
+        status.Update(StatusCode.SUCCESS, "")
+
+    threads = [
+        threading.Thread(target=complete, args=(status, 0.01 * (idx + 1)))
+        for idx, status in enumerate(statuses)
+    ]
+    for thread in threads:
+        thread.start()
+
+    rc = engine.wait_all(statuses, timeout_ms=500)
+    for thread in threads:
+        thread.join()
+
+    assert rc == StatusCode.SUCCESS
+    assert all(status.Succeeded() for status in statuses)
+
+
+def test_wait_all_zero_timeout_failure_wins():
+    engine = IOEngine(
+        "py_wait_all_zero_failure", IOEngineConfig(host="127.0.0.1", port=0)
+    )
+    success = TransferStatus()
+    in_progress = make_status_in_progress()
+    failed = TransferStatus()
+    success.SetCode(StatusCode.SUCCESS)
+    failed.SetCode(StatusCode.ERR_RDMA_OP)
+
+    rc = engine.wait_all([success, in_progress, failed], timeout_ms=0)
+    assert rc == StatusCode.ERR_RDMA_OP


### PR DESCRIPTION
## Summary
Adds a synchronous wait API for transfers, giving callers timeout control and a batch-wait helper on top of the existing `TransferStatus::Wait()`.

- **`TransferStatus::WaitFor(timeoutMs)`** — single-status wait with timeout semantics:
  - `< 0` (default): wait indefinitely
  - `== 0`: poll once, non-blocking
  - `> 0`: wait up to the deadline (may return `IN_PROGRESS` on timeout)
- **`IOEngine::WaitAll(statuses, timeoutMs)`** — batch wait with **failure-wins** precedence; empty input returns `SUCCESS`. The timeout is shared across the whole batch.
- `Wait()` now delegates to `WaitFor(-1)` and blocks on a `condition_variable` instead of busy-spinning (woken by `Update`/`SetCode`).
- `TransferStatus` is now non-copyable/non-movable (it owns a mutex + condvar; all usages are by-pointer or stack locals).
- Python bindings: `WaitFor` / `wait_all` exposed; `Wait` / `WaitFor` / `WaitAll` release the GIL while waiting.

## Behavior notes
- RDMA (background CQ thread) and bare statuses are responsive on timed waits via condvar notification.
- The indefinite `Wait()` on XGMI uses the blocking finalize callback (unchanged, efficient).
- Bounded `WaitFor(timeout>0)` on XGMI (poll-driven, no background notifier) polls once up front then re-polls at the deadline — correct result, but completion may be observed late within the timeout window. This is intentional and covered by tests.

## Testing
- `BUILD_UMBP=1 BUILD_TESTS=1 pip install .` builds clean.
- C++ `test_transfer_wait`: 21/21 pass.
- Python `tests/python/io/test_transfer_wait.py`: 3/3 pass.
