### PR TITLE
docs: list libibverbs packages in README prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,10 @@ GPU Direct RDMA READ, pairwise, 128 consecutive transfers, 1 GPU, MI300X + Thor2
 ### Prerequisites
 
 - ROCm >= 6.4 (hipcc needed at runtime for JIT kernel compilation, not at install time)
-- System packages: `libpci-dev` (see [Dockerfile.dev](docker/Dockerfile.dev))
+- System packages (required for `pip install`; not bundled in wheels). On Debian/Ubuntu install at least:
+  - `libpci-dev`
+  - `libibverbs-dev`, `ibverbs-utils`
+  See [docker/Dockerfile.dev](docker/Dockerfile.dev) for the full apt list used in CI/dev images.
 - Optional: `libopenmpi-dev`, `openmpi-bin` — only needed when building C++ examples (`BUILD_EXAMPLES=ON`) or enabling MPI bootstrap (`MORI_WITH_MPI=ON`)
 
 Or build docker image with:


### PR DESCRIPTION
## Summary
- Expand README prerequisites to include `libibverbs-dev` and `ibverbs-utils`, matching `docker/Dockerfile.dev`.
- Clarify that pip/wheel installs do not bundle these system packages.

## Motivation
Users following `pip install --pre amd-mori-nightly` only see `libpci-dev` in the README, but the dev Docker image also installs IB verbs packages required for RDMA/JIT paths.

## Test plan
- [x] Docs-only change; aligned with existing `docker/Dockerfile.dev` package list.


Made with [Cursor](https://cursor.com)