### PR TITLE
Feat: Enable SSD tier in distributed UMBP

### DIFF
--- a/docs/MORI-UMBP-SINGLE-NODE-GUIDE.md
+++ b/docs/MORI-UMBP-SINGLE-NODE-GUIDE.md
@@ -52,6 +52,7 @@ Export the variables below to adapt the run to your environment. The script read
 | `UMBP_NODE_ADDRESS` | `127.0.0.1` | IP advertised to clients. | `<node-ip>` |
 | `UMBP_IO_ENGINE_PORT` | `16000` | Hicache IO engine port. | `16010` |
 | `UMBP_PEER_SERVICE_PORT` | `17000` | Peer service port. | `17010` |
+| `UMBP_SSD_STAGING_BYTES` | `268435456` (256 MiB) | Size of the dedicated remote-SSD read staging buffer. Allocated **only** when SSD is enabled (DRAM-only runs allocate nothing and are unaffected). Raise for large-KV models so each read slot fits one key's value. | `268435456` |
 | `USE_DUMMY_WEIGHTS` | `false` | Skip checkpoint validation. | `true` |
 | `MEM_FRACTION_STATIC` | `0.7` | Fraction reserved for static allocations. | `0.6` |
 | `PROBE_MAX_TIME` | `300` | Timeout for probe request in seconds. | `600` |
@@ -121,5 +122,6 @@ Make sure the directory exists and has enough space.
 - **UMBP master logs**: Saved alongside server logs when `START_UMBP_MASTER=true`.
 - **Model validation**: The script validates that `MODEL_PATH` contains `model-*.safetensors` when running with real weights.
 - **Probe failures**: Inspect the tail of the server log; the script prints it automatically on errors.
+- **Remote SSD reads silently recompute (`size_too_large`)**: A remote SSD read must fit a key's whole value into one slot, where `per_slot = ssd_staging_buffer_size / ssd_read_slots` (defaults 256 MiB / 16 = 16 MiB). The single-key page KV for an MLA model ≈ `page_size × (kv_lora_rank + qk_rope_head_dim) × dtype_bytes × num_layers` (DeepSeek-V3 5-layer ≈ 360 KB; full R1/V3 61-layer ≈ 4.5 MB). If `per_slot` is smaller, the read is dropped and the block is recomputed — requests don't error, but `mori_umbp_ssd_read_total{status="size_too_large"}` climbs and hit rate/throughput fall. Fix: raise `UMBP_SSD_STAGING_BYTES` or lower `ssd_read_slots` (now settable via `UMBP_SSD_READ_SLOTS`) so `per_slot ≥` the single-key page KV. (`ssd_staging_buffer_size` is allocated only when SSD is enabled, separate from the general `staging_buffer_size`.)
 
 Refer back to this document whenever the single-node smoke test needs to be run or automated. For the original skill instructions see `/home/ditian12/.codex/skills/umbp-single-node-launcher/SKILL.md`.

--- a/examples/monitoring/grafana/dashboards/umbp_ssd_tier.json
+++ b/examples/monitoring/grafana/dashboards/umbp_ssd_tier.json
@@ -1,0 +1,142 @@
+{
+  "title": "UMBP SSD Tier",
+  "uid": "9b1d4e2a-ssd-tier-umbp-0001",
+  "tags": ["umbp", "ssd", "tier", "cold-tier"],
+  "schemaVersion": 36,
+  "refresh": "5s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "type": "datasource",
+        "name": "datasource",
+        "label": "Data Source",
+        "pluginId": "prometheus",
+        "current": { "text": "Prometheus", "value": "PBFA97CFB590B2093" },
+        "hide": 0,
+        "query": "prometheus"
+      },
+      {
+        "type": "query",
+        "name": "node",
+        "label": "Client (node label)",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "query": "label_values(mori_umbp_ssd_copy_enqueued_total, node)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".+",
+        "current": { "text": "All", "value": "$__all" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "SSD reads served (ok, total)",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "green", "value": null } ] } } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(mori_umbp_ssd_read_total{node=~\"$node\", status=\"ok\"})", "legendFormat": "read ok" } ]
+    },
+    {
+      "type": "stat",
+      "title": "SSD copies succeeded (total)",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(mori_umbp_ssd_copy_succeeded_total{node=~\"$node\"})", "legendFormat": "copy ok" } ]
+    },
+    {
+      "type": "stat",
+      "title": "SSD capacity used",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(mori_umbp_client_capacity_used_bytes{node=~\"$node\", tier=\"SSD\"})", "legendFormat": "used" } ]
+    },
+    {
+      "type": "stat",
+      "title": "Copy failed + dropped (total)",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] } } },
+      "targets": [ { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(mori_umbp_ssd_copy_failed_total{node=~\"$node\"}) + sum(mori_umbp_ssd_copy_dropped_total{node=~\"$node\"})", "legendFormat": "failed+dropped" } ]
+    },
+    {
+      "type": "timeseries",
+      "title": "SSD copy-on-commit throughput (ops/s)",
+      "description": "enqueued vs succeeded vs failed copy tasks (rate). enqueued≈succeeded with ~0 failed is healthy.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(mori_umbp_ssd_copy_enqueued_total{node=~\"$node\"}[$__rate_interval]))", "legendFormat": "enqueued" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(mori_umbp_ssd_copy_succeeded_total{node=~\"$node\"}[$__rate_interval]))", "legendFormat": "succeeded" },
+        { "refId": "C", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(mori_umbp_ssd_copy_failed_total{node=~\"$node\"}[$__rate_interval]))", "legendFormat": "failed" },
+        { "refId": "D", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum by (reason) (rate(mori_umbp_ssd_copy_dropped_total{node=~\"$node\"}[$__rate_interval]))", "legendFormat": "dropped {{reason}}" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "SSD read outcomes (ops/s, by status)",
+      "description": "ok / not_found / no_slot / size_too_large / error. no_slot is transient (not a miss).",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 20, "stacking": { "mode": "normal" } } } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum by (status) (rate(mori_umbp_ssd_read_total{node=~\"$node\"}[$__rate_interval]))", "legendFormat": "{{status}}" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "SSD capacity used / total (bytes)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "mori_umbp_client_capacity_used_bytes{node=~\"$node\", tier=\"SSD\"}", "legendFormat": "used {{node}}" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "mori_umbp_client_capacity_total_bytes{node=~\"$node\", tier=\"SSD\"}", "legendFormat": "total {{node}}" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "SSD local eviction (ops/s & bytes/s)",
+      "description": "Rounds / victims / backend failures (left), bytes freed (right). Stays flat until SSD hits the high watermark.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [ { "matcher": { "id": "byName", "options": "bytes_freed/s" }, "properties": [ { "id": "unit", "value": "Bps" }, { "id": "custom.axisPlacement", "value": "right" } ] } ] },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(mori_umbp_ssd_eviction_rounds_total{node=~\"$node\"}[$__rate_interval]))", "legendFormat": "rounds/s" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(mori_umbp_ssd_eviction_victims_total{node=~\"$node\"}[$__rate_interval]))", "legendFormat": "victims/s" },
+        { "refId": "C", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(mori_umbp_ssd_eviction_backend_failed_total{node=~\"$node\"}[$__rate_interval]))", "legendFormat": "backend_failed/s" },
+        { "refId": "D", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(mori_umbp_ssd_eviction_bytes_freed_total{node=~\"$node\"}[$__rate_interval]))", "legendFormat": "bytes_freed/s" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "SSD IO throughput (offered, bytes/s)",
+      "description": "Achieved/offered SSD throughput = SSD IO bytes / wall-clock over the window (rate()), summed across ranks. This is a LOAD signal (how much the workload drove the SSD tier), NOT the device's per-IO bandwidth: it averages in idle gaps so it under-reads bursty copy. For true device bandwidth (bytes / actual IO time) use fio or add ssd_*_io_seconds_total counters.",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 20 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "Bps", "custom": { "drawStyle": "line", "fillOpacity": 15 } } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(mori_umbp_ssd_copy_bytes_total{node=~\"$node\"}[$__rate_interval]))", "legendFormat": "SSD write (copy)" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(mori_umbp_ssd_read_bytes_total{node=~\"$node\"}[$__rate_interval]))", "legendFormat": "SSD read" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "SSD read staging health",
+      "description": "slots in use (gauge), plus slot_full_rejects / expired_reclaims / reader-local transient (ops/s). Non-zero rejects/transient = staging pressure.",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 28 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(mori_umbp_ssd_staging_slots_in_use{node=~\"$node\"})", "legendFormat": "slots in use" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(mori_umbp_ssd_staging_slot_full_rejects_total{node=~\"$node\"}[$__rate_interval]))", "legendFormat": "slot_full_rejects/s" },
+        { "refId": "C", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(mori_umbp_ssd_staging_expired_reclaims_total{node=~\"$node\"}[$__rate_interval]))", "legendFormat": "expired_reclaims/s" },
+        { "refId": "D", "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(mori_umbp_ssd_read_client_transient_total{node=~\"$node\"}[$__rate_interval]))", "legendFormat": "client_transient/s" }
+      ]
+    }
+  ]
+}

--- a/examples/monitoring/grafana/dashboards/umbp_ssd_tier.json
+++ b/examples/monitoring/grafana/dashboards/umbp_ssd_tier.json
@@ -1,5 +1,5 @@
 {
-  "title": "UMBP SSD Tier",
+  "title": "UMBP Master - SSD Metrics",
   "uid": "9b1d4e2a-ssd-tier-umbp-0001",
   "tags": ["umbp", "ssd", "tier", "cold-tier"],
   "schemaVersion": 36,

--- a/src/pybind/pybind_umbp.cpp
+++ b/src/pybind/pybind_umbp.cpp
@@ -159,7 +159,28 @@ void RegisterMoriUmbp(py::module_& m) {
       .def_readwrite("layout_mode", &UMBPSsdConfig::layout_mode)
       .def_readwrite("segment_size_bytes", &UMBPSsdConfig::segment_size_bytes)
       .def_readwrite("io", &UMBPSsdConfig::io)
-      .def_readwrite("durability", &UMBPSsdConfig::durability);
+      .def_readwrite("durability", &UMBPSsdConfig::durability)
+      .def_readwrite("ssd_backend", &UMBPSsdConfig::ssd_backend)
+      .def_readwrite("spdk_bdev_name", &UMBPSsdConfig::spdk_bdev_name)
+      .def_readwrite("spdk_reactor_mask", &UMBPSsdConfig::spdk_reactor_mask)
+      .def_readwrite("spdk_mem_size_mb", &UMBPSsdConfig::spdk_mem_size_mb)
+      .def_readwrite("spdk_nvme_pci_addr", &UMBPSsdConfig::spdk_nvme_pci_addr)
+      .def_readwrite("spdk_nvme_ctrl_name", &UMBPSsdConfig::spdk_nvme_ctrl_name)
+      .def_readwrite("spdk_io_workers", &UMBPSsdConfig::spdk_io_workers)
+      .def_readwrite("spdk_proxy_shm_name", &UMBPSsdConfig::spdk_proxy_shm_name)
+      .def_readwrite("spdk_proxy_bin", &UMBPSsdConfig::spdk_proxy_bin)
+      .def_readwrite("spdk_proxy_tenant_id", &UMBPSsdConfig::spdk_proxy_tenant_id)
+      .def_readwrite("spdk_proxy_tenant_quota_bytes", &UMBPSsdConfig::spdk_proxy_tenant_quota_bytes)
+      .def_readwrite("spdk_proxy_max_channels", &UMBPSsdConfig::spdk_proxy_max_channels)
+      .def_readwrite("spdk_proxy_data_per_channel_mb",
+                     &UMBPSsdConfig::spdk_proxy_data_per_channel_mb)
+      .def_readwrite("spdk_proxy_startup_timeout_ms", &UMBPSsdConfig::spdk_proxy_startup_timeout_ms)
+      .def_readwrite("spdk_proxy_auto_start", &UMBPSsdConfig::spdk_proxy_auto_start)
+      .def_readwrite("spdk_proxy_idle_exit_timeout_ms",
+                     &UMBPSsdConfig::spdk_proxy_idle_exit_timeout_ms)
+      .def_readwrite("spdk_proxy_allow_borrow", &UMBPSsdConfig::spdk_proxy_allow_borrow)
+      .def_readwrite("spdk_proxy_reserved_shared_bytes",
+                     &UMBPSsdConfig::spdk_proxy_reserved_shared_bytes);
 
   py::class_<UMBPEvictionConfig>(m, "UMBPEvictionConfig")
       .def(py::init<>())
@@ -206,20 +227,6 @@ void RegisterMoriUmbp(py::module_& m) {
       .def_readwrite("role", &UMBPConfig::role)
       .def_readwrite("follower_mode", &UMBPConfig::follower_mode)
       .def_readwrite("force_ssd_copy_on_write", &UMBPConfig::force_ssd_copy_on_write)
-      .def_readwrite("ssd_backend", &UMBPConfig::ssd_backend)
-      .def_readwrite("spdk_nvme_pci_addr", &UMBPConfig::spdk_nvme_pci_addr)
-      .def_readwrite("spdk_proxy_shm_name", &UMBPConfig::spdk_proxy_shm_name)
-      .def_readwrite("spdk_proxy_tenant_id", &UMBPConfig::spdk_proxy_tenant_id)
-      .def_readwrite("spdk_proxy_tenant_quota_bytes", &UMBPConfig::spdk_proxy_tenant_quota_bytes)
-      .def_readwrite("spdk_proxy_max_channels", &UMBPConfig::spdk_proxy_max_channels)
-      .def_readwrite("spdk_proxy_data_per_channel_mb", &UMBPConfig::spdk_proxy_data_per_channel_mb)
-      .def_readwrite("spdk_proxy_startup_timeout_ms", &UMBPConfig::spdk_proxy_startup_timeout_ms)
-      .def_readwrite("spdk_proxy_auto_start", &UMBPConfig::spdk_proxy_auto_start)
-      .def_readwrite("spdk_proxy_idle_exit_timeout_ms",
-                     &UMBPConfig::spdk_proxy_idle_exit_timeout_ms)
-      .def_readwrite("spdk_proxy_allow_borrow", &UMBPConfig::spdk_proxy_allow_borrow)
-      .def_readwrite("spdk_proxy_reserved_shared_bytes",
-                     &UMBPConfig::spdk_proxy_reserved_shared_bytes)
       .def_readwrite("distributed", &UMBPConfig::distributed);
 
   py::class_<IUMBPClient, std::unique_ptr<IUMBPClient>>(m, "UMBPClient")

--- a/src/pybind/pybind_umbp.cpp
+++ b/src/pybind/pybind_umbp.cpp
@@ -215,6 +215,8 @@ void RegisterMoriUmbp(py::module_& m) {
       .def_readwrite("master_config", &UMBPDistributedConfig::master_config)
       .def_readwrite("io_engine", &UMBPDistributedConfig::io_engine)
       .def_readwrite("staging_buffer_size", &UMBPDistributedConfig::staging_buffer_size)
+      .def_readwrite("ssd_staging_buffer_size", &UMBPDistributedConfig::ssd_staging_buffer_size)
+      .def_readwrite("ssd_read_slots", &UMBPDistributedConfig::ssd_read_slots)
       .def_readwrite("peer_service_port", &UMBPDistributedConfig::peer_service_port)
       .def_readwrite("cache_remote_fetches", &UMBPDistributedConfig::cache_remote_fetches)
       .def_readwrite("dram_page_size", &UMBPDistributedConfig::dram_page_size);

--- a/src/pybind/pybind_umbp.cpp
+++ b/src/pybind/pybind_umbp.cpp
@@ -158,6 +158,8 @@ void RegisterMoriUmbp(py::module_& m) {
       .def_readwrite("capacity_bytes", &UMBPSsdConfig::capacity_bytes)
       .def_readwrite("layout_mode", &UMBPSsdConfig::layout_mode)
       .def_readwrite("segment_size_bytes", &UMBPSsdConfig::segment_size_bytes)
+      .def_readwrite("high_watermark", &UMBPSsdConfig::high_watermark)
+      .def_readwrite("low_watermark", &UMBPSsdConfig::low_watermark)
       .def_readwrite("io", &UMBPSsdConfig::io)
       .def_readwrite("durability", &UMBPSsdConfig::durability)
       .def_readwrite("ssd_backend", &UMBPSsdConfig::ssd_backend)

--- a/src/umbp/CMakeLists.txt
+++ b/src/umbp/CMakeLists.txt
@@ -321,6 +321,7 @@ add_library(
   distributed/routing/route_put_strategy.cpp
   distributed/peer/peer_dram_allocator.cpp
   distributed/peer/peer_ssd_manager.cpp
+  distributed/peer/ssd_copy_pipeline.cpp
   distributed/peer/peer_service.cpp
   distributed/pool_client.cpp
   distributed/distributed_client.cpp)

--- a/src/umbp/CMakeLists.txt
+++ b/src/umbp/CMakeLists.txt
@@ -320,6 +320,7 @@ add_library(
   distributed/routing/route_get_strategy.cpp
   distributed/routing/route_put_strategy.cpp
   distributed/peer/peer_dram_allocator.cpp
+  distributed/peer/peer_ssd_manager.cpp
   distributed/peer/peer_service.cpp
   distributed/pool_client.cpp
   distributed/distributed_client.cpp)
@@ -338,8 +339,12 @@ if(NOT EXISTS "${_PROTOBUF_COMPAT_DIR}/google")
 endif()
 target_include_directories(umbp_common BEFORE PUBLIC "${_PROTOBUF_COMPAT_DIR}")
 
-target_link_libraries(umbp_common PUBLIC mori_logging mori_io mori_metrics
-                                         ${_PROTOBUF_LIBS} ${_GRPCPP_LIB})
+# umbp_core provides the SSD tier backend (SSDTier/TierBackend) that
+# PeerSsdManager builds on.  This is the one new link dependency the SSD-tier
+# redesign introduces (umbp_core does not depend on umbp_common, so no cycle).
+target_link_libraries(
+  umbp_common PUBLIC mori_logging mori_io mori_metrics umbp_core
+                     ${_PROTOBUF_LIBS} ${_GRPCPP_LIB})
 
 target_compile_features(umbp_common PUBLIC cxx_std_17)
 

--- a/src/umbp/distributed/distributed_client.cpp
+++ b/src/umbp/distributed/distributed_client.cpp
@@ -38,8 +38,10 @@ DistributedClient::DistributedClient(const UMBPConfig& config) : config_(config)
 
   const auto& dc = config.distributed.value();
 
-  // TODO(distributed-ssd): remove or narrow this guard once DistributedClient
-  // actually wires in ssd_stores + PeerService for the distributed data path.
+  // TODO(Phase 1): remove this guard together with wiring in PeerSsdManager +
+  // ssd_stores/SSD TierCapacity lowering at the ToPoolClientConfig call below.
+  // See docs/umbp-ssd-tier-interface-contract-zh.md (§0.5, §7). Until then the
+  // distributed data path stays DRAM-only.
   if (config_.ssd.enabled) {
     MORI_UMBP_WARN(
         "[DistributedClient] SSD tier is currently not wired in distributed "
@@ -74,6 +76,10 @@ DistributedClient::DistributedClient(const UMBPConfig& config) : config_(config)
   // 2 MiB, so this only matters with non-default page size combinations.
   dram_pool_size_ = dram_pool_handle_.mapped_size;
 
+  // TODO(Phase 1): when SSD is enabled, also pass ssd_stores and a
+  // TierType::SSD entry in tier_capacities here so the peer constructs a
+  // PeerSsdManager and reports SSD capacity (contract §0.5/§7). Kept DRAM-only
+  // for now by the guard above.
   auto pc_config = ToPoolClientConfig(
       dc,
       /*dram_buffers=*/{{dram_pool_, dram_pool_size_}},

--- a/src/umbp/distributed/distributed_client.cpp
+++ b/src/umbp/distributed/distributed_client.cpp
@@ -38,20 +38,6 @@ DistributedClient::DistributedClient(const UMBPConfig& config) : config_(config)
 
   const auto& dc = config.distributed.value();
 
-  // TODO(Phase 1): remove this guard together with wiring in PeerSsdManager +
-  // ssd_stores/SSD TierCapacity lowering at the ToPoolClientConfig call below.
-  // See docs/umbp-ssd-tier-interface-contract-zh.md (§0.5, §7). Until then the
-  // distributed data path stays DRAM-only.
-  if (config_.ssd.enabled) {
-    MORI_UMBP_WARN(
-        "[DistributedClient] SSD tier is currently not wired in distributed "
-        "mode (node_id={}); ignoring ssd.enabled={} ssd.capacity_bytes={} "
-        "and running DRAM-only.",
-        dc.master_config.node_id, config_.ssd.enabled, config_.ssd.capacity_bytes);
-    config_.ssd.enabled = false;
-    config_.ssd.capacity_bytes = 0;
-  }
-
   HostMemAllocator allocator;
   HostBufferOptions opts;
   opts.backing = config.dram.use_hugepages ? HostBufferBacking::kAnonymousHugetlb
@@ -76,14 +62,22 @@ DistributedClient::DistributedClient(const UMBPConfig& config) : config_(config)
   // 2 MiB, so this only matters with non-default page size combinations.
   dram_pool_size_ = dram_pool_handle_.mapped_size;
 
-  // TODO(Phase 1): when SSD is enabled, also pass ssd_stores and a
-  // TierType::SSD entry in tier_capacities here so the peer constructs a
-  // PeerSsdManager and reports SSD capacity (contract §0.5/§7). Kept DRAM-only
-  // for now by the guard above.
-  auto pc_config = ToPoolClientConfig(
-      dc,
-      /*dram_buffers=*/{{dram_pool_, dram_pool_size_}},
-      /*tier_capacities=*/{{TierType::DRAM, {dram_pool_size_, dram_pool_size_}}});
+  // Lower SSD config to the peer.  When ssd.enabled, the peer builds a
+  // PeerSsdManager (SSDTier backend) from the SSD config (UMBPSsdConfig) and
+  // reports SSD capacity via TierType::SSD; when disabled, behavior is exactly
+  // DRAM-only (no PeerSsdManager, no SSD capacity, no SSD event source).
+  std::map<TierType, TierCapacity> tier_capacities = {
+      {TierType::DRAM, {dram_pool_size_, dram_pool_size_}}};
+  PeerSsdConfig ssd_cfg;
+  if (config_.ssd.enabled) {
+    ssd_cfg.enabled = true;
+    ssd_cfg.ssd = config_.ssd;
+    const uint64_t ssd_cap = config_.ssd.capacity_bytes;
+    tier_capacities[TierType::SSD] = {ssd_cap, ssd_cap};
+  }
+  auto pc_config = ToPoolClientConfig(dc,
+                                      /*dram_buffers=*/{{dram_pool_, dram_pool_size_}},
+                                      std::move(tier_capacities), std::move(ssd_cfg));
 
   pool_client_ = std::make_unique<PoolClient>(std::move(pc_config));
   if (!pool_client_->Init()) {

--- a/src/umbp/distributed/master/eviction_manager.cpp
+++ b/src/umbp/distributed/master/eviction_manager.cpp
@@ -84,6 +84,11 @@ void EvictionManager::RunOnce() {
 
   for (const auto& client : clients) {
     for (const auto& [tier, cap] : client.tier_capacities) {
+      // v1 SSD eviction is purely peer-local (Phase 4).  Master must NOT turn
+      // an SSD overload into an EvictKey: EvictKey only acts on the peer's
+      // PeerDramAllocator, so it would wrongly evict the DRAM copy of the same
+      // key while leaving SSD untouched.
+      if (tier == TierType::SSD) continue;
       if (cap.total_bytes == 0) continue;
       uint64_t used = cap.total_bytes - cap.available_bytes;
       double usage = static_cast<double>(used) / static_cast<double>(cap.total_bytes);

--- a/src/umbp/distributed/master/eviction_manager.cpp
+++ b/src/umbp/distributed/master/eviction_manager.cpp
@@ -69,12 +69,10 @@ void EvictionManager::EvictionLoop() {
   }
 }
 
-// In the master-as-advisor design, master decides what to evict but the
-// peer executes — and master's view of the index only changes when the
-// peer ships REMOVE events on the next heartbeat.  This function picks
-// victims; phase D wires the actual EvictKey RPC dispatch via the
-// master-server-owned peer-stub pool.  Until then, this is a no-op
-// beyond logging the intent.
+// Master decides what to evict but the peer executes — master's view of the
+// index only changes when the peer ships REMOVE events on the next heartbeat.
+// This function picks victims and dispatches EvictKey to each peer via the
+// dispatcher; master state itself is left untouched here.
 void EvictionManager::RunOnce() {
   auto clients = registry_.GetAliveClients();
 
@@ -84,8 +82,8 @@ void EvictionManager::RunOnce() {
 
   for (const auto& client : clients) {
     for (const auto& [tier, cap] : client.tier_capacities) {
-      // v1 SSD eviction is purely peer-local (Phase 4).  Master must NOT turn
-      // an SSD overload into an EvictKey: EvictKey only acts on the peer's
+      // SSD eviction is purely peer-local.  Master must NOT turn an SSD
+      // overload into an EvictKey: EvictKey only acts on the peer's
       // PeerDramAllocator, so it would wrongly evict the DRAM copy of the same
       // key while leaving SSD untouched.
       if (tier == TierType::SSD) continue;

--- a/src/umbp/distributed/master/master_client.cpp
+++ b/src/umbp/distributed/master/master_client.cpp
@@ -149,6 +149,8 @@ grpc::Status MasterClient::RegisterSelf(const std::map<TierType, TierCapacity>& 
   req.set_peer_address(peer_address);
   req.set_engine_desc(engine_desc_bytes.data(), engine_desc_bytes.size());
   FillTierCapacities(req.mutable_tier_capacities(), tier_capacities);
+  // DEPRECATED: master does not consume ssd_store_capacities. SSD capacity now
+  // travels in tier_capacities as TierType::SSD (Phase 1). Kept for wire compat.
   for (uint64_t cap : ssd_store_capacities) req.add_ssd_store_capacities(cap);
   for (const auto& tag : config_.tags) req.add_tags(tag);
 

--- a/src/umbp/distributed/master/master_client.cpp
+++ b/src/umbp/distributed/master/master_client.cpp
@@ -716,6 +716,18 @@ void MasterClient::RecordRpcError(std::string_view method, std::string_view code
              MORI_UMBP_METRIC_MASTER_CLIENT_RPC_ERRORS_TOTAL_HELP, std::move(labels), 1.0);
 }
 
+void MasterClient::AddMetricsProvider(std::function<void()> provider) {
+  // Reject late registration: MetricsLoop reads metrics_providers_ lock-free, so
+  // adding after the thread starts would race the reader (see header).
+  if (metrics_running_.load(std::memory_order_relaxed)) {
+    MORI_UMBP_ERROR(
+        "[Client] AddMetricsProvider called after the metrics thread started; ignoring "
+        "(providers must be registered before RegisterSelf)");
+    return;
+  }
+  if (provider) metrics_providers_.push_back(std::move(provider));
+}
+
 void MasterClient::StartMetricsReporting() {
   if (!registered_) return;
   if (metrics_running_) return;
@@ -746,76 +758,92 @@ void MasterClient::MetricsLoop() {
                            [this] { return !metrics_running_.load(); });
     }
     if (!metrics_running_) break;
+    FlushMetricsOnce();
+  }
+  // Final flush: ship the last sub-interval of provider deltas before the
+  // thread exits.  PoolClient::Shutdown calls StopMetricsReporting() BEFORE
+  // UnregisterSelf, so the master is still reachable here; without this final
+  // flush the last (<metrics_interval_ms_) of SSD counter deltas would be
+  // dropped at shutdown.
+  FlushMetricsOnce();
+}
 
-    std::unordered_map<std::string, PendingSample> counters;
-    std::unordered_map<std::string, PendingSample> gauges;
-    std::unordered_map<std::string, HistogramAccumulator> histogram_aggregates;
-    {
-      std::lock_guard lock(metrics_mutex_);
-      counters.swap(pending_counters_);
-      gauges.swap(pending_gauges_);
-      histogram_aggregates.swap(pending_histogram_aggregates_);
-    }
-    auto dropped_delta = metrics_dropped_count_.exchange(0, std::memory_order_relaxed);
-    if (counters.empty() && gauges.empty() && histogram_aggregates.empty() && dropped_delta == 0)
-      continue;
+void MasterClient::FlushMetricsOnce() {
+  // Let registered providers publish their latest counters/gauges into the
+  // pending buffers BEFORE we swap them out.  Runs in the metrics thread (no
+  // extra thread); providers are set before the thread starts.
+  for (const auto& provider : metrics_providers_) {
+    if (provider) provider();
+  }
 
-    ::umbp::ReportMetricsRequest req;
-    req.set_node_id(config_.node_id);
+  std::unordered_map<std::string, PendingSample> counters;
+  std::unordered_map<std::string, PendingSample> gauges;
+  std::unordered_map<std::string, HistogramAccumulator> histogram_aggregates;
+  {
+    std::lock_guard lock(metrics_mutex_);
+    counters.swap(pending_counters_);
+    gauges.swap(pending_gauges_);
+    histogram_aggregates.swap(pending_histogram_aggregates_);
+  }
+  auto dropped_delta = metrics_dropped_count_.exchange(0, std::memory_order_relaxed);
+  if (counters.empty() && gauges.empty() && histogram_aggregates.empty() && dropped_delta == 0)
+    return;
 
-    for (const auto& [key, s] : counters) {
-      auto* sample = req.add_metrics();
-      sample->set_name(s.name);
-      sample->set_help(s.help);
-      for (const auto& [k, v] : s.labels) {
-        auto* l = sample->add_labels();
-        l->set_name(k);
-        l->set_value(v);
-      }
-      sample->set_counter_delta(s.value);
-    }
-    for (const auto& [key, s] : gauges) {
-      auto* sample = req.add_metrics();
-      sample->set_name(s.name);
-      sample->set_help(s.help);
-      for (const auto& [k, v] : s.labels) {
-        auto* l = sample->add_labels();
-        l->set_name(k);
-        l->set_value(v);
-      }
-      sample->set_gauge_value(s.value);
-    }
-    for (const auto& [key, h] : histogram_aggregates) {
-      auto* sample = req.add_metrics();
-      sample->set_name(h.name);
-      sample->set_help(h.help);
-      for (const auto& [k, v] : h.labels) {
-        auto* l = sample->add_labels();
-        l->set_name(k);
-        l->set_value(v);
-      }
-      auto* agg = sample->mutable_histogram_aggregate();
-      for (double b : h.bounds) agg->add_bounds(b);
-      for (uint64_t c : h.bucket_counts) agg->add_bucket_counts(c);
-      agg->set_count(h.count);
-      agg->set_sum(h.sum);
-    }
-    if (dropped_delta > 0) {
-      auto* sample = req.add_metrics();
-      sample->set_name(MORI_UMBP_METRIC_MASTER_CLIENT_METRICS_DROPPED_TOTAL);
-      sample->set_help(MORI_UMBP_METRIC_MASTER_CLIENT_METRICS_DROPPED_TOTAL_HELP);
-      sample->set_counter_delta(static_cast<double>(dropped_delta));
-    }
+  ::umbp::ReportMetricsRequest req;
+  req.set_node_id(config_.node_id);
 
-    ::umbp::ReportMetricsResponse resp;
-    grpc::ClientContext ctx;
-    ctx.set_deadline(std::chrono::system_clock::now() +
-                     std::chrono::milliseconds(RpcShutdownTimeoutMs()));
-    auto status = GetStub(stub_.get())->ReportMetrics(&ctx, req, &resp);
-    if (!status.ok()) {
-      MORI_UMBP_WARN("[Client] ReportMetrics RPC failed: node_id={}, error={}", config_.node_id,
-                     status.error_message());
+  for (const auto& [key, s] : counters) {
+    auto* sample = req.add_metrics();
+    sample->set_name(s.name);
+    sample->set_help(s.help);
+    for (const auto& [k, v] : s.labels) {
+      auto* l = sample->add_labels();
+      l->set_name(k);
+      l->set_value(v);
     }
+    sample->set_counter_delta(s.value);
+  }
+  for (const auto& [key, s] : gauges) {
+    auto* sample = req.add_metrics();
+    sample->set_name(s.name);
+    sample->set_help(s.help);
+    for (const auto& [k, v] : s.labels) {
+      auto* l = sample->add_labels();
+      l->set_name(k);
+      l->set_value(v);
+    }
+    sample->set_gauge_value(s.value);
+  }
+  for (const auto& [key, h] : histogram_aggregates) {
+    auto* sample = req.add_metrics();
+    sample->set_name(h.name);
+    sample->set_help(h.help);
+    for (const auto& [k, v] : h.labels) {
+      auto* l = sample->add_labels();
+      l->set_name(k);
+      l->set_value(v);
+    }
+    auto* agg = sample->mutable_histogram_aggregate();
+    for (double b : h.bounds) agg->add_bounds(b);
+    for (uint64_t c : h.bucket_counts) agg->add_bucket_counts(c);
+    agg->set_count(h.count);
+    agg->set_sum(h.sum);
+  }
+  if (dropped_delta > 0) {
+    auto* sample = req.add_metrics();
+    sample->set_name(MORI_UMBP_METRIC_MASTER_CLIENT_METRICS_DROPPED_TOTAL);
+    sample->set_help(MORI_UMBP_METRIC_MASTER_CLIENT_METRICS_DROPPED_TOTAL_HELP);
+    sample->set_counter_delta(static_cast<double>(dropped_delta));
+  }
+
+  ::umbp::ReportMetricsResponse resp;
+  grpc::ClientContext ctx;
+  ctx.set_deadline(std::chrono::system_clock::now() +
+                   std::chrono::milliseconds(RpcShutdownTimeoutMs()));
+  auto status = GetStub(stub_.get())->ReportMetrics(&ctx, req, &resp);
+  if (!status.ok()) {
+    MORI_UMBP_WARN("[Client] ReportMetrics RPC failed: node_id={}, error={}", config_.node_id,
+                   status.error_message());
   }
 }
 

--- a/src/umbp/distributed/master/master_client.cpp
+++ b/src/umbp/distributed/master/master_client.cpp
@@ -35,6 +35,7 @@
 #include "umbp/distributed/master/master_metrics.h"
 #include "umbp/distributed/master/rpc_latency_timer.h"
 #include "umbp/distributed/peer/peer_dram_allocator.h"
+#include "umbp/distributed/peer/peer_ssd_manager.h"
 
 namespace mori::umbp {
 
@@ -136,8 +137,7 @@ MasterClient::~MasterClient() {
 
 grpc::Status MasterClient::RegisterSelf(const std::map<TierType, TierCapacity>& tier_capacities,
                                         const std::string& peer_address,
-                                        const std::vector<uint8_t>& engine_desc_bytes,
-                                        const std::vector<uint64_t>& ssd_store_capacities) {
+                                        const std::vector<uint8_t>& engine_desc_bytes) {
   ScopedRpcTimer _rpc_timer(this, "RegisterClient");
   if (registered_) {
     return grpc::Status(grpc::StatusCode::ALREADY_EXISTS, "node is already registered");
@@ -149,9 +149,6 @@ grpc::Status MasterClient::RegisterSelf(const std::map<TierType, TierCapacity>& 
   req.set_peer_address(peer_address);
   req.set_engine_desc(engine_desc_bytes.data(), engine_desc_bytes.size());
   FillTierCapacities(req.mutable_tier_capacities(), tier_capacities);
-  // DEPRECATED: master does not consume ssd_store_capacities. SSD capacity now
-  // travels in tier_capacities as TierType::SSD (Phase 1). Kept for wire compat.
-  for (uint64_t cap : ssd_store_capacities) req.add_ssd_store_capacities(cap);
   for (const auto& tag : config_.tags) req.add_tags(tag);
 
   ::umbp::RegisterClientResponse resp;
@@ -360,7 +357,20 @@ grpc::Status MasterClient::BatchLookup(const std::vector<std::string>& keys,
   return grpc::Status::OK;
 }
 
-void MasterClient::SetPeerDramAllocator(PeerDramAllocator* alloc) { peer_alloc_ = alloc; }
+void MasterClient::SetPeerDramAllocator(PeerDramAllocator* dram_alloc) {
+  peer_alloc_ = dram_alloc;
+  AddOwnedLocationSource(dram_alloc);
+}
+
+void MasterClient::SetPeerSsdManager(PeerSsdManager* ssd_manager) {
+  ssd_manager_ = ssd_manager;
+  AddOwnedLocationSource(ssd_manager);
+}
+
+void MasterClient::AddOwnedLocationSource(OwnedLocationSource* source) {
+  if (source == nullptr) return;
+  owned_sources_.push_back(source);
+}
 
 bool MasterClient::ClearFullSync() {
   std::lock_guard send_lock(hb_send_mutex_);
@@ -439,17 +449,28 @@ void MasterClient::HeartbeatLoop() {
 }
 
 std::map<TierType, TierCapacity> MasterClient::SnapshotAndCacheTierCapacities() {
+  std::map<TierType, TierCapacity> caps;
+  bool have_live = false;
   if (peer_alloc_ != nullptr) {
-    auto caps = peer_alloc_->TierCapacitiesSnapshot();
-    std::lock_guard lock(caps_mutex_);
-    for (auto& [t, c] : current_capacities_) {
-      if (caps.find(t) == caps.end()) caps[t] = c;
+    caps = peer_alloc_->TierCapacitiesSnapshot();  // DRAM/HBM, bitmap-derived
+    have_live = true;
+  }
+  if (ssd_manager_ != nullptr) {
+    auto [used, total] = ssd_manager_->Capacity();
+    if (total > 0) {
+      const uint64_t avail = used < total ? total - used : 0;
+      caps[TierType::SSD] = TierCapacity{total, avail};
+      have_live = true;
     }
-    current_capacities_ = caps;
-    return caps;
   }
   std::lock_guard lock(caps_mutex_);
-  return current_capacities_;
+  if (!have_live) return current_capacities_;
+  // Fill tiers we have no live source for from the cached snapshot.
+  for (auto& [t, c] : current_capacities_) {
+    if (caps.find(t) == caps.end()) caps[t] = c;
+  }
+  current_capacities_ = caps;
+  return caps;
 }
 
 bool MasterClient::SendHeartbeatOnce() {
@@ -489,7 +510,7 @@ bool MasterClient::SendFullSyncHeartbeatLocked(const std::map<TierType, TierCapa
     snapshot.seq = next_bundle_seq_ - 1;
     req.set_delta_seq_baseline(snapshot.seq);
   }
-  if (peer_alloc_ != nullptr) snapshot.events = peer_alloc_->SnapshotOwnedKeys();
+  snapshot.events = SnapshotAllSources(owned_sources_);
   FillBundle(req.add_bundles(), snapshot);
 
   ::umbp::HeartbeatResponse resp;
@@ -503,12 +524,13 @@ bool MasterClient::SendFullSyncHeartbeatLocked(const std::map<TierType, TierCapa
 
 bool MasterClient::SendDeltaHeartbeatLocked(const std::map<TierType, TierCapacity>& caps,
                                             const std::map<TierType, uint64_t>& kv_counts) {
-  if (peer_alloc_ != nullptr) {
-    auto new_events = peer_alloc_->DrainPendingEvents();
-    if (!new_events.empty()) {
-      std::lock_guard state_lock(hb_state_mutex_);
-      outbox_.push_back(EventBundle{next_bundle_seq_++, std::move(new_events)});
-    }
+  // Drain every owned-location source (DRAM allocator + SSD manager) and
+  // concat into ONE bundle under ONE monotonic seq — never one seq per source,
+  // which would break ack / seq-gap full-sync recovery.
+  auto new_events = DrainAllSources(owned_sources_);
+  if (!new_events.empty()) {
+    std::lock_guard state_lock(hb_state_mutex_);
+    outbox_.push_back(EventBundle{next_bundle_seq_++, std::move(new_events)});
   }
 
   ::umbp::HeartbeatRequest req;

--- a/src/umbp/distributed/peer/peer_dram_allocator.cpp
+++ b/src/umbp/distributed/peer/peer_dram_allocator.cpp
@@ -22,6 +22,7 @@
 #include "umbp/distributed/peer/peer_dram_allocator.h"
 
 #include <algorithm>
+#include <cassert>
 #include <stdexcept>
 #include <utility>
 
@@ -61,8 +62,14 @@ PeerDramAllocator::PeerDramAllocator(uint64_t page_size, TierConfig dram, TierCo
     if (cfg.buffer_sizes.size() != cfg.buffer_descs.size()) {
       throw std::invalid_argument("PeerDramAllocator: buffer_sizes / buffer_descs length mismatch");
     }
+    // buffer_bases is optional (deployments / tests that never pin leave it
+    // empty); when present it must line up with the buffers one-to-one.
+    if (!cfg.buffer_bases.empty() && cfg.buffer_bases.size() != cfg.buffer_sizes.size()) {
+      throw std::invalid_argument("PeerDramAllocator: buffer_bases / buffer_sizes length mismatch");
+    }
     allocators_.emplace(tier, std::make_unique<PageBitmapAllocator>(page_size, cfg.buffer_sizes));
     tier_descs_.emplace(tier, std::move(cfg.buffer_descs));
+    tier_bases_.emplace(tier, std::move(cfg.buffer_bases));
   };
   install_tier(TierType::DRAM, dram);
   install_tier(TierType::HBM, hbm);
@@ -295,6 +302,13 @@ std::vector<PeerDramAllocator::EvictResult> PeerDramAllocator::Evict(
       out.push_back(std::move(r));
       continue;
     }
+    if (HasActivePinLocked(key)) {
+      // An SSD copy worker is reading these pages.  Do NOT free them, do
+      // NOT emit REMOVE DRAM, keep the key owned.  bytes_freed=0 tells
+      // master to retry; the pin is released when the copy finishes.
+      out.push_back(std::move(r));
+      continue;
+    }
     if (auto* alloc = AllocatorForLocked(it->second.tier)) {
       alloc->Deallocate(it->second.pages);
     }
@@ -306,6 +320,55 @@ std::vector<PeerDramAllocator::EvictResult> PeerDramAllocator::Evict(
   return out;
 }
 
+std::optional<PeerDramAllocator::DramCopyPin> PeerDramAllocator::AcquireDramCopyPin(
+    const std::string& key) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = owned_.find(key);
+  if (it == owned_.end()) return std::nullopt;              // already evicted -> drop task
+  if (pins_.find(key) != pins_.end()) return std::nullopt;  // duplicate task
+
+  DramCopyPin pin;
+  pin.total_size = it->second.size;
+  pin.segments = BuildCopySegmentsLocked(it->second.tier, it->second.pages, it->second.size);
+  pin.pin_token = next_pin_token_++;
+  pins_[key] = PinState{pin.pin_token, std::chrono::steady_clock::now()};
+  return pin;
+}
+
+void PeerDramAllocator::ReleaseDramCopyPin(const std::string& key, uint64_t pin_token) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = pins_.find(key);
+  if (it == pins_.end() || it->second.token != pin_token) return;  // tolerate late/dup release
+  pins_.erase(it);
+}
+
+bool PeerDramAllocator::HasActivePinLocked(const std::string& key) const {
+  return pins_.find(key) != pins_.end();
+}
+
+std::vector<std::pair<const void*, size_t>> PeerDramAllocator::BuildCopySegmentsLocked(
+    TierType tier, const std::vector<PageLocation>& pages, uint64_t total_size) const {
+  std::vector<std::pair<const void*, size_t>> segments;
+  auto it = tier_bases_.find(tier);
+  if (it == tier_bases_.end() || it->second.empty()) return segments;
+  const auto& bases = it->second;
+  segments.reserve(pages.size());
+  uint64_t remaining = total_size;
+  for (const auto& p : pages) {
+    if (p.buffer_index >= bases.size() || bases[p.buffer_index] == nullptr) {
+      MORI_UMBP_ERROR("[PeerDramAllocator] copy segment: bad buffer_index {} (bases={})",
+                      p.buffer_index, bases.size());
+      return {};
+    }
+    // Last page may be partial; earlier pages are full page_size.
+    const uint64_t bytes = std::min<uint64_t>(page_size_, remaining);
+    const char* base = static_cast<const char*>(bases[p.buffer_index]);
+    segments.emplace_back(base + static_cast<uint64_t>(p.page_index) * page_size_, bytes);
+    remaining -= bytes;
+  }
+  return segments;
+}
+
 void PeerDramAllocator::ClearLocal() {
   std::lock_guard<std::mutex> lock(mutex_);
   const auto now = std::chrono::steady_clock::now();
@@ -315,9 +378,23 @@ void PeerDramAllocator::ClearLocal() {
   // freed by the writer's Commit or by the reaper's TTL path.
   ++allocator_generation_;
 
-  // Owned: defer pages with an active read lease (RDMA read may still
-  // be in flight); free others immediately.  No REMOVE events — the
-  // upcoming full-sync empty snapshot collapses master's index.
+  // pins_ should be empty because PoolClient::Clear quiesces the copy pipeline.
+  // If not, this is a caller bug; log loudly.  We do not support clearing with
+  // active copy pins and make no attempt to salvage them here.  A debug assert
+  // turns this into a hard failure under test/CI; release builds keep running
+  // (the freed pages cannot be reused until ClearFullSyncAcked re-enables
+  // Allocate, so this stays UAF-safe in practice).
+  if (!pins_.empty()) {
+    MORI_UMBP_ERROR(
+        "[PeerDramAllocator] ClearLocal with {} active copy pin(s) — caller did not quiesce "
+        "the copy pipeline (bug)",
+        pins_.size());
+    assert(pins_.empty() && "ClearLocal called with active copy pins; quiesce the pipeline first");
+  }
+
+  // Owned: defer pages with an active read lease (an RDMA read may still be in
+  // flight) until their lease deadline; free the rest immediately.  No REMOVE
+  // events — the upcoming full-sync empty snapshot collapses master's index.
   for (auto& [key, slot] : owned_) {
     auto lease_it = read_lease_until_.find(key);
     if (lease_it != read_lease_until_.end() && lease_it->second > now) {
@@ -335,8 +412,9 @@ void PeerDramAllocator::ClearLocal() {
   }
   owned_.clear();
 
-  // Active deadlines that mattered are already in deferred_frees_.
+  // Active read-lease deadlines that mattered are already in deferred_frees_.
   read_lease_until_.clear();
+  pins_.clear();
 
   // Drop any queued ADD/REMOVE that the heartbeat hasn't shipped yet:
   // the snapshot we're about to send is the authoritative state.
@@ -484,6 +562,18 @@ void PeerDramAllocator::ReaperSweep() {
       it = read_lease_until_.erase(it);
     } else {
       ++it;
+    }
+  }
+
+  // Warn about copy pins held far longer than any healthy copy should
+  // take.  We never force-free a pin (a worker may still be reading its
+  // segments — freeing would be a use-after-free); this is purely an
+  // observability signal that a copy worker is stuck.
+  constexpr std::chrono::seconds kLongRunningPinWarn{30};
+  for (const auto& [key, pin] : pins_) {
+    if (now - pin.acquired_at > kLongRunningPinWarn) {
+      MORI_UMBP_WARN("[PeerDramAllocator] copy pin for key='{}' held >{}s — copy worker stuck?",
+                     key, kLongRunningPinWarn.count());
     }
   }
 

--- a/src/umbp/distributed/peer/peer_dram_allocator.cpp
+++ b/src/umbp/distributed/peer/peer_dram_allocator.cpp
@@ -341,7 +341,6 @@ void PeerDramAllocator::ClearLocal() {
   // Drop any queued ADD/REMOVE that the heartbeat hasn't shipped yet:
   // the snapshot we're about to send is the authoritative state.
   pending_events_.clear();
-  owned_external_ssd_.clear();
 
   clear_full_sync_pending_.store(true, std::memory_order_release);
   MORI_UMBP_INFO("[PeerDramAllocator] ClearLocal — pending writes will be rejected until ack");
@@ -349,24 +348,6 @@ void PeerDramAllocator::ClearLocal() {
 
 void PeerDramAllocator::ClearFullSyncAcked() {
   clear_full_sync_pending_.store(false, std::memory_order_release);
-}
-
-void PeerDramAllocator::QueueExternalEvent(KvEvent ev) {
-  std::lock_guard<std::mutex> lock(mutex_);
-  if (ev.tier == TierType::SSD) {
-    switch (ev.kind) {
-      case KvEvent::Kind::ADD:
-        owned_external_ssd_[ev.key] = SsdEntry{ev.size};
-        break;
-      case KvEvent::Kind::REMOVE:
-        owned_external_ssd_.erase(ev.key);
-        break;
-      case KvEvent::Kind::CLEAR_AT_TIER:
-        owned_external_ssd_.clear();
-        break;
-    }
-  }
-  pending_events_.push_back(std::move(ev));
 }
 
 std::vector<KvEvent> PeerDramAllocator::DrainPendingEvents() {
@@ -379,12 +360,9 @@ std::vector<KvEvent> PeerDramAllocator::DrainPendingEvents() {
 std::vector<KvEvent> PeerDramAllocator::SnapshotOwnedKeys() const {
   std::lock_guard<std::mutex> lock(mutex_);
   std::vector<KvEvent> out;
-  out.reserve(owned_.size() + owned_external_ssd_.size());
+  out.reserve(owned_.size());
   for (const auto& kv : owned_) {
     out.push_back(KvEvent{KvEvent::Kind::ADD, kv.first, kv.second.tier, kv.second.size});
-  }
-  for (const auto& kv : owned_external_ssd_) {
-    out.push_back(KvEvent{KvEvent::Kind::ADD, kv.first, TierType::SSD, kv.second.size});
   }
   return out;
 }
@@ -394,7 +372,6 @@ std::map<TierType, uint64_t> PeerDramAllocator::OwnedKeyCountByTier() const {
   std::map<TierType, uint64_t> result;
   for (TierType t : {TierType::HBM, TierType::DRAM, TierType::SSD}) result[t] = 0;
   for (const auto& [key, slot] : owned_) result[slot.tier]++;
-  result[TierType::SSD] += owned_external_ssd_.size();
   return result;
 }
 

--- a/src/umbp/distributed/peer/peer_service.cpp
+++ b/src/umbp/distributed/peer/peer_service.cpp
@@ -162,8 +162,8 @@ class PeerServiceServer::UMBPPeerServiceImpl final : public ::umbp::UMBPPeer::Se
                       const std::vector<uint8_t>& ssd_staging_mem_desc_bytes,
                       LocalStorageManager* storage, LocalBlockIndex* index,
                       PeerDramAllocator* dram_alloc, MasterClient* master_client,
-                      StagingMetrics& metrics, int num_read_slots, int num_write_slots,
-                      int lease_timeout_s, const std::vector<uint8_t>& engine_desc_bytes)
+                      StagingMetrics& metrics, int num_read_slots, int lease_timeout_s,
+                      const std::vector<uint8_t>& engine_desc_bytes)
       : ssd_staging_base_(ssd_staging_base),
         ssd_staging_size_(ssd_staging_size),
         ssd_staging_mem_desc_bytes_(ssd_staging_mem_desc_bytes),
@@ -174,17 +174,15 @@ class PeerServiceServer::UMBPPeerServiceImpl final : public ::umbp::UMBPPeer::Se
         metrics_(metrics),
         lease_timeout_(std::max(lease_timeout_s, 1)),
         num_read_slots_(std::max(num_read_slots, 1)),
-        num_write_slots_(std::max(num_write_slots, 1)),
+        // Read staging currently lives in the upper half of the buffer; the
+        // lower half was the removed direct-put write staging and is reclaimed
+        // when read staging is rebuilt in Phase 3.
         read_region_base_(ssd_staging_size / 2),
         read_slot_size_((ssd_staging_size / 2) / static_cast<size_t>(std::max(num_read_slots, 1))),
-        write_slot_size_((ssd_staging_size / 2) /
-                         static_cast<size_t>(std::max(num_write_slots, 1))),
         read_slots_(std::max(num_read_slots, 1)),
-        write_slots_(std::max(num_write_slots, 1)),
         master_client_(master_client) {
-    if (num_read_slots <= 0 || num_write_slots <= 0) {
-      MORI_UMBP_ERROR("[PeerService] num_read_slots={} num_write_slots={} invalid, clamped to 1",
-                      num_read_slots, num_write_slots);
+    if (num_read_slots <= 0) {
+      MORI_UMBP_ERROR("[PeerService] num_read_slots={} invalid, clamped to 1", num_read_slots);
     }
   }
 
@@ -219,149 +217,12 @@ class PeerServiceServer::UMBPPeerServiceImpl final : public ::umbp::UMBPPeer::Se
     return grpc::Status::OK;
   }
 
-  // ---- Write path: AllocateWriteSlot + CommitSsdWrite ----
-
-  grpc::Status AllocateWriteSlot(grpc::ServerContext* /*context*/,
-                                 const ::umbp::AllocateWriteSlotRequest* request,
-                                 ::umbp::AllocateWriteSlotResponse* response) override {
-    if (!SsdRpcAvailable()) {
-      response->set_success(false);
-      return grpc::Status::OK;
-    }
-    if (request->size() > write_slot_size_ || request->size() == 0) {
-      response->set_success(false);
-      return grpc::Status::OK;
-    }
-
-    int slot_idx;
-    uint64_t offset, lease_id;
-    std::chrono::steady_clock::time_point alloc_time;
-    {
-      std::lock_guard<std::mutex> lock(write_slots_mutex_);
-      slot_idx =
-          ClaimStagingSlot(write_slots_, next_lease_id_, lease_timeout_, request->size(), metrics_);
-      if (slot_idx < 0) {
-        metrics_.slot_full_rejects.fetch_add(1, std::memory_order_relaxed);
-        response->set_success(false);
-        return grpc::Status::OK;
-      }
-      offset = static_cast<uint64_t>(slot_idx) * write_slot_size_;
-      lease_id = write_slots_[slot_idx].lease_id;
-      alloc_time = write_slots_[slot_idx].allocated_at;
-    }
-
-    response->set_success(true);
-    response->set_staging_offset(offset);
-    response->set_lease_id(lease_id);
-    response->set_lease_ttl_ms(RemainingTtlMs(alloc_time, lease_timeout_));
-    return grpc::Status::OK;
-  }
-
-  grpc::Status CommitSsdWrite(grpc::ServerContext* /*context*/,
-                              const ::umbp::CommitSsdWriteRequest* request,
-                              ::umbp::CommitSsdWriteResponse* response) override {
-    const uint64_t commit_lease_id = request->lease_id();
-    uint64_t offset;
-    {
-      std::lock_guard<std::mutex> lock(write_slots_mutex_);
-      int slot_idx = FindSlotByLeaseId(write_slots_, commit_lease_id);
-      if (slot_idx < 0) {
-        metrics_.invalid_lease_rejects.fetch_add(1, std::memory_order_relaxed);
-        MORI_UMBP_ERROR("[PeerService] CommitSsdWrite: invalid/expired lease_id={}",
-                        commit_lease_id);
-        response->set_success(false);
-        return grpc::Status::OK;
-      }
-      offset = static_cast<uint64_t>(slot_idx) * write_slot_size_;
-
-      if (request->store_index() != 0) {
-        MORI_UMBP_ERROR("[PeerService] CommitSsdWrite: store_index {} != 0, rejected",
-                        request->store_index());
-        ReleaseSlotByLeaseId(write_slots_, commit_lease_id);
-        response->set_success(false);
-        return grpc::Status::OK;
-      }
-      if (request->size() > write_slots_[slot_idx].allocated_size) {
-        MORI_UMBP_ERROR("[PeerService] CommitSsdWrite: size {} > allocated {}", request->size(),
-                        write_slots_[slot_idx].allocated_size);
-        ReleaseSlotByLeaseId(write_slots_, commit_lease_id);
-        response->set_success(false);
-        return grpc::Status::OK;
-      }
-      if (request->staging_offset() != offset) {
-        MORI_UMBP_ERROR("[PeerService] CommitSsdWrite: staging_offset {} != slot offset {}",
-                        request->staging_offset(), offset);
-        ReleaseSlotByLeaseId(write_slots_, commit_lease_id);
-        response->set_success(false);
-        return grpc::Status::OK;
-      }
-    }
-
-    const std::string& key = request->key();
-    const size_t size = request->size();
-
-    // Local-only dedup: if this peer already has the key in its block
-    // index, treat the commit as a no-op success.  The cross-node
-    // FinalizeAllocation gate is gone in the master-as-advisor design;
-    // master will see the existing key via heartbeat events.
-    if (!SsdRpcAvailable()) {
-      response->set_success(false);
-      return grpc::Status::OK;
-    }
-    auto existing = index_->Lookup(key);
-    if (existing.has_value()) {
-      std::lock_guard<std::mutex> lock(write_slots_mutex_);
-      ReleaseSlotByLeaseId(write_slots_, commit_lease_id);
-      response->set_success(true);
-      return grpc::Status::OK;
-    }
-
-    const void* src = static_cast<const uint8_t*>(ssd_staging_base_) + offset;
-    bool ok = storage_->Write(key, src, size, StorageTier::LOCAL_SSD);
-    if (!ok) {
-      MORI_UMBP_ERROR("[PeerService] CommitSsdWrite: local SSD write failed for '{}'", key);
-      std::lock_guard<std::mutex> lock(write_slots_mutex_);
-      ReleaseSlotByLeaseId(write_slots_, commit_lease_id);
-      response->set_success(false);
-      return grpc::Status::OK;
-    }
-    index_->Insert(key, {StorageTier::LOCAL_SSD, 0, size});
-
-    auto* ssd = storage_->GetTier(StorageTier::LOCAL_SSD);
-    auto loc_id = ssd ? ssd->GetLocationId(key) : std::nullopt;
-    if (!loc_id.has_value()) {
-      storage_->Evict(key);
-      index_->Remove(key);
-      MORI_UMBP_ERROR("[PeerService] CommitSsdWrite: GetLocationId failed for '{}'", key);
-      std::lock_guard<std::mutex> lock(write_slots_mutex_);
-      ReleaseSlotByLeaseId(write_slots_, commit_lease_id);
-      response->set_success(false);
-      return grpc::Status::OK;
-    }
-    std::string location_id = "0:" + *loc_id;
-
-    // Master learns about this SSD-tier ADD via the heartbeat-shipped
-    // event log.  The peer's universal outbox lives on the DRAM
-    // allocator; SSD-only deployments still construct one (with empty
-    // tier configs) so this hand-off works.  When dram_alloc_ is null
-    // the SSD path is non-distributed: master simply never sees the key.
-    if (dram_alloc_ != nullptr) {
-      dram_alloc_->QueueExternalEvent(KvEvent{KvEvent::Kind::ADD, key, TierType::SSD, size});
-    }
-
-    {
-      std::lock_guard<std::mutex> lock(write_slots_mutex_);
-      ReleaseSlotByLeaseId(write_slots_, commit_lease_id);
-    }
-    response->set_success(true);
-    response->set_ssd_location_id(location_id);
-    MORI_UMBP_INFO("[PeerService] CommitSsdWrite: key={}, size={}, location={}", key, size,
-                   location_id);
-    RecordInboundPut(static_cast<uint64_t>(size), "remote");
-    return grpc::Status::OK;
-  }
-
-  // ---- Read path: PrepareSsdRead + ReleaseSsdLease ----
+  // ---- SSD read staging: PrepareSsdRead + ReleaseSsdLease ----
+  // Direct-SSD-put (AllocateWriteSlot / CommitSsdWrite) was removed in the
+  // SSD-tier redesign — SSD is now an async copy-on-commit cold tier, not a
+  // writer-driven put target.  TODO(Phase 3): refactor the two read RPCs to
+  // key-based + status enum + size (docs/umbp-ssd-tier-interface-contract-zh.md
+  // §5), and reclaim the now-vestigial lower half of the staging buffer.
 
   grpc::Status PrepareSsdRead(grpc::ServerContext* /*context*/,
                               const ::umbp::PrepareSsdReadRequest* request,
@@ -667,15 +528,11 @@ class PeerServiceServer::UMBPPeerServiceImpl final : public ::umbp::UMBPPeer::Se
 
   const std::chrono::seconds lease_timeout_;
   const int num_read_slots_;
-  const int num_write_slots_;
   const uint64_t read_region_base_;
   const size_t read_slot_size_;
-  const size_t write_slot_size_;
 
   std::mutex read_slots_mutex_;
-  std::mutex write_slots_mutex_;
   std::vector<StagingSlot> read_slots_;
-  std::vector<StagingSlot> write_slots_;
   std::atomic<uint64_t> next_lease_id_{1};
 };
 
@@ -683,8 +540,7 @@ PeerServiceServer::PeerServiceServer(void* ssd_staging_base, size_t ssd_staging_
                                      const std::vector<uint8_t>& ssd_staging_mem_desc_bytes,
                                      LocalStorageManager& storage, LocalBlockIndex& index,
                                      PeerDramAllocator* dram_alloc, int num_read_slots,
-                                     int num_write_slots, int lease_timeout_s,
-                                     std::vector<uint8_t> engine_desc_bytes,
+                                     int lease_timeout_s, std::vector<uint8_t> engine_desc_bytes,
                                      MasterClient* master_client)
     : ssd_staging_base_(ssd_staging_base),
       ssd_staging_size_(ssd_staging_size),
@@ -696,13 +552,11 @@ PeerServiceServer::PeerServiceServer(void* ssd_staging_base, size_t ssd_staging_
       engine_desc_bytes_(std::move(engine_desc_bytes)) {
   service_ = std::make_unique<UMBPPeerServiceImpl>(
       ssd_staging_base_, ssd_staging_size_, ssd_staging_mem_desc_bytes_, storage_, index_,
-      dram_alloc_, master_client_, metrics_, num_read_slots, num_write_slots, lease_timeout_s,
-      engine_desc_bytes_);
+      dram_alloc_, master_client_, metrics_, num_read_slots, lease_timeout_s, engine_desc_bytes_);
 }
 
 PeerServiceServer::PeerServiceServer(PeerDramAllocator* dram_alloc, int num_read_slots,
-                                     int num_write_slots, int lease_timeout_s,
-                                     std::vector<uint8_t> engine_desc_bytes,
+                                     int lease_timeout_s, std::vector<uint8_t> engine_desc_bytes,
                                      MasterClient* master_client)
     : ssd_staging_base_(nullptr),
       ssd_staging_size_(0),
@@ -713,8 +567,7 @@ PeerServiceServer::PeerServiceServer(PeerDramAllocator* dram_alloc, int num_read
       engine_desc_bytes_(std::move(engine_desc_bytes)) {
   service_ = std::make_unique<UMBPPeerServiceImpl>(
       ssd_staging_base_, ssd_staging_size_, ssd_staging_mem_desc_bytes_, storage_, index_,
-      dram_alloc_, master_client_, metrics_, num_read_slots, num_write_slots, lease_timeout_s,
-      engine_desc_bytes_);
+      dram_alloc_, master_client_, metrics_, num_read_slots, lease_timeout_s, engine_desc_bytes_);
 }
 
 PeerServiceServer::~PeerServiceServer() { Stop(); }

--- a/src/umbp/distributed/peer/peer_service.cpp
+++ b/src/umbp/distributed/peer/peer_service.cpp
@@ -33,6 +33,7 @@
 #include "umbp/distributed/master/master_client.h"
 #include "umbp/distributed/master/master_metrics.h"
 #include "umbp/distributed/peer/peer_dram_allocator.h"
+#include "umbp/distributed/peer/ssd_copy_pipeline.h"
 #include "umbp/distributed/types.h"
 #include "umbp/local/block_index/local_block_index.h"
 #include "umbp/local/tiers/local_storage_manager.h"
@@ -163,13 +164,14 @@ class PeerServiceServer::UMBPPeerServiceImpl final : public ::umbp::UMBPPeer::Se
                       LocalStorageManager* storage, LocalBlockIndex* index,
                       PeerDramAllocator* dram_alloc, MasterClient* master_client,
                       StagingMetrics& metrics, int num_read_slots, int lease_timeout_s,
-                      const std::vector<uint8_t>& engine_desc_bytes)
+                      const std::vector<uint8_t>& engine_desc_bytes, SsdCopyPipeline* copy_pipeline)
       : ssd_staging_base_(ssd_staging_base),
         ssd_staging_size_(ssd_staging_size),
         ssd_staging_mem_desc_bytes_(ssd_staging_mem_desc_bytes),
         storage_(storage),
         index_(index),
         dram_alloc_(dram_alloc),
+        copy_pipeline_(copy_pipeline),
         engine_desc_bytes_(engine_desc_bytes),
         metrics_(metrics),
         lease_timeout_(std::max(lease_timeout_s, 1)),
@@ -333,7 +335,10 @@ class PeerServiceServer::UMBPPeerServiceImpl final : public ::umbp::UMBPPeer::Se
     uint64_t committed_bytes = 0;
     const bool ok = dram_alloc_->Commit(request->slot_id(), request->key(), committed_bytes);
     response->set_success(ok);
-    if (ok) RecordInboundPut(committed_bytes, "remote");
+    if (ok) {
+      RecordInboundPut(committed_bytes, "remote");
+      EnqueueSsdCopy(request->key(), committed_bytes);
+    }
     return grpc::Status::OK;
   }
 
@@ -446,9 +451,13 @@ class PeerServiceServer::UMBPPeerServiceImpl final : public ::umbp::UMBPPeer::Se
 
     auto results = dram_alloc_->BatchCommit(entries);
     uint64_t total_committed = 0;
-    for (const auto& result : results) {
+    for (size_t i = 0; i < results.size(); ++i) {
+      const auto& result = results[i];
       response->add_success(result.success);
-      if (result.success) total_committed += result.bytes_committed;
+      if (result.success) {
+        total_committed += result.bytes_committed;
+        EnqueueSsdCopy(entries[i].key, result.bytes_committed);
+      }
     }
     if (total_committed > 0) RecordInboundPut(total_committed, "remote");
     return grpc::Status::OK;
@@ -500,6 +509,13 @@ class PeerServiceServer::UMBPPeerServiceImpl final : public ::umbp::UMBPPeer::Se
            ssd_staging_size_ > 0;
   }
 
+  // Best-effort enqueue of an async SSD copy after a successful DRAM commit.
+  // No-op when SSD is disabled; never blocks (a full/stopped queue drops).
+  void EnqueueSsdCopy(const std::string& key, uint64_t bytes) {
+    if (copy_pipeline_ == nullptr) return;
+    copy_pipeline_->Enqueue(SsdCopyTask{key, TierType::DRAM, static_cast<size_t>(bytes)});
+  }
+
   void RecordInboundPut(uint64_t bytes, const char* traffic) {
     if (master_client_ == nullptr || bytes == 0) return;
     MasterClient::Labels labels = {{"traffic", std::string(traffic)}};
@@ -522,6 +538,7 @@ class PeerServiceServer::UMBPPeerServiceImpl final : public ::umbp::UMBPPeer::Se
   LocalStorageManager* storage_;
   LocalBlockIndex* index_;
   PeerDramAllocator* dram_alloc_;
+  SsdCopyPipeline* copy_pipeline_;
   MasterClient* master_client_;
   const std::vector<uint8_t>& engine_desc_bytes_;
   StagingMetrics& metrics_;
@@ -552,22 +569,25 @@ PeerServiceServer::PeerServiceServer(void* ssd_staging_base, size_t ssd_staging_
       engine_desc_bytes_(std::move(engine_desc_bytes)) {
   service_ = std::make_unique<UMBPPeerServiceImpl>(
       ssd_staging_base_, ssd_staging_size_, ssd_staging_mem_desc_bytes_, storage_, index_,
-      dram_alloc_, master_client_, metrics_, num_read_slots, lease_timeout_s, engine_desc_bytes_);
+      dram_alloc_, master_client_, metrics_, num_read_slots, lease_timeout_s, engine_desc_bytes_,
+      /*copy_pipeline=*/nullptr);
 }
 
 PeerServiceServer::PeerServiceServer(PeerDramAllocator* dram_alloc, int num_read_slots,
                                      int lease_timeout_s, std::vector<uint8_t> engine_desc_bytes,
-                                     MasterClient* master_client)
+                                     MasterClient* master_client, SsdCopyPipeline* copy_pipeline)
     : ssd_staging_base_(nullptr),
       ssd_staging_size_(0),
       storage_(nullptr),
       index_(nullptr),
       dram_alloc_(dram_alloc),
       master_client_(master_client),
+      copy_pipeline_(copy_pipeline),
       engine_desc_bytes_(std::move(engine_desc_bytes)) {
   service_ = std::make_unique<UMBPPeerServiceImpl>(
       ssd_staging_base_, ssd_staging_size_, ssd_staging_mem_desc_bytes_, storage_, index_,
-      dram_alloc_, master_client_, metrics_, num_read_slots, lease_timeout_s, engine_desc_bytes_);
+      dram_alloc_, master_client_, metrics_, num_read_slots, lease_timeout_s, engine_desc_bytes_,
+      copy_pipeline_);
 }
 
 PeerServiceServer::~PeerServiceServer() { Stop(); }
@@ -593,6 +613,11 @@ void PeerServiceServer::Stop() {
     const auto deadline = std::chrono::system_clock::now() + GrpcShutdownDeadline();
     MORI_UMBP_INFO("[PeerService] Shutting down");
     server_->Shutdown(deadline);
+    // Block until every in-flight handler has returned (Shutdown's deadline
+    // force-cancels any that overrun).  This guarantees no RPC handler is still
+    // touching borrowed state (dram_alloc_ / copy_pipeline_) after Stop()
+    // returns, so PoolClient can safely tear those down next.
+    server_->Wait();
     server_.reset();
   }
 }

--- a/src/umbp/distributed/peer/peer_service.cpp
+++ b/src/umbp/distributed/peer/peer_service.cpp
@@ -33,10 +33,9 @@
 #include "umbp/distributed/master/master_client.h"
 #include "umbp/distributed/master/master_metrics.h"
 #include "umbp/distributed/peer/peer_dram_allocator.h"
+#include "umbp/distributed/peer/peer_ssd_manager.h"
 #include "umbp/distributed/peer/ssd_copy_pipeline.h"
 #include "umbp/distributed/types.h"
-#include "umbp/local/block_index/local_block_index.h"
-#include "umbp/local/tiers/local_storage_manager.h"
 #include "umbp_peer.grpc.pb.h"
 
 namespace mori::umbp {
@@ -49,40 +48,36 @@ std::chrono::seconds GrpcShutdownDeadline() {
   return v;
 }
 
+// Free -> Preparing -> Leased.  SSD IO runs while Preparing; the TTL only
+// starts on Leased, and Preparing slots are never reclaimed — so a slow IO
+// can't let the reaper reassign a slot and corrupt bytes a reader will RDMA.
+enum class SlotState { kFree, kPreparing, kLeased };
+
 struct StagingSlot {
-  bool in_use = false;
+  SlotState state = SlotState::kFree;
   uint64_t lease_id = 0;
   size_t allocated_size = 0;
-  std::chrono::steady_clock::time_point allocated_at;
+  std::chrono::steady_clock::time_point leased_at;  // valid only while kLeased
 };
 
+// Reclaim TTL-expired leased slots, then claim a free one as Preparing (TTL not
+// yet started) and return its index, or -1 if none free.
 int ClaimStagingSlot(std::vector<StagingSlot>& slots, std::atomic<uint64_t>& next_lease_id,
-                     std::chrono::seconds lease_timeout, size_t request_size,
-                     StagingMetrics& metrics) {
+                     std::chrono::seconds lease_timeout, StagingMetrics& metrics) {
   auto now = std::chrono::steady_clock::now();
   for (auto& slot : slots) {
-    if (slot.in_use && now - slot.allocated_at > lease_timeout) {
+    if (slot.state == SlotState::kLeased && now - slot.leased_at > lease_timeout) {
       metrics.expired_reclaims.fetch_add(1, std::memory_order_relaxed);
       MORI_UMBP_WARN("[PeerService] Reclaiming expired slot (lease_id={})", slot.lease_id);
-      slot.in_use = false;
+      slot.state = SlotState::kFree;
     }
   }
   for (auto& slot : slots) {
-    if (!slot.in_use) {
-      slot.in_use = true;
+    if (slot.state == SlotState::kFree) {
+      slot.state = SlotState::kPreparing;
       slot.lease_id = next_lease_id.fetch_add(1, std::memory_order_relaxed);
-      slot.allocated_size = request_size;
-      slot.allocated_at = now;
+      slot.allocated_size = 0;
       return static_cast<int>(&slot - &slots[0]);
-    }
-  }
-  return -1;
-}
-
-int FindSlotByLeaseId(const std::vector<StagingSlot>& slots, uint64_t lease_id) {
-  for (size_t i = 0; i < slots.size(); ++i) {
-    if (slots[i].in_use && slots[i].lease_id == lease_id) {
-      return static_cast<int>(i);
     }
   }
   return -1;
@@ -90,20 +85,12 @@ int FindSlotByLeaseId(const std::vector<StagingSlot>& slots, uint64_t lease_id) 
 
 bool ReleaseSlotByLeaseId(std::vector<StagingSlot>& slots, uint64_t lease_id) {
   for (auto& slot : slots) {
-    if (slot.in_use && slot.lease_id == lease_id) {
-      slot.in_use = false;
+    if (slot.state == SlotState::kLeased && slot.lease_id == lease_id) {
+      slot.state = SlotState::kFree;
       return true;
     }
   }
   return false;
-}
-
-uint64_t RemainingTtlMs(std::chrono::steady_clock::time_point alloc_time,
-                        std::chrono::seconds lease_timeout) {
-  auto elapsed = std::chrono::steady_clock::now() - alloc_time;
-  auto remaining_ms = std::max<int64_t>(
-      0, std::chrono::duration_cast<std::chrono::milliseconds>(lease_timeout - elapsed).count());
-  return static_cast<uint64_t>(remaining_ms);
 }
 }  // namespace
 
@@ -136,6 +123,23 @@ TierType FromProtoTier(::umbp::TierType t) {
   }
 }
 
+// Map a PeerSsdManager read outcome (data-level: ok/not_found/size/error) to the
+// wire status.  NO_SLOT / LEASE_EXPIRED are staging-layer concerns owned by the
+// peer service, not PeerSsdManager, and are set directly by the handler.
+::umbp::SsdReadStatus ToProtoReadStatus(SsdReadStatus s) {
+  switch (s) {
+    case SsdReadStatus::kOk:
+      return ::umbp::SSD_READ_OK;
+    case SsdReadStatus::kNotFound:
+      return ::umbp::SSD_READ_NOT_FOUND;
+    case SsdReadStatus::kSizeTooLarge:
+      return ::umbp::SSD_READ_SIZE_TOO_LARGE;
+    case SsdReadStatus::kError:
+      return ::umbp::SSD_READ_ERROR;
+  }
+  return ::umbp::SSD_READ_ERROR;
+}
+
 // Drop a (pages, page_size, descs) tuple into a slot-shaped response
 // that exposes those fields directly.  Templated so the same body
 // covers AllocateSlotResponse and ResolveKeyResponse.
@@ -161,26 +165,25 @@ class PeerServiceServer::UMBPPeerServiceImpl final : public ::umbp::UMBPPeer::Se
  public:
   UMBPPeerServiceImpl(void* ssd_staging_base, size_t ssd_staging_size,
                       const std::vector<uint8_t>& ssd_staging_mem_desc_bytes,
-                      LocalStorageManager* storage, LocalBlockIndex* index,
-                      PeerDramAllocator* dram_alloc, MasterClient* master_client,
-                      StagingMetrics& metrics, int num_read_slots, int lease_timeout_s,
-                      const std::vector<uint8_t>& engine_desc_bytes, SsdCopyPipeline* copy_pipeline)
+                      PeerSsdManager* peer_ssd, PeerDramAllocator* dram_alloc,
+                      MasterClient* master_client, StagingMetrics& metrics, int num_read_slots,
+                      int lease_timeout_s, const std::vector<uint8_t>& engine_desc_bytes,
+                      SsdCopyPipeline* copy_pipeline)
       : ssd_staging_base_(ssd_staging_base),
         ssd_staging_size_(ssd_staging_size),
         ssd_staging_mem_desc_bytes_(ssd_staging_mem_desc_bytes),
-        storage_(storage),
-        index_(index),
+        peer_ssd_(peer_ssd),
         dram_alloc_(dram_alloc),
         copy_pipeline_(copy_pipeline),
         engine_desc_bytes_(engine_desc_bytes),
         metrics_(metrics),
         lease_timeout_(std::max(lease_timeout_s, 1)),
         num_read_slots_(std::max(num_read_slots, 1)),
-        // Read staging currently lives in the upper half of the buffer; the
-        // lower half was the removed direct-put write staging and is reclaimed
-        // when read staging is rebuilt in Phase 3.
-        read_region_base_(ssd_staging_size / 2),
-        read_slot_size_((ssd_staging_size / 2) / static_cast<size_t>(std::max(num_read_slots, 1))),
+        // The whole staging buffer is the read region now: the lower half used
+        // to be direct-put write staging, removed in the SSD-tier redesign and
+        // reclaimed here so reads get more / larger slots.
+        read_region_base_(0),
+        read_slot_size_(ssd_staging_size / static_cast<size_t>(std::max(num_read_slots, 1))),
         read_slots_(std::max(num_read_slots, 1)),
         master_client_(master_client) {
     if (num_read_slots <= 0) {
@@ -220,74 +223,75 @@ class PeerServiceServer::UMBPPeerServiceImpl final : public ::umbp::UMBPPeer::Se
   }
 
   // ---- SSD read staging: PrepareSsdRead + ReleaseSsdLease ----
-  // Direct-SSD-put (AllocateWriteSlot / CommitSsdWrite) was removed in the
-  // SSD-tier redesign — SSD is now an async copy-on-commit cold tier, not a
-  // writer-driven put target.  TODO(Phase 3): refactor the two read RPCs to
-  // key-based + status enum + size (docs/umbp-ssd-tier-interface-contract-zh.md
-  // §5), and reclaim the now-vestigial lower half of the staging buffer.
-
+  // Key-based: claim a slot -> PeerSsdManager::PrepareRead fills it -> reader
+  // RDMAs the bytes out of the published staging buffer -> best-effort release.
   grpc::Status PrepareSsdRead(grpc::ServerContext* /*context*/,
                               const ::umbp::PrepareSsdReadRequest* request,
                               ::umbp::PrepareSsdReadResponse* response) override {
     if (!SsdRpcAvailable()) {
-      response->set_success(false);
-      return grpc::Status::OK;
-    }
-    if (request->size() > read_slot_size_ || request->size() == 0) {
-      MORI_UMBP_ERROR("[PeerService] PrepareSsdRead: size {} invalid (slot_size={})",
-                      request->size(), read_slot_size_);
-      response->set_success(false);
+      response->set_status(::umbp::SSD_READ_ERROR);
       return grpc::Status::OK;
     }
 
+    // Claim a slot first (Preparing — not yet TTL-tracked).  NO_SLOT is a
+    // transient/retryable condition, not a miss.
     int slot_idx;
     uint64_t offset, lease_id;
-    std::chrono::steady_clock::time_point alloc_time;
     {
       std::lock_guard<std::mutex> lock(read_slots_mutex_);
-      slot_idx =
-          ClaimStagingSlot(read_slots_, next_lease_id_, lease_timeout_, request->size(), metrics_);
+      slot_idx = ClaimStagingSlot(read_slots_, next_lease_id_, lease_timeout_, metrics_);
       if (slot_idx < 0) {
         metrics_.slot_full_rejects.fetch_add(1, std::memory_order_relaxed);
         MORI_UMBP_WARN("[PeerService] PrepareSsdRead: no free staging slots");
-        response->set_success(false);
+        response->set_status(::umbp::SSD_READ_NO_SLOT);
         return grpc::Status::OK;
       }
       offset = read_region_base_ + static_cast<uint64_t>(slot_idx) * read_slot_size_;
       lease_id = read_slots_[slot_idx].lease_id;
-      alloc_time = read_slots_[slot_idx].allocated_at;
     }
 
+    // Cap the read at min(reader capacity, slot size); PrepareRead rejects an
+    // over-cap key BEFORE doing any SSD IO, so an oversized key costs no read.
     void* dst = static_cast<uint8_t*>(ssd_staging_base_) + offset;
-    bool ok = storage_->ReadIntoPtrNoPromote(request->key(), reinterpret_cast<uintptr_t>(dst),
-                                             request->size());
-    if (!ok) {
+    size_t cap = std::min<uint64_t>(request->max_size(), read_slot_size_);
+    SsdReadOutcome outcome = peer_ssd_->PrepareRead(request->key(), dst, cap);
+
+    if (outcome.status != SsdReadStatus::kOk) {
       std::lock_guard<std::mutex> lock(read_slots_mutex_);
-      ReleaseSlotByLeaseId(read_slots_, lease_id);
-      response->set_success(false);
+      read_slots_[slot_idx].state = SlotState::kFree;  // give the slot straight back
+      response->set_status(ToProtoReadStatus(outcome.status));
+      response->set_size(outcome.size);
       return grpc::Status::OK;
     }
 
-    response->set_success(true);
+    // Data is in the slot: promote Preparing -> Leased and start the TTL now.
+    {
+      std::lock_guard<std::mutex> lock(read_slots_mutex_);
+      auto& slot = read_slots_[slot_idx];
+      slot.state = SlotState::kLeased;
+      slot.leased_at = std::chrono::steady_clock::now();
+      slot.allocated_size = outcome.size;
+    }
+    response->set_status(::umbp::SSD_READ_OK);
     response->set_staging_offset(offset);
+    response->set_size(outcome.size);
     response->set_lease_id(lease_id);
-    response->set_lease_ttl_ms(RemainingTtlMs(alloc_time, lease_timeout_));
-    MORI_UMBP_INFO("[PeerService] PrepareSsdRead: key={}, slot={}, offset={}, lease_id={}",
-                   request->key(), slot_idx, offset, lease_id);
+    response->set_lease_ttl_ms(static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(lease_timeout_).count()));
+    MORI_UMBP_DEBUG(
+        "[PeerService] PrepareSsdRead: key={}, slot={}, offset={}, size={}, lease_id={}",
+        request->key(), slot_idx, offset, outcome.size, lease_id);
     return grpc::Status::OK;
   }
 
   grpc::Status ReleaseSsdLease(grpc::ServerContext* /*context*/,
                                const ::umbp::ReleaseSsdLeaseRequest* request,
                                ::umbp::ReleaseSsdLeaseResponse* response) override {
+    // Best-effort fast release; correctness does not depend on it (the slot is
+    // also reclaimed by the lease TTL).  Returns false only when the lease is
+    // already gone (released earlier or TTL-reclaimed).
     std::lock_guard<std::mutex> lock(read_slots_mutex_);
-    int idx = FindSlotByLeaseId(read_slots_, request->lease_id());
-    if (idx >= 0) {
-      read_slots_[idx].in_use = false;
-      response->set_success(true);
-    } else {
-      response->set_success(false);
-    }
+    response->set_success(ReleaseSlotByLeaseId(read_slots_, request->lease_id()));
     return grpc::Status::OK;
   }
 
@@ -505,8 +509,7 @@ class PeerServiceServer::UMBPPeerServiceImpl final : public ::umbp::UMBPPeer::Se
 
  private:
   bool SsdRpcAvailable() const {
-    return storage_ != nullptr && index_ != nullptr && ssd_staging_base_ != nullptr &&
-           ssd_staging_size_ > 0;
+    return peer_ssd_ != nullptr && ssd_staging_base_ != nullptr && ssd_staging_size_ > 0;
   }
 
   // Best-effort enqueue of an async SSD copy after a successful DRAM commit.
@@ -535,8 +538,7 @@ class PeerServiceServer::UMBPPeerServiceImpl final : public ::umbp::UMBPPeer::Se
   void* ssd_staging_base_;
   size_t ssd_staging_size_;
   const std::vector<uint8_t>& ssd_staging_mem_desc_bytes_;
-  LocalStorageManager* storage_;
-  LocalBlockIndex* index_;
+  PeerSsdManager* peer_ssd_;
   PeerDramAllocator* dram_alloc_;
   SsdCopyPipeline* copy_pipeline_;
   MasterClient* master_client_;
@@ -553,40 +555,23 @@ class PeerServiceServer::UMBPPeerServiceImpl final : public ::umbp::UMBPPeer::Se
   std::atomic<uint64_t> next_lease_id_{1};
 };
 
-PeerServiceServer::PeerServiceServer(void* ssd_staging_base, size_t ssd_staging_size,
-                                     const std::vector<uint8_t>& ssd_staging_mem_desc_bytes,
-                                     LocalStorageManager& storage, LocalBlockIndex& index,
-                                     PeerDramAllocator* dram_alloc, int num_read_slots,
-                                     int lease_timeout_s, std::vector<uint8_t> engine_desc_bytes,
-                                     MasterClient* master_client)
+PeerServiceServer::PeerServiceServer(PeerDramAllocator* dram_alloc, PeerSsdManager* peer_ssd,
+                                     void* ssd_staging_base, size_t ssd_staging_size,
+                                     std::vector<uint8_t> ssd_staging_mem_desc_bytes,
+                                     int num_read_slots, int lease_timeout_s,
+                                     std::vector<uint8_t> engine_desc_bytes,
+                                     MasterClient* master_client, SsdCopyPipeline* copy_pipeline)
     : ssd_staging_base_(ssd_staging_base),
       ssd_staging_size_(ssd_staging_size),
-      storage_(&storage),
-      index_(&index),
-      dram_alloc_(dram_alloc),
-      ssd_staging_mem_desc_bytes_(ssd_staging_mem_desc_bytes),
-      master_client_(master_client),
-      engine_desc_bytes_(std::move(engine_desc_bytes)) {
-  service_ = std::make_unique<UMBPPeerServiceImpl>(
-      ssd_staging_base_, ssd_staging_size_, ssd_staging_mem_desc_bytes_, storage_, index_,
-      dram_alloc_, master_client_, metrics_, num_read_slots, lease_timeout_s, engine_desc_bytes_,
-      /*copy_pipeline=*/nullptr);
-}
-
-PeerServiceServer::PeerServiceServer(PeerDramAllocator* dram_alloc, int num_read_slots,
-                                     int lease_timeout_s, std::vector<uint8_t> engine_desc_bytes,
-                                     MasterClient* master_client, SsdCopyPipeline* copy_pipeline)
-    : ssd_staging_base_(nullptr),
-      ssd_staging_size_(0),
-      storage_(nullptr),
-      index_(nullptr),
+      peer_ssd_(peer_ssd),
       dram_alloc_(dram_alloc),
       master_client_(master_client),
       copy_pipeline_(copy_pipeline),
+      ssd_staging_mem_desc_bytes_(std::move(ssd_staging_mem_desc_bytes)),
       engine_desc_bytes_(std::move(engine_desc_bytes)) {
   service_ = std::make_unique<UMBPPeerServiceImpl>(
-      ssd_staging_base_, ssd_staging_size_, ssd_staging_mem_desc_bytes_, storage_, index_,
-      dram_alloc_, master_client_, metrics_, num_read_slots, lease_timeout_s, engine_desc_bytes_,
+      ssd_staging_base_, ssd_staging_size_, ssd_staging_mem_desc_bytes_, peer_ssd_, dram_alloc_,
+      master_client_, metrics_, num_read_slots, lease_timeout_s, engine_desc_bytes_,
       copy_pipeline_);
 }
 

--- a/src/umbp/distributed/peer/peer_service.cpp
+++ b/src/umbp/distributed/peer/peer_service.cpp
@@ -565,6 +565,19 @@ class PeerServiceServer::UMBPPeerServiceImpl final : public ::umbp::UMBPPeer::Se
   std::mutex read_slots_mutex_;
   std::vector<StagingSlot> read_slots_;
   std::atomic<uint64_t> next_lease_id_{1};
+
+ public:
+  // SSD read staging slots currently busy (Preparing or Leased).  Sampled once
+  // per metrics flush by PoolClient's provider; a brief lock + small scan
+  // (num_read_slots, default 16) — not a busy loop.
+  size_t ReadSlotsInUse() {
+    std::lock_guard<std::mutex> lock(read_slots_mutex_);
+    size_t in_use = 0;
+    for (const auto& slot : read_slots_) {
+      if (slot.state != SlotState::kFree) ++in_use;
+    }
+    return in_use;
+  }
 };
 
 PeerServiceServer::PeerServiceServer(PeerDramAllocator* dram_alloc, PeerSsdManager* peer_ssd,
@@ -588,6 +601,10 @@ PeerServiceServer::PeerServiceServer(PeerDramAllocator* dram_alloc, PeerSsdManag
 }
 
 PeerServiceServer::~PeerServiceServer() { Stop(); }
+
+size_t PeerServiceServer::SnapshotReadSlotsInUse() const {
+  return service_ ? service_->ReadSlotsInUse() : 0;
+}
 
 bool PeerServiceServer::Start(uint16_t port) {
   std::string address = "0.0.0.0:" + std::to_string(port);

--- a/src/umbp/distributed/peer/peer_service.cpp
+++ b/src/umbp/distributed/peer/peer_service.cpp
@@ -48,9 +48,13 @@ std::chrono::seconds GrpcShutdownDeadline() {
   return v;
 }
 
-// Free -> Preparing -> Leased.  SSD IO runs while Preparing; the TTL only
-// starts on Leased, and Preparing slots are never reclaimed — so a slow IO
-// can't let the reaper reassign a slot and corrupt bytes a reader will RDMA.
+// Free -> Preparing -> Leased.  Preparing slots (IO in flight) are never
+// reclaimed, so a slow IO can't have its slot reassigned mid-write.  The TTL is
+// anchored at request receipt (leased_at = received_at, set on promotion) to
+// align the peer's reclaim point (received_at + ttl) with the reader's deadline
+// (t_send + ttl, t_send < received_at).  A reader trusting bytes from a slot
+// reclaimed mid-use is prevented by Preparing (IO safety) + the reader's own
+// lease gating (see ssd_read_lease.h).
 enum class SlotState { kFree, kPreparing, kLeased };
 
 struct StagingSlot {
@@ -124,8 +128,9 @@ TierType FromProtoTier(::umbp::TierType t) {
 }
 
 // Map a PeerSsdManager read outcome (data-level: ok/not_found/size/error) to the
-// wire status.  NO_SLOT / LEASE_EXPIRED are staging-layer concerns owned by the
-// peer service, not PeerSsdManager, and are set directly by the handler.
+// wire status.  NO_SLOT is a staging-layer concern owned by the peer service,
+// not PeerSsdManager, and is set directly by the handler.  Lease expiry is not
+// a wire status: the reader decides it locally and the peer reclaims by TTL.
 ::umbp::SsdReadStatus ToProtoReadStatus(SsdReadStatus s) {
   switch (s) {
     case SsdReadStatus::kOk:
@@ -233,6 +238,12 @@ class PeerServiceServer::UMBPPeerServiceImpl final : public ::umbp::UMBPPeer::Se
       return grpc::Status::OK;
     }
 
+    // Anchor the lease TTL at request receipt (see SlotState comment): the slot
+    // is promoted to Leased with this timestamp once the IO completes, so the
+    // peer's reclaim point stays aligned with the reader's t_send-based
+    // deadline rather than starting only after the (variable) SSD IO.
+    const auto received_at = std::chrono::steady_clock::now();
+
     // Claim a slot first (Preparing — not yet TTL-tracked).  NO_SLOT is a
     // transient/retryable condition, not a miss.
     int slot_idx;
@@ -264,12 +275,13 @@ class PeerServiceServer::UMBPPeerServiceImpl final : public ::umbp::UMBPPeer::Se
       return grpc::Status::OK;
     }
 
-    // Data is in the slot: promote Preparing -> Leased and start the TTL now.
+    // Data is in the slot: promote Preparing -> Leased with the request-receipt
+    // TTL anchor (leased_at = received_at).
     {
       std::lock_guard<std::mutex> lock(read_slots_mutex_);
       auto& slot = read_slots_[slot_idx];
       slot.state = SlotState::kLeased;
-      slot.leased_at = std::chrono::steady_clock::now();
+      slot.leased_at = received_at;
       slot.allocated_size = outcome.size;
     }
     response->set_status(::umbp::SSD_READ_OK);

--- a/src/umbp/distributed/peer/peer_ssd_manager.cpp
+++ b/src/umbp/distributed/peer/peer_ssd_manager.cpp
@@ -1,0 +1,142 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#include "umbp/distributed/peer/peer_ssd_manager.h"
+
+#include <cstring>
+
+#include "mori/utils/mori_log.hpp"
+#include "umbp/local/tiers/ssd_tier.h"
+#include "umbp/local/tiers/tier_backend.h"
+
+namespace mori::umbp {
+
+PeerSsdManager::PeerSsdManager(const PeerSsdConfig& cfg) {
+  if (!cfg.enabled) {
+    MORI_UMBP_INFO("[PeerSsdManager] constructed disabled (no SSD backend)");
+    return;
+  }
+  // v1 builds the POSIX/io_uring SSDTier directly from UMBPSsdConfig.  SPDK
+  // backend selection is not wired into the distributed peer path yet (see
+  // PeerSsdConfig TODO); when it is, branch on the backend here.
+  const auto& ssd = cfg.ssd;
+  backend_ = std::make_unique<SSDTier>(ssd.storage_dir, ssd.capacity_bytes, ssd);
+  MORI_UMBP_INFO("[PeerSsdManager] SSDTier ready dir={} capacity={}B", ssd.storage_dir,
+                 ssd.capacity_bytes);
+}
+
+PeerSsdManager::~PeerSsdManager() = default;
+
+std::pair<size_t, size_t> PeerSsdManager::Capacity() const {
+  if (!backend_) return {0, 0};
+  return backend_->Capacity();
+}
+
+bool PeerSsdManager::Exists(const std::string& key) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return owned_.find(key) != owned_.end();
+}
+
+bool PeerSsdManager::Write(const std::string& key,
+                           const std::vector<std::pair<const void*, size_t>>& segments,
+                           size_t total_size) {
+  if (!backend_) return false;
+
+  // Assemble (possibly non-contiguous) DRAM source segments into one
+  // contiguous buffer before handing it to the backend.  v1 accepts the extra
+  // memcpy; a writev/batch path can replace this later.  When the source is
+  // already a single contiguous segment of the right size we write it directly.
+  const void* data = nullptr;
+  std::vector<char> scratch;
+  if (segments.size() == 1 && segments[0].second == total_size) {
+    data = segments[0].first;
+  } else {
+    scratch.resize(total_size);
+    size_t off = 0;
+    for (const auto& [ptr, len] : segments) {
+      if (off + len > total_size) {
+        MORI_UMBP_ERROR("[PeerSsdManager] Write key={} segments exceed total_size={}", key,
+                        total_size);
+        return false;
+      }
+      if (len > 0) std::memcpy(scratch.data() + off, ptr, len);
+      off += len;
+    }
+    if (off != total_size) {
+      MORI_UMBP_ERROR("[PeerSsdManager] Write key={} assembled {} != total_size={}", key, off,
+                      total_size);
+      return false;
+    }
+    data = scratch.data();
+  }
+
+  // Backend IO outside our mutex_ — SSDTier is internally synchronized.
+  if (!backend_->Write(key, data, total_size)) {
+    MORI_UMBP_WARN("[PeerSsdManager] backend Write failed key={} size={}", key, total_size);
+    return false;
+  }
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  owned_[key] = total_size;
+  pending_events_.push_back(KvEvent{KvEvent::Kind::ADD, key, TierType::SSD, total_size});
+  return true;
+}
+
+bool PeerSsdManager::Evict(const std::string& key) {
+  if (!backend_) return false;
+  backend_->Evict(key);
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = owned_.find(key);
+  if (it == owned_.end()) return false;
+  owned_.erase(it);
+  pending_events_.push_back(KvEvent{KvEvent::Kind::REMOVE, key, TierType::SSD, 0});
+  return true;
+}
+
+std::vector<std::string> PeerSsdManager::SelectVictims(size_t /*bytes_to_free*/) {
+  // TODO(Phase 4): local watermark + LRU victim selection.
+  return {};
+}
+
+SsdReadOutcome PeerSsdManager::PrepareRead(const std::string& /*key*/, void* /*staging_ptr*/,
+                                           size_t /*staging_cap*/) {
+  // TODO(Phase 3): key-based read into staging (local vs remote SSD get).
+  return SsdReadOutcome{SsdReadStatus::kNotFound, 0};
+}
+
+std::vector<KvEvent> PeerSsdManager::DrainPendingEvents() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::vector<KvEvent> drained;
+  drained.swap(pending_events_);
+  return drained;
+}
+
+std::vector<KvEvent> PeerSsdManager::SnapshotOwnedKeys() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::vector<KvEvent> out;
+  out.reserve(owned_.size());
+  for (const auto& [key, size] : owned_) {
+    out.push_back(KvEvent{KvEvent::Kind::ADD, key, TierType::SSD, size});
+  }
+  return out;
+}
+
+}  // namespace mori::umbp

--- a/src/umbp/distributed/peer/peer_ssd_manager.cpp
+++ b/src/umbp/distributed/peer/peer_ssd_manager.cpp
@@ -183,6 +183,11 @@ bool PeerSsdManager::Write(const std::string& key,
     }
   }
 
+  // Bytes physically written to the SSD device (write IO bandwidth source).
+  // Counted on every successful backend Write, including the rare dup-content
+  // re-write by a second copy worker (real device IO happened either way).
+  metrics_.copy_bytes.fetch_add(total_size, std::memory_order_relaxed);
+
   // Record the location.  Re-check owned_: with > 1 copy worker, two of them
   // could have both seen "absent" above and written the same (identical,
   // content-addressed) bytes — only the first records it + emits ADD SSD.
@@ -229,11 +234,14 @@ bool PeerSsdManager::Evict(const std::string& key) {
   std::lock_guard<std::mutex> lock(mutex_);
   evicting_.erase(key);
   if (!ok) {
+    metrics_.evict_backend_failures.fetch_add(1, std::memory_order_relaxed);
     MORI_UMBP_WARN("[PeerSsdManager] backend Evict failed key={} — keeping for retry", key);
     return false;
   }
   auto it = owned_.find(key);
   if (it != owned_.end()) {  // still present (a racing ClearLocal could have dropped it)
+    metrics_.evict_victims.fetch_add(1, std::memory_order_relaxed);
+    metrics_.evict_bytes_freed.fetch_add(it->second.size, std::memory_order_relaxed);
     lru_.erase(it->second.lru_it);
     owned_.erase(it);
     pending_events_.push_back(KvEvent{KvEvent::Kind::REMOVE, key, TierType::SSD, 0});
@@ -276,6 +284,10 @@ void PeerSsdManager::EvictToLowWatermark() {
   if (static_cast<double>(used) <= low_bytes) return;
   size_t bytes_to_free = used - static_cast<size_t>(low_bytes);
 
+  // A real round is about to run (we own the round lock and are over the low
+  // watermark).  Count it before selecting victims.
+  metrics_.evict_rounds.fetch_add(1, std::memory_order_relaxed);
+
   // Single pass, no retry loop: if everything reclaimable is in use we free
   // what we can and stop, so a fully-pinned tier cannot starve the worker.
   for (const auto& key : SelectVictims(bytes_to_free)) {
@@ -288,6 +300,11 @@ void PeerSsdManager::EvictToLowWatermark() {
 // ---------------------------------------------------------------------------
 
 void PeerSsdManager::ClearLocal() {
+  // CALLER INVARIANT: quiesce the copy pipeline before calling this.  We drain
+  // in-flight reads (below) but not in-flight Writes, so a racing Write could
+  // re-add owned_/ADD SSD after backend->Clear() wipes its bytes.
+  // PoolClient::Clear() Quiesce()s first; new callers must too.
+  //
   // Exclude eviction rounds for the whole operation (lock order: eviction_mu_
   // before mutex_, matching EvictToLowWatermark).
   std::lock_guard<std::mutex> round(eviction_mu_);
@@ -305,13 +322,31 @@ void PeerSsdManager::ClearLocal() {
   if (backend_) backend_->Clear();  // delete physical SSD bytes (user Clear = discard cache)
 }
 
+void PeerSsdManager::DiscardLeftoverOnStartup() {
+  // owned_ is empty on a fresh process, so there is nothing to reconcile: just
+  // wipe any orphan bytes the backend loaded from disk so used capacity starts
+  // at 0 (cache is re-fetchable; safe to drop).  See header for the policy.
+  if (!backend_) return;
+  auto [used, total] = backend_->Capacity();
+  if (used == 0) {
+    MORI_UMBP_INFO("[PeerSsdManager] startup discard: no SSD leftover (used=0)");
+    return;
+  }
+  MORI_UMBP_INFO("[PeerSsdManager] startup discard: wiping {}B SSD leftover (total={}B)", used,
+                 total);
+  backend_->Clear();
+}
+
 // ---------------------------------------------------------------------------
 //  Read
 // ---------------------------------------------------------------------------
 
 SsdReadOutcome PeerSsdManager::PrepareRead(const std::string& key, void* staging_ptr,
                                            size_t staging_cap) {
-  if (!backend_) return SsdReadOutcome{SsdReadStatus::kNotFound, 0};
+  if (!backend_) {
+    metrics_.read_not_found.fetch_add(1, std::memory_order_relaxed);
+    return SsdReadOutcome{SsdReadStatus::kNotFound, 0};
+  }
 
   // Resolve size and mark the read in flight under the lock, then run the
   // blocking SSD IO outside it (so a concurrent copy Write is not serialized).
@@ -319,13 +354,20 @@ SsdReadOutcome PeerSsdManager::PrepareRead(const std::string& key, void* staging
   {
     std::lock_guard<std::mutex> lock(mutex_);
     auto it = owned_.find(key);
-    if (it == owned_.end()) return SsdReadOutcome{SsdReadStatus::kNotFound, 0};
+    if (it == owned_.end()) {
+      metrics_.read_not_found.fetch_add(1, std::memory_order_relaxed);
+      return SsdReadOutcome{SsdReadStatus::kNotFound, 0};
+    }
     // Being evicted: bytes about to vanish — treat a new read as a stale-route
     // miss rather than racing the backend delete.
-    if (evicting_.count(key) != 0) return SsdReadOutcome{SsdReadStatus::kNotFound, 0};
+    if (evicting_.count(key) != 0) {
+      metrics_.read_not_found.fetch_add(1, std::memory_order_relaxed);
+      return SsdReadOutcome{SsdReadStatus::kNotFound, 0};
+    }
     size = it->second.size;
     // Reject over-capacity before touching the device (no in-flight mark, no IO).
     if (size > staging_cap) {
+      metrics_.read_size_too_large.fetch_add(1, std::memory_order_relaxed);
       MORI_UMBP_WARN("[PeerSsdManager] PrepareRead key={} size={} exceeds cap={}", key, size,
                      staging_cap);
       return SsdReadOutcome{SsdReadStatus::kSizeTooLarge, size};
@@ -348,9 +390,12 @@ SsdReadOutcome PeerSsdManager::PrepareRead(const std::string& key, void* staging
   if (!read_ok) {
     // owned_ had the key but the backend couldn't serve it (e.g. a Phase 4
     // local evict raced us, or a corrupt record): kError, not a definitive miss.
+    metrics_.read_error.fetch_add(1, std::memory_order_relaxed);
     MORI_UMBP_WARN("[PeerSsdManager] PrepareRead backend read failed key={} size={}", key, size);
     return SsdReadOutcome{SsdReadStatus::kError, size};
   }
+  metrics_.read_ok.fetch_add(1, std::memory_order_relaxed);
+  metrics_.read_bytes.fetch_add(size, std::memory_order_relaxed);  // SSD read IO bandwidth source
   return SsdReadOutcome{SsdReadStatus::kOk, size};
 }
 

--- a/src/umbp/distributed/peer/peer_ssd_manager.cpp
+++ b/src/umbp/distributed/peer/peer_ssd_manager.cpp
@@ -151,10 +151,36 @@ void PeerSsdManager::ClearLocal() {
   pending_events_.clear();
 }
 
-SsdReadOutcome PeerSsdManager::PrepareRead(const std::string& /*key*/, void* /*staging_ptr*/,
-                                           size_t /*staging_cap*/) {
-  // TODO(Phase 3): key-based read into staging (local vs remote SSD get).
-  return SsdReadOutcome{SsdReadStatus::kNotFound, 0};
+SsdReadOutcome PeerSsdManager::PrepareRead(const std::string& key, void* staging_ptr,
+                                           size_t staging_cap) {
+  if (!backend_) return SsdReadOutcome{SsdReadStatus::kNotFound, 0};
+
+  // Look up the authoritative size under the lock, then release it before the
+  // blocking SSD IO so a concurrent copy Write() is not serialized behind this
+  // read (the lock only guards the owned_ map, not the backend IO).
+  size_t size = 0;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = owned_.find(key);
+    if (it == owned_.end()) return SsdReadOutcome{SsdReadStatus::kNotFound, 0};
+    size = it->second;
+  }
+
+  // Reject before touching the device: a key larger than the caller's capacity
+  // (reader buffer / staging slot) must not trigger a wasted SSD read.
+  if (size > staging_cap) {
+    MORI_UMBP_WARN("[PeerSsdManager] PrepareRead key={} size={} exceeds cap={}", key, size,
+                   staging_cap);
+    return SsdReadOutcome{SsdReadStatus::kSizeTooLarge, size};
+  }
+
+  if (!backend_->ReadIntoPtr(key, reinterpret_cast<uintptr_t>(staging_ptr), size)) {
+    // owned_ had the key but the backend couldn't serve it (e.g. a Phase 4
+    // local evict raced us, or a corrupt record): kError, not a definitive miss.
+    MORI_UMBP_WARN("[PeerSsdManager] PrepareRead backend read failed key={} size={}", key, size);
+    return SsdReadOutcome{SsdReadStatus::kError, size};
+  }
+  return SsdReadOutcome{SsdReadStatus::kOk, size};
 }
 
 std::vector<KvEvent> PeerSsdManager::DrainPendingEvents() {

--- a/src/umbp/distributed/peer/peer_ssd_manager.cpp
+++ b/src/umbp/distributed/peer/peer_ssd_manager.cpp
@@ -22,8 +22,10 @@
 #include "umbp/distributed/peer/peer_ssd_manager.h"
 
 #include <cstring>
+#include <stdexcept>
 
 #include "mori/utils/mori_log.hpp"
+#include "umbp/local/tiers/spdk_proxy_tier.h"
 #include "umbp/local/tiers/ssd_tier.h"
 #include "umbp/local/tiers/tier_backend.h"
 
@@ -34,13 +36,40 @@ PeerSsdManager::PeerSsdManager(const PeerSsdConfig& cfg) {
     MORI_UMBP_INFO("[PeerSsdManager] constructed disabled (no SSD backend)");
     return;
   }
-  // v1 builds the POSIX/io_uring SSDTier directly from UMBPSsdConfig.  SPDK
-  // backend selection is not wired into the distributed peer path yet (see
-  // PeerSsdConfig TODO); when it is, branch on the backend here.
   const auto& ssd = cfg.ssd;
-  backend_ = std::make_unique<SSDTier>(ssd.storage_dir, ssd.capacity_bytes, ssd);
-  MORI_UMBP_INFO("[PeerSsdManager] SSDTier ready dir={} capacity={}B", ssd.storage_dir,
-                 ssd.capacity_bytes);
+
+  // Explicit backend selection — an unknown value is a configuration error, not
+  // a reason to silently fall back to POSIX.
+  if (ssd.ssd_backend == "posix") {
+    backend_ = std::make_unique<SSDTier>(ssd.storage_dir, ssd.capacity_bytes, ssd);
+    MORI_UMBP_INFO("[PeerSsdManager] SSDTier ready dir={} capacity={}B", ssd.storage_dir,
+                   ssd.capacity_bytes);
+    return;
+  }
+
+  // The distributed peer shares one physical device across processes, so SPDK
+  // is reached through the spdk_proxy daemon, never the single-process direct
+  // SpdkSsdTier.  Both "spdk" and "spdk_proxy" therefore map to SpdkProxyTier:
+  // "spdk" here means "use SPDK via the proxy".
+  if (ssd.ssd_backend == "spdk" || ssd.ssd_backend == "spdk_proxy") {
+    MORI_UMBP_INFO("[PeerSsdManager] distributed ssd_backend={} uses SpdkProxyTier",
+                   ssd.ssd_backend);
+    auto proxy = std::make_unique<SpdkProxyTier>(ssd);
+    // PeerSsdManager only connects to an already-ready proxy; it does not spawn
+    // the daemon.  A connect failure with an explicit SPDK config is fatal — we
+    // must not silently disable SSD or fall back to POSIX.
+    if (!proxy->IsValid()) {
+      throw std::runtime_error("[PeerSsdManager] ssd_backend=" + ssd.ssd_backend +
+                               ": SPDK proxy connect failed (shm=" + ssd.spdk_proxy_shm_name +
+                               "). Ensure the spdk_proxy daemon is running and READY.");
+    }
+    backend_ = std::move(proxy);
+    MORI_UMBP_INFO("[PeerSsdManager] SpdkProxyTier ready (shm={})", ssd.spdk_proxy_shm_name);
+    return;
+  }
+
+  throw std::runtime_error("[PeerSsdManager] unknown ssd_backend='" + ssd.ssd_backend +
+                           "' (expected one of: posix, spdk, spdk_proxy)");
 }
 
 PeerSsdManager::~PeerSsdManager() = default;

--- a/src/umbp/distributed/peer/peer_ssd_manager.cpp
+++ b/src/umbp/distributed/peer/peer_ssd_manager.cpp
@@ -147,7 +147,7 @@ bool PeerSsdManager::Write(const std::string& key,
 
   // Assemble (possibly non-contiguous) DRAM source segments into one contiguous
   // buffer for the backend.  A single right-sized segment is written directly;
-  // otherwise we memcpy into scratch (v1 accepts the copy; writev can replace).
+  // otherwise we memcpy into scratch (a writev-style path could avoid the copy).
   const void* data = nullptr;
   std::vector<char> scratch;
   if (segments.size() == 1 && segments[0].second == total_size) {
@@ -388,8 +388,8 @@ SsdReadOutcome PeerSsdManager::PrepareRead(const std::string& key, void* staging
   }
 
   if (!read_ok) {
-    // owned_ had the key but the backend couldn't serve it (e.g. a Phase 4
-    // local evict raced us, or a corrupt record): kError, not a definitive miss.
+    // owned_ had the key but the backend couldn't serve it (e.g. a local evict
+    // raced us, or a corrupt record): kError, not a definitive miss.
     metrics_.read_error.fetch_add(1, std::memory_order_relaxed);
     MORI_UMBP_WARN("[PeerSsdManager] PrepareRead backend read failed key={} size={}", key, size);
     return SsdReadOutcome{SsdReadStatus::kError, size};

--- a/src/umbp/distributed/peer/peer_ssd_manager.cpp
+++ b/src/umbp/distributed/peer/peer_ssd_manager.cpp
@@ -145,6 +145,12 @@ std::vector<std::string> PeerSsdManager::SelectVictims(size_t /*bytes_to_free*/)
   return {};
 }
 
+void PeerSsdManager::ClearLocal() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  owned_.clear();
+  pending_events_.clear();
+}
+
 SsdReadOutcome PeerSsdManager::PrepareRead(const std::string& /*key*/, void* /*staging_ptr*/,
                                            size_t /*staging_cap*/) {
   // TODO(Phase 3): key-based read into staging (local vs remote SSD get).

--- a/src/umbp/distributed/peer/peer_ssd_manager.cpp
+++ b/src/umbp/distributed/peer/peer_ssd_manager.cpp
@@ -368,8 +368,11 @@ SsdReadOutcome PeerSsdManager::PrepareRead(const std::string& key, void* staging
     // Reject over-capacity before touching the device (no in-flight mark, no IO).
     if (size > staging_cap) {
       metrics_.read_size_too_large.fetch_add(1, std::memory_order_relaxed);
-      MORI_UMBP_WARN("[PeerSsdManager] PrepareRead key={} size={} exceeds cap={}", key, size,
-                     staging_cap);
+      // staging_cap = per-slot cap (ssd_staging_buffer_size / ssd_read_slots).
+      MORI_UMBP_WARN(
+          "[PeerSsdManager] remote SSD read key={} size={}B exceeds per-slot staging cap {}B; "
+          "raise ssd_staging_buffer_size (UMBP_SSD_STAGING_BYTES) or lower ssd_read_slots",
+          key, size, staging_cap);
       return SsdReadOutcome{SsdReadStatus::kSizeTooLarge, size};
     }
     ++inflight_reads_[key];

--- a/src/umbp/distributed/peer/peer_ssd_manager.cpp
+++ b/src/umbp/distributed/peer/peer_ssd_manager.cpp
@@ -31,12 +31,32 @@
 
 namespace mori::umbp {
 
+namespace {
+// Watermarks must satisfy 0 < low < high <= 1.  We fail fast on a bad value
+// rather than silently clamping, so a misconfigured env surfaces immediately.
+bool WatermarksValid(double high, double low) {
+  return high > 0.0 && high <= 1.0 && low > 0.0 && low < high;
+}
+}  // namespace
+
+// ---------------------------------------------------------------------------
+//  Construction
+// ---------------------------------------------------------------------------
+
 PeerSsdManager::PeerSsdManager(const PeerSsdConfig& cfg) {
   if (!cfg.enabled) {
     MORI_UMBP_INFO("[PeerSsdManager] constructed disabled (no SSD backend)");
     return;
   }
   const auto& ssd = cfg.ssd;
+
+  if (!WatermarksValid(ssd.high_watermark, ssd.low_watermark)) {
+    throw std::runtime_error(
+        "[PeerSsdManager] invalid SSD watermarks (require 0 < low_watermark < "
+        "high_watermark <= 1)");
+  }
+  high_watermark_ = ssd.high_watermark;
+  low_watermark_ = ssd.low_watermark;
 
   // Explicit backend selection — an unknown value is a configuration error, not
   // a reason to silently fall back to POSIX.
@@ -72,7 +92,21 @@ PeerSsdManager::PeerSsdManager(const PeerSsdConfig& cfg) {
                            "' (expected one of: posix, spdk, spdk_proxy)");
 }
 
+PeerSsdManager::PeerSsdManager(std::unique_ptr<TierBackend> backend, double high_watermark,
+                               double low_watermark)
+    : backend_(std::move(backend)), high_watermark_(high_watermark), low_watermark_(low_watermark) {
+  if (!WatermarksValid(high_watermark_, low_watermark_)) {
+    throw std::runtime_error(
+        "[PeerSsdManager] invalid SSD watermarks (require 0 < low_watermark < "
+        "high_watermark <= 1)");
+  }
+}
+
 PeerSsdManager::~PeerSsdManager() = default;
+
+// ---------------------------------------------------------------------------
+//  Capacity & queries
+// ---------------------------------------------------------------------------
 
 std::pair<size_t, size_t> PeerSsdManager::Capacity() const {
   if (!backend_) return {0, 0};
@@ -84,15 +118,36 @@ bool PeerSsdManager::Exists(const std::string& key) const {
   return owned_.find(key) != owned_.end();
 }
 
+void PeerSsdManager::TouchLocked(const std::string& key) {
+  auto it = owned_.find(key);
+  if (it == owned_.end()) return;
+  lru_.splice(lru_.begin(), lru_, it->second.lru_it);  // move-to-front; iterator stays valid
+  it->second.lru_it = lru_.begin();
+}
+
+// ---------------------------------------------------------------------------
+//  Write (copy-on-commit landing)
+// ---------------------------------------------------------------------------
+
 bool PeerSsdManager::Write(const std::string& key,
                            const std::vector<std::pair<const void*, size_t>>& segments,
                            size_t total_size) {
   if (!backend_) return false;
 
-  // Assemble (possibly non-contiguous) DRAM source segments into one
-  // contiguous buffer before handing it to the backend.  v1 accepts the extra
-  // memcpy; a writev/batch path can replace this later.  When the source is
-  // already a single contiguous segment of the right size we write it directly.
+  // Optimization, not just defense: the DRAM pin only dedups *concurrent*
+  // copies, so a sequential re-put of an already-resident key would otherwise
+  // repeat the whole SSD write.  Skip it and refresh LRU instead.
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (owned_.find(key) != owned_.end()) {
+      TouchLocked(key);
+      return true;
+    }
+  }
+
+  // Assemble (possibly non-contiguous) DRAM source segments into one contiguous
+  // buffer for the backend.  A single right-sized segment is written directly;
+  // otherwise we memcpy into scratch (v1 accepts the copy; writev can replace).
   const void* data = nullptr;
   std::vector<char> scratch;
   if (segments.size() == 1 && segments[0].second == total_size) {
@@ -117,64 +172,180 @@ bool PeerSsdManager::Write(const std::string& key,
     data = scratch.data();
   }
 
-  // Backend IO outside our mutex_ — SSDTier is internally synchronized.
+  // Backend IO outside our mutex_ — SSDTier is internally synchronized.  A
+  // failure may be ENOSPC: run one eviction round to reclaim space and retry
+  // once before giving up (best-effort, no event/record on final failure).
   if (!backend_->Write(key, data, total_size)) {
-    MORI_UMBP_WARN("[PeerSsdManager] backend Write failed key={} size={}", key, total_size);
-    return false;
+    EvictToLowWatermark();
+    if (!backend_->Write(key, data, total_size)) {
+      MORI_UMBP_WARN("[PeerSsdManager] backend Write failed key={} size={}", key, total_size);
+      return false;
+    }
   }
 
-  std::lock_guard<std::mutex> lock(mutex_);
-  owned_[key] = total_size;
-  pending_events_.push_back(KvEvent{KvEvent::Kind::ADD, key, TierType::SSD, total_size});
+  // Record the location.  Re-check owned_: with > 1 copy worker, two of them
+  // could have both seen "absent" above and written the same (identical,
+  // content-addressed) bytes — only the first records it + emits ADD SSD.
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (owned_.find(key) != owned_.end()) {
+      TouchLocked(key);
+    } else {
+      lru_.push_front(key);
+      owned_.emplace(key, OwnedEntry{total_size, lru_.begin()});
+      pending_events_.push_back(KvEvent{KvEvent::Kind::ADD, key, TierType::SSD, total_size});
+    }
+  }
+
+  // Check-after-write trigger, on this copy worker (no dedicated thread).
+  auto [used, total] = Capacity();
+  if (total > 0 && static_cast<double>(used) >= high_watermark_ * static_cast<double>(total)) {
+    EvictToLowWatermark();
+  }
   return true;
 }
+
+// ---------------------------------------------------------------------------
+//  Eviction (local, read-priority)
+// ---------------------------------------------------------------------------
 
 bool PeerSsdManager::Evict(const std::string& key) {
   if (!backend_) return false;
-  backend_->Evict(key);
+
+  // Reserve under the lock: skip if a read is in flight (read priority), if the
+  // key is gone, or if another worker is already evicting it.  owned_ is kept
+  // until the backend confirms the delete.
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (owned_.find(key) == owned_.end()) return false;
+    if (inflight_reads_.count(key) != 0) return false;
+    if (!evicting_.insert(key).second) return false;
+  }
+
+  bool ok = backend_->Evict(key);  // backend IO outside the lock
+
+  // Commit only if the backend freed the bytes; on failure keep owned_ for a
+  // later retry, so REMOVE SSD is never emitted while the bytes still exist.
   std::lock_guard<std::mutex> lock(mutex_);
+  evicting_.erase(key);
+  if (!ok) {
+    MORI_UMBP_WARN("[PeerSsdManager] backend Evict failed key={} — keeping for retry", key);
+    return false;
+  }
   auto it = owned_.find(key);
-  if (it == owned_.end()) return false;
-  owned_.erase(it);
-  pending_events_.push_back(KvEvent{KvEvent::Kind::REMOVE, key, TierType::SSD, 0});
+  if (it != owned_.end()) {  // still present (a racing ClearLocal could have dropped it)
+    lru_.erase(it->second.lru_it);
+    owned_.erase(it);
+    pending_events_.push_back(KvEvent{KvEvent::Kind::REMOVE, key, TierType::SSD, 0});
+  }
   return true;
 }
 
-std::vector<std::string> PeerSsdManager::SelectVictims(size_t /*bytes_to_free*/) {
-  // TODO(Phase 4): local watermark + LRU victim selection.
-  return {};
+std::vector<std::string> PeerSsdManager::SelectVictims(size_t bytes_to_free) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::vector<std::string> victims;
+  if (bytes_to_free == 0) return victims;
+
+  // Oldest first (LRU tail -> MRU front), skipping keys being read or evicted.
+  size_t freed = 0;
+  for (auto it = lru_.rbegin(); it != lru_.rend(); ++it) {
+    const std::string& key = *it;
+    if (inflight_reads_.count(key) != 0) continue;
+    if (evicting_.count(key) != 0) continue;
+    auto owned_it = owned_.find(key);
+    if (owned_it == owned_.end()) continue;  // defensive; lru_/owned_ stay in sync
+    victims.push_back(key);
+    freed += owned_it->second.size;
+    if (freed >= bytes_to_free) break;
+  }
+  return victims;
 }
 
-void PeerSsdManager::ClearLocal() {
-  std::lock_guard<std::mutex> lock(mutex_);
-  owned_.clear();
-  pending_events_.clear();
+void PeerSsdManager::EvictToLowWatermark() {
+  if (!backend_) return;
+
+  // Only one eviction round at a time: a second concurrent worker (or a worker
+  // racing ClearLocal) backs off instead of over-evicting.  try_lock keeps the
+  // copy path non-blocking.
+  std::unique_lock<std::mutex> round(eviction_mu_, std::try_to_lock);
+  if (!round.owns_lock()) return;
+
+  auto [used, total] = Capacity();
+  if (total == 0) return;
+  double low_bytes = low_watermark_ * static_cast<double>(total);
+  if (static_cast<double>(used) <= low_bytes) return;
+  size_t bytes_to_free = used - static_cast<size_t>(low_bytes);
+
+  // Single pass, no retry loop: if everything reclaimable is in use we free
+  // what we can and stop, so a fully-pinned tier cannot starve the worker.
+  for (const auto& key : SelectVictims(bytes_to_free)) {
+    Evict(key);
+  }
 }
+
+// ---------------------------------------------------------------------------
+//  Clear (drop metadata + wipe physical bytes)
+// ---------------------------------------------------------------------------
+
+void PeerSsdManager::ClearLocal() {
+  // Exclude eviction rounds for the whole operation (lock order: eviction_mu_
+  // before mutex_, matching EvictToLowWatermark).
+  std::lock_guard<std::mutex> round(eviction_mu_);
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    owned_.clear();
+    lru_.clear();
+    pending_events_.clear();
+    evicting_.clear();
+    // Read priority: new reads already miss (owned_ is empty), but a read that
+    // already started holds inflight_reads_ and is doing backend IO.  Wait for
+    // it to finish before wiping the bytes — SSD reads cannot be safely aborted.
+    reads_drained_cv_.wait(lock, [this] { return inflight_reads_.empty(); });
+  }
+  if (backend_) backend_->Clear();  // delete physical SSD bytes (user Clear = discard cache)
+}
+
+// ---------------------------------------------------------------------------
+//  Read
+// ---------------------------------------------------------------------------
 
 SsdReadOutcome PeerSsdManager::PrepareRead(const std::string& key, void* staging_ptr,
                                            size_t staging_cap) {
   if (!backend_) return SsdReadOutcome{SsdReadStatus::kNotFound, 0};
 
-  // Look up the authoritative size under the lock, then release it before the
-  // blocking SSD IO so a concurrent copy Write() is not serialized behind this
-  // read (the lock only guards the owned_ map, not the backend IO).
+  // Resolve size and mark the read in flight under the lock, then run the
+  // blocking SSD IO outside it (so a concurrent copy Write is not serialized).
   size_t size = 0;
   {
     std::lock_guard<std::mutex> lock(mutex_);
     auto it = owned_.find(key);
     if (it == owned_.end()) return SsdReadOutcome{SsdReadStatus::kNotFound, 0};
-    size = it->second;
+    // Being evicted: bytes about to vanish — treat a new read as a stale-route
+    // miss rather than racing the backend delete.
+    if (evicting_.count(key) != 0) return SsdReadOutcome{SsdReadStatus::kNotFound, 0};
+    size = it->second.size;
+    // Reject over-capacity before touching the device (no in-flight mark, no IO).
+    if (size > staging_cap) {
+      MORI_UMBP_WARN("[PeerSsdManager] PrepareRead key={} size={} exceeds cap={}", key, size,
+                     staging_cap);
+      return SsdReadOutcome{SsdReadStatus::kSizeTooLarge, size};
+    }
+    ++inflight_reads_[key];
   }
 
-  // Reject before touching the device: a key larger than the caller's capacity
-  // (reader buffer / staging slot) must not trigger a wasted SSD read.
-  if (size > staging_cap) {
-    MORI_UMBP_WARN("[PeerSsdManager] PrepareRead key={} size={} exceeds cap={}", key, size,
-                   staging_cap);
-    return SsdReadOutcome{SsdReadStatus::kSizeTooLarge, size};
+  bool read_ok = backend_->ReadIntoPtr(key, reinterpret_cast<uintptr_t>(staging_ptr), size);
+
+  // Always release the in-flight mark (even on error), refresh LRU on success,
+  // and wake a waiting ClearLocal once the last read drains.
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto rit = inflight_reads_.find(key);
+    if (rit != inflight_reads_.end() && --rit->second <= 0) inflight_reads_.erase(rit);
+    if (read_ok && owned_.find(key) != owned_.end()) TouchLocked(key);
+    if (inflight_reads_.empty()) reads_drained_cv_.notify_all();
   }
 
-  if (!backend_->ReadIntoPtr(key, reinterpret_cast<uintptr_t>(staging_ptr), size)) {
+  if (!read_ok) {
     // owned_ had the key but the backend couldn't serve it (e.g. a Phase 4
     // local evict raced us, or a corrupt record): kError, not a definitive miss.
     MORI_UMBP_WARN("[PeerSsdManager] PrepareRead backend read failed key={} size={}", key, size);
@@ -182,6 +353,10 @@ SsdReadOutcome PeerSsdManager::PrepareRead(const std::string& key, void* staging
   }
   return SsdReadOutcome{SsdReadStatus::kOk, size};
 }
+
+// ---------------------------------------------------------------------------
+//  OwnedLocationSource (heartbeat event drain / snapshot)
+// ---------------------------------------------------------------------------
 
 std::vector<KvEvent> PeerSsdManager::DrainPendingEvents() {
   std::lock_guard<std::mutex> lock(mutex_);
@@ -194,8 +369,8 @@ std::vector<KvEvent> PeerSsdManager::SnapshotOwnedKeys() const {
   std::lock_guard<std::mutex> lock(mutex_);
   std::vector<KvEvent> out;
   out.reserve(owned_.size());
-  for (const auto& [key, size] : owned_) {
-    out.push_back(KvEvent{KvEvent::Kind::ADD, key, TierType::SSD, size});
+  for (const auto& [key, entry] : owned_) {
+    out.push_back(KvEvent{KvEvent::Kind::ADD, key, TierType::SSD, entry.size});
   }
   return out;
 }

--- a/src/umbp/distributed/peer/peer_ssd_manager.cpp
+++ b/src/umbp/distributed/peer/peer_ssd_manager.cpp
@@ -371,7 +371,7 @@ SsdReadOutcome PeerSsdManager::PrepareRead(const std::string& key, void* staging
       // staging_cap = per-slot cap (ssd_staging_buffer_size / ssd_read_slots).
       MORI_UMBP_WARN(
           "[PeerSsdManager] remote SSD read key={} size={}B exceeds per-slot staging cap {}B; "
-          "raise ssd_staging_buffer_size (UMBP_SSD_STAGING_BYTES) or lower ssd_read_slots",
+          "raise ssd_staging_buffer_size or lower ssd_read_slots",
           key, size, staging_cap);
       return SsdReadOutcome{SsdReadStatus::kSizeTooLarge, size};
     }

--- a/src/umbp/distributed/peer/ssd_copy_pipeline.cpp
+++ b/src/umbp/distributed/peer/ssd_copy_pipeline.cpp
@@ -1,0 +1,174 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#include "umbp/distributed/peer/ssd_copy_pipeline.h"
+
+#include <algorithm>
+#include <utility>
+
+#include "mori/utils/mori_log.hpp"
+#include "umbp/distributed/peer/peer_dram_allocator.h"
+#include "umbp/distributed/peer/peer_ssd_manager.h"
+
+namespace mori::umbp {
+
+namespace {
+
+// RAII guard: releases a DramCopyPin on every scope exit (success, failure,
+// or exception), so a worker can never leak a pin and strand a key's DRAM
+// pages against eviction.
+class DramCopyPinGuard {
+ public:
+  DramCopyPinGuard(PeerDramAllocator* dram, std::string key, uint64_t token)
+      : dram_(dram), key_(std::move(key)), token_(token) {}
+  ~DramCopyPinGuard() { dram_->ReleaseDramCopyPin(key_, token_); }
+
+  DramCopyPinGuard(const DramCopyPinGuard&) = delete;
+  DramCopyPinGuard& operator=(const DramCopyPinGuard&) = delete;
+
+ private:
+  PeerDramAllocator* dram_;
+  std::string key_;
+  uint64_t token_;
+};
+
+}  // namespace
+
+SsdCopyPipeline::SsdCopyPipeline(PeerDramAllocator* dram, PeerSsdManager* ssd, size_t queue_depth,
+                                 size_t worker_threads)
+    : dram_(dram),
+      ssd_(ssd),
+      queue_depth_(std::max<size_t>(1, queue_depth)),
+      worker_threads_(std::max<size_t>(1, worker_threads)) {}
+
+SsdCopyPipeline::~SsdCopyPipeline() { Stop(); }
+
+void SsdCopyPipeline::Start() {
+  std::lock_guard<std::mutex> lock(mu_);
+  if (!workers_.empty()) return;  // already started
+  stop_ = false;
+  paused_ = false;
+  workers_.reserve(worker_threads_);
+  for (size_t i = 0; i < worker_threads_; ++i) {
+    workers_.emplace_back([this] { WorkerLoop(); });
+  }
+  MORI_UMBP_INFO("[SsdCopyPipeline] started workers={} queue_depth={}", worker_threads_,
+                 queue_depth_);
+}
+
+void SsdCopyPipeline::Stop() {
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    if (stop_ && workers_.empty()) return;
+    stop_ = true;
+    queue_.clear();  // drop queued tasks; in-flight task finishes below
+  }
+  cv_.notify_all();
+  for (auto& w : workers_) {
+    if (w.joinable()) w.join();
+  }
+  workers_.clear();
+}
+
+void SsdCopyPipeline::Quiesce() {
+  std::unique_lock<std::mutex> lock(mu_);
+  paused_ = true;
+  queue_.clear();
+  // Block until the in-flight task (if any) has finished and released its pin.
+  idle_cv_.wait(lock, [this] { return active_ == 0; });
+}
+
+void SsdCopyPipeline::Resume() {
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    if (stop_) return;
+    paused_ = false;
+  }
+  cv_.notify_all();
+}
+
+bool SsdCopyPipeline::Enqueue(SsdCopyTask task) {
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    if (stop_ || paused_) {
+      MORI_UMBP_DEBUG("[SsdCopyPipeline] drop key='{}' — pipeline {}", task.key,
+                      stop_ ? "stopped" : "paused");
+      return false;
+    }
+    if (queue_.size() >= queue_depth_) {
+      dropped_.fetch_add(1, std::memory_order_relaxed);
+      MORI_UMBP_DEBUG("[SsdCopyPipeline] drop key='{}' — queue full (depth={})", task.key,
+                      queue_depth_);
+      return false;  // full — drop, never block commit
+    }
+    queue_.push_back(std::move(task));
+  }
+  cv_.notify_one();
+  return true;
+}
+
+void SsdCopyPipeline::WorkerLoop() {
+  while (true) {
+    SsdCopyTask task;
+    {
+      std::unique_lock<std::mutex> lock(mu_);
+      cv_.wait(lock, [this] { return stop_ || (!paused_ && !queue_.empty()); });
+      if (stop_) return;                        // queue already cleared by Stop
+      if (paused_ || queue_.empty()) continue;  // quiescing / spurious wakeup
+      task = std::move(queue_.front());
+      queue_.pop_front();
+      ++active_;
+    }
+
+    RunTask(task);
+
+    {
+      std::lock_guard<std::mutex> lock(mu_);
+      --active_;
+      if (active_ == 0) idle_cv_.notify_all();
+    }
+  }
+}
+
+void SsdCopyPipeline::RunTask(const SsdCopyTask& task) {
+  auto pin = dram_->AcquireDramCopyPin(task.key);
+  if (!pin.has_value()) {
+    // Key was already evicted (or a duplicate task) — nothing to copy.
+    MORI_UMBP_DEBUG("[SsdCopyPipeline] key='{}' not pinnable (evicted/duplicate) — drop", task.key);
+    return;
+  }
+  // From here the pin is released no matter how we exit.
+  DramCopyPinGuard guard(dram_, task.key, pin->pin_token);
+
+  if (pin->segments.empty() || pin->total_size == 0) {
+    MORI_UMBP_WARN("[SsdCopyPipeline] key='{}' has no readable segments (size={}) — skip", task.key,
+                   pin->total_size);
+    return;
+  }
+
+  // Backend IO runs outside the allocator lock; the pin keeps the source
+  // pages alive for the duration of this synchronous Write.
+  if (ssd_->Write(task.key, pin->segments, pin->total_size)) {
+    copied_ok_.fetch_add(1, std::memory_order_relaxed);
+  }
+}
+
+}  // namespace mori::umbp

--- a/src/umbp/distributed/peer/ssd_copy_pipeline.cpp
+++ b/src/umbp/distributed/peer/ssd_copy_pipeline.cpp
@@ -109,17 +109,19 @@ bool SsdCopyPipeline::Enqueue(SsdCopyTask task) {
   {
     std::lock_guard<std::mutex> lock(mu_);
     if (stop_ || paused_) {
+      metrics_.dropped_stopped.fetch_add(1, std::memory_order_relaxed);
       MORI_UMBP_DEBUG("[SsdCopyPipeline] drop key='{}' — pipeline {}", task.key,
                       stop_ ? "stopped" : "paused");
       return false;
     }
     if (queue_.size() >= queue_depth_) {
-      dropped_.fetch_add(1, std::memory_order_relaxed);
+      metrics_.dropped_queue_full.fetch_add(1, std::memory_order_relaxed);
       MORI_UMBP_DEBUG("[SsdCopyPipeline] drop key='{}' — queue full (depth={})", task.key,
                       queue_depth_);
       return false;  // full — drop, never block commit
     }
     queue_.push_back(std::move(task));
+    metrics_.enqueued.fetch_add(1, std::memory_order_relaxed);
   }
   cv_.notify_one();
   return true;
@@ -159,6 +161,7 @@ void SsdCopyPipeline::RunTask(const SsdCopyTask& task) {
   DramCopyPinGuard guard(dram_, task.key, pin->pin_token);
 
   if (pin->segments.empty() || pin->total_size == 0) {
+    metrics_.failed.fetch_add(1, std::memory_order_relaxed);
     MORI_UMBP_WARN("[SsdCopyPipeline] key='{}' has no readable segments (size={}) — skip", task.key,
                    pin->total_size);
     return;
@@ -167,7 +170,9 @@ void SsdCopyPipeline::RunTask(const SsdCopyTask& task) {
   // Backend IO runs outside the allocator lock; the pin keeps the source
   // pages alive for the duration of this synchronous Write.
   if (ssd_->Write(task.key, pin->segments, pin->total_size)) {
-    copied_ok_.fetch_add(1, std::memory_order_relaxed);
+    metrics_.copied_ok.fetch_add(1, std::memory_order_relaxed);
+  } else {
+    metrics_.failed.fetch_add(1, std::memory_order_relaxed);
   }
 }
 

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -38,6 +38,7 @@
 #include "umbp/distributed/master/master_metrics.h"
 #include "umbp/distributed/peer/peer_dram_allocator.h"
 #include "umbp/distributed/peer/peer_service.h"
+#include "umbp/distributed/peer/peer_ssd_manager.h"
 #include "umbp_peer.grpc.pb.h"
 
 namespace mori::umbp {
@@ -250,6 +251,16 @@ bool PoolClient::Init() {
   peer_alloc_->StartReaper();
   master_client_->SetPeerDramAllocator(peer_alloc_.get());
 
+  // Peer-side SSD tier owner.  Built only when SSD is enabled; registered as an
+  // owned-location event source + SSD capacity provider.  Phase 1: present and
+  // reporting capacity, but nothing writes (copy = Phase 2) or reads (Phase 3)
+  // it yet.  TODO(Phase 2): PoolClient::Clear() must also clear peer_ssd_'s
+  // owned keys once copy-on-commit can populate them.
+  if (config_.ssd.enabled) {
+    peer_ssd_ = std::make_unique<PeerSsdManager>(config_.ssd);
+    master_client_->SetPeerSsdManager(peer_ssd_.get());
+  }
+
   // Pack engine_desc for master registration.
   std::vector<uint8_t> engine_desc_bytes;
   if (io_engine_) {
@@ -258,8 +269,9 @@ bool PoolClient::Init() {
     engine_desc_bytes.assign(sbuf.data(), sbuf.data() + sbuf.size());
   }
 
-  // SSD staging buffer (one per process; not part of DRAM exports).
-  if (!config_.ssd_stores.empty()) {
+  // SSD staging buffer (one per process; not part of DRAM exports).  Phase 3
+  // serves remote SSD reads out of it; allocated up front when SSD is enabled.
+  if (config_.ssd.enabled) {
     ssd_staging_buffer_ = std::make_unique<char[]>(config_.staging_buffer_size);
     std::memset(ssd_staging_buffer_.get(), 0, config_.staging_buffer_size);
     if (io_engine_) {
@@ -290,16 +302,11 @@ bool PoolClient::Init() {
     peer_address = host + ":" + std::to_string(config_.peer_service_port);
   }
 
-  // DEPRECATED: ssd_store_capacities is legacy and unconsumed by master. The
-  // SSD-tier redesign reports SSD capacity via config_.tier_capacities
-  // (TierType::SSD), wired in Phase 1. Left empty here for wire compat.
-  std::vector<uint64_t> ssd_store_capacities;
-  for (const auto& store : config_.ssd_stores) ssd_store_capacities.push_back(store.capacity);
-
   // Master register.  In the new design master holds no DRAM-side
-  // metadata; only membership + capacity-snapshot.
-  auto status = master_client_->RegisterSelf(config_.tier_capacities, peer_address,
-                                             engine_desc_bytes, ssd_store_capacities);
+  // metadata; only membership + capacity-snapshot (SSD capacity rides in
+  // tier_capacities as TierType::SSD).
+  auto status =
+      master_client_->RegisterSelf(config_.tier_capacities, peer_address, engine_desc_bytes);
   if (!status.ok()) {
     MORI_UMBP_ERROR("[PoolClient] RegisterSelf failed: {}", status.error_message());
     initialized_ = false;
@@ -335,6 +342,10 @@ void PoolClient::Shutdown() {
     peer_alloc_->StopReaper();
     peer_alloc_.reset();
   }
+
+  // Heartbeat thread is already stopped above, so MasterClient no longer reads
+  // ssd_manager_; safe to drop the SSD tier owner here.
+  peer_ssd_.reset();
 
   if (io_engine_) {
     {

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -337,11 +337,11 @@ bool PoolClient::Init() {
   // SSD staging buffer (one per process; not part of DRAM exports).  Remote SSD
   // reads are served out of it; allocated up front when SSD is enabled.
   if (config_.ssd.enabled) {
-    ssd_staging_buffer_ = std::make_unique<char[]>(config_.staging_buffer_size);
-    std::memset(ssd_staging_buffer_.get(), 0, config_.staging_buffer_size);
+    ssd_staging_buffer_ = std::make_unique<char[]>(config_.ssd_staging_buffer_size);
+    std::memset(ssd_staging_buffer_.get(), 0, config_.ssd_staging_buffer_size);
     if (io_engine_) {
       ssd_staging_mem_ =
-          io_engine_->RegisterMemory(ssd_staging_buffer_.get(), config_.staging_buffer_size, -1,
+          io_engine_->RegisterMemory(ssd_staging_buffer_.get(), config_.ssd_staging_buffer_size, -1,
                                      mori::io::MemoryLocationType::CPU);
       msgpack::sbuffer sbuf;
       msgpack::pack(sbuf, ssd_staging_mem_);
@@ -354,7 +354,7 @@ bool PoolClient::Init() {
     // (both null/empty when SSD is disabled, leaving SsdRpcAvailable() false).
     peer_service_ = std::make_unique<PeerServiceServer>(
         peer_alloc_.get(), peer_ssd_.get(), ssd_staging_buffer_.get(),
-        ssd_staging_buffer_ ? config_.staging_buffer_size : 0, ssd_staging_mem_desc_bytes_,
+        ssd_staging_buffer_ ? config_.ssd_staging_buffer_size : 0, ssd_staging_mem_desc_bytes_,
         config_.ssd_read_slots, config_.ssd_lease_timeout_s, engine_desc_bytes,
         master_client_.get(), ssd_copy_pipeline_.get());
     if (!peer_service_->Start(config_.peer_service_port)) {

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdlib>
 #include <cstring>
 #include <msgpack.hpp>
 #include <numeric>
@@ -147,6 +148,17 @@ std::vector<ScatterGroup> GroupPagesByBuffer(const std::vector<PageLocation>& pa
 uint32_t ReleaseLeaseMaxRetries() {
   static const uint32_t v = GetEnvUint32("UMBP_RELEASE_LEASE_MAX_RETRIES", 2, /*min_allowed=*/1);
   return v;
+}
+
+// Crash-restart SSD leftover policy (v1 = discard): wipe physical SSD bytes a
+// previous crashed process left behind at startup.  Default on; set
+// UMBP_SSD_STARTUP_DISCARD=0/false to keep leftover (opt-out hook for a future
+// rebuild-from-backend policy — there is no rebuild path yet).
+bool SsdStartupDiscardEnabled() {
+  const char* v = std::getenv("UMBP_SSD_STARTUP_DISCARD");
+  if (v == nullptr) return true;
+  const std::string s(v);
+  return !(s == "0" || s == "false" || s == "FALSE" || s == "off");
 }
 
 // Total attempts for a remote SSD get.  Retryable outcomes (kRetry) are
@@ -303,6 +315,10 @@ bool PoolClient::Init() {
   // quiesces the pipeline and clears peer_ssd_ alongside peer_alloc_.
   if (config_.ssd.enabled) {
     peer_ssd_ = std::make_unique<PeerSsdManager>(config_.ssd);
+    // Crash-restart leftover (v1 = discard): wipe stale SSD bytes before the
+    // pipeline starts so used capacity and the empty owned_ map start consistent
+    // (env-gated; see SsdStartupDiscardEnabled / DiscardLeftoverOnStartup).
+    if (SsdStartupDiscardEnabled()) peer_ssd_->DiscardLeftoverOnStartup();
     master_client_->SetPeerSsdManager(peer_ssd_.get());
     // Copy-on-commit pipeline: commits enqueue here, a worker pins the DRAM
     // pages and writes them to the local SSD tier.  Started below.
@@ -356,6 +372,12 @@ bool PoolClient::Init() {
     peer_address = host + ":" + std::to_string(config_.peer_service_port);
   }
 
+  // Register the SSD metrics provider before RegisterSelf starts the metrics
+  // thread (the list is read lock-free afterwards).  See PublishSsdMetrics.
+  if (config_.ssd.enabled) {
+    master_client_->AddMetricsProvider([this] { PublishSsdMetrics(); });
+  }
+
   // Master register.  In the new design master holds no DRAM-side
   // metadata; only membership + capacity-snapshot (SSD capacity rides in
   // tier_capacities as TierType::SSD).
@@ -379,6 +401,10 @@ void PoolClient::Shutdown() {
 
   if (master_client_) {
     master_client_->StopHeartbeat();
+    // Stop the periodic metrics thread before tearing down the SSD components
+    // its provider reads (peer_service_ / ssd_copy_pipeline_ / peer_ssd_), so no
+    // provider callback runs against freed state.  Idempotent with ~MasterClient.
+    master_client_->StopMetricsReporting();
     auto status = master_client_->UnregisterSelf();
     if (!status.ok()) {
       MORI_UMBP_WARN("[PoolClient] UnregisterSelf failed: {}", status.error_message());
@@ -1954,6 +1980,7 @@ void PoolClient::ProcessRemoteSsdBatchGet(const std::vector<BatchGetItem>& items
   auto& peer = GetOrConnectPeer(first.route.node_id, first.route.peer_address);
 
   const uint32_t max_attempts = SsdGetTransientMaxAttempts();
+  uint64_t transient_not_served = 0;  // aggregated per batch → one AddCounter below
   for (const auto& item : items) {
     bool done = false;
     for (uint32_t attempt = 0; attempt < max_attempts && !done; ++attempt) {
@@ -1973,11 +2000,105 @@ void PoolClient::ProcessRemoteSsdBatchGet(const std::vector<BatchGetItem>& items
       }
     }
     if (!done) {
+      ++transient_not_served;
       MORI_UMBP_WARN(
           "[PoolClient] Remote SSD get key='{}' still transient-failing (NO_SLOT/lease-expired) "
           "after {} attempts; reporting as not-served this round (not a definitive miss)",
           *item.key, max_attempts);
     }
+  }
+  // Optional reader-side diagnostic: lease expiry is reader-local and never
+  // shows up in the peer's ssd_read_total, so surface transient not-served here.
+  // Aggregated to a single AddCounter per batch (cheap, no per-key lock churn).
+  if (transient_not_served > 0 && master_client_) {
+    master_client_->AddCounter(MORI_UMBP_METRIC_SSD_READ_CLIENT_TRANSIENT_TOTAL,
+                               MORI_UMBP_METRIC_SSD_READ_CLIENT_TRANSIENT_TOTAL_HELP, {},
+                               static_cast<double>(transient_not_served));
+  }
+}
+
+void PoolClient::PublishSsdMetrics() {
+  if (!master_client_) return;
+
+  // Ship a monotonic peer-side counter as the delta since the last tick.  `last`
+  // is updated even on a zero delta (or a defensive counter reset) so the next
+  // tick stays correct.  Runs once per metrics flush in the metrics thread.
+  auto ship_counter = [&](const char* name, const char* help, MasterClient::Labels labels,
+                          uint64_t current, uint64_t& last) {
+    if (current > last) {
+      master_client_->AddCounter(name, help, std::move(labels),
+                                 static_cast<double>(current - last));
+    }
+    last = current;
+  };
+
+  if (ssd_copy_pipeline_) {
+    ship_counter(MORI_UMBP_METRIC_SSD_COPY_ENQUEUED_TOTAL,
+                 MORI_UMBP_METRIC_SSD_COPY_ENQUEUED_TOTAL_HELP, {}, ssd_copy_pipeline_->Enqueued(),
+                 ssd_metrics_last_.copy_enqueued);
+    ship_counter(MORI_UMBP_METRIC_SSD_COPY_SUCCEEDED_TOTAL,
+                 MORI_UMBP_METRIC_SSD_COPY_SUCCEEDED_TOTAL_HELP, {}, ssd_copy_pipeline_->CopiedOk(),
+                 ssd_metrics_last_.copy_succeeded);
+    ship_counter(MORI_UMBP_METRIC_SSD_COPY_FAILED_TOTAL,
+                 MORI_UMBP_METRIC_SSD_COPY_FAILED_TOTAL_HELP, {}, ssd_copy_pipeline_->Failed(),
+                 ssd_metrics_last_.copy_failed);
+    ship_counter(MORI_UMBP_METRIC_SSD_COPY_DROPPED_TOTAL,
+                 MORI_UMBP_METRIC_SSD_COPY_DROPPED_TOTAL_HELP, {{"reason", "queue_full"}},
+                 ssd_copy_pipeline_->Dropped(), ssd_metrics_last_.copy_dropped_queue_full);
+    ship_counter(MORI_UMBP_METRIC_SSD_COPY_DROPPED_TOTAL,
+                 MORI_UMBP_METRIC_SSD_COPY_DROPPED_TOTAL_HELP, {{"reason", "stopped"}},
+                 ssd_copy_pipeline_->DroppedStopped(), ssd_metrics_last_.copy_dropped_stopped);
+  }
+
+  if (peer_ssd_) {
+    ship_counter(MORI_UMBP_METRIC_SSD_READ_TOTAL, MORI_UMBP_METRIC_SSD_READ_TOTAL_HELP,
+                 {{"status", "ok"}}, peer_ssd_->ReadOk(), ssd_metrics_last_.read_ok);
+    ship_counter(MORI_UMBP_METRIC_SSD_READ_TOTAL, MORI_UMBP_METRIC_SSD_READ_TOTAL_HELP,
+                 {{"status", "not_found"}}, peer_ssd_->ReadNotFound(),
+                 ssd_metrics_last_.read_not_found);
+    ship_counter(MORI_UMBP_METRIC_SSD_READ_TOTAL, MORI_UMBP_METRIC_SSD_READ_TOTAL_HELP,
+                 {{"status", "size_too_large"}}, peer_ssd_->ReadSizeTooLarge(),
+                 ssd_metrics_last_.read_size_too_large);
+    ship_counter(MORI_UMBP_METRIC_SSD_READ_TOTAL, MORI_UMBP_METRIC_SSD_READ_TOTAL_HELP,
+                 {{"status", "error"}}, peer_ssd_->ReadError(), ssd_metrics_last_.read_error);
+
+    // SSD IO byte counters -> bandwidth via rate() in Grafana.
+    ship_counter(MORI_UMBP_METRIC_SSD_COPY_BYTES_TOTAL, MORI_UMBP_METRIC_SSD_COPY_BYTES_TOTAL_HELP,
+                 {}, peer_ssd_->CopyBytes(), ssd_metrics_last_.copy_bytes);
+    ship_counter(MORI_UMBP_METRIC_SSD_READ_BYTES_TOTAL, MORI_UMBP_METRIC_SSD_READ_BYTES_TOTAL_HELP,
+                 {}, peer_ssd_->ReadBytes(), ssd_metrics_last_.read_bytes);
+
+    ship_counter(MORI_UMBP_METRIC_SSD_EVICTION_ROUNDS_TOTAL,
+                 MORI_UMBP_METRIC_SSD_EVICTION_ROUNDS_TOTAL_HELP, {}, peer_ssd_->EvictionRounds(),
+                 ssd_metrics_last_.evict_rounds);
+    ship_counter(MORI_UMBP_METRIC_SSD_EVICTION_VICTIMS_TOTAL,
+                 MORI_UMBP_METRIC_SSD_EVICTION_VICTIMS_TOTAL_HELP, {}, peer_ssd_->EvictionVictims(),
+                 ssd_metrics_last_.evict_victims);
+    ship_counter(MORI_UMBP_METRIC_SSD_EVICTION_BYTES_FREED_TOTAL,
+                 MORI_UMBP_METRIC_SSD_EVICTION_BYTES_FREED_TOTAL_HELP, {},
+                 peer_ssd_->EvictionBytesFreed(), ssd_metrics_last_.evict_bytes_freed);
+    ship_counter(MORI_UMBP_METRIC_SSD_EVICTION_BACKEND_FAILED_TOTAL,
+                 MORI_UMBP_METRIC_SSD_EVICTION_BACKEND_FAILED_TOTAL_HELP, {},
+                 peer_ssd_->EvictionBackendFailures(), ssd_metrics_last_.evict_backend_failed);
+  }
+
+  if (peer_service_) {
+    const auto& m = peer_service_->Metrics();
+    const uint64_t expired = m.expired_reclaims.load(std::memory_order_relaxed);
+    const uint64_t slot_full = m.slot_full_rejects.load(std::memory_order_relaxed);
+    ship_counter(MORI_UMBP_METRIC_SSD_STAGING_EXPIRED_RECLAIMS_TOTAL,
+                 MORI_UMBP_METRIC_SSD_STAGING_EXPIRED_RECLAIMS_TOTAL_HELP, {}, expired,
+                 ssd_metrics_last_.staging_expired_reclaims);
+    ship_counter(MORI_UMBP_METRIC_SSD_STAGING_SLOT_FULL_REJECTS_TOTAL,
+                 MORI_UMBP_METRIC_SSD_STAGING_SLOT_FULL_REJECTS_TOTAL_HELP, {}, slot_full,
+                 ssd_metrics_last_.staging_slot_full_rejects);
+    // A NO_SLOT read outcome IS a slot-full reject; surface it under the unified
+    // read_total{status=no_slot} too (same event, peer-service view of reads).
+    ship_counter(MORI_UMBP_METRIC_SSD_READ_TOTAL, MORI_UMBP_METRIC_SSD_READ_TOTAL_HELP,
+                 {{"status", "no_slot"}}, slot_full, ssd_metrics_last_.read_no_slot);
+    master_client_->SetGauge(MORI_UMBP_METRIC_SSD_STAGING_SLOTS_IN_USE,
+                             MORI_UMBP_METRIC_SSD_STAGING_SLOTS_IN_USE_HELP, {},
+                             static_cast<double>(peer_service_->SnapshotReadSlotsInUse()));
   }
 }
 

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -39,6 +39,7 @@
 #include "umbp/distributed/peer/peer_dram_allocator.h"
 #include "umbp/distributed/peer/peer_service.h"
 #include "umbp/distributed/peer/peer_ssd_manager.h"
+#include "umbp/distributed/peer/ssd_copy_pipeline.h"
 #include "umbp_peer.grpc.pb.h"
 
 namespace mori::umbp {
@@ -159,6 +160,9 @@ PeerDramAllocator::TierConfig BuildDramTierConfig(const std::vector<ExportableDr
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, mems[i]);
     cfg.buffer_descs.emplace_back(sbuf.data(), sbuf.data() + sbuf.size());
+    // Local host base pointer, so PeerDramAllocator can resolve a committed
+    // key's pages to readable segments for the SSD copy worker (Phase 2).
+    cfg.buffer_bases.push_back(bufs[i].buffer);
   }
   return cfg;
 }
@@ -252,13 +256,16 @@ bool PoolClient::Init() {
   master_client_->SetPeerDramAllocator(peer_alloc_.get());
 
   // Peer-side SSD tier owner.  Built only when SSD is enabled; registered as an
-  // owned-location event source + SSD capacity provider.  Phase 1: present and
-  // reporting capacity, but nothing writes (copy = Phase 2) or reads (Phase 3)
-  // it yet.  TODO(Phase 2): PoolClient::Clear() must also clear peer_ssd_'s
-  // owned keys once copy-on-commit can populate them.
+  // owned-location event source + SSD capacity provider.  Phase 2 populates it
+  // via the copy-on-commit pipeline below; reads remain Phase 3.  Clear() now
+  // quiesces the pipeline and clears peer_ssd_ alongside peer_alloc_.
   if (config_.ssd.enabled) {
     peer_ssd_ = std::make_unique<PeerSsdManager>(config_.ssd);
     master_client_->SetPeerSsdManager(peer_ssd_.get());
+    // Copy-on-commit pipeline: commits enqueue here, a worker pins the DRAM
+    // pages and writes them to the local SSD tier.  Started below.
+    ssd_copy_pipeline_ = std::make_unique<SsdCopyPipeline>(peer_alloc_.get(), peer_ssd_.get());
+    ssd_copy_pipeline_->Start();
   }
 
   // Pack engine_desc for master registration.
@@ -285,8 +292,9 @@ bool PoolClient::Init() {
   }
 
   if (config_.peer_service_port > 0) {
-    peer_service_ = std::make_unique<PeerServiceServer>(peer_alloc_.get(), 8, 10, engine_desc_bytes,
-                                                        master_client_.get());
+    peer_service_ =
+        std::make_unique<PeerServiceServer>(peer_alloc_.get(), 8, 10, engine_desc_bytes,
+                                            master_client_.get(), ssd_copy_pipeline_.get());
     if (!peer_service_->Start(config_.peer_service_port)) {
       MORI_UMBP_ERROR("[PoolClient] PeerService failed to start on port {}",
                       config_.peer_service_port);
@@ -338,6 +346,15 @@ void PoolClient::Shutdown() {
 
   peer_service_.reset();
 
+  // Stop the copy pipeline AFTER the peer service (RPC commit path) is gone so
+  // no commit can enqueue into a stopping pipeline.  Stop() drops queued tasks
+  // and waits for the in-flight copy to finish + release its DRAM pin before
+  // we tear down peer_alloc_ / peer_ssd_ below.
+  if (ssd_copy_pipeline_) {
+    ssd_copy_pipeline_->Stop();
+    ssd_copy_pipeline_.reset();
+  }
+
   if (peer_alloc_) {
     peer_alloc_->StopReaper();
     peer_alloc_.reset();
@@ -372,14 +389,24 @@ bool PoolClient::Clear() {
   // clear and no master to notify.  Treat as success so callers in
   // shutdown / teardown paths do not surface a spurious error.
   if (!initialized_.load()) return true;
+  // Quiesce the copy pipeline first: drop queued tasks and wait for any
+  // in-flight copy to finish + release its pin.  Otherwise a copy completing
+  // after the clear below would re-record an SSD location and emit ADD SSD
+  // for a key we just collapsed.
+  if (ssd_copy_pipeline_) ssd_copy_pipeline_->Quiesce();
   if (peer_alloc_) peer_alloc_->ClearLocal();
+  if (peer_ssd_) peer_ssd_->ClearLocal();
+
+  bool ok = true;
   if (master_client_) {
-    if (!master_client_->ClearFullSync()) {
-      MORI_UMBP_WARN("[PoolClient] Clear full-sync heartbeat failed");
-      return false;
-    }
+    ok = master_client_->ClearFullSync();
+    if (!ok) MORI_UMBP_WARN("[PoolClient] Clear full-sync heartbeat failed");
   }
-  return true;
+
+  // Always resume — even if the full-sync RPC failed — so the pipeline is
+  // never left permanently paused (the heartbeat loop retries convergence).
+  if (ssd_copy_pipeline_) ssd_copy_pipeline_->Resume();
+  return ok;
 }
 
 bool PoolClient::IsInitialized() const { return initialized_; }
@@ -504,6 +531,10 @@ PoolClient::PutAttemptOutcome PoolClient::ExecuteLocalPut(const std::string& key
   if (!peer_alloc_->Commit(pending.slot_id, key, committed_bytes)) {
     peer_alloc_->Abort(pending.slot_id);
     return PutAttemptOutcome::kFatal;
+  }
+  // Owner-side commit succeeded: best-effort async copy to local SSD.
+  if (ssd_copy_pipeline_) {
+    ssd_copy_pipeline_->Enqueue(SsdCopyTask{key, tier, size});
   }
   master_client_->AddCounter(MORI_UMBP_METRIC_CLIENT_OUTBOUND_PUT_BYTES_TOTAL,
                              MORI_UMBP_METRIC_CLIENT_OUTBOUND_PUT_BYTES_TOTAL_HELP,

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -41,6 +41,7 @@
 #include "umbp/distributed/peer/peer_service.h"
 #include "umbp/distributed/peer/peer_ssd_manager.h"
 #include "umbp/distributed/peer/ssd_copy_pipeline.h"
+#include "umbp/distributed/ssd_read_lease.h"
 #include "umbp_peer.grpc.pb.h"
 
 namespace mori::umbp {
@@ -148,19 +149,43 @@ uint32_t ReleaseLeaseMaxRetries() {
   return v;
 }
 
-// How many times a remote SSD get retries a TRANSIENT peer failure
-// (NO_SLOT / LEASE_EXPIRED) before giving up.  These are not misses: with only
-// a handful of staging slots a large prefetch batch will hit slot contention,
-// so we retry with a short backoff rather than surfacing a false miss.  A
-// definitive NOT_FOUND short-circuits immediately (no retry).
+// Total attempts for a remote SSD get.  Retryable outcomes (kRetry) are
+// NO_SLOT (transient slot exhaustion, no slot claimed) and a reader-local lease
+// expiry.  Defaults to 1 (no retry); operators opt into bounded retry to absorb
+// slot contention.  A slow/failed PrepareSsdRead (DEADLINE_EXCEEDED etc.) is a
+// hard failure, NOT retried — the peer may already hold a claimed slot, so a
+// retry would only pile up more staging-slot occupation.  NOT_FOUND is always a
+// definitive miss (no retry).
 uint32_t SsdGetTransientMaxAttempts() {
-  static const uint32_t v = GetEnvUint32("UMBP_SSD_GET_MAX_ATTEMPTS", 4, /*min_allowed=*/1);
+  static const uint32_t v = GetEnvUint32("UMBP_SSD_GET_MAX_ATTEMPTS", 1, /*min_allowed=*/1);
   return v;
 }
 
 std::chrono::milliseconds SsdGetRetryBackoff() {
   static const auto v = std::chrono::milliseconds(
       GetEnvUint32("UMBP_SSD_GET_RETRY_BACKOFF_MS", 2, /*min_allowed=*/1));
+  return v;
+}
+
+// Bounded client deadline for a single PrepareSsdRead RPC so a hung/slow peer
+// cannot block the serial per-key remote SSD read loop indefinitely.  A read
+// that cannot even return within this budget is past any useful lease window
+// and is treated as a hard failure (NOT retried: the peer may already hold a
+// claimed slot, and a retry would only claim another).  When the env is unset
+// the caller falls back to the configured lease timeout (cluster-homogeneous
+// assumption); 0 here means "use the fallback".
+std::chrono::milliseconds SsdPrepareRpcTimeoutOverride() {
+  static const auto v = GetEnvMilliseconds("UMBP_SSD_PREPARE_TIMEOUT_MS",
+                                           std::chrono::milliseconds(0), /*min_allowed=*/0);
+  return v;
+}
+
+// Bounded client deadline for a best-effort ReleaseSsdLease RPC.  Release is
+// never on the critical path (the slot is also reclaimed by TTL), so cap it
+// tightly to avoid blocking on a slow peer.
+std::chrono::milliseconds ReleaseLeaseRpcTimeout() {
+  static const auto v = GetEnvMilliseconds("UMBP_RELEASE_LEASE_TIMEOUT_MS",
+                                           std::chrono::milliseconds(1000), /*min_allowed=*/1);
   return v;
 }
 
@@ -1780,23 +1805,51 @@ bool PoolClient::EnsurePeerServiceConnection(PeerConnection& peer) {
 
 // Remote SSD get for one key (reader != owner): key-based PrepareSsdRead on the
 // peer reads the bytes into its serving staging slot; we RDMA them out of the
-// published staging buffer, then issue a best-effort ReleaseSsdLease.  The
-// returned outcome lets the caller separate a true miss (kMiss / NOT_FOUND)
-// from a retryable transient failure (kRetry / NO_SLOT / LEASE_EXPIRED).
+// published staging buffer, then issue a best-effort ReleaseSsdLease.  Outcomes:
+// kMiss (NOT_FOUND, definitive miss); kRetry (retryable: NO_SLOT or a
+// reader-local lease expiry); kError (not-served, not retried: rpc failure
+// incl. DEADLINE_EXCEEDED, size mismatch, RDMA failure).
+//
+// Lease gating: the deadline is anchored at t_send (before the RPC) so it stays
+// conservative against the peer, which counts the same TTL from request receipt
+// (see ssd_read_lease.h).  A read is reported successful only if RDMA finished
+// before that deadline; once expired we return a transient retry and do NOT
+// release (the peer reclaims the slot by TTL).  A late-returning PrepareSsdRead
+// is caught by the pre-RDMA expiry check; a hung one by the RPC deadline.
 PoolClient::SsdGetOutcome PoolClient::RemoteSsdReadOnce(PeerConnection& peer,
                                                         const std::string& key, void* dst,
                                                         size_t size) {
+  namespace lease = ssd_read_lease;
   if (!io_engine_) return SsdGetOutcome::kError;
   if (!EnsurePeerServiceConnection(peer)) return SsdGetOutcome::kError;
   if (!IsValidMemoryDesc(peer.ssd_staging_mem)) return SsdGetOutcome::kError;
   auto* stub = static_cast<::umbp::UMBPPeer::Stub*>(peer.peer_stub.get());
+
+  // Anchor the lease deadline before sending; also bound the RPC itself so a
+  // hung peer can't stall the serial batch.  Fall back to the configured lease
+  // timeout when the dedicated timeout env is unset (cluster-homogeneous).
+  const auto t_send = std::chrono::steady_clock::now();
+  auto rpc_timeout = SsdPrepareRpcTimeoutOverride();
+  if (rpc_timeout.count() == 0) {
+    rpc_timeout = std::chrono::seconds(std::max(config_.ssd_lease_timeout_s, 1));
+  }
 
   ::umbp::PrepareSsdReadRequest req;
   req.set_key(key);
   req.set_max_size(size);
   ::umbp::PrepareSsdReadResponse resp;
   grpc::ClientContext ctx;
-  if (!stub->PrepareSsdRead(&ctx, req, &resp).ok()) return SsdGetOutcome::kError;
+  // gRPC deadlines are specialized for system_clock; the lease gating below
+  // uses the monotonic steady_clock t_send for the actual validity window.
+  ctx.set_deadline(std::chrono::system_clock::now() + rpc_timeout);
+  const grpc::Status rpc = stub->PrepareSsdRead(&ctx, req, &resp);
+  if (!rpc.ok()) {
+    // Includes DEADLINE_EXCEEDED (peer slow / may already hold a claimed slot)
+    // and UNAVAILABLE: hard failure, not retried — see SsdGetTransientMaxAttempts.
+    MORI_UMBP_DEBUG("[PoolClient] RemoteSsdRead key='{}' PrepareSsdRead rpc failed (code={})", key,
+                    static_cast<int>(rpc.error_code()));
+    return SsdGetOutcome::kError;
+  }
 
   switch (resp.status()) {
     case ::umbp::SSD_READ_OK:
@@ -1804,12 +1857,23 @@ PoolClient::SsdGetOutcome PoolClient::RemoteSsdReadOnce(PeerConnection& peer,
     case ::umbp::SSD_READ_NOT_FOUND:
       return SsdGetOutcome::kMiss;
     case ::umbp::SSD_READ_NO_SLOT:
-    case ::umbp::SSD_READ_LEASE_EXPIRED:
+      // Transient slot exhaustion (no slot was claimed): retryable, not a miss.
       return SsdGetOutcome::kRetry;
     default:  // SIZE_TOO_LARGE / ERROR / unexpected
       MORI_UMBP_WARN("[PoolClient] RemoteSsdRead key='{}' status={}", key,
                      static_cast<int>(resp.status()));
       return SsdGetOutcome::kError;
+  }
+
+  const auto deadline_ttl = resp.lease_ttl_ms();
+
+  // If the lease already elapsed (slow/late PrepareSsdRead return), don't even
+  // RDMA — the staging bytes may already be getting recycled.  Transient, not a
+  // miss; leave the slot for the peer's TTL reclaim (no release).
+  if (lease::LeaseExpired(t_send, deadline_ttl, std::chrono::steady_clock::now())) {
+    MORI_UMBP_DEBUG("[PoolClient] RemoteSsdRead key='{}' lease expired before RDMA (ttl_ms={})",
+                    key, deadline_ttl);
+    return SsdGetOutcome::kRetry;
   }
 
   if (resp.size() != size) {
@@ -1844,20 +1908,41 @@ PoolClient::SsdGetOutcome PoolClient::RemoteSsdReadOnce(PeerConnection& peer,
     }
   }
 
-  ReleaseSsdLeaseBestEffort(stub, resp.lease_id());
-  return rdma_ok ? SsdGetOutcome::kSuccess : SsdGetOutcome::kError;
+  // Decide against the lease deadline: a read that finished after the deadline
+  // is untrusted (the peer may have recycled the slot mid-RDMA), so it becomes
+  // a transient retry and we skip release.  The caller uses the return value;
+  // any bytes already written to dst on the expired path are not consumed.
+  const bool expired = lease::LeaseExpired(t_send, deadline_ttl, std::chrono::steady_clock::now());
+  const auto decision = lease::DecideSsdReadOutcome(expired, rdma_ok);
+  if (decision.release) ReleaseSsdLeaseBestEffort(stub, resp.lease_id());
+  if (expired && rdma_ok) {
+    MORI_UMBP_DEBUG("[PoolClient] RemoteSsdRead key='{}' lease expired after RDMA (ttl_ms={})", key,
+                    deadline_ttl);
+  }
+  switch (decision.outcome) {
+    case lease::GateOutcome::kSuccess:
+      return SsdGetOutcome::kSuccess;
+    case lease::GateOutcome::kRetry:
+      return SsdGetOutcome::kRetry;
+    case lease::GateOutcome::kError:
+      return SsdGetOutcome::kError;
+  }
+  return SsdGetOutcome::kError;
 }
 
 // Best-effort lease release.  Correctness does not depend on it: if it fails or
-// is never called, the peer reclaims the slot when the lease TTL expires.
+// is never called, the peer reclaims the slot when the lease TTL expires.  Each
+// attempt is bounded by a short deadline so a slow peer can't stall the caller.
 void PoolClient::ReleaseSsdLeaseBestEffort(::umbp::UMBPPeer::Stub* stub, uint64_t lease_id) {
   if (lease_id == 0) return;
   const uint32_t max_retries = ReleaseLeaseMaxRetries();
+  const auto timeout = ReleaseLeaseRpcTimeout();
   for (uint32_t attempt = 0; attempt < max_retries; ++attempt) {
     ::umbp::ReleaseSsdLeaseRequest rel_req;
     rel_req.set_lease_id(lease_id);
     ::umbp::ReleaseSsdLeaseResponse rel_resp;
     grpc::ClientContext rel_ctx;
+    rel_ctx.set_deadline(std::chrono::system_clock::now() + timeout);
     if (stub->ReleaseSsdLease(&rel_ctx, rel_req, &rel_resp).ok()) break;
   }
 }
@@ -1882,15 +1967,15 @@ void PoolClient::ProcessRemoteSsdBatchGet(const std::vector<BatchGetItem>& items
         case SsdGetOutcome::kError:  // hard failure (already logged)
           done = true;
           break;
-        case SsdGetOutcome::kRetry:  // transient NO_SLOT / LEASE_EXPIRED, not a miss
-          std::this_thread::sleep_for(SsdGetRetryBackoff());
+        case SsdGetOutcome::kRetry:  // transient NO_SLOT / reader-local lease expiry; not a miss
+          if (attempt + 1 < max_attempts) std::this_thread::sleep_for(SsdGetRetryBackoff());
           break;
       }
     }
     if (!done) {
       MORI_UMBP_WARN(
-          "[PoolClient] Remote SSD get key='{}' still transient-failing after {} attempts "
-          "(NO_SLOT/LEASE_EXPIRED); reporting as not-served this round (not a definitive miss)",
+          "[PoolClient] Remote SSD get key='{}' still transient-failing (NO_SLOT/lease-expired) "
+          "after {} attempts; reporting as not-served this round (not a definitive miss)",
           *item.key, max_attempts);
     }
   }

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -30,6 +30,7 @@
 #include <numeric>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <unordered_map>
 
 #include "mori/io/backend.hpp"
@@ -144,6 +145,22 @@ std::vector<ScatterGroup> GroupPagesByBuffer(const std::vector<PageLocation>& pa
 
 uint32_t ReleaseLeaseMaxRetries() {
   static const uint32_t v = GetEnvUint32("UMBP_RELEASE_LEASE_MAX_RETRIES", 2, /*min_allowed=*/1);
+  return v;
+}
+
+// How many times a remote SSD get retries a TRANSIENT peer failure
+// (NO_SLOT / LEASE_EXPIRED) before giving up.  These are not misses: with only
+// a handful of staging slots a large prefetch batch will hit slot contention,
+// so we retry with a short backoff rather than surfacing a false miss.  A
+// definitive NOT_FOUND short-circuits immediately (no retry).
+uint32_t SsdGetTransientMaxAttempts() {
+  static const uint32_t v = GetEnvUint32("UMBP_SSD_GET_MAX_ATTEMPTS", 4, /*min_allowed=*/1);
+  return v;
+}
+
+std::chrono::milliseconds SsdGetRetryBackoff() {
+  static const auto v = std::chrono::milliseconds(
+      GetEnvUint32("UMBP_SSD_GET_RETRY_BACKOFF_MS", 2, /*min_allowed=*/1));
   return v;
 }
 
@@ -292,9 +309,13 @@ bool PoolClient::Init() {
   }
 
   if (config_.peer_service_port > 0) {
-    peer_service_ =
-        std::make_unique<PeerServiceServer>(peer_alloc_.get(), 8, 10, engine_desc_bytes,
-                                            master_client_.get(), ssd_copy_pipeline_.get());
+    // Wire the SSD read path: peer_ssd_ + the RDMA-registered SSD staging buffer
+    // (both null/empty when SSD is disabled, leaving SsdRpcAvailable() false).
+    peer_service_ = std::make_unique<PeerServiceServer>(
+        peer_alloc_.get(), peer_ssd_.get(), ssd_staging_buffer_.get(),
+        ssd_staging_buffer_ ? config_.staging_buffer_size : 0, ssd_staging_mem_desc_bytes_,
+        config_.ssd_read_slots, config_.ssd_lease_timeout_s, engine_desc_bytes,
+        master_client_.get(), ssd_copy_pipeline_.get());
     if (!peer_service_->Start(config_.peer_service_port)) {
       MORI_UMBP_ERROR("[PoolClient] PeerService failed to start on port {}",
                       config_.peer_service_port);
@@ -567,6 +588,42 @@ PoolClient::GetAttemptOutcome PoolClient::ExecuteLocalGet(const std::string& key
   return GetAttemptOutcome::kSuccess;
 }
 
+PoolClient::GetAttemptOutcome PoolClient::ExecuteLocalSsdGet(const std::string& key, void* dst,
+                                                             size_t size) {
+  // reader == owner: read straight into the user buffer (no staging / RDMA /
+  // lease — those serve remote readers).  kNotFound -> kRetry (miss, not error).
+  if (!peer_ssd_) {
+    MORI_UMBP_ERROR("[PoolClient] Local SSD Get requested but PeerSsdManager unavailable");
+    return GetAttemptOutcome::kFatal;
+  }
+  SsdReadOutcome outcome = peer_ssd_->PrepareRead(key, dst, size);
+  switch (outcome.status) {
+    case SsdReadStatus::kOk:
+      break;
+    case SsdReadStatus::kNotFound:
+      return GetAttemptOutcome::kRetry;
+    case SsdReadStatus::kSizeTooLarge:
+    case SsdReadStatus::kError:
+      MORI_UMBP_WARN("[PoolClient] Local SSD Get key='{}' failed (status={}, size={})", key,
+                     static_cast<int>(outcome.status), outcome.size);
+      return GetAttemptOutcome::kFatal;
+  }
+  // Guard against a short read filling only part of the user buffer (mirrors the
+  // remote path's size check).
+  if (outcome.size != size) {
+    MORI_UMBP_WARN("[PoolClient] Local SSD Get key='{}' size mismatch (wanted {}, got {})", key,
+                   size, outcome.size);
+    return GetAttemptOutcome::kFatal;
+  }
+  master_client_->AddCounter(MORI_UMBP_METRIC_CLIENT_OUTBOUND_GET_BYTES_TOTAL,
+                             MORI_UMBP_METRIC_CLIENT_OUTBOUND_GET_BYTES_TOTAL_HELP,
+                             {{"traffic", "local"}}, static_cast<double>(size));
+  master_client_->AddCounter(MORI_UMBP_METRIC_CLIENT_INBOUND_GET_BYTES_TOTAL,
+                             MORI_UMBP_METRIC_CLIENT_INBOUND_GET_BYTES_TOTAL_HELP,
+                             {{"traffic", "local"}}, static_cast<double>(size));
+  return GetAttemptOutcome::kSuccess;
+}
+
 std::unordered_map<std::string, std::vector<PoolClient::BatchPutItem>>
 PoolClient::PartitionBatchPutTargets(const std::vector<std::string>& keys,
                                      const std::vector<const void*>& srcs,
@@ -701,7 +758,11 @@ std::vector<bool> PoolClient::BatchGet(const std::vector<std::string>& keys,
     routes.resize(keys.size());
   }
 
+  // DRAM/HBM remote reads go through the batched RDMA path (remote_groups);
+  // remote SSD reads go through a per-key staging path (ssd_remote_groups)
+  // because each needs its own peer-side staging slot + lease.
   std::unordered_map<std::string, std::vector<BatchGetItem>> remote_groups;
+  std::unordered_map<std::string, std::vector<BatchGetItem>> ssd_remote_groups;
   for (size_t i = 0; i < keys.size(); ++i) {
     if (i >= routes.size() || !routes[i].has_value()) {
       if (peer_alloc_) {
@@ -714,14 +775,14 @@ std::vector<bool> PoolClient::BatchGet(const std::vector<std::string>& keys,
     }
     const auto& route = routes[i].value();
     if (route.node_id == config_.master_config.node_id) {
-      auto outcome = ExecuteLocalGet(keys[i], const_cast<void*>(dsts[i]), sizes[i]);
+      // Self-target fast path: SSD via PeerSsdManager, DRAM/HBM via the allocator.
+      GetAttemptOutcome outcome =
+          route.tier == TierType::SSD
+              ? ExecuteLocalSsdGet(keys[i], const_cast<void*>(dsts[i]), sizes[i])
+              : ExecuteLocalGet(keys[i], const_cast<void*>(dsts[i]), sizes[i]);
       if (outcome == GetAttemptOutcome::kSuccess) {
         results[i] = true;
       }
-      continue;
-    }
-    if (route.tier != TierType::DRAM && route.tier != TierType::HBM) {
-      results[i] = false;
       continue;
     }
     BatchGetItem item{.index = i,
@@ -729,11 +790,18 @@ std::vector<bool> PoolClient::BatchGet(const std::vector<std::string>& keys,
                       .dst = const_cast<void*>(dsts[i]),
                       .size = sizes[i],
                       .route = route};
-    remote_groups[route.node_id].push_back(std::move(item));
+    if (route.tier == TierType::SSD) {
+      ssd_remote_groups[route.node_id].push_back(std::move(item));
+    } else {
+      remote_groups[route.node_id].push_back(std::move(item));
+    }
   }
 
   for (auto& [node_id, items] : remote_groups) {
     ProcessRemoteBatchGet(items, &results);
+  }
+  for (auto& [node_id, items] : ssd_remote_groups) {
+    ProcessRemoteSsdBatchGet(items, &results);
   }
 
   for (size_t i = 0; i < keys.size(); ++i) {
@@ -1710,42 +1778,60 @@ bool PoolClient::EnsurePeerServiceConnection(PeerConnection& peer) {
   return true;
 }
 
-// TODO(Phase 3): RemoteSsdRead is the legacy client-side SSD read glue.  It is
-// currently dead (no callers) and will be rewritten for the new SSD get path
-// (local vs remote, key-based PrepareSsdRead) per the interface contract §5.
-// Direct-SSD-put (RemoteSsdWrite) was removed in the SSD-tier redesign — SSD is
-// an async copy-on-commit cold tier, not a writer-driven put target.
-bool PoolClient::RemoteSsdRead(PeerConnection& peer, const std::string& key,
-                               const std::string& location_id, void* dst, size_t size,
-                               bool zero_copy) {
-  if (!io_engine_) return false;
-  if (!EnsurePeerServiceConnection(peer)) return false;
-  if (!IsValidMemoryDesc(peer.ssd_staging_mem)) return false;
+// Remote SSD get for one key (reader != owner): key-based PrepareSsdRead on the
+// peer reads the bytes into its serving staging slot; we RDMA them out of the
+// published staging buffer, then issue a best-effort ReleaseSsdLease.  The
+// returned outcome lets the caller separate a true miss (kMiss / NOT_FOUND)
+// from a retryable transient failure (kRetry / NO_SLOT / LEASE_EXPIRED).
+PoolClient::SsdGetOutcome PoolClient::RemoteSsdReadOnce(PeerConnection& peer,
+                                                        const std::string& key, void* dst,
+                                                        size_t size) {
+  if (!io_engine_) return SsdGetOutcome::kError;
+  if (!EnsurePeerServiceConnection(peer)) return SsdGetOutcome::kError;
+  if (!IsValidMemoryDesc(peer.ssd_staging_mem)) return SsdGetOutcome::kError;
   auto* stub = static_cast<::umbp::UMBPPeer::Stub*>(peer.peer_stub.get());
 
   ::umbp::PrepareSsdReadRequest req;
   req.set_key(key);
-  req.set_ssd_location_id(location_id);
-  req.set_size(size);
+  req.set_max_size(size);
   ::umbp::PrepareSsdReadResponse resp;
   grpc::ClientContext ctx;
-  auto grpc_status = stub->PrepareSsdRead(&ctx, req, &resp);
-  if (!grpc_status.ok() || !resp.success()) return false;
+  if (!stub->PrepareSsdRead(&ctx, req, &resp).ok()) return SsdGetOutcome::kError;
 
-  bool rdma_ok = false;
-  if (zero_copy) {
-    auto reg = FindRegisteredMemory(dst, size);
-    if (reg) {
-      auto uid = io_engine_->AllocateTransferUniqueId();
-      mori::io::TransferStatus status;
-      io_engine_->Read(reg->first, reg->second, peer.ssd_staging_mem, resp.staging_offset(), size,
-                       &status, uid);
-      status.Wait();
-      rdma_ok = status.Succeeded();
-    }
+  switch (resp.status()) {
+    case ::umbp::SSD_READ_OK:
+      break;
+    case ::umbp::SSD_READ_NOT_FOUND:
+      return SsdGetOutcome::kMiss;
+    case ::umbp::SSD_READ_NO_SLOT:
+    case ::umbp::SSD_READ_LEASE_EXPIRED:
+      return SsdGetOutcome::kRetry;
+    default:  // SIZE_TOO_LARGE / ERROR / unexpected
+      MORI_UMBP_WARN("[PoolClient] RemoteSsdRead key='{}' status={}", key,
+                     static_cast<int>(resp.status()));
+      return SsdGetOutcome::kError;
   }
-  if (!rdma_ok) {
-    if (size > config_.staging_buffer_size) return false;
+
+  if (resp.size() != size) {
+    MORI_UMBP_WARN("[PoolClient] RemoteSsdRead key='{}' size mismatch (wanted {}, got {})", key,
+                   size, resp.size());
+    ReleaseSsdLeaseBestEffort(stub, resp.lease_id());
+    return SsdGetOutcome::kError;
+  }
+
+  // RDMA the staged bytes home: zero-copy if the dst is registered, else stage
+  // through our own buffer and memcpy.
+  bool rdma_ok = false;
+  auto reg = FindRegisteredMemory(dst, size);
+  if (reg) {
+    auto uid = io_engine_->AllocateTransferUniqueId();
+    mori::io::TransferStatus status;
+    io_engine_->Read(reg->first, reg->second, peer.ssd_staging_mem, resp.staging_offset(), size,
+                     &status, uid);
+    status.Wait();
+    rdma_ok = status.Succeeded();
+  }
+  if (!rdma_ok && size <= config_.staging_buffer_size) {
     std::lock_guard<std::mutex> lock(staging_mutex_);
     auto uid = io_engine_->AllocateTransferUniqueId();
     mori::io::TransferStatus status;
@@ -1758,17 +1844,56 @@ bool PoolClient::RemoteSsdRead(PeerConnection& peer, const std::string& key,
     }
   }
 
-  if (resp.lease_id() > 0) {
-    const uint32_t max_retries = ReleaseLeaseMaxRetries();
-    for (uint32_t attempt = 0; attempt < max_retries; ++attempt) {
-      ::umbp::ReleaseSsdLeaseRequest rel_req;
-      rel_req.set_lease_id(resp.lease_id());
-      ::umbp::ReleaseSsdLeaseResponse rel_resp;
-      grpc::ClientContext rel_ctx;
-      if (stub->ReleaseSsdLease(&rel_ctx, rel_req, &rel_resp).ok()) break;
+  ReleaseSsdLeaseBestEffort(stub, resp.lease_id());
+  return rdma_ok ? SsdGetOutcome::kSuccess : SsdGetOutcome::kError;
+}
+
+// Best-effort lease release.  Correctness does not depend on it: if it fails or
+// is never called, the peer reclaims the slot when the lease TTL expires.
+void PoolClient::ReleaseSsdLeaseBestEffort(::umbp::UMBPPeer::Stub* stub, uint64_t lease_id) {
+  if (lease_id == 0) return;
+  const uint32_t max_retries = ReleaseLeaseMaxRetries();
+  for (uint32_t attempt = 0; attempt < max_retries; ++attempt) {
+    ::umbp::ReleaseSsdLeaseRequest rel_req;
+    rel_req.set_lease_id(lease_id);
+    ::umbp::ReleaseSsdLeaseResponse rel_resp;
+    grpc::ClientContext rel_ctx;
+    if (stub->ReleaseSsdLease(&rel_ctx, rel_req, &rel_resp).ok()) break;
+  }
+}
+
+void PoolClient::ProcessRemoteSsdBatchGet(const std::vector<BatchGetItem>& items,
+                                          std::vector<bool>* results) {
+  if (items.empty()) return;
+  const auto& first = items.front();
+  auto& peer = GetOrConnectPeer(first.route.node_id, first.route.peer_address);
+
+  const uint32_t max_attempts = SsdGetTransientMaxAttempts();
+  for (const auto& item : items) {
+    bool done = false;
+    for (uint32_t attempt = 0; attempt < max_attempts && !done; ++attempt) {
+      SsdGetOutcome outcome = RemoteSsdReadOnce(peer, *item.key, item.dst, item.size);
+      switch (outcome) {
+        case SsdGetOutcome::kSuccess:
+          (*results)[item.index] = true;
+          done = true;
+          break;
+        case SsdGetOutcome::kMiss:   // definitive miss
+        case SsdGetOutcome::kError:  // hard failure (already logged)
+          done = true;
+          break;
+        case SsdGetOutcome::kRetry:  // transient NO_SLOT / LEASE_EXPIRED, not a miss
+          std::this_thread::sleep_for(SsdGetRetryBackoff());
+          break;
+      }
+    }
+    if (!done) {
+      MORI_UMBP_WARN(
+          "[PoolClient] Remote SSD get key='{}' still transient-failing after {} attempts "
+          "(NO_SLOT/LEASE_EXPIRED); reporting as not-served this round (not a definitive miss)",
+          *item.key, max_attempts);
     }
   }
-  return rdma_ok;
 }
 
 }  // namespace mori::umbp

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -150,7 +150,7 @@ uint32_t ReleaseLeaseMaxRetries() {
   return v;
 }
 
-// Crash-restart SSD leftover policy (v1 = discard): wipe physical SSD bytes a
+// Crash-restart SSD leftover policy (discard): wipe physical SSD bytes a
 // previous crashed process left behind at startup.  Default on; set
 // UMBP_SSD_STARTUP_DISCARD=0/false to keep leftover (opt-out hook for a future
 // rebuild-from-backend policy — there is no rebuild path yet).
@@ -215,7 +215,7 @@ PeerDramAllocator::TierConfig BuildDramTierConfig(const std::vector<ExportableDr
     msgpack::pack(sbuf, mems[i]);
     cfg.buffer_descs.emplace_back(sbuf.data(), sbuf.data() + sbuf.size());
     // Local host base pointer, so PeerDramAllocator can resolve a committed
-    // key's pages to readable segments for the SSD copy worker (Phase 2).
+    // key's pages to readable segments for the SSD copy worker.
     cfg.buffer_bases.push_back(bufs[i].buffer);
   }
   return cfg;
@@ -310,12 +310,12 @@ bool PoolClient::Init() {
   master_client_->SetPeerDramAllocator(peer_alloc_.get());
 
   // Peer-side SSD tier owner.  Built only when SSD is enabled; registered as an
-  // owned-location event source + SSD capacity provider.  Phase 2 populates it
-  // via the copy-on-commit pipeline below; reads remain Phase 3.  Clear() now
-  // quiesces the pipeline and clears peer_ssd_ alongside peer_alloc_.
+  // owned-location event source + SSD capacity provider.  The copy-on-commit
+  // pipeline below populates it.  Clear() quiesces the pipeline and clears
+  // peer_ssd_ alongside peer_alloc_.
   if (config_.ssd.enabled) {
     peer_ssd_ = std::make_unique<PeerSsdManager>(config_.ssd);
-    // Crash-restart leftover (v1 = discard): wipe stale SSD bytes before the
+    // Crash-restart leftover (discard): wipe stale SSD bytes before the
     // pipeline starts so used capacity and the empty owned_ map start consistent
     // (env-gated; see SsdStartupDiscardEnabled / DiscardLeftoverOnStartup).
     if (SsdStartupDiscardEnabled()) peer_ssd_->DiscardLeftoverOnStartup();
@@ -334,8 +334,8 @@ bool PoolClient::Init() {
     engine_desc_bytes.assign(sbuf.data(), sbuf.data() + sbuf.size());
   }
 
-  // SSD staging buffer (one per process; not part of DRAM exports).  Phase 3
-  // serves remote SSD reads out of it; allocated up front when SSD is enabled.
+  // SSD staging buffer (one per process; not part of DRAM exports).  Remote SSD
+  // reads are served out of it; allocated up front when SSD is enabled.
   if (config_.ssd.enabled) {
     ssd_staging_buffer_ = std::make_unique<char[]>(config_.staging_buffer_size);
     std::memset(ssd_staging_buffer_.get(), 0, config_.staging_buffer_size);

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -273,8 +273,8 @@ bool PoolClient::Init() {
   }
 
   if (config_.peer_service_port > 0) {
-    peer_service_ = std::make_unique<PeerServiceServer>(peer_alloc_.get(), 8, 8, 10,
-                                                        engine_desc_bytes, master_client_.get());
+    peer_service_ = std::make_unique<PeerServiceServer>(peer_alloc_.get(), 8, 10, engine_desc_bytes,
+                                                        master_client_.get());
     if (!peer_service_->Start(config_.peer_service_port)) {
       MORI_UMBP_ERROR("[PoolClient] PeerService failed to start on port {}",
                       config_.peer_service_port);
@@ -290,6 +290,9 @@ bool PoolClient::Init() {
     peer_address = host + ":" + std::to_string(config_.peer_service_port);
   }
 
+  // DEPRECATED: ssd_store_capacities is legacy and unconsumed by master. The
+  // SSD-tier redesign reports SSD capacity via config_.tier_capacities
+  // (TierType::SSD), wired in Phase 1. Left empty here for wire compat.
   std::vector<uint64_t> ssd_store_capacities;
   for (const auto& store : config_.ssd_stores) ssd_store_capacities.push_back(store.capacity);
 
@@ -1665,57 +1668,11 @@ bool PoolClient::EnsurePeerServiceConnection(PeerConnection& peer) {
   return true;
 }
 
-bool PoolClient::RemoteSsdWrite(PeerConnection& peer, const std::string& key, const void* src,
-                                size_t size, bool zero_copy, uint32_t store_index) {
-  if (!io_engine_) return false;
-  if (!EnsurePeerServiceConnection(peer)) return false;
-  if (!IsValidMemoryDesc(peer.ssd_staging_mem)) return false;
-  auto* stub = static_cast<::umbp::UMBPPeer::Stub*>(peer.peer_stub.get());
-
-  ::umbp::AllocateWriteSlotRequest alloc_req;
-  alloc_req.set_size(size);
-  ::umbp::AllocateWriteSlotResponse alloc_resp;
-  grpc::ClientContext alloc_ctx;
-  auto alloc_status = stub->AllocateWriteSlot(&alloc_ctx, alloc_req, &alloc_resp);
-  if (!alloc_status.ok() || !alloc_resp.success()) return false;
-  uint64_t write_offset = alloc_resp.staging_offset();
-
-  bool used_zero_copy = false;
-  if (zero_copy) {
-    auto reg = FindRegisteredMemory(src, size);
-    if (reg) {
-      auto uid = io_engine_->AllocateTransferUniqueId();
-      mori::io::TransferStatus status;
-      io_engine_->Write(reg->first, reg->second, peer.ssd_staging_mem, write_offset, size, &status,
-                        uid);
-      status.Wait();
-      if (!status.Succeeded()) return false;
-      used_zero_copy = true;
-    }
-  }
-  if (!used_zero_copy) {
-    if (size > config_.staging_buffer_size) return false;
-    std::lock_guard<std::mutex> lock(staging_mutex_);
-    std::memcpy(staging_buffer_.get(), src, size);
-    auto uid = io_engine_->AllocateTransferUniqueId();
-    mori::io::TransferStatus status;
-    io_engine_->Write(staging_mem_, 0, peer.ssd_staging_mem, write_offset, size, &status, uid);
-    status.Wait();
-    if (!status.Succeeded()) return false;
-  }
-
-  ::umbp::CommitSsdWriteRequest req;
-  req.set_key(key);
-  req.set_staging_offset(write_offset);
-  req.set_size(size);
-  req.set_store_index(store_index);
-  req.set_lease_id(alloc_resp.lease_id());
-  ::umbp::CommitSsdWriteResponse resp;
-  grpc::ClientContext ctx;
-  auto grpc_status = stub->CommitSsdWrite(&ctx, req, &resp);
-  return grpc_status.ok() && resp.success();
-}
-
+// TODO(Phase 3): RemoteSsdRead is the legacy client-side SSD read glue.  It is
+// currently dead (no callers) and will be rewritten for the new SSD get path
+// (local vs remote, key-based PrepareSsdRead) per the interface contract §5.
+// Direct-SSD-put (RemoteSsdWrite) was removed in the SSD-tier redesign — SSD is
+// an async copy-on-commit cold tier, not a writer-driven put target.
 bool PoolClient::RemoteSsdRead(PeerConnection& peer, const std::string& key,
                                const std::string& location_id, void* dst, size_t size,
                                bool zero_copy) {

--- a/src/umbp/distributed/proto/umbp.proto
+++ b/src/umbp/distributed/proto/umbp.proto
@@ -48,17 +48,20 @@ enum ClientStatus {
 }
 
 // Master no longer owns DRAM/HBM allocators, so descs / buffer sizes /
-// page sizes have moved to the peer.  ssd_store_capacities stays as
-// advisory capacity metadata for the routing strategy.  engine_desc is
-// retained so writers can resolve the target peer's IO engine without
-// an extra GetPeerInfo round trip on first contact.
+// page sizes have moved to the peer.  engine_desc is retained so writers can
+// resolve the target peer's IO engine without an extra GetPeerInfo round trip
+// on first contact.
 message RegisterClientRequest {
   string node_id                      = 1;
   string node_address                 = 2;   // Network address (e.g. "10.0.1.5:8080")
-  repeated TierCapacity tier_capacities = 3; // Capacity per tier
+  repeated TierCapacity tier_capacities = 3; // Capacity per tier (incl. SSD — see field 12)
   string peer_address                 = 4;   // PeerService gRPC address
   bytes  engine_desc                  = 5;   // packed EngineDesc
-  repeated uint64 ssd_store_capacities = 12; // per-SSD-store capacity in bytes
+  // DEPRECATED/legacy: master does not consume this field.  The SSD-tier
+  // redesign reports SSD capacity via TierCapacity{tier=TIER_SSD} in
+  // tier_capacities (field 3), same as DRAM/HBM.  Kept for wire compat; do not
+  // build new behavior on it.  See docs/umbp-ssd-tier-interface-contract-zh.md §0.5.
+  repeated uint64 ssd_store_capacities = 12; // [deprecated] per-SSD-store capacity in bytes
   repeated string tags                = 13;  // opaque key=value labels (e.g. "sgl_role=prefill")
 }
 message RegisterClientResponse {

--- a/src/umbp/distributed/proto/umbp.proto
+++ b/src/umbp/distributed/proto/umbp.proto
@@ -57,11 +57,12 @@ message RegisterClientRequest {
   repeated TierCapacity tier_capacities = 3; // Capacity per tier (incl. SSD — see field 12)
   string peer_address                 = 4;   // PeerService gRPC address
   bytes  engine_desc                  = 5;   // packed EngineDesc
-  // DEPRECATED/legacy: master does not consume this field.  The SSD-tier
-  // redesign reports SSD capacity via TierCapacity{tier=TIER_SSD} in
-  // tier_capacities (field 3), same as DRAM/HBM.  Kept for wire compat; do not
-  // build new behavior on it.  See docs/umbp-ssd-tier-interface-contract-zh.md §0.5.
-  repeated uint64 ssd_store_capacities = 12; // [deprecated] per-SSD-store capacity in bytes
+  // Field 12 was `repeated uint64 ssd_store_capacities` — removed in the
+  // SSD-tier redesign.  SSD capacity now flows via TierCapacity{tier=TIER_SSD}
+  // in tier_capacities (field 3), same as DRAM/HBM.  Reserved so the tag is
+  // never silently reused with a different type.
+  reserved 12;
+  reserved "ssd_store_capacities";
   repeated string tags                = 13;  // opaque key=value labels (e.g. "sgl_role=prefill")
 }
 message RegisterClientResponse {

--- a/src/umbp/distributed/proto/umbp.proto
+++ b/src/umbp/distributed/proto/umbp.proto
@@ -54,15 +54,9 @@ enum ClientStatus {
 message RegisterClientRequest {
   string node_id                      = 1;
   string node_address                 = 2;   // Network address (e.g. "10.0.1.5:8080")
-  repeated TierCapacity tier_capacities = 3; // Capacity per tier (incl. SSD — see field 12)
+  repeated TierCapacity tier_capacities = 3; // Capacity per tier (incl. SSD)
   string peer_address                 = 4;   // PeerService gRPC address
   bytes  engine_desc                  = 5;   // packed EngineDesc
-  // Field 12 was `repeated uint64 ssd_store_capacities` — removed in the
-  // SSD-tier redesign.  SSD capacity now flows via TierCapacity{tier=TIER_SSD}
-  // in tier_capacities (field 3), same as DRAM/HBM.  Reserved so the tag is
-  // never silently reused with a different type.
-  reserved 12;
-  reserved "ssd_store_capacities";
   repeated string tags                = 13;  // opaque key=value labels (e.g. "sgl_role=prefill")
 }
 message RegisterClientResponse {
@@ -82,9 +76,6 @@ message UnregisterClientResponse {}
 // One mutation in the peer's owned-key set.  ADD carries `size`; REMOVE
 // elides it because master already knows the size from the prior ADD.
 message KvEvent {
-  reserved 5;
-  reserved "owner";
-
   enum Kind {
     ADD           = 0;
     REMOVE        = 1;
@@ -109,9 +100,6 @@ message TierKvCount {
 }
 
 message HeartbeatRequest {
-  reserved 5;
-  reserved "seq", "last_acked_seq", "events";
-
   string node_id            = 1;
   repeated EventBundle bundles = 2; // unacked delta bundles in seq order, or full-sync snapshot
   bool is_full_sync = 3;

--- a/src/umbp/distributed/proto/umbp_peer.proto
+++ b/src/umbp/distributed/proto/umbp_peer.proto
@@ -47,14 +47,14 @@ message GetPeerInfoResponse {
 }
 
 // ============================================================
-//  SSD read staging (key-based; see UMBPPeer service comment + contract §5)
+//  SSD read staging (key-based; see the UMBPPeer service comment above)
 // ============================================================
 
 // Per-key SSD read outcome.  Callers MUST distinguish a transient failure
 // (NO_SLOT) from a definitive miss (NOT_FOUND): a transient failure must never
 // be surfaced to hicache as a cache miss.  Lease expiry is NOT a wire status:
 // the reader decides it locally against lease_ttl_ms and the peer reclaims the
-// slot by TTL (see PrepareSsdReadResponse + contract §5).
+// slot by TTL (see PrepareSsdReadResponse).
 enum SsdReadStatus {
   SSD_READ_OK             = 0;
   SSD_READ_NOT_FOUND      = 1;   // key not on this peer's SSD tier → caller treats as miss
@@ -140,7 +140,7 @@ message AbortSlotResponse {
 
 // Resolve a key the writer has been routed to.  Returns the page set
 // the reader needs to RDMA from.  Peer bumps its in-flight read counter
-// for `key` to defer concurrent eviction (Bug #7 resolution).
+// for `key` to defer concurrent eviction.
 message ResolveKeyRequest {
   string key = 1;
 }

--- a/src/umbp/distributed/proto/umbp_peer.proto
+++ b/src/umbp/distributed/proto/umbp_peer.proto
@@ -9,8 +9,9 @@ service UMBPPeer {
   // SSD read staging.  The direct-SSD-put RPCs (AllocateWriteSlot /
   // CommitSsdWrite) were removed in the SSD-tier redesign: SSD is now an
   // async copy-on-commit cold tier, not a writer-driven put target.
-  // TODO(Phase 3): refactor these two to key-based + status enum + size per
-  // docs/umbp-ssd-tier-interface-contract-zh.md §5.
+  // PrepareSsdRead is key-based (the peer looks up the SSD location by key via
+  // PeerSsdManager) and returns a typed status + the actual size; ReleaseSsdLease
+  // is a best-effort fast release (slots are also reclaimed by lease TTL).
   rpc PrepareSsdRead   (PrepareSsdReadRequest)   returns (PrepareSsdReadResponse);
   rpc ReleaseSsdLease  (ReleaseSsdLeaseRequest)  returns (ReleaseSsdLeaseResponse);
 
@@ -34,8 +35,7 @@ service UMBPPeer {
 message GetPeerInfoRequest {}
 message GetPeerInfoResponse {
   bytes  engine_desc           = 1;
-  uint64 ssd_capacity          = 3;
-  uint64 ssd_available         = 4;
+  // SSD capacity is reported via heartbeat tier_capacities, not here.
   bytes  ssd_staging_mem_desc  = 6;  // packed MemoryDesc for dedicated SSD staging buffer
   uint64 ssd_staging_size      = 7;  // total staging buffer size
 
@@ -47,19 +47,33 @@ message GetPeerInfoResponse {
 }
 
 // ============================================================
-//  SSD read staging (Phase 3 will refactor — see service comment)
+//  SSD read staging (key-based; see UMBPPeer service comment + contract §5)
 // ============================================================
 
+// Per-key SSD read outcome.  Callers MUST distinguish retryable transient
+// failures (NO_SLOT / LEASE_EXPIRED) from a definitive miss (NOT_FOUND): a
+// transient failure must never be surfaced to hicache as a cache miss.
+enum SsdReadStatus {
+  SSD_READ_OK             = 0;
+  SSD_READ_NOT_FOUND      = 1;   // key not on this peer's SSD tier → caller treats as miss
+  SSD_READ_NO_SLOT        = 2;   // staging slots exhausted → retryable
+  SSD_READ_SIZE_TOO_LARGE = 3;   // actual size > reader cap / staging slot size
+  SSD_READ_LEASE_EXPIRED  = 4;   // lease elapsed before use → retryable
+  SSD_READ_ERROR          = 5;   // backend read error (e.g. concurrent evict / corruption)
+}
+
 message PrepareSsdReadRequest {
-  string key              = 1;
-  string ssd_location_id  = 2;
-  uint64 size             = 3;
+  string key      = 1;
+  // Reader's destination buffer size (capacity upper bound).  The peer rejects
+  // with SSD_READ_SIZE_TOO_LARGE when the key's actual size exceeds it.
+  uint64 max_size = 2;
 }
 message PrepareSsdReadResponse {
-  bool   success          = 1;
-  uint64 staging_offset   = 2;
-  uint64 lease_id         = 3;
-  uint64 lease_ttl_ms     = 4;
+  SsdReadStatus status        = 1;
+  uint64        staging_offset = 2;   // offset into the published ssd_staging_mem_desc
+  uint64        size           = 3;   // actual readable bytes
+  uint64        lease_id       = 4;
+  uint64        lease_ttl_ms   = 5;
 }
 
 message ReleaseSsdLeaseRequest {

--- a/src/umbp/distributed/proto/umbp_peer.proto
+++ b/src/umbp/distributed/proto/umbp_peer.proto
@@ -6,9 +6,11 @@ import "umbp.proto";
 service UMBPPeer {
   rpc GetPeerInfo(GetPeerInfoRequest) returns (GetPeerInfoResponse);
 
-  // SSD staging (unchanged in this redesign).
-  rpc AllocateWriteSlot(AllocateWriteSlotRequest) returns (AllocateWriteSlotResponse);
-  rpc CommitSsdWrite   (CommitSsdWriteRequest)   returns (CommitSsdWriteResponse);
+  // SSD read staging.  The direct-SSD-put RPCs (AllocateWriteSlot /
+  // CommitSsdWrite) were removed in the SSD-tier redesign: SSD is now an
+  // async copy-on-commit cold tier, not a writer-driven put target.
+  // TODO(Phase 3): refactor these two to key-based + status enum + size per
+  // docs/umbp-ssd-tier-interface-contract-zh.md §5.
   rpc PrepareSsdRead   (PrepareSsdReadRequest)   returns (PrepareSsdReadResponse);
   rpc ReleaseSsdLease  (ReleaseSsdLeaseRequest)  returns (ReleaseSsdLeaseResponse);
 
@@ -45,31 +47,8 @@ message GetPeerInfoResponse {
 }
 
 // ============================================================
-//  SSD slot machinery (unchanged)
+//  SSD read staging (Phase 3 will refactor — see service comment)
 // ============================================================
-
-message AllocateWriteSlotRequest {
-  uint64 size = 1;
-}
-message AllocateWriteSlotResponse {
-  bool   success        = 1;
-  uint64 staging_offset = 2;
-  uint64 lease_id       = 3;
-  uint64 lease_ttl_ms   = 4;
-}
-
-message CommitSsdWriteRequest {
-  string key              = 1;
-  uint64 staging_offset   = 2;
-  uint64 size             = 3;
-  uint32 store_index      = 4;
-  string allocation_id    = 5;  // historical echo from RoutePut; ignored in the new design
-  uint64 lease_id         = 6;
-}
-message CommitSsdWriteResponse {
-  bool   success          = 1;
-  string ssd_location_id  = 2;
-}
 
 message PrepareSsdReadRequest {
   string key              = 1;

--- a/src/umbp/distributed/proto/umbp_peer.proto
+++ b/src/umbp/distributed/proto/umbp_peer.proto
@@ -50,16 +50,17 @@ message GetPeerInfoResponse {
 //  SSD read staging (key-based; see UMBPPeer service comment + contract §5)
 // ============================================================
 
-// Per-key SSD read outcome.  Callers MUST distinguish retryable transient
-// failures (NO_SLOT / LEASE_EXPIRED) from a definitive miss (NOT_FOUND): a
-// transient failure must never be surfaced to hicache as a cache miss.
+// Per-key SSD read outcome.  Callers MUST distinguish a transient failure
+// (NO_SLOT) from a definitive miss (NOT_FOUND): a transient failure must never
+// be surfaced to hicache as a cache miss.  Lease expiry is NOT a wire status:
+// the reader decides it locally against lease_ttl_ms and the peer reclaims the
+// slot by TTL (see PrepareSsdReadResponse + contract §5).
 enum SsdReadStatus {
   SSD_READ_OK             = 0;
   SSD_READ_NOT_FOUND      = 1;   // key not on this peer's SSD tier → caller treats as miss
-  SSD_READ_NO_SLOT        = 2;   // staging slots exhausted → retryable
+  SSD_READ_NO_SLOT        = 2;   // staging slots exhausted → transient/retryable, not a miss
   SSD_READ_SIZE_TOO_LARGE = 3;   // actual size > reader cap / staging slot size
-  SSD_READ_LEASE_EXPIRED  = 4;   // lease elapsed before use → retryable
-  SSD_READ_ERROR          = 5;   // backend read error (e.g. concurrent evict / corruption)
+  SSD_READ_ERROR          = 4;   // backend read error (e.g. concurrent evict / corruption)
 }
 
 message PrepareSsdReadRequest {

--- a/src/umbp/distributed/routing/route_get_strategy.cpp
+++ b/src/umbp/distributed/routing/route_get_strategy.cpp
@@ -21,6 +21,7 @@
 // SOFTWARE.
 #include "umbp/distributed/routing/route_get_strategy.h"
 
+#include <algorithm>
 #include <random>
 #include <sstream>
 
@@ -40,6 +41,30 @@ std::string SummarizeLocations(const std::vector<Location>& locations) {
     oss << loc.node_id << ':' << TierTypeName(loc.tier) << '/' << loc.size;
   }
   return oss.str();
+}
+
+// Lower rank = higher read priority.  SSD is the slow cold tier, so it ranks
+// last among the real tiers; UNKNOWN sorts after everything so a malformed
+// location never wins over a usable one.
+int TierReadRank(TierType tier) {
+  switch (tier) {
+    case TierType::HBM:
+      return 0;
+    case TierType::DRAM:
+      return 1;
+    case TierType::SSD:
+      return 2;
+    default:
+      return 3;
+  }
+}
+
+// Pick a uniformly random element of a non-empty index list using the shared
+// thread_local RNG.
+size_t PickRandomIndex(const std::vector<size_t>& indices) {
+  thread_local std::mt19937 rng{std::random_device{}()};
+  std::uniform_int_distribution<size_t> dist(0, indices.size() - 1);
+  return indices[dist(rng)];
 }
 
 }  // namespace
@@ -66,6 +91,35 @@ Location RandomRouteGetStrategy::Select(const std::vector<Location>& locations,
       "[RouteGetStrategy] {} candidates -> choice={} node={} tier={} size={}, candidates=[{}]",
       locations.size(), choice, selected.node_id, TierTypeName(selected.tier), selected.size,
       SummarizeLocations(locations));
+  return selected;
+}
+
+Location TierPriorityRouteGetStrategy::Select(const std::vector<Location>& locations,
+                                              const std::string& /*node_id*/) {
+  if (locations.empty()) {
+    MORI_UMBP_WARN(
+        "[TierPriorityRouteGetStrategy] received empty location set; returning default Location");
+    return {};
+  }
+
+  // Find the best (lowest-rank) tier present, then collect every replica on it
+  // and choose one at random so load still spreads within a tier.
+  int best_rank = TierReadRank(locations[0].tier);
+  for (const auto& loc : locations) {
+    best_rank = std::min(best_rank, TierReadRank(loc.tier));
+  }
+  std::vector<size_t> best_tier_indices;
+  for (size_t i = 0; i < locations.size(); ++i) {
+    if (TierReadRank(locations[i].tier) == best_rank) best_tier_indices.push_back(i);
+  }
+
+  size_t choice = PickRandomIndex(best_tier_indices);
+  const auto& selected = locations[choice];
+  MORI_UMBP_DEBUG(
+      "[TierPriorityRouteGetStrategy] {} candidates -> best_tier={} ({} replicas) choice node={} "
+      "tier={} size={}, candidates=[{}]",
+      locations.size(), TierTypeName(selected.tier), best_tier_indices.size(), selected.node_id,
+      TierTypeName(selected.tier), selected.size, SummarizeLocations(locations));
   return selected;
 }
 

--- a/src/umbp/distributed/routing/route_put_strategy.cpp
+++ b/src/umbp/distributed/routing/route_put_strategy.cpp
@@ -76,8 +76,11 @@ std::string SummarizeClientTiers(const std::vector<ClientRecord>& alive_clients)
 std::optional<RoutePutResult> TierAwareMostAvailableStrategy::Select(
     const std::vector<ClientRecord>& alive_clients, uint64_t block_size,
     const std::unordered_set<std::string>& exclude_nodes) {
-  static constexpr std::array<TierType, 3> kTierOrder = {TierType::HBM, TierType::DRAM,
-                                                         TierType::SSD};
+  // SSD is intentionally excluded: in the SSD-tier redesign there is no direct
+  // SSD put — the SSD copy is filled asynchronously by copy-on-commit (Phase
+  // 2).  Even after SSD capacity is reported via heartbeat, RoutePut must never
+  // steer a put at a tier with no direct-put semantics.
+  static constexpr std::array<TierType, 2> kTierOrder = {TierType::HBM, TierType::DRAM};
 
   const std::string exclude_snapshot = FormatExcludeSet(exclude_nodes);
 

--- a/src/umbp/distributed/routing/route_put_strategy.cpp
+++ b/src/umbp/distributed/routing/route_put_strategy.cpp
@@ -76,10 +76,10 @@ std::string SummarizeClientTiers(const std::vector<ClientRecord>& alive_clients)
 std::optional<RoutePutResult> TierAwareMostAvailableStrategy::Select(
     const std::vector<ClientRecord>& alive_clients, uint64_t block_size,
     const std::unordered_set<std::string>& exclude_nodes) {
-  // SSD is intentionally excluded: in the SSD-tier redesign there is no direct
-  // SSD put — the SSD copy is filled asynchronously by copy-on-commit (Phase
-  // 2).  Even after SSD capacity is reported via heartbeat, RoutePut must never
-  // steer a put at a tier with no direct-put semantics.
+  // SSD is intentionally excluded: there is no direct SSD put — the SSD copy is
+  // filled asynchronously by copy-on-commit.  Even though SSD capacity is
+  // reported via heartbeat, RoutePut must never steer a put at a tier with no
+  // direct-put semantics.
   static constexpr std::array<TierType, 2> kTierOrder = {TierType::HBM, TierType::DRAM};
 
   const std::string exclude_snapshot = FormatExcludeSet(exclude_nodes);

--- a/src/umbp/distributed/routing/router.cpp
+++ b/src/umbp/distributed/routing/router.cpp
@@ -32,8 +32,12 @@ Router::Router(GlobalBlockIndex& index, ClientRegistry& registry,
                std::unique_ptr<RouteGetStrategy> get_strategy,
                std::unique_ptr<RoutePutStrategy> put_strategy)
     : index_(index), registry_(registry) {
+  // Default to tier-priority (HBM > DRAM > SSD): with the SSD cold tier live, a
+  // random pick could route a key that also has a DRAM/HBM copy to the slow
+  // SSD.  Callers can still inject RandomRouteGetStrategy (or any other) via
+  // config_.get_strategy.
   get_strategy_ =
-      get_strategy ? std::move(get_strategy) : std::make_unique<RandomRouteGetStrategy>();
+      get_strategy ? std::move(get_strategy) : std::make_unique<TierPriorityRouteGetStrategy>();
   put_strategy_ =
       put_strategy ? std::move(put_strategy) : std::make_unique<TierAwareMostAvailableStrategy>();
 }

--- a/src/umbp/doc/design-master-control-plane.md
+++ b/src/umbp/doc/design-master-control-plane.md
@@ -25,11 +25,17 @@ SGLang or vLLM worker). Each peer owns:
 
 - a **`PeerDramAllocator`** — page-bitmap allocator for HBM/DRAM tiers,
   the canonical owner of every per-key page set on this node,
-- a **`PeerServiceServer`** (`UMBPPeer` gRPC) — exposes
-  `AllocateSlot`/`CommitSlot`/`AbortSlot`/`ResolveKey`/`EvictKey` plus
-  the SSD staging slot machinery,
+- a **`PeerSsdManager`** (present when the SSD tier is enabled) — the
+  canonical owner of this node's SSD copies: the SSD backend, the
+  `key → SSD location` map, SSD capacity accounting, the local
+  watermark + LRU eviction sweep, and the SSD read staging buffer,
+- a **`PeerServiceServer`** (`UMBPPeer` gRPC) — exposes the DRAM/HBM
+  allocator RPCs `AllocateSlot`/`CommitSlot`/`AbortSlot`/`ResolveKey`/
+  `EvictKey` plus the key-based SSD read staging RPCs
+  `PrepareSsdRead`/`ReleaseSsdLease`,
 - a **`MasterClient`** — gRPC stub + heartbeat thread that ships
-  `KvEvent`s, capacity snapshots, and Prometheus samples to master.
+  `KvEvent`s (DRAM/HBM and SSD), capacity snapshots, and Prometheus
+  samples to master.
 
 `PoolClient` glues these together and is what `DistributedClient`
 (behind `IUMBPClient`) drives on the Put/Get hot path.
@@ -92,6 +98,17 @@ SGLang or vLLM worker). Each peer owns:
    (`pending_ttl`). Master no longer maintains an allocation TTL —
    `UMBP_ALLOCATION_TTL_SEC` is retained as a config knob for legacy
    compatibility but is unused by the live path.
+6. **SSD is a peer-owned, best-effort, eventually-consistent cold
+   tier.** An SSD copy is an asynchronous replica filled by
+   copy-on-commit on the owner peer after the DRAM/HBM commit succeeds;
+   the bytes and all physical IO live on the peer. Master is purely an
+   advisor over SSD: it learns of SSD copies only through
+   `KvEvent{tier=SSD}` on the heartbeat, never directs an SSD write
+   (`RoutePut` cannot target SSD), and never sends `EvictKey` for the
+   SSD tier — SSD capacity is reclaimed peer-locally by a
+   watermark + LRU sweep. SSD is not guaranteed to mirror DRAM: a copy
+   that fails or is dropped under back-pressure simply has no replica
+   and no event.
 
 ### Design space — advisor vs. strong-consistency master
 
@@ -160,7 +177,7 @@ include/umbp/
 │   ├── distributed_client.h           # DistributedClient (IUMBPClient impl)
 │   ├── pool_client.h                  # PoolClient (master + peer + IO engine glue)
 │   ├── pool_allocator.h
-│   ├── obs_counters.h                 # UMBP_METRIC_* constants
+│   ├── obs_counters.h                 # MORI_UMBP_OBS_* / test-seam build switch
 │   ├── types.h                        # TierType, Location, KvEvent, ClientRecord, ...
 │   ├── master/
 │   │   ├── master_server.h
@@ -169,14 +186,16 @@ include/umbp/
 │   │   ├── global_block_index.h
 │   │   ├── external_kv_block_index.h
 │   │   ├── eviction_manager.h
-│   │   └── master_metrics.h
+│   │   └── master_metrics.h           # MORI_UMBP_METRIC_* name/help strings
 │   ├── peer/
 │   │   ├── peer_service.h             # UMBPPeer gRPC server
-│   │   ├── peer_dram_allocator.h      # canonical per-node owner
+│   │   ├── peer_dram_allocator.h      # canonical per-node DRAM/HBM owner
+│   │   ├── peer_ssd_manager.h         # canonical per-node SSD owner
+│   │   ├── ssd_copy_pipeline.h        # async copy-on-commit DRAM→SSD
 │   │   └── peer_page_allocator.h      # PageBitmapAllocator
 │   └── routing/
 │       ├── router.h
-│       ├── route_get_strategy.h       # RandomRouteGetStrategy
+│       ├── route_get_strategy.h       # TierPriorityRouteGetStrategy (default), RandomRouteGetStrategy
 │       └── route_put_strategy.h       # TierAwareMostAvailableStrategy
 └── local/                             # Standalone (no-net) DRAM+SSD path
     ├── standalone_client.h
@@ -218,13 +237,22 @@ struct Location {
   TierType tier = TierType::UNKNOWN;
 };
 
-// One mutation in a peer's owned-key set, shipped via heartbeat.
+// One mutation in a peer's owned-key set, shipped via heartbeat.  The
+// tier is carried on every event and may be HBM, DRAM, or SSD — the
+// index keys locations by (node, tier), so a key can hold a DRAM and an
+// SSD location at once and a REMOVE only drops the matching tier.
 struct KvEvent {
-  enum class Kind : int { ADD = 0, REMOVE = 1 };
+  enum class Kind : int { ADD = 0, REMOVE = 1, CLEAR_AT_TIER = 2 };
   Kind kind = Kind::ADD;
-  std::string key;
+  std::string key;            // empty for CLEAR_AT_TIER
   TierType tier = TierType::UNKNOWN;
-  uint64_t size = 0;          // ADD only; REMOVE leaves this 0
+  uint64_t size = 0;          // ADD only; REMOVE / CLEAR_AT_TIER leave this 0
+};
+
+// Heartbeat events ride in seq-numbered bundles for ack / gap recovery.
+struct EventBundle {
+  uint64_t seq = 0;
+  std::vector<KvEvent> events;
 };
 
 // Peer-internal page handle (writer/reader use it to slice RDMA buffers).
@@ -241,6 +269,7 @@ struct ClientRecord {
   std::string peer_address;                           // UMBPPeer gRPC addr
   std::vector<uint8_t> engine_desc_bytes;             // packed mori::io::EngineDesc
   uint64_t last_applied_seq = 0;                      // gap-recovery cursor
+  std::vector<std::string> tags;                      // opaque metric labels
 };
 ```
 
@@ -253,20 +282,23 @@ struct ClientRecord {
 Membership ledger + heartbeat ingestion.
 
 - `RegisterClient(node_id, node_address, tier_capacities, peer_address,
-  engine_desc_bytes)` — inserts a fresh `ClientRecord` or refreshes an
-  expired one; rejects when a live record with the same `node_id` is
+  engine_desc_bytes, tags)` — inserts a fresh `ClientRecord` or refreshes
+  an expired one; rejects when a live record with the same `node_id` is
   already present.
 - `UnregisterClient(node_id)` — drops the record and clears every index
   entry that belonged to it (delegated to `GlobalBlockIndex` and
   `ExternalKvBlockIndex`).
-- `Heartbeat(node_id, seq, last_acked_seq, tier_capacities, events,
-  is_full_sync, out_acked_seq, out_request_full_sync)` — applies one
-  heartbeat batch: replaces capacity, applies events to
-  `GlobalBlockIndex` (or `ReplaceNodeLocations` on `is_full_sync`), and
-  advances `last_applied_seq`. If `seq != last_applied_seq + 1` and
-  not full sync, the call is rejected: `out_request_full_sync = true`
-  and `out_acked_seq` echoes the stored cursor so the peer reships from
-  scratch.
+- `Heartbeat(node_id, tier_capacities, bundles, is_full_sync,
+  delta_seq_baseline, out_acked_seq, out_request_full_sync)` — applies
+  one heartbeat: replaces capacity, then applies each `EventBundle` in
+  `bundles` to `GlobalBlockIndex` in seq order (bundles at or below the
+  stored cursor are skipped as retransmissions), advancing
+  `last_applied_seq`. On `is_full_sync` it instead replays the full
+  owned-key set via `ReplaceNodeLocations` and adopts
+  `delta_seq_baseline` as the new cursor. If a delta bundle's seq leaves
+  a gap (`!= last_applied_seq + 1`), the call requests recovery:
+  `out_request_full_sync = true` and `out_acked_seq` echoes the stored
+  cursor so the peer reships a full sync.
 - **Reaper** — background thread expires nodes that miss
   `heartbeat_ttl × max_missed_heartbeats` and triggers full GC. There is
   no separate allocation reaper in the new design.
@@ -299,14 +331,32 @@ struct BlockEntry {
 };
 ```
 
+The index is **additive over `(key, node, tier)`**. A location's dedup
+key is `(node_id, tier)`, so the same key on the same node can carry a
+DRAM (or HBM) location and an SSD location side by side, as two
+independent `Location` entries. This is what lets a key remain
+discoverable on SSD after its DRAM copy is gone, and is the only
+master-side support the SSD cold tier needs — ADD/REMOVE/exists/route
+all fall out of the per-tier bookkeeping.
+
 Mutators:
 
-- `ApplyEvents(node_id, events[])` — apply a peer's batch of
-  ADD/REMOVE. ADD with an existing `(node_id, tier)` replaces the
-  entry's `size`. REMOVE for an unknown `(key, node_id, tier)` is a
-  silent no-op.
+- `ApplyEvents(node_id, events[])` — apply a peer's batch.
+  - **ADD** inserts a `(node_id, tier)` location with the event's
+    `size`. A duplicate ADD for an existing `(node_id, tier)` is an
+    idempotent no-op (the existing location is kept and a warning is
+    logged); it does not overwrite the stored size.
+  - **REMOVE** drops only the location matching `(key, node_id, tier)`.
+    Removing the DRAM copy leaves the SSD copy (and vice versa)
+    untouched; REMOVE for an unknown `(key, node_id, tier)` is a silent
+    no-op. The key's entry is erased only once its last location is
+    gone.
+  - **CLEAR_AT_TIER** drops every location for `(node_id, tier)` across
+    all keys (keyless event); used to wipe one tier's placements for a
+    node.
 - `ReplaceNodeLocations(node_id, adds[])` — drop every prior location
-  for `node_id` and reseed from `adds`. Used on full-sync.
+  for `node_id` and reseed from `adds` (which may mix DRAM/HBM and SSD
+  ADDs). Used on full-sync.
 - `RecordAccess(key)` / `GrantLease(key, duration)` — under the shared
   lock; both `last_accessed_rep` and `lease_expiry_rep` are atomic
   reps, so neither needs an exclusive lock.
@@ -314,9 +364,17 @@ Mutators:
 Queries:
 
 - `Lookup(key)` / `BatchLookupExists(keys[])` / `GetMetrics(key)`.
+  `BatchLookupExists` returns `true` as long as the key has **any**
+  location, so a key that lives only on SSD still reports as resident —
+  hicache will prefetch it.
+- `BatchLookupForRouteGet(keys[], exclude_nodes, lease_duration)` —
+  returns **all** tiers' locations per key (so RouteGet sees SSD
+  replicas), and on a non-empty result bumps `RecordAccess` + grants a
+  lease, under one shared lock.
 - `FindEvictionCandidates(overloaded_node_tiers)` — returns
   `EvictionCandidate{key, location, last_accessed_at, size}` rows for
   the given `(node_id, tier)` set. Skips entries with active leases.
+  Only DRAM/HBM `(node, tier)` pairs are ever passed in (see §4.5).
 
 ### 4.3 ExternalKvBlockIndex  (`external_kv_block_index.h`)
 
@@ -334,11 +392,27 @@ This index is **not** updated by heartbeat events — clients call
 clean-up on node expiry is `UnregisterByNode(node_id)`, called from the
 reaper / `UnregisterClient` path.
 
+**Do not confuse this index's `tier=SSD` with the UMBP-owned SSD cold
+tier.** They are two separate mechanisms:
+
+- The **UMBP-owned SSD tier** (the cold tier described throughout this
+  doc) lives in `GlobalBlockIndex`. Its bytes are real, owned by a
+  peer's `PeerSsdManager`, populated by copy-on-commit, advertised via
+  `KvEvent{tier=SSD}` on the heartbeat, and readable through `RouteGet`
+  → `PrepareSsdRead`.
+- An **external-KV block with `tier=SSD`** (e.g. an entry hicache
+  reports for its own L3) lives in `ExternalKvBlockIndex`. It is pure
+  scheduling metadata: no bytes move through UMBP, `RouteGet` never
+  consults it, and `PrepareSsdRead` cannot read it.
+
+A hash/key may appear in both, but the serving paths are disjoint.
+`RouteGet` only ever resolves `GlobalBlockIndex` locations.
+
 ### 4.4 Router  (`include/umbp/distributed/routing/router.h`)
 
 Stateless façade over the two index objects + `ClientRegistry`.
 Dispatches to pluggable strategies; defaults are
-`RandomRouteGetStrategy` and `TierAwareMostAvailableStrategy`.
+`TierPriorityRouteGetStrategy` and `TierAwareMostAvailableStrategy`.
 
 - `RouteGet(key, node_id, exclude_nodes)` returns
   `RouteGetResolution{Location, peer_address}` (so the reader doesn't
@@ -354,11 +428,25 @@ Dispatches to pluggable strategies; defaults are
   not-found" steer set: subsequent retries fold the failed peer into
   this set so master picks a different replica or destination.
 
+`RouteGetStrategy::Select(locations, node_id)` —
+`TierPriorityRouteGetStrategy` is the default: it picks the
+fastest tier present in the **read priority order HBM > DRAM > SSD**
+(`UNKNOWN` ranks last), then chooses a random replica within that tier
+so load still spreads. So a key that has both a DRAM and an SSD copy is
+served from DRAM, and SSD is read only when it is the sole tier
+present. `RandomRouteGetStrategy` (uniform across all replicas
+regardless of tier) remains available to inject via
+`MasterServerConfig::get_strategy`.
+
 `RoutePutStrategy::Select(alive_clients, block_size, exclude_nodes)` —
-`TierAwareMostAvailableStrategy` walks `[HBM, DRAM, SSD]` in order and,
+`TierAwareMostAvailableStrategy` walks **`[HBM, DRAM]`** in order and,
 on the first tier with any node holding `>= block_size` available
 capacity, picks the node with the most available bytes (load
-spreading).
+spreading). **SSD is intentionally not a `RoutePut` target**: there is
+no direct-SSD-put path — the SSD copy is filled asynchronously by
+copy-on-commit, so even with SSD capacity reported on the heartbeat,
+`RoutePut` must never steer a write at a tier with no direct-put
+semantics.
 
 ### 4.5 EvictionManager  (`eviction_manager.h`)
 
@@ -367,7 +455,13 @@ each tick:
 
 1. Walk `ClientRegistry` for nodes whose tier(s) have crossed
    `EvictionConfig::high_watermark` (default 0.9). Collect overloaded
-   `(node_id, tier)` pairs.
+   `(node_id, tier)` pairs. **The SSD tier is skipped here** — master
+   never turns an SSD overload into an `EvictKey`. `EvictKey` acts only
+   on the peer's `PeerDramAllocator`, so dispatching it for an SSD
+   overload would wrongly evict the DRAM copy of a key while leaving the
+   SSD bytes in place. SSD capacity is reclaimed entirely peer-locally
+   (watermark + LRU in `PeerSsdManager`), and the resulting
+   `KvEvent{REMOVE, tier=SSD}` shrinks the index on the next heartbeat.
 2. Call `GlobalBlockIndex::FindEvictionCandidates(...)` to get a
    sorted-by-LRU candidate list, skipping leased keys.
 3. Group the victims by `node_id` and dispatch `EvictKey` to each peer
@@ -423,9 +517,9 @@ Master-facing service. Sources of truth are the proto file and the
 
 | RPC | Purpose |
 |---|---|
-| `RegisterClient(RegisterClientRequest)` | Membership announce. Carries `peer_address`, packed `engine_desc`, per-tier capacities, and `ssd_store_capacities`. Response includes recommended heartbeat interval and the initial `ack_seq`. |
+| `RegisterClient(RegisterClientRequest)` | Membership announce. Carries `peer_address`, packed `engine_desc`, optional `tags`, and per-tier `tier_capacities` — **SSD capacity rides here as `TierCapacity{tier=TIER_SSD}`**, there is no separate `ssd_store_capacities` field. Response includes recommended heartbeat interval and the initial `ack_seq`. |
 | `UnregisterClient(UnregisterClientRequest)` | Graceful shutdown. |
-| `Heartbeat(HeartbeatRequest)` | The authoritative update channel. `seq` is monotonic and peer-assigned; `last_acked_seq` echoes master's most recent ack; `events[]` is the queue since the last ack; `is_full_sync` flips the request into a complete owned-key set replay. Response has `acked_seq` and `request_full_sync` for gap recovery. |
+| `Heartbeat(HeartbeatRequest)` | The authoritative update channel. Carries `tier_capacities` (ground truth, including SSD) and `bundles[]` — seq-numbered `EventBundle`s of `KvEvent`s since the last ack, with DRAM/HBM and SSD events merged into one bundle under one monotonic seq. `is_full_sync` flips the request into a complete owned-key set replay; `delta_seq_baseline` carries the cursor for that replay. Response has `acked_seq` and `request_full_sync` for gap recovery. |
 | `RouteGet(RouteGetRequest)` | Pick a replica. Read-only against `GlobalBlockIndex`. |
 | `RoutePut(RoutePutRequest)` | Pick a target node + tier. Read-only against `ClientRegistry`. |
 | `BatchRouteGet`/`BatchRoutePut` | Parallel-key variants. `BatchRoutePut` also performs **master-side Put dedup**: any key already present in `GlobalBlockIndex` is returned with `already_exists=true` (and no node selection) so the caller can skip the Put entirely — primary defense against re-uploading the same kv-cache from multiple ranks (sglang DP-attention). Peer's `AllocateSlot` carries a key field and applies the same dedup as a defensive layer against master-index lag. |
@@ -447,13 +541,14 @@ has a DRAM/HBM tier or an SSD tier.
 | RPC | Purpose |
 |---|---|
 | `GetPeerInfo` | First-contact hydration: packed `engine_desc`, SSD staging buffer descriptor, all DRAM/HBM `BufferMemoryDesc`s, and the tier `dram_page_size`. |
-| `AllocateSlot(key, size, tier)` | Reserve a pending DRAM/HBM slot. Response carries `slot_id`, the `pages` it covers, `page_size`, the dedup'd `descs` for those pages, and a `pending_ttl_ms`. ENOSPC is `success=false` + `already_exists=false`. **Duplicate-key dedup**: if `owned_[key]` is already present (master-index-lag fallback), response is `success=false` + `already_exists=true` — caller treats this as a no-op success and skips RDMA. |
-| `CommitSlot(slot_id, key)` | Move pending → owned. Queues `KvEvent{ADD, key, tier, size}`. |
+| `AllocateSlot(key, size, tier)` | Reserve a pending **DRAM/HBM** slot (`tier` is HBM or DRAM only — SSD is never a direct put target). Response carries an `AllocateSlotOutcome` and, on success, `slot_id`, the `pages` it covers, `page_size`, the dedup'd `descs` for those pages, and a `pending_ttl_ms`. Outcomes: `SUCCESS_ALLOCATED`, `FAILED_NO_SPACE` (ENOSPC — writer retries `RoutePut` with the node added to `exclude_nodes`), or `FAILED` (generic). **Duplicate-key dedup**: if `owned_[key]` is already present (master-index-lag fallback), outcome is `SUCCESS_ALREADY_EXISTS` — caller treats it as a no-op success and skips RDMA. |
+| `CommitSlot(slot_id, key)` | Move pending → owned. Queues `KvEvent{ADD, key, tier, size}` for the next heartbeat, and — when the SSD tier is enabled — enqueues an async copy-on-commit task so the bytes are mirrored to SSD (best-effort; the eventual SSD copy emits its own `KvEvent{ADD, tier=SSD}`). |
 | `AbortSlot(slot_id)` | Drop a pending slot. Idempotent. |
-| `ResolveKey(key)` | Read-side lookup. Bumps the per-key read-lease counter (Bug #7 mitigation). Returns `pages`, `page_size`, `descs`, `size`. |
-| `EvictKey(keys[])` | Master-driven eviction. Read-leased keys produce `bytes_freed=0`; everything actually freed yields a `KvEvent{REMOVE}` on the next heartbeat. |
+| `ResolveKey(key)` | DRAM/HBM read-side lookup. Bumps the per-key read-lease counter (Bug #7 mitigation). Returns `pages`, `page_size`, `descs`, `size`. |
+| `EvictKey(keys[])` | Master-driven eviction of **DRAM/HBM** keys only. Read-leased (or copy-pinned) keys produce `bytes_freed=0`; everything actually freed yields a `KvEvent{REMOVE}` on the next heartbeat. |
 | Batch variants | `BatchAllocateSlots`/`BatchCommitSlots`/`BatchAbortSlots`/`BatchResolveKeys`. |
-| SSD slot machinery | `AllocateWriteSlot`, `CommitSsdWrite`, `PrepareSsdRead`, `ReleaseSsdLease` — preserved for the SSD tier; uses a separate dedicated staging buffer + lease ID. |
+| `PrepareSsdRead(key, max_size)` | Key-based SSD read staging. The peer looks the key up in `PeerSsdManager`, reads the bytes into the published SSD staging buffer, and returns an `SsdReadStatus` (`OK` / `NOT_FOUND` / `NO_SLOT` / `SIZE_TOO_LARGE` / `ERROR`), the `staging_offset`, the actual `size`, and a `lease_id` + `lease_ttl_ms`. `NOT_FOUND` is a definitive miss; `NO_SLOT` is transient and must be retried, never reported as a miss. |
+| `ReleaseSsdLease(lease_id)` | Best-effort fast release of an SSD read staging slot. Slots are also reclaimed by lease TTL, so a missed release is harmless. |
 
 ---
 
@@ -497,6 +592,14 @@ has a DRAM/HBM tier or an SSD tier.
        │                         │ ApplyEvents → GlobalBlockIndex
 ```
 
+When the SSD tier is enabled, a successful `CommitSlot` on the owner
+peer also enqueues an async **copy-on-commit** task. A copy worker pins
+the just-committed DRAM/HBM pages, writes them to the SSD backend, and —
+only on a successful write — records the SSD location and queues a
+`KvEvent{ADD, tier=SSD}`. This is best-effort and off the writer's hot
+path: a failed or dropped copy simply leaves no SSD replica. The writer
+never targets SSD directly.
+
 ### 6.2 Get
 
 ```
@@ -521,6 +624,16 @@ has a DRAM/HBM tier or an SSD tier.
 If `ResolveKey` returns `found=false` (peer evicted between RouteGet
 and Resolve), the reader retries `RouteGet` with the failed node added
 to `exclude_nodes`. If every replica fails, the get returns `false`.
+
+When `RouteGet` resolves to a `tier=SSD` location (only when no
+DRAM/HBM replica exists, per the tier-priority strategy), the read
+follows the SSD path instead of `ResolveKey`: a remote reader calls
+`PrepareSsdRead(key, max_size)`, RDMA-reads from the returned
+`{staging_offset, size}` inside the peer's published SSD staging
+buffer, then `ReleaseSsdLease(lease_id)`; a reader that is itself the
+owner reads its own SSD bytes directly without staging. Transient
+`NO_SLOT` results are retried with bounded attempts and must never be
+surfaced as a cache miss — only `NOT_FOUND` is a miss.
 
 ### 6.3 Eviction
 
@@ -608,32 +721,107 @@ Lifecycle:
 | `DrainPendingEvents()` | Returns and clears `pending_events_`; called by the heartbeat thread. |
 | `SnapshotOwnedKeys()` | Build the full ADD list for full-sync. |
 | `TierCapacitiesSnapshot()` | Live `(total, available)` per tier; reported with every heartbeat. |
-| `QueueExternalEvent(ev)` | Lets the SSD `CommitSsdWrite` path enqueue ADD/REMOVE for keys it manages — one outbox per peer. |
+| `AcquireDramCopyPin(key)` / `ReleaseDramCopyPin(key, token)` | Pin a committed key's pages so the SSD copy worker can read them safely; pinned keys cannot be freed by `Evict` until released. |
+
+`PeerDramAllocator` covers only the DRAM/HBM tiers. SSD ADD/REMOVE
+events are **not** routed back through this allocator — they originate
+in `PeerSsdManager`, which is a separate `OwnedLocationSource`. The
+heartbeat shipper (`MasterClient`) drains both sources and concatenates
+their events into one bundle per seq (see `PeerSsdManager` below).
 
 A reaper thread sweeps `pending_` for expired slots (`pending_ttl`) and
 `read_lease_until_` for expired entries (`read_lease_ttl_`).
 
-### 7.2 PeerServiceServer  (`peer/peer_service.h`)
+### 7.2 PeerSsdManager  (`peer/peer_ssd_manager.h`)
+
+Canonical owner of every SSD copy on the local node, present only when
+`ssd.enabled`. It is a separate, single-responsibility class — it does
+**not** reuse the standalone `LocalStorageManager`/`LocalBlockIndex` and
+has no DRAM tier or demote/promote logic. It wraps one `TierBackend`
+(`SSDTier` for `posix`, `SpdkProxyTier` for `spdk`/`spdk_proxy`) and
+implements `OwnedLocationSource`.
+
+State:
+
+```cpp
+unordered_map<string, OwnedEntry>   owned_;            // key -> {size, lru_it}
+list<string>                        lru_;              // front = MRU, back = LRU
+unordered_map<string, int>          inflight_reads_;   // read-priority guard
+unordered_set<string>               evicting_;
+vector<KvEvent>                     pending_events_;    // SSD ADD/REMOVE outbox
+```
+
+Behavior:
+
+| Op | Effect |
+|---|---|
+| `Capacity()` | `(used, total)` from the backend; reported on the heartbeat as `TierCapacity{tier=SSD}`. |
+| `Write(key, segments, total_size)` | Copy-on-commit landing. Assembles the (possibly non-contiguous) DRAM source segments and writes to the backend; on success records the SSD location and queues `KvEvent{ADD, tier=SSD}`. Idempotent on an already-resident key (content-addressed): no rewrite, no duplicate ADD, just an LRU touch. |
+| `PrepareRead(key, staging_ptr, cap)` | Resolve size under the lock, run the blocking backend read outside it, return `SsdReadOutcome{status, size}`. `kNotFound` for a missing or currently-evicting key, `kSizeTooLarge` when the key exceeds the reader's cap, `kError` on a backend read failure. |
+| `Evict(key)` | Local eviction. Skips keys with in-flight reads (read priority); frees the backend bytes and, only on success, drops `owned_`/`lru_` and queues `KvEvent{REMOVE, tier=SSD}`. |
+| `EvictToLowWatermark()` | Check-after-write trigger: when `used/total ≥ high_watermark` it evicts oldest-first down to `low_watermark`. Runs on the copy worker — no dedicated thread — and serializes rounds with a try-lock. |
+| `ClearLocal()` | Drop the logical map + pending events and wipe the physical SSD bytes (user `Clear` = discard cache). Drains in-flight reads first; the caller must quiesce the copy pipeline before calling. |
+| `DrainPendingEvents()` / `SnapshotOwnedKeys()` | `OwnedLocationSource` — feed SSD ADD/REMOVE into the heartbeat and rebuild the full SSD ADD list on full-sync. |
+
+SSD capacity reclamation is entirely peer-local (this class's
+watermark + LRU); master is never involved. The resulting
+`KvEvent{REMOVE, tier=SSD}` is what shrinks `GlobalBlockIndex` on the
+next heartbeat.
+
+### 7.3 SsdCopyPipeline  (`peer/ssd_copy_pipeline.h`)
+
+Bounded async worker pool that mirrors committed DRAM/HBM keys to SSD.
+Owned by `PoolClient`, constructed only when `ssd.enabled`; it borrows
+`PeerDramAllocator` (the pin source) and `PeerSsdManager` (the write
+target). A successful `CommitSlot` on the owner peer enqueues an
+`SsdCopyTask{key, ...}` (the task carries no user pointer — the worker
+re-reads the bytes from the owner's DRAM pages by key). Each worker:
+
+1. dequeues a task and calls `AcquireDramCopyPin(key)` — a `nullopt`
+   (key already evicted, or a duplicate task) drops the task,
+2. holds the pin under a RAII guard (always released),
+3. calls `PeerSsdManager::Write(key, pin.segments, pin.total_size)`,
+4. releases the pin when the guard leaves scope.
+
+`Enqueue` never blocks the commit hot path: a full or stopped queue
+drops the task and bumps a counter. The pin protects the pages against
+`EvictKey` for the lifetime of the copy — a copy-pinned key returns
+`bytes_freed=0` from `EvictKey` and master retries it on a later
+eviction round.
+
+### 7.4 PeerServiceServer  (`peer/peer_service.h`)
 
 Hosts the `UMBPPeer` gRPC service. Holds non-owning pointers to
-`LocalStorageManager` (SSD), `LocalBlockIndex` (SSD key→location), and
-`PeerDramAllocator` (DRAM/HBM). `dram_alloc` may be null on SSD-only
-deployments — the DRAM/HBM RPCs respond with `success=false` /
-`found=false` in that case while SSD staging continues to work.
+`PeerDramAllocator` (DRAM/HBM) and `PeerSsdManager` (SSD), plus the SSD
+read staging region (base / size / packed `MemoryDesc`). `dram_alloc`
+may be null when the process has no DRAM/HBM tier — the DRAM/HBM RPCs
+then respond `FAILED` / `found=false` while the SSD read RPCs keep
+working. Symmetrically, when `peer_ssd` (or the staging region) is null,
+`SsdRpcAvailable()` is false and `PrepareSsdRead` returns
+`SSD_READ_ERROR`. The published `ssd_staging_mem_desc` / `ssd_staging_size`
+in `GetPeerInfo` come straight from this staging region.
 
 `engine_desc_bytes` is the packed `mori::io::EngineDesc` that the IO
 engine published when `PoolClient` constructed it. It's plumbed through
 `GetPeerInfo` and the `descs` payloads so writers/readers can wire up
 RDMA without a separate engine-discovery step.
 
-### 7.3 PoolClient  (`distributed/pool_client.h`)
+### 7.5 PoolClient  (`distributed/pool_client.h`)
 
-Glues the four subsystems on a peer process:
+Glues the peer-side subsystems on a peer process:
 
 - `MasterClient` (gRPC stub + heartbeat + metrics threads),
 - `PeerDramAllocator` (owned),
+- `PeerSsdManager` + `SsdCopyPipeline` (owned, only when `ssd.enabled`),
 - `PeerServiceServer` (owned, started on `peer_service_port`),
 - `mori::io::IOEngine` (owned, published as `engine_desc`).
+
+`MasterClient` registers both `PeerDramAllocator` and `PeerSsdManager`
+as `OwnedLocationSource`s, so the heartbeat ships DRAM/HBM and SSD
+events together and the capacity snapshot includes SSD. `Clear()`
+quiesces the copy pipeline, clears both the allocator and the SSD
+manager (the latter also wiping the physical SSD bytes), then resumes
+the pipeline so no stale copy re-adds an SSD location afterward.
 
 Hot path (`Put` / `Get`):
 
@@ -653,7 +841,7 @@ Hot path (`Put` / `Get`):
 On the hot path, `FindRegisteredMemory(src, size)` swaps in the
 registered descriptor and skips the staging buffer entirely.
 
-### 7.4 DistributedClient  (`distributed/distributed_client.h`)
+### 7.6 DistributedClient  (`distributed/distributed_client.h`)
 
 `IUMBPClient` adaptor over `PoolClient`. `CreateUMBPClient(config)`
 returns a `DistributedClient` when `config.distributed.has_value()` and
@@ -691,12 +879,13 @@ fields:
 | `ssd` | `storage_dir` | `/tmp/umbp_ssd` | POSIX backend root. |
 | `ssd` | `capacity_bytes` | 32 GiB | |
 | `ssd` | `segment_size_bytes` | 256 MiB | SegmentedLog segment size. |
+| `ssd` | `high_watermark` / `low_watermark` | 0.9 / 0.7 | Peer-local SSD eviction band (`UMBP_SSD_HIGH_WM` / `UMBP_SSD_LOW_WM`). Must satisfy `0 < low < high <= 1` or construction throws. |
+| `ssd` | `ssd_backend` | `posix` | `posix`, `spdk`, or `spdk_proxy`. Distributed peers reach SPDK only via the proxy. |
+| `ssd` | `spdk_*` | — | SPDK/proxy tuning (BDF, reactor mask, channels, shm name, ...), all under `ssd.*`. |
 | `ssd.io` | `backend` | `IoUring` | `PThread` or `IoUring`. |
 | `ssd.durability` | `mode` | `Strict` | `Strict` or `Relaxed`. |
 | `eviction` | `policy` | `lru` | |
-| `copy_pipeline` | `worker_threads` | 2 | Async DRAM↔SSD copy workers. |
-| top-level | `ssd_backend` | `posix` | `posix` or `spdk`. |
-| top-level | `spdk_*` | — | SPDK/proxy tuning (BDF, reactor mask, channels, ...). |
+| `copy_pipeline` | `worker_threads` | 2 | Async DRAM→SSD copy-on-commit workers. |
 | top-level | `role` | `Standalone` | `Standalone` / `SharedSSDLeader` / `SharedSSDFollower`. |
 | top-level | `distributed` | `nullopt` | Set to enable master-led mode. |
 
@@ -741,16 +930,22 @@ both locks.
 Custom routing strategies must be thread-safe — the gRPC handler thread
 pool calls `Select` concurrently. The defaults are:
 
-- `RandomRouteGetStrategy` — `thread_local std::mt19937`, no mutexes.
-- `TierAwareMostAvailableStrategy` — stateless.
+- `TierPriorityRouteGetStrategy` (default get) — `thread_local
+  std::mt19937` for the within-tier random pick, no mutexes.
+- `RandomRouteGetStrategy` (injectable) — `thread_local std::mt19937`,
+  no mutexes.
+- `TierAwareMostAvailableStrategy` (default put) — stateless.
 
 ---
 
 ## 11. Observability
 
-`include/umbp/distributed/obs_counters.h` defines a long list of
-`UMBP_METRIC_*` constants (counter / histogram / gauge name + help
-strings) that flow through:
+`include/umbp/distributed/master/master_metrics.h` defines the
+`MORI_UMBP_METRIC_*` constants (counter / histogram / gauge name + help
+strings) — that header is the single source of truth for metric names.
+(`obs_counters.h` is unrelated: it only holds the `MORI_UMBP_OBS_*`
+increment macros and the test-seam build switch.) Samples flow
+through:
 
 1. peer-side `MasterClient::AddCounter` / `SetGauge` / `Observe` →
 2. buffered in `pending_counters_` / `pending_gauges_` /
@@ -765,11 +960,35 @@ Built-in metric families include:
 
 - per-client `route_get` / `route_put` / `batch_route_get` /
   `batch_route_put` counters and bandwidth histograms,
-- per-client `capacity_total` / `capacity_avail` gauges and
-  `client_count` master gauge,
-- `heartbeat_events_applied_total` / `heartbeat_seq_gap_total` master
-  counters,
-- `external_kv_*_total` counters for the external-KV index.
+- per-client capacity gauges
+  `mori_umbp_client_capacity_{total,available,used}_bytes` +
+  `mori_umbp_client_capacity_utilization_ratio`, each labeled
+  `node=<id>, tier=<HBM|DRAM|SSD>` — **SSD capacity is reported here
+  with `tier="SSD"`** (upper-cased, matching `TierTypeName`), not via a
+  separate metric; plus the `mori_umbp_client_count` master gauge,
+- `mori_umbp_heartbeat_events_applied_total` /
+  `mori_umbp_heartbeat_seq_gap_total` master counters,
+- `mori_umbp_external_kv_*` counters/gauges for the external-KV index.
+
+SSD-tier families are reported by the owner peer (`node=<id>`) via
+`ReportMetrics` — names per `master_metrics.h`:
+
+- copy-on-commit: `mori_umbp_ssd_copy_enqueued_total`,
+  `mori_umbp_ssd_copy_succeeded_total`,
+  `mori_umbp_ssd_copy_failed_total`,
+  `mori_umbp_ssd_copy_dropped_total` (`reason=queue_full|stopped`),
+  and `mori_umbp_ssd_copy_bytes_total`,
+- reads: `mori_umbp_ssd_read_total`
+  (`status=ok|not_found|no_slot|size_too_large|error`),
+  `mori_umbp_ssd_read_bytes_total`, and the reader-side
+  `mori_umbp_ssd_read_client_transient_total`,
+- peer-local eviction: `mori_umbp_ssd_eviction_rounds_total`,
+  `mori_umbp_ssd_eviction_victims_total`,
+  `mori_umbp_ssd_eviction_bytes_freed_total`,
+  `mori_umbp_ssd_eviction_backend_failed_total`,
+- read staging: `mori_umbp_ssd_staging_slots_in_use`,
+  `mori_umbp_ssd_staging_expired_reclaims_total`,
+  `mori_umbp_ssd_staging_slot_full_rejects_total`.
 
 Set `MORI_UMBP_LOG_LEVEL=DEBUG` (or `UMBP_LOG_LEVEL=0`) to surface
 per-RPC traces from `MORI_UMBP_INFO` / `MORI_UMBP_DEBUG`.
@@ -880,6 +1099,12 @@ Unit and integration tests live in `tests/cpp/umbp/`:
 - `distributed/test_pool_client_*.cpp` — full Put/Get round-trips
   including `BatchPut` / `BatchGet`,
 - `distributed/test_env_time.cpp` — `UMBP_*` parser helpers,
+- SSD tier (under `src/umbp/tests/`): `test_peer_ssd_manager.cpp`
+  (write / read / capacity), `test_peer_ssd_eviction.cpp` (peer-local
+  watermark + LRU), `test_ssd_copy_pipeline.cpp` (copy-on-commit),
+  `test_peer_ssd_read_rpc.cpp` / `test_ssd_read_lease_gating.cpp`
+  (`PrepareSsdRead` / lease staging), `test_tier_priority_route_get.cpp`
+  (HBM > DRAM > SSD selection), `test_ssd_reliability.cpp` (end-to-end),
 - Python: `tests/python/test_umbp_master_client.py`,
   `tests/python/test_umbp_packaging.py`.
 

--- a/src/umbp/doc/design-master-control-plane.md
+++ b/src/umbp/doc/design-master-control-plane.md
@@ -900,6 +900,8 @@ fields:
 | `io_engine.host` | "" | Empty selects RDMA; sites typically use `127.0.0.1` for local IO engine. |
 | `io_engine.port` | 0 | `0` = OS-assigned ephemeral. |
 | `staging_buffer_size` | 64 MiB | Host staging for non-zero-copy RDMA. |
+| `ssd_staging_buffer_size` | 256 MiB | Dedicated SSD read staging, allocated only when SSD is enabled. A slot (`ssd_staging_buffer_size / ssd_read_slots`) must fit the largest single-key value. |
+| `ssd_read_slots` | 16 | Number of remote SSD read staging slots. |
 | `peer_service_port` | 0 | `0` = OS-assigned. |
 | `cache_remote_fetches` | true | Locally re-cache blocks fetched from a remote peer. |
 | `dram_page_size` | 0 | `0` ⇒ use master's `default_dram_page_size` (2 MiB). |

--- a/src/umbp/doc/runtime-env-vars.md
+++ b/src/umbp/doc/runtime-env-vars.md
@@ -77,6 +77,10 @@ that has loaded `libmori_pybinds.so`).
 | `UMBP_GRPC_SHUTDOWN_DEADLINE_SEC` | `3` | sec | `server_->Shutdown(deadline)` budget, shared by master and peer service. |
 | `UMBP_METRICS_REPORT_INTERVAL_MS` | `1000` | ms | Cadence at which the pool client's `MasterClient` flushes buffered counters/gauges/histograms via `ReportMetrics`. |
 | `UMBP_RELEASE_LEASE_MAX_RETRIES` | `2` | count | `ReleaseSsdLease` RPC attempt cap on the SSD read path. `min_allowed=1`. |
+| `UMBP_SSD_GET_MAX_ATTEMPTS` | `1` | count | Total remote SSD get attempts per key. `1` = no retry. Only NO_SLOT and a reader-local lease expiry retry; rpc failure / NOT_FOUND do not. Raise to absorb staging-slot contention. `min_allowed=1`. |
+| `UMBP_SSD_GET_RETRY_BACKOFF_MS` | `2` | ms | Sleep between remote SSD get retries (only applied when another attempt follows). `min_allowed=1`. |
+| `UMBP_RELEASE_LEASE_TIMEOUT_MS` | `1000` | ms | Per-attempt gRPC deadline for the best-effort `ReleaseSsdLease` RPC so a slow peer can't stall the reader. `min_allowed=1`. |
+| `UMBP_SSD_PREPARE_TIMEOUT_MS` | `0` | ms | Per-call gRPC deadline for `PrepareSsdRead` so a hung/slow peer can't stall the serial batch. `0` = fall back to `ssd_lease_timeout_s` (cluster-homogeneous). A timed-out / failed prepare is a hard not-served outcome (NOT retried, and never a miss). `min_allowed=0`. |
 
 ## SPDK proxy
 

--- a/src/umbp/include/umbp/common/config.h
+++ b/src/umbp/include/umbp/common/config.h
@@ -85,6 +85,32 @@ struct UMBPSsdConfig {
   UMBPIoConfig io;
   UMBPDurabilityConfig durability;
 
+  // SSD backend selection. "posix" uses the segmented-log SSDTier; "spdk" /
+  // "spdk_proxy" use the SPDK NVMe path (direct SpdkSsdTier in standalone, or
+  // SpdkProxyTier when sharing the device across processes).  Kept here (rather
+  // than at UMBPConfig top level) so both the standalone LocalStorageManager and
+  // the distributed PeerSsdManager select the backend from the same config.
+  std::string ssd_backend = "posix";      // "posix" or "spdk"
+  std::string spdk_bdev_name;             // e.g. "Malloc0" or "NVMe0n1"
+  std::string spdk_reactor_mask = "0x1";  // CPU core mask for SPDK reactors
+  int spdk_mem_size_mb = 256;             // DPDK hugepage limit (MB)
+  std::string spdk_nvme_pci_addr;         // PCI BDF, e.g. "0000:47:00.0"
+  std::string spdk_nvme_ctrl_name = "NVMe0";
+  int spdk_io_workers = 4;  // Internal I/O worker threads for SpdkSsdTier batch ops
+
+  // SPDK Proxy configuration
+  std::string spdk_proxy_shm_name = "/umbp_spdk_proxy";
+  uint32_t spdk_proxy_tenant_id = 0;
+  size_t spdk_proxy_tenant_quota_bytes = 0;
+  uint32_t spdk_proxy_max_channels = 8;
+  size_t spdk_proxy_data_per_channel_mb = 32;  // MB of SHM data region per channel
+  std::string spdk_proxy_bin;                  // Path to spdk_proxy binary (empty = search PATH)
+  int spdk_proxy_startup_timeout_ms = 30000;   // Max ms to wait for proxy READY
+  bool spdk_proxy_auto_start = true;
+  int spdk_proxy_idle_exit_timeout_ms = 30000;
+  bool spdk_proxy_allow_borrow = false;
+  size_t spdk_proxy_reserved_shared_bytes = 0;
+
   // Focused validation for the SSD tier alone (used by SSDTier, which depends
   // on UMBPSsdConfig rather than the whole UMBPConfig).  UMBPConfig::Validate()
   // remains the global validator.
@@ -93,6 +119,12 @@ struct UMBPSsdConfig {
     // when the tier is actually enabled (mirrors UMBPConfig::Validate's
     // `if (ssd.enabled)` gate).
     if (!enabled) return true;
+    if (ssd_backend != "posix" && ssd_backend != "spdk" && ssd_backend != "spdk_proxy" &&
+        ssd_backend != "dummy_storage") {
+      if (error_message)
+        *error_message = "ssd.ssd_backend must be one of: posix, spdk, spdk_proxy, dummy_storage";
+      return false;
+    }
     if (capacity_bytes == 0) {
       if (error_message) *error_message = "ssd.capacity_bytes must be > 0";
       return false;
@@ -163,28 +195,6 @@ struct UMBPConfig {
   UMBPEvictionConfig eviction;
   UMBPCopyPipelineConfig copy_pipeline;
 
-  // SPDK SSD tier configuration (only used when ssd_backend == "spdk")
-  std::string ssd_backend = "posix";      // "posix" or "spdk"
-  std::string spdk_bdev_name;             // e.g. "Malloc0" or "NVMe0n1"
-  std::string spdk_reactor_mask = "0x1";  // CPU core mask for SPDK reactors
-  int spdk_mem_size_mb = 256;             // DPDK hugepage limit (MB)
-  std::string spdk_nvme_pci_addr;         // PCI BDF, e.g. "0000:47:00.0"
-  std::string spdk_nvme_ctrl_name = "NVMe0";
-  int spdk_io_workers = 4;  // Internal I/O worker threads for SpdkSsdTier batch ops
-
-  // SPDK Proxy configuration
-  std::string spdk_proxy_shm_name = "/umbp_spdk_proxy";
-  uint32_t spdk_proxy_tenant_id = 0;
-  size_t spdk_proxy_tenant_quota_bytes = 0;
-  uint32_t spdk_proxy_max_channels = 8;
-  size_t spdk_proxy_data_per_channel_mb = 32;  // MB of SHM data region per channel
-  std::string spdk_proxy_bin;                  // Path to spdk_proxy binary (empty = search PATH)
-  int spdk_proxy_startup_timeout_ms = 30000;   // Max ms to wait for proxy READY
-  bool spdk_proxy_auto_start = true;
-  int spdk_proxy_idle_exit_timeout_ms = 30000;
-  bool spdk_proxy_allow_borrow = false;
-  size_t spdk_proxy_reserved_shared_bytes = 0;
-
   // Role is the source of truth for runtime behavior.
   UMBPRole role = UMBPRole::Standalone;
 
@@ -243,8 +253,8 @@ struct UMBPConfig {
       if (error_message) *error_message = "copy_pipeline.batch_max_ops must be > 0";
       return false;
     }
-    if (spdk_proxy_max_channels == 0) {
-      if (error_message) *error_message = "spdk_proxy_max_channels must be > 0";
+    if (ssd.spdk_proxy_max_channels == 0) {
+      if (error_message) *error_message = "ssd.spdk_proxy_max_channels must be > 0";
       return false;
     }
     if (distributed.has_value()) {
@@ -299,47 +309,47 @@ struct UMBPConfig {
     cfg.dram.numa_node = getenv_int("UMBP_DRAM_NUMA_NODE", cfg.dram.numa_node);
     cfg.dram.prefault = getenv_int("UMBP_DRAM_PREFAULT", cfg.dram.prefault ? 1 : 0) != 0;
 
-    cfg.ssd_backend = getenv_str("UMBP_SSD_BACKEND", cfg.ssd_backend);
-    if (cfg.ssd_backend == "posix" && !std::getenv("UMBP_SSD_BACKEND") &&
+    cfg.ssd.ssd_backend = getenv_str("UMBP_SSD_BACKEND", cfg.ssd.ssd_backend);
+    if (cfg.ssd.ssd_backend == "posix" && !std::getenv("UMBP_SSD_BACKEND") &&
         std::getenv("UMBP_SPDK_NVME_PCI")) {
-      cfg.ssd_backend = "spdk";
+      cfg.ssd.ssd_backend = "spdk";
     }
-    cfg.spdk_bdev_name = getenv_str("UMBP_SPDK_BDEV", cfg.spdk_bdev_name);
-    cfg.spdk_reactor_mask = getenv_str("UMBP_SPDK_REACTOR_MASK", cfg.spdk_reactor_mask);
-    cfg.spdk_mem_size_mb = getenv_int("UMBP_SPDK_MEM_MB", cfg.spdk_mem_size_mb);
-    cfg.spdk_nvme_pci_addr = getenv_str("UMBP_SPDK_NVME_PCI", cfg.spdk_nvme_pci_addr);
-    cfg.spdk_nvme_ctrl_name = getenv_str("UMBP_SPDK_NVME_CTRL", cfg.spdk_nvme_ctrl_name);
-    cfg.spdk_io_workers = getenv_int("UMBP_SPDK_IO_WORKERS", cfg.spdk_io_workers);
+    cfg.ssd.spdk_bdev_name = getenv_str("UMBP_SPDK_BDEV", cfg.ssd.spdk_bdev_name);
+    cfg.ssd.spdk_reactor_mask = getenv_str("UMBP_SPDK_REACTOR_MASK", cfg.ssd.spdk_reactor_mask);
+    cfg.ssd.spdk_mem_size_mb = getenv_int("UMBP_SPDK_MEM_MB", cfg.ssd.spdk_mem_size_mb);
+    cfg.ssd.spdk_nvme_pci_addr = getenv_str("UMBP_SPDK_NVME_PCI", cfg.ssd.spdk_nvme_pci_addr);
+    cfg.ssd.spdk_nvme_ctrl_name = getenv_str("UMBP_SPDK_NVME_CTRL", cfg.ssd.spdk_nvme_ctrl_name);
+    cfg.ssd.spdk_io_workers = getenv_int("UMBP_SPDK_IO_WORKERS", cfg.ssd.spdk_io_workers);
 
-    cfg.spdk_proxy_shm_name = getenv_str("UMBP_SPDK_PROXY_SHM", cfg.spdk_proxy_shm_name);
-    cfg.spdk_proxy_tenant_id = static_cast<uint32_t>(
-        getenv_int("UMBP_SPDK_PROXY_TENANT_ID", static_cast<int>(cfg.spdk_proxy_tenant_id)));
-    cfg.spdk_proxy_tenant_quota_bytes =
-        getenv_size("UMBP_SPDK_PROXY_TENANT_QUOTA_BYTES", cfg.spdk_proxy_tenant_quota_bytes);
+    cfg.ssd.spdk_proxy_shm_name = getenv_str("UMBP_SPDK_PROXY_SHM", cfg.ssd.spdk_proxy_shm_name);
+    cfg.ssd.spdk_proxy_tenant_id = static_cast<uint32_t>(
+        getenv_int("UMBP_SPDK_PROXY_TENANT_ID", static_cast<int>(cfg.ssd.spdk_proxy_tenant_id)));
+    cfg.ssd.spdk_proxy_tenant_quota_bytes =
+        getenv_size("UMBP_SPDK_PROXY_TENANT_QUOTA_BYTES", cfg.ssd.spdk_proxy_tenant_quota_bytes);
 
     const char* max_channels_env = std::getenv("UMBP_SPDK_PROXY_MAX_CHANNELS");
     if (!max_channels_env) max_channels_env = std::getenv("UMBP_SPDK_PROXY_MAX_RANKS");
     if (max_channels_env) {
-      cfg.spdk_proxy_max_channels = static_cast<uint32_t>(std::atoi(max_channels_env));
+      cfg.ssd.spdk_proxy_max_channels = static_cast<uint32_t>(std::atoi(max_channels_env));
     }
 
     const char* data_mb_env = std::getenv("UMBP_SPDK_PROXY_DATA_PER_CHANNEL_MB");
     if (!data_mb_env) data_mb_env = std::getenv("UMBP_SPDK_PROXY_DATA_MB");
     if (data_mb_env) {
-      cfg.spdk_proxy_data_per_channel_mb = static_cast<size_t>(std::stoull(data_mb_env));
+      cfg.ssd.spdk_proxy_data_per_channel_mb = static_cast<size_t>(std::stoull(data_mb_env));
     }
 
-    cfg.spdk_proxy_bin = getenv_str("UMBP_SPDK_PROXY_BIN", cfg.spdk_proxy_bin);
-    cfg.spdk_proxy_startup_timeout_ms =
-        getenv_int("UMBP_SPDK_PROXY_TIMEOUT_MS", cfg.spdk_proxy_startup_timeout_ms);
-    cfg.spdk_proxy_auto_start =
-        getenv_int("UMBP_SPDK_PROXY_AUTO_START", cfg.spdk_proxy_auto_start ? 1 : 0) != 0;
-    cfg.spdk_proxy_idle_exit_timeout_ms =
-        getenv_int("UMBP_SPDK_PROXY_IDLE_EXIT_TIMEOUT_MS", cfg.spdk_proxy_idle_exit_timeout_ms);
-    cfg.spdk_proxy_allow_borrow =
-        getenv_int("UMBP_SPDK_PROXY_ALLOW_BORROW", cfg.spdk_proxy_allow_borrow ? 1 : 0) != 0;
-    cfg.spdk_proxy_reserved_shared_bytes =
-        getenv_size("UMBP_SPDK_PROXY_RESERVED_SHARED_BYTES", cfg.spdk_proxy_reserved_shared_bytes);
+    cfg.ssd.spdk_proxy_bin = getenv_str("UMBP_SPDK_PROXY_BIN", cfg.ssd.spdk_proxy_bin);
+    cfg.ssd.spdk_proxy_startup_timeout_ms =
+        getenv_int("UMBP_SPDK_PROXY_TIMEOUT_MS", cfg.ssd.spdk_proxy_startup_timeout_ms);
+    cfg.ssd.spdk_proxy_auto_start =
+        getenv_int("UMBP_SPDK_PROXY_AUTO_START", cfg.ssd.spdk_proxy_auto_start ? 1 : 0) != 0;
+    cfg.ssd.spdk_proxy_idle_exit_timeout_ms =
+        getenv_int("UMBP_SPDK_PROXY_IDLE_EXIT_TIMEOUT_MS", cfg.ssd.spdk_proxy_idle_exit_timeout_ms);
+    cfg.ssd.spdk_proxy_allow_borrow =
+        getenv_int("UMBP_SPDK_PROXY_ALLOW_BORROW", cfg.ssd.spdk_proxy_allow_borrow ? 1 : 0) != 0;
+    cfg.ssd.spdk_proxy_reserved_shared_bytes = getenv_size(
+        "UMBP_SPDK_PROXY_RESERVED_SHARED_BYTES", cfg.ssd.spdk_proxy_reserved_shared_bytes);
 
     std::string role_str = getenv_str("UMBP_ROLE", "");
     if (role_str == "leader")

--- a/src/umbp/include/umbp/common/config.h
+++ b/src/umbp/include/umbp/common/config.h
@@ -84,6 +84,25 @@ struct UMBPSsdConfig {
   size_t segment_size_bytes = 256ULL * 1024 * 1024;
   UMBPIoConfig io;
   UMBPDurabilityConfig durability;
+
+  // Focused validation for the SSD tier alone (used by SSDTier, which depends
+  // on UMBPSsdConfig rather than the whole UMBPConfig).  UMBPConfig::Validate()
+  // remains the global validator.
+  bool Validate(std::string* error_message = nullptr) const {
+    // capacity_bytes == 0 is legal when SSD is not in use; only enforce sizing
+    // when the tier is actually enabled (mirrors UMBPConfig::Validate's
+    // `if (ssd.enabled)` gate).
+    if (!enabled) return true;
+    if (capacity_bytes == 0) {
+      if (error_message) *error_message = "ssd.capacity_bytes must be > 0";
+      return false;
+    }
+    if (segment_size_bytes == 0) {
+      if (error_message) *error_message = "ssd.segment_size_bytes must be > 0";
+      return false;
+    }
+    return true;
+  }
 };
 
 struct UMBPEvictionConfig {

--- a/src/umbp/include/umbp/common/config.h
+++ b/src/umbp/include/umbp/common/config.h
@@ -85,6 +85,14 @@ struct UMBPSsdConfig {
   UMBPIoConfig io;
   UMBPDurabilityConfig durability;
 
+  // Local SSD-tier capacity watermarks for the distributed PeerSsdManager
+  // (Phase 4 local eviction).  When used/total crosses high_watermark the owner
+  // peer evicts its oldest keys down to low_watermark.  Mirrors the DRAM tier's
+  // env-tunable convention (UMBP_DRAM_HIGH_WM / LOW_WM); NOT the master-side
+  // EvictionConfig (whose watermarks are intentionally not env-tunable).
+  double high_watermark = 0.9;
+  double low_watermark = 0.7;
+
   // SSD backend selection. "posix" uses the segmented-log SSDTier; "spdk" /
   // "spdk_proxy" use the SPDK NVMe path (direct SpdkSsdTier in standalone, or
   // SpdkProxyTier when sharing the device across processes).  Kept here (rather
@@ -131,6 +139,14 @@ struct UMBPSsdConfig {
     }
     if (segment_size_bytes == 0) {
       if (error_message) *error_message = "ssd.segment_size_bytes must be > 0";
+      return false;
+    }
+    // Watermarks must satisfy 0 < low < high <= 1.  Fail fast on a misconfigured
+    // value rather than silently clamping (a clamp would hide the config error).
+    if (!(high_watermark > 0.0 && high_watermark <= 1.0 && low_watermark > 0.0 &&
+          low_watermark < high_watermark)) {
+      if (error_message)
+        *error_message = "ssd watermarks must satisfy 0 < low_watermark < high_watermark <= 1";
       return false;
     }
     return true;
@@ -303,6 +319,8 @@ struct UMBPConfig {
     cfg.eviction.policy = getenv_str("UMBP_EVICTION_POLICY", cfg.eviction.policy);
     cfg.dram.high_watermark = getenv_double("UMBP_DRAM_HIGH_WM", cfg.dram.high_watermark);
     cfg.dram.low_watermark = getenv_double("UMBP_DRAM_LOW_WM", cfg.dram.low_watermark);
+    cfg.ssd.high_watermark = getenv_double("UMBP_SSD_HIGH_WM", cfg.ssd.high_watermark);
+    cfg.ssd.low_watermark = getenv_double("UMBP_SSD_LOW_WM", cfg.ssd.low_watermark);
     cfg.dram.use_hugepages =
         getenv_int("UMBP_DRAM_USE_HUGEPAGES", cfg.dram.use_hugepages ? 1 : 0) != 0;
     cfg.dram.hugepage_size = getenv_size("UMBP_DRAM_HUGEPAGE_SIZE", cfg.dram.hugepage_size);

--- a/src/umbp/include/umbp/common/config.h
+++ b/src/umbp/include/umbp/common/config.h
@@ -85,8 +85,8 @@ struct UMBPSsdConfig {
   UMBPIoConfig io;
   UMBPDurabilityConfig durability;
 
-  // Local SSD-tier capacity watermarks for the distributed PeerSsdManager
-  // (Phase 4 local eviction).  When used/total crosses high_watermark the owner
+  // Local SSD-tier capacity watermarks for the distributed PeerSsdManager's
+  // local eviction.  When used/total crosses high_watermark the owner
   // peer evicts its oldest keys down to low_watermark.  Mirrors the DRAM tier's
   // env-tunable convention (UMBP_DRAM_HIGH_WM / LOW_WM); NOT the master-side
   // EvictionConfig (whose watermarks are intentionally not env-tunable).

--- a/src/umbp/include/umbp/common/config.h
+++ b/src/umbp/include/umbp/common/config.h
@@ -192,6 +192,14 @@ struct UMBPDistributedConfig {
 
   size_t staging_buffer_size = 64ULL * 1024 * 1024;  // 64 MB
 
+  // Dedicated SSD read staging, allocated only when ssd.enabled. Per-slot
+  // (this / ssd_read_slots) must be >= the largest single-key page KV
+  // (61-layer MLA page ~= 4.5 MB).
+  size_t ssd_staging_buffer_size = 268435456;  // 256 MiB
+
+  // Remote SSD read staging slots; per-slot = ssd_staging_buffer_size / this.
+  int ssd_read_slots = 16;
+
   uint16_t peer_service_port = 0;  // gRPC peer service port
 
   bool cache_remote_fetches = true;  // cache remotely-fetched blocks locally

--- a/src/umbp/include/umbp/distributed/config.h
+++ b/src/umbp/include/umbp/distributed/config.h
@@ -118,9 +118,16 @@ struct ExportableDram {
   size_t size = 0;
 };
 
-struct ExportableSsd {
-  std::string dir;
-  size_t capacity = 0;
+// SSD-tier construction parameters lowered from the user-facing UMBPConfig.
+// SSDTier depends on UMBPSsdConfig (io backend/queue_depth, segment_size,
+// durability, storage_dir, capacity), so the peer only needs that subset — not
+// the whole global config.  (SPDK/proxy backend selection lives at UMBPConfig
+// top level and is not yet wired into the distributed peer path; v1 builds the
+// POSIX SSDTier.  TODO(follow-up): fold ssd_backend/spdk* into UMBPSsdConfig so
+// the distributed path can select SpdkSsdTier too.)
+struct PeerSsdConfig {
+  bool enabled = false;
+  UMBPSsdConfig ssd;
 };
 
 struct PoolClientConfig {
@@ -130,7 +137,7 @@ struct PoolClientConfig {
   size_t staging_buffer_size = 64ULL * 1024 * 1024;
 
   std::vector<ExportableDram> dram_buffers;
-  std::vector<ExportableSsd> ssd_stores;
+  PeerSsdConfig ssd;
 
   std::map<TierType, TierCapacity> tier_capacities;
 
@@ -153,7 +160,8 @@ struct PoolClientConfig {
 // DistributedClient (pool mmap'd memory), not in the user-facing config.
 inline PoolClientConfig ToPoolClientConfig(const UMBPDistributedConfig& dc,
                                            std::vector<ExportableDram> dram_buffers,
-                                           std::map<TierType, TierCapacity> tier_capacities) {
+                                           std::map<TierType, TierCapacity> tier_capacities,
+                                           PeerSsdConfig ssd = {}) {
   PoolClientConfig pc;
   pc.master_config = dc.master_config;
   pc.io_engine = dc.io_engine;
@@ -165,6 +173,7 @@ inline PoolClientConfig ToPoolClientConfig(const UMBPDistributedConfig& dc,
   pc.dram_page_size = dc.dram_page_size;
   pc.dram_buffers = std::move(dram_buffers);
   pc.tier_capacities = std::move(tier_capacities);
+  pc.ssd = std::move(ssd);
   return pc;
 }
 

--- a/src/umbp/include/umbp/distributed/config.h
+++ b/src/umbp/include/umbp/distributed/config.h
@@ -120,11 +120,10 @@ struct ExportableDram {
 
 // SSD-tier construction parameters lowered from the user-facing UMBPConfig.
 // SSDTier depends on UMBPSsdConfig (io backend/queue_depth, segment_size,
-// durability, storage_dir, capacity), so the peer only needs that subset — not
-// the whole global config.  (SPDK/proxy backend selection lives at UMBPConfig
-// top level and is not yet wired into the distributed peer path; v1 builds the
-// POSIX SSDTier.  TODO(follow-up): fold ssd_backend/spdk* into UMBPSsdConfig so
-// the distributed path can select SpdkSsdTier too.)
+// durability, storage_dir, capacity, watermarks, backend selection), so the
+// peer only needs that subset — not the whole global config.  ssd_backend
+// (posix / spdk / spdk_proxy) lives inside UMBPSsdConfig, so PeerSsdManager
+// picks the backend from cfg.ssd directly.
 struct PeerSsdConfig {
   bool enabled = false;
   UMBPSsdConfig ssd;

--- a/src/umbp/include/umbp/distributed/config.h
+++ b/src/umbp/include/umbp/distributed/config.h
@@ -143,6 +143,11 @@ struct PoolClientConfig {
   int ssd_read_slots = 16;
   int ssd_lease_timeout_s = 10;
 
+  // Backs ssd_staging_buffer_, allocated only when ssd.enabled. A remote SSD
+  // read fits one whole key value in a slot, so this / ssd_read_slots must be
+  // >= the largest single-key page KV (61-layer MLA page ~= 4.5 MB).
+  size_t ssd_staging_buffer_size = 268435456;  // 256 MiB
+
   std::vector<ExportableDram> dram_buffers;
   PeerSsdConfig ssd;
 
@@ -173,6 +178,8 @@ inline PoolClientConfig ToPoolClientConfig(const UMBPDistributedConfig& dc,
   pc.master_config = dc.master_config;
   pc.io_engine = dc.io_engine;
   pc.staging_buffer_size = dc.staging_buffer_size;
+  pc.ssd_staging_buffer_size = dc.ssd_staging_buffer_size;
+  pc.ssd_read_slots = dc.ssd_read_slots;
   pc.peer_service_port = dc.peer_service_port;
   // 0 propagates through PoolClient -> MasterClient::RegisterSelf ->
   // proto -> ClientRegistry, where it is interpreted as "use the

--- a/src/umbp/include/umbp/distributed/config.h
+++ b/src/umbp/include/umbp/distributed/config.h
@@ -136,6 +136,14 @@ struct PoolClientConfig {
 
   size_t staging_buffer_size = 64ULL * 1024 * 1024;
 
+  // SSD read-staging tuning (peer side).  More slots reduce NO_SLOT under large
+  // concurrent prefetch batches, but shrink per-slot size (= staging_buffer_size
+  // / slots), which must stay >= the largest single SSD block.  The lease TTL
+  // is the primary slot-reclaim mechanism (ReleaseSsdLease is best-effort), so
+  // it should comfortably exceed one SSD read's latency.
+  int ssd_read_slots = 16;
+  int ssd_lease_timeout_s = 10;
+
   std::vector<ExportableDram> dram_buffers;
   PeerSsdConfig ssd;
 

--- a/src/umbp/include/umbp/distributed/master/master_client.h
+++ b/src/umbp/include/umbp/distributed/master/master_client.h
@@ -82,6 +82,10 @@ class MasterClient {
   // Register with master.  In the master-as-advisor design only
   // membership + capacity-snapshot metadata is shipped — DRAM/HBM
   // descriptors are peer-internal now.
+  // `tier_capacities` is the single source of per-tier capacity, including SSD
+  // (TierType::SSD) in the SSD-tier redesign.  `ssd_store_capacities` is a
+  // deprecated/legacy param master does not consume; left for compat and slated
+  // for removal once SSD capacity is wired via tier_capacities (Phase 1).
   grpc::Status RegisterSelf(const std::map<TierType, TierCapacity>& tier_capacities,
                             const std::string& peer_address = "",
                             const std::vector<uint8_t>& engine_desc_bytes = {},

--- a/src/umbp/include/umbp/distributed/master/master_client.h
+++ b/src/umbp/include/umbp/distributed/master/master_client.h
@@ -28,6 +28,7 @@
 #include <condition_variable>
 #include <cstdint>
 #include <deque>
+#include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -158,6 +159,17 @@ class MasterClient {
   void SetGauge(std::string name, std::string help, Labels labels, double value);
   void Observe(std::string name, std::string help, Labels labels, const std::vector<double>& bounds,
                double value);
+
+  // Register a callback run once per metrics flush tick in the existing metrics
+  // thread (no new thread) so a component can publish counters/gauges from its
+  // own atomics, keeping AddCounter off hot paths.  MUST be called before
+  // RegisterSelf() (the list is read lock-free afterwards; late calls are
+  // rejected).  Caller keeps the provider's data alive until StopMetricsReporting().
+  void AddMetricsProvider(std::function<void()> provider);
+
+  // Stop and join the metrics thread.  Idempotent.  PoolClient::Shutdown calls
+  // it before tearing down the components its provider reads.
+  void StopMetricsReporting();
 
   bool IsRegistered() const { return registered_; }
 
@@ -308,8 +320,14 @@ class MasterClient {
   std::condition_variable metrics_cv_;
 
   void StartMetricsReporting();
-  void StopMetricsReporting();
   void MetricsLoop();
+  // Run providers, swap the pending buffers, and ship one ReportMetrics.  Called
+  // every tick and once more after the loop exits (final shutdown flush).
+  void FlushMetricsOnce();
+
+  // Callbacks run at the top of every MetricsLoop tick (see AddMetricsProvider).
+  // Written only before StartMetricsReporting(); read-only afterwards.
+  std::vector<std::function<void()>> metrics_providers_;
 
   // --- ScopedRpcTimer integration ---
   // Called by ScopedRpcTimer at the end of every monitored MasterClient RPC.

--- a/src/umbp/include/umbp/distributed/master/master_client.h
+++ b/src/umbp/include/umbp/distributed/master/master_client.h
@@ -41,6 +41,7 @@
 #include <vector>
 
 #include "umbp/distributed/config.h"
+#include "umbp/distributed/peer/owned_location_source.h"
 #include "umbp/distributed/routing/route_put_strategy.h"
 #include "umbp/distributed/types.h"
 
@@ -53,6 +54,7 @@ class HeartbeatResponse;
 namespace mori::umbp {
 
 class PeerDramAllocator;
+class PeerSsdManager;
 
 inline constexpr std::size_t kMasterClientMaxPendingHistograms = 15000;
 
@@ -81,15 +83,11 @@ class MasterClient {
 
   // Register with master.  In the master-as-advisor design only
   // membership + capacity-snapshot metadata is shipped — DRAM/HBM
-  // descriptors are peer-internal now.
-  // `tier_capacities` is the single source of per-tier capacity, including SSD
-  // (TierType::SSD) in the SSD-tier redesign.  `ssd_store_capacities` is a
-  // deprecated/legacy param master does not consume; left for compat and slated
-  // for removal once SSD capacity is wired via tier_capacities (Phase 1).
+  // descriptors are peer-internal now.  `tier_capacities` is the single
+  // source of per-tier capacity, including SSD (TierType::SSD).
   grpc::Status RegisterSelf(const std::map<TierType, TierCapacity>& tier_capacities,
                             const std::string& peer_address = "",
-                            const std::vector<uint8_t>& engine_desc_bytes = {},
-                            const std::vector<uint64_t>& ssd_store_capacities = {});
+                            const std::vector<uint8_t>& engine_desc_bytes = {});
   grpc::Status UnregisterSelf();
 
   // --- Router ---
@@ -124,9 +122,23 @@ class MasterClient {
 
   // --- Heartbeat (event-driven) ---
   // Bind a PeerDramAllocator whose outbox the heartbeat thread will
-  // drain.  Pass nullptr for SSD-only peers.  Must be set before
-  // StartHeartbeat() — the heartbeat thread reads it once per tick.
-  void SetPeerDramAllocator(PeerDramAllocator* alloc);
+  // drain.  Pass nullptr for SSD-only peers (skipped, not registered).
+  // Also keeps the concrete pointer for DRAM-specific duties the
+  // OwnedLocationSource interface does not cover (capacity snapshot,
+  // owned-key counts, distributed-clear write gate).  Must be set before
+  // StartHeartbeat() — the heartbeat thread reads sources once per tick.
+  void SetPeerDramAllocator(PeerDramAllocator* dram_alloc);
+
+  // Bind the SSD manager: registers it as an owned-location event source
+  // AND keeps the concrete pointer so heartbeat can merge live SSD
+  // capacity into tier_capacities.  Pass nullptr to skip.  Must be set
+  // before StartHeartbeat().
+  void SetPeerSsdManager(PeerSsdManager* ssd_manager);
+
+  // Register an additional owned-location event source whose events are
+  // drained/snapshotted into the same heartbeat bundle (single monotonic
+  // seq).  Null is ignored.  Must be set before StartHeartbeat().
+  void AddOwnedLocationSource(OwnedLocationSource* source);
 
   void StartHeartbeat();
   void StopHeartbeat();
@@ -206,8 +218,20 @@ class MasterClient {
   std::map<TierType, TierCapacity> current_capacities_;
 
   // Peer-event source for the heartbeat thread.  Non-owning; lifetime
-  // is managed by PoolClient.
+  // is managed by PoolClient.  Kept as a concrete pointer (in addition to
+  // its slot in owned_sources_) for DRAM-specific duties the
+  // OwnedLocationSource interface does not cover: TierCapacitiesSnapshot,
+  // OwnedKeyCountByTier, ClearLocal/ClearFullSyncAcked.
   PeerDramAllocator* peer_alloc_ = nullptr;
+
+  // Non-owning.  Kept concrete (in addition to owned_sources_) so heartbeat
+  // can merge live SSD capacity into tier_capacities.
+  PeerSsdManager* ssd_manager_ = nullptr;
+
+  // All owned-location event sources (DRAM allocator + SSD manager).  Drained
+  // and snapshotted into a single heartbeat bundle under one monotonic seq.
+  // Populated before StartHeartbeat(); read-only afterwards (no lock needed).
+  std::vector<OwnedLocationSource*> owned_sources_;
 
   // Serializes the actual Heartbeat RPC: at most one full-sync or
   // delta heartbeat is on the wire at a time. ClearFullSync() takes

--- a/src/umbp/include/umbp/distributed/master/master_metrics.h
+++ b/src/umbp/include/umbp/distributed/master/master_metrics.h
@@ -207,3 +207,100 @@
 #define MORI_UMBP_METRIC_MASTER_CLIENT_METRICS_DROPPED_TOTAL_HELP                                \
   "Number of histogram observations dropped client-side because the pending buffer hit its cap " \
   "(see kMasterClientMaxPendingHistograms in master_client.h)"
+
+// --- SSD tier: copy / read / eviction / staging (peer-reported) ------------
+// All shipped via ReportMetrics from the owner peer (node=<node_id>).  Labels
+// are low-cardinality fixed enums only — status / reason — never key / path /
+// error string / lease id.  Counters are accumulated peer-side as cheap relaxed
+// atomics at the event point and converted to ReportMetrics deltas once per
+// metrics flush tick (no per-key AddCounter on the commit / read hot paths).
+// SSD capacity is NOT re-exported here: it rides heartbeat tier_capacities as
+// mori_umbp_client_capacity_{used,total}_bytes{tier="SSD"} (master emits the
+// tier label upper-cased, e.g. tier="SSD" — match that casing in queries).
+
+// copy-on-commit pipeline (ssd_copy_pipeline.cpp)
+#define MORI_UMBP_METRIC_SSD_COPY_ENQUEUED_TOTAL "mori_umbp_ssd_copy_enqueued_total"
+#define MORI_UMBP_METRIC_SSD_COPY_ENQUEUED_TOTAL_HELP \
+  "SSD copy-on-commit tasks accepted into the async copy queue"
+
+#define MORI_UMBP_METRIC_SSD_COPY_SUCCEEDED_TOTAL "mori_umbp_ssd_copy_succeeded_total"
+#define MORI_UMBP_METRIC_SSD_COPY_SUCCEEDED_TOTAL_HELP                                           \
+  "SSD copy-on-commit tasks that completed successfully: either the bytes were written to the "  \
+  "backend (emits ADD SSD) OR the content-addressed key was already resident (dedup fast path, " \
+  "no write, no event).  Not a count of physical writes — see "                                  \
+  "mori_umbp_ssd_copy_bytes_total for physical SSD write bytes."
+
+#define MORI_UMBP_METRIC_SSD_COPY_FAILED_TOTAL "mori_umbp_ssd_copy_failed_total"
+#define MORI_UMBP_METRIC_SSD_COPY_FAILED_TOTAL_HELP \
+  "SSD copy-on-commit tasks whose backend Write failed (no SSD copy, no event)"
+
+// label: reason=queue_full|stopped
+#define MORI_UMBP_METRIC_SSD_COPY_DROPPED_TOTAL "mori_umbp_ssd_copy_dropped_total"
+#define MORI_UMBP_METRIC_SSD_COPY_DROPPED_TOTAL_HELP                             \
+  "SSD copy tasks dropped at enqueue (reason=queue_full when the bounded queue " \
+  "was full, reason=stopped when the pipeline was stopped/quiescing)"
+
+// label: status=ok|not_found|no_slot|size_too_large|error
+#define MORI_UMBP_METRIC_SSD_READ_TOTAL "mori_umbp_ssd_read_total"
+#define MORI_UMBP_METRIC_SSD_READ_TOTAL_HELP                                    \
+  "SSD reads served by this peer's SSD tier, by outcome (covers local owner "   \
+  "reads and remote PrepareSsdRead).  not_found = stale-route miss; no_slot = " \
+  "staging slots exhausted (transient, not a miss)"
+
+// SSD IO byte counters.  Bandwidth is derived in Grafana/Prometheus via
+// rate(<counter>[<window>]) (bytes/s) — same convention as the client
+// inbound/outbound byte counters.  copy_bytes = bytes landed on SSD by a
+// successful copy-on-commit Write; read_bytes = bytes served by a successful
+// SSD read (local owner read or remote PrepareSsdRead).
+#define MORI_UMBP_METRIC_SSD_COPY_BYTES_TOTAL "mori_umbp_ssd_copy_bytes_total"
+#define MORI_UMBP_METRIC_SSD_COPY_BYTES_TOTAL_HELP                                 \
+  "Bytes written to the SSD tier by successful copy-on-commit.  rate() = offered " \
+  "SSD write throughput (bytes / wall-clock; a load signal, not device per-IO "    \
+  "bandwidth — it averages in idle gaps)"
+
+#define MORI_UMBP_METRIC_SSD_READ_BYTES_TOTAL "mori_umbp_ssd_read_bytes_total"
+#define MORI_UMBP_METRIC_SSD_READ_BYTES_TOTAL_HELP                                \
+  "Bytes read from the SSD tier by successful reads.  rate() = offered SSD read " \
+  "throughput (bytes / wall-clock; a load signal, not device per-IO bandwidth)"
+
+// eviction (peer_ssd_manager.cpp, local watermark + LRU)
+#define MORI_UMBP_METRIC_SSD_EVICTION_ROUNDS_TOTAL "mori_umbp_ssd_eviction_rounds_total"
+#define MORI_UMBP_METRIC_SSD_EVICTION_ROUNDS_TOTAL_HELP \
+  "Local SSD eviction rounds that actually ran (used above high watermark)"
+
+#define MORI_UMBP_METRIC_SSD_EVICTION_VICTIMS_TOTAL "mori_umbp_ssd_eviction_victims_total"
+#define MORI_UMBP_METRIC_SSD_EVICTION_VICTIMS_TOTAL_HELP \
+  "SSD keys evicted locally (REMOVE SSD emitted)"
+
+#define MORI_UMBP_METRIC_SSD_EVICTION_BYTES_FREED_TOTAL "mori_umbp_ssd_eviction_bytes_freed_total"
+#define MORI_UMBP_METRIC_SSD_EVICTION_BYTES_FREED_TOTAL_HELP "Bytes freed by local SSD eviction"
+
+#define MORI_UMBP_METRIC_SSD_EVICTION_BACKEND_FAILED_TOTAL \
+  "mori_umbp_ssd_eviction_backend_failed_total"
+#define MORI_UMBP_METRIC_SSD_EVICTION_BACKEND_FAILED_TOTAL_HELP \
+  "Local SSD evictions where the backend Evict failed (key kept for retry)"
+
+// staging (peer_service.cpp SSD read slots)
+#define MORI_UMBP_METRIC_SSD_STAGING_SLOTS_IN_USE "mori_umbp_ssd_staging_slots_in_use"
+#define MORI_UMBP_METRIC_SSD_STAGING_SLOTS_IN_USE_HELP \
+  "SSD read staging slots currently in use (Preparing or Leased), sampled once per flush"
+
+#define MORI_UMBP_METRIC_SSD_STAGING_EXPIRED_RECLAIMS_TOTAL \
+  "mori_umbp_ssd_staging_expired_reclaims_total"
+#define MORI_UMBP_METRIC_SSD_STAGING_EXPIRED_RECLAIMS_TOTAL_HELP \
+  "SSD read staging slots reclaimed after lease TTL expiry"
+
+#define MORI_UMBP_METRIC_SSD_STAGING_SLOT_FULL_REJECTS_TOTAL \
+  "mori_umbp_ssd_staging_slot_full_rejects_total"
+#define MORI_UMBP_METRIC_SSD_STAGING_SLOT_FULL_REJECTS_TOTAL_HELP \
+  "PrepareSsdRead calls rejected with NO_SLOT because all staging slots were busy"
+
+// Optional reader-side diagnostic: per-batch count of remote SSD reads that
+// stayed transient-not-served (NO_SLOT / reader-local lease expiry) after the
+// configured attempts.  Reported by the reader node; no reason label (kept
+// cheap — one AddCounter per batch).  lease expiry is reader-local and never
+// visible in the peer-side ssd_read_total, so this is its only observability.
+#define MORI_UMBP_METRIC_SSD_READ_CLIENT_TRANSIENT_TOTAL "mori_umbp_ssd_read_client_transient_total"
+#define MORI_UMBP_METRIC_SSD_READ_CLIENT_TRANSIENT_TOTAL_HELP                   \
+  "Remote SSD reads reported not-served this round due to transient NO_SLOT / " \
+  "reader-local lease expiry (not a definitive miss)"

--- a/src/umbp/include/umbp/distributed/peer/owned_location_source.h
+++ b/src/umbp/include/umbp/distributed/peer/owned_location_source.h
@@ -1,0 +1,84 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+#include <iterator>
+#include <vector>
+
+#include "umbp/distributed/types.h"
+
+namespace mori::umbp {
+
+// A peer-side source of owned-location mutations (ADD/REMOVE KvEvents) that the
+// heartbeat shipper drains and snapshots.  Each tier-owning component on a peer
+// (PeerDramAllocator for DRAM/HBM, PeerSsdManager for SSD) implements this so
+// MasterClient can aggregate every source into one heartbeat bundle under a
+// single monotonic sequence number — never one seq per tier (that would break
+// the ack / seq-gap full-sync recovery).
+//
+// This interface deliberately covers ONLY events.  Per-tier capacity, owned-key
+// counts and the distributed-clear write gate stay on the concrete owners
+// (PeerDramAllocator / PeerSsdManager) because they are tier-specific and not
+// shared across all sources.
+class OwnedLocationSource {
+ public:
+  virtual ~OwnedLocationSource() = default;
+
+  // Drain the events queued since the last call (delta heartbeat).  Clears the
+  // source's outbox.
+  virtual std::vector<KvEvent> DrainPendingEvents() = 0;
+
+  // Full snapshot of every owned key as ADD events (full sync on seq gap or
+  // master restart).  const: a snapshot must not mutate the source's state.
+  virtual std::vector<KvEvent> SnapshotOwnedKeys() const = 0;
+};
+
+// Drain every source and concat into one event list, in source order.  The
+// heartbeat shipper wraps the result in a SINGLE EventBundle under one
+// monotonic seq — concat here, never one bundle/seq per source.  Null sources
+// are skipped.  Exposed (vs. private to MasterClient) so it can be unit-tested
+// against mock sources without standing up a master RPC.
+inline std::vector<KvEvent> DrainAllSources(const std::vector<OwnedLocationSource*>& sources) {
+  std::vector<KvEvent> merged;
+  for (auto* src : sources) {
+    if (src == nullptr) continue;
+    auto events = src->DrainPendingEvents();
+    merged.insert(merged.end(), std::make_move_iterator(events.begin()),
+                  std::make_move_iterator(events.end()));
+  }
+  return merged;
+}
+
+// Snapshot every source and concat into one event list, in source order.  Null
+// sources are skipped.
+inline std::vector<KvEvent> SnapshotAllSources(const std::vector<OwnedLocationSource*>& sources) {
+  std::vector<KvEvent> merged;
+  for (const auto* src : sources) {
+    if (src == nullptr) continue;
+    auto events = src->SnapshotOwnedKeys();
+    merged.insert(merged.end(), std::make_move_iterator(events.begin()),
+                  std::make_move_iterator(events.end()));
+  }
+  return merged;
+}
+
+}  // namespace mori::umbp

--- a/src/umbp/include/umbp/distributed/peer/peer_dram_allocator.h
+++ b/src/umbp/include/umbp/distributed/peer/peer_dram_allocator.h
@@ -78,7 +78,7 @@ class PeerDramAllocator : public OwnedLocationSource {
   // `pending_ttl` is the only TTL in the system.  After this elapses
   // without a matching Commit / Abort, the reaper frees the slot's
   // pages.  `read_lease_ttl` is how long a single Resolve protects its
-  // key from concurrent Evict (Bug #7 resolution).  `reaper_interval`
+  // key from concurrent Evict.  `reaper_interval`
   // is the wakeup cadence for sweeping expired pendings and read
   // leases.
   PeerDramAllocator(uint64_t page_size, TierConfig dram, TierConfig hbm,
@@ -205,7 +205,7 @@ class PeerDramAllocator : public OwnedLocationSource {
   // For every key actually freed, a REMOVE event is queued.
   std::vector<EvictResult> Evict(const std::vector<std::string>& keys);
 
-  // -------- DRAM copy pin (SSD copy-on-commit, Phase 2) --------
+  // -------- DRAM copy pin (SSD copy-on-commit) --------
 
   // A copy pin protects a committed key's DRAM pages from eviction while
   // the SSD copy worker reads them.  It is an in-process lifetime guard

--- a/src/umbp/include/umbp/distributed/peer/peer_dram_allocator.h
+++ b/src/umbp/include/umbp/distributed/peer/peer_dram_allocator.h
@@ -34,6 +34,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "umbp/distributed/peer/owned_location_source.h"
 #include "umbp/distributed/peer/peer_page_allocator.h"
 #include "umbp/distributed/types.h"
 
@@ -57,7 +58,7 @@ namespace mori::umbp {
 //   2. Peer service calls Evict(keys) here.
 //   3. For each key actually freed, a REMOVE event is queued.
 //   4. Heartbeat ships the REMOVE events and master drops the index entry.
-class PeerDramAllocator {
+class PeerDramAllocator : public OwnedLocationSource {
  public:
   // Per-tier inputs: each i'th buffer's size in bytes, and the matching
   // packed mori::io::MemoryDesc that the writer will use to RDMA into
@@ -99,10 +100,6 @@ class PeerDramAllocator {
   struct OwnedSlot {
     TierType tier = TierType::UNKNOWN;
     std::vector<PageLocation> pages;
-    uint64_t size = 0;
-  };
-
-  struct SsdEntry {
     uint64_t size = 0;
   };
 
@@ -202,14 +199,6 @@ class PeerDramAllocator {
   // For every key actually freed, a REMOVE event is queued.
   std::vector<EvictResult> Evict(const std::vector<std::string>& keys);
 
-  // -------- Event outbox (used by other peer-side code paths) --------
-
-  // Push a KvEvent onto the outbox without touching the bitmap or
-  // owned/pending maps.  Used by the SSD CommitSsdWrite path to ship
-  // ADD events for keys this allocator doesn't manage — one outbox per
-  // peer is the canonical event source for the heartbeat.
-  void QueueExternalEvent(KvEvent ev);
-
   // -------- Distributed Clear --------
 
   // Drop owned/lease state, bump allocator_generation_ so pre-clear
@@ -230,12 +219,12 @@ class PeerDramAllocator {
   // -------- Heartbeat helpers --------
 
   // Drain the outbox of events queued since the last call.  Called by
-  // the heartbeat shipper; clears the buffer.
-  std::vector<KvEvent> DrainPendingEvents();
+  // the heartbeat shipper; clears the buffer.  OwnedLocationSource.
+  std::vector<KvEvent> DrainPendingEvents() override;
 
   // Full snapshot of every owned key as ADD events.  Used when master
-  // requests a full sync (seq gap or master restart).
-  std::vector<KvEvent> SnapshotOwnedKeys() const;
+  // requests a full sync (seq gap or master restart).  OwnedLocationSource.
+  std::vector<KvEvent> SnapshotOwnedKeys() const override;
 
   // Live owned-key count per tier.  O(tiers) — cheap to call every
   // heartbeat.  Used by the heartbeat shipper for per-client metrics.
@@ -313,7 +302,6 @@ class PeerDramAllocator {
 
   std::unordered_map<uint64_t, PendingSlot> pending_;
   std::unordered_map<std::string, OwnedSlot> owned_;
-  std::unordered_map<std::string, SsdEntry> owned_external_ssd_;
   std::unordered_map<std::string, std::chrono::steady_clock::time_point> read_lease_until_;
   std::vector<KvEvent> pending_events_;
 

--- a/src/umbp/include/umbp/distributed/peer/peer_dram_allocator.h
+++ b/src/umbp/include/umbp/distributed/peer/peer_dram_allocator.h
@@ -67,6 +67,12 @@ class PeerDramAllocator : public OwnedLocationSource {
   struct TierConfig {
     std::vector<uint64_t> buffer_sizes;
     std::vector<std::vector<uint8_t>> buffer_descs;  // packed mori::io::MemoryDesc bytes
+    // Local host base pointer of each buffer (same order as buffer_sizes).
+    // Used by AcquireDramCopyPin to resolve a (buffer_index, page_index)
+    // page to a directly-readable local pointer for the SSD copy worker.
+    // Empty is allowed for tiers/deployments with no DRAM copy (e.g. unit
+    // tests that never pin); pin acquisition then yields no segments.
+    std::vector<void*> buffer_bases;
   };
 
   // `pending_ttl` is the only TTL in the system.  After this elapses
@@ -199,6 +205,32 @@ class PeerDramAllocator : public OwnedLocationSource {
   // For every key actually freed, a REMOVE event is queued.
   std::vector<EvictResult> Evict(const std::vector<std::string>& keys);
 
+  // -------- DRAM copy pin (SSD copy-on-commit, Phase 2) --------
+
+  // A copy pin protects a committed key's DRAM pages from eviction while
+  // the SSD copy worker reads them.  It is an in-process lifetime guard
+  // (NOT a master lease): pages stay readable until ReleaseDramCopyPin.
+  // `segments` are directly-readable local pointers + lengths (pages may
+  // be non-contiguous across buffers).
+  struct DramCopyPin {
+    std::vector<std::pair<const void*, size_t>> segments;
+    size_t total_size = 0;
+    uint64_t pin_token = 0;  // release-time validation
+  };
+
+  // Atomically (under mutex_) confirm `key` is owned, mark it pinned, and
+  // resolve its pages to local segments.  Returns nullopt if the key is
+  // not owned (already evicted -> worker drops the task) or is already
+  // pinned (duplicate task).  While pinned, Evict(key) reports
+  // bytes_freed=0 and emits no REMOVE DRAM (master retries next round).
+  // There is NO TTL: the pin lives until ReleaseDramCopyPin.  The caller
+  // MUST release (use a RAII guard) so a worker exit always frees the pin.
+  std::optional<DramCopyPin> AcquireDramCopyPin(const std::string& key);
+
+  // Release a pin.  No-op if the key is not pinned or the token does not
+  // match (tolerates duplicate / late release).
+  void ReleaseDramCopyPin(const std::string& key, uint64_t pin_token);
+
   // -------- Distributed Clear --------
 
   // Drop owned/lease state, bump allocator_generation_ so pre-clear
@@ -275,6 +307,16 @@ class PeerDramAllocator : public OwnedLocationSource {
   // is still in the future.  Drops the entry if it has expired.
   bool HasActiveReadLeaseLocked(const std::string& key);
 
+  // Caller MUST hold `mutex_`.  True iff `key` currently has an active
+  // copy pin (protects its pages from eviction).
+  bool HasActivePinLocked(const std::string& key) const;
+
+  // Caller MUST hold `mutex_`.  Resolve `pages` to directly-readable
+  // local segments via the per-tier buffer bases.  Empty if the tier has
+  // no bases configured.
+  std::vector<std::pair<const void*, size_t>> BuildCopySegmentsLocked(
+      TierType tier, const std::vector<PageLocation>& pages, uint64_t total_size) const;
+
   // Caller MUST hold `mutex_`.
   std::vector<BufferMemoryDescBytes> BuildBufferDescsLocked(
       TierType tier, const std::vector<PageLocation>& pages) const;
@@ -299,11 +341,26 @@ class PeerDramAllocator : public OwnedLocationSource {
 
   std::map<TierType, std::unique_ptr<PageBitmapAllocator>> allocators_;
   std::map<TierType, std::vector<std::vector<uint8_t>>> tier_descs_;
+  // Per-tier local host base pointer per buffer_index (parallel to the
+  // allocator's buffers).  Source of truth for page -> local pointer used
+  // by AcquireDramCopyPin.
+  std::map<TierType, std::vector<void*>> tier_bases_;
 
   std::unordered_map<uint64_t, PendingSlot> pending_;
   std::unordered_map<std::string, OwnedSlot> owned_;
   std::unordered_map<std::string, std::chrono::steady_clock::time_point> read_lease_until_;
   std::vector<KvEvent> pending_events_;
+
+  // Active copy pins.  An entry means `key`'s owned pages are protected
+  // from eviction until ReleaseDramCopyPin.  No TTL: lifetime is bound to
+  // the worker via a RAII guard, not a deadline (force-freeing under an
+  // in-flight backend Write would be a use-after-free).
+  struct PinState {
+    uint64_t token = 0;
+    std::chrono::steady_clock::time_point acquired_at;  // for long-running warning only
+  };
+  std::unordered_map<std::string, PinState> pins_;
+  uint64_t next_pin_token_ = 1;
 
   std::vector<DeferredFree> deferred_frees_;
 

--- a/src/umbp/include/umbp/distributed/peer/peer_service.h
+++ b/src/umbp/include/umbp/distributed/peer/peer_service.h
@@ -37,10 +37,13 @@ class PeerSsdManager;
 class MasterClient;
 class SsdCopyPipeline;
 
+// Prometheus-only observability counters for the SSD read-staging slots.  NOT
+// correctness state (the slot state machine in peer_service.cpp is the source
+// of truth) — relaxed atomics incremented at discrete events and read once per
+// metrics tick by PoolClient::PublishSsdMetrics.
 struct StagingMetrics {
-  std::atomic<uint64_t> expired_reclaims{0};
-  std::atomic<uint64_t> invalid_lease_rejects{0};
-  std::atomic<uint64_t> slot_full_rejects{0};
+  std::atomic<uint64_t> expired_reclaims{0};   // leased slot reclaimed past TTL
+  std::atomic<uint64_t> slot_full_rejects{0};  // PrepareSsdRead -> NO_SLOT
 };
 
 class PeerServiceServer {
@@ -73,6 +76,10 @@ class PeerServiceServer {
   void Stop();
 
   const StagingMetrics& Metrics() const { return metrics_; }
+
+  // SSD read staging slots currently in use (Preparing or Leased).  Sampled
+  // once per metrics flush by PoolClient's metrics provider for a gauge.
+  size_t SnapshotReadSlotsInUse() const;
 
   // Read-only access for the heartbeat shipper (lives in MasterClient
   // / PoolClient).  Never null after construction with a non-null

--- a/src/umbp/include/umbp/distributed/peer/peer_service.h
+++ b/src/umbp/include/umbp/distributed/peer/peer_service.h
@@ -36,6 +36,7 @@ class LocalStorageManager;
 class LocalBlockIndex;
 class PeerDramAllocator;
 class MasterClient;
+class SsdCopyPipeline;
 
 struct StagingMetrics {
   std::atomic<uint64_t> expired_reclaims{0};
@@ -59,9 +60,13 @@ class PeerServiceServer {
                     PeerDramAllocator* dram_alloc = nullptr, int num_read_slots = 8,
                     int lease_timeout_s = 10, std::vector<uint8_t> engine_desc_bytes = {},
                     MasterClient* master_client = nullptr);
+  // `copy_pipeline` (non-owning, may be null when SSD is disabled) receives an
+  // SsdCopyTask after each successful DRAM commit so the owner peer copies the
+  // committed bytes to its local SSD tier asynchronously.
   PeerServiceServer(PeerDramAllocator* dram_alloc, int num_read_slots = 8, int lease_timeout_s = 10,
                     std::vector<uint8_t> engine_desc_bytes = {},
-                    MasterClient* master_client = nullptr);
+                    MasterClient* master_client = nullptr,
+                    SsdCopyPipeline* copy_pipeline = nullptr);
   ~PeerServiceServer();
 
   bool Start(uint16_t port);
@@ -81,6 +86,7 @@ class PeerServiceServer {
   LocalBlockIndex* index_;
   PeerDramAllocator* dram_alloc_;
   MasterClient* master_client_;
+  SsdCopyPipeline* copy_pipeline_ = nullptr;
 
   StagingMetrics metrics_;
 

--- a/src/umbp/include/umbp/distributed/peer/peer_service.h
+++ b/src/umbp/include/umbp/distributed/peer/peer_service.h
@@ -32,9 +32,8 @@
 
 namespace mori::umbp {
 
-class LocalStorageManager;
-class LocalBlockIndex;
 class PeerDramAllocator;
+class PeerSsdManager;
 class MasterClient;
 class SsdCopyPipeline;
 
@@ -49,22 +48,23 @@ class PeerServiceServer {
   // `dram_alloc` is non-owning and may be null when the host process has
   // no DRAM/HBM tier (SSD-only deployments).  When null, the
   // AllocateSlot/CommitSlot/AbortSlot/ResolveKey/EvictKey handlers
-  // respond with success=false / found=false; the SSD read-staging RPCs
-  // continue to work unchanged.  The allocator's outbox is where owned-tier
-  // ADD/REMOVE events are queued for heartbeat shipment.
-  // (Direct-SSD-put RPCs were removed in the SSD-tier redesign; only the SSD
-  // read-staging RPCs remain, pending Phase 3 refactor.)
-  PeerServiceServer(void* ssd_staging_base, size_t ssd_staging_size,
-                    const std::vector<uint8_t>& ssd_staging_mem_desc_bytes,
-                    LocalStorageManager& storage, LocalBlockIndex& index,
-                    PeerDramAllocator* dram_alloc = nullptr, int num_read_slots = 8,
-                    int lease_timeout_s = 10, std::vector<uint8_t> engine_desc_bytes = {},
-                    MasterClient* master_client = nullptr);
+  // respond with success=false / found=false.
+  //
+  // `peer_ssd` + the SSD staging region (base / size / packed MemoryDesc) drive
+  // the SSD read RPCs: when all are present the peer serves PrepareSsdRead out
+  // of `peer_ssd` into the staging buffer.  When `peer_ssd` is null (SSD
+  // disabled) the staging args are typically null/0 and the SSD read RPCs
+  // report SSD_READ_ERROR (SsdRpcAvailable() == false).  The staging buffer
+  // must be RDMA-registered by the caller; its MemoryDesc is published via
+  // GetPeerInfo so readers can RDMA out of it.
+  //
   // `copy_pipeline` (non-owning, may be null when SSD is disabled) receives an
   // SsdCopyTask after each successful DRAM commit so the owner peer copies the
   // committed bytes to its local SSD tier asynchronously.
-  PeerServiceServer(PeerDramAllocator* dram_alloc, int num_read_slots = 8, int lease_timeout_s = 10,
-                    std::vector<uint8_t> engine_desc_bytes = {},
+  PeerServiceServer(PeerDramAllocator* dram_alloc, PeerSsdManager* peer_ssd = nullptr,
+                    void* ssd_staging_base = nullptr, size_t ssd_staging_size = 0,
+                    std::vector<uint8_t> ssd_staging_mem_desc_bytes = {}, int num_read_slots = 16,
+                    int lease_timeout_s = 10, std::vector<uint8_t> engine_desc_bytes = {},
                     MasterClient* master_client = nullptr,
                     SsdCopyPipeline* copy_pipeline = nullptr);
   ~PeerServiceServer();
@@ -82,8 +82,7 @@ class PeerServiceServer {
  private:
   void* ssd_staging_base_;
   size_t ssd_staging_size_;
-  LocalStorageManager* storage_;
-  LocalBlockIndex* index_;
+  PeerSsdManager* peer_ssd_;
   PeerDramAllocator* dram_alloc_;
   MasterClient* master_client_;
   SsdCopyPipeline* copy_pipeline_ = nullptr;

--- a/src/umbp/include/umbp/distributed/peer/peer_service.h
+++ b/src/umbp/include/umbp/distributed/peer/peer_service.h
@@ -46,20 +46,21 @@ struct StagingMetrics {
 class PeerServiceServer {
  public:
   // `dram_alloc` is non-owning and may be null when the host process has
-  // no DRAM/HBM tier (SSD-only deployments).  When null, the new
+  // no DRAM/HBM tier (SSD-only deployments).  When null, the
   // AllocateSlot/CommitSlot/AbortSlot/ResolveKey/EvictKey handlers
-  // respond with success=false / found=false; SSD staging RPCs continue
-  // to work unchanged.  The allocator's outbox is also where the SSD
-  // commit path queues its ADD events for heartbeat shipment.
+  // respond with success=false / found=false; the SSD read-staging RPCs
+  // continue to work unchanged.  The allocator's outbox is where owned-tier
+  // ADD/REMOVE events are queued for heartbeat shipment.
+  // (Direct-SSD-put RPCs were removed in the SSD-tier redesign; only the SSD
+  // read-staging RPCs remain, pending Phase 3 refactor.)
   PeerServiceServer(void* ssd_staging_base, size_t ssd_staging_size,
                     const std::vector<uint8_t>& ssd_staging_mem_desc_bytes,
                     LocalStorageManager& storage, LocalBlockIndex& index,
                     PeerDramAllocator* dram_alloc = nullptr, int num_read_slots = 8,
-                    int num_write_slots = 8, int lease_timeout_s = 10,
-                    std::vector<uint8_t> engine_desc_bytes = {},
-                    MasterClient* master_client = nullptr);
-  PeerServiceServer(PeerDramAllocator* dram_alloc, int num_read_slots = 8, int num_write_slots = 8,
                     int lease_timeout_s = 10, std::vector<uint8_t> engine_desc_bytes = {},
+                    MasterClient* master_client = nullptr);
+  PeerServiceServer(PeerDramAllocator* dram_alloc, int num_read_slots = 8, int lease_timeout_s = 10,
+                    std::vector<uint8_t> engine_desc_bytes = {},
                     MasterClient* master_client = nullptr);
   ~PeerServiceServer();
 

--- a/src/umbp/include/umbp/distributed/peer/peer_ssd_manager.h
+++ b/src/umbp/include/umbp/distributed/peer/peer_ssd_manager.h
@@ -124,7 +124,7 @@ class PeerSsdManager : public OwnedLocationSource {
   std::vector<KvEvent> DrainPendingEvents() override;
   std::vector<KvEvent> SnapshotOwnedKeys() const override;
 
-  // Crash-restart leftover (v1 = discard): after a crash owned_ is empty but
+  // Crash-restart leftover policy (discard): after a crash owned_ is empty but
   // physical SSD bytes may remain, diverging used capacity from owned_.  This
   // best-effort wipes them at startup for a clean, consistent tier (cache is
   // re-fetchable).  Call before the copy pipeline starts / before any IO (not

--- a/src/umbp/include/umbp/distributed/peer/peer_ssd_manager.h
+++ b/src/umbp/include/umbp/distributed/peer/peer_ssd_manager.h
@@ -21,12 +21,15 @@
 // SOFTWARE.
 #pragma once
 
+#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
+#include <list>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -46,18 +49,20 @@ struct SsdReadOutcome {
 
 // Peer-side owner of the local SSD tier in the master-as-advisor design.
 // Single responsibility: manage one SSD TierBackend + the key->SSD-location
-// map + capacity + the owned-location event outbox (and, from Phase 3, the
-// read-prepare path).  It deliberately reuses ONLY the low-level TierBackend
+// map + capacity + the owned-location event outbox + the read-prepare and
+// local-eviction paths.  It deliberately reuses ONLY the low-level TierBackend
 // (SSDTier); it must NOT pull in LocalStorageManager / LocalBlockIndex (which
 // carry their own DRAM tier + demote/promote) — peer DRAM is owned by
 // PeerDramAllocator and two DRAM concepts would scramble ownership.
-//
-// Phase 1 builds the ownership model + reporting channel but does NOT move
-// data: nothing writes to SSD yet (copy-on-commit = Phase 2), so Write() is
-// only driven by unit tests; reads are a stub (Phase 3).
 class PeerSsdManager : public OwnedLocationSource {
  public:
   explicit PeerSsdManager(const PeerSsdConfig& cfg);
+
+  // Test-only: inject a ready-made backend and explicit watermarks so unit
+  // tests can drive eviction with a controllable (e.g. blocking) fake backend.
+  // Production code must use the config constructor.
+  PeerSsdManager(std::unique_ptr<TierBackend> backend, double high_watermark, double low_watermark);
+
   ~PeerSsdManager() override;
 
   PeerSsdManager(const PeerSsdManager&) = delete;
@@ -71,29 +76,47 @@ class PeerSsdManager : public OwnedLocationSource {
   // Write the key's bytes (assembled from possibly non-contiguous DRAM source
   // segments) to the SSD backend.  On success records the SSD location and
   // queues an ADD SSD event; on failure records nothing and queues nothing
-  // (best-effort clean).  In Phase 1 this is exercised only by unit tests; the
-  // copy worker that drives it lands in Phase 2.
+  // (best-effort clean).
   bool Write(const std::string& key, const std::vector<std::pair<const void*, size_t>>& segments,
              size_t total_size);
 
-  // Phase 4: local eviction.  Removes the key from the backend + map and
-  // queues a REMOVE SSD event.  Implemented here but not yet wired to any
-  // caller in Phase 1.
+  // Local eviction of a single key.  Read priority: a key with an
+  // in-flight PrepareRead (inflight_reads_ > 0) is NOT evicted (returns false).
+  // Concurrency: marks the key in evicting_ under the lock, runs the backend
+  // evict outside the lock, and only on backend success removes owned_/lru_ and
+  // queues a REMOVE SSD event (so REMOVE is never emitted while the bytes still
+  // exist, and two workers cannot double-evict the same victim).
+  //
+  // Does NOT itself hold eviction_mu_ (EvictToLowWatermark already holds it
+  // while looping over victims, so taking it here would deadlock).  The normal
+  // caller is EvictToLowWatermark; a direct caller must not run concurrently
+  // with ClearLocal (production relies on PoolClient::Clear quiescing the copy
+  // pipeline first, so no eviction is in flight during a Clear).
   bool Evict(const std::string& key);
 
-  // Phase 4: local LRU victim selection.  Minimal stub in Phase 1.
+  // Local LRU victim selection (oldest first), skipping keys that are
+  // being read (inflight_reads_ > 0) or already being evicted (evicting_).
+  // Accumulates sizes until >= bytes_to_free; returns fewer if not enough
+  // free-able keys exist (never blocks).
   std::vector<std::string> SelectVictims(size_t bytes_to_free);
 
-  // Distributed Clear: drop the logical owned-location map + undrained
-  // events so a post-Clear full-sync snapshot is empty and no stale ADD
-  // SSD is shipped.  Physical backend bytes are intentionally left in
-  // place (best-effort cache; reclaimed by Phase 4 local eviction).
-  // Callers MUST quiesce the SSD copy pipeline first so no in-flight copy
-  // re-populates owned_ right after this returns.
+  // Distributed Clear: drop the logical owned-location map + undrained events,
+  // then delete the physical SSD bytes (a user Clear means the cache is no
+  // longer wanted).  Read priority: clears the logical map first (so new reads
+  // immediately miss with kNotFound), waits for any in-flight PrepareRead to
+  // finish (SSD reads cannot be safely aborted), and only then wipes the
+  // backend.  Serializes against eviction rounds via eviction_mu_.
+  // Precondition: callers (PoolClient::Clear) MUST quiesce the SSD copy
+  // pipeline first so no in-flight copy re-populates owned_ right after this
+  // returns.  Crash-restart leftover (metadata gone, files remain) is a
+  // known follow-up.
   void ClearLocal();
 
-  // Phase 3: read the key's bytes into a staging slot.  Minimal stub in
-  // Phase 1 (always kNotFound); the real key-based read path lands in Phase 3.
+  // Read the key's bytes into a staging slot.  Returns kNotFound when
+  // the key is unknown OR currently being evicted (evicting_); kSizeTooLarge
+  // when the key is bigger than staging_cap; otherwise reads the bytes and
+  // returns kOk.  The backend IO runs outside the lock; the key is marked
+  // in-flight (inflight_reads_) across that window so eviction skips it.
   SsdReadOutcome PrepareRead(const std::string& key, void* staging_ptr, size_t staging_cap);
 
   // OwnedLocationSource — all events carry TierType::SSD.
@@ -101,10 +124,44 @@ class PeerSsdManager : public OwnedLocationSource {
   std::vector<KvEvent> SnapshotOwnedKeys() const override;
 
  private:
+  // One owned SSD key: its size plus a hook into the LRU recency list so that
+  // a touch is an O(1) splice and a victim lookup is an O(1) walk from the tail.
+  struct OwnedEntry {
+    uint64_t size = 0;
+    std::list<std::string>::iterator lru_it;  // position of this key in lru_
+  };
+
+  // Splice |key| to the MRU (front) of the recency list.  Caller holds mutex_
+  // and must have already inserted the key into owned_.
+  void TouchLocked(const std::string& key);
+
+  // Evict oldest keys until used <= low_watermark * total.  Runs the backend
+  // IO outside mutex_ (via Evict); serialized by eviction_mu_ so concurrent
+  // copy workers do not run overlapping eviction rounds (and never over-evict).
+  void EvictToLowWatermark();
+
+  // Serializes eviction rounds (EvictToLowWatermark) and excludes ClearLocal.
+  // Always acquired BEFORE mutex_ to keep a single lock order.
+  std::mutex eviction_mu_;
+
   mutable std::mutex mutex_;
-  std::unique_ptr<TierBackend> backend_;             // null when cfg.enabled == false
-  std::unordered_map<std::string, uint64_t> owned_;  // key -> size (SSD location)
+  std::unique_ptr<TierBackend> backend_;  // null when cfg.enabled == false
+  double high_watermark_ = 0.9;
+  double low_watermark_ = 0.7;
+
+  // key -> {size, lru position}.  The authoritative owned-location map.
+  std::unordered_map<std::string, OwnedEntry> owned_;
+  std::list<std::string> lru_;  // front = most-recently-used, back = LRU
   std::vector<KvEvent> pending_events_;
+
+  // Read priority + eviction coordination (all guarded by mutex_):
+  //   inflight_reads_: key -> active PrepareRead count (entry exists only while
+  //     > 0).  Eviction skips keys with a live read.
+  //   evicting_: keys currently inside Evict's backend-evict window; new reads
+  //     of these miss (kNotFound) and SelectVictims skips them.
+  std::unordered_map<std::string, int> inflight_reads_;
+  std::unordered_set<std::string> evicting_;
+  std::condition_variable reads_drained_cv_;  // notified when inflight_reads_ empties
 };
 
 }  // namespace mori::umbp

--- a/src/umbp/include/umbp/distributed/peer/peer_ssd_manager.h
+++ b/src/umbp/include/umbp/distributed/peer/peer_ssd_manager.h
@@ -1,0 +1,102 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "umbp/distributed/config.h"  // PeerSsdConfig
+#include "umbp/distributed/peer/owned_location_source.h"
+#include "umbp/distributed/types.h"
+
+namespace mori::umbp {
+
+class TierBackend;  // umbp/local/tiers/tier_backend.h — kept out of this header.
+
+enum class SsdReadStatus { kOk, kNotFound, kSizeTooLarge, kError };
+struct SsdReadOutcome {
+  SsdReadStatus status = SsdReadStatus::kError;
+  size_t size = 0;
+};
+
+// Peer-side owner of the local SSD tier in the master-as-advisor design.
+// Single responsibility: manage one SSD TierBackend + the key->SSD-location
+// map + capacity + the owned-location event outbox (and, from Phase 3, the
+// read-prepare path).  It deliberately reuses ONLY the low-level TierBackend
+// (SSDTier); it must NOT pull in LocalStorageManager / LocalBlockIndex (which
+// carry their own DRAM tier + demote/promote) — peer DRAM is owned by
+// PeerDramAllocator and two DRAM concepts would scramble ownership.
+//
+// Phase 1 builds the ownership model + reporting channel but does NOT move
+// data: nothing writes to SSD yet (copy-on-commit = Phase 2), so Write() is
+// only driven by unit tests; reads are a stub (Phase 3).
+class PeerSsdManager : public OwnedLocationSource {
+ public:
+  explicit PeerSsdManager(const PeerSsdConfig& cfg);
+  ~PeerSsdManager() override;
+
+  PeerSsdManager(const PeerSsdManager&) = delete;
+  PeerSsdManager& operator=(const PeerSsdManager&) = delete;
+
+  // {used_bytes, total_bytes}.  Reported via heartbeat as TierType::SSD.
+  std::pair<size_t, size_t> Capacity() const;
+
+  bool Exists(const std::string& key) const;
+
+  // Write the key's bytes (assembled from possibly non-contiguous DRAM source
+  // segments) to the SSD backend.  On success records the SSD location and
+  // queues an ADD SSD event; on failure records nothing and queues nothing
+  // (best-effort clean).  In Phase 1 this is exercised only by unit tests; the
+  // copy worker that drives it lands in Phase 2.
+  bool Write(const std::string& key, const std::vector<std::pair<const void*, size_t>>& segments,
+             size_t total_size);
+
+  // Phase 4: local eviction.  Removes the key from the backend + map and
+  // queues a REMOVE SSD event.  Implemented here but not yet wired to any
+  // caller in Phase 1.
+  bool Evict(const std::string& key);
+
+  // Phase 4: local LRU victim selection.  Minimal stub in Phase 1.
+  std::vector<std::string> SelectVictims(size_t bytes_to_free);
+
+  // Phase 3: read the key's bytes into a staging slot.  Minimal stub in
+  // Phase 1 (always kNotFound); the real key-based read path lands in Phase 3.
+  SsdReadOutcome PrepareRead(const std::string& key, void* staging_ptr, size_t staging_cap);
+
+  // OwnedLocationSource — all events carry TierType::SSD.
+  std::vector<KvEvent> DrainPendingEvents() override;
+  std::vector<KvEvent> SnapshotOwnedKeys() const override;
+
+ private:
+  mutable std::mutex mutex_;
+  std::unique_ptr<TierBackend> backend_;             // null when cfg.enabled == false
+  std::unordered_map<std::string, uint64_t> owned_;  // key -> size (SSD location)
+  std::vector<KvEvent> pending_events_;
+};
+
+}  // namespace mori::umbp

--- a/src/umbp/include/umbp/distributed/peer/peer_ssd_manager.h
+++ b/src/umbp/include/umbp/distributed/peer/peer_ssd_manager.h
@@ -84,6 +84,14 @@ class PeerSsdManager : public OwnedLocationSource {
   // Phase 4: local LRU victim selection.  Minimal stub in Phase 1.
   std::vector<std::string> SelectVictims(size_t bytes_to_free);
 
+  // Distributed Clear: drop the logical owned-location map + undrained
+  // events so a post-Clear full-sync snapshot is empty and no stale ADD
+  // SSD is shipped.  Physical backend bytes are intentionally left in
+  // place (best-effort cache; reclaimed by Phase 4 local eviction).
+  // Callers MUST quiesce the SSD copy pipeline first so no in-flight copy
+  // re-populates owned_ right after this returns.
+  void ClearLocal();
+
   // Phase 3: read the key's bytes into a staging slot.  Minimal stub in
   // Phase 1 (always kNotFound); the real key-based read path lands in Phase 3.
   SsdReadOutcome PrepareRead(const std::string& key, void* staging_ptr, size_t staging_cap);

--- a/src/umbp/include/umbp/distributed/peer/peer_ssd_manager.h
+++ b/src/umbp/include/umbp/distributed/peer/peer_ssd_manager.h
@@ -21,6 +21,7 @@
 // SOFTWARE.
 #pragma once
 
+#include <atomic>
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
@@ -123,6 +124,35 @@ class PeerSsdManager : public OwnedLocationSource {
   std::vector<KvEvent> DrainPendingEvents() override;
   std::vector<KvEvent> SnapshotOwnedKeys() const override;
 
+  // Crash-restart leftover (v1 = discard): after a crash owned_ is empty but
+  // physical SSD bytes may remain, diverging used capacity from owned_.  This
+  // best-effort wipes them at startup for a clean, consistent tier (cache is
+  // re-fetchable).  Call before the copy pipeline starts / before any IO (not
+  // synchronized against Write/PrepareRead).  No-op when SSD is disabled.
+  void DiscardLeftoverOnStartup();
+
+  // Prometheus-only observability snapshots (see metrics_ below); sampled once
+  // per metrics tick by PublishSsdMetrics(), never drive correctness.
+  uint64_t ReadOk() const { return metrics_.read_ok.load(std::memory_order_relaxed); }
+  uint64_t ReadNotFound() const { return metrics_.read_not_found.load(std::memory_order_relaxed); }
+  uint64_t ReadSizeTooLarge() const {
+    return metrics_.read_size_too_large.load(std::memory_order_relaxed);
+  }
+  uint64_t ReadError() const { return metrics_.read_error.load(std::memory_order_relaxed); }
+  // Byte counters for SSD IO bandwidth (rate() in Grafana = bytes/s).
+  uint64_t CopyBytes() const { return metrics_.copy_bytes.load(std::memory_order_relaxed); }
+  uint64_t ReadBytes() const { return metrics_.read_bytes.load(std::memory_order_relaxed); }
+  uint64_t EvictionRounds() const { return metrics_.evict_rounds.load(std::memory_order_relaxed); }
+  uint64_t EvictionVictims() const {
+    return metrics_.evict_victims.load(std::memory_order_relaxed);
+  }
+  uint64_t EvictionBytesFreed() const {
+    return metrics_.evict_bytes_freed.load(std::memory_order_relaxed);
+  }
+  uint64_t EvictionBackendFailures() const {
+    return metrics_.evict_backend_failures.load(std::memory_order_relaxed);
+  }
+
  private:
   // One owned SSD key: its size plus a hook into the LRU recency list so that
   // a touch is an O(1) splice and a victim lookup is an O(1) walk from the tail.
@@ -162,6 +192,23 @@ class PeerSsdManager : public OwnedLocationSource {
   std::unordered_map<std::string, int> inflight_reads_;
   std::unordered_set<std::string> evicting_;
   std::condition_variable reads_drained_cv_;  // notified when inflight_reads_ empties
+
+  // Prometheus-only observability counters: relaxed atomics bumped at discrete
+  // events, read once per metrics tick.  NOT correctness state
+  // (owned_/lru_/inflight_reads_ are authoritative); deletable with the provider.
+  struct MetricsCounters {
+    std::atomic<uint64_t> read_ok{0};
+    std::atomic<uint64_t> read_not_found{0};
+    std::atomic<uint64_t> read_size_too_large{0};
+    std::atomic<uint64_t> read_error{0};
+    std::atomic<uint64_t> copy_bytes{0};  // bytes written to SSD (write IO)
+    std::atomic<uint64_t> read_bytes{0};  // bytes read from SSD (read IO)
+    std::atomic<uint64_t> evict_rounds{0};
+    std::atomic<uint64_t> evict_victims{0};
+    std::atomic<uint64_t> evict_bytes_freed{0};
+    std::atomic<uint64_t> evict_backend_failures{0};
+  };
+  MetricsCounters metrics_;
 };
 
 }  // namespace mori::umbp

--- a/src/umbp/include/umbp/distributed/peer/ssd_copy_pipeline.h
+++ b/src/umbp/include/umbp/distributed/peer/ssd_copy_pipeline.h
@@ -48,11 +48,11 @@ struct SsdCopyTask {
   size_t size = 0;                        // informational; pin reports true size
 };
 
-// Peer-local copy-on-commit pipeline (Phase 2).  After a key's DRAM pages are
+// Peer-local copy-on-commit pipeline.  After a key's DRAM pages are
 // committed on this owner peer, the commit path enqueues an SsdCopyTask; a
 // background worker copies the bytes to the local SSD tier best-effort.
 //
-// Key properties (see docs/ssd dev/umbp-ssd-tier-interface-contract-zh.md §4):
+// Key properties:
 //   - Enqueue never blocks commit: a full queue (or a stopped/quiescing
 //     pipeline) drops the task and counts it.
 //   - The worker holds a DramCopyPin across the backend Write so eviction

--- a/src/umbp/include/umbp/distributed/peer/ssd_copy_pipeline.h
+++ b/src/umbp/include/umbp/distributed/peer/ssd_copy_pipeline.h
@@ -1,0 +1,122 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "umbp/distributed/types.h"
+
+namespace mori::umbp {
+
+class PeerDramAllocator;
+class PeerSsdManager;
+
+// One async SSD copy request, enqueued after a DRAM commit succeeds.  It
+// deliberately carries NO source pointer: the worker re-derives the readable
+// segments from `key` via PeerDramAllocator::AcquireDramCopyPin, so an
+// already-evicted key is simply dropped (the pin acquisition fails).
+struct SsdCopyTask {
+  std::string key;
+  TierType source_tier = TierType::DRAM;  // informational; worker reads via key
+  size_t size = 0;                        // informational; pin reports true size
+};
+
+// Peer-local copy-on-commit pipeline (Phase 2).  After a key's DRAM pages are
+// committed on this owner peer, the commit path enqueues an SsdCopyTask; a
+// background worker copies the bytes to the local SSD tier best-effort.
+//
+// Key properties (see docs/ssd dev/umbp-ssd-tier-interface-contract-zh.md §4):
+//   - Enqueue never blocks commit: a full queue (or a stopped/quiescing
+//     pipeline) drops the task and counts it.
+//   - The worker holds a DramCopyPin across the backend Write so eviction
+//     cannot free the pages underneath it; a RAII guard guarantees the pin is
+//     released on every exit (success, failure, or early return).
+//   - Only a successful PeerSsdManager::Write records the SSD location and
+//     emits ADD SSD.
+class SsdCopyPipeline {
+ public:
+  SsdCopyPipeline(PeerDramAllocator* dram, PeerSsdManager* ssd, size_t queue_depth = 4096,
+                  size_t worker_threads = 1);
+  ~SsdCopyPipeline();
+
+  SsdCopyPipeline(const SsdCopyPipeline&) = delete;
+  SsdCopyPipeline& operator=(const SsdCopyPipeline&) = delete;
+
+  // Spawn worker threads and begin accepting tasks.  Idempotent.
+  void Start();
+
+  // Stop accepting, drop any queued tasks, let the in-flight task finish (its
+  // pin is released by the RAII guard), then join the workers.  Idempotent.
+  void Stop();
+
+  // Pause intake and drain in-flight work without tearing down the workers:
+  // stop accepting, drop queued tasks, and block until no task is running.
+  // Used by PoolClient::Clear so no in-flight copy re-populates SSD state
+  // right after the managers are cleared.  Pair with Resume().
+  void Quiesce();
+
+  // Resume accepting tasks after Quiesce().
+  void Resume();
+
+  // Enqueue a copy task.  Returns false (without blocking) when the pipeline
+  // is not accepting (stopped/quiescing) or the bounded queue is full; a
+  // full-queue drop is counted in dropped().
+  bool Enqueue(SsdCopyTask task);
+
+  uint64_t Dropped() const { return dropped_.load(std::memory_order_relaxed); }
+  uint64_t CopiedOk() const { return copied_ok_.load(std::memory_order_relaxed); }
+
+ private:
+  void WorkerLoop();
+  void RunTask(const SsdCopyTask& task);
+
+  PeerDramAllocator* dram_;
+  PeerSsdManager* ssd_;
+  const size_t queue_depth_;
+  const size_t worker_threads_;
+
+  std::mutex mu_;
+  std::condition_variable cv_;       // wakes workers on new work / stop
+  std::condition_variable idle_cv_;  // wakes Quiesce when no task is running
+  std::deque<SsdCopyTask> queue_;
+  // Intake is open unless stopped (Stop) or paused (Quiesce).  Default-open so
+  // the bounded-queue drop path is exercised even before Start spawns workers;
+  // in production Start() is always called before the first commit.
+  bool stop_ = false;
+  bool paused_ = false;
+  size_t active_ = 0;  // tasks currently being processed by workers
+
+  std::atomic<uint64_t> dropped_{0};
+  std::atomic<uint64_t> copied_ok_{0};
+
+  std::vector<std::thread> workers_;
+};
+
+}  // namespace mori::umbp

--- a/src/umbp/include/umbp/distributed/peer/ssd_copy_pipeline.h
+++ b/src/umbp/include/umbp/distributed/peer/ssd_copy_pipeline.h
@@ -90,8 +90,19 @@ class SsdCopyPipeline {
   // full-queue drop is counted in dropped().
   bool Enqueue(SsdCopyTask task);
 
-  uint64_t Dropped() const { return dropped_.load(std::memory_order_relaxed); }
-  uint64_t CopiedOk() const { return copied_ok_.load(std::memory_order_relaxed); }
+  // Prometheus-only observability snapshots (see metrics_ below).  Not
+  // correctness state; sampled once per metrics tick by PublishSsdMetrics().
+  uint64_t Enqueued() const { return metrics_.enqueued.load(std::memory_order_relaxed); }
+  // CopiedOk counts completed copies: a real backend Write OR a content-addressed
+  // dedup hit (already resident) — both report success, only the former emits ADD SSD.
+  uint64_t CopiedOk() const { return metrics_.copied_ok.load(std::memory_order_relaxed); }
+  uint64_t Failed() const { return metrics_.failed.load(std::memory_order_relaxed); }
+  // Dropped because the bounded queue was full (kept name for existing tests).
+  uint64_t Dropped() const { return metrics_.dropped_queue_full.load(std::memory_order_relaxed); }
+  // Dropped because the pipeline was stopped / quiescing at enqueue time.
+  uint64_t DroppedStopped() const {
+    return metrics_.dropped_stopped.load(std::memory_order_relaxed);
+  }
 
  private:
   void WorkerLoop();
@@ -113,8 +124,17 @@ class SsdCopyPipeline {
   bool paused_ = false;
   size_t active_ = 0;  // tasks currently being processed by workers
 
-  std::atomic<uint64_t> dropped_{0};
-  std::atomic<uint64_t> copied_ok_{0};
+  // Prometheus-only observability counters (see getters above): relaxed atomics
+  // bumped at the enqueue/run events, read once per metrics tick.  NOT
+  // correctness state (queue_/stop_/paused_ are authoritative).
+  struct MetricsCounters {
+    std::atomic<uint64_t> enqueued{0};            // tasks accepted into the queue
+    std::atomic<uint64_t> copied_ok{0};           // copy completed (write OK or dedup hit)
+    std::atomic<uint64_t> failed{0};              // backend Write failed / unusable pin
+    std::atomic<uint64_t> dropped_queue_full{0};  // dropped: bounded queue full
+    std::atomic<uint64_t> dropped_stopped{0};     // dropped: pipeline stopped/quiescing
+  };
+  MetricsCounters metrics_;
 
   std::vector<std::thread> workers_;
 };

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -44,6 +44,7 @@ namespace mori::umbp {
 class PeerDramAllocator;
 class PeerServiceServer;
 class PeerSsdManager;
+class SsdCopyPipeline;
 
 // Short name for log output. Generic FAILED maps to "FAILED" — the
 // detailed reason for that case lives in the peer's allocator log.
@@ -167,6 +168,11 @@ class PoolClient {
   // with MasterClient as an owned-location source + SSD capacity provider.
   // Phase 1: present and reporting, but nothing writes/reads it yet.
   std::unique_ptr<PeerSsdManager> peer_ssd_;
+  // Async copy-on-commit pipeline (Phase 2).  Built only when SSD is enabled;
+  // borrows peer_alloc_ (pin source) + peer_ssd_ (write target).  Started in
+  // Init, stopped in Shutdown (after the peer service so no commit can enqueue
+  // into a stopped pipeline).
+  std::unique_ptr<SsdCopyPipeline> ssd_copy_pipeline_;
   std::unique_ptr<PeerServiceServer> peer_service_;
 
   std::unique_ptr<mori::io::IOEngine> io_engine_;

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -43,6 +43,7 @@ namespace mori::umbp {
 
 class PeerDramAllocator;
 class PeerServiceServer;
+class PeerSsdManager;
 
 // Short name for log output. Generic FAILED maps to "FAILED" — the
 // detailed reason for that case lives in the peer's allocator log.
@@ -162,6 +163,10 @@ class PoolClient {
   // the natural lifetime anchor for the per-process IO engine + DRAM
   // buffers; PeerServiceServer borrows it.
   std::unique_ptr<PeerDramAllocator> peer_alloc_;
+  // Peer-side SSD tier owner.  Built only when config_.ssd.enabled; registered
+  // with MasterClient as an owned-location source + SSD capacity provider.
+  // Phase 1: present and reporting, but nothing writes/reads it yet.
+  std::unique_ptr<PeerSsdManager> peer_ssd_;
   std::unique_ptr<PeerServiceServer> peer_service_;
 
   std::unique_ptr<mori::io::IOEngine> io_engine_;

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -316,6 +316,23 @@ class PoolClient {
   // (default off) on transient NO_SLOT / reader-local lease expiry; an rpc
   // failure is hard not-served, and a NOT_FOUND short-circuits as a miss.
   void ProcessRemoteSsdBatchGet(const std::vector<BatchGetItem>& items, std::vector<bool>* results);
+
+  // Periodic SSD metrics provider (registered in Init() when SSD is enabled, run
+  // once per metrics flush tick in the metrics thread).  Reads the cheap atomics
+  // on the pipeline / PeerSsdManager / PeerService and ships counter deltas + a
+  // staging gauge, keeping AddCounter off the commit/read hot paths.  The
+  // last-shipped values below make each tick report only the delta.
+  void PublishSsdMetrics();
+  struct SsdMetricsLastShipped {
+    uint64_t copy_enqueued = 0, copy_succeeded = 0, copy_failed = 0;
+    uint64_t copy_dropped_queue_full = 0, copy_dropped_stopped = 0;
+    uint64_t read_ok = 0, read_not_found = 0, read_size_too_large = 0, read_error = 0;
+    uint64_t read_no_slot = 0;
+    uint64_t copy_bytes = 0, read_bytes = 0;
+    uint64_t evict_rounds = 0, evict_victims = 0, evict_bytes_freed = 0, evict_backend_failed = 0;
+    uint64_t staging_expired_reclaims = 0, staging_slot_full_rejects = 0;
+  };
+  SsdMetricsLastShipped ssd_metrics_last_;
   void ExecuteRemoteBatchPut(const std::vector<BatchPutItem>& items,
                              std::vector<PutEntryOutcome>* results, PeerConnection& peer,
                              ::umbp::UMBPPeer::Stub* stub);

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -120,7 +120,7 @@ class PoolClient {
   std::vector<bool> BatchExists(const std::vector<std::string>& keys);
 
   void* SsdStagingPtr() const { return ssd_staging_buffer_.get(); }
-  size_t SsdStagingSize() const { return config_.staging_buffer_size; }
+  size_t SsdStagingSize() const { return config_.ssd_staging_buffer_size; }
   const std::vector<uint8_t>& SsdStagingMemDescBytes() const { return ssd_staging_mem_desc_bytes_; }
 
   MasterClient& Master();

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -223,10 +223,12 @@ class PoolClient {
 
   bool EnsurePeerServiceConnection(PeerConnection& peer);
 
-  // Outcome of one remote SSD get attempt.  kRetry (NO_SLOT / LEASE_EXPIRED) is
-  // a transient peer-side condition the caller retries; kMiss (NOT_FOUND) is a
-  // definitive miss; kError is a hard failure.  Keeping these distinct is what
-  // lets BatchGet avoid surfacing transient slot contention as a cache miss.
+  // Outcome of one remote SSD get attempt.  kRetry is a retryable transient
+  // condition (NO_SLOT or a reader-local lease expiry); kMiss (NOT_FOUND) is a
+  // definitive miss; kError is the not-served, not-retried catch-all (rpc
+  // failure incl. DEADLINE_EXCEEDED, size mismatch, RDMA failure) — not strictly
+  // a hard error.  Keeping kMiss distinct lets BatchGet avoid surfacing a
+  // non-served key as a cache miss.
   enum class SsdGetOutcome { kSuccess, kMiss, kRetry, kError };
 
   // Remote SSD get path (reader != owner): key-based PrepareSsdRead -> RDMA out
@@ -310,8 +312,9 @@ class PoolClient {
   void ProcessRemoteBatchPut(const std::vector<BatchPutItem>& items,
                              std::vector<PutEntryOutcome>* results);
   void ProcessRemoteBatchGet(const std::vector<BatchGetItem>& items, std::vector<bool>* results);
-  // Remote SSD reads (one staging slot + lease per key) with bounded retry on
-  // transient NO_SLOT / LEASE_EXPIRED; a NOT_FOUND short-circuits as a miss.
+  // Remote SSD reads (one staging slot + lease per key) with bounded retry
+  // (default off) on transient NO_SLOT / reader-local lease expiry; an rpc
+  // failure is hard not-served, and a NOT_FOUND short-circuits as a miss.
   void ProcessRemoteSsdBatchGet(const std::vector<BatchGetItem>& items, std::vector<bool>* results);
   void ExecuteRemoteBatchPut(const std::vector<BatchPutItem>& items,
                              std::vector<PutEntryOutcome>* results, PeerConnection& peer,

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -210,12 +210,10 @@ class PoolClient {
   bool LocalGetPages(const std::vector<PageLocation>& pages, uint64_t page_size, void* dst,
                      size_t size);
 
-  // SSD path helpers — preserved so the SSD CommitSsdWrite slot
-  // pre-allocation flow keeps working.  The peer side re-shaping of
-  // those RPCs is not in scope for this commit.
   bool EnsurePeerServiceConnection(PeerConnection& peer);
-  bool RemoteSsdWrite(PeerConnection& peer, const std::string& key, const void* src, size_t size,
-                      bool zero_copy, uint32_t store_index = 0);
+  // SSD read glue. TODO(Phase 3): rewrite for the new SSD get path (local vs
+  // remote, key-based PrepareSsdRead) per the interface contract §5. Direct
+  // SSD put (RemoteSsdWrite) was removed in the SSD-tier redesign.
   bool RemoteSsdRead(PeerConnection& peer, const std::string& key, const std::string& location_id,
                      void* dst, size_t size, bool zero_copy);
 

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -222,11 +222,18 @@ class PoolClient {
                      size_t size);
 
   bool EnsurePeerServiceConnection(PeerConnection& peer);
-  // SSD read glue. TODO(Phase 3): rewrite for the new SSD get path (local vs
-  // remote, key-based PrepareSsdRead) per the interface contract §5. Direct
-  // SSD put (RemoteSsdWrite) was removed in the SSD-tier redesign.
-  bool RemoteSsdRead(PeerConnection& peer, const std::string& key, const std::string& location_id,
-                     void* dst, size_t size, bool zero_copy);
+
+  // Outcome of one remote SSD get attempt.  kRetry (NO_SLOT / LEASE_EXPIRED) is
+  // a transient peer-side condition the caller retries; kMiss (NOT_FOUND) is a
+  // definitive miss; kError is a hard failure.  Keeping these distinct is what
+  // lets BatchGet avoid surfacing transient slot contention as a cache miss.
+  enum class SsdGetOutcome { kSuccess, kMiss, kRetry, kError };
+
+  // Remote SSD get path (reader != owner): key-based PrepareSsdRead -> RDMA out
+  // of the peer's published SSD staging buffer -> best-effort ReleaseSsdLease.
+  SsdGetOutcome RemoteSsdReadOnce(PeerConnection& peer, const std::string& key, void* dst,
+                                  size_t size);
+  void ReleaseSsdLeaseBestEffort(::umbp::UMBPPeer::Stub* stub, uint64_t lease_id);
 
   // Zero-copy registered memory regions.
   struct RegisteredRegion {
@@ -247,6 +254,9 @@ class PoolClient {
   PutAttemptOutcome ExecuteLocalPut(const std::string& key, const void* src, size_t size,
                                     TierType tier);
   GetAttemptOutcome ExecuteLocalGet(const std::string& key, void* dst, size_t size);
+  // Self-target SSD get: read straight from the local SSD tier into the user
+  // buffer (no staging / RDMA / lease).
+  GetAttemptOutcome ExecuteLocalSsdGet(const std::string& key, void* dst, size_t size);
   struct BatchPutItem {
     size_t index;
     const std::string* key;
@@ -300,6 +310,9 @@ class PoolClient {
   void ProcessRemoteBatchPut(const std::vector<BatchPutItem>& items,
                              std::vector<PutEntryOutcome>* results);
   void ProcessRemoteBatchGet(const std::vector<BatchGetItem>& items, std::vector<bool>* results);
+  // Remote SSD reads (one staging slot + lease per key) with bounded retry on
+  // transient NO_SLOT / LEASE_EXPIRED; a NOT_FOUND short-circuits as a miss.
+  void ProcessRemoteSsdBatchGet(const std::vector<BatchGetItem>& items, std::vector<bool>* results);
   void ExecuteRemoteBatchPut(const std::vector<BatchPutItem>& items,
                              std::vector<PutEntryOutcome>* results, PeerConnection& peer,
                              ::umbp::UMBPPeer::Stub* stub);

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -166,9 +166,8 @@ class PoolClient {
   std::unique_ptr<PeerDramAllocator> peer_alloc_;
   // Peer-side SSD tier owner.  Built only when config_.ssd.enabled; registered
   // with MasterClient as an owned-location source + SSD capacity provider.
-  // Phase 1: present and reporting, but nothing writes/reads it yet.
   std::unique_ptr<PeerSsdManager> peer_ssd_;
-  // Async copy-on-commit pipeline (Phase 2).  Built only when SSD is enabled;
+  // Async copy-on-commit pipeline.  Built only when SSD is enabled;
   // borrows peer_alloc_ (pin source) + peer_ssd_ (write target).  Started in
   // Init, stopped in Shutdown (after the peer service so no commit can enqueue
   // into a stopped pipeline).

--- a/src/umbp/include/umbp/distributed/routing/route_get_strategy.h
+++ b/src/umbp/include/umbp/distributed/routing/route_get_strategy.h
@@ -48,4 +48,13 @@ class RandomRouteGetStrategy : public RouteGetStrategy {
   Location Select(const std::vector<Location>& locations, const std::string& node_id) override;
 };
 
+/// Tier-priority strategy: prefer the fastest tier present (HBM > DRAM > SSD),
+/// then pick a random replica within that tier.  This is the distributed read
+/// path's default — without it a key with both a DRAM and an SSD copy could be
+/// routed to the slow SSD at random.  Unknown-tier locations rank last.
+class TierPriorityRouteGetStrategy : public RouteGetStrategy {
+ public:
+  Location Select(const std::vector<Location>& locations, const std::string& node_id) override;
+};
+
 }  // namespace mori::umbp

--- a/src/umbp/include/umbp/distributed/ssd_read_lease.h
+++ b/src/umbp/include/umbp/distributed/ssd_read_lease.h
@@ -1,0 +1,76 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+// Pure decision helpers for the reader-side remote SSD read lease path.
+//
+// These are intentionally free of PoolClient / RDMA / IO state so the lease
+// gating policy can be unit-tested in isolation.  The reader anchors its lease
+// deadline at the moment BEFORE sending PrepareSsdRead (t_send) and treats the
+// read as valid only while now <= t_send + lease_ttl_ms.  This is strictly
+// conservative against the peer: the peer starts the same TTL when it RECEIVES
+// the request (received_at > t_send), so its reclaim point (received_at + ttl)
+// is always later than the reader's deadline (t_send + ttl) — the reader gives
+// up before the peer can reclaim and reassign the slot, so a read is never
+// reported successful against a slot the peer has already recycled.
+//
+// Lease expiry is therefore a reader-local decision, not a wire status: there
+// is no SSD_READ_LEASE_EXPIRED.  On expiry the reader returns a transient
+// retry (never a miss) and does NOT release — the peer reclaims by TTL.  A
+// reader-local lease expiry and a NO_SLOT response are the retryable outcomes;
+// a failed/timed-out PrepareSsdRead is a hard failure (retrying a slow peer
+// that may already hold a claimed slot just piles up more staging occupation),
+// so it does not route through kRetry.
+
+#include <chrono>
+#include <cstdint>
+
+namespace mori::umbp::ssd_read_lease {
+
+// Reader-local lease outcome category, independent of PoolClient internals.
+// Translated to PoolClient::SsdGetOutcome at the call site.
+enum class GateOutcome { kSuccess, kRetry, kError };
+
+struct GateDecision {
+  GateOutcome outcome;
+  bool release;  // whether to issue a best-effort ReleaseSsdLease
+};
+
+// True once now is strictly past the deadline (t_send + lease_ttl_ms); now ==
+// deadline is still valid.  ttl 0 expires as soon as now > t_send.
+inline bool LeaseExpired(std::chrono::steady_clock::time_point t_send, uint64_t lease_ttl_ms,
+                         std::chrono::steady_clock::time_point now) {
+  return now > t_send + std::chrono::milliseconds(lease_ttl_ms);
+}
+
+// Decide the outcome of a prepared read.  `expired` short-circuits to a
+// transient retry with no release (the slot is left for the peer's TTL
+// reclaim).  Otherwise a successful RDMA serves the data and frees the slot
+// fast via release; a failed RDMA is a hard error but still releases (the
+// lease is still ours and matching by lease_id is safe).
+inline GateDecision DecideSsdReadOutcome(bool expired, bool rdma_ok) {
+  if (expired) return {GateOutcome::kRetry, /*release=*/false};
+  if (rdma_ok) return {GateOutcome::kSuccess, /*release=*/true};
+  return {GateOutcome::kError, /*release=*/true};
+}
+
+}  // namespace mori::umbp::ssd_read_lease

--- a/src/umbp/include/umbp/local/tiers/spdk_proxy_tier.h
+++ b/src/umbp/include/umbp/local/tiers/spdk_proxy_tier.h
@@ -42,7 +42,7 @@ namespace umbp {
 
 class SpdkProxyTier : public TierBackend {
  public:
-  explicit SpdkProxyTier(const UMBPConfig& config);
+  explicit SpdkProxyTier(const UMBPSsdConfig& config);
   ~SpdkProxyTier() override;
 
   bool IsValid() const { return connected_; }

--- a/src/umbp/include/umbp/local/tiers/spdk_ssd_tier.h
+++ b/src/umbp/include/umbp/local/tiers/spdk_ssd_tier.h
@@ -66,8 +66,8 @@ class SpdkSsdTier : public TierBackend {
   };
   using SharedDmaPool = std::shared_ptr<DmaPool>;
 
-  explicit SpdkSsdTier(const UMBPConfig& config);
-  SpdkSsdTier(const UMBPConfig& config, uint64_t base_offset, size_t capacity_bytes,
+  explicit SpdkSsdTier(const UMBPSsdConfig& config);
+  SpdkSsdTier(const UMBPSsdConfig& config, uint64_t base_offset, size_t capacity_bytes,
               SharedDmaPool shared_dma_pool = nullptr);
   ~SpdkSsdTier() override;
 

--- a/src/umbp/include/umbp/local/tiers/ssd_tier.h
+++ b/src/umbp/include/umbp/local/tiers/ssd_tier.h
@@ -46,7 +46,7 @@ enum class SSDAccessMode : int {
 
 class SSDTier : public TierBackend {
  public:
-  SSDTier(const std::string& dir, size_t capacity, const UMBPConfig& config,
+  SSDTier(const std::string& dir, size_t capacity, const UMBPSsdConfig& ssd_config,
           SSDAccessMode access_mode = SSDAccessMode::ReadWrite);
   ~SSDTier() override;
 
@@ -80,7 +80,7 @@ class SSDTier : public TierBackend {
  private:
   bool IsReadOnlyShared() const { return access_mode_ == SSDAccessMode::ReadOnlyShared; }
   bool ShouldSyncOnWrite() const {
-    return config_.ssd.durability.mode == UMBPDurabilityMode::Strict;
+    return ssd_config_.durability.mode == UMBPDurabilityMode::Strict;
   }
 
   bool EnsureActiveSegment(size_t need_bytes);
@@ -96,7 +96,7 @@ class SSDTier : public TierBackend {
 
   std::string dir_;
   size_t capacity_;
-  UMBPConfig config_;
+  UMBPSsdConfig ssd_config_;
   SSDAccessMode access_mode_;
 
   mutable std::mutex mu_;

--- a/src/umbp/local/standalone_client.cpp
+++ b/src/umbp/local/standalone_client.cpp
@@ -63,7 +63,7 @@ StandaloneClient::StandaloneClient(const UMBPConfig& config)
       "eviction={} copy_pipeline_threads={} copy_pipeline_qdepth={}",
       RoleStr(role_), config_.dram.capacity_bytes / (1024 * 1024), config_.dram.use_hugepages,
       config_.dram.hugepage_size / (1024 * 1024), config_.dram.numa_node, config_.ssd.enabled,
-      config_.ssd_backend, config_.ssd.capacity_bytes / (1024 * 1024), config_.ssd.storage_dir,
+      config_.ssd.ssd_backend, config_.ssd.capacity_bytes / (1024 * 1024), config_.ssd.storage_dir,
       config_.eviction.policy, config_.copy_pipeline.worker_threads,
       config_.copy_pipeline.queue_depth);
 }

--- a/src/umbp/local/tiers/local_storage_manager.cpp
+++ b/src/umbp/local/tiers/local_storage_manager.cpp
@@ -317,7 +317,7 @@ static void SetEnvVarFromConfig(const char* name, bool value) {
 }
 
 int LocalStorageManager::SpawnProxyDaemon(const std::string& shm_name) {
-  std::string bin = FindProxyBinary(config_.spdk_proxy_bin);
+  std::string bin = FindProxyBinary(config_.ssd.spdk_proxy_bin);
   MORI_UMBP_INFO("LSM: launching spdk_proxy binary '{}' for shm '{}'", bin, shm_name);
   pid_t pid = fork();
   if (pid < 0) {
@@ -330,21 +330,21 @@ int LocalStorageManager::SpawnProxyDaemon(const std::string& shm_name) {
 
     SetEnvVarFromConfig("UMBP_SPDK_PROXY_SHM", shm_name);
     SetEnvVarFromConfig("UMBP_SPDK_PROXY_MAX_CHANNELS",
-                        static_cast<int>(config_.spdk_proxy_max_channels));
+                        static_cast<int>(config_.ssd.spdk_proxy_max_channels));
     SetEnvVarFromConfig("UMBP_SPDK_PROXY_DATA_PER_CHANNEL_MB",
-                        config_.spdk_proxy_data_per_channel_mb);
+                        config_.ssd.spdk_proxy_data_per_channel_mb);
     SetEnvVarFromConfig("UMBP_SPDK_PROXY_IDLE_EXIT_TIMEOUT_MS",
-                        config_.spdk_proxy_idle_exit_timeout_ms);
-    SetEnvVarFromConfig("UMBP_SPDK_PROXY_ALLOW_BORROW", config_.spdk_proxy_allow_borrow);
+                        config_.ssd.spdk_proxy_idle_exit_timeout_ms);
+    SetEnvVarFromConfig("UMBP_SPDK_PROXY_ALLOW_BORROW", config_.ssd.spdk_proxy_allow_borrow);
     SetEnvVarFromConfig("UMBP_SPDK_PROXY_RESERVED_SHARED_BYTES",
-                        config_.spdk_proxy_reserved_shared_bytes);
+                        config_.ssd.spdk_proxy_reserved_shared_bytes);
     SetEnvVarFromConfig("UMBP_SSD_CAPACITY", config_.ssd.capacity_bytes);
-    SetEnvVarFromConfig("UMBP_SPDK_NVME_PCI", config_.spdk_nvme_pci_addr);
-    SetEnvVarFromConfig("UMBP_SPDK_NVME_CTRL", config_.spdk_nvme_ctrl_name);
-    SetEnvVarFromConfig("UMBP_SPDK_BDEV", config_.spdk_bdev_name);
-    SetEnvVarFromConfig("UMBP_SPDK_REACTOR_MASK", config_.spdk_reactor_mask);
-    SetEnvVarFromConfig("UMBP_SPDK_MEM_MB", config_.spdk_mem_size_mb);
-    SetEnvVarFromConfig("UMBP_SPDK_IO_WORKERS", config_.spdk_io_workers);
+    SetEnvVarFromConfig("UMBP_SPDK_NVME_PCI", config_.ssd.spdk_nvme_pci_addr);
+    SetEnvVarFromConfig("UMBP_SPDK_NVME_CTRL", config_.ssd.spdk_nvme_ctrl_name);
+    SetEnvVarFromConfig("UMBP_SPDK_BDEV", config_.ssd.spdk_bdev_name);
+    SetEnvVarFromConfig("UMBP_SPDK_REACTOR_MASK", config_.ssd.spdk_reactor_mask);
+    SetEnvVarFromConfig("UMBP_SPDK_MEM_MB", config_.ssd.spdk_mem_size_mb);
+    SetEnvVarFromConfig("UMBP_SPDK_IO_WORKERS", config_.ssd.spdk_io_workers);
 
     // Suppress child output unless verbose logging is requested.
     // Uses direct getenv (fork-safe, no spdlog) to check the Mori log level.
@@ -379,9 +379,10 @@ int LocalStorageManager::EnsureProxyDaemon(const std::string& shm_name) {
     MORI_UMBP_ERROR("LSM: proxy protocol version mismatch on SHM '{}'", shm_name);
     return -1;
   }
-  if (!config_.spdk_proxy_auto_start) {
+  if (!config_.ssd.spdk_proxy_auto_start) {
     if (probe == -1) {
-      return SpdkProxyTier::WaitForProxy(shm_name, config_.spdk_proxy_startup_timeout_ms) ? 0 : -1;
+      return SpdkProxyTier::WaitForProxy(shm_name, config_.ssd.spdk_proxy_startup_timeout_ms) ? 0
+                                                                                              : -1;
     }
     MORI_UMBP_ERROR("LSM: SPDK proxy absent on SHM '{}' and auto-start disabled", shm_name);
     return -1;
@@ -397,7 +398,7 @@ int LocalStorageManager::EnsureProxyDaemon(const std::string& shm_name) {
     return -1;
   }
   if (probe == -1) {
-    if (SpdkProxyTier::WaitForProxy(shm_name, config_.spdk_proxy_startup_timeout_ms)) {
+    if (SpdkProxyTier::WaitForProxy(shm_name, config_.ssd.spdk_proxy_startup_timeout_ms)) {
       return 0;
     }
 
@@ -425,7 +426,7 @@ int LocalStorageManager::EnsureProxyDaemon(const std::string& shm_name) {
   ::umbp::proxy::ProxyShmRegion::CleanupStale(shm_name);
   if (SpawnProxyDaemon(shm_name) != 0) return -1;
 
-  return SpdkProxyTier::WaitForProxy(shm_name, config_.spdk_proxy_startup_timeout_ms) ? 0 : -1;
+  return SpdkProxyTier::WaitForProxy(shm_name, config_.ssd.spdk_proxy_startup_timeout_ms) ? 0 : -1;
 }
 #endif
 
@@ -449,12 +450,12 @@ LocalStorageManager::LocalStorageManager(const UMBPConfig& config,
     std::unique_ptr<TierBackend> ssd_backend;
     bool use_proxy = false;
 
-    if (config_.ssd_backend == "spdk") {
+    if (config_.ssd.ssd_backend == "spdk") {
 #ifdef USE_SPDK
       if (role_ == UMBPRole::Standalone) {
         // Standalone with USE_SPDK compiled: try direct SPDK access first
         // (best perf, single process, no proxy overhead).
-        auto spdk_tier = std::make_unique<SpdkSsdTier>(config_);
+        auto spdk_tier = std::make_unique<SpdkSsdTier>(config_.ssd);
         if (spdk_tier->IsValid()) {
           ssd_backend = std::unique_ptr<TierBackend>(spdk_tier.release());
         } else {
@@ -473,42 +474,43 @@ LocalStorageManager::LocalStorageManager(const UMBPConfig& config,
       // (pure POSIX SHM), and the separate spdk_proxy daemon handles NVMe.
       use_proxy = true;
 #endif
-    } else if (config_.ssd_backend == "spdk_proxy") {
+    } else if (config_.ssd.ssd_backend == "spdk_proxy") {
       use_proxy = true;
     }
 
 #ifdef __linux__
     if (use_proxy && !ssd_backend) {
-      std::string proxy_shm_name = config_.spdk_proxy_shm_name;
+      std::string proxy_shm_name = config_.ssd.spdk_proxy_shm_name;
       if (proxy_shm_name.empty()) proxy_shm_name = ::umbp::proxy::kDefaultShmName;
 
       bool proxy_ready = false;
-      if (config_.spdk_proxy_auto_start) {
+      if (config_.ssd.spdk_proxy_auto_start) {
         proxy_ready = (EnsureProxyDaemon(proxy_shm_name) == 0);
       } else {
         proxy_ready =
-            SpdkProxyTier::WaitForProxy(proxy_shm_name, config_.spdk_proxy_startup_timeout_ms);
+            SpdkProxyTier::WaitForProxy(proxy_shm_name, config_.ssd.spdk_proxy_startup_timeout_ms);
       }
 
       if (proxy_ready) {
-        auto proxy_tier = std::make_unique<SpdkProxyTier>(config_);
+        auto proxy_tier = std::make_unique<SpdkProxyTier>(config_.ssd);
         if (proxy_tier->IsValid()) {
           ssd_backend = std::unique_ptr<TierBackend>(proxy_tier.release());
         }
       }
 
       if (!ssd_backend) {
-        bool explicit_spdk = (config_.ssd_backend == "spdk" || config_.ssd_backend == "spdk_proxy");
+        bool explicit_spdk =
+            (config_.ssd.ssd_backend == "spdk" || config_.ssd.ssd_backend == "spdk_proxy");
         if (explicit_spdk) {
           throw std::runtime_error(
-              "UMBP_SSD_BACKEND=" + config_.ssd_backend + ": SPDK proxy connect failed (shm=" +
+              "UMBP_SSD_BACKEND=" + config_.ssd.ssd_backend + ": SPDK proxy connect failed (shm=" +
               proxy_shm_name + "). Run 'tools/umbp_spdk_preflight.sh --pci <addr>' to diagnose.");
         }
         fprintf(stderr, "[UMBP WARN] SPDK proxy connect failed. Falling back to POSIX SSD.\n");
       }
     }
 #endif
-    if (!ssd_backend && config_.ssd_backend == "dummy_storage") {
+    if (!ssd_backend && config_.ssd.ssd_backend == "dummy_storage") {
       ssd_backend = std::make_unique<DummySsdTier>(config_.ssd.capacity_bytes);
     }
 

--- a/src/umbp/local/tiers/local_storage_manager.cpp
+++ b/src/umbp/local/tiers/local_storage_manager.cpp
@@ -518,7 +518,7 @@ LocalStorageManager::LocalStorageManager(const UMBPConfig& config,
         segmented_access_mode = SSDAccessMode::ReadOnlyShared;
       }
       ssd_backend = std::make_unique<SSDTier>(config_.ssd.storage_dir, config_.ssd.capacity_bytes,
-                                              config_, segmented_access_mode);
+                                              config_.ssd, segmented_access_mode);
     }
     tiers_.push_back({StorageTier::LOCAL_SSD, std::move(ssd_backend)});
   }

--- a/src/umbp/local/tiers/spdk_proxy_tier.cpp
+++ b/src/umbp/local/tiers/spdk_proxy_tier.cpp
@@ -74,7 +74,7 @@ std::chrono::milliseconds ProxyPollInterval() {
 // ---------------------------------------------------------------------------
 // Construction / Destruction
 // ---------------------------------------------------------------------------
-SpdkProxyTier::SpdkProxyTier(const UMBPConfig& config) : TierBackend(StorageTier::LOCAL_SSD) {
+SpdkProxyTier::SpdkProxyTier(const UMBPSsdConfig& config) : TierBackend(StorageTier::LOCAL_SSD) {
   std::string shm_name = config.spdk_proxy_shm_name;
   if (shm_name.empty()) shm_name = kDefaultShmName;
   tenant_id_ = config.spdk_proxy_tenant_id;

--- a/src/umbp/local/tiers/spdk_ssd_tier.cpp
+++ b/src/umbp/local/tiers/spdk_ssd_tier.cpp
@@ -92,10 +92,10 @@ SpdkSsdTier::SharedDmaPool SpdkSsdTier::EnsureDmaPool() {
   return dma_pool_;
 }
 
-SpdkSsdTier::SpdkSsdTier(const UMBPConfig& config)
-    : SpdkSsdTier(config, 0, config.ssd.capacity_bytes, nullptr) {}
+SpdkSsdTier::SpdkSsdTier(const UMBPSsdConfig& config)
+    : SpdkSsdTier(config, 0, config.capacity_bytes, nullptr) {}
 
-SpdkSsdTier::SpdkSsdTier(const UMBPConfig& config, uint64_t base_offset, size_t capacity_bytes,
+SpdkSsdTier::SpdkSsdTier(const UMBPSsdConfig& config, uint64_t base_offset, size_t capacity_bytes,
                          SharedDmaPool shared_dma_pool)
     : TierBackend(StorageTier::LOCAL_SSD) {
   auto& env = ::umbp::SpdkEnv::Instance();

--- a/src/umbp/local/tiers/ssd_tier.cpp
+++ b/src/umbp/local/tiers/ssd_tier.cpp
@@ -37,21 +37,21 @@ namespace fs = std::filesystem;
 
 namespace mori::umbp {
 
-SSDTier::SSDTier(const std::string& dir, size_t capacity, const UMBPConfig& config,
+SSDTier::SSDTier(const std::string& dir, size_t capacity, const UMBPSsdConfig& ssd_config,
                  SSDAccessMode access_mode)
     : TierBackend(StorageTier::LOCAL_SSD),
       dir_(dir),
       capacity_(capacity),
-      config_(config),
+      ssd_config_(ssd_config),
       access_mode_(access_mode),
-      io_driver_(CreateStorageIoDriver(config.ssd.io.backend,
-                                       static_cast<uint32_t>(config.ssd.io.queue_depth))),
+      io_driver_(CreateStorageIoDriver(ssd_config.io.backend,
+                                       static_cast<uint32_t>(ssd_config.io.queue_depth))),
       index_(capacity) {
   std::string error_message;
-  if (!config_.Validate(&error_message)) {
-    throw std::runtime_error("invalid UMBP config: " + error_message);
+  if (!ssd_config_.Validate(&error_message)) {
+    throw std::runtime_error("invalid UMBP SSD config: " + error_message);
   }
-  if (config_.ssd.io.backend == UMBPIoBackend::IoUring &&
+  if (ssd_config_.io.backend == UMBPIoBackend::IoUring &&
       !io_driver_->Capabilities().native_async) {
     MORI_UMBP_WARN(
         "SSDTier: io_uring backend requested but unavailable (kernel missing io_uring "
@@ -120,7 +120,7 @@ bool SSDTier::EnsureActiveSegment(size_t need_bytes) {
   }
   if (!seg) return false;
 
-  if (seg->write_offset + need_bytes <= config_.ssd.segment_size_bytes) return true;
+  if (seg->write_offset + need_bytes <= ssd_config_.segment_size_bytes) return true;
 
   uint64_t new_id = index_.next_segment_id();
   if (!OpenOrCreateSegmentLocked(new_id)) return false;
@@ -197,7 +197,7 @@ bool SSDTier::WriteBatch(const std::vector<std::string>& keys,
   for (size_t i = 0; i < keys.size(); ++i) {
     total_bytes += sizeof(segment::RecordHeader) + keys[i].size() + sizes[i];
   }
-  if (total_bytes > config_.ssd.segment_size_bytes) {
+  if (total_bytes > ssd_config_.segment_size_bytes) {
     bool all_ok = true;
     for (size_t i = 0; i < keys.size(); ++i) {
       if (!Write(keys[i], data_ptrs[i], sizes[i])) all_ok = false;

--- a/src/umbp/storage/spdk/proxy/spdk_proxy_daemon.cpp
+++ b/src/umbp/storage/spdk/proxy/spdk_proxy_daemon.cpp
@@ -282,7 +282,7 @@ struct TenantRuntime {
 
 class TenantRegistry {
  public:
-  TenantRegistry(ProxyShmRegion& shm, const UMBPConfig& tier_cfg, size_t total_capacity_bytes,
+  TenantRegistry(ProxyShmRegion& shm, const UMBPSsdConfig& tier_cfg, size_t total_capacity_bytes,
                  size_t reserved_shared_bytes, size_t default_tenant_quota_bytes,
                  uint32_t block_size, bool allow_borrow, bool write_back, uint64_t tenant_grace_ms,
                  SpdkSsdTier::SharedDmaPool shared_dma_pool)
@@ -605,7 +605,7 @@ class TenantRegistry {
   }
 
   ProxyShmRegion& shm_;
-  UMBPConfig tier_cfg_;
+  UMBPSsdConfig tier_cfg_;
   size_t total_capacity_bytes_ = 0;
   size_t reserved_shared_bytes_ = 0;
   size_t usable_capacity_bytes_ = 0;
@@ -1302,7 +1302,7 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  UMBPConfig tier_cfg;
+  UMBPSsdConfig tier_cfg;
   tier_cfg.ssd_backend = "spdk";
   tier_cfg.spdk_bdev_name = bdev_name;
   tier_cfg.spdk_reactor_mask = reactor_mask;
@@ -1310,7 +1310,7 @@ int main(int argc, char** argv) {
   tier_cfg.spdk_nvme_pci_addr = nvme_pci;
   tier_cfg.spdk_nvme_ctrl_name = nvme_ctrl;
   tier_cfg.spdk_io_workers = io_workers;
-  tier_cfg.ssd.capacity_bytes = service_capacity;
+  tier_cfg.capacity_bytes = service_capacity;
 
   auto shared_dma_pool =
       SpdkSsdTier::CreateSharedDmaPool(2ULL * 1024 * 1024, 128 * std::max(1, io_workers));

--- a/src/umbp/tests/CMakeLists.txt
+++ b/src/umbp/tests/CMakeLists.txt
@@ -159,3 +159,16 @@ target_link_libraries(
 target_compile_features(test_peer_ssd_read_rpc PRIVATE cxx_std_17)
 
 gtest_discover_tests(test_peer_ssd_read_rpc)
+
+# ---------------------------------------------------------------------------
+# test_ssd_read_lease_gating — pure reader-side lease gating decision logic
+# (ssd_read_lease.h).  Header-only under test (no gRPC / RDMA deps).
+# ---------------------------------------------------------------------------
+add_executable(test_ssd_read_lease_gating test_ssd_read_lease_gating.cpp)
+
+target_link_libraries(test_ssd_read_lease_gating PRIVATE umbp_common
+                                                         GTest::gtest_main)
+
+target_compile_features(test_ssd_read_lease_gating PRIVATE cxx_std_17)
+
+gtest_discover_tests(test_ssd_read_lease_gating)

--- a/src/umbp/tests/CMakeLists.txt
+++ b/src/umbp/tests/CMakeLists.txt
@@ -93,3 +93,15 @@ target_link_libraries(test_router_dedup PRIVATE umbp_common GTest::gtest_main)
 target_compile_features(test_router_dedup PRIVATE cxx_std_17)
 
 gtest_discover_tests(test_router_dedup)
+
+# ---------------------------------------------------------------------------
+# test_peer_ssd_manager — Phase 1 SSD tier ownership + owned-location source
+# ---------------------------------------------------------------------------
+add_executable(test_peer_ssd_manager test_peer_ssd_manager.cpp)
+
+target_link_libraries(test_peer_ssd_manager PRIVATE umbp_common
+                                                    GTest::gtest_main)
+
+target_compile_features(test_peer_ssd_manager PRIVATE cxx_std_17)
+
+gtest_discover_tests(test_peer_ssd_manager)

--- a/src/umbp/tests/CMakeLists.txt
+++ b/src/umbp/tests/CMakeLists.txt
@@ -105,3 +105,15 @@ target_link_libraries(test_peer_ssd_manager PRIVATE umbp_common
 target_compile_features(test_peer_ssd_manager PRIVATE cxx_std_17)
 
 gtest_discover_tests(test_peer_ssd_manager)
+
+# ---------------------------------------------------------------------------
+# test_ssd_copy_pipeline — Phase 2 DramCopyPin + async copy-on-commit pipeline
+# ---------------------------------------------------------------------------
+add_executable(test_ssd_copy_pipeline test_ssd_copy_pipeline.cpp)
+
+target_link_libraries(test_ssd_copy_pipeline PRIVATE umbp_common
+                                                     GTest::gtest_main)
+
+target_compile_features(test_ssd_copy_pipeline PRIVATE cxx_std_17)
+
+gtest_discover_tests(test_ssd_copy_pipeline)

--- a/src/umbp/tests/CMakeLists.txt
+++ b/src/umbp/tests/CMakeLists.txt
@@ -117,3 +117,33 @@ target_link_libraries(test_ssd_copy_pipeline PRIVATE umbp_common
 target_compile_features(test_ssd_copy_pipeline PRIVATE cxx_std_17)
 
 gtest_discover_tests(test_ssd_copy_pipeline)
+
+# ---------------------------------------------------------------------------
+# test_tier_priority_route_get — Phase 3 RouteGet tier-priority strategy
+# ---------------------------------------------------------------------------
+add_executable(test_tier_priority_route_get test_tier_priority_route_get.cpp)
+
+target_link_libraries(test_tier_priority_route_get PRIVATE umbp_common
+                                                           GTest::gtest_main)
+
+target_compile_features(test_tier_priority_route_get PRIVATE cxx_std_17)
+
+gtest_discover_tests(test_tier_priority_route_get)
+
+# ---------------------------------------------------------------------------
+# test_peer_ssd_read_rpc — Phase 3 SSD read RPC over a gRPC loopback (status
+# distinctions: OK / NOT_FOUND / NO_SLOT / SIZE_TOO_LARGE + slot lifecycle).
+# Needs the gRPC peer service + generated stubs (umbp_core) and protobuf/gRPC.
+# ---------------------------------------------------------------------------
+add_executable(test_peer_ssd_read_rpc test_peer_ssd_read_rpc.cpp)
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  target_link_options(test_peer_ssd_read_rpc PRIVATE -Wl,--no-as-needed)
+endif()
+
+target_link_libraries(
+  test_peer_ssd_read_rpc PRIVATE umbp_core umbp_common ${_PROTOBUF_LIB}
+                                 ${_GRPCPP_LIB} GTest::gtest_main)
+
+target_compile_features(test_peer_ssd_read_rpc PRIVATE cxx_std_17)
+
+gtest_discover_tests(test_peer_ssd_read_rpc)

--- a/src/umbp/tests/CMakeLists.txt
+++ b/src/umbp/tests/CMakeLists.txt
@@ -172,3 +172,17 @@ target_link_libraries(test_ssd_read_lease_gating PRIVATE umbp_common
 target_compile_features(test_ssd_read_lease_gating PRIVATE cxx_std_17)
 
 gtest_discover_tests(test_ssd_read_lease_gating)
+
+# ---------------------------------------------------------------------------
+# test_ssd_reliability — cross-component reliability: owned-source
+# DRAM+SSD merge, SSD evict -> REMOVE -> master index convergence, tier-priority
+# over the real index, crash-restart discard, and observability counters.
+# ---------------------------------------------------------------------------
+add_executable(test_ssd_reliability test_ssd_reliability.cpp)
+
+target_link_libraries(test_ssd_reliability PRIVATE umbp_common
+                                                   GTest::gtest_main)
+
+target_compile_features(test_ssd_reliability PRIVATE cxx_std_17)
+
+gtest_discover_tests(test_ssd_reliability)

--- a/src/umbp/tests/CMakeLists.txt
+++ b/src/umbp/tests/CMakeLists.txt
@@ -107,6 +107,18 @@ target_compile_features(test_peer_ssd_manager PRIVATE cxx_std_17)
 gtest_discover_tests(test_peer_ssd_manager)
 
 # ---------------------------------------------------------------------------
+# test_peer_ssd_eviction — Phase 4 LRU + watermark eviction + in-flight guard
+# ---------------------------------------------------------------------------
+add_executable(test_peer_ssd_eviction test_peer_ssd_eviction.cpp)
+
+target_link_libraries(test_peer_ssd_eviction PRIVATE umbp_common
+                                                     GTest::gtest_main)
+
+target_compile_features(test_peer_ssd_eviction PRIVATE cxx_std_17)
+
+gtest_discover_tests(test_peer_ssd_eviction)
+
+# ---------------------------------------------------------------------------
 # test_ssd_copy_pipeline — Phase 2 DramCopyPin + async copy-on-commit pipeline
 # ---------------------------------------------------------------------------
 add_executable(test_ssd_copy_pipeline test_ssd_copy_pipeline.cpp)

--- a/src/umbp/tests/CMakeLists.txt
+++ b/src/umbp/tests/CMakeLists.txt
@@ -95,7 +95,7 @@ target_compile_features(test_router_dedup PRIVATE cxx_std_17)
 gtest_discover_tests(test_router_dedup)
 
 # ---------------------------------------------------------------------------
-# test_peer_ssd_manager — Phase 1 SSD tier ownership + owned-location source
+# test_peer_ssd_manager — SSD tier ownership + owned-location source
 # ---------------------------------------------------------------------------
 add_executable(test_peer_ssd_manager test_peer_ssd_manager.cpp)
 
@@ -107,7 +107,7 @@ target_compile_features(test_peer_ssd_manager PRIVATE cxx_std_17)
 gtest_discover_tests(test_peer_ssd_manager)
 
 # ---------------------------------------------------------------------------
-# test_peer_ssd_eviction — Phase 4 LRU + watermark eviction + in-flight guard
+# test_peer_ssd_eviction — LRU + watermark eviction + in-flight guard
 # ---------------------------------------------------------------------------
 add_executable(test_peer_ssd_eviction test_peer_ssd_eviction.cpp)
 
@@ -119,7 +119,7 @@ target_compile_features(test_peer_ssd_eviction PRIVATE cxx_std_17)
 gtest_discover_tests(test_peer_ssd_eviction)
 
 # ---------------------------------------------------------------------------
-# test_ssd_copy_pipeline — Phase 2 DramCopyPin + async copy-on-commit pipeline
+# test_ssd_copy_pipeline — DramCopyPin + async copy-on-commit pipeline
 # ---------------------------------------------------------------------------
 add_executable(test_ssd_copy_pipeline test_ssd_copy_pipeline.cpp)
 
@@ -131,7 +131,7 @@ target_compile_features(test_ssd_copy_pipeline PRIVATE cxx_std_17)
 gtest_discover_tests(test_ssd_copy_pipeline)
 
 # ---------------------------------------------------------------------------
-# test_tier_priority_route_get — Phase 3 RouteGet tier-priority strategy
+# test_tier_priority_route_get — RouteGet tier-priority strategy
 # ---------------------------------------------------------------------------
 add_executable(test_tier_priority_route_get test_tier_priority_route_get.cpp)
 
@@ -143,7 +143,7 @@ target_compile_features(test_tier_priority_route_get PRIVATE cxx_std_17)
 gtest_discover_tests(test_tier_priority_route_get)
 
 # ---------------------------------------------------------------------------
-# test_peer_ssd_read_rpc — Phase 3 SSD read RPC over a gRPC loopback (status
+# test_peer_ssd_read_rpc — SSD read RPC over a gRPC loopback (status
 # distinctions: OK / NOT_FOUND / NO_SLOT / SIZE_TOO_LARGE + slot lifecycle).
 # Needs the gRPC peer service + generated stubs (umbp_core) and protobuf/gRPC.
 # ---------------------------------------------------------------------------
@@ -174,9 +174,9 @@ target_compile_features(test_ssd_read_lease_gating PRIVATE cxx_std_17)
 gtest_discover_tests(test_ssd_read_lease_gating)
 
 # ---------------------------------------------------------------------------
-# test_ssd_reliability — cross-component reliability: owned-source
-# DRAM+SSD merge, SSD evict -> REMOVE -> master index convergence, tier-priority
-# over the real index, crash-restart discard, and observability counters.
+# test_ssd_reliability — cross-component reliability: owned-source DRAM+SSD
+# merge, SSD evict -> REMOVE -> master index convergence, tier-priority over the
+# real index, crash-restart discard, and observability counters.
 # ---------------------------------------------------------------------------
 add_executable(test_ssd_reliability test_ssd_reliability.cpp)
 

--- a/src/umbp/tests/test_global_block_index_events.cpp
+++ b/src/umbp/tests/test_global_block_index_events.cpp
@@ -114,6 +114,24 @@ TEST(GlobalBlockIndexEvents, RemoveUnknownIsNoop) {
   EXPECT_EQ(idx.ApplyEvents("ghost", {Remove("ghost-key", TierType::DRAM)}), 0u);
 }
 
+// A key mirrored on both DRAM and SSD of one node: a DRAM eviction
+// (REMOVE DRAM) must drop only the DRAM bucket and leave the SSD location
+// readable.  This is the additive-index invariant the Phase 4 SSD tier relies
+// on (DRAM evict never touches the SSD copy); no master code is exercised here
+// beyond ApplyEvents.
+TEST(GlobalBlockIndexEvents, RemoveDramKeepsSsdBucket) {
+  GlobalBlockIndex idx;
+  idx.ApplyEvents("node-A", {Add("k", TierType::DRAM, 100), Add("k", TierType::SSD, 100)});
+  ASSERT_TRUE(HasLocation(idx.Lookup("k"), "node-A", TierType::DRAM, 100));
+  ASSERT_TRUE(HasLocation(idx.Lookup("k"), "node-A", TierType::SSD, 100));
+
+  idx.ApplyEvents("node-A", {Remove("k", TierType::DRAM)});
+
+  auto locs = idx.Lookup("k");
+  EXPECT_FALSE(HasLocation(locs, "node-A", TierType::DRAM, 100));  // DRAM bucket gone
+  EXPECT_TRUE(HasLocation(locs, "node-A", TierType::SSD, 100));    // SSD bucket retained
+}
+
 TEST(GlobalBlockIndexEvents, ClearAtTierClearsOnlyTargetNodeTier) {
   GlobalBlockIndex idx;
   idx.ApplyEvents("node-A", {Add("k1", TierType::DRAM, 1), Add("k2", TierType::SSD, 2),

--- a/src/umbp/tests/test_global_block_index_events.cpp
+++ b/src/umbp/tests/test_global_block_index_events.cpp
@@ -116,7 +116,7 @@ TEST(GlobalBlockIndexEvents, RemoveUnknownIsNoop) {
 
 // A key mirrored on both DRAM and SSD of one node: a DRAM eviction
 // (REMOVE DRAM) must drop only the DRAM bucket and leave the SSD location
-// readable.  This is the additive-index invariant the Phase 4 SSD tier relies
+// readable.  This is the additive-index invariant the SSD tier relies
 // on (DRAM evict never touches the SSD copy); no master code is exercised here
 // beyond ApplyEvents.
 TEST(GlobalBlockIndexEvents, RemoveDramKeepsSsdBucket) {

--- a/src/umbp/tests/test_peer_dram_allocator.cpp
+++ b/src/umbp/tests/test_peer_dram_allocator.cpp
@@ -333,29 +333,6 @@ TEST(PeerDramAllocator, SnapshotOwnedKeysReturnsEveryAdd) {
   EXPECT_TRUE(a->DrainPendingEvents().empty());
 }
 
-TEST(PeerDramAllocator, SnapshotOwnedKeysTracksExternalSsdEvents) {
-  auto a = MakeAllocator();
-  a->QueueExternalEvent(KvEvent{KvEvent::Kind::ADD, "ssd-a", TierType::SSD, 123});
-  a->QueueExternalEvent(KvEvent{KvEvent::Kind::ADD, "ssd-b", TierType::SSD, 456});
-
-  auto snap = a->SnapshotOwnedKeys();
-  ASSERT_EQ(snap.size(), 2u);
-  EXPECT_TRUE(std::any_of(snap.begin(), snap.end(), [](const KvEvent& ev) {
-    return ev.key == "ssd-a" && ev.tier == TierType::SSD && ev.size == 123;
-  }));
-  EXPECT_TRUE(std::any_of(snap.begin(), snap.end(), [](const KvEvent& ev) {
-    return ev.key == "ssd-b" && ev.tier == TierType::SSD && ev.size == 456;
-  }));
-
-  a->QueueExternalEvent(KvEvent{KvEvent::Kind::REMOVE, "ssd-a", TierType::SSD, 0});
-  snap = a->SnapshotOwnedKeys();
-  ASSERT_EQ(snap.size(), 1u);
-  EXPECT_EQ(snap[0].key, "ssd-b");
-
-  a->QueueExternalEvent(KvEvent{KvEvent::Kind::CLEAR_AT_TIER, "", TierType::SSD, 0});
-  EXPECT_TRUE(a->SnapshotOwnedKeys().empty());
-}
-
 // ---- Buffer descs filtered to the page set ---------------------------------
 
 TEST(PeerDramAllocator, BufferDescsForPagesDedupAndOrder) {

--- a/src/umbp/tests/test_peer_ssd_eviction.cpp
+++ b/src/umbp/tests/test_peer_ssd_eviction.cpp
@@ -1,0 +1,406 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Phase 4: SSD local capacity management + eviction.  Drives PeerSsdManager
+// through a controllable in-memory TierBackend (the test-only constructor) so
+// LRU ordering, watermark eviction, the in-flight-read guard, idempotent Write,
+// backend-evict failure, concurrent eviction, and physical Clear are all
+// deterministic without real disk IO.
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "umbp/distributed/peer/peer_ssd_manager.h"
+#include "umbp/local/tiers/tier_backend.h"
+
+namespace mori::umbp {
+namespace {
+
+// In-memory TierBackend with test hooks: blockable reads (to hold the in-flight
+// guard), forced evict failure, and call counters.
+class FakeBackend : public TierBackend {
+ public:
+  explicit FakeBackend(size_t capacity)
+      : TierBackend(StorageTier::LOCAL_SSD), capacity_(capacity) {}
+
+  bool Write(const std::string& key, const void* data, size_t size) override {
+    std::lock_guard<std::mutex> lk(mu_);
+    ++write_calls_;
+    auto it = store_.find(key);
+    size_t prev = (it == store_.end()) ? 0 : it->second.size();
+    if (used_ - prev + size > capacity_) return false;  // ENOSPC
+    store_[key].assign(static_cast<const char*>(data), static_cast<const char*>(data) + size);
+    used_ = used_ - prev + size;
+    return true;
+  }
+
+  bool ReadIntoPtr(const std::string& key, uintptr_t dst, size_t size) override {
+    {
+      std::unique_lock<std::mutex> lk(gate_mu_);
+      ++reads_started_;
+      started_cv_.notify_all();
+      gate_cv_.wait(lk, [this] { return !read_blocked_; });
+    }
+    std::lock_guard<std::mutex> lk(mu_);
+    auto it = store_.find(key);
+    if (it == store_.end() || it->second.size() != size) return false;
+    std::memcpy(reinterpret_cast<void*>(dst), it->second.data(), size);
+    return true;
+  }
+
+  bool Exists(const std::string& key) const override {
+    std::lock_guard<std::mutex> lk(mu_);
+    return store_.count(key) != 0;
+  }
+
+  bool Evict(const std::string& key) override {
+    std::lock_guard<std::mutex> lk(mu_);
+    if (fail_evict_) return false;
+    auto it = store_.find(key);
+    if (it == store_.end()) return false;
+    used_ -= it->second.size();
+    store_.erase(it);
+    return true;
+  }
+
+  std::pair<size_t, size_t> Capacity() const override {
+    std::lock_guard<std::mutex> lk(mu_);
+    return {used_, capacity_};
+  }
+
+  void Clear() override {
+    std::lock_guard<std::mutex> lk(mu_);
+    ++clear_calls_;
+    store_.clear();
+    used_ = 0;
+  }
+
+  // --- test controls ---
+  void BlockReads() {
+    std::lock_guard<std::mutex> lk(gate_mu_);
+    read_blocked_ = true;
+  }
+  void UnblockReads() {
+    {
+      std::lock_guard<std::mutex> lk(gate_mu_);
+      read_blocked_ = false;
+    }
+    gate_cv_.notify_all();
+  }
+  void WaitReadsStarted(int n) {
+    std::unique_lock<std::mutex> lk(gate_mu_);
+    started_cv_.wait(lk, [&] { return reads_started_ >= n; });
+  }
+  void SetFailEvict(bool f) {
+    std::lock_guard<std::mutex> lk(mu_);
+    fail_evict_ = f;
+  }
+  int write_calls() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return write_calls_;
+  }
+  int clear_calls() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return clear_calls_;
+  }
+
+ private:
+  mutable std::mutex mu_;
+  std::unordered_map<std::string, std::vector<char>> store_;
+  size_t used_ = 0;
+  size_t capacity_;
+  int write_calls_ = 0;
+  int clear_calls_ = 0;
+  bool fail_evict_ = false;
+
+  std::mutex gate_mu_;
+  std::condition_variable gate_cv_;
+  std::condition_variable started_cv_;
+  bool read_blocked_ = false;
+  int reads_started_ = 0;
+};
+
+std::vector<std::pair<const void*, size_t>> OneSeg(const std::string& s) {
+  return {{s.data(), s.size()}};
+}
+
+// Manager owning a FakeBackend we keep a raw pointer to for test inspection.
+struct Harness {
+  FakeBackend* backend;
+  std::unique_ptr<PeerSsdManager> mgr;
+};
+
+Harness MakeHarness(size_t capacity, double high = 0.9, double low = 0.7) {
+  auto be = std::make_unique<FakeBackend>(capacity);
+  FakeBackend* raw = be.get();
+  return Harness{raw, std::make_unique<PeerSsdManager>(std::move(be), high, low)};
+}
+
+int CountKind(const std::vector<KvEvent>& events, KvEvent::Kind kind) {
+  int n = 0;
+  for (const auto& e : events) {
+    if (e.kind == kind && e.tier == TierType::SSD) ++n;
+  }
+  return n;
+}
+
+bool HasRemove(const std::vector<KvEvent>& events, const std::string& key) {
+  for (const auto& e : events) {
+    if (e.kind == KvEvent::Kind::REMOVE && e.tier == TierType::SSD && e.key == key) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+
+TEST(PeerSsdEviction, WriteAndPrepareReadRefreshLru) {
+  auto h = MakeHarness(/*capacity=*/1'000'000);
+  ASSERT_TRUE(h.mgr->Write("A", OneSeg("aaaa"), 4));
+  ASSERT_TRUE(h.mgr->Write("B", OneSeg("bbbb"), 4));
+  ASSERT_TRUE(h.mgr->Write("C", OneSeg("cccc"), 4));
+
+  // LRU now (oldest->newest): A, B, C.  Reading A promotes it to MRU, so the
+  // oldest becomes B and SelectVictims must pick B first (not the just-read A).
+  std::vector<char> buf(4);
+  auto out = h.mgr->PrepareRead("A", buf.data(), buf.size());
+  ASSERT_EQ(out.status, SsdReadStatus::kOk);
+  EXPECT_EQ(std::string(buf.data(), out.size), "aaaa");
+
+  auto victims = h.mgr->SelectVictims(/*bytes_to_free=*/1);
+  ASSERT_FALSE(victims.empty());
+  EXPECT_EQ(victims.front(), "B");
+  EXPECT_NE(victims.front(), "A");
+}
+
+TEST(PeerSsdEviction, WatermarkTriggersEvictionDownToLow) {
+  // capacity 1000, high 0.9 (=>900), low 0.7 (=>700); 100-byte values.
+  auto h = MakeHarness(/*capacity=*/1000, /*high=*/0.9, /*low=*/0.7);
+  std::string val(100, 'x');
+  for (int i = 1; i <= 9; ++i) {
+    ASSERT_TRUE(h.mgr->Write("k" + std::to_string(i), OneSeg(val), val.size()));
+  }
+  // After k9: used hit 900 >= high -> evict oldest down to <= 700.
+  auto [used, total] = h.mgr->Capacity();
+  EXPECT_EQ(total, 1000u);
+  EXPECT_LE(used, 700u);
+
+  // Oldest (k1, k2) evicted first; newest still present.
+  EXPECT_FALSE(h.mgr->Exists("k1"));
+  EXPECT_FALSE(h.mgr->Exists("k2"));
+  EXPECT_TRUE(h.mgr->Exists("k9"));
+
+  auto events = h.mgr->DrainPendingEvents();
+  EXPECT_TRUE(HasRemove(events, "k1"));
+  EXPECT_TRUE(HasRemove(events, "k2"));
+  EXPECT_EQ(CountKind(events, KvEvent::Kind::REMOVE), 2);
+}
+
+TEST(PeerSsdEviction, EnospcTriggersEvictThenRetry) {
+  // Fill to 800/1000 (below the 0.9 high watermark, so no watermark eviction
+  // fires during the fill), then write a 300-byte value that overflows the
+  // device: backend Write -> ENOSPC -> one evict round (frees the oldest down
+  // to the 0.5 low watermark) -> retry succeeds.  After the retry used is 800,
+  // still below high, so no second round disturbs the just-written key.
+  auto h = MakeHarness(/*capacity=*/1000, /*high=*/0.9, /*low=*/0.5);
+  for (int i = 1; i <= 8; ++i) {
+    ASSERT_TRUE(h.mgr->Write("k" + std::to_string(i), OneSeg(std::string(100, 'a')), 100));
+  }
+  ASSERT_TRUE(h.mgr->Write("big", OneSeg(std::string(300, 'c')), 300));
+  EXPECT_TRUE(h.mgr->Exists("big"));
+  EXPECT_FALSE(h.mgr->Exists("k1"));  // oldest reclaimed to make room
+  EXPECT_LE(h.mgr->Capacity().first, 1000u);
+}
+
+TEST(PeerSsdEviction, InFlightReadIsNotEvicted) {
+  auto h = MakeHarness(/*capacity=*/1'000'000);
+  const std::string val = "payload-payload";
+  ASSERT_TRUE(h.mgr->Write("K", OneSeg(val), val.size()));
+
+  h.backend->BlockReads();
+  std::vector<char> buf(val.size());
+  SsdReadOutcome out{};
+  std::thread reader([&] { out = h.mgr->PrepareRead("K", buf.data(), buf.size()); });
+  h.backend->WaitReadsStarted(1);  // PrepareRead has marked K in-flight and is blocked in the read
+
+  // Eviction must skip a key that is being read.
+  EXPECT_FALSE(h.mgr->Evict("K"));
+  EXPECT_TRUE(h.mgr->SelectVictims(1'000'000).empty());
+  EXPECT_TRUE(h.mgr->Exists("K"));
+
+  h.backend->UnblockReads();
+  reader.join();
+  EXPECT_EQ(out.status, SsdReadStatus::kOk);
+  EXPECT_EQ(std::string(buf.data(), out.size), val);
+
+  // Once the read finished, the key can be evicted.
+  EXPECT_TRUE(h.mgr->Evict("K"));
+  EXPECT_FALSE(h.mgr->Exists("K"));
+}
+
+TEST(PeerSsdEviction, StaleRouteReadAfterEvictIsNotFound) {
+  auto h = MakeHarness(/*capacity=*/1'000'000);
+  ASSERT_TRUE(h.mgr->Write("K", OneSeg("data"), 4));
+  ASSERT_TRUE(h.mgr->Evict("K"));
+
+  std::vector<char> buf(4);
+  auto out = h.mgr->PrepareRead("K", buf.data(), buf.size());
+  EXPECT_EQ(out.status, SsdReadStatus::kNotFound);
+}
+
+TEST(PeerSsdEviction, DuplicateWriteIsIdempotent) {
+  auto h = MakeHarness(/*capacity=*/1'000'000);
+  ASSERT_TRUE(h.mgr->Write("K", OneSeg("data"), 4));
+  ASSERT_TRUE(h.mgr->Write("K", OneSeg("data"), 4));  // same content-addressed key
+
+  EXPECT_EQ(h.backend->write_calls(), 1);  // no second backend write
+  auto events = h.mgr->DrainPendingEvents();
+  EXPECT_EQ(CountKind(events, KvEvent::Kind::ADD), 1);  // no duplicate ADD SSD
+}
+
+TEST(PeerSsdEviction, BackendEvictFailureKeepsMetadata) {
+  auto h = MakeHarness(/*capacity=*/1'000'000);
+  ASSERT_TRUE(h.mgr->Write("K", OneSeg("data"), 4));
+  h.mgr->DrainPendingEvents();  // discard ADD
+
+  h.backend->SetFailEvict(true);
+  EXPECT_FALSE(h.mgr->Evict("K"));
+  EXPECT_TRUE(h.mgr->Exists("K"));                   // kept for retry
+  EXPECT_TRUE(h.mgr->DrainPendingEvents().empty());  // no REMOVE emitted
+
+  h.backend->SetFailEvict(false);
+  EXPECT_TRUE(h.mgr->Evict("K"));  // retry succeeds
+  EXPECT_FALSE(h.mgr->Exists("K"));
+  auto events = h.mgr->DrainPendingEvents();
+  EXPECT_EQ(CountKind(events, KvEvent::Kind::REMOVE), 1);
+}
+
+TEST(PeerSsdEviction, ConcurrentEvictOfSameKeyRemovesOnce) {
+  auto h = MakeHarness(/*capacity=*/1'000'000);
+  ASSERT_TRUE(h.mgr->Write("K", OneSeg("data"), 4));
+  h.mgr->DrainPendingEvents();
+
+  std::atomic<int> wins{0};
+  std::vector<std::thread> threads;
+  for (int i = 0; i < 4; ++i) {
+    threads.emplace_back([&] {
+      if (h.mgr->Evict("K")) wins.fetch_add(1);
+    });
+  }
+  for (auto& t : threads) t.join();
+
+  EXPECT_EQ(wins.load(), 1);  // exactly one evictor wins
+  EXPECT_FALSE(h.mgr->Exists("K"));
+  auto events = h.mgr->DrainPendingEvents();
+  EXPECT_EQ(CountKind(events, KvEvent::Kind::REMOVE), 1);  // no double REMOVE
+}
+
+TEST(PeerSsdEviction, ClearLocalWipesPhysicalBytes) {
+  auto h = MakeHarness(/*capacity=*/1'000'000);
+  ASSERT_TRUE(h.mgr->Write("a", OneSeg("1111"), 4));
+  ASSERT_TRUE(h.mgr->Write("b", OneSeg("2222"), 4));
+
+  h.mgr->ClearLocal();
+
+  EXPECT_EQ(h.backend->clear_calls(), 1);  // physical wipe happened
+  EXPECT_FALSE(h.mgr->Exists("a"));
+  EXPECT_FALSE(h.mgr->Exists("b"));
+  EXPECT_TRUE(h.mgr->SnapshotOwnedKeys().empty());
+  auto [used, total] = h.mgr->Capacity();
+  EXPECT_EQ(used, 0u);
+}
+
+TEST(PeerSsdEviction, ClearLocalWaitsForInFlightRead) {
+  auto h = MakeHarness(/*capacity=*/1'000'000);
+  const std::string val = "read-priority";
+  ASSERT_TRUE(h.mgr->Write("K", OneSeg(val), val.size()));
+
+  h.backend->BlockReads();
+  std::vector<char> buf(val.size());
+  SsdReadOutcome out{};
+  std::thread reader([&] { out = h.mgr->PrepareRead("K", buf.data(), buf.size()); });
+  h.backend->WaitReadsStarted(1);
+
+  std::thread clearer([&] { h.mgr->ClearLocal(); });
+
+  // The read is in flight; let it complete, then ClearLocal may wipe.  If
+  // ClearLocal had wiped the backend before the read finished, the read would
+  // return kError instead of the correct bytes — so kOk proves read priority.
+  h.backend->UnblockReads();
+  reader.join();
+  clearer.join();
+
+  EXPECT_EQ(out.status, SsdReadStatus::kOk);
+  EXPECT_EQ(std::string(buf.data(), out.size), val);
+  EXPECT_EQ(h.backend->clear_calls(), 1);
+  EXPECT_FALSE(h.mgr->Exists("K"));
+}
+
+TEST(PeerSsdEviction, InvalidWatermarksThrow) {
+  // low >= high, and high > 1 are both rejected (fail-fast, no silent clamp).
+  EXPECT_THROW(PeerSsdManager(std::make_unique<FakeBackend>(1000), 0.5, 0.7), std::runtime_error);
+  EXPECT_THROW(PeerSsdManager(std::make_unique<FakeBackend>(1000), 1.5, 0.7), std::runtime_error);
+  EXPECT_THROW(PeerSsdManager(std::make_unique<FakeBackend>(1000), 0.9, 0.0), std::runtime_error);
+}
+
+TEST(PeerSsdEviction, SelectVictimsBoundaries) {
+  auto h = MakeHarness(/*capacity=*/1'000'000);
+  ASSERT_TRUE(h.mgr->Write("K", OneSeg("data"), 4));
+
+  EXPECT_TRUE(h.mgr->SelectVictims(0).empty());  // nothing to free
+
+  // All candidates in flight -> no victim, no spin.
+  h.backend->BlockReads();
+  std::vector<char> buf(4);
+  SsdReadOutcome out{};
+  std::thread reader([&] { out = h.mgr->PrepareRead("K", buf.data(), buf.size()); });
+  h.backend->WaitReadsStarted(1);
+  EXPECT_TRUE(h.mgr->SelectVictims(1'000'000).empty());
+  h.backend->UnblockReads();
+  reader.join();
+  EXPECT_EQ(out.status, SsdReadStatus::kOk);
+}
+
+TEST(PeerSsdEviction, DisabledManagerIsInert) {
+  PeerSsdConfig cfg;
+  cfg.enabled = false;
+  PeerSsdManager mgr(cfg);
+
+  EXPECT_FALSE(mgr.Write("K", OneSeg("data"), 4));
+  EXPECT_FALSE(mgr.Evict("K"));
+  EXPECT_TRUE(mgr.SelectVictims(100).empty());
+  std::vector<char> buf(4);
+  EXPECT_EQ(mgr.PrepareRead("K", buf.data(), buf.size()).status, SsdReadStatus::kNotFound);
+  mgr.ClearLocal();  // no backend -> no crash, no-op
+  EXPECT_TRUE(mgr.SnapshotOwnedKeys().empty());
+}
+
+}  // namespace
+}  // namespace mori::umbp

--- a/src/umbp/tests/test_peer_ssd_eviction.cpp
+++ b/src/umbp/tests/test_peer_ssd_eviction.cpp
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-// Phase 4: SSD local capacity management + eviction.  Drives PeerSsdManager
+// SSD local capacity management + eviction.  Drives PeerSsdManager
 // through a controllable in-memory TierBackend (the test-only constructor) so
 // LRU ordering, watermark eviction, the in-flight-read guard, idempotent Write,
 // backend-evict failure, concurrent eviction, and physical Clear are all

--- a/src/umbp/tests/test_peer_ssd_manager.cpp
+++ b/src/umbp/tests/test_peer_ssd_manager.cpp
@@ -1,0 +1,206 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "umbp/distributed/peer/owned_location_source.h"
+#include "umbp/distributed/peer/peer_ssd_manager.h"
+
+namespace mori::umbp {
+namespace {
+
+namespace fs = std::filesystem;
+
+// Unique temp dir per fixture instance; backend uses PThread/posix to avoid
+// io_uring availability differences inside the build container.
+class PeerSsdManagerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    static std::atomic<uint64_t> counter{0};
+    dir_ = fs::temp_directory_path() / ("umbp_ssd_test_" + std::to_string(::getpid()) + "_" +
+                                        std::to_string(counter.fetch_add(1)));
+    fs::remove_all(dir_);
+  }
+
+  void TearDown() override {
+    std::error_code ec;
+    fs::remove_all(dir_, ec);
+  }
+
+  PeerSsdConfig MakeConfig(size_t capacity = 64ULL * 1024 * 1024) const {
+    PeerSsdConfig cfg;
+    cfg.enabled = true;
+    cfg.ssd.enabled = true;
+    cfg.ssd.storage_dir = dir_.string();
+    cfg.ssd.capacity_bytes = capacity;
+    cfg.ssd.io.backend = UMBPIoBackend::PThread;  // avoid io_uring container flakiness
+    return cfg;
+  }
+
+  static std::vector<std::pair<const void*, size_t>> OneSegment(const std::string& s) {
+    return {{s.data(), s.size()}};
+  }
+
+  fs::path dir_;
+};
+
+TEST_F(PeerSsdManagerTest, WriteRecordsOwnershipAndQueuesAddEvent) {
+  PeerSsdManager mgr(MakeConfig());
+  const std::string key = "key-1";
+  const std::string value = "hello-ssd-payload";
+
+  ASSERT_TRUE(mgr.Write(key, OneSegment(value), value.size()));
+  EXPECT_TRUE(mgr.Exists(key));
+
+  auto events = mgr.DrainPendingEvents();
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_EQ(events[0].kind, KvEvent::Kind::ADD);
+  EXPECT_EQ(events[0].key, key);
+  EXPECT_EQ(events[0].tier, TierType::SSD);
+  EXPECT_EQ(events[0].size, value.size());
+
+  // Drain is destructive.
+  EXPECT_TRUE(mgr.DrainPendingEvents().empty());
+
+  auto snap = mgr.SnapshotOwnedKeys();
+  ASSERT_EQ(snap.size(), 1u);
+  EXPECT_EQ(snap[0].key, key);
+  EXPECT_EQ(snap[0].tier, TierType::SSD);
+  EXPECT_EQ(snap[0].size, value.size());
+}
+
+TEST_F(PeerSsdManagerTest, WriteAssemblesNonContiguousSegments) {
+  PeerSsdManager mgr(MakeConfig());
+  const std::string a = "abc";
+  const std::string b = "defgh";
+  std::vector<std::pair<const void*, size_t>> segs = {{a.data(), a.size()}, {b.data(), b.size()}};
+
+  ASSERT_TRUE(mgr.Write("multi", segs, a.size() + b.size()));
+  EXPECT_TRUE(mgr.Exists("multi"));
+  auto snap = mgr.SnapshotOwnedKeys();
+  ASSERT_EQ(snap.size(), 1u);
+  EXPECT_EQ(snap[0].size, a.size() + b.size());
+}
+
+TEST_F(PeerSsdManagerTest, CapacityReportsTotalAndGrowsWithWrites) {
+  const size_t cap = 32ULL * 1024 * 1024;
+  PeerSsdManager mgr(MakeConfig(cap));
+
+  auto [used_before, total_before] = mgr.Capacity();
+  EXPECT_EQ(total_before, cap);
+
+  std::string value(4096, 'x');
+  ASSERT_TRUE(mgr.Write("big", OneSegment(value), value.size()));
+
+  auto [used_after, total_after] = mgr.Capacity();
+  EXPECT_EQ(total_after, cap);
+  EXPECT_GE(used_after, used_before);
+}
+
+TEST_F(PeerSsdManagerTest, EvictRemovesOwnershipAndQueuesRemoveEvent) {
+  PeerSsdManager mgr(MakeConfig());
+  const std::string key = "key-evict";
+  const std::string value = "payload";
+  ASSERT_TRUE(mgr.Write(key, OneSegment(value), value.size()));
+  mgr.DrainPendingEvents();  // discard the ADD
+
+  EXPECT_TRUE(mgr.Evict(key));
+  EXPECT_FALSE(mgr.Exists(key));
+
+  auto events = mgr.DrainPendingEvents();
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_EQ(events[0].kind, KvEvent::Kind::REMOVE);
+  EXPECT_EQ(events[0].key, key);
+  EXPECT_EQ(events[0].tier, TierType::SSD);
+
+  // Evicting an unknown key is a no-op (no event, returns false).
+  EXPECT_FALSE(mgr.Evict("never-written"));
+  EXPECT_TRUE(mgr.DrainPendingEvents().empty());
+}
+
+TEST_F(PeerSsdManagerTest, PrepareReadIsStubInPhase1) {
+  PeerSsdManager mgr(MakeConfig());
+  std::vector<char> staging(64);
+  auto out = mgr.PrepareRead("any", staging.data(), staging.size());
+  EXPECT_EQ(out.status, SsdReadStatus::kNotFound);
+}
+
+// ---- Unified owned-location source aggregation ------------------------------
+
+// Minimal OwnedLocationSource that replays a fixed event list, used to verify
+// MasterClient's multi-source concat logic without a live master.
+class FakeSource : public OwnedLocationSource {
+ public:
+  explicit FakeSource(std::vector<KvEvent> events) : events_(std::move(events)) {}
+  std::vector<KvEvent> DrainPendingEvents() override {
+    auto out = events_;
+    drained_ = true;
+    return out;
+  }
+  std::vector<KvEvent> SnapshotOwnedKeys() const override { return events_; }
+  bool drained_ = false;
+
+ private:
+  std::vector<KvEvent> events_;
+};
+
+TEST(OwnedLocationSourceAgg, DrainAndSnapshotConcatAcrossSourcesInOrder) {
+  FakeSource dram({{KvEvent::Kind::ADD, "d1", TierType::DRAM, 10},
+                   {KvEvent::Kind::ADD, "d2", TierType::DRAM, 20}});
+  FakeSource ssd({{KvEvent::Kind::ADD, "s1", TierType::SSD, 30}});
+
+  std::vector<OwnedLocationSource*> sources = {&dram, &ssd};
+
+  auto drained = DrainAllSources(sources);
+  ASSERT_EQ(drained.size(), 3u);
+  EXPECT_EQ(drained[0].key, "d1");
+  EXPECT_EQ(drained[0].tier, TierType::DRAM);
+  EXPECT_EQ(drained[1].key, "d2");
+  EXPECT_EQ(drained[2].key, "s1");
+  EXPECT_EQ(drained[2].tier, TierType::SSD);
+  EXPECT_TRUE(dram.drained_);
+  EXPECT_TRUE(ssd.drained_);
+
+  auto snap = SnapshotAllSources(sources);
+  ASSERT_EQ(snap.size(), 3u);
+  EXPECT_EQ(snap[2].tier, TierType::SSD);
+}
+
+TEST(OwnedLocationSourceAgg, NullSourcesAreSkipped) {
+  FakeSource only({{KvEvent::Kind::ADD, "x", TierType::SSD, 1}});
+  std::vector<OwnedLocationSource*> sources = {nullptr, &only, nullptr};
+  auto drained = DrainAllSources(sources);
+  ASSERT_EQ(drained.size(), 1u);
+  EXPECT_EQ(drained[0].key, "x");
+  EXPECT_TRUE(SnapshotAllSources({nullptr}).empty());
+}
+
+}  // namespace
+}  // namespace mori::umbp

--- a/src/umbp/tests/test_peer_ssd_manager.cpp
+++ b/src/umbp/tests/test_peer_ssd_manager.cpp
@@ -145,11 +145,38 @@ TEST_F(PeerSsdManagerTest, EvictRemovesOwnershipAndQueuesRemoveEvent) {
   EXPECT_TRUE(mgr.DrainPendingEvents().empty());
 }
 
-TEST_F(PeerSsdManagerTest, PrepareReadIsStubInPhase1) {
+TEST_F(PeerSsdManagerTest, PrepareReadReturnsBytesForOwnedKey) {
+  PeerSsdManager mgr(MakeConfig());
+  const std::string key = "key-read";
+  const std::string value = "hello-ssd-read-path";
+  ASSERT_TRUE(mgr.Write(key, OneSegment(value), value.size()));
+
+  std::vector<char> staging(value.size());
+  auto out = mgr.PrepareRead(key, staging.data(), staging.size());
+  EXPECT_EQ(out.status, SsdReadStatus::kOk);
+  EXPECT_EQ(out.size, value.size());
+  EXPECT_EQ(std::string(staging.data(), out.size), value);
+}
+
+TEST_F(PeerSsdManagerTest, PrepareReadUnknownKeyIsNotFound) {
   PeerSsdManager mgr(MakeConfig());
   std::vector<char> staging(64);
-  auto out = mgr.PrepareRead("any", staging.data(), staging.size());
+  auto out = mgr.PrepareRead("never-written", staging.data(), staging.size());
   EXPECT_EQ(out.status, SsdReadStatus::kNotFound);
+}
+
+TEST_F(PeerSsdManagerTest, PrepareReadRejectsOverCapBeforeIo) {
+  PeerSsdManager mgr(MakeConfig());
+  const std::string key = "key-big";
+  const std::string value(4096, 'z');
+  ASSERT_TRUE(mgr.Write(key, OneSegment(value), value.size()));
+
+  // Capacity smaller than the actual size must be rejected as kSizeTooLarge
+  // (and the reported size is the real size) without reading into the buffer.
+  std::vector<char> staging(value.size() / 2);
+  auto out = mgr.PrepareRead(key, staging.data(), staging.size());
+  EXPECT_EQ(out.status, SsdReadStatus::kSizeTooLarge);
+  EXPECT_EQ(out.size, value.size());
 }
 
 // ---- Unified owned-location source aggregation ------------------------------

--- a/src/umbp/tests/test_peer_ssd_read_rpc.cpp
+++ b/src/umbp/tests/test_peer_ssd_read_rpc.cpp
@@ -177,6 +177,48 @@ TEST_F(PeerSsdReadRpcTest, NoSlotIsDistinctFromNotFound) {
   EXPECT_EQ(Prepare("absent-extra", 64).status(), ::umbp::SSD_READ_NO_SLOT);
 }
 
+// Many concurrent readers contend for a fixed pool of staging slots: at most
+// kNumReadSlots win OK, the rest get NO_SLOT (a retryable transient), and NEVER
+// NOT_FOUND for a present key.  Also exercises the staging observability
+// (slot_full_rejects counter + the in-use gauge accessor).
+TEST_F(PeerSsdReadRpcTest, ConcurrentReadersExhaustSlotsWithoutFalseMiss) {
+  const std::string data = "concurrent-payload";
+  for (int i = 0; i < 32; ++i) WriteSsd("ck-" + std::to_string(i), data);
+
+  const uint64_t slot_full_before = server_->Metrics().slot_full_rejects.load();
+
+  constexpr int kReaders = 24;  // >> kNumReadSlots, leases held (never released)
+  std::atomic<int> ok{0}, no_slot{0}, other{0};
+  std::vector<std::thread> threads;
+  for (int i = 0; i < kReaders; ++i) {
+    threads.emplace_back([&, i] {
+      auto resp = Prepare("ck-" + std::to_string(i), data.size());
+      switch (resp.status()) {
+        case ::umbp::SSD_READ_OK:
+          ok.fetch_add(1);
+          break;
+        case ::umbp::SSD_READ_NO_SLOT:
+          no_slot.fetch_add(1);
+          break;
+        default:
+          other.fetch_add(1);  // NOT_FOUND / SIZE_TOO_LARGE / ERROR must never happen here
+          break;
+      }
+    });
+  }
+  for (auto& t : threads) t.join();
+
+  EXPECT_EQ(other.load(), 0) << "present keys never report a false miss under contention";
+  EXPECT_LE(ok.load(), kNumReadSlots) << "at most one OK per staging slot";
+  EXPECT_EQ(ok.load() + no_slot.load(), kReaders);
+  EXPECT_GT(no_slot.load(), 0) << "with more readers than slots, some must see NO_SLOT";
+
+  // The NO_SLOT rejections were counted, and the gauge sees the held leases.
+  EXPECT_GE(server_->Metrics().slot_full_rejects.load() - slot_full_before,
+            static_cast<uint64_t>(no_slot.load()));
+  EXPECT_EQ(server_->SnapshotReadSlotsInUse(), static_cast<size_t>(ok.load()));
+}
+
 // A best-effort release frees the slot; double release reports false.
 TEST_F(PeerSsdReadRpcTest, ReleaseFreesSlotAndIsBestEffort) {
   WriteSsd("k-rel", "payload");

--- a/src/umbp/tests/test_peer_ssd_read_rpc.cpp
+++ b/src/umbp/tests/test_peer_ssd_read_rpc.cpp
@@ -1,0 +1,216 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// RPC-level integration test for the SSD read path: a real PeerServiceServer
+// (backed by a real PeerSsdManager / POSIX SSDTier) served over a gRPC loopback
+// channel.  It exercises prepare -> read-from-staging -> release / TTL and,
+// crucially, asserts that OK / NOT_FOUND / NO_SLOT / SIZE_TOO_LARGE are each
+// reported as distinct statuses so a transient failure is never collapsed into
+// a NOT_FOUND miss.  RDMA is intentionally out of scope here (the staging buffer
+// is read directly); the full BatchGet -> RDMA path needs a live cluster.
+#include <grpcpp/grpcpp.h>
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "umbp/distributed/config.h"
+#include "umbp/distributed/peer/peer_service.h"
+#include "umbp/distributed/peer/peer_ssd_manager.h"
+#include "umbp_peer.grpc.pb.h"
+
+namespace mori::umbp {
+namespace {
+
+namespace fs = std::filesystem;
+
+constexpr size_t kStagingSize = 4096;
+constexpr int kNumReadSlots = 4;  // -> 1024 B per slot
+constexpr int kLeaseTimeoutS = 2;
+
+uint16_t AllocPort() {
+  static std::atomic<uint16_t> next{51300};
+  return next.fetch_add(1);
+}
+
+class PeerSsdReadRpcTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    staging_buffer_ = std::malloc(kStagingSize);
+    ASSERT_NE(staging_buffer_, nullptr);
+    std::memset(staging_buffer_, 0, kStagingSize);
+
+    dir_ = fs::temp_directory_path() /
+           ("umbp_ssd_rpc_" + std::to_string(::getpid()) + "_" + std::to_string(AllocPort()));
+    fs::remove_all(dir_);
+
+    PeerSsdConfig cfg;
+    cfg.enabled = true;
+    cfg.ssd.enabled = true;
+    cfg.ssd.storage_dir = dir_.string();
+    cfg.ssd.capacity_bytes = 1 << 20;
+    cfg.ssd.io.backend = UMBPIoBackend::PThread;  // avoid io_uring container flakiness
+    peer_ssd_ = std::make_unique<PeerSsdManager>(cfg);
+
+    // Fake staging MemoryDesc bytes — GetPeerInfo just echoes them; this test
+    // reads the staging buffer directly rather than RDMA-ing it.
+    staging_desc_ = {0xAB, 0xCD};
+
+    port_ = AllocPort();
+    server_ = std::make_unique<PeerServiceServer>(
+        /*dram_alloc=*/nullptr, peer_ssd_.get(), staging_buffer_, kStagingSize, staging_desc_,
+        kNumReadSlots, kLeaseTimeoutS);
+    ASSERT_TRUE(server_->Start(port_));
+    std::this_thread::sleep_for(std::chrono::milliseconds(150));
+
+    auto channel = grpc::CreateChannel("localhost:" + std::to_string(port_),
+                                       grpc::InsecureChannelCredentials());
+    stub_ = ::umbp::UMBPPeer::NewStub(channel);
+  }
+
+  void TearDown() override {
+    server_->Stop();
+    server_.reset();
+    peer_ssd_.reset();
+    std::free(staging_buffer_);
+    fs::remove_all(dir_);
+  }
+
+  void WriteSsd(const std::string& key, const std::string& data) {
+    ASSERT_TRUE(peer_ssd_->Write(key, {{data.data(), data.size()}}, data.size()));
+  }
+
+  ::umbp::PrepareSsdReadResponse Prepare(const std::string& key, uint64_t max_size) {
+    ::umbp::PrepareSsdReadRequest req;
+    req.set_key(key);
+    req.set_max_size(max_size);
+    ::umbp::PrepareSsdReadResponse resp;
+    grpc::ClientContext ctx;
+    EXPECT_TRUE(stub_->PrepareSsdRead(&ctx, req, &resp).ok());
+    return resp;
+  }
+
+  void* staging_buffer_ = nullptr;
+  fs::path dir_;
+  std::vector<uint8_t> staging_desc_;
+  uint16_t port_ = 0;
+  std::unique_ptr<PeerSsdManager> peer_ssd_;
+  std::unique_ptr<PeerServiceServer> server_;
+  std::unique_ptr<::umbp::UMBPPeer::Stub> stub_;
+};
+
+TEST_F(PeerSsdReadRpcTest, OkReadsBytesIntoStaging) {
+  const std::string data = "ssd-read-rpc-ok";
+  WriteSsd("k-ok", data);
+
+  auto resp = Prepare("k-ok", data.size());
+  ASSERT_EQ(resp.status(), ::umbp::SSD_READ_OK);
+  EXPECT_EQ(resp.size(), data.size());
+  EXPECT_LT(resp.staging_offset(), kStagingSize);
+  EXPECT_GT(resp.lease_id(), 0u);
+  std::string loaded(static_cast<const char*>(staging_buffer_) + resp.staging_offset(),
+                     resp.size());
+  EXPECT_EQ(loaded, data);
+}
+
+TEST_F(PeerSsdReadRpcTest, NotFoundIsADistinctMiss) {
+  auto resp = Prepare("absent", 64);
+  EXPECT_EQ(resp.status(), ::umbp::SSD_READ_NOT_FOUND);
+}
+
+TEST_F(PeerSsdReadRpcTest, SizeTooLargeIsDistinct) {
+  // A key bigger than one slot (1024 B) must report SIZE_TOO_LARGE, not OK and
+  // not NOT_FOUND.
+  const std::string big(2048, 'q');
+  WriteSsd("k-big", big);
+  auto resp = Prepare("k-big", kStagingSize);
+  EXPECT_EQ(resp.status(), ::umbp::SSD_READ_SIZE_TOO_LARGE);
+}
+
+// The key assertion the review asked for: slot exhaustion is NO_SLOT
+// (retryable), never collapsed into NOT_FOUND.  A present key and an absent key
+// under exhaustion are distinguishable.
+TEST_F(PeerSsdReadRpcTest, NoSlotIsDistinctFromNotFound) {
+  std::vector<::umbp::PrepareSsdReadResponse> held;
+  for (int i = 0; i < kNumReadSlots; ++i) {
+    const std::string key = "hold-" + std::to_string(i);
+    WriteSsd(key, "payload");
+    auto resp = Prepare(key, 64);
+    ASSERT_EQ(resp.status(), ::umbp::SSD_READ_OK);
+    held.push_back(resp);  // keep the lease held (no release) so slots stay busy
+  }
+
+  // A present key with all slots busy -> NO_SLOT (retryable), NOT a miss.
+  WriteSsd("present-extra", "payload");
+  EXPECT_EQ(Prepare("present-extra", 64).status(), ::umbp::SSD_READ_NO_SLOT);
+
+  // An absent key under the same exhaustion is still NO_SLOT (slot check
+  // precedes the key lookup), so the caller cannot mistake exhaustion for a
+  // definitive miss.
+  EXPECT_EQ(Prepare("absent-extra", 64).status(), ::umbp::SSD_READ_NO_SLOT);
+}
+
+// A best-effort release frees the slot; double release reports false.
+TEST_F(PeerSsdReadRpcTest, ReleaseFreesSlotAndIsBestEffort) {
+  WriteSsd("k-rel", "payload");
+  auto resp = Prepare("k-rel", 64);
+  ASSERT_EQ(resp.status(), ::umbp::SSD_READ_OK);
+
+  ::umbp::ReleaseSsdLeaseRequest rel;
+  rel.set_lease_id(resp.lease_id());
+  ::umbp::ReleaseSsdLeaseResponse rel_resp;
+  grpc::ClientContext ctx;
+  ASSERT_TRUE(stub_->ReleaseSsdLease(&ctx, rel, &rel_resp).ok());
+  EXPECT_TRUE(rel_resp.success());
+
+  ::umbp::ReleaseSsdLeaseResponse rel_resp2;
+  grpc::ClientContext ctx2;
+  ASSERT_TRUE(stub_->ReleaseSsdLease(&ctx2, rel, &rel_resp2).ok());
+  EXPECT_FALSE(rel_resp2.success()) << "double release is a no-op";
+}
+
+// Leased slots are reclaimed by TTL even without a release, so a fresh prepare
+// succeeds after the lease elapses (slot lifecycle: Leased -> reclaimed).
+TEST_F(PeerSsdReadRpcTest, LeasedSlotsReclaimedByTtl) {
+  for (int i = 0; i < kNumReadSlots; ++i) {
+    const std::string key = "ttl-" + std::to_string(i);
+    WriteSsd(key, "payload");
+    ASSERT_EQ(Prepare(key, 64).status(), ::umbp::SSD_READ_OK);  // never released
+  }
+  EXPECT_EQ(Prepare("ttl-0", 64).status(), ::umbp::SSD_READ_NO_SLOT);  // all busy
+
+  std::this_thread::sleep_for(std::chrono::seconds(kLeaseTimeoutS + 1));
+
+  WriteSsd("ttl-after", "payload");
+  EXPECT_EQ(Prepare("ttl-after", 64).status(), ::umbp::SSD_READ_OK) << "TTL should reclaim a slot";
+}
+
+}  // namespace
+}  // namespace mori::umbp

--- a/src/umbp/tests/test_ssd_copy_pipeline.cpp
+++ b/src/umbp/tests/test_ssd_copy_pipeline.cpp
@@ -1,0 +1,336 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "umbp/distributed/peer/peer_dram_allocator.h"
+#include "umbp/distributed/peer/peer_ssd_manager.h"
+#include "umbp/distributed/peer/ssd_copy_pipeline.h"
+
+namespace mori::umbp {
+namespace {
+
+namespace fs = std::filesystem;
+
+constexpr uint64_t kPageSize = 1024;
+
+// Concatenate a pin's segments into one buffer for content comparison.
+std::string Concat(const PeerDramAllocator::DramCopyPin& pin) {
+  std::string out;
+  for (const auto& [ptr, len] : pin.segments) {
+    out.append(static_cast<const char*>(ptr), len);
+  }
+  return out;
+}
+
+// ---- DramCopyPin unit tests (direct on PeerDramAllocator) -------------------
+
+class DramCopyPinTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    backing_.assign(kPageSize * 8, 0);
+    PeerDramAllocator::TierConfig dram;
+    dram.buffer_sizes = {kPageSize * 8};
+    dram.buffer_descs = {{0x01, 0x02}};
+    dram.buffer_bases = {backing_.data()};
+    dram_ = std::make_unique<PeerDramAllocator>(kPageSize, std::move(dram),
+                                                PeerDramAllocator::TierConfig{},
+                                                /*pending_ttl=*/std::chrono::milliseconds{5000},
+                                                /*read_lease_ttl=*/std::chrono::milliseconds{0});
+  }
+
+  // Allocate, write `value` into its pages, commit.  Backing memory is owned
+  // by the test, so we resolve pages -> offset exactly like the real writer.
+  void PutLocal(const std::string& key, const std::string& value) {
+    auto res = dram_->Allocate(key, value.size(), TierType::DRAM);
+    ASSERT_EQ(res.outcome, PeerDramAllocator::Outcome::kSuccessAllocated);
+    const auto& slot = *res.slot;
+    size_t off = 0;
+    for (const auto& p : slot.pages) {
+      const size_t bytes = std::min<size_t>(kPageSize, value.size() - off);
+      std::memcpy(backing_.data() + static_cast<size_t>(p.page_index) * kPageSize,
+                  value.data() + off, bytes);
+      off += bytes;
+    }
+    uint64_t committed = 0;
+    ASSERT_TRUE(dram_->Commit(slot.slot_id, key, committed));
+    ASSERT_EQ(committed, value.size());
+  }
+
+  std::vector<char> backing_;
+  std::unique_ptr<PeerDramAllocator> dram_;
+};
+
+TEST_F(DramCopyPinTest, AcquireResolvesSegmentsToCommittedBytes) {
+  const std::string value(kPageSize + 17, 'Z');  // spans 2 pages, last partial
+  PutLocal("k", value);
+
+  auto pin = dram_->AcquireDramCopyPin("k");
+  ASSERT_TRUE(pin.has_value());
+  EXPECT_EQ(pin->total_size, value.size());
+  EXPECT_EQ(Concat(*pin), value);
+  dram_->ReleaseDramCopyPin("k", pin->pin_token);
+}
+
+TEST_F(DramCopyPinTest, AcquireMissingKeyReturnsNullopt) {
+  EXPECT_FALSE(dram_->AcquireDramCopyPin("never").has_value());
+}
+
+TEST_F(DramCopyPinTest, DuplicatePinReturnsNullopt) {
+  PutLocal("k", "payload");
+  auto first = dram_->AcquireDramCopyPin("k");
+  ASSERT_TRUE(first.has_value());
+  EXPECT_FALSE(dram_->AcquireDramCopyPin("k").has_value());  // already pinned
+  dram_->ReleaseDramCopyPin("k", first->pin_token);
+}
+
+TEST_F(DramCopyPinTest, EvictBlockedWhilePinnedThenAllowedAfterRelease) {
+  PutLocal("k", "payload");
+  dram_->DrainPendingEvents();  // discard the commit's ADD DRAM event
+  auto pin = dram_->AcquireDramCopyPin("k");
+  ASSERT_TRUE(pin.has_value());
+
+  // Pinned: Evict must not free, not emit REMOVE, keep ownership.
+  auto evicted = dram_->Evict({"k"});
+  ASSERT_EQ(evicted.size(), 1u);
+  EXPECT_EQ(evicted[0].bytes_freed, 0u);
+  EXPECT_TRUE(dram_->DrainPendingEvents().empty());  // no REMOVE DRAM
+  ASSERT_EQ(dram_->SnapshotOwnedKeys().size(), 1u);  // still owned
+
+  // Release -> next Evict frees and emits REMOVE.
+  dram_->ReleaseDramCopyPin("k", pin->pin_token);
+  auto evicted2 = dram_->Evict({"k"});
+  ASSERT_EQ(evicted2.size(), 1u);
+  EXPECT_GT(evicted2[0].bytes_freed, 0u);
+  auto events = dram_->DrainPendingEvents();
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_EQ(events[0].kind, KvEvent::Kind::REMOVE);
+  EXPECT_EQ(events[0].tier, TierType::DRAM);
+}
+
+TEST(DramCopyPinNonContiguous, SegmentsSpanMultipleBuffers) {
+  // Two 1-page buffers force a cross-buffer page set for a 2-page key.
+  std::vector<char> b0(kPageSize, 0), b1(kPageSize, 0);
+  PeerDramAllocator::TierConfig dram;
+  dram.buffer_sizes = {kPageSize, kPageSize};
+  dram.buffer_descs = {{0x01}, {0x02}};
+  dram.buffer_bases = {b0.data(), b1.data()};
+  PeerDramAllocator alloc(kPageSize, std::move(dram), PeerDramAllocator::TierConfig{},
+                          std::chrono::milliseconds{5000}, std::chrono::milliseconds{0});
+
+  const std::string value(kPageSize + 5, 'Q');
+  auto res = alloc.Allocate("k", value.size(), TierType::DRAM);
+  ASSERT_EQ(res.outcome, PeerDramAllocator::Outcome::kSuccessAllocated);
+  const auto& slot = *res.slot;
+  ASSERT_EQ(slot.pages.size(), 2u);
+  std::vector<char*> bases = {b0.data(), b1.data()};
+  size_t off = 0;
+  for (const auto& p : slot.pages) {
+    const size_t bytes = std::min<size_t>(kPageSize, value.size() - off);
+    std::memcpy(bases[p.buffer_index] + static_cast<size_t>(p.page_index) * kPageSize,
+                value.data() + off, bytes);
+    off += bytes;
+  }
+  uint64_t committed = 0;
+  ASSERT_TRUE(alloc.Commit(slot.slot_id, "k", committed));
+
+  auto pin = alloc.AcquireDramCopyPin("k");
+  ASSERT_TRUE(pin.has_value());
+  EXPECT_EQ(pin->segments.size(), 2u);
+  EXPECT_EQ(Concat(*pin), value);
+  alloc.ReleaseDramCopyPin("k", pin->pin_token);
+}
+
+// ---- Pipeline integration tests (allocator + SSD manager + pipeline) --------
+
+class SsdCopyPipelineTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    static std::atomic<uint64_t> counter{0};
+    dir_ = fs::temp_directory_path() / ("umbp_copy_test_" + std::to_string(::getpid()) + "_" +
+                                        std::to_string(counter.fetch_add(1)));
+    fs::remove_all(dir_);
+
+    backing_.assign(kPageSize * 16, 0);
+    PeerDramAllocator::TierConfig dram;
+    dram.buffer_sizes = {kPageSize * 16};
+    dram.buffer_descs = {{0x01}};
+    dram.buffer_bases = {backing_.data()};
+    dram_ = std::make_unique<PeerDramAllocator>(
+        kPageSize, std::move(dram), PeerDramAllocator::TierConfig{},
+        std::chrono::milliseconds{5000}, std::chrono::milliseconds{0});
+
+    PeerSsdConfig ssd_cfg;
+    ssd_cfg.enabled = true;
+    ssd_cfg.ssd.enabled = true;
+    ssd_cfg.ssd.storage_dir = dir_.string();
+    ssd_cfg.ssd.capacity_bytes = 64ULL * 1024 * 1024;
+    ssd_cfg.ssd.io.backend = UMBPIoBackend::PThread;  // avoid io_uring container flakiness
+    ssd_ = std::make_unique<PeerSsdManager>(ssd_cfg);
+  }
+
+  void TearDown() override {
+    std::error_code ec;
+    fs::remove_all(dir_, ec);
+  }
+
+  void PutLocal(const std::string& key, const std::string& value) {
+    auto res = dram_->Allocate(key, value.size(), TierType::DRAM);
+    ASSERT_EQ(res.outcome, PeerDramAllocator::Outcome::kSuccessAllocated);
+    const auto& slot = *res.slot;
+    size_t off = 0;
+    for (const auto& p : slot.pages) {
+      const size_t bytes = std::min<size_t>(kPageSize, value.size() - off);
+      std::memcpy(backing_.data() + static_cast<size_t>(p.page_index) * kPageSize,
+                  value.data() + off, bytes);
+      off += bytes;
+    }
+    uint64_t committed = 0;
+    ASSERT_TRUE(dram_->Commit(slot.slot_id, key, committed));
+  }
+
+  bool WaitForSsd(const std::string& key, std::chrono::milliseconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+      if (ssd_->Exists(key)) return true;
+      std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    return ssd_->Exists(key);
+  }
+
+  fs::path dir_;
+  std::vector<char> backing_;
+  std::unique_ptr<PeerDramAllocator> dram_;
+  std::unique_ptr<PeerSsdManager> ssd_;
+};
+
+TEST_F(SsdCopyPipelineTest, CommitCopiesToSsdAndEmitsAddEvent) {
+  SsdCopyPipeline pipeline(dram_.get(), ssd_.get());
+  pipeline.Start();
+
+  PutLocal("k", "hello-ssd-copy-on-commit");
+  ASSERT_TRUE(pipeline.Enqueue(SsdCopyTask{"k", TierType::DRAM, 24}));
+
+  ASSERT_TRUE(WaitForSsd("k", std::chrono::seconds(2)));
+  EXPECT_GE(pipeline.CopiedOk(), 1u);
+
+  auto events = ssd_->DrainPendingEvents();
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_EQ(events[0].kind, KvEvent::Kind::ADD);
+  EXPECT_EQ(events[0].tier, TierType::SSD);
+  EXPECT_EQ(events[0].key, "k");
+
+  pipeline.Stop();
+}
+
+TEST_F(SsdCopyPipelineTest, QueuedTaskForEvictedKeyIsDropped) {
+  SsdCopyPipeline pipeline(dram_.get(), ssd_.get());
+
+  PutLocal("gone", "data");
+  // Evict before the copy ever runs (no pin held) -> key removed from owned_.
+  auto ev = dram_->Evict({"gone"});
+  ASSERT_EQ(ev.size(), 1u);
+  EXPECT_GT(ev[0].bytes_freed, 0u);
+
+  // Now start draining: the worker's AcquireDramCopyPin returns nullopt -> drop.
+  ASSERT_TRUE(pipeline.Enqueue(SsdCopyTask{"gone", TierType::DRAM, 4}));
+  pipeline.Start();
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  EXPECT_FALSE(ssd_->Exists("gone"));
+  EXPECT_EQ(pipeline.CopiedOk(), 0u);
+  pipeline.Stop();
+}
+
+TEST_F(SsdCopyPipelineTest, FullQueueDropsWithoutBlocking) {
+  // queue_depth=2, no workers started -> nothing drains, so the 3rd+ enqueue
+  // overflows and is dropped (and returns immediately).
+  SsdCopyPipeline pipeline(dram_.get(), ssd_.get(), /*queue_depth=*/2, /*workers=*/1);
+  EXPECT_TRUE(pipeline.Enqueue(SsdCopyTask{"a", TierType::DRAM, 1}));
+  EXPECT_TRUE(pipeline.Enqueue(SsdCopyTask{"b", TierType::DRAM, 1}));
+  EXPECT_FALSE(pipeline.Enqueue(SsdCopyTask{"c", TierType::DRAM, 1}));  // full -> drop
+  EXPECT_FALSE(pipeline.Enqueue(SsdCopyTask{"d", TierType::DRAM, 1}));
+  EXPECT_EQ(pipeline.Dropped(), 2u);
+}
+
+TEST_F(SsdCopyPipelineTest, EnqueueRejectedWhileStopped) {
+  SsdCopyPipeline pipeline(dram_.get(), ssd_.get());
+  pipeline.Start();
+  pipeline.Stop();
+  EXPECT_FALSE(pipeline.Enqueue(SsdCopyTask{"k", TierType::DRAM, 1}));
+  EXPECT_EQ(pipeline.Dropped(), 0u);  // stopped path is not counted as a full-drop
+}
+
+TEST_F(SsdCopyPipelineTest, StopAfterCopyIsCleanAndReleasesPin) {
+  SsdCopyPipeline pipeline(dram_.get(), ssd_.get());
+  pipeline.Start();
+
+  const std::string value(8 * 1024, 'X');
+  PutLocal("big", value);
+  ASSERT_TRUE(pipeline.Enqueue(SsdCopyTask{"big", TierType::DRAM, value.size()}));
+
+  // Let the copy run, then Stop().  Stop() joins the worker; the RAII pin guard
+  // guarantees the pin is released before the worker exits (Stop() never
+  // force-frees an in-flight pin — that join is the in-flight-wait guarantee).
+  ASSERT_TRUE(WaitForSsd("big", std::chrono::seconds(2)));
+  pipeline.Stop();
+
+  EXPECT_EQ(pipeline.CopiedOk(), 1u);
+  // Pin released -> the key is now evictable (no copy holding its pages).
+  auto ev = dram_->Evict({"big"});
+  ASSERT_EQ(ev.size(), 1u);
+  EXPECT_GT(ev[0].bytes_freed, 0u);
+}
+
+TEST_F(SsdCopyPipelineTest, QuiesceThenClearLeavesNoStaleSsdState) {
+  SsdCopyPipeline pipeline(dram_.get(), ssd_.get());
+  pipeline.Start();
+
+  PutLocal("k", "payload");
+  ASSERT_TRUE(pipeline.Enqueue(SsdCopyTask{"k", TierType::DRAM, 7}));
+  ASSERT_TRUE(WaitForSsd("k", std::chrono::seconds(2)));
+
+  // Clear path: quiesce (drain in-flight) then clear both tiers.
+  pipeline.Quiesce();
+  dram_->ClearLocal();
+  ssd_->ClearLocal();
+  pipeline.Resume();
+
+  EXPECT_FALSE(ssd_->Exists("k"));
+  EXPECT_TRUE(ssd_->SnapshotOwnedKeys().empty());
+  EXPECT_TRUE(ssd_->DrainPendingEvents().empty());
+
+  pipeline.Stop();
+}
+
+}  // namespace
+}  // namespace mori::umbp

--- a/src/umbp/tests/test_ssd_copy_pipeline.cpp
+++ b/src/umbp/tests/test_ssd_copy_pipeline.cpp
@@ -242,6 +242,8 @@ TEST_F(SsdCopyPipelineTest, CommitCopiesToSsdAndEmitsAddEvent) {
 
   ASSERT_TRUE(WaitForSsd("k", std::chrono::seconds(2)));
   EXPECT_GE(pipeline.CopiedOk(), 1u);
+  EXPECT_GE(pipeline.Enqueued(), 1u);  // observability: task was accepted
+  EXPECT_EQ(pipeline.Failed(), 0u);
 
   auto events = ssd_->DrainPendingEvents();
   ASSERT_EQ(events.size(), 1u);
@@ -280,6 +282,8 @@ TEST_F(SsdCopyPipelineTest, FullQueueDropsWithoutBlocking) {
   EXPECT_FALSE(pipeline.Enqueue(SsdCopyTask{"c", TierType::DRAM, 1}));  // full -> drop
   EXPECT_FALSE(pipeline.Enqueue(SsdCopyTask{"d", TierType::DRAM, 1}));
   EXPECT_EQ(pipeline.Dropped(), 2u);
+  EXPECT_EQ(pipeline.Enqueued(), 2u);        // only the two accepted tasks
+  EXPECT_EQ(pipeline.DroppedStopped(), 0u);  // these are queue-full, not stopped, drops
 }
 
 TEST_F(SsdCopyPipelineTest, EnqueueRejectedWhileStopped) {
@@ -287,7 +291,8 @@ TEST_F(SsdCopyPipelineTest, EnqueueRejectedWhileStopped) {
   pipeline.Start();
   pipeline.Stop();
   EXPECT_FALSE(pipeline.Enqueue(SsdCopyTask{"k", TierType::DRAM, 1}));
-  EXPECT_EQ(pipeline.Dropped(), 0u);  // stopped path is not counted as a full-drop
+  EXPECT_EQ(pipeline.Dropped(), 0u);         // stopped path is not counted as a full-drop
+  EXPECT_EQ(pipeline.DroppedStopped(), 1u);  // counted under the stopped reason instead
 }
 
 TEST_F(SsdCopyPipelineTest, StopAfterCopyIsCleanAndReleasesPin) {

--- a/src/umbp/tests/test_ssd_read_lease_gating.cpp
+++ b/src/umbp/tests/test_ssd_read_lease_gating.cpp
@@ -1,0 +1,97 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Pure-logic unit tests for the reader-side remote SSD read lease gating
+// (umbp/distributed/ssd_read_lease.h).  These cover the decision policy without
+// a cluster / RDMA: the full PrepareSsdRead -> RDMA path is exercised at the
+// RPC level in test_peer_ssd_read_rpc.cpp.  Retryable outcomes are NO_SLOT and
+// a reader-local lease expiry; rpc failures are not-served (RPC-test covered).
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+#include "umbp/distributed/ssd_read_lease.h"
+
+namespace mori::umbp::ssd_read_lease {
+namespace {
+
+using std::chrono::milliseconds;
+using std::chrono::steady_clock;
+
+// ---- LeaseExpired ----
+
+TEST(SsdReadLeaseGating, NotExpiredBeforeDeadline) {
+  const auto t_send = steady_clock::now();
+  EXPECT_FALSE(LeaseExpired(t_send, /*lease_ttl_ms=*/1000, t_send + milliseconds(500)));
+}
+
+TEST(SsdReadLeaseGating, ExpiredAfterDeadline) {
+  const auto t_send = steady_clock::now();
+  EXPECT_TRUE(LeaseExpired(t_send, /*lease_ttl_ms=*/1000, t_send + milliseconds(1001)));
+}
+
+TEST(SsdReadLeaseGating, ExactlyAtDeadlineIsNotExpired) {
+  // Boundary: now == t_send + ttl uses '>' so it is still valid.
+  const auto t_send = steady_clock::now();
+  EXPECT_FALSE(LeaseExpired(t_send, /*lease_ttl_ms=*/1000, t_send + milliseconds(1000)));
+}
+
+TEST(SsdReadLeaseGating, ZeroTtlIsBornExpired) {
+  const auto t_send = steady_clock::now();
+  EXPECT_FALSE(LeaseExpired(t_send, /*lease_ttl_ms=*/0, t_send));  // exactly t_send: valid
+  EXPECT_TRUE(LeaseExpired(t_send, /*lease_ttl_ms=*/0, t_send + milliseconds(1)));
+}
+
+// ---- DecideSsdReadOutcome ----
+// Situation A (not expired): a good RDMA serves + releases; a failed RDMA is a
+// hard error but still releases (the lease is still ours).
+// Situation B (expired): always a transient retry, and NEVER release (the slot
+// is left for the peer's TTL reclaim), regardless of whether the RDMA "worked".
+
+TEST(SsdReadLeaseGating, ValidAndRdmaOk_ServesAndReleases) {
+  const auto d = DecideSsdReadOutcome(/*expired=*/false, /*rdma_ok=*/true);
+  EXPECT_EQ(d.outcome, GateOutcome::kSuccess);
+  EXPECT_TRUE(d.release);
+}
+
+TEST(SsdReadLeaseGating, ValidAndRdmaFailed_ErrorButReleases) {
+  const auto d = DecideSsdReadOutcome(/*expired=*/false, /*rdma_ok=*/false);
+  EXPECT_EQ(d.outcome, GateOutcome::kError);
+  EXPECT_TRUE(d.release);
+}
+
+TEST(SsdReadLeaseGating, ExpiredWithRdmaOk_RetryNoRelease) {
+  // The dangerous case: RDMA "succeeded" but the lease elapsed, so the bytes
+  // are untrusted (the peer may have recycled the slot).  Must NOT be success.
+  const auto d = DecideSsdReadOutcome(/*expired=*/true, /*rdma_ok=*/true);
+  EXPECT_EQ(d.outcome, GateOutcome::kRetry);
+  EXPECT_FALSE(d.release);
+}
+
+TEST(SsdReadLeaseGating, ExpiredWithRdmaFailed_RetryNoRelease) {
+  const auto d = DecideSsdReadOutcome(/*expired=*/true, /*rdma_ok=*/false);
+  EXPECT_EQ(d.outcome, GateOutcome::kRetry);
+  EXPECT_FALSE(d.release);
+}
+
+}  // namespace
+}  // namespace mori::umbp::ssd_read_lease

--- a/src/umbp/tests/test_ssd_reliability.cpp
+++ b/src/umbp/tests/test_ssd_reliability.cpp
@@ -253,7 +253,7 @@ TEST(SsdReliability, TierPriorityRoutesDramThenSsdAfterDramRemoved) {
 }
 
 // ---------------------------------------------------------------------------
-//  Crash-restart leftover handling (v1 = discard).
+//  Crash-restart leftover handling (discard).
 // ---------------------------------------------------------------------------
 
 // After a crash owned_ is empty but the backend still holds bytes from the

--- a/src/umbp/tests/test_ssd_reliability.cpp
+++ b/src/umbp/tests/test_ssd_reliability.cpp
@@ -1,0 +1,345 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Cross-component reliability tests: combinations no single-component test
+// covers.  All deterministic, no real disk / RDMA / master RPC:
+//   * the unified owned-location event source merges DRAM + SSD into one
+//     snapshot/delta (so a heartbeat full-sync ships SSD owned keys too);
+//   * a local SSD eviction's REMOVE SSD event converges the master
+//     GlobalBlockIndex while leaving the DRAM bucket intact;
+//   * tier-priority RouteGet over the real index picks DRAM, then SSD once the
+//     DRAM replica is removed;
+//   * crash-restart leftover is discarded at startup;
+//   * the SSD observability counters increment at the right events.
+//
+// (copy-pin vs DRAM evict is covered by test_ssd_copy_pipeline's
+// EvictBlockedWhilePinnedThenAllowedAfterRelease; seq-gap -> full-sync by
+// test_global_block_index_events' ClientRegistryHeartbeat.SeqGap*.)
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "umbp/distributed/master/global_block_index.h"
+#include "umbp/distributed/peer/owned_location_source.h"
+#include "umbp/distributed/peer/peer_ssd_manager.h"
+#include "umbp/distributed/routing/route_get_strategy.h"
+#include "umbp/distributed/types.h"
+#include "umbp/local/tiers/tier_backend.h"
+
+namespace mori::umbp {
+namespace {
+
+// Minimal in-memory TierBackend (mirrors the one in test_peer_ssd_eviction) so
+// PeerSsdManager runs without real disk IO.  Exposes a forced evict failure for
+// the backend-failure counter and lets the test pre-seed bytes (crash leftover).
+class FakeBackend : public TierBackend {
+ public:
+  explicit FakeBackend(size_t capacity)
+      : TierBackend(StorageTier::LOCAL_SSD), capacity_(capacity) {}
+
+  bool Write(const std::string& key, const void* data, size_t size) override {
+    std::lock_guard<std::mutex> lk(mu_);
+    auto it = store_.find(key);
+    size_t prev = (it == store_.end()) ? 0 : it->second.size();
+    if (used_ - prev + size > capacity_) return false;
+    store_[key].assign(static_cast<const char*>(data), static_cast<const char*>(data) + size);
+    used_ = used_ - prev + size;
+    return true;
+  }
+  bool ReadIntoPtr(const std::string& key, uintptr_t dst, size_t size) override {
+    std::lock_guard<std::mutex> lk(mu_);
+    auto it = store_.find(key);
+    if (it == store_.end() || it->second.size() != size) return false;
+    std::memcpy(reinterpret_cast<void*>(dst), it->second.data(), size);
+    return true;
+  }
+  bool Exists(const std::string& key) const override {
+    std::lock_guard<std::mutex> lk(mu_);
+    return store_.count(key) != 0;
+  }
+  bool Evict(const std::string& key) override {
+    std::lock_guard<std::mutex> lk(mu_);
+    if (fail_evict_) return false;
+    auto it = store_.find(key);
+    if (it == store_.end()) return false;
+    used_ -= it->second.size();
+    store_.erase(it);
+    return true;
+  }
+  std::pair<size_t, size_t> Capacity() const override {
+    std::lock_guard<std::mutex> lk(mu_);
+    return {used_, capacity_};
+  }
+  void Clear() override {
+    std::lock_guard<std::mutex> lk(mu_);
+    ++clear_calls_;
+    store_.clear();
+    used_ = 0;
+  }
+  void SetFailEvict(bool f) {
+    std::lock_guard<std::mutex> lk(mu_);
+    fail_evict_ = f;
+  }
+  int clear_calls() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return clear_calls_;
+  }
+
+ private:
+  mutable std::mutex mu_;
+  std::unordered_map<std::string, std::vector<char>> store_;
+  size_t used_ = 0;
+  size_t capacity_;
+  bool fail_evict_ = false;
+  int clear_calls_ = 0;
+};
+
+std::vector<std::pair<const void*, size_t>> OneSeg(const std::string& s) {
+  return {{s.data(), s.size()}};
+}
+
+bool HasLoc(const std::vector<Location>& locs, const std::string& node, TierType tier) {
+  for (const auto& l : locs) {
+    if (l.node_id == node && l.tier == tier) return true;
+  }
+  return false;
+}
+
+int CountTier(const std::vector<KvEvent>& events, KvEvent::Kind kind, TierType tier) {
+  int n = 0;
+  for (const auto& e : events) {
+    if (e.kind == kind && e.tier == tier) ++n;
+  }
+  return n;
+}
+
+// A canned owned-location source standing in for PeerDramAllocator so the
+// aggregation can be tested without standing up a DRAM allocator.
+class FakeOwnedSource : public OwnedLocationSource {
+ public:
+  std::vector<KvEvent> delta;
+  std::vector<KvEvent> snapshot;
+  std::vector<KvEvent> DrainPendingEvents() override {
+    std::vector<KvEvent> out;
+    out.swap(delta);
+    return out;
+  }
+  std::vector<KvEvent> SnapshotOwnedKeys() const override { return snapshot; }
+};
+
+// ---------------------------------------------------------------------------
+//  Unified owned-location source: DRAM + SSD merge into one bundle.
+// ---------------------------------------------------------------------------
+
+// A heartbeat full-sync snapshots ALL sources; SSD owned keys must be present
+// alongside DRAM in the merged snapshot (otherwise master would drop the SSD
+// tier on a seq-gap recovery).
+TEST(SsdReliability, FullSyncSnapshotMergesDramAndSsdOwnedKeys) {
+  FakeOwnedSource dram;
+  dram.snapshot = {KvEvent{KvEvent::Kind::ADD, "d-key", TierType::DRAM, 10}};
+
+  auto be = std::make_unique<FakeBackend>(1'000'000);
+  PeerSsdManager ssd(std::move(be), 0.9, 0.7);
+  ASSERT_TRUE(ssd.Write("s-key", OneSeg("ssddata"), 7));
+  ssd.DrainPendingEvents();  // the ADD SSD delta; snapshot is independent
+
+  std::vector<OwnedLocationSource*> sources = {&dram, &ssd};
+  auto snap = SnapshotAllSources(sources);
+
+  EXPECT_EQ(CountTier(snap, KvEvent::Kind::ADD, TierType::DRAM), 1);
+  EXPECT_EQ(CountTier(snap, KvEvent::Kind::ADD, TierType::SSD), 1);
+}
+
+// A delta heartbeat drains ALL sources and concatenates into one list.
+TEST(SsdReliability, DeltaDrainMergesDramAndSsdEvents) {
+  FakeOwnedSource dram;
+  dram.delta = {KvEvent{KvEvent::Kind::REMOVE, "d-key", TierType::DRAM, 0}};
+
+  auto be = std::make_unique<FakeBackend>(1'000'000);
+  PeerSsdManager ssd(std::move(be), 0.9, 0.7);
+  ASSERT_TRUE(ssd.Write("s-key", OneSeg("ssddata"), 7));  // queues ADD SSD delta
+
+  std::vector<OwnedLocationSource*> sources = {&dram, &ssd};
+  auto merged = DrainAllSources(sources);
+
+  EXPECT_EQ(CountTier(merged, KvEvent::Kind::REMOVE, TierType::DRAM), 1);
+  EXPECT_EQ(CountTier(merged, KvEvent::Kind::ADD, TierType::SSD), 1);
+  // Draining again yields nothing (outbox cleared on both sources).
+  EXPECT_TRUE(DrainAllSources(sources).empty());
+}
+
+// ---------------------------------------------------------------------------
+//  SSD local eviction -> REMOVE SSD -> master GlobalBlockIndex converges.
+// ---------------------------------------------------------------------------
+
+// A key mirrored on DRAM + SSD of one owner: a local SSD eviction emits
+// REMOVE SSD, and applying that to the master index drops only the SSD bucket
+// (the DRAM replica, owned independently, stays routable).
+TEST(SsdReliability, LocalSsdEvictionRemoveConvergesMasterIndex) {
+  GlobalBlockIndex idx;
+
+  auto be = std::make_unique<FakeBackend>(1'000'000);
+  PeerSsdManager ssd(std::move(be), 0.9, 0.7);
+
+  // DRAM replica added independently (a DRAM owner would emit this).
+  idx.ApplyEvents("owner", {KvEvent{KvEvent::Kind::ADD, "k", TierType::DRAM, 100}});
+  // SSD copy lands -> ADD SSD drained into the index.
+  ASSERT_TRUE(ssd.Write("k", OneSeg(std::string(100, 'x')), 100));
+  idx.ApplyEvents("owner", ssd.DrainPendingEvents());
+
+  auto both = idx.Lookup("k");
+  ASSERT_TRUE(HasLoc(both, "owner", TierType::DRAM));
+  ASSERT_TRUE(HasLoc(both, "owner", TierType::SSD));
+
+  // Local SSD eviction -> REMOVE SSD -> index drops only the SSD bucket.
+  ASSERT_TRUE(ssd.Evict("k"));
+  auto ssd_events = ssd.DrainPendingEvents();
+  EXPECT_EQ(CountTier(ssd_events, KvEvent::Kind::REMOVE, TierType::SSD), 1);
+  idx.ApplyEvents("owner", ssd_events);
+
+  auto after = idx.Lookup("k");
+  EXPECT_TRUE(HasLoc(after, "owner", TierType::DRAM));  // DRAM replica still routable
+  EXPECT_FALSE(HasLoc(after, "owner", TierType::SSD));  // SSD bucket converged away
+}
+
+// ---------------------------------------------------------------------------
+//  Tier-priority RouteGet over the real index: DRAM first, SSD after evict.
+// ---------------------------------------------------------------------------
+
+TEST(SsdReliability, TierPriorityRoutesDramThenSsdAfterDramRemoved) {
+  GlobalBlockIndex idx;
+  idx.ApplyEvents("owner", {KvEvent{KvEvent::Kind::ADD, "k", TierType::DRAM, 100},
+                            KvEvent{KvEvent::Kind::ADD, "k", TierType::SSD, 100}});
+
+  TierPriorityRouteGetStrategy strategy;
+
+  auto locs = idx.BatchLookupForRouteGet({"k"}, {}, std::chrono::seconds{10});
+  ASSERT_EQ(locs.size(), 1u);
+  auto dram_pick = strategy.Select(locs[0], "reader");
+  EXPECT_EQ(dram_pick.tier, TierType::DRAM) << "prefers the fast DRAM replica";
+
+  // DRAM evicted -> only the SSD bucket remains -> RouteGet must serve from SSD.
+  idx.ApplyEvents("owner", {KvEvent{KvEvent::Kind::REMOVE, "k", TierType::DRAM, 0}});
+  auto locs2 = idx.BatchLookupForRouteGet({"k"}, {}, std::chrono::seconds{10});
+  ASSERT_EQ(locs2.size(), 1u);
+  auto ssd_pick = strategy.Select(locs2[0], "reader");
+  EXPECT_EQ(ssd_pick.tier, TierType::SSD) << "falls back to the surviving SSD replica";
+  EXPECT_EQ(ssd_pick.node_id, "owner");
+}
+
+// ---------------------------------------------------------------------------
+//  Crash-restart leftover handling (v1 = discard).
+// ---------------------------------------------------------------------------
+
+// After a crash owned_ is empty but the backend still holds bytes from the
+// previous run.  DiscardLeftoverOnStartup wipes them so used capacity starts
+// at 0 (no divergence between the empty owned_ map and the physical device).
+TEST(SsdReliability, StartupDiscardWipesLeftoverBytes) {
+  auto be = std::make_unique<FakeBackend>(1'000'000);
+  FakeBackend* raw = be.get();
+  // Simulate a previous process's bytes left on the device.
+  ASSERT_TRUE(raw->Write("orphan-1", "leftover-a", 10));
+  ASSERT_TRUE(raw->Write("orphan-2", "leftover-b", 10));
+  ASSERT_GT(raw->Capacity().first, 0u);
+
+  // Fresh manager: owned_ is empty, but the backend reports used > 0.
+  PeerSsdManager ssd(std::move(be), 0.9, 0.7);
+  EXPECT_TRUE(ssd.SnapshotOwnedKeys().empty());
+  ASSERT_GT(ssd.Capacity().first, 0u);
+
+  ssd.DiscardLeftoverOnStartup();
+
+  EXPECT_EQ(raw->clear_calls(), 1);
+  EXPECT_EQ(ssd.Capacity().first, 0u);  // leftover gone -> consistent with empty owned_
+}
+
+TEST(SsdReliability, StartupDiscardOnCleanTierIsNoop) {
+  auto be = std::make_unique<FakeBackend>(1'000'000);
+  FakeBackend* raw = be.get();
+  PeerSsdManager ssd(std::move(be), 0.9, 0.7);
+
+  ssd.DiscardLeftoverOnStartup();  // used == 0 -> skip the wipe entirely
+  EXPECT_EQ(raw->clear_calls(), 0);
+}
+
+// ---------------------------------------------------------------------------
+//  Observability counters increment at the right events.
+// ---------------------------------------------------------------------------
+
+TEST(SsdReliability, ReadCountersTrackOutcomes) {
+  auto be = std::make_unique<FakeBackend>(1'000'000);
+  PeerSsdManager ssd(std::move(be), 0.9, 0.7);
+  ASSERT_TRUE(ssd.Write("k", OneSeg("0123456789"), 10));
+
+  std::vector<char> buf(10);
+  EXPECT_EQ(ssd.PrepareRead("k", buf.data(), buf.size()).status, SsdReadStatus::kOk);
+  EXPECT_EQ(ssd.PrepareRead("absent", buf.data(), buf.size()).status, SsdReadStatus::kNotFound);
+  EXPECT_EQ(ssd.PrepareRead("k", buf.data(), /*cap=*/1).status, SsdReadStatus::kSizeTooLarge);
+
+  EXPECT_EQ(ssd.ReadOk(), 1u);
+  EXPECT_EQ(ssd.ReadNotFound(), 1u);
+  EXPECT_EQ(ssd.ReadSizeTooLarge(), 1u);
+  EXPECT_EQ(ssd.ReadError(), 0u);
+}
+
+TEST(SsdReliability, EvictionCountersTrackVictimsBytesAndBackendFailures) {
+  auto be = std::make_unique<FakeBackend>(1'000'000);
+  FakeBackend* raw = be.get();
+  PeerSsdManager ssd(std::move(be), 0.9, 0.7);
+  ASSERT_TRUE(ssd.Write("a", OneSeg(std::string(40, 'a')), 40));
+  ASSERT_TRUE(ssd.Write("b", OneSeg(std::string(60, 'b')), 60));
+
+  ASSERT_TRUE(ssd.Evict("a"));
+  EXPECT_EQ(ssd.EvictionVictims(), 1u);
+  EXPECT_EQ(ssd.EvictionBytesFreed(), 40u);
+  EXPECT_EQ(ssd.EvictionBackendFailures(), 0u);
+
+  // Backend refuses the next evict -> the failure is counted, the key kept.
+  raw->SetFailEvict(true);
+  EXPECT_FALSE(ssd.Evict("b"));
+  EXPECT_EQ(ssd.EvictionBackendFailures(), 1u);
+  EXPECT_EQ(ssd.EvictionVictims(), 1u);  // unchanged
+  EXPECT_TRUE(ssd.Exists("b"));
+}
+
+TEST(SsdReliability, WatermarkEvictionCountsARound) {
+  // capacity 1000, high 0.9 (=>900), low 0.5 (=>500); 100-byte values.  After
+  // the 9th write used hits 900 -> one eviction round runs.
+  auto be = std::make_unique<FakeBackend>(1000);
+  PeerSsdManager ssd(std::move(be), 0.9, 0.5);
+  std::string val(100, 'x');
+  for (int i = 1; i <= 9; ++i) {
+    ASSERT_TRUE(ssd.Write("k" + std::to_string(i), OneSeg(val), val.size()));
+  }
+  EXPECT_GE(ssd.EvictionRounds(), 1u);
+  EXPECT_GE(ssd.EvictionVictims(), 1u);
+  EXPECT_LE(ssd.Capacity().first, 500u);
+}
+
+}  // namespace
+}  // namespace mori::umbp

--- a/src/umbp/tests/test_tier_priority_route_get.cpp
+++ b/src/umbp/tests/test_tier_priority_route_get.cpp
@@ -1,0 +1,112 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#include <gtest/gtest.h>
+
+#include <set>
+#include <string>
+#include <vector>
+
+#include "umbp/distributed/routing/route_get_strategy.h"
+
+namespace mori::umbp {
+namespace {
+
+Location MakeLoc(const std::string& node_id, TierType tier) {
+  Location loc;
+  loc.node_id = node_id;
+  loc.size = 4096;
+  loc.tier = tier;
+  return loc;
+}
+
+// With a DRAM (or HBM) replica present alongside an SSD one, the strategy must
+// never route to the slow SSD tier.
+TEST(TierPriorityRouteGetStrategyTest, PrefersDramOverSsd) {
+  TierPriorityRouteGetStrategy strategy;
+  std::vector<Location> locations = {
+      MakeLoc("ssd-node", TierType::SSD),
+      MakeLoc("dram-node", TierType::DRAM),
+  };
+  for (int i = 0; i < 100; ++i) {
+    auto selected = strategy.Select(locations, "requester");
+    EXPECT_EQ(selected.tier, TierType::DRAM);
+    EXPECT_EQ(selected.node_id, "dram-node");
+  }
+}
+
+// HBM beats both DRAM and SSD.
+TEST(TierPriorityRouteGetStrategyTest, PrefersHbmOverDramAndSsd) {
+  TierPriorityRouteGetStrategy strategy;
+  std::vector<Location> locations = {
+      MakeLoc("ssd-node", TierType::SSD),
+      MakeLoc("dram-node", TierType::DRAM),
+      MakeLoc("hbm-node", TierType::HBM),
+  };
+  for (int i = 0; i < 100; ++i) {
+    auto selected = strategy.Select(locations, "requester");
+    EXPECT_EQ(selected.tier, TierType::HBM);
+  }
+}
+
+// When SSD is the only tier present it is selected (read-from-SSD is valid).
+TEST(TierPriorityRouteGetStrategyTest, FallsBackToSsdWhenOnlyTier) {
+  TierPriorityRouteGetStrategy strategy;
+  std::vector<Location> locations = {
+      MakeLoc("ssd-a", TierType::SSD),
+      MakeLoc("ssd-b", TierType::SSD),
+  };
+  for (int i = 0; i < 50; ++i) {
+    auto selected = strategy.Select(locations, "requester");
+    EXPECT_EQ(selected.tier, TierType::SSD);
+  }
+}
+
+// Within the winning tier, selection spreads across all replicas on that tier
+// and never leaks to a lower tier.
+TEST(TierPriorityRouteGetStrategyTest, RandomWithinBestTierOnly) {
+  TierPriorityRouteGetStrategy strategy;
+  std::vector<Location> locations = {
+      MakeLoc("dram-a", TierType::DRAM),
+      MakeLoc("dram-b", TierType::DRAM),
+      MakeLoc("dram-c", TierType::DRAM),
+      MakeLoc("ssd-x", TierType::SSD),
+  };
+  std::set<std::string> seen;
+  for (int i = 0; i < 2000; ++i) {
+    auto selected = strategy.Select(locations, "requester");
+    ASSERT_EQ(selected.tier, TierType::DRAM) << "must never pick the SSD replica";
+    seen.insert(selected.node_id);
+  }
+  EXPECT_EQ(seen.size(), 3u) << "all three DRAM replicas should be reachable";
+  EXPECT_EQ(seen.count("ssd-x"), 0u);
+}
+
+TEST(TierPriorityRouteGetStrategyTest, EmptyReturnsDefault) {
+  TierPriorityRouteGetStrategy strategy;
+  std::vector<Location> locations;
+  auto selected = strategy.Select(locations, "requester");
+  EXPECT_EQ(selected.tier, TierType::UNKNOWN);
+  EXPECT_TRUE(selected.node_id.empty());
+}
+
+}  // namespace
+}  // namespace mori::umbp

--- a/tests/cpp/umbp/distributed/test_peer_service.cpp
+++ b/tests/cpp/umbp/distributed/test_peer_service.cpp
@@ -43,7 +43,6 @@ namespace {
 constexpr size_t kStagingSize = 4096;
 constexpr uint16_t kBasePort = 50200;
 constexpr int kNumReadSlots = 4;
-constexpr int kNumWriteSlots = 4;
 constexpr int kLeaseTimeoutS = 2;
 
 static uint16_t AllocPort() {
@@ -80,8 +79,8 @@ class PeerServiceSlotTest : public ::testing::Test {
 
     server_ = std::make_unique<PeerServiceServer>(
         staging_buffer_, kStagingSize, ssd_staging_mem_desc_, *storage_, index_,
-        coordinator_->DramAllocator(), kNumReadSlots, kNumWriteSlots, kLeaseTimeoutS,
-        std::vector<uint8_t>{}, &coordinator_->Master());
+        coordinator_->DramAllocator(), kNumReadSlots, kLeaseTimeoutS, std::vector<uint8_t>{},
+        &coordinator_->Master());
     server_->Start(port_);
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
@@ -127,85 +126,6 @@ TEST_F(PeerServiceSlotTest, GetPeerInfoReturnsStagingInfo) {
   EXPECT_EQ(response.ssd_staging_mem_desc(),
             std::string(ssd_staging_mem_desc_.begin(), ssd_staging_mem_desc_.end()));
   EXPECT_EQ(response.ssd_staging_size(), kStagingSize);
-}
-
-// --- AllocateWriteSlot ---
-
-TEST_F(PeerServiceSlotTest, AllocateWriteSlotSuccess) {
-  ::umbp::AllocateWriteSlotRequest req;
-  req.set_size(64);
-  ::umbp::AllocateWriteSlotResponse resp;
-  grpc::ClientContext ctx;
-
-  auto status = stub_->AllocateWriteSlot(&ctx, req, &resp);
-  ASSERT_TRUE(status.ok());
-  ASSERT_TRUE(resp.success());
-  EXPECT_GT(resp.lease_id(), 0u);
-  EXPECT_GT(resp.lease_ttl_ms(), 0u);
-  EXPECT_LT(resp.staging_offset(), kStagingSize / 2);
-}
-
-TEST_F(PeerServiceSlotTest, AllocateWriteSlotTooLarge) {
-  ::umbp::AllocateWriteSlotRequest req;
-  req.set_size(kStagingSize);  // exceeds slot size
-  ::umbp::AllocateWriteSlotResponse resp;
-  grpc::ClientContext ctx;
-
-  auto status = stub_->AllocateWriteSlot(&ctx, req, &resp);
-  ASSERT_TRUE(status.ok());
-  EXPECT_FALSE(resp.success());
-}
-
-TEST_F(PeerServiceSlotTest, AllocateWriteSlotZeroSize) {
-  ::umbp::AllocateWriteSlotRequest req;
-  req.set_size(0);
-  ::umbp::AllocateWriteSlotResponse resp;
-  grpc::ClientContext ctx;
-
-  auto status = stub_->AllocateWriteSlot(&ctx, req, &resp);
-  ASSERT_TRUE(status.ok());
-  EXPECT_FALSE(resp.success());
-}
-
-TEST_F(PeerServiceSlotTest, AllocateWriteSlotExhaustAll) {
-  for (int i = 0; i < kNumWriteSlots; ++i) {
-    ::umbp::AllocateWriteSlotRequest req;
-    req.set_size(32);
-    ::umbp::AllocateWriteSlotResponse resp;
-    grpc::ClientContext ctx;
-    auto status = stub_->AllocateWriteSlot(&ctx, req, &resp);
-    ASSERT_TRUE(status.ok());
-    ASSERT_TRUE(resp.success()) << "Slot " << i << " should succeed";
-  }
-
-  ::umbp::AllocateWriteSlotRequest req;
-  req.set_size(32);
-  ::umbp::AllocateWriteSlotResponse resp;
-  grpc::ClientContext ctx;
-  auto status = stub_->AllocateWriteSlot(&ctx, req, &resp);
-  ASSERT_TRUE(status.ok());
-  EXPECT_FALSE(resp.success()) << "Should fail when all slots exhausted";
-}
-
-TEST_F(PeerServiceSlotTest, AllocateWriteSlotTtlReclaim) {
-  for (int i = 0; i < kNumWriteSlots; ++i) {
-    ::umbp::AllocateWriteSlotRequest req;
-    req.set_size(32);
-    ::umbp::AllocateWriteSlotResponse resp;
-    grpc::ClientContext ctx;
-    stub_->AllocateWriteSlot(&ctx, req, &resp);
-  }
-
-  std::this_thread::sleep_for(std::chrono::seconds(kLeaseTimeoutS + 1));
-
-  ::umbp::AllocateWriteSlotRequest req;
-  req.set_size(32);
-  ::umbp::AllocateWriteSlotResponse resp;
-  grpc::ClientContext ctx;
-  auto status = stub_->AllocateWriteSlot(&ctx, req, &resp);
-  ASSERT_TRUE(status.ok());
-  EXPECT_TRUE(resp.success()) << "Should succeed after TTL reclaim";
-  EXPECT_GT(server_->Metrics().expired_reclaims.load(), 0u);
 }
 
 // --- PrepareSsdRead ---
@@ -341,90 +261,6 @@ TEST_F(PeerServiceSlotTest, ReleaseSsdLeaseInvalid) {
   EXPECT_FALSE(resp.success());
 }
 
-// --- CommitSsdWrite with lease_id ---
-
-TEST_F(PeerServiceSlotTest, CommitSsdWriteInvalidLeaseId) {
-  ::umbp::CommitSsdWriteRequest req;
-  req.set_key("block_bad_lease");
-  req.set_staging_offset(0);
-  req.set_size(10);
-  req.set_store_index(0);
-  req.set_lease_id(9999);
-  ::umbp::CommitSsdWriteResponse resp;
-  grpc::ClientContext ctx;
-
-  auto status = stub_->CommitSsdWrite(&ctx, req, &resp);
-  ASSERT_TRUE(status.ok());
-  EXPECT_FALSE(resp.success());
-  EXPECT_GT(server_->Metrics().invalid_lease_rejects.load(), 0u);
-}
-
-TEST_F(PeerServiceSlotTest, CommitSsdWriteBadStoreIndex) {
-  ::umbp::AllocateWriteSlotRequest alloc_req;
-  alloc_req.set_size(32);
-  ::umbp::AllocateWriteSlotResponse alloc_resp;
-  grpc::ClientContext alloc_ctx;
-  stub_->AllocateWriteSlot(&alloc_ctx, alloc_req, &alloc_resp);
-  ASSERT_TRUE(alloc_resp.success());
-
-  ::umbp::CommitSsdWriteRequest req;
-  req.set_key("block_bad_store");
-  req.set_staging_offset(alloc_resp.staging_offset());
-  req.set_size(32);
-  req.set_store_index(99);
-  req.set_lease_id(alloc_resp.lease_id());
-  ::umbp::CommitSsdWriteResponse resp;
-  grpc::ClientContext ctx;
-
-  auto status = stub_->CommitSsdWrite(&ctx, req, &resp);
-  ASSERT_TRUE(status.ok());
-  EXPECT_FALSE(resp.success());
-}
-
-TEST_F(PeerServiceSlotTest, CommitSsdWriteSizeTooLarge) {
-  ::umbp::AllocateWriteSlotRequest alloc_req;
-  alloc_req.set_size(32);
-  ::umbp::AllocateWriteSlotResponse alloc_resp;
-  grpc::ClientContext alloc_ctx;
-  stub_->AllocateWriteSlot(&alloc_ctx, alloc_req, &alloc_resp);
-  ASSERT_TRUE(alloc_resp.success());
-
-  ::umbp::CommitSsdWriteRequest req;
-  req.set_key("block_size_check");
-  req.set_staging_offset(alloc_resp.staging_offset());
-  req.set_size(64);  // larger than allocated 32
-  req.set_store_index(0);
-  req.set_lease_id(alloc_resp.lease_id());
-  ::umbp::CommitSsdWriteResponse resp;
-  grpc::ClientContext ctx;
-
-  auto status = stub_->CommitSsdWrite(&ctx, req, &resp);
-  ASSERT_TRUE(status.ok());
-  EXPECT_FALSE(resp.success());
-}
-
-TEST_F(PeerServiceSlotTest, CommitSsdWriteOffsetMismatch) {
-  ::umbp::AllocateWriteSlotRequest alloc_req;
-  alloc_req.set_size(32);
-  ::umbp::AllocateWriteSlotResponse alloc_resp;
-  grpc::ClientContext alloc_ctx;
-  stub_->AllocateWriteSlot(&alloc_ctx, alloc_req, &alloc_resp);
-  ASSERT_TRUE(alloc_resp.success());
-
-  ::umbp::CommitSsdWriteRequest req;
-  req.set_key("block_offset_check");
-  req.set_staging_offset(alloc_resp.staging_offset() + 1);  // wrong offset
-  req.set_size(32);
-  req.set_store_index(0);
-  req.set_lease_id(alloc_resp.lease_id());
-  ::umbp::CommitSsdWriteResponse resp;
-  grpc::ClientContext ctx;
-
-  auto status = stub_->CommitSsdWrite(&ctx, req, &resp);
-  ASSERT_TRUE(status.ok());
-  EXPECT_FALSE(resp.success());
-}
-
 // --- Slot isolation: different slots get different offsets ---
 
 TEST_F(PeerServiceSlotTest, MultipleReadSlotsDifferentOffsets) {
@@ -451,25 +287,6 @@ TEST_F(PeerServiceSlotTest, MultipleReadSlotsDifferentOffsets) {
   for (size_t i = 0; i < offsets.size(); ++i) {
     for (size_t j = i + 1; j < offsets.size(); ++j) {
       EXPECT_NE(offsets[i], offsets[j]) << "Slots " << i << " and " << j << " overlap";
-    }
-  }
-}
-
-TEST_F(PeerServiceSlotTest, MultipleWriteSlotsDifferentOffsets) {
-  std::vector<uint64_t> offsets;
-  for (int i = 0; i < kNumWriteSlots; ++i) {
-    ::umbp::AllocateWriteSlotRequest req;
-    req.set_size(32);
-    ::umbp::AllocateWriteSlotResponse resp;
-    grpc::ClientContext ctx;
-    stub_->AllocateWriteSlot(&ctx, req, &resp);
-    ASSERT_TRUE(resp.success());
-    offsets.push_back(resp.staging_offset());
-  }
-
-  for (size_t i = 0; i < offsets.size(); ++i) {
-    for (size_t j = i + 1; j < offsets.size(); ++j) {
-      EXPECT_NE(offsets[i], offsets[j]) << "Write slots " << i << " and " << j << " overlap";
     }
   }
 }

--- a/tests/cpp/umbp/distributed/test_peer_service.cpp
+++ b/tests/cpp/umbp/distributed/test_peer_service.cpp
@@ -31,10 +31,10 @@
 #include <vector>
 
 #include "umbp/common/config.h"
+#include "umbp/distributed/config.h"
 #include "umbp/distributed/peer/peer_service.h"
+#include "umbp/distributed/peer/peer_ssd_manager.h"
 #include "umbp/distributed/pool_client.h"
-#include "umbp/local/block_index/local_block_index.h"
-#include "umbp/local/tiers/local_storage_manager.h"
 #include "umbp_peer.grpc.pb.h"
 
 namespace mori::umbp {
@@ -63,12 +63,15 @@ class PeerServiceSlotTest : public ::testing::Test {
 
     ssd_staging_mem_desc_ = {0xD0, 0xE0, 0xF0};
 
-    UMBPConfig cfg;
-    cfg.dram.capacity_bytes = 1 << 20;
-    cfg.ssd.enabled = true;
-    cfg.ssd.storage_dir = ssd_dir_.string();
-    cfg.ssd.capacity_bytes = 1 << 20;
-    storage_ = std::make_unique<LocalStorageManager>(cfg, &index_);
+    // Peer-side SSD tier owner (posix SSDTier on a temp dir; PThread backend to
+    // avoid io_uring availability differences inside the build container).
+    PeerSsdConfig ssd_cfg;
+    ssd_cfg.enabled = true;
+    ssd_cfg.ssd.enabled = true;
+    ssd_cfg.ssd.storage_dir = ssd_dir_.string();
+    ssd_cfg.ssd.capacity_bytes = 1 << 20;
+    ssd_cfg.ssd.io.backend = UMBPIoBackend::PThread;
+    peer_ssd_ = std::make_unique<PeerSsdManager>(ssd_cfg);
 
     PoolClientConfig pc_cfg;
     pc_cfg.master_config.master_address = "localhost:9999";
@@ -78,8 +81,8 @@ class PeerServiceSlotTest : public ::testing::Test {
     port_ = AllocPort();
 
     server_ = std::make_unique<PeerServiceServer>(
-        staging_buffer_, kStagingSize, ssd_staging_mem_desc_, *storage_, index_,
-        coordinator_->DramAllocator(), kNumReadSlots, kLeaseTimeoutS, std::vector<uint8_t>{},
+        coordinator_->DramAllocator(), peer_ssd_.get(), staging_buffer_, kStagingSize,
+        ssd_staging_mem_desc_, kNumReadSlots, kLeaseTimeoutS, std::vector<uint8_t>{},
         &coordinator_->Master());
     server_->Start(port_);
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
@@ -93,22 +96,20 @@ class PeerServiceSlotTest : public ::testing::Test {
     server_->Stop();
     server_.reset();
     coordinator_.reset();
-    storage_.reset();
+    peer_ssd_.reset();
     std::free(staging_buffer_);
     std::filesystem::remove_all(ssd_dir_);
   }
 
   void WriteTestDataToSsd(const std::string& key, const std::string& data) {
-    storage_->Write(key, data.data(), data.size(), StorageTier::LOCAL_SSD);
-    index_.Insert(key, {StorageTier::LOCAL_SSD, 0, data.size()});
+    peer_ssd_->Write(key, {{data.data(), data.size()}}, data.size());
   }
 
   void* staging_buffer_ = nullptr;
   std::filesystem::path ssd_dir_;
   std::vector<uint8_t> ssd_staging_mem_desc_;
   uint16_t port_ = 0;
-  LocalBlockIndex index_;
-  std::unique_ptr<LocalStorageManager> storage_;
+  std::unique_ptr<PeerSsdManager> peer_ssd_;
   std::unique_ptr<PoolClient> coordinator_;
   std::unique_ptr<PeerServiceServer> server_;
   std::unique_ptr<::umbp::UMBPPeer::Stub> stub_;
@@ -136,47 +137,50 @@ TEST_F(PeerServiceSlotTest, PrepareSsdReadSuccess) {
 
   ::umbp::PrepareSsdReadRequest req;
   req.set_key("block_read");
-  req.set_ssd_location_id("0:block_read");
-  req.set_size(data.size());
+  req.set_max_size(data.size());
   ::umbp::PrepareSsdReadResponse resp;
   grpc::ClientContext ctx;
 
   auto status = stub_->PrepareSsdRead(&ctx, req, &resp);
   ASSERT_TRUE(status.ok()) << status.error_message();
-  ASSERT_TRUE(resp.success());
-  EXPECT_GE(resp.staging_offset(), kStagingSize / 2);
+  ASSERT_EQ(resp.status(), ::umbp::SSD_READ_OK);
+  EXPECT_LT(resp.staging_offset(), kStagingSize);
+  EXPECT_EQ(resp.size(), data.size());
   EXPECT_GT(resp.lease_id(), 0u);
   EXPECT_GT(resp.lease_ttl_ms(), 0u);
 
   std::string loaded(static_cast<const char*>(staging_buffer_) + resp.staging_offset(),
-                     data.size());
+                     resp.size());
   EXPECT_EQ(loaded, data);
 }
 
 TEST_F(PeerServiceSlotTest, PrepareSsdReadNotFound) {
   ::umbp::PrepareSsdReadRequest req;
   req.set_key("nonexistent");
-  req.set_ssd_location_id("nonexistent");
-  req.set_size(64);
+  req.set_max_size(64);
   ::umbp::PrepareSsdReadResponse resp;
   grpc::ClientContext ctx;
 
   auto status = stub_->PrepareSsdRead(&ctx, req, &resp);
   ASSERT_TRUE(status.ok());
-  EXPECT_FALSE(resp.success());
+  EXPECT_EQ(resp.status(), ::umbp::SSD_READ_NOT_FOUND);
 }
 
 TEST_F(PeerServiceSlotTest, PrepareSsdReadTooLarge) {
+  // A key whose actual size exceeds the per-slot size must report
+  // SIZE_TOO_LARGE (distinct from NOT_FOUND), not be silently served.
+  const std::string big(kStagingSize, 'x');  // larger than one slot (kStagingSize/kNumReadSlots)
+  WriteTestDataToSsd("block_big", big);
+
   ::umbp::PrepareSsdReadRequest req;
-  req.set_key("anything");
-  req.set_ssd_location_id("anything");
-  req.set_size(kStagingSize);
+  req.set_key("block_big");
+  req.set_max_size(kStagingSize);
   ::umbp::PrepareSsdReadResponse resp;
   grpc::ClientContext ctx;
 
   auto status = stub_->PrepareSsdRead(&ctx, req, &resp);
   ASSERT_TRUE(status.ok());
-  EXPECT_FALSE(resp.success());
+  EXPECT_EQ(resp.status(), ::umbp::SSD_READ_SIZE_TOO_LARGE);
 }
 
 TEST_F(PeerServiceSlotTest, PrepareSsdReadExhaustSlots) {
@@ -190,25 +194,24 @@ TEST_F(PeerServiceSlotTest, PrepareSsdReadExhaustSlots) {
     const std::string key = "block_" + std::to_string(i);
     ::umbp::PrepareSsdReadRequest req;
     req.set_key(key);
-    req.set_ssd_location_id("0:" + key);
-    req.set_size(6);
+    req.set_max_size(64);
     ::umbp::PrepareSsdReadResponse resp;
     grpc::ClientContext ctx;
     auto status = stub_->PrepareSsdRead(&ctx, req, &resp);
     ASSERT_TRUE(status.ok());
-    ASSERT_TRUE(resp.success()) << "Slot " << i << " should succeed";
+    ASSERT_EQ(resp.status(), ::umbp::SSD_READ_OK) << "Slot " << i << " should succeed";
   }
 
   WriteTestDataToSsd("block_extra", "extra");
   ::umbp::PrepareSsdReadRequest req;
   req.set_key("block_extra");
-  req.set_ssd_location_id("0:block_extra");
-  req.set_size(5);
+  req.set_max_size(64);
   ::umbp::PrepareSsdReadResponse resp;
   grpc::ClientContext ctx;
   auto status = stub_->PrepareSsdRead(&ctx, req, &resp);
   ASSERT_TRUE(status.ok());
-  EXPECT_FALSE(resp.success()) << "Should fail when all read slots exhausted";
+  // Transient slot exhaustion is NO_SLOT (retryable) — never a NOT_FOUND miss.
+  EXPECT_EQ(resp.status(), ::umbp::SSD_READ_NO_SLOT) << "Should be NO_SLOT when slots exhausted";
 }
 
 // --- ReleaseSsdLease ---
@@ -221,12 +224,11 @@ TEST_F(PeerServiceSlotTest, ReleaseSsdLeaseSuccess) {
   {
     ::umbp::PrepareSsdReadRequest req;
     req.set_key("block_rel");
-    req.set_ssd_location_id("0:block_rel");
-    req.set_size(data.size());
+    req.set_max_size(data.size());
     ::umbp::PrepareSsdReadResponse resp;
     grpc::ClientContext ctx;
     stub_->PrepareSsdRead(&ctx, req, &resp);
-    ASSERT_TRUE(resp.success());
+    ASSERT_EQ(resp.status(), ::umbp::SSD_READ_OK);
     lease_id = resp.lease_id();
   }
 
@@ -275,12 +277,11 @@ TEST_F(PeerServiceSlotTest, MultipleReadSlotsDifferentOffsets) {
     const std::string key = "iso_" + std::to_string(i);
     ::umbp::PrepareSsdReadRequest req;
     req.set_key(key);
-    req.set_ssd_location_id("0:" + key);
-    req.set_size(16);
+    req.set_max_size(16);
     ::umbp::PrepareSsdReadResponse resp;
     grpc::ClientContext ctx;
     stub_->PrepareSsdRead(&ctx, req, &resp);
-    ASSERT_TRUE(resp.success());
+    ASSERT_EQ(resp.status(), ::umbp::SSD_READ_OK);
     offsets.push_back(resp.staging_offset());
   }
 
@@ -304,12 +305,11 @@ TEST_F(PeerServiceSlotTest, ReadSlotTtlReclaim) {
     const std::string key = "ttl_" + std::to_string(i);
     ::umbp::PrepareSsdReadRequest req;
     req.set_key(key);
-    req.set_ssd_location_id("0:" + key);
-    req.set_size(10);
+    req.set_max_size(10);
     ::umbp::PrepareSsdReadResponse resp;
     grpc::ClientContext ctx;
     stub_->PrepareSsdRead(&ctx, req, &resp);
-    ASSERT_TRUE(resp.success());
+    ASSERT_EQ(resp.status(), ::umbp::SSD_READ_OK);
   }
 
   std::this_thread::sleep_for(std::chrono::seconds(kLeaseTimeoutS + 1));
@@ -317,13 +317,12 @@ TEST_F(PeerServiceSlotTest, ReadSlotTtlReclaim) {
   const std::string key = "ttl_0";
   ::umbp::PrepareSsdReadRequest req;
   req.set_key(key);
-  req.set_ssd_location_id("0:" + key);
-  req.set_size(10);
+  req.set_max_size(10);
   ::umbp::PrepareSsdReadResponse resp;
   grpc::ClientContext ctx;
   auto status = stub_->PrepareSsdRead(&ctx, req, &resp);
   ASSERT_TRUE(status.ok());
-  EXPECT_TRUE(resp.success()) << "Should succeed after TTL reclaim";
+  EXPECT_EQ(resp.status(), ::umbp::SSD_READ_OK) << "Should succeed after TTL reclaim";
 }
 
 }  // namespace

--- a/tests/cpp/umbp/local/bench_proxy_ipc.cpp
+++ b/tests/cpp/umbp/local/bench_proxy_ipc.cpp
@@ -121,7 +121,7 @@ static void RunBatch(SpdkProxyTier& tier, uint32_t rank_id, const std::string& s
 }
 
 int main() {
-  auto cfg = UMBPConfig::FromEnvironment();
+  auto cfg = UMBPConfig::FromEnvironment().ssd;
   cfg.ssd_backend = "spdk_proxy";
 
   SpdkProxyTier tier(cfg);

--- a/tests/cpp/umbp/local/bench_spdk_raw.cpp
+++ b/tests/cpp/umbp/local/bench_spdk_raw.cpp
@@ -486,7 +486,7 @@ int main(int argc, char** argv) {
       std::vector<double> wbw, rbw;
       for (int iter = 0; iter < bench.iterations; ++iter) {
         UMBPConfig posix_cfg;
-        SSDTier posix_tier(posix_dir, 8ULL * 1024 * 1024 * 1024, posix_cfg);
+        SSDTier posix_tier(posix_dir, 8ULL * 1024 * 1024 * 1024, posix_cfg.ssd);
 
         std::vector<std::string> keys(count);
         std::vector<std::vector<char>> bufs(count);

--- a/tests/cpp/umbp/local/bench_spdk_raw.cpp
+++ b/tests/cpp/umbp/local/bench_spdk_raw.cpp
@@ -391,7 +391,7 @@ int main(int argc, char** argv) {
   {
     PrintHeader("SpdkSsdTier BATCH THROUGHPUT");
 
-    UMBPConfig tier_cfg;
+    UMBPSsdConfig tier_cfg;
     tier_cfg.ssd_backend = "spdk";
     tier_cfg.spdk_bdev_name = ecfg.bdev_name;
     tier_cfg.spdk_reactor_mask = ecfg.reactor_mask;
@@ -399,7 +399,7 @@ int main(int argc, char** argv) {
     tier_cfg.spdk_nvme_pci_addr = ecfg.nvme_pci_addr;
     tier_cfg.spdk_nvme_ctrl_name = ecfg.nvme_ctrl_name;
     tier_cfg.spdk_io_workers = bench.threads;
-    tier_cfg.ssd.capacity_bytes = env.GetBdevSize();
+    tier_cfg.capacity_bytes = env.GetBdevSize();
 
     SpdkSsdTier tier(tier_cfg);
     if (!tier.IsValid()) {

--- a/tests/cpp/umbp/local/bench_umbp_e2e.cpp
+++ b/tests/cpp/umbp/local/bench_umbp_e2e.cpp
@@ -419,7 +419,7 @@ static int RunBenchmarkProcess(int rank_id, int num_ranks, int pipe_fd, void* co
   const char* role_str = (role == UMBPRole::Standalone)        ? "Standalone"
                          : (role == UMBPRole::SharedSSDLeader) ? "Leader"
                                                                : "Follower";
-  const char* backend = cfg.ssd_backend.c_str();
+  const char* backend = cfg.ssd.ssd_backend.c_str();
 
   const int iterations = 2;  // 0=cold (O_DIRECT/bypass cache), 1=hot
 
@@ -493,7 +493,7 @@ static int RunLatencyBench() {
     return 1;
   }
 
-  const char* backend = cfg.ssd_backend.c_str();
+  const char* backend = cfg.ssd.ssd_backend.c_str();
   std::string session = MakeSessionId();
 
   ssd->SetColdRead(true);
@@ -666,7 +666,7 @@ int main(int argc, char** argv) {
   printf("\n=== %d/%d ranks completed successfully ===\n", num_ranks - failures, num_ranks);
 
   auto cfg = UMBPConfig::FromEnvironment();
-  const char* backend = cfg.ssd_backend.c_str();
+  const char* backend = cfg.ssd.ssd_backend.c_str();
   bool is_phased = (num_ranks > 1);
 
   for (auto& rr : all_results) {

--- a/tests/cpp/umbp/local/bench_umbp_micro.cpp
+++ b/tests/cpp/umbp/local/bench_umbp_micro.cpp
@@ -409,7 +409,7 @@ static bool IsSpdk(const BenchConfig& cfg) { return cfg.ssd_backend == "spdk"; }
 static UMBPConfig MakeBaseSsdConfig(const BenchConfig& cfg) {
   UMBPConfig ucfg = IsSpdk(cfg) ? UMBPConfig::FromEnvironment() : UMBPConfig();
   ucfg.ssd.enabled = true;
-  ucfg.ssd_backend = cfg.ssd_backend;
+  ucfg.ssd.ssd_backend = cfg.ssd_backend;
   ucfg.ssd.capacity_bytes = cfg.ssd_capacity;
   ucfg.ssd.io.backend = cfg.ssd_io_backend;
   ucfg.ssd.io.queue_depth = cfg.ssd_io_queue_depth;
@@ -424,7 +424,7 @@ static UMBPConfig MakeBaseSsdConfig(const BenchConfig& cfg, UMBPIoBackend backen
   ucfg.ssd.io.backend = backend;
   ucfg.ssd.io.queue_depth = queue_depth;
   ucfg.ssd.durability.mode = durability;
-  ucfg.ssd_backend = cfg.ssd_backend;
+  ucfg.ssd.ssd_backend = cfg.ssd_backend;
   return ucfg;
 }
 

--- a/tests/cpp/umbp/local/bench_umbp_micro.cpp
+++ b/tests/cpp/umbp/local/bench_umbp_micro.cpp
@@ -870,7 +870,7 @@ struct TierScope {
   // POSIX: create local SSDTier
   TierScope(const std::string& dir, size_t capacity, const UMBPConfig& ucfg)
       : tmp(std::make_unique<ScopedTempDir>(dir)),
-        local_tier(std::make_unique<SSDTier>(tmp->path, capacity, ucfg)),
+        local_tier(std::make_unique<SSDTier>(tmp->path, capacity, ucfg.ssd)),
         tier(local_tier.get()) {}
 
   // SPDK: borrow external tier
@@ -2011,7 +2011,7 @@ static void BenchIOBackend(const BenchConfig& cfg, const std::vector<std::string
       ScopedTempDir tmp(cfg.base_dir + "/io_" + std::string(spec.path_suffix) + "_w");
       std::unique_ptr<SSDTier> tier;
       try {
-        tier = std::make_unique<SSDTier>(tmp.path, cfg.ssd_capacity, ucfg);
+        tier = std::make_unique<SSDTier>(tmp.path, cfg.ssd_capacity, ucfg.ssd);
       } catch (const std::exception& e) {
         std::printf("[SKIP] %s not available: %s\n", variant.c_str(), e.what());
         return;
@@ -2050,7 +2050,7 @@ static void BenchIOBackend(const BenchConfig& cfg, const std::vector<std::string
       ScopedTempDir tmp(cfg.base_dir + "/io_" + std::string(spec.path_suffix) + "_r");
       std::unique_ptr<SSDTier> tier;
       try {
-        tier = std::make_unique<SSDTier>(tmp.path, cfg.ssd_capacity, ucfg);
+        tier = std::make_unique<SSDTier>(tmp.path, cfg.ssd_capacity, ucfg.ssd);
       } catch (const std::exception& e) {
         std::printf("[SKIP] %s not available: %s\n", variant.c_str(), e.what());
         return;
@@ -2122,7 +2122,7 @@ static void BenchDurability(const BenchConfig& cfg, const std::vector<std::strin
     UMBPConfig ucfg = MakeBaseSsdConfig(cfg, cfg.ssd_io_backend, mode, cfg.ssd_io_queue_depth);
 
     ScopedTempDir tmp(cfg.base_dir + "/dur_" + label);
-    SSDTier tier(tmp.path, cfg.ssd_capacity, ucfg);
+    SSDTier tier(tmp.path, cfg.ssd_capacity, ucfg.ssd);
 
     // Warmup
     for (size_t w = 0; w < cfg.warmup_iters; ++w) {

--- a/tests/cpp/umbp/local/test_dummy_ssd_tier.cpp
+++ b/tests/cpp/umbp/local/test_dummy_ssd_tier.cpp
@@ -373,7 +373,7 @@ static UMBPConfig MakeDummyConfig(size_t dram_bytes, size_t ssd_bytes) {
   UMBPConfig cfg;
   cfg.dram.capacity_bytes = dram_bytes;
   cfg.ssd.enabled = true;
-  cfg.ssd_backend = "dummy_storage";
+  cfg.ssd.ssd_backend = "dummy_storage";
   cfg.ssd.capacity_bytes = ssd_bytes;
   return cfg;
 }

--- a/tests/cpp/umbp/local/test_follower_mode.cpp
+++ b/tests/cpp/umbp/local/test_follower_mode.cpp
@@ -42,11 +42,11 @@ static void cleanup_dir(const std::string& dir) {
   }
 }
 
-static UMBPConfig make_ssd_config() {
-  UMBPConfig cfg;
-  cfg.ssd.io.backend = UMBPIoBackend::PThread;
-  cfg.ssd.durability.mode = UMBPDurabilityMode::Relaxed;
-  cfg.ssd.segment_size_bytes = 4 * 1024 * 1024;
+static UMBPSsdConfig make_ssd_config() {
+  UMBPSsdConfig cfg;
+  cfg.io.backend = UMBPIoBackend::PThread;
+  cfg.durability.mode = UMBPDurabilityMode::Relaxed;
+  cfg.segment_size_bytes = 4 * 1024 * 1024;
   return cfg;
 }
 

--- a/tests/cpp/umbp/local/test_spdk_proxy.cpp
+++ b/tests/cpp/umbp/local/test_spdk_proxy.cpp
@@ -42,8 +42,8 @@
 
 using namespace mori::umbp;
 
-static UMBPConfig MakeProxyConfig() {
-  auto cfg = UMBPConfig::FromEnvironment();
+static UMBPSsdConfig MakeProxyConfig() {
+  auto cfg = UMBPConfig::FromEnvironment().ssd;
   cfg.ssd_backend = "spdk_proxy";
   // rank auto-allocated via CAS (spdk_proxy_rank_id == kAutoRankId from env)
   if (cfg.spdk_proxy_shm_name.empty()) cfg.spdk_proxy_shm_name = "/umbp_spdk_proxy";

--- a/tests/cpp/umbp/local/test_spdk_ssd_tier.cpp
+++ b/tests/cpp/umbp/local/test_spdk_ssd_tier.cpp
@@ -36,10 +36,10 @@
 
 using namespace mori::umbp;
 
-static UMBPConfig MakeTestConfig() {
-  UMBPConfig cfg;
+static UMBPSsdConfig MakeTestConfig() {
+  UMBPSsdConfig cfg;
   cfg.ssd_backend = "spdk";
-  cfg.ssd.capacity_bytes = 512ULL * 1024 * 1024;  // 512 MB
+  cfg.capacity_bytes = 512ULL * 1024 * 1024;  // 512 MB
 
   const char* bdev = std::getenv("UMBP_SPDK_BDEV");
   const char* pci = std::getenv("UMBP_SPDK_NVME_PCI");

--- a/tests/cpp/umbp/local/test_umbp_e2e.cpp
+++ b/tests/cpp/umbp/local/test_umbp_e2e.cpp
@@ -100,7 +100,7 @@ static UMBPConfig MakePosixConfig(size_t dram_mb = 64, size_t ssd_mb = 256) {
   cfg.dram.capacity_bytes = dram_mb * 1024 * 1024;
   cfg.ssd.capacity_bytes = ssd_mb * 1024 * 1024;
   cfg.ssd.io.backend = UMBPIoBackend::PThread;
-  cfg.ssd_backend = "posix";
+  cfg.ssd.ssd_backend = "posix";
   cfg.ssd.storage_dir = "/tmp/umbp_e2e_test_" + std::to_string(getpid());
   cfg.role = UMBPRole::Standalone;
   return cfg;
@@ -397,16 +397,16 @@ static bool test_spdk_standalone_write_read() {
   pid_t pid = fork();
   if (pid == 0) {
     UMBPConfig cfg;
-    cfg.ssd_backend = "spdk";
+    cfg.ssd.ssd_backend = "spdk";
     cfg.role = UMBPRole::Standalone;
     cfg.dram.capacity_bytes = 64ULL * 1024 * 1024;
     cfg.ssd.capacity_bytes = 1024ULL * 1024 * 1024;
 
     auto env_cfg = UMBPConfig::FromEnvironment();
-    cfg.spdk_nvme_pci_addr = env_cfg.spdk_nvme_pci_addr;
-    cfg.spdk_reactor_mask = env_cfg.spdk_reactor_mask;
-    cfg.spdk_mem_size_mb = env_cfg.spdk_mem_size_mb;
-    cfg.spdk_io_workers = env_cfg.spdk_io_workers;
+    cfg.ssd.spdk_nvme_pci_addr = env_cfg.ssd.spdk_nvme_pci_addr;
+    cfg.ssd.spdk_reactor_mask = env_cfg.ssd.spdk_reactor_mask;
+    cfg.ssd.spdk_mem_size_mb = env_cfg.ssd.spdk_mem_size_mb;
+    cfg.ssd.spdk_io_workers = env_cfg.ssd.spdk_io_workers;
 
     StandaloneClient client(cfg);
 
@@ -682,9 +682,9 @@ static bool test_proxy_cas_rank_allocation() {
 
       // Wait for proxy, then auto-allocate rank via CAS
       std::string shm_name =
-          cfg.spdk_proxy_shm_name.empty() ? "/umbp_spdk_proxy" : cfg.spdk_proxy_shm_name;
+          cfg.ssd.spdk_proxy_shm_name.empty() ? "/umbp_spdk_proxy" : cfg.ssd.spdk_proxy_shm_name;
       SpdkProxyTier::WaitForProxy(shm_name, 15000);
-      SpdkProxyTier tier(cfg);
+      SpdkProxyTier tier(cfg.ssd);
       uint8_t result = tier.IsValid() ? 1 : 0;
       write(pipe_fds[i][1], &result, 1);
       close(pipe_fds[i][1]);


### PR DESCRIPTION
## Summary
Adds an SSD cold tier to distributed UMBP — a best-effort, eventually-consistent
level below DRAM/HBM — serving as the L3 backend for SGLang HiCache. DRAM/HBM
stays the hot tier and the write-ack point; SSD is a UMBP-owned cold replica.
The master keeps only a routable projection; each peer stays the source of truth.

## Architecture
- **Master stays an advisor.** The global block index is per-(key, node, tier)
  additive; the master never owns SSD physical layout — it only learns SSD
  capacity and locations from heartbeats.
- **New `PeerSsdManager` per peer** owns the local SSD tier (reusing the
  `SSDTier` / `SpdkProxyTier` backends; posix/spdk selected via `UMBPSsdConfig`),
  tracking key→SSD location, capacity, and owned-location events.
- **Unified owned-location event source.** DRAM-allocator and SSD-manager
  ADD/REMOVE events merge into a single heartbeat stream (one monotonic seq);
  SSD capacity is reported via `tier_capacities`.
- **Write path (copy-on-commit).** A put still only needs DRAM/HBM to succeed.
  After commit, the owner peer asynchronously copies the just-committed DRAM
  pages to local SSD, pinning those pages against eviction during the copy; an
  SSD location is published only on copy success. A full queue or a failed copy
  never blocks the put.
- **Read path.** RouteGet prefers HBM > DRAM > SSD. On an SSD hit, a local
  reader reads SSD straight into its buffer; a remote reader uses a key-based
  SSD read RPC that stages into an RDMA-registrable buffer and reads it back.
  Stale/miss degrades safely.
- **Eviction coordination.** SSD eviction is peer-local (the master never drives
  it); DRAM eviction drops only the DRAM bucket and keeps the SSD replica; a key
  with an in-flight copy is skipped by DRAM eviction and retried next round.
- **Compatibility.** With `ssd.enabled=false`, behavior is identical to the
  previous DRAM-only path; legacy synchronous direct-SSD-put code is removed.

## Test plan
- [ ] Unit tests for PeerSsdManager, async copy pipeline, SSD read path, and tier-priority routing
- [ ] Full build green in the build container; relevant ctest suites pass
- [ ] DRAM-only path (ssd disabled) shows no regression