### PR TITLE
refactor(jit): silence Ionic CCQE probe logs and clean up caching

### DIFF
--- a/python/mori/jit/core.py
+++ b/python/mori/jit/core.py
@@ -35,8 +35,6 @@ import tempfile
 import time
 from pathlib import Path
 
-logger = logging.getLogger(__name__)
-
 from mori.jit.cache import get_cache_dir, get_cache_root
 from mori.jit.config import (
     BuildConfig,
@@ -47,6 +45,8 @@ from mori.jit.config import (
     is_debuginfo_enabled,
     is_profiler_enabled,
 )
+
+logger = logging.getLogger(__name__)
 
 _BC_FILENAME = "libmori_shmem_device.bc"
 
@@ -246,7 +246,12 @@ def _is_all_ionic_support_ccqe() -> bool:
 @functools.cache
 def is_ccqe_enabled() -> bool:
     """Return True if CCQE should be enabled (cached after first call)."""
-    if os.environ.get("MORI_DISABLE_IONIC_CCQE", "").lower() in ("1", "true", "on", "yes"):
+    if os.environ.get("MORI_DISABLE_IONIC_CCQE", "").lower() in (
+        "1",
+        "true",
+        "on",
+        "yes",
+    ):
         logger.info("Ionic _ccqe_enabled: False (disabled by MORI_DISABLE_IONIC_CCQE)")
         return False
     lib_support = _lib_has_ionic_ccqe()

--- a/python/mori/jit/core.py
+++ b/python/mori/jit/core.py
@@ -25,6 +25,8 @@
 
 from __future__ import annotations
 
+import functools
+import logging
 import os
 import re
 import subprocess
@@ -32,6 +34,8 @@ import sys
 import tempfile
 import time
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 from mori.jit.cache import get_cache_dir, get_cache_root
 from mori.jit.config import (
@@ -230,7 +234,7 @@ def _is_all_ionic_support_ccqe() -> bool:
     if len(set(versions)) != 1:
         return False
 
-    print(f"ionic ver: {versions[-1]}")
+    logger.debug("ionic ver: %s", versions[-1])
 
     for ver in versions:
         if not _is_firmware_support_ccqe(ver):
@@ -239,25 +243,22 @@ def _is_all_ionic_support_ccqe() -> bool:
     return True
 
 
-_ccqe_enabled: bool | None = None
-
-
+@functools.cache
 def is_ccqe_enabled() -> bool:
     """Return True if CCQE should be enabled (cached after first call)."""
-    global _ccqe_enabled
-    if _ccqe_enabled is None:
-        if os.environ.get("MORI_DISABLE_IONIC_CCQE") == "1":
-            _ccqe_enabled = False
-            print("Ionic _ccqe_enabled: False (disabled by MORI_DISABLE_IONIC_CCQE)")
-        else:
-            lib_support = _lib_has_ionic_ccqe()
-            nic_support = _is_all_ionic_support_ccqe()
-            _ccqe_enabled = lib_support and nic_support
-            print(
-                f"Ionic _ccqe_enabled: {_ccqe_enabled} lib_support {lib_support} nic_support: {nic_support}"
-            )
-
-    return _ccqe_enabled
+    if os.environ.get("MORI_DISABLE_IONIC_CCQE", "").lower() in ("1", "true", "on", "yes"):
+        logger.info("Ionic _ccqe_enabled: False (disabled by MORI_DISABLE_IONIC_CCQE)")
+        return False
+    lib_support = _lib_has_ionic_ccqe()
+    nic_support = _is_all_ionic_support_ccqe()
+    enabled = lib_support and nic_support
+    logger.info(
+        "Ionic _ccqe_enabled: %s lib_support %s nic_support: %s",
+        enabled,
+        lib_support,
+        nic_support,
+    )
+    return enabled
 
 
 def _ccqe_defines() -> list[str]:


### PR DESCRIPTION
## Summary

- Migrate Ionic CCQE detection messages from unconditional `print` to the `logging` module. They were printing on every `import mori` and cluttering CI / user output. JIT compilation progress lines (`[mori-jit] Compiling ...`, `[mori-jit] Cached: ...`) are intentionally **kept as `print`** and remain visible by default.
- Replace the `_ccqe_enabled` module-global + `None`-sentinel cache in `is_ccqe_enabled()` with `@functools.cache`. This gives us thread-safe single-execution semantics for free, removes the `global` statement, and exposes `is_ccqe_enabled.cache_clear()` for tests.
- Make `MORI_DISABLE_IONIC_CCQE` parsing case-insensitive and accept `1` / `true` / `on` / `yes`, matching the conventions used by `ENABLE_PROFILER` and `MORI_DEBUG_INFO` elsewhere in mori python (and `IsEnvVarEnabled` on the C++ side).

## Behavior change

Default behavior for end users:

| Log line | Before | After |
|---|---|---|
| `Ionic _ccqe_enabled: ... lib_support ... nic_support: ...` | always printed | silent (visible at `INFO` level) |
| `ionic ver: <N>` | always printed | silent (visible at `DEBUG` level) |
| `[mori-jit] Compiling ...` / `Cached: ...` | printed | **unchanged**, still printed |

To re-enable the Ionic diagnostic line, an application can do:

```python
import logging
logging.getLogger("mori").setLevel(logging.INFO)
logging.basicConfig()
```

## Test plan

- [x] `import mori` no longer emits the `Ionic _ccqe_enabled: ...` line
- [x] `MORI_PRECOMPILE=1 python -c 'import mori'` still shows `[mori-jit] Compiling ...` / `Cached: ...` lines
- [x] `MORI_DISABLE_IONIC_CCQE=true` / `=on` / `=yes` / `=1` all disable CCQE
- [x] Existing CI green