### PR TITLE
feat(io): add RDMA telemetry snapshot APIs

### DIFF
--- a/include/mori/io/backend.hpp
+++ b/include/mori/io/backend.hpp
@@ -23,6 +23,7 @@
 
 #include "mori/io/common.hpp"
 #include "mori/io/enum.hpp"
+#include "mori/io/telemetry.hpp"
 
 namespace mori {
 namespace io {
@@ -166,6 +167,8 @@ class Backend {
                                         TransferStatus* status) = 0;
 
   virtual bool CanHandle(const MemoryDesc& local, const MemoryDesc& remote) const { return true; }
+
+  virtual TelemetrySnapshot GetTelemetrySnapshot() const { return {}; }
 };
 
 }  // namespace io

--- a/include/mori/io/backend.hpp
+++ b/include/mori/io/backend.hpp
@@ -25,6 +25,7 @@
 
 #include "mori/io/common.hpp"
 #include "mori/io/enum.hpp"
+#include "mori/io/telemetry.hpp"
 
 namespace mori {
 namespace io {
@@ -194,6 +195,8 @@ class Backend {
                                         TransferStatus* status) = 0;
 
   virtual bool CanHandle(const MemoryDesc& local, const MemoryDesc& remote) const { return true; }
+
+  virtual TelemetrySnapshot GetTelemetrySnapshot() const { return {}; }
 };
 
 }  // namespace io

--- a/include/mori/io/engine.hpp
+++ b/include/mori/io/engine.hpp
@@ -111,6 +111,8 @@ class IOEngine {
   void LoadScatterGatherModule(const std::string& hsacoPath);
   void LoadFabricCopyModule(const std::string& hsacoPath);
 
+  TelemetrySnapshot GetTelemetrySnapshot(BackendType type) const;
+
  private:
   struct RouteCacheKey {
     EngineKey remoteEngineKey;

--- a/include/mori/io/engine.hpp
+++ b/include/mori/io/engine.hpp
@@ -110,6 +110,8 @@ class IOEngine {
   std::optional<IOEngineSession> CreateSession(const MemoryDesc& local, const MemoryDesc& remote);
   void LoadScatterGatherModule(const std::string& hsacoPath);
 
+  TelemetrySnapshot GetTelemetrySnapshot(BackendType type) const;
+
  private:
   struct RouteCacheKey {
     EngineKey remoteEngineKey;

--- a/include/mori/io/io.hpp
+++ b/include/mori/io/io.hpp
@@ -25,3 +25,4 @@
 #include "mori/io/engine.hpp"
 #include "mori/io/enum.hpp"
 #include "mori/io/logging.hpp"
+#include "mori/io/telemetry.hpp"

--- a/include/mori/io/telemetry.hpp
+++ b/include/mori/io/telemetry.hpp
@@ -1,0 +1,106 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "mori/io/common.hpp"
+#include "mori/io/enum.hpp"
+
+namespace mori {
+namespace io {
+
+struct TelemetryInitOptions {
+  std::optional<bool> enabled;
+};
+
+void InitTelemetry(const TelemetryInitOptions& opts = {});
+
+struct TelemetrySnapshot {
+  struct ApiStats {
+    uint64_t read_calls{0};
+    uint64_t write_calls{0};
+    uint64_t batch_read_calls{0};
+    uint64_t batch_write_calls{0};
+    uint64_t rejected_calls{0};
+    uint64_t total_bytes_read{0};
+    uint64_t total_bytes_written{0};
+    // Initiator-local JCT: API entry -> local CQE completion.
+    // Does NOT include notification round-trip to remote side.
+    // Values are 0.0 when jct_sample_count == 0.
+    double jct_ewma_us{0.0};
+    double jct_min_us{0.0};
+    double jct_max_us{0.0};
+    uint64_t jct_sample_count{0};
+  } api;
+
+  struct VerbsStats {
+    uint64_t bytes_posted{0};
+    uint64_t bytes_completed{0};
+    uint64_t ops_posted{0};
+    uint64_t ops_completed{0};
+    uint64_t cqe_errors{0};
+    uint64_t post_send_errors{0};
+    uint64_t sq_full_events{0};
+    uint64_t cq_polls{0};
+    uint64_t cq_empty_polls{0};
+    // Fraction of CQ polls that found work.
+    // Only meaningful in POLLING mode. In EVENT mode, value is ~1.0
+    // because polls only occur after completion channel notification.
+    double cq_utilization{0.0};
+    PollCqMode poll_mode{PollCqMode::POLLING};
+    int sq_depth{0};
+    int sq_depth_hwm{0};
+    int sq_depth_max{0};
+    // Per-signaled-WR post-to-CQE latency (NIC + wire time).
+    // Values are 0.0 when rdma_latency_sample_count == 0.
+    double rdma_latency_ewma_us{0.0};
+    double rdma_latency_min_us{0.0};
+    double rdma_latency_max_us{0.0};
+    uint64_t rdma_latency_sample_count{0};
+  } verbs;
+
+  // Latency breakdown (makespan-based, EWMA).
+  // Values are 0.0 when api.jct_sample_count == 0.
+  struct LatencyBreakdown {
+    double api_total_ewma_us{0.0};
+    double rdma_wall_ewma_us{0.0};
+    double sw_overhead_ewma_us{0.0};
+  } breakdown;
+
+  struct EpDetail {
+    uint64_t ep_id{0};
+    VerbsStats verbs;
+  };
+  std::vector<EpDetail> per_ep;
+
+  // TSC at snapshot time. Diff two snapshots' tsc values and divide by
+  // (tsc_freq_ghz * 1e9) to get elapsed seconds for bandwidth computation.
+  uint64_t snapshot_tsc{0};
+  double tsc_freq_ghz{0.0};
+};
+
+}  // namespace io
+}  // namespace mori

--- a/python/mori/io/engine.py
+++ b/python/mori/io/engine.py
@@ -216,3 +216,6 @@ class IOEngine:
 
     def wait_all(self, statuses, timeout_ms: int = -1) -> "mori_cpp.StatusCode":
         return self._engine.WaitAll(statuses, timeout_ms)
+
+    def get_telemetry_snapshot(self, backend_type=mori_cpp.BackendType.RDMA):
+        return self._engine.GetTelemetrySnapshot(backend_type)

--- a/python/mori/io/engine.py
+++ b/python/mori/io/engine.py
@@ -237,3 +237,6 @@ class IOEngine:
 
     def wait_all(self, statuses, timeout_ms: int = -1) -> "mori_cpp.StatusCode":
         return self._engine.WaitAll(statuses, timeout_ms)
+
+    def get_telemetry_snapshot(self, backend_type=mori_cpp.BackendType.RDMA):
+        return self._engine.GetTelemetrySnapshot(backend_type)

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -5,6 +5,7 @@ set(MORI_IO_SOURCES
     rdma/executor.cpp
     rdma/common.cpp
     rdma/ledger.cpp
+    rdma/telemetry.cpp
     xgmi/backend_impl.cpp
     xgmi/hip_resource_pool.cpp)
 

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -6,6 +6,7 @@ set(MORI_IO_SOURCES
     rdma/executor.cpp
     rdma/common.cpp
     rdma/ledger.cpp
+    rdma/telemetry.cpp
     xgmi/backend_impl.cpp
     xgmi/hip_resource_pool.cpp
     fabric/backend_impl.cpp

--- a/src/io/engine.cpp
+++ b/src/io/engine.cpp
@@ -647,5 +647,11 @@ StatusCode IOEngine::WaitAll(const std::vector<TransferStatus*>& statuses, int t
   return firstError;
 }
 
+TelemetrySnapshot IOEngine::GetTelemetrySnapshot(BackendType type) const {
+  auto it = backends.find(type);
+  if (it == backends.end()) return {};
+  return it->second->GetTelemetrySnapshot();
+}
+
 }  // namespace io
 }  // namespace mori

--- a/src/io/engine.cpp
+++ b/src/io/engine.cpp
@@ -613,5 +613,11 @@ StatusCode IOEngine::WaitAll(const std::vector<TransferStatus*>& statuses, int t
   return firstError;
 }
 
+TelemetrySnapshot IOEngine::GetTelemetrySnapshot(BackendType type) const {
+  auto it = backends.find(type);
+  if (it == backends.end()) return {};
+  return it->second->GetTelemetrySnapshot();
+}
+
 }  // namespace io
 }  // namespace mori

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -27,6 +27,7 @@
 #include <cstdlib>
 #include <limits>
 #include <memory>
+#include <numeric>
 #include <shared_mutex>
 #include <stdexcept>
 #include <string>
@@ -144,8 +145,9 @@ static CqeFailureAdvice DescribeCqeFailure(ibv_wc_status status, CqeFailureOrigi
 /*                                           RdmaManager                                          */
 /* ---------------------------------------------------------------------------------------------- */
 
-RdmaManager::RdmaManager(const RdmaBackendConfig cfg, application::RdmaContext* ctx)
-    : config(cfg), ctx(ctx) {
+RdmaManager::RdmaManager(const RdmaBackendConfig cfg, application::RdmaContext* ctx,
+                         TelemetryRegistry* telemetry)
+    : config(cfg), ctx(ctx), telemetry_(telemetry) {
   application::RdmaDeviceList devices = ctx->GetRdmaDeviceList();
   availDevices = GetActiveDevicePortList(devices);
   if (availDevices.empty()) {
@@ -367,9 +369,12 @@ EndpointId RdmaManager::ConnectEndpoint(EngineKey remoteKey, int devId,
             static_cast<int>(epConfig.maxMsgsNum),
             std::make_shared<std::atomic<bool>>(false),
             std::make_shared<SubmissionLedger>(config.notifPerQp)};
-  meta.rTable[topoKey].push_back(ep);
-
   EndpointId id = nextEndpointId_.fetch_add(1);
+  if (TelemetryConfig::Enabled() && telemetry_) {
+    ep.telem = telemetry_->CreateEpTelemetry(id, ep.sqDepth, ep.maxSqDepth);
+  }
+
+  meta.rTable[topoKey].push_back(ep);
   auto rt = std::make_shared<EndpointRuntime>(id, ep);
   endpointsById_[id] = rt;
   return id;
@@ -410,8 +415,9 @@ application::RdmaDeviceContext* RdmaManager::GetOrCreateDeviceContext(int devId)
 /* ---------------------------------------------------------------------------------------------- */
 /*                                      Notification Manager                                      */
 /* ---------------------------------------------------------------------------------------------- */
-NotifManager::NotifManager(RdmaManager* rdmaMgr, const RdmaBackendConfig& cfg)
-    : rdma(rdmaMgr), config(cfg) {}
+NotifManager::NotifManager(RdmaManager* rdmaMgr, const RdmaBackendConfig& cfg,
+                           TelemetryRegistry* telemetry)
+    : rdma(rdmaMgr), config(cfg), telemetry_(telemetry) {}
 
 NotifManager::~NotifManager() { Shutdown(); }
 
@@ -422,6 +428,10 @@ void NotifManager::RegisterEndpoint(const std::shared_ptr<EndpointRuntime>& rt) 
     ev.data.u64 = rt->id;
     assert(rt->ep.local.ibvHandle.compCh);
     SYSCALL_RETURN_ZERO(epoll_ctl(epfd, EPOLL_CTL_ADD, rt->ep.local.ibvHandle.compCh->fd, &ev));
+  }
+
+  if (rt->ep.telem && rt->ep.ledger) {
+    rt->ep.ledger->EnableTimestamping();
   }
 
   // Skip notification setup if disabled
@@ -483,9 +493,15 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
 
   const int batchSize = 32;
   struct ibv_wc wc[batchSize];
-  int n = 0;
 
-  while ((n = ibv_poll_cq(cq, batchSize, wc)) > 0) {
+  int n = ibv_poll_cq(cq, batchSize, wc);
+
+  if (MORI_IO_TELEM_UNLIKELY(ep.telem)) {
+    ep.telem->counters.cq_poll_count.fetch_add(1, std::memory_order_relaxed);
+    if (n == 0) ep.telem->counters.cq_empty_poll_count.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  while (n > 0) {
     for (int i = 0; i < n; ++i) {
       if (wc[i].status != IBV_WC_SUCCESS) {
         const bool isFlush = (wc[i].status == IBV_WC_WR_FLUSH_ERR);
@@ -514,6 +530,10 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
                 wc[i].wr_id, static_cast<uint32_t>(wc[i].status), failureAdvice.statusText,
                 wc[i].qp_num, wc[i].vendor_err);
           }
+        }
+
+        if (MORI_IO_TELEM_UNLIKELY(ep.telem)) {
+          ep.telem->counters.cqe_errors.fetch_add(1, std::memory_order_relaxed);
         }
 
         int mergedBatchSize = 0;
@@ -614,14 +634,49 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
         // Batch path: wr_id carries a recordId from the SubmissionLedger.
         uint64_t recordId = wc[i].wr_id;
         int mergedBatchSize = 0;
-        auto meta = ep.ledger
-                        ? ep.ledger->ReleaseByCqe(recordId, ep.sqDepth.get(), &mergedBatchSize)
-                        : nullptr;
+        uint64_t recordBytes = 0;
+        uint64_t post_tsc = 0;
+        auto meta = ep.ledger ? ep.ledger->ReleaseByCqe(recordId, ep.sqDepth.get(),
+                                                        &mergedBatchSize, &recordBytes, &post_tsc)
+                              : nullptr;
         if (meta) {
+          if (MORI_IO_TELEM_UNLIKELY(ep.telem)) {
+            ep.telem->counters.ops_completed.fetch_add(mergedBatchSize, std::memory_order_relaxed);
+            ep.telem->counters.bytes_completed.fetch_add(recordBytes, std::memory_order_relaxed);
+
+            if (post_tsc != 0) {
+              uint64_t delta = __rdtsc() - post_tsc;
+              ep.telem->stats.Update(delta);
+            }
+          }
+
           uint32_t finishedBefore = meta->finishedBatchSize.fetch_add(mergedBatchSize);
           TransferStatus* statusPtr = meta->status;
-          if (statusPtr != nullptr && (finishedBefore + mergedBatchSize) == meta->totalBatchSize) {
+          if (statusPtr != nullptr &&
+              (finishedBefore + mergedBatchSize) == static_cast<uint32_t>(meta->totalBatchSize)) {
             statusPtr->Update(StatusCode::SUCCESS, ibv_wc_status_str(wc[i].status));
+
+            if (MORI_IO_TELEM_UNLIKELY(meta->telem) && meta->telem->api_start_tsc != 0) {
+              uint64_t now = __rdtsc();
+              uint64_t first_post = meta->telem->first_post_tsc.load(std::memory_order_relaxed);
+              uint64_t jct = now - meta->telem->api_start_tsc;
+              uint64_t rdma_wall =
+                  (first_post != UINT64_MAX && first_post <= now) ? (now - first_post) : 0;
+              uint64_t sw_overhead =
+                  (first_post != UINT64_MAX && first_post >= meta->telem->api_start_tsc)
+                      ? (first_post - meta->telem->api_start_tsc)
+                      : 0;
+              if (telemetry_) telemetry_->RecordJct(jct, rdma_wall, sw_overhead);
+
+              if (meta->telem->api_counters) {
+                if (meta->telem->is_read)
+                  meta->telem->api_counters->total_bytes_read.fetch_add(meta->telem->total_bytes,
+                                                                        std::memory_order_relaxed);
+                else
+                  meta->telem->api_counters->total_bytes_written.fetch_add(
+                      meta->telem->total_bytes, std::memory_order_relaxed);
+              }
+            }
           }
           MORI_IO_TRACE("ProcessOneCqe: batch CQE for task {} total={} finished={} cur={}",
                         meta->id, meta->totalBatchSize, finishedBefore, mergedBatchSize);
@@ -632,6 +687,7 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
         }
       }
     }
+    n = ibv_poll_cq(cq, batchSize, wc);
   }
 
   if (!flushDrain.Empty()) {
@@ -962,8 +1018,8 @@ void ControlPlaneServer::Shutdown() {
 RdmaBackendSession::RdmaBackendSession(const RdmaBackendConfig& config,
                                        const application::RdmaMemoryRegion& l,
                                        const application::RdmaMemoryRegion& r, const EpPairVec& e,
-                                       Executor* exec)
-    : config(config), local(l), remote(r), eps(e), executor(exec) {}
+                                       Executor* exec, TelemetryRegistry* telemetry)
+    : config(config), local(l), remote(r), eps(e), executor(exec), telemetry_(telemetry) {}
 
 void RdmaBackendSession::ReadWrite(size_t localOffset, size_t remoteOffset, size_t size,
                                    TransferStatus* status, TransferUniqueId id, bool isRead) {
@@ -972,12 +1028,31 @@ void RdmaBackendSession::ReadWrite(size_t localOffset, size_t remoteOffset, size
   auto callbackMeta = std::make_shared<CqCallbackMeta>(status, id, 1);
   internal::PublishCurrentIoCallDiagnostics(callbackMeta);
 
+  if (MORI_IO_TELEM_UNLIKELY(telemetry_)) {
+    auto tm = std::make_unique<TelemetryMeta>();
+    tm->api_start_tsc = __rdtsc();
+    tm->total_bytes = size;
+    tm->is_read = isRead;
+    tm->api_counters = &telemetry_->ApiCounters();
+    callbackMeta->telem = std::move(tm);
+
+    auto& api = telemetry_->ApiCounters();
+    if (isRead)
+      api.read_calls.fetch_add(1, std::memory_order_relaxed);
+    else
+      api.write_calls.fetch_add(1, std::memory_order_relaxed);
+  }
+
   RdmaOpRet ret =
       RdmaReadWrite(eps, local, localOffset, remote, remoteOffset, size, callbackMeta, id, isRead);
 
   assert(!ret.Init());
   if (ret.Failed() || ret.Succeeded()) {
     status->Update(ret.code, ret.message);
+  }
+
+  if (MORI_IO_TELEM_UNLIKELY(callbackMeta->telem) && ret.code == StatusCode::ERR_INVALID_ARGS) {
+    callbackMeta->telem->api_counters->rejected_calls.fetch_add(1, std::memory_order_relaxed);
   }
   if (!ret.Failed() && config.enableNotification) {
     RdmaOpRet notifRet = RdmaNotifyTransfer(eps, status, id);
@@ -994,6 +1069,22 @@ void RdmaBackendSession::BatchReadWrite(const SizeVec& localOffsets, const SizeV
   status->SetCode(StatusCode::IN_PROGRESS);
   auto callbackMeta = std::make_shared<CqCallbackMeta>(status, id, sizes.size());
   internal::PublishCurrentIoCallDiagnostics(callbackMeta);
+
+  if (MORI_IO_TELEM_UNLIKELY(telemetry_)) {
+    auto tm = std::make_unique<TelemetryMeta>();
+    tm->api_start_tsc = __rdtsc();
+    tm->total_bytes = std::accumulate(sizes.begin(), sizes.end(), uint64_t{0});
+    tm->is_read = isRead;
+    tm->api_counters = &telemetry_->ApiCounters();
+    callbackMeta->telem = std::move(tm);
+
+    auto& api = telemetry_->ApiCounters();
+    if (isRead)
+      api.batch_read_calls.fetch_add(1, std::memory_order_relaxed);
+    else
+      api.batch_write_calls.fetch_add(1, std::memory_order_relaxed);
+  }
+
   RdmaOpRet ret;
   if (executor) {
     ExecutorReq req{eps,          local, localOffsets,         remote, remoteOffsets, sizes,
@@ -1007,6 +1098,11 @@ void RdmaBackendSession::BatchReadWrite(const SizeVec& localOffsets, const SizeV
   if (ret.Failed() || ret.Succeeded()) {
     status->Update(ret.code, ret.message);
   }
+
+  if (MORI_IO_TELEM_UNLIKELY(callbackMeta->telem) && ret.code == StatusCode::ERR_INVALID_ARGS) {
+    callbackMeta->telem->api_counters->rejected_calls.fetch_add(1, std::memory_order_relaxed);
+  }
+
   if (!ret.Failed() && config.enableNotification) {
     RdmaOpRet notifRet = RdmaNotifyTransfer(eps, status, id);
     if (notifRet.Failed()) {
@@ -1035,11 +1131,17 @@ RdmaBackend::RdmaBackend(EngineKey k, const IOEngineConfig& engConfig,
                 mori::env::detail::ParseBool);
   ValidateRdmaNotificationConfig(config);
 
+  TelemetryConfig::Init();
+  if (TelemetryConfig::Enabled()) {
+    telemetry_ = std::make_unique<TelemetryRegistry>();
+    telemetry_->SetPollMode(config.pollCqMode);
+  }
+
   auto rdmaCtx = std::make_unique<application::RdmaContext>(application::RdmaBackendType::IBVerbs);
-  rdma.reset(new mori::io::RdmaManager(config, rdmaCtx.get()));
+  rdma.reset(new mori::io::RdmaManager(config, rdmaCtx.get(), telemetry_.get()));
   (void)rdmaCtx.release();
 
-  notif.reset(new NotifManager(rdma.get(), config));
+  notif.reset(new NotifManager(rdma.get(), config, telemetry_.get()));
   notif->Start();
 
   server.reset(
@@ -1151,12 +1253,18 @@ void RdmaBackend::CreateSession(const MemoryDesc& local, const MemoryDesc& remot
     rdma->RegisterRemoteMemory(ekey, ep.rdevId, remote.id, remoteMr.value());
   }
 
-  sess = RdmaBackendSession(config, localMr.value(), remoteMr.value(), epSet, executor.get());
+  sess = RdmaBackendSession(config, localMr.value(), remoteMr.value(), epSet, executor.get(),
+                            telemetry_.get());
 }
 
 bool RdmaBackend::PopInboundTransferStatus(EngineKey remote, TransferUniqueId id,
                                            TransferStatus* status) {
   return notif->PopInboundTransferStatus(remote, id, status);
+}
+
+TelemetrySnapshot RdmaBackend::GetTelemetrySnapshot() const {
+  if (!telemetry_) return {};
+  return telemetry_->Snapshot();
 }
 
 RdmaBackendSession* RdmaBackend::GetOrCreateSessionCached(const MemoryDesc& local,

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -30,6 +30,7 @@
 #include <cstring>
 #include <limits>
 #include <memory>
+#include <numeric>
 #include <optional>
 #include <shared_mutex>
 #include <stdexcept>
@@ -249,8 +250,9 @@ static CqeFailureAdvice DescribeCqeFailure(ibv_wc_status status, CqeFailureOrigi
 /*                                           RdmaManager                                          */
 /* ---------------------------------------------------------------------------------------------- */
 
-RdmaManager::RdmaManager(const RdmaBackendConfig cfg, application::RdmaContext* ctx)
-    : config(cfg), ctx(ctx) {
+RdmaManager::RdmaManager(const RdmaBackendConfig cfg, application::RdmaContext* ctx,
+                         TelemetryRegistry* telemetry)
+    : config(cfg), ctx(ctx), telemetry_(telemetry) {
   application::RdmaDeviceList devices = ctx->GetRdmaDeviceList();
   availDevices = GetActiveDevicePortList(devices);
   if (availDevices.empty()) {
@@ -585,9 +587,12 @@ EndpointId RdmaManager::ConnectEndpoint(EngineKey remoteKey, int devId,
             std::make_shared<std::atomic<bool>>(false),
             std::make_shared<SubmissionLedger>(config.notifPerQp),
             std::make_shared<SqAdmissionEvent>()};
-  meta.rTable[topoKey].push_back(ep);
-
   EndpointId id = nextEndpointId_.fetch_add(1);
+  if (TelemetryConfig::Enabled() && telemetry_) {
+    ep.telem = telemetry_->CreateEpTelemetry(id, ep.sqDepth, ep.maxSqDepth);
+  }
+
+  meta.rTable[topoKey].push_back(ep);
   auto rt = std::make_shared<EndpointRuntime>(id, ep);
   endpointsById_[id] = rt;
   return id;
@@ -639,8 +644,9 @@ application::RdmaDeviceContext* RdmaManager::GetOrCreateDeviceContext(int devId)
 /* ---------------------------------------------------------------------------------------------- */
 /*                                      Notification Manager                                      */
 /* ---------------------------------------------------------------------------------------------- */
-NotifManager::NotifManager(RdmaManager* rdmaMgr, const RdmaBackendConfig& cfg)
-    : rdma(rdmaMgr), config(cfg) {}
+NotifManager::NotifManager(RdmaManager* rdmaMgr, const RdmaBackendConfig& cfg,
+                           TelemetryRegistry* telemetry)
+    : rdma(rdmaMgr), config(cfg), telemetry_(telemetry) {}
 
 NotifManager::~NotifManager() { Shutdown(); }
 
@@ -651,6 +657,10 @@ void NotifManager::RegisterEndpoint(const std::shared_ptr<EndpointRuntime>& rt) 
     ev.data.u64 = rt->id;
     assert(rt->ep.local.ibvHandle.compCh);
     SYSCALL_RETURN_ZERO(epoll_ctl(epfd, EPOLL_CTL_ADD, rt->ep.local.ibvHandle.compCh->fd, &ev));
+  }
+
+  if (rt->ep.telem && rt->ep.ledger) {
+    rt->ep.ledger->EnableTimestamping();
   }
 
   // Skip notification setup if disabled
@@ -712,9 +722,15 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
 
   const int batchSize = 32;
   struct ibv_wc wc[batchSize];
-  int n = 0;
 
-  while ((n = ibv_poll_cq(cq, batchSize, wc)) > 0) {
+  int n = ibv_poll_cq(cq, batchSize, wc);
+
+  if (MORI_IO_TELEM_UNLIKELY(ep.telem)) {
+    ep.telem->counters.cq_poll_count.fetch_add(1, std::memory_order_relaxed);
+    if (n == 0) ep.telem->counters.cq_empty_poll_count.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  while (n > 0) {
     for (int i = 0; i < n; ++i) {
       if (wc[i].status != IBV_WC_SUCCESS) {
         const bool isFlush = (wc[i].status == IBV_WC_WR_FLUSH_ERR);
@@ -743,6 +759,10 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
                 wc[i].wr_id, static_cast<uint32_t>(wc[i].status), failureAdvice.statusText,
                 wc[i].qp_num, wc[i].vendor_err);
           }
+        }
+
+        if (MORI_IO_TELEM_UNLIKELY(ep.telem)) {
+          ep.telem->counters.cqe_errors.fetch_add(1, std::memory_order_relaxed);
         }
 
         int mergedBatchSize = 0;
@@ -850,15 +870,51 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
         // Batch path: wr_id carries a recordId from the SubmissionLedger.
         uint64_t recordId = wc[i].wr_id;
         int mergedBatchSize = 0;
-        auto meta = ep.ledger
-                        ? ep.ledger->ReleaseByCqe(recordId, ep.sqDepth.get(), &mergedBatchSize)
-                        : nullptr;
+        uint64_t recordBytes = 0;
+        uint64_t post_tsc = 0;
+        auto meta = ep.ledger ? ep.ledger->ReleaseByCqe(recordId, ep.sqDepth.get(),
+                                                        &mergedBatchSize, &recordBytes, &post_tsc)
+                              : nullptr;
         if (meta) {
           NotifySqStateChanged(ep);
+
+          if (MORI_IO_TELEM_UNLIKELY(ep.telem)) {
+            ep.telem->counters.ops_completed.fetch_add(mergedBatchSize, std::memory_order_relaxed);
+            ep.telem->counters.bytes_completed.fetch_add(recordBytes, std::memory_order_relaxed);
+
+            if (post_tsc != 0) {
+              uint64_t delta = __rdtsc() - post_tsc;
+              ep.telem->stats.Update(delta);
+            }
+          }
+
           uint32_t finishedBefore = meta->finishedBatchSize.fetch_add(mergedBatchSize);
           TransferStatus* statusPtr = meta->status;
-          if (statusPtr != nullptr && (finishedBefore + mergedBatchSize) == meta->totalBatchSize) {
+          if (statusPtr != nullptr &&
+              (finishedBefore + mergedBatchSize) == static_cast<uint32_t>(meta->totalBatchSize)) {
             statusPtr->Update(StatusCode::SUCCESS, ibv_wc_status_str(wc[i].status));
+
+            if (MORI_IO_TELEM_UNLIKELY(meta->telem) && meta->telem->api_start_tsc != 0) {
+              uint64_t now = __rdtsc();
+              uint64_t first_post = meta->telem->first_post_tsc.load(std::memory_order_relaxed);
+              uint64_t jct = now - meta->telem->api_start_tsc;
+              uint64_t rdma_wall =
+                  (first_post != UINT64_MAX && first_post <= now) ? (now - first_post) : 0;
+              uint64_t sw_overhead =
+                  (first_post != UINT64_MAX && first_post >= meta->telem->api_start_tsc)
+                      ? (first_post - meta->telem->api_start_tsc)
+                      : 0;
+              if (telemetry_) telemetry_->RecordJct(jct, rdma_wall, sw_overhead);
+
+              if (meta->telem->api_counters) {
+                if (meta->telem->is_read)
+                  meta->telem->api_counters->total_bytes_read.fetch_add(meta->telem->total_bytes,
+                                                                        std::memory_order_relaxed);
+                else
+                  meta->telem->api_counters->total_bytes_written.fetch_add(
+                      meta->telem->total_bytes, std::memory_order_relaxed);
+              }
+            }
           }
           MORI_IO_TRACE("ProcessOneCqe: batch CQE for task {} total={} finished={} cur={}",
                         meta->id, meta->totalBatchSize, finishedBefore, mergedBatchSize);
@@ -869,6 +925,7 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
         }
       }
     }
+    n = ibv_poll_cq(cq, batchSize, wc);
   }
 
   if (!flushDrain.Empty()) {
@@ -1325,13 +1382,14 @@ RdmaBackendSession::RdmaBackendSession(const RdmaBackendConfig& config,
                                        std::vector<application::RdmaMemoryRegion> localMrPerEp,
                                        std::vector<application::RdmaMemoryRegion> remoteMrPerEp,
                                        const EpPairVec& e, Executor* exec,
-                                       MemoryLocationType localLoc)
+                                       MemoryLocationType localLoc, TelemetryRegistry* telemetry)
     : config(config),
       localMrPerEp(std::move(localMrPerEp)),
       remoteMrPerEp(std::move(remoteMrPerEp)),
       eps(e),
       executor(exec),
-      localLoc_(localLoc) {}
+      localLoc_(localLoc),
+      telemetry_(telemetry) {}
 
 void RdmaBackendSession::ReadWrite(size_t localOffset, size_t remoteOffset, size_t size,
                                    TransferStatus* status, TransferUniqueId id, bool isRead) {
@@ -1339,6 +1397,21 @@ void RdmaBackendSession::ReadWrite(size_t localOffset, size_t remoteOffset, size
   status->SetCode(StatusCode::IN_PROGRESS);
   auto callbackMeta = std::make_shared<CqCallbackMeta>(status, id, 1);
   internal::PublishCurrentIoCallDiagnostics(callbackMeta);
+
+  if (MORI_IO_TELEM_UNLIKELY(telemetry_)) {
+    auto tm = std::make_unique<TelemetryMeta>();
+    tm->api_start_tsc = __rdtsc();
+    tm->total_bytes = size;
+    tm->is_read = isRead;
+    tm->api_counters = &telemetry_->ApiCounters();
+    callbackMeta->telem = std::move(tm);
+
+    auto& api = telemetry_->ApiCounters();
+    if (isRead)
+      api.read_calls.fetch_add(1, std::memory_order_relaxed);
+    else
+      api.write_calls.fetch_add(1, std::memory_order_relaxed);
+  }
 
   RdmaOpRet ret = RdmaBatchReadWrite(eps, localMrPerEp, remoteMrPerEp, {localOffset},
                                      {remoteOffset}, {size}, callbackMeta, id, isRead, 1,
@@ -1348,6 +1421,10 @@ void RdmaBackendSession::ReadWrite(size_t localOffset, size_t remoteOffset, size
   assert(!ret.Init());
   if (ret.Failed() || ret.Succeeded()) {
     status->Update(ret.code, ret.message);
+  }
+
+  if (MORI_IO_TELEM_UNLIKELY(callbackMeta->telem) && ret.code == StatusCode::ERR_INVALID_ARGS) {
+    callbackMeta->telem->api_counters->rejected_calls.fetch_add(1, std::memory_order_relaxed);
   }
   if (!ret.Failed() && config.enableNotification) {
     RdmaOpRet notifRet = RdmaNotifyTransfer(eps, status, id);
@@ -1407,6 +1484,22 @@ void RdmaBackendSession::BatchReadWrite(const SizeVec& localOffsets, const SizeV
 
   auto callbackMeta = std::make_shared<CqCallbackMeta>(status, id, totalCredit);
   internal::PublishCurrentIoCallDiagnostics(callbackMeta);
+
+  if (MORI_IO_TELEM_UNLIKELY(telemetry_)) {
+    auto tm = std::make_unique<TelemetryMeta>();
+    tm->api_start_tsc = __rdtsc();
+    tm->total_bytes = std::accumulate(sizes.begin(), sizes.end(), uint64_t{0});
+    tm->is_read = isRead;
+    tm->api_counters = &telemetry_->ApiCounters();
+    callbackMeta->telem = std::move(tm);
+
+    auto& api = telemetry_->ApiCounters();
+    if (isRead)
+      api.batch_read_calls.fetch_add(1, std::memory_order_relaxed);
+    else
+      api.batch_write_calls.fetch_add(1, std::memory_order_relaxed);
+  }
+
   RdmaOpRet ret;
   if (canUseWorkerChunking) {
     ExecutorReq req{eps,
@@ -1448,6 +1541,11 @@ void RdmaBackendSession::BatchReadWrite(const SizeVec& localOffsets, const SizeV
   if (ret.Failed() || ret.Succeeded()) {
     status->Update(ret.code, ret.message);
   }
+
+  if (MORI_IO_TELEM_UNLIKELY(callbackMeta->telem) && ret.code == StatusCode::ERR_INVALID_ARGS) {
+    callbackMeta->telem->api_counters->rejected_calls.fetch_add(1, std::memory_order_relaxed);
+  }
+
   if (!ret.Failed() && config.enableNotification) {
     RdmaOpRet notifRet = RdmaNotifyTransfer(eps, status, id);
     if (notifRet.Failed()) {
@@ -1492,11 +1590,17 @@ RdmaBackend::RdmaBackend(EngineKey k, const IOEngineConfig& engConfig,
   ValidateRdmaNotificationConfig(config);
   ValidateRdmaTransferConfig(config);
 
+  TelemetryConfig::Init();
+  if (TelemetryConfig::Enabled()) {
+    telemetry_ = std::make_unique<TelemetryRegistry>();
+    telemetry_->SetPollMode(config.pollCqMode);
+  }
+
   auto rdmaCtx = std::make_unique<application::RdmaContext>(application::RdmaBackendType::IBVerbs);
-  rdma.reset(new mori::io::RdmaManager(config, rdmaCtx.get()));
+  rdma.reset(new mori::io::RdmaManager(config, rdmaCtx.get(), telemetry_.get()));
   (void)rdmaCtx.release();
 
-  notif.reset(new NotifManager(rdma.get(), config));
+  notif.reset(new NotifManager(rdma.get(), config, telemetry_.get()));
   notif->Start();
 
   server.reset(new ControlPlaneServer(myEngKey, engConfig.host, engConfig.port, config, rdma.get(),
@@ -1698,12 +1802,17 @@ void RdmaBackend::CreateSession(const MemoryDesc& local, const MemoryDesc& remot
   }
 
   sess = RdmaBackendSession(config, std::move(localMrPerEp), std::move(remoteMrPerEp), epSet,
-                            executor.get(), local.loc);
+                            executor.get(), local.loc, telemetry_.get());
 }
 
 bool RdmaBackend::PopInboundTransferStatus(EngineKey remote, TransferUniqueId id,
                                            TransferStatus* status) {
   return notif->PopInboundTransferStatus(remote, id, status);
+}
+
+TelemetrySnapshot RdmaBackend::GetTelemetrySnapshot() const {
+  if (!telemetry_) return {};
+  return telemetry_->Snapshot();
 }
 
 RdmaBackendSession* RdmaBackend::GetOrCreateSessionCached(const MemoryDesc& local,

--- a/src/io/rdma/backend_impl.hpp
+++ b/src/io/rdma/backend_impl.hpp
@@ -39,6 +39,7 @@
 #include "mori/io/engine.hpp"
 #include "src/io/rdma/common.hpp"
 #include "src/io/rdma/executor.hpp"
+#include "src/io/rdma/telemetry.hpp"
 
 namespace mori {
 namespace io {
@@ -56,7 +57,8 @@ inline constexpr uint16_t kXgmiOnlyFallbackPlaceholderPort = 1;
 /* ---------------------------------------------------------------------------------------------- */
 class RdmaManager {
  public:
-  RdmaManager(const RdmaBackendConfig cfg, application::RdmaContext* ctx);
+  RdmaManager(const RdmaBackendConfig cfg, application::RdmaContext* ctx,
+              TelemetryRegistry* telemetry = nullptr);
   ~RdmaManager();
 
   application::RdmaEndpointConfig GetRdmaEndpointConfig(int devId);
@@ -106,6 +108,8 @@ class RdmaManager {
 
   std::unique_ptr<application::TopoSystem> topo{nullptr};
   std::atomic<uint32_t> roundRobinCounter{0};
+
+  TelemetryRegistry* telemetry_{nullptr};
 };
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -113,7 +117,7 @@ class RdmaManager {
 /* ---------------------------------------------------------------------------------------------- */
 class NotifManager {
  public:
-  NotifManager(RdmaManager*, const RdmaBackendConfig&);
+  NotifManager(RdmaManager*, const RdmaBackendConfig&, TelemetryRegistry* telemetry = nullptr);
   ~NotifManager();
 
   void RegisterEndpoint(const std::shared_ptr<EndpointRuntime>& rt);
@@ -186,6 +190,7 @@ class NotifManager {
   // Accessed only by the single NotifManager poll loop thread to rate-limit
   // repeated summaries for the same consecutive flush episode.
   uint64_t flushSummaryStreak_{0};
+  TelemetryRegistry* telemetry_{nullptr};
 };
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -249,7 +254,7 @@ class RdmaBackendSession : public BackendSession {
   RdmaBackendSession() = default;
   RdmaBackendSession(const RdmaBackendConfig& config, const application::RdmaMemoryRegion& local,
                      const application::RdmaMemoryRegion& remote, const EpPairVec& eps,
-                     Executor* executor);
+                     Executor* executor, TelemetryRegistry* telemetry = nullptr);
   ~RdmaBackendSession() = default;
 
   void ReadWrite(size_t localOffset, size_t remoteOffset, size_t size, TransferStatus* status,
@@ -267,6 +272,7 @@ class RdmaBackendSession : public BackendSession {
   application::RdmaMemoryRegion remote{};
   EpPairVec eps{};
   Executor* executor{nullptr};
+  TelemetryRegistry* telemetry_{nullptr};
 };
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -300,6 +306,7 @@ class RdmaBackend : public Backend {
   bool PopInboundTransferStatus(EngineKey remote, TransferUniqueId id,
                                 TransferStatus* status) override;
   bool CanHandle(const MemoryDesc& local, const MemoryDesc& remote) const override;
+  TelemetrySnapshot GetTelemetrySnapshot() const override;
 
  private:
   void CreateSession(const MemoryDesc& local, const MemoryDesc& remote, RdmaBackendSession& sess);
@@ -340,6 +347,7 @@ class RdmaBackend : public Backend {
   std::unordered_map<SessionCacheKey, std::unique_ptr<RdmaBackendSession>, SessionCacheKeyHash>
       sessionCache;
   std::mutex sessionCacheMu;
+  std::unique_ptr<TelemetryRegistry> telemetry_;
 };
 
 }  // namespace io

--- a/src/io/rdma/backend_impl.hpp
+++ b/src/io/rdma/backend_impl.hpp
@@ -40,6 +40,7 @@
 #include "mori/io/engine.hpp"
 #include "src/io/rdma/common.hpp"
 #include "src/io/rdma/executor.hpp"
+#include "src/io/rdma/telemetry.hpp"
 
 namespace mori {
 namespace io {
@@ -68,7 +69,8 @@ EpPairVec InterleaveEndpointsByLocalDevice(const EpPairVec& eps,
 /* ---------------------------------------------------------------------------------------------- */
 class RdmaManager {
  public:
-  RdmaManager(const RdmaBackendConfig cfg, application::RdmaContext* ctx);
+  RdmaManager(const RdmaBackendConfig cfg, application::RdmaContext* ctx,
+              TelemetryRegistry* telemetry = nullptr);
   ~RdmaManager();
 
   application::RdmaEndpointConfig GetRdmaEndpointConfig(int devId);
@@ -124,6 +126,7 @@ class RdmaManager {
   std::atomic<uint32_t> roundRobinCounter{0};
 
   std::unique_ptr<RdmaAsyncEventMonitor> asyncEventMonitor_;
+  TelemetryRegistry* telemetry_{nullptr};
 };
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -131,7 +134,7 @@ class RdmaManager {
 /* ---------------------------------------------------------------------------------------------- */
 class NotifManager {
  public:
-  NotifManager(RdmaManager*, const RdmaBackendConfig&);
+  NotifManager(RdmaManager*, const RdmaBackendConfig&, TelemetryRegistry* telemetry = nullptr);
   ~NotifManager();
 
   void RegisterEndpoint(const std::shared_ptr<EndpointRuntime>& rt);
@@ -204,6 +207,7 @@ class NotifManager {
   // Accessed only by the single NotifManager poll loop thread to rate-limit
   // repeated summaries for the same consecutive flush episode.
   uint64_t flushSummaryStreak_{0};
+  TelemetryRegistry* telemetry_{nullptr};
 };
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -270,7 +274,8 @@ class RdmaBackendSession : public BackendSession {
   RdmaBackendSession(const RdmaBackendConfig& config,
                      std::vector<application::RdmaMemoryRegion> localMrPerEp,
                      std::vector<application::RdmaMemoryRegion> remoteMrPerEp, const EpPairVec& eps,
-                     Executor* executor, MemoryLocationType localLoc = MemoryLocationType::CPU);
+                     Executor* executor, MemoryLocationType localLoc = MemoryLocationType::CPU,
+                     TelemetryRegistry* telemetry = nullptr);
   ~RdmaBackendSession() = default;
 
   void ReadWrite(size_t localOffset, size_t remoteOffset, size_t size, TransferStatus* status,
@@ -291,6 +296,7 @@ class RdmaBackendSession : public BackendSession {
   MemoryLocationType localLoc_{MemoryLocationType::CPU};
   std::shared_ptr<std::atomic<bool>> warnedChunkedWorkerFallback_{
       std::make_shared<std::atomic<bool>>(false)};
+  TelemetryRegistry* telemetry_{nullptr};
 };
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -324,6 +330,7 @@ class RdmaBackend : public Backend {
   bool PopInboundTransferStatus(EngineKey remote, TransferUniqueId id,
                                 TransferStatus* status) override;
   bool CanHandle(const MemoryDesc& local, const MemoryDesc& remote) const override;
+  TelemetrySnapshot GetTelemetrySnapshot() const override;
 
  private:
   void CreateSession(const MemoryDesc& local, const MemoryDesc& remote, RdmaBackendSession& sess);
@@ -382,6 +389,7 @@ class RdmaBackend : public Backend {
   std::mutex sessionCacheMu;
   std::mutex connBuildMapMu_;
   std::unordered_map<ConnBuildKey, std::shared_ptr<std::mutex>, ConnBuildKeyHash> connBuildMu_;
+  std::unique_ptr<TelemetryRegistry> telemetry_;
 };
 
 }  // namespace io

--- a/src/io/rdma/common.cpp
+++ b/src/io/rdma/common.cpp
@@ -21,6 +21,8 @@
 // SOFTWARE.
 #include "src/io/rdma/common.hpp"
 
+#include <x86intrin.h>
+
 #include <cerrno>
 #include <chrono>
 #include <cstdlib>
@@ -31,6 +33,7 @@
 
 #include "mori/io/env.hpp"
 #include "mori/io/logging.hpp"
+#include "src/io/rdma/telemetry.hpp"
 
 namespace mori {
 namespace io {
@@ -222,6 +225,9 @@ static bool TryReserveSqDepth(const EpPair& ep, int wrCount, int epId, const cha
         MORI_IO_WARN(
             "SQ full timeout ({}): ep={} depth={} requested={} max={} after {} us (backoff={})",
             opTag, epId, cur, wrCount, ep.maxSqDepth, kBackoffTimeoutUs, backoff);
+        if (MORI_IO_TELEM_UNLIKELY(ep.telem)) {
+          ep.telem->counters.sq_full_events.fetch_add(1, std::memory_order_relaxed);
+        }
         if (errMsg) {
           *errMsg = "SQ full (" + std::string(opTag) + "): ep=" + std::to_string(epId) +
                     " depth=" + std::to_string(cur) + " requested=" + std::to_string(wrCount) +
@@ -445,6 +451,7 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
   // accumulated since the last signaled WR on each EP.
   std::vector<int> epWrsSinceSignal(epNum, 0);
   std::vector<size_t> epMergedSinceSignal(epNum, 0);
+  std::vector<uint64_t> epBytesSinceSignal(epNum, 0);
 
   for (int i = 0; i < numPostBatch; i++) {
     int st = i * postBatchSize;
@@ -464,15 +471,18 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
     }
 
     size_t mergedReqSize = 0;
+    uint64_t batchBytes = 0;
     for (int j = st; j < end; j++) {
       struct ibv_send_wr& wr = mergedWrs[j].wr;
       wr.wr_id = 0;
       wr.next = (j + 1 < end) ? &mergedWrs[j + 1].wr : nullptr;
       mergedReqSize += mergedWrs[j].mergedRequests;
+      batchBytes += mergedWrs[j].totalRemoteLength;
     }
 
     epWrsSinceSignal[epId] += batchWrNum;
     epMergedSinceSignal[epId] += mergedReqSize;
+    epBytesSinceSignal[epId] += batchBytes;
 
     bool isLastBatchForEp = ((i + epNum) >= numPostBatch);
     bool sqNearFull = eps[epId].sqDepth && (epWrsSinceSignal[epId] >= eps[epId].maxSqDepth);
@@ -487,7 +497,8 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
                 "submission ledger is not initialized for signaled WR tracking"};
       }
       recordId = eps[epId].ledger->Insert(epWrsSinceSignal[epId], true, callbackMeta,
-                                          static_cast<int>(epMergedSinceSignal[epId]));
+                                          static_cast<int>(epMergedSinceSignal[epId]),
+                                          epBytesSinceSignal[epId]);
       last.wr_id = recordId;
       last.send_flags = IBV_SEND_SIGNALED;
     }
@@ -495,6 +506,10 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
     struct ibv_send_wr* badWr = nullptr;
     int ret = ibv_post_send(eps[epId].local.ibvHandle.qp, &mergedWrs[st].wr, &badWr);
     if (ret != 0) {
+      if (MORI_IO_TELEM_UNLIKELY(eps[epId].telem)) {
+        eps[epId].telem->counters.post_send_errors.fetch_add(1, std::memory_order_relaxed);
+      }
+
       int postedCount = 0;
       if (badWr != nullptr) {
         struct ibv_send_wr* cur = &mergedWrs[st].wr;
@@ -510,13 +525,20 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
         epWrsSinceSignal[epId] = std::max(0, epWrsSinceSignal[epId] - unpostedCount);
 
         size_t mergedUnposted = 0;
+        uint64_t bytesUnposted = 0;
         for (int j = st + postedCount; j < end; ++j) {
           mergedUnposted += mergedWrs[j].mergedRequests;
+          bytesUnposted += mergedWrs[j].totalRemoteLength;
         }
         if (epMergedSinceSignal[epId] >= mergedUnposted) {
           epMergedSinceSignal[epId] -= mergedUnposted;
         } else {
           epMergedSinceSignal[epId] = 0;
+        }
+        if (epBytesSinceSignal[epId] >= bytesUnposted) {
+          epBytesSinceSignal[epId] -= bytesUnposted;
+        } else {
+          epBytesSinceSignal[epId] = 0;
         }
       }
 
@@ -543,7 +565,8 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
         // on this EP): sqDepth held by ledger until recovery.
         if (eps[epId].ledger) {
           eps[epId].ledger->InsertOrphaned(epWrsSinceSignal[epId], callbackMeta,
-                                           static_cast<int>(epMergedSinceSignal[epId]));
+                                           static_cast<int>(epMergedSinceSignal[epId]),
+                                           epBytesSinceSignal[epId]);
         }
       }
 
@@ -559,7 +582,8 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
         }
         if (eps[otherEpId].ledger) {
           eps[otherEpId].ledger->InsertOrphaned(epWrsSinceSignal[otherEpId], callbackMeta,
-                                                static_cast<int>(epMergedSinceSignal[otherEpId]));
+                                                static_cast<int>(epMergedSinceSignal[otherEpId]),
+                                                epBytesSinceSignal[otherEpId]);
         } else {
           MORI_IO_WARN(
               "EP {} has pending unsignaled WRs but no submission ledger; "
@@ -576,9 +600,34 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
       return {StatusCode::ERR_RDMA_OP, std::move(message)};
     }
 
+    // ── Telemetry: successful ibv_post_send ──
+    if (MORI_IO_TELEM_UNLIKELY(callbackMeta->telem)) {
+      uint64_t now = __rdtsc();
+      uint64_t cur = callbackMeta->telem->first_post_tsc.load(std::memory_order_relaxed);
+      while (now < cur && !callbackMeta->telem->first_post_tsc.compare_exchange_weak(
+                              cur, now, std::memory_order_relaxed)) {
+      }
+    }
+
+    if (EpTelemetryState* telem = eps[epId].telem.get(); needSignal && telem) {
+      telem->counters.bytes_posted.fetch_add(epBytesSinceSignal[epId], std::memory_order_relaxed);
+      telem->counters.ops_posted.fetch_add(epMergedSinceSignal[epId], std::memory_order_relaxed);
+
+      eps[epId].ledger->RecordPostTimestamp(recordId, __rdtsc());
+
+      if (eps[epId].sqDepth) {
+        int depth = eps[epId].sqDepth->load(std::memory_order_relaxed);
+        int hwm = telem->counters.sq_depth_hwm.load(std::memory_order_relaxed);
+        while (depth > hwm && !telem->counters.sq_depth_hwm.compare_exchange_weak(
+                                  hwm, depth, std::memory_order_relaxed)) {
+        }
+      }
+    }
+
     if (needSignal) {
       epWrsSinceSignal[epId] = 0;
       epMergedSinceSignal[epId] = 0;
+      epBytesSinceSignal[epId] = 0;
     }
     MORI_IO_TRACE("ibv_post_send ep index {} batch index range [{}, {})", epId, st, end);
   }

--- a/src/io/rdma/common.cpp
+++ b/src/io/rdma/common.cpp
@@ -25,6 +25,7 @@
 #include <linux/futex.h>
 #include <sys/syscall.h>
 #include <unistd.h>
+#include <x86intrin.h>
 
 #include <algorithm>
 #include <cerrno>
@@ -39,6 +40,7 @@
 
 #include "mori/io/env.hpp"
 #include "mori/io/logging.hpp"
+#include "src/io/rdma/telemetry.hpp"
 
 namespace mori {
 namespace io {
@@ -303,6 +305,9 @@ static bool TryReserveSqDepthSpin(const EpPair& ep, int wrCount, int epId, const
       MORI_IO_WARN(
           "SQ full timeout ({}): ep={} depth={} requested={} max={} after {} us (backoff={})",
           opTag, epId, cur, wrCount, ep.maxSqDepth, kBackoffTimeoutUs, backoff);
+      if (MORI_IO_TELEM_UNLIKELY(ep.telem)) {
+        ep.telem->counters.sq_full_events.fetch_add(1, std::memory_order_relaxed);
+      }
       if (errMsg) {
         *errMsg = "SQ full (" + std::string(opTag) + "): ep=" + std::to_string(epId) +
                   " depth=" + std::to_string(cur) + " requested=" + std::to_string(wrCount) +
@@ -377,6 +382,9 @@ static bool TryReserveSqDepth(const EpPair& ep, int wrCount, int epId, const cha
       const int cur = ep.sqDepth->load(kSqAdmissionOrder);
       MORI_IO_WARN("SQ full timeout ({}): ep={} depth={} requested={} max={} after {} us", opTag,
                    epId, cur, wrCount, ep.maxSqDepth, timeoutUs);
+      if (MORI_IO_TELEM_UNLIKELY(ep.telem)) {
+        ep.telem->counters.sq_full_events.fetch_add(1, std::memory_order_relaxed);
+      }
       if (errMsg) {
         *errMsg = "SQ full (" + std::string(opTag) + "): ep=" + std::to_string(epId) +
                   " depth=" + std::to_string(cur) + " requested=" + std::to_string(wrCount) +
@@ -654,6 +662,7 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
   thread_local std::vector<ChunkedSgeSegment> tlChunkPlan;
   thread_local std::vector<int> tlEpWrsSinceSignal;
   thread_local std::vector<size_t> tlEpMergedSinceSignal;
+  thread_local std::vector<uint64_t> tlEpBytesSinceSignal;
   thread_local int reentryDepth = 0;
 
   struct ReentryGuard {
@@ -670,6 +679,7 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
   std::vector<ChunkedSgeSegment> localChunkPlan;
   std::vector<int> localEpWrsSinceSignal;
   std::vector<size_t> localEpMergedSinceSignal;
+  std::vector<uint64_t> localEpBytesSinceSignal;
 
   std::vector<size_t>& indices = usePool ? tlIndices : localIndices;
   std::vector<MergedWorkRequest>& mergedPool = usePool ? tlMergedPool : localMergedPool;
@@ -678,6 +688,8 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
   std::vector<int>& epWrsSinceSignal = usePool ? tlEpWrsSinceSignal : localEpWrsSinceSignal;
   std::vector<size_t>& epMergedSinceSignal =
       usePool ? tlEpMergedSinceSignal : localEpMergedSinceSignal;
+  std::vector<uint64_t>& epBytesSinceSignal =
+      usePool ? tlEpBytesSinceSignal : localEpBytesSinceSignal;
 
   // Bound peak retained memory: if an earlier very large batch grew the pools far
   // beyond the current need, release the excess so it doesn't stay resident.
@@ -881,8 +893,11 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
   if (postBatchSize <= 0) postBatchSize = 1;
   int numPostBatch = (mergedWrCount + postBatchSize - 1) / postBatchSize;
 
+  // Per-EP state for adaptive signaling: track WRs, merged requests, and bytes
+  // accumulated since the last signaled WR on each EP.
   epWrsSinceSignal.assign(epNum, 0);
   epMergedSinceSignal.assign(epNum, 0);
+  epBytesSinceSignal.assign(epNum, 0);
 
   // Rotate the starting EP by transfer id so single-segment (single WR)
   // transfers spread evenly across all QPs instead of always landing on eps[0].
@@ -905,6 +920,7 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
     const auto& localMr = localMrPerEp[epId];
     const auto& remoteMr = remoteMrPerEp[epId];
     size_t mergedReqSize = 0;
+    uint64_t batchBytes = 0;
     for (int j = st; j < end; j++) {
       MergedWorkRequest& mergedWr = mergedWrs[j];
       for (auto& sge : mergedWr.sges) sge.lkey = localMr.lkey;
@@ -915,10 +931,12 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
       wr.wr_id = 0;
       wr.next = (j + 1 < end) ? &mergedWrs[j + 1].wr : nullptr;
       mergedReqSize += mergedWr.mergedRequests;
+      batchBytes += mergedWr.totalRemoteLength;
     }
 
     epWrsSinceSignal[epId] += batchWrNum;
     epMergedSinceSignal[epId] += mergedReqSize;
+    epBytesSinceSignal[epId] += batchBytes;
 
     bool isLastBatchForEp = ((i + epNum) >= numPostBatch);
     bool sqNearFull = eps[epId].sqDepth && (epWrsSinceSignal[epId] >= eps[epId].maxSqDepth);
@@ -933,7 +951,8 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
                 "submission ledger is not initialized for signaled WR tracking"};
       }
       recordId = eps[epId].ledger->Insert(epWrsSinceSignal[epId], true, callbackMeta,
-                                          static_cast<int>(epMergedSinceSignal[epId]));
+                                          static_cast<int>(epMergedSinceSignal[epId]),
+                                          epBytesSinceSignal[epId]);
       last.wr_id = recordId;
       last.send_flags = IBV_SEND_SIGNALED;
     }
@@ -941,6 +960,10 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
     struct ibv_send_wr* badWr = nullptr;
     int ret = ibv_post_send(eps[epId].local.ibvHandle.qp, &mergedWrs[st].wr, &badWr);
     if (ret != 0) {
+      if (MORI_IO_TELEM_UNLIKELY(eps[epId].telem)) {
+        eps[epId].telem->counters.post_send_errors.fetch_add(1, std::memory_order_relaxed);
+      }
+
       int postedCount = 0;
       if (badWr != nullptr) {
         struct ibv_send_wr* cur = &mergedWrs[st].wr;
@@ -956,13 +979,20 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
         epWrsSinceSignal[epId] = std::max(0, epWrsSinceSignal[epId] - unpostedCount);
 
         size_t mergedUnposted = 0;
+        uint64_t bytesUnposted = 0;
         for (int j = st + postedCount; j < end; ++j) {
           mergedUnposted += mergedWrs[j].mergedRequests;
+          bytesUnposted += mergedWrs[j].totalRemoteLength;
         }
         if (epMergedSinceSignal[epId] >= mergedUnposted) {
           epMergedSinceSignal[epId] -= mergedUnposted;
         } else {
           epMergedSinceSignal[epId] = 0;
+        }
+        if (epBytesSinceSignal[epId] >= bytesUnposted) {
+          epBytesSinceSignal[epId] -= bytesUnposted;
+        } else {
+          epBytesSinceSignal[epId] = 0;
         }
       }
 
@@ -981,7 +1011,8 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
             postedCount, batchWrNum, epId);
         if (eps[epId].ledger) {
           eps[epId].ledger->InsertOrphaned(epWrsSinceSignal[epId], callbackMeta,
-                                           static_cast<int>(epMergedSinceSignal[epId]));
+                                           static_cast<int>(epMergedSinceSignal[epId]),
+                                           epBytesSinceSignal[epId]);
         }
         if (eps[epId].degraded) {
           eps[epId].degraded->store(true, kSqAdmissionOrder);
@@ -998,7 +1029,8 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
             epId, otherEpId, epWrsSinceSignal[otherEpId], epMergedSinceSignal[otherEpId]);
         if (eps[otherEpId].ledger) {
           eps[otherEpId].ledger->InsertOrphaned(epWrsSinceSignal[otherEpId], callbackMeta,
-                                                static_cast<int>(epMergedSinceSignal[otherEpId]));
+                                                static_cast<int>(epMergedSinceSignal[otherEpId]),
+                                                epBytesSinceSignal[otherEpId]);
         } else {
           MORI_IO_WARN(
               "EP {} has pending unsignaled WRs but no submission ledger; "
@@ -1019,9 +1051,34 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
       return {StatusCode::ERR_RDMA_OP, std::move(message)};
     }
 
+    // ── Telemetry: successful ibv_post_send ──
+    if (MORI_IO_TELEM_UNLIKELY(callbackMeta->telem)) {
+      uint64_t now = __rdtsc();
+      uint64_t cur = callbackMeta->telem->first_post_tsc.load(std::memory_order_relaxed);
+      while (now < cur && !callbackMeta->telem->first_post_tsc.compare_exchange_weak(
+                              cur, now, std::memory_order_relaxed)) {
+      }
+    }
+
+    if (EpTelemetryState* telem = eps[epId].telem.get(); needSignal && telem) {
+      telem->counters.bytes_posted.fetch_add(epBytesSinceSignal[epId], std::memory_order_relaxed);
+      telem->counters.ops_posted.fetch_add(epMergedSinceSignal[epId], std::memory_order_relaxed);
+
+      eps[epId].ledger->RecordPostTimestamp(recordId, __rdtsc());
+
+      if (eps[epId].sqDepth) {
+        int depth = eps[epId].sqDepth->load(std::memory_order_relaxed);
+        int hwm = telem->counters.sq_depth_hwm.load(std::memory_order_relaxed);
+        while (depth > hwm && !telem->counters.sq_depth_hwm.compare_exchange_weak(
+                                  hwm, depth, std::memory_order_relaxed)) {
+        }
+      }
+    }
+
     if (needSignal) {
       epWrsSinceSignal[epId] = 0;
       epMergedSinceSignal[epId] = 0;
+      epBytesSinceSignal[epId] = 0;
     }
     MORI_IO_TRACE("ibv_post_send ep index {} batch index range [{}, {})", epId, st, end);
   }

--- a/src/io/rdma/common.hpp
+++ b/src/io/rdma/common.hpp
@@ -36,6 +36,17 @@
 namespace mori {
 namespace io {
 
+struct EpTelemetryState;
+struct ApiCounterSet;
+
+struct TelemetryMeta {
+  uint64_t api_start_tsc{0};
+  std::atomic<uint64_t> first_post_tsc{UINT64_MAX};
+  ApiCounterSet* api_counters{nullptr};
+  uint64_t total_bytes{0};
+  bool is_read{false};
+};
+
 /* ---------------------------------------------------------------------------------------------- */
 /*                                     Common Data Structures                                     */
 /* ---------------------------------------------------------------------------------------------- */
@@ -129,12 +140,15 @@ uint64_t MakeNotifSendWrId(TransferUniqueId id);
 struct CqCallbackMeta {
   CqCallbackMeta(TransferStatus* s, TransferUniqueId id_, int n)
       : status(s), id(id_), totalBatchSize(n) {}
+  ~CqCallbackMeta();
 
   TransferStatus* status{nullptr};
   TransferUniqueId id{0};
   int totalBatchSize{0};
   std::atomic<uint32_t> finishedBatchSize{0};
   internal::IoCallDiagnostics diagnostics{};
+
+  std::unique_ptr<TelemetryMeta> telem;
 };
 
 // SubmissionLedger: tracks per-EP WR submissions and enables precise sqDepth release.
@@ -150,23 +164,33 @@ struct SubmissionRecord {
   SubmissionState state{SubmissionState::Posted};
   std::shared_ptr<CqCallbackMeta> meta;
   int batchSize{0};
+  uint64_t totalBytes{0};
+  uint64_t post_tsc{0};
 };
 
 class SubmissionLedger {
  public:
   explicit SubmissionLedger(uint32_t notifPerQp) : nextId_{notifPerQp} {}
 
+  void EnableTimestamping() { timestamping_ = true; }
+
   // Allocate recordId, insert Posted record, return recordId.
   uint64_t Insert(int postedWr, bool hasSignaledTail, std::shared_ptr<CqCallbackMeta> meta,
-                  int batchSize);
+                  int batchSize, uint64_t totalBytes = 0);
 
   // Insert an Orphaned record (partial post, no signaled tail).
-  void InsertOrphaned(int postedWr, std::shared_ptr<CqCallbackMeta> meta, int batchSize);
+  void InsertOrphaned(int postedWr, std::shared_ptr<CqCallbackMeta> meta, int batchSize,
+                      uint64_t totalBytes = 0);
+
+  // Record post timestamp AFTER successful ibv_post_send.
+  // If the record has already been consumed by ReleaseByCqe, this is a no-op.
+  void RecordPostTimestamp(uint64_t recordId, uint64_t tsc);
 
   // CQE path: find record by recordId, release sqDepth, return CqCallbackMeta.
   // Returns nullptr if record not found.
   std::shared_ptr<CqCallbackMeta> ReleaseByCqe(uint64_t recordId, std::atomic<int>* sqDepth,
-                                               int* outBatchSize);
+                                               int* outBatchSize, uint64_t* outTotalBytes = nullptr,
+                                               uint64_t* out_post_tsc = nullptr);
 
   // Recovery path: release only Orphaned records and keep Posted records.
   int ReleaseOrphanedByRecovery(std::atomic<int>* sqDepth);
@@ -177,6 +201,7 @@ class SubmissionLedger {
   mutable std::mutex mu_;
   uint64_t nextId_;
   std::unordered_map<uint64_t, SubmissionRecord> records_;
+  bool timestamping_{false};
 };
 
 struct EpPair {
@@ -192,6 +217,7 @@ struct EpPair {
   // Degraded flag — set on partial post without signaled tail.
   std::shared_ptr<std::atomic<bool>> degraded;
   std::shared_ptr<SubmissionLedger> ledger;
+  std::shared_ptr<EpTelemetryState> telem;
 };
 
 using EndpointId = uint64_t;

--- a/src/io/rdma/common.hpp
+++ b/src/io/rdma/common.hpp
@@ -38,6 +38,17 @@
 namespace mori {
 namespace io {
 
+struct EpTelemetryState;
+struct ApiCounterSet;
+
+struct TelemetryMeta {
+  uint64_t api_start_tsc{0};
+  std::atomic<uint64_t> first_post_tsc{UINT64_MAX};
+  ApiCounterSet* api_counters{nullptr};
+  uint64_t total_bytes{0};
+  bool is_read{false};
+};
+
 /* ---------------------------------------------------------------------------------------------- */
 /*                                     Common Data Structures                                     */
 /* ---------------------------------------------------------------------------------------------- */
@@ -158,12 +169,15 @@ void PlanSgeStreamChunks(std::vector<ChunkedSgeSegment>& plan, const std::vector
 struct CqCallbackMeta {
   CqCallbackMeta(TransferStatus* s, TransferUniqueId id_, int n)
       : status(s), id(id_), totalBatchSize(n) {}
+  ~CqCallbackMeta();
 
   TransferStatus* status{nullptr};
   TransferUniqueId id{0};
   int totalBatchSize{0};
   std::atomic<uint32_t> finishedBatchSize{0};
   internal::IoCallDiagnostics diagnostics{};
+
+  std::unique_ptr<TelemetryMeta> telem;
 };
 
 // SubmissionLedger: tracks per-EP WR submissions and enables precise sqDepth release.
@@ -179,23 +193,33 @@ struct SubmissionRecord {
   SubmissionState state{SubmissionState::Posted};
   std::shared_ptr<CqCallbackMeta> meta;
   int batchSize{0};
+  uint64_t totalBytes{0};
+  uint64_t post_tsc{0};
 };
 
 class SubmissionLedger {
  public:
   explicit SubmissionLedger(uint32_t notifPerQp) : nextId_{notifPerQp} {}
 
+  void EnableTimestamping() { timestamping_ = true; }
+
   // Allocate recordId, insert Posted record, return recordId.
   uint64_t Insert(int postedWr, bool hasSignaledTail, std::shared_ptr<CqCallbackMeta> meta,
-                  int batchSize);
+                  int batchSize, uint64_t totalBytes = 0);
 
   // Insert an Orphaned record (partial post, no signaled tail).
-  void InsertOrphaned(int postedWr, std::shared_ptr<CqCallbackMeta> meta, int batchSize);
+  void InsertOrphaned(int postedWr, std::shared_ptr<CqCallbackMeta> meta, int batchSize,
+                      uint64_t totalBytes = 0);
+
+  // Record post timestamp AFTER successful ibv_post_send.
+  // If the record has already been consumed by ReleaseByCqe, this is a no-op.
+  void RecordPostTimestamp(uint64_t recordId, uint64_t tsc);
 
   // CQE path: find record by recordId, release sqDepth, return CqCallbackMeta.
   // Returns nullptr if record not found.
   std::shared_ptr<CqCallbackMeta> ReleaseByCqe(uint64_t recordId, std::atomic<int>* sqDepth,
-                                               int* outBatchSize);
+                                               int* outBatchSize, uint64_t* outTotalBytes = nullptr,
+                                               uint64_t* out_post_tsc = nullptr);
 
   // Recovery path: release only Orphaned records and keep Posted records.
   int ReleaseOrphanedByRecovery(std::atomic<int>* sqDepth);
@@ -206,6 +230,7 @@ class SubmissionLedger {
   mutable std::mutex mu_;
   uint64_t nextId_;
   std::unordered_map<uint64_t, SubmissionRecord> records_;
+  bool timestamping_{false};
 };
 
 inline constexpr std::memory_order kSqAdmissionOrder = std::memory_order_seq_cst;
@@ -230,6 +255,7 @@ struct EpPair {
   std::shared_ptr<SubmissionLedger> ledger;
   // Shared across EpPair copies that refer to the same QP.
   std::shared_ptr<SqAdmissionEvent> sqAdmission;
+  std::shared_ptr<EpTelemetryState> telem;
 };
 
 using EndpointId = uint64_t;

--- a/src/io/rdma/ledger.cpp
+++ b/src/io/rdma/ledger.cpp
@@ -20,36 +20,65 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 #include "src/io/rdma/common.hpp"
+#include "src/io/rdma/telemetry.hpp"
 
 namespace mori {
 namespace io {
 
+CqCallbackMeta::~CqCallbackMeta() = default;
+
 uint64_t SubmissionLedger::Insert(int postedWr, bool hasSignaledTail,
-                                  std::shared_ptr<CqCallbackMeta> meta, int batchSize) {
+                                  std::shared_ptr<CqCallbackMeta> meta, int batchSize,
+                                  uint64_t totalBytes) {
   std::lock_guard<std::mutex> lock(mu_);
   uint64_t id = nextId_++;
-  records_[id] = SubmissionRecord{
-      id, postedWr, hasSignaledTail, SubmissionState::Posted, std::move(meta), batchSize};
+  records_[id] = SubmissionRecord{id,
+                                  postedWr,
+                                  hasSignaledTail,
+                                  SubmissionState::Posted,
+                                  std::move(meta),
+                                  batchSize,
+                                  totalBytes,
+                                  /*post_tsc=*/0};
   return id;
 }
 
 void SubmissionLedger::InsertOrphaned(int postedWr, std::shared_ptr<CqCallbackMeta> meta,
-                                      int batchSize) {
+                                      int batchSize, uint64_t totalBytes) {
   std::lock_guard<std::mutex> lock(mu_);
   uint64_t id = nextId_++;
-  records_[id] =
-      SubmissionRecord{id, postedWr, false, SubmissionState::Orphaned, std::move(meta), batchSize};
+  records_[id] = SubmissionRecord{id,
+                                  postedWr,
+                                  false,
+                                  SubmissionState::Orphaned,
+                                  std::move(meta),
+                                  batchSize,
+                                  totalBytes,
+                                  /*post_tsc=*/0};
+}
+
+void SubmissionLedger::RecordPostTimestamp(uint64_t recordId, uint64_t tsc) {
+  if (!timestamping_) return;
+  std::lock_guard<std::mutex> lock(mu_);
+  auto it = records_.find(recordId);
+  if (it != records_.end()) {
+    it->second.post_tsc = tsc;
+  }
 }
 
 std::shared_ptr<CqCallbackMeta> SubmissionLedger::ReleaseByCqe(uint64_t recordId,
                                                                std::atomic<int>* sqDepth,
-                                                               int* outBatchSize) {
+                                                               int* outBatchSize,
+                                                               uint64_t* outTotalBytes,
+                                                               uint64_t* out_post_tsc) {
   std::lock_guard<std::mutex> lock(mu_);
   auto it = records_.find(recordId);
   if (it == records_.end()) return nullptr;
   SubmissionRecord& rec = it->second;
   if (sqDepth && rec.postedWr > 0) sqDepth->fetch_sub(rec.postedWr, std::memory_order_relaxed);
   if (outBatchSize) *outBatchSize = rec.batchSize;
+  if (outTotalBytes) *outTotalBytes = rec.totalBytes;
+  if (out_post_tsc) *out_post_tsc = rec.post_tsc;
   auto meta = std::move(rec.meta);
   records_.erase(it);
   return meta;

--- a/src/io/rdma/ledger.cpp
+++ b/src/io/rdma/ledger.cpp
@@ -20,36 +20,65 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 #include "src/io/rdma/common.hpp"
+#include "src/io/rdma/telemetry.hpp"
 
 namespace mori {
 namespace io {
 
+CqCallbackMeta::~CqCallbackMeta() = default;
+
 uint64_t SubmissionLedger::Insert(int postedWr, bool hasSignaledTail,
-                                  std::shared_ptr<CqCallbackMeta> meta, int batchSize) {
+                                  std::shared_ptr<CqCallbackMeta> meta, int batchSize,
+                                  uint64_t totalBytes) {
   std::lock_guard<std::mutex> lock(mu_);
   uint64_t id = nextId_++;
-  records_[id] = SubmissionRecord{
-      id, postedWr, hasSignaledTail, SubmissionState::Posted, std::move(meta), batchSize};
+  records_[id] = SubmissionRecord{id,
+                                  postedWr,
+                                  hasSignaledTail,
+                                  SubmissionState::Posted,
+                                  std::move(meta),
+                                  batchSize,
+                                  totalBytes,
+                                  /*post_tsc=*/0};
   return id;
 }
 
 void SubmissionLedger::InsertOrphaned(int postedWr, std::shared_ptr<CqCallbackMeta> meta,
-                                      int batchSize) {
+                                      int batchSize, uint64_t totalBytes) {
   std::lock_guard<std::mutex> lock(mu_);
   uint64_t id = nextId_++;
-  records_[id] =
-      SubmissionRecord{id, postedWr, false, SubmissionState::Orphaned, std::move(meta), batchSize};
+  records_[id] = SubmissionRecord{id,
+                                  postedWr,
+                                  false,
+                                  SubmissionState::Orphaned,
+                                  std::move(meta),
+                                  batchSize,
+                                  totalBytes,
+                                  /*post_tsc=*/0};
+}
+
+void SubmissionLedger::RecordPostTimestamp(uint64_t recordId, uint64_t tsc) {
+  if (!timestamping_) return;
+  std::lock_guard<std::mutex> lock(mu_);
+  auto it = records_.find(recordId);
+  if (it != records_.end()) {
+    it->second.post_tsc = tsc;
+  }
 }
 
 std::shared_ptr<CqCallbackMeta> SubmissionLedger::ReleaseByCqe(uint64_t recordId,
                                                                std::atomic<int>* sqDepth,
-                                                               int* outBatchSize) {
+                                                               int* outBatchSize,
+                                                               uint64_t* outTotalBytes,
+                                                               uint64_t* out_post_tsc) {
   std::lock_guard<std::mutex> lock(mu_);
   auto it = records_.find(recordId);
   if (it == records_.end()) return nullptr;
   SubmissionRecord& rec = it->second;
   if (sqDepth && rec.postedWr > 0) sqDepth->fetch_sub(rec.postedWr, kSqAdmissionOrder);
   if (outBatchSize) *outBatchSize = rec.batchSize;
+  if (outTotalBytes) *outTotalBytes = rec.totalBytes;
+  if (out_post_tsc) *out_post_tsc = rec.post_tsc;
   auto meta = std::move(rec.meta);
   records_.erase(it);
   return meta;

--- a/src/io/rdma/telemetry.cpp
+++ b/src/io/rdma/telemetry.cpp
@@ -1,0 +1,289 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#include "src/io/rdma/telemetry.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <fstream>
+#include <string>
+#include <thread>
+
+#include "mori/io/logging.hpp"
+#include "mori/utils/env_utils.hpp"
+
+namespace mori {
+namespace io {
+
+// ── TelemetryConfig statics ─────────────────────────────────────
+
+std::atomic<bool> TelemetryConfig::enabled_{false};
+std::atomic<bool> TelemetryConfig::initialized_{false};
+double TelemetryConfig::tsc_ghz_{0.0};
+
+static void CalibrateIfNeeded() {
+  if (TelemetryConfig::TscGhz() > 0.0) return;
+
+  auto t0 = std::chrono::steady_clock::now();
+  uint64_t tsc0 = __rdtsc();
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  uint64_t tsc1 = __rdtsc();
+  auto t1 = std::chrono::steady_clock::now();
+
+  double elapsed_ns =
+      static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
+  TelemetryConfig::SetTscGhz(elapsed_ns > 0 ? static_cast<double>(tsc1 - tsc0) / elapsed_ns : 1.0);
+  MORI_IO_INFO("Telemetry: TSC calibrated at {:.3f} GHz", TelemetryConfig::TscGhz());
+}
+
+void TelemetryConfig::Init() {
+  bool expected = false;
+  if (!initialized_.compare_exchange_strong(expected, true)) return;
+
+  if (!env::IsEnvVarEnabled("MORI_IO_TELEMETRY_ENABLED")) return;
+  enabled_.store(true, std::memory_order_relaxed);
+
+  bool has_constant_tsc = false;
+  bool has_nonstop_tsc = false;
+  {
+    std::ifstream cpuinfo("/proc/cpuinfo");
+    std::string line;
+    while (std::getline(cpuinfo, line)) {
+      if (line.find("flags") == std::string::npos) continue;
+      has_constant_tsc = line.find("constant_tsc") != std::string::npos;
+      has_nonstop_tsc = line.find("nonstop_tsc") != std::string::npos;
+      break;
+    }
+  }
+  if (!has_constant_tsc || !has_nonstop_tsc) {
+    MORI_IO_WARN(
+        "Telemetry: CPU lacks constant_tsc ({}) or nonstop_tsc ({}); "
+        "TSC-based latency measurements may drift",
+        has_constant_tsc, has_nonstop_tsc);
+  }
+
+  CalibrateIfNeeded();
+}
+
+void TelemetryConfig::Apply(const TelemetryInitOptions& opts) {
+  if (opts.enabled.has_value()) {
+    enabled_.store(opts.enabled.value(), std::memory_order_relaxed);
+    if (opts.enabled.value()) {
+      CalibrateIfNeeded();
+    }
+  }
+}
+
+void InitTelemetry(const TelemetryInitOptions& opts) {
+  TelemetryConfig::Init();
+  TelemetryConfig::Apply(opts);
+}
+
+// ── LatencyStats ────────────────────────────────────────────────
+
+void LatencyStats::Update(uint64_t delta_tsc) {
+  uint64_t prev = ewma_tsc.load(std::memory_order_relaxed);
+  uint64_t next;
+  if (prev == 0) {
+    next = delta_tsc;
+  } else {
+    next = prev + (static_cast<int64_t>(delta_tsc - prev) >> 4);
+  }
+  ewma_tsc.store(next, std::memory_order_relaxed);
+
+  uint64_t cur_min = min_tsc.load(std::memory_order_relaxed);
+  while (delta_tsc < cur_min &&
+         !min_tsc.compare_exchange_weak(cur_min, delta_tsc, std::memory_order_relaxed)) {
+  }
+
+  uint64_t cur_max = max_tsc.load(std::memory_order_relaxed);
+  while (delta_tsc > cur_max &&
+         !max_tsc.compare_exchange_weak(cur_max, delta_tsc, std::memory_order_relaxed)) {
+  }
+
+  count.fetch_add(1, std::memory_order_relaxed);
+}
+
+// ── TelemetryRegistry ───────────────────────────────────────────
+
+void TelemetryRegistry::UpdateEwmaCas(std::atomic<uint64_t>& ewma, uint64_t sample) {
+  uint64_t prev = ewma.load(std::memory_order_relaxed);
+  uint64_t next;
+  do {
+    if (prev == 0) {
+      next = sample;
+    } else {
+      next = prev + (static_cast<int64_t>(sample - prev) >> 4);
+    }
+  } while (!ewma.compare_exchange_weak(prev, next, std::memory_order_relaxed));
+}
+
+void TelemetryRegistry::RecordJct(uint64_t jct_tsc, uint64_t rdma_wall_tsc,
+                                  uint64_t sw_overhead_tsc) {
+  UpdateEwmaCas(jct_ewma_tsc_, jct_tsc);
+  UpdateEwmaCas(rdma_wall_ewma_tsc_, rdma_wall_tsc);
+  UpdateEwmaCas(sw_overhead_ewma_tsc_, sw_overhead_tsc);
+
+  uint64_t cur_min = jct_min_tsc_.load(std::memory_order_relaxed);
+  while (jct_tsc < cur_min &&
+         !jct_min_tsc_.compare_exchange_weak(cur_min, jct_tsc, std::memory_order_relaxed)) {
+  }
+
+  uint64_t cur_max = jct_max_tsc_.load(std::memory_order_relaxed);
+  while (jct_tsc > cur_max &&
+         !jct_max_tsc_.compare_exchange_weak(cur_max, jct_tsc, std::memory_order_relaxed)) {
+  }
+
+  jct_count_.fetch_add(1, std::memory_order_relaxed);
+}
+
+std::shared_ptr<EpTelemetryState> TelemetryRegistry::CreateEpTelemetry(
+    EndpointId id, const std::shared_ptr<std::atomic<int>>& sq_depth, int sq_depth_max) {
+  auto state = std::make_shared<EpTelemetryState>();
+  state->id = id;
+  state->sq_depth = sq_depth;
+  state->sq_depth_max = sq_depth_max;
+
+  std::unique_lock lock(mu_);
+  ep_telemetry_[id] = state;
+  return state;
+}
+
+TelemetrySnapshot TelemetryRegistry::Snapshot() const {
+  TelemetrySnapshot snap{};
+  snap.snapshot_tsc = __rdtsc();
+  snap.tsc_freq_ghz = TelemetryConfig::TscGhz();
+  auto relaxed = std::memory_order_relaxed;
+
+  // API counters
+  snap.api.read_calls = api_counters_.read_calls.load(relaxed);
+  snap.api.write_calls = api_counters_.write_calls.load(relaxed);
+  snap.api.batch_read_calls = api_counters_.batch_read_calls.load(relaxed);
+  snap.api.batch_write_calls = api_counters_.batch_write_calls.load(relaxed);
+  snap.api.rejected_calls = api_counters_.rejected_calls.load(relaxed);
+  snap.api.total_bytes_read = api_counters_.total_bytes_read.load(relaxed);
+  snap.api.total_bytes_written = api_counters_.total_bytes_written.load(relaxed);
+
+  // JCT stats
+  uint64_t jc = jct_count_.load(relaxed);
+  snap.api.jct_sample_count = jc;
+  if (jc > 0) {
+    snap.api.jct_ewma_us = TscToUs(jct_ewma_tsc_.load(relaxed));
+    snap.api.jct_min_us = TscToUs(jct_min_tsc_.load(relaxed));
+    snap.api.jct_max_us = TscToUs(jct_max_tsc_.load(relaxed));
+  }
+
+  // JCT breakdown
+  if (jc > 0) {
+    snap.breakdown.api_total_ewma_us = snap.api.jct_ewma_us;
+    snap.breakdown.rdma_wall_ewma_us = TscToUs(rdma_wall_ewma_tsc_.load(relaxed));
+    snap.breakdown.sw_overhead_ewma_us = TscToUs(sw_overhead_ewma_tsc_.load(relaxed));
+  }
+
+  // Per-EP aggregation
+  snap.verbs.poll_mode = poll_mode_;
+
+  uint64_t total_latency_samples = 0;
+  double weighted_ewma_sum = 0.0;
+  double agg_min = 0.0;
+  double agg_max = 0.0;
+  bool has_any_latency = false;
+
+  {
+    std::shared_lock lock(mu_);
+    for (const auto& [id, ept] : ep_telemetry_) {
+      TelemetrySnapshot::EpDetail detail;
+      detail.ep_id = id;
+      detail.verbs.bytes_posted = ept->counters.bytes_posted.load(relaxed);
+      detail.verbs.bytes_completed = ept->counters.bytes_completed.load(relaxed);
+      detail.verbs.ops_posted = ept->counters.ops_posted.load(relaxed);
+      detail.verbs.ops_completed = ept->counters.ops_completed.load(relaxed);
+      detail.verbs.cqe_errors = ept->counters.cqe_errors.load(relaxed);
+      detail.verbs.sq_full_events = ept->counters.sq_full_events.load(relaxed);
+      detail.verbs.post_send_errors = ept->counters.post_send_errors.load(relaxed);
+      detail.verbs.cq_polls = ept->counters.cq_poll_count.load(relaxed);
+      detail.verbs.cq_empty_polls = ept->counters.cq_empty_poll_count.load(relaxed);
+      detail.verbs.poll_mode = poll_mode_;
+      detail.verbs.sq_depth = ept->sq_depth ? ept->sq_depth->load(relaxed) : 0;
+      detail.verbs.sq_depth_hwm = ept->counters.sq_depth_hwm.load(relaxed);
+      detail.verbs.sq_depth_max = ept->sq_depth_max;
+
+      if (detail.verbs.cq_polls > 0) {
+        detail.verbs.cq_utilization =
+            1.0 - static_cast<double>(detail.verbs.cq_empty_polls) / detail.verbs.cq_polls;
+      }
+
+      uint64_t sc = ept->stats.count.load(relaxed);
+      detail.verbs.rdma_latency_sample_count = sc;
+      if (sc > 0) {
+        detail.verbs.rdma_latency_ewma_us = TscToUs(ept->stats.ewma_tsc.load(relaxed));
+        detail.verbs.rdma_latency_min_us = TscToUs(ept->stats.min_tsc.load(relaxed));
+        detail.verbs.rdma_latency_max_us = TscToUs(ept->stats.max_tsc.load(relaxed));
+
+        weighted_ewma_sum += detail.verbs.rdma_latency_ewma_us * sc;
+        total_latency_samples += sc;
+        if (!has_any_latency) {
+          agg_min = detail.verbs.rdma_latency_min_us;
+          agg_max = detail.verbs.rdma_latency_max_us;
+          has_any_latency = true;
+        } else {
+          agg_min = std::min(agg_min, detail.verbs.rdma_latency_min_us);
+          agg_max = std::max(agg_max, detail.verbs.rdma_latency_max_us);
+        }
+      }
+
+      // Aggregate counters
+      snap.verbs.bytes_posted += detail.verbs.bytes_posted;
+      snap.verbs.bytes_completed += detail.verbs.bytes_completed;
+      snap.verbs.ops_posted += detail.verbs.ops_posted;
+      snap.verbs.ops_completed += detail.verbs.ops_completed;
+      snap.verbs.cqe_errors += detail.verbs.cqe_errors;
+      snap.verbs.sq_full_events += detail.verbs.sq_full_events;
+      snap.verbs.post_send_errors += detail.verbs.post_send_errors;
+      snap.verbs.cq_polls += detail.verbs.cq_polls;
+      snap.verbs.cq_empty_polls += detail.verbs.cq_empty_polls;
+      snap.verbs.sq_depth += detail.verbs.sq_depth;
+      snap.verbs.sq_depth_hwm += detail.verbs.sq_depth_hwm;
+      snap.verbs.sq_depth_max += detail.verbs.sq_depth_max;
+
+      snap.per_ep.push_back(detail);
+    }
+  }
+
+  // Aggregated CQ utilization
+  if (snap.verbs.cq_polls > 0) {
+    snap.verbs.cq_utilization =
+        1.0 - static_cast<double>(snap.verbs.cq_empty_polls) / snap.verbs.cq_polls;
+  }
+
+  // Aggregated RDMA latency
+  snap.verbs.rdma_latency_sample_count = total_latency_samples;
+  if (total_latency_samples > 0) {
+    snap.verbs.rdma_latency_ewma_us = weighted_ewma_sum / total_latency_samples;
+    snap.verbs.rdma_latency_min_us = agg_min;
+    snap.verbs.rdma_latency_max_us = agg_max;
+  }
+
+  return snap;
+}
+
+}  // namespace io
+}  // namespace mori

--- a/src/io/rdma/telemetry.hpp
+++ b/src/io/rdma/telemetry.hpp
@@ -1,0 +1,149 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+#include <x86intrin.h>
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <shared_mutex>
+#include <unordered_map>
+
+#include "mori/io/telemetry.hpp"
+#include "src/io/rdma/common.hpp"
+
+namespace mori {
+namespace io {
+
+// ── Global config (read-only after init) ─────────────────────────
+class TelemetryConfig {
+ public:
+  static void Init();
+  static void Apply(const TelemetryInitOptions& opts);
+  static bool Enabled() { return enabled_.load(std::memory_order_relaxed); }
+  static double TscGhz() { return tsc_ghz_; }
+  static void SetTscGhz(double v) { tsc_ghz_ = v; }
+
+ private:
+  static std::atomic<bool> enabled_;
+  static std::atomic<bool> initialized_;
+  static double tsc_ghz_;
+};
+
+#define MORI_IO_TELEM_UNLIKELY(expr) __builtin_expect(!!(expr), 0)
+
+// ── Per-EP verbs counters (cache-line aligned) ───────────────────
+struct alignas(64) VerbsCounterSet {
+  // --- cache line 1: post path (written by post threads) ---
+  std::atomic<uint64_t> bytes_posted{0};
+  std::atomic<uint64_t> ops_posted{0};
+  std::atomic<uint64_t> sq_full_events{0};
+  std::atomic<uint64_t> post_send_errors{0};
+  char pad0_[64 - 4 * sizeof(std::atomic<uint64_t>)];
+
+  // --- cache line 2: completion path (written by CQ poll thread) ---
+  std::atomic<uint64_t> bytes_completed{0};
+  std::atomic<uint64_t> ops_completed{0};
+  std::atomic<uint64_t> cqe_errors{0};
+  char pad1_[64 - 3 * sizeof(std::atomic<uint64_t>)];
+
+  // --- cache line 3: CQ poll stats (CQ poll thread only) ---
+  std::atomic<uint64_t> cq_poll_count{0};
+  std::atomic<uint64_t> cq_empty_poll_count{0};
+  char pad2_[64 - 2 * sizeof(std::atomic<uint64_t>)];
+
+  // --- cache line 4: SQ depth high watermark (written by post threads) ---
+  std::atomic<int> sq_depth_hwm{0};
+  char pad3_[64 - sizeof(std::atomic<int>)];
+};
+
+// ── API-level counters ───────────────────────────────────────────
+struct alignas(64) ApiCounterSet {
+  std::atomic<uint64_t> read_calls{0};
+  std::atomic<uint64_t> write_calls{0};
+  std::atomic<uint64_t> batch_read_calls{0};
+  std::atomic<uint64_t> batch_write_calls{0};
+  std::atomic<uint64_t> rejected_calls{0};
+  std::atomic<uint64_t> total_bytes_read{0};
+  std::atomic<uint64_t> total_bytes_written{0};
+};
+
+// ── Per-EP RDMA latency stats (EWMA + min/max) ──────────────────
+//    Updated by CQ poll thread only — no cross-thread contention.
+struct LatencyStats {
+  std::atomic<uint64_t> ewma_tsc{0};
+  std::atomic<uint64_t> min_tsc{UINT64_MAX};
+  std::atomic<uint64_t> max_tsc{0};
+  std::atomic<uint64_t> count{0};
+
+  void Update(uint64_t delta_tsc);
+};
+
+// ── Shared per-EP telemetry state ────────────────────────────────
+struct EpTelemetryState {
+  EndpointId id{0};
+  VerbsCounterSet counters;
+  LatencyStats stats;
+  std::shared_ptr<std::atomic<int>> sq_depth;
+  int sq_depth_max{0};
+};
+
+// ── Per-backend registry ─────────────────────────────────────────
+class TelemetryRegistry {
+ public:
+  ApiCounterSet& ApiCounters() { return api_counters_; }
+  PollCqMode GetPollMode() const { return poll_mode_; }
+  void SetPollMode(PollCqMode m) { poll_mode_ = m; }
+
+  std::shared_ptr<EpTelemetryState> CreateEpTelemetry(
+      EndpointId id, const std::shared_ptr<std::atomic<int>>& sq_depth, int sq_depth_max);
+
+  // May be called concurrently from multiple CQ poll threads.
+  void RecordJct(uint64_t jct_tsc, uint64_t rdma_wall_tsc, uint64_t sw_overhead_tsc);
+
+  TelemetrySnapshot Snapshot() const;
+
+ private:
+  ApiCounterSet api_counters_;
+  PollCqMode poll_mode_{PollCqMode::POLLING};
+
+  mutable std::shared_mutex mu_;
+  std::unordered_map<EndpointId, std::shared_ptr<EpTelemetryState>> ep_telemetry_;
+
+  std::atomic<uint64_t> jct_ewma_tsc_{0};
+  std::atomic<uint64_t> jct_min_tsc_{UINT64_MAX};
+  std::atomic<uint64_t> jct_max_tsc_{0};
+  std::atomic<uint64_t> jct_count_{0};
+
+  std::atomic<uint64_t> rdma_wall_ewma_tsc_{0};
+  std::atomic<uint64_t> sw_overhead_ewma_tsc_{0};
+
+  static void UpdateEwmaCas(std::atomic<uint64_t>& ewma, uint64_t sample);
+};
+
+inline double TscToUs(uint64_t tsc) {
+  return static_cast<double>(tsc) / (TelemetryConfig::TscGhz() * 1000.0);
+}
+
+}  // namespace io
+}  // namespace mori

--- a/src/pybind/pybind_io.cpp
+++ b/src/pybind/pybind_io.cpp
@@ -185,7 +185,77 @@ void RegisterMoriIo(pybind11::module_& m) {
            py::call_guard<py::gil_scoped_release>())
       .def("WaitAll", &mori::io::IOEngine::WaitAll, py::arg("statuses"), py::arg("timeout_ms") = -1,
            py::call_guard<py::gil_scoped_release>())
-      .def("LoadScatterGatherModule", &mori::io::IOEngine::LoadScatterGatherModule);
+      .def("LoadScatterGatherModule", &mori::io::IOEngine::LoadScatterGatherModule)
+      .def(
+          "GetTelemetrySnapshot",
+          [](const mori::io::IOEngine& self, mori::io::BackendType type) -> py::dict {
+            auto snap = self.GetTelemetrySnapshot(type);
+            auto verbs_to_dict = [](const mori::io::TelemetrySnapshot::VerbsStats& v) -> py::dict {
+              py::dict d;
+              d["bytes_posted"] = v.bytes_posted;
+              d["bytes_completed"] = v.bytes_completed;
+              d["ops_posted"] = v.ops_posted;
+              d["ops_completed"] = v.ops_completed;
+              d["cqe_errors"] = v.cqe_errors;
+              d["post_send_errors"] = v.post_send_errors;
+              d["sq_full_events"] = v.sq_full_events;
+              d["cq_polls"] = v.cq_polls;
+              d["cq_empty_polls"] = v.cq_empty_polls;
+              d["cq_utilization"] = v.cq_utilization;
+              d["poll_mode"] = v.poll_mode;
+              d["sq_depth"] = v.sq_depth;
+              d["sq_depth_hwm"] = v.sq_depth_hwm;
+              d["sq_depth_max"] = v.sq_depth_max;
+              d["rdma_latency_ewma_us"] = v.rdma_latency_ewma_us;
+              d["rdma_latency_min_us"] = v.rdma_latency_min_us;
+              d["rdma_latency_max_us"] = v.rdma_latency_max_us;
+              d["rdma_latency_sample_count"] = v.rdma_latency_sample_count;
+              return d;
+            };
+
+            py::dict result;
+
+            // API stats
+            py::dict api;
+            api["read_calls"] = snap.api.read_calls;
+            api["write_calls"] = snap.api.write_calls;
+            api["batch_read_calls"] = snap.api.batch_read_calls;
+            api["batch_write_calls"] = snap.api.batch_write_calls;
+            api["rejected_calls"] = snap.api.rejected_calls;
+            api["total_bytes_read"] = snap.api.total_bytes_read;
+            api["total_bytes_written"] = snap.api.total_bytes_written;
+            api["jct_ewma_us"] = snap.api.jct_ewma_us;
+            api["jct_min_us"] = snap.api.jct_min_us;
+            api["jct_max_us"] = snap.api.jct_max_us;
+            api["jct_sample_count"] = snap.api.jct_sample_count;
+            result["api"] = api;
+
+            // Verbs stats
+            result["verbs"] = verbs_to_dict(snap.verbs);
+
+            // Breakdown
+            py::dict breakdown;
+            breakdown["api_total_ewma_us"] = snap.breakdown.api_total_ewma_us;
+            breakdown["rdma_wall_ewma_us"] = snap.breakdown.rdma_wall_ewma_us;
+            breakdown["sw_overhead_ewma_us"] = snap.breakdown.sw_overhead_ewma_us;
+            result["breakdown"] = breakdown;
+
+            // Per-EP
+            py::list per_ep;
+            for (const auto& ep : snap.per_ep) {
+              py::dict ep_dict;
+              ep_dict["ep_id"] = ep.ep_id;
+              ep_dict["verbs"] = verbs_to_dict(ep.verbs);
+              per_ep.append(ep_dict);
+            }
+            result["per_ep"] = per_ep;
+
+            result["snapshot_tsc"] = snap.snapshot_tsc;
+            result["tsc_freq_ghz"] = snap.tsc_freq_ghz;
+
+            return result;
+          },
+          py::arg("backend_type") = mori::io::BackendType::RDMA);
 }
 
 }  // namespace mori

--- a/src/pybind/pybind_io.cpp
+++ b/src/pybind/pybind_io.cpp
@@ -219,7 +219,77 @@ void RegisterMoriIo(pybind11::module_& m) {
       .def("WaitAll", &mori::io::IOEngine::WaitAll, py::arg("statuses"), py::arg("timeout_ms") = -1,
            py::call_guard<py::gil_scoped_release>())
       .def("LoadScatterGatherModule", &mori::io::IOEngine::LoadScatterGatherModule)
-      .def("LoadFabricCopyModule", &mori::io::IOEngine::LoadFabricCopyModule);
+      .def("LoadFabricCopyModule", &mori::io::IOEngine::LoadFabricCopyModule)
+      .def(
+          "GetTelemetrySnapshot",
+          [](const mori::io::IOEngine& self, mori::io::BackendType type) -> py::dict {
+            auto snap = self.GetTelemetrySnapshot(type);
+            auto verbs_to_dict = [](const mori::io::TelemetrySnapshot::VerbsStats& v) -> py::dict {
+              py::dict d;
+              d["bytes_posted"] = v.bytes_posted;
+              d["bytes_completed"] = v.bytes_completed;
+              d["ops_posted"] = v.ops_posted;
+              d["ops_completed"] = v.ops_completed;
+              d["cqe_errors"] = v.cqe_errors;
+              d["post_send_errors"] = v.post_send_errors;
+              d["sq_full_events"] = v.sq_full_events;
+              d["cq_polls"] = v.cq_polls;
+              d["cq_empty_polls"] = v.cq_empty_polls;
+              d["cq_utilization"] = v.cq_utilization;
+              d["poll_mode"] = v.poll_mode;
+              d["sq_depth"] = v.sq_depth;
+              d["sq_depth_hwm"] = v.sq_depth_hwm;
+              d["sq_depth_max"] = v.sq_depth_max;
+              d["rdma_latency_ewma_us"] = v.rdma_latency_ewma_us;
+              d["rdma_latency_min_us"] = v.rdma_latency_min_us;
+              d["rdma_latency_max_us"] = v.rdma_latency_max_us;
+              d["rdma_latency_sample_count"] = v.rdma_latency_sample_count;
+              return d;
+            };
+
+            py::dict result;
+
+            // API stats
+            py::dict api;
+            api["read_calls"] = snap.api.read_calls;
+            api["write_calls"] = snap.api.write_calls;
+            api["batch_read_calls"] = snap.api.batch_read_calls;
+            api["batch_write_calls"] = snap.api.batch_write_calls;
+            api["rejected_calls"] = snap.api.rejected_calls;
+            api["total_bytes_read"] = snap.api.total_bytes_read;
+            api["total_bytes_written"] = snap.api.total_bytes_written;
+            api["jct_ewma_us"] = snap.api.jct_ewma_us;
+            api["jct_min_us"] = snap.api.jct_min_us;
+            api["jct_max_us"] = snap.api.jct_max_us;
+            api["jct_sample_count"] = snap.api.jct_sample_count;
+            result["api"] = api;
+
+            // Verbs stats
+            result["verbs"] = verbs_to_dict(snap.verbs);
+
+            // Breakdown
+            py::dict breakdown;
+            breakdown["api_total_ewma_us"] = snap.breakdown.api_total_ewma_us;
+            breakdown["rdma_wall_ewma_us"] = snap.breakdown.rdma_wall_ewma_us;
+            breakdown["sw_overhead_ewma_us"] = snap.breakdown.sw_overhead_ewma_us;
+            result["breakdown"] = breakdown;
+
+            // Per-EP
+            py::list per_ep;
+            for (const auto& ep : snap.per_ep) {
+              py::dict ep_dict;
+              ep_dict["ep_id"] = ep.ep_id;
+              ep_dict["verbs"] = verbs_to_dict(ep.verbs);
+              per_ep.append(ep_dict);
+            }
+            result["per_ep"] = per_ep;
+
+            result["snapshot_tsc"] = snap.snapshot_tsc;
+            result["tsc_freq_ghz"] = snap.tsc_freq_ghz;
+
+            return result;
+          },
+          py::arg("backend_type") = mori::io::BackendType::RDMA);
 }
 
 }  // namespace mori


### PR DESCRIPTION
## Summary
- add telemetry snapshot types and IO engine/backend APIs
- collect RDMA API, verbs, and latency metrics in the RDMA backend
- expose telemetry snapshots through pybind and the Python IO engine wrapper

## Testing
- Passed