### PR TITLE
feat(io): single-transfer chunking + adaptive multi-NIC striping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,12 +435,12 @@ jobs:
       - name: Install mori (node1)
         run: |
           $CT exec $CONTAINER bash -c \
-            "cd $GITHUB_WORKSPACE && BUILD_EXAMPLES=ON pip install . && pip install prettytable"
+            "cd $GITHUB_WORKSPACE && BUILD_EXAMPLES=ON pip install . && pip install prettytable && (command -v numactl >/dev/null || (apt-get update && apt-get install -y numactl))"
 
       - name: Install mori (node2)
         run: |
           ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST \
-            "$CT exec $CONTAINER bash -c 'cd $GITHUB_WORKSPACE && BUILD_EXAMPLES=ON pip install . && pip install prettytable'"
+            "$CT exec $CONTAINER bash -c 'cd $GITHUB_WORKSPACE && BUILD_EXAMPLES=ON pip install . && pip install prettytable && (command -v numactl >/dev/null || (apt-get update && apt-get install -y numactl))'"
 
       - name: MORI-IO internode write sweep
         run: |
@@ -454,7 +454,7 @@ jobs:
             -- --op-type write --transfer-batch-size 128 --all
             --sweep-start-size 1024 --sweep-max-size 16777216 --iters 4
             --enable-sess --enable-batch-transfer
-            --num-qp-per-transfer 2 --num-worker-threads 2
+            --num-qp-per-transfer 2
             --num-initiator-dev 8 --num-target-dev 8
           )
           ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
@@ -464,7 +464,7 @@ jobs:
             -- --op-type write --transfer-batch-size 128 --all \
             --sweep-start-size 1024 --sweep-max-size 16777216 --iters 4 \
             --enable-sess --enable-batch-transfer \
-            --num-qp-per-transfer 2 --num-worker-threads 2 \
+            --num-qp-per-transfer 2 \
             --num-initiator-dev 8 --num-target-dev 8
           wait
 
@@ -479,7 +479,7 @@ jobs:
             --ifname $NODE2_IFNAME
             -- --op-type read --buffer-size 4096 --transfer-batch-size 128 --iters 8
             --enable-batch-transfer --enable-sess --poll_cq_mode event
-            --num-qp-per-transfer 2 --num-worker-threads 2
+            --num-qp-per-transfer 2
             --num-initiator-dev 8 --num-target-dev 8
           )
           ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
@@ -488,7 +488,64 @@ jobs:
             --ifname $NODE1_IFNAME \
             -- --op-type read --buffer-size 4096 --transfer-batch-size 128 --iters 8 \
             --enable-batch-transfer --enable-sess --poll_cq_mode event \
-            --num-qp-per-transfer 2 --num-worker-threads 2 \
+            --num-qp-per-transfer 2 \
+            --num-initiator-dev 8 --num-target-dev 8
+          wait
+
+      - name: MORI-IO internode CPU memory sweep (chunking + 4 NIC x 4 QP)
+        run: |
+          SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_io_benchmark.sh"
+          # CPU host memory, chunking on (default), striped across 4 NUMA-local NICs
+          # with 16 QPs total (= 4 QP per NIC). Single posting thread (inline).
+          PORT=29122
+          for OP in write read; do
+            echo "=== MORI-IO internode benchmark: cpu-mem $OP sweep (chunking, 4 NIC x 4 QP) port=$PORT ==="
+            NODE2_CMD=(
+              $CT exec -e MORI_IO_NUM_NICS_PER_TRANSFER=4 $CONTAINER bash $SCRIPT
+              --rank 1 --master-addr $NODE1_HOST --master-port $PORT
+              --ifname $NODE2_IFNAME --numa 0
+              -- --mem-type cpu --op-type $OP --transfer-batch-size 64 --all
+              --sweep-start-size 1024 --sweep-max-size 1048576 --iters 4
+              --enable-sess --enable-batch-transfer
+              --num-qp-per-transfer 16 --num-initiator-dev 1 --num-target-dev 1
+            )
+            ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
+            $CT exec -e MORI_IO_NUM_NICS_PER_TRANSFER=4 $CONTAINER bash $SCRIPT \
+              --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
+              --ifname $NODE1_IFNAME --numa 0 \
+              -- --mem-type cpu --op-type $OP --transfer-batch-size 64 --all \
+              --sweep-start-size 1024 --sweep-max-size 1048576 --iters 4 \
+              --enable-sess --enable-batch-transfer \
+              --num-qp-per-transfer 16 --num-initiator-dev 1 --num-target-dev 1
+          wait
+            PORT=$((PORT + 1))
+          done
+
+      - name: MORI-IO internode multi-worker executor correctness (chunking off)
+        run: |
+          SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_io_benchmark.sh"
+          PORT=29124
+          # Legacy multi-worker executor path: only active when chunking is off and
+          # single NIC. Small write run to guard byte-for-byte correctness of that path.
+          echo "=== MORI-IO internode benchmark: multi-worker executor (chunking off) port=$PORT ==="
+          NODE2_CMD=(
+            $CT exec $CONTAINER bash $SCRIPT
+            --rank 1 --master-addr $NODE1_HOST --master-port $PORT
+            --ifname $NODE2_IFNAME
+            -- --op-type write --disable-chunking --transfer-batch-size 64 --all
+            --sweep-start-size 1024 --sweep-max-size 1048576 --iters 4
+            --enable-sess --enable-batch-transfer
+            --num-qp-per-transfer 4 --num-worker-threads 2
+            --num-initiator-dev 8 --num-target-dev 8
+          )
+          ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
+          $CT exec $CONTAINER bash $SCRIPT \
+            --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
+            --ifname $NODE1_IFNAME \
+            -- --op-type write --disable-chunking --transfer-batch-size 64 --all \
+            --sweep-start-size 1024 --sweep-max-size 1048576 --iters 4 \
+            --enable-sess --enable-batch-transfer \
+            --num-qp-per-transfer 4 --num-worker-threads 2 \
             --num-initiator-dev 8 --num-target-dev 8
           wait
 

--- a/docs/MORI-IO-BENCHMARK.md
+++ b/docs/MORI-IO-BENCHMARK.md
@@ -39,11 +39,16 @@ torchrun --nnodes=2 --node_rank=0 --nproc_per_node=1 \
 | `--enable-sess` | Enable session transfer (lower latency) |
 | `--num-initiator-dev` | Number of initiator devices |
 | `--num-target-dev` | Number of target devices |
-| `--num-qp-per-transfer` | Number of queue pairs used |
+| `--num-qp-per-transfer` | Number of queue pairs used (default `4`) |
 | `--op-type` | Operation type: `read` or `write` |
 | `--poll_cq_mode` | CQ polling mode: `polling` or `event` |
-| `--num-worker-threads` | Number of worker threads |
+| `--num-worker-threads` | Number of worker threads (default `1`; ignored when chunking/multi-NIC is on — posting is single-thread inline) |
+| `--disable-chunking` | Disable single-transfer chunking (chunking is **on by default**) |
+| `--chunk-bytes` | Chunk size in bytes when chunking is on (default `65536` = 64 KB) |
+| `--max-chunks` | Max chunks per transfer (default `64`) |
 | `--log-level` | Log level (e.g., `info`) |
+
+> Multi-NIC striping is controlled by the env var `MORI_IO_NUM_NICS_PER_TRANSFER` (default `1`). For host memory, set it to the number of NUMA-local NICs and keep `--num-qp-per-transfer ≥ 2 × NICs` so each NIC gets ≥2 QPs. GPU memory should stay single-NIC (PCIe-bound).
 
 ## Results: Thor2 RDMA Read
 

--- a/docs/MORI-IO-GUIDE.md
+++ b/docs/MORI-IO-GUIDE.md
@@ -67,7 +67,7 @@ from mori.io import (
 | `IOEngine` | Primary engine for P2P transfers — create backends, register engines/memory, issue transfers |
 | `IOEngineSession` | Lightweight reusable session between two memory regions, lower per-transfer overhead |
 | `IOEngineConfig` | Engine configuration: `host` (str), `port` (int) |
-| `RdmaBackendConfig` | RDMA backend config: `qp_per_transfer`, `post_batch_size`, `num_worker_threads`, `poll_cq_mode`, `enable_notification` |
+| `RdmaBackendConfig` | RDMA backend config: `qp_per_transfer`, `post_batch_size`, `num_worker_threads`, `poll_cq_mode`, `enable_notification`, `enable_transfer_chunking`, `chunk_bytes`, `max_chunks_per_transfer`, `num_nics_per_transfer` |
 | `XgmiBackendConfig` | XGMI backend config: `num_streams` (default 64), `num_events` (default 64) |
 
 **Enums:**
@@ -166,9 +166,13 @@ See `examples/io/example.py` for more complete examples including batch transfer
 | Setting | Description |
 |---------|-------------|
 | `set_log_level(level)` | Set MORI-IO log verbosity level |
-| `RdmaBackendConfig.qp_per_transfer` | Queue pairs per transfer (default 1, increase for higher bandwidth) |
+| `RdmaBackendConfig.qp_per_transfer` | Queue pairs per transfer (default 1, increase for higher bandwidth; with multi-NIC these QPs are spread across NICs, so aim for ≥2 QP per NIC) |
 | `RdmaBackendConfig.poll_cq_mode` | CQ polling mode: `POLLING` (busy-wait, lower latency) or `EVENT` (interrupt-driven) |
 | `RdmaBackendConfig.enable_notification` | Enable target-side completion notifications (default `True`) |
+| `RdmaBackendConfig.enable_transfer_chunking` | Split a large single transfer into `chunk_bytes` chunks pipelined across QPs (default `False`). Lifts single-transfer bandwidth from single-outstanding (~28 GB/s) to NIC line rate. Forces single-thread inline posting (ignores `num_worker_threads`). Env: `MORI_IO_ENABLE_CHUNKING` |
+| `RdmaBackendConfig.chunk_bytes` | Chunk size when chunking is on (default `65536` = 64 KB). Messages ≤ this are unchanged. Env: `MORI_IO_CHUNK_BYTES` |
+| `RdmaBackendConfig.max_chunks_per_transfer` | Cap on chunks per transfer to bound WR/SQ usage (default `64`). Env: `MORI_IO_MAX_CHUNKS` |
+| `RdmaBackendConfig.num_nics_per_transfer` | Stripe a transfer across this many NICs (default `1`). Adaptive by memory type: GPU memory stays single-NIC (PCIe-bound); host memory stripes across NUMA-local NICs. Env: `MORI_IO_NUM_NICS_PER_TRANSFER` |
 | `IOEngineConfig.port = 0` | Auto-bind to a free port |
 
 ## Source Files

--- a/include/mori/application/topology/system.hpp
+++ b/include/mori/application/topology/system.hpp
@@ -45,6 +45,8 @@ class TopoSystem {
   TopoSystemNet* GetTopoSystemNet() { return net.get(); }
 
   std::string MatchGpuAndNic(int id);
+  std::vector<std::string> MatchGpuAndNics(int id, int k);
+  std::vector<std::string> MatchCpuNics(int numaNode, int k);
   std::vector<std::string> MatchAllGpusAndNics();
 
  private:

--- a/include/mori/io/backend.hpp
+++ b/include/mori/io/backend.hpp
@@ -21,6 +21,8 @@
 // SOFTWARE.
 #pragma once
 
+#include <cstddef>
+
 #include "mori/io/common.hpp"
 #include "mori/io/enum.hpp"
 
@@ -45,14 +47,20 @@ struct BackendConfig {
 struct RdmaBackendConfig : public BackendConfig {
   RdmaBackendConfig() : BackendConfig(BackendType::RDMA) {}
   RdmaBackendConfig(int qpPerTransfer_, int postBatchSize_, int numWorkerThreads_,
-                    PollCqMode pollCqMode_, bool enableNotification_, uint32_t notifPerQp_ = 1024)
+                    PollCqMode pollCqMode_, bool enableNotification_, uint32_t notifPerQp_ = 1024,
+                    bool enableTransferChunking_ = false, size_t chunkBytes_ = 131072,
+                    int maxChunksPerTransfer_ = 64, int numNicsPerTransfer_ = 1)
       : BackendConfig(BackendType::RDMA),
         qpPerTransfer(qpPerTransfer_),
         postBatchSize(postBatchSize_),
         numWorkerThreads(numWorkerThreads_),
         pollCqMode(pollCqMode_),
         enableNotification(enableNotification_),
-        notifPerQp(notifPerQp_) {}
+        notifPerQp(notifPerQp_),
+        enableTransferChunking(enableTransferChunking_),
+        chunkBytes(chunkBytes_),
+        maxChunksPerTransfer(maxChunksPerTransfer_),
+        numNicsPerTransfer(numNicsPerTransfer_) {}
 
   int qpPerTransfer{1};
   int postBatchSize{-1};
@@ -60,6 +68,10 @@ struct RdmaBackendConfig : public BackendConfig {
   PollCqMode pollCqMode{PollCqMode::POLLING};
   bool enableNotification{true};  // Enable/disable notification mechanism for transfer completion
   uint32_t notifPerQp{1024};      // Pre-posted RECV WRs per QP; defines the Zone A boundary
+  bool enableTransferChunking{false};
+  size_t chunkBytes{131072};
+  int maxChunksPerTransfer{64};
+  int numNicsPerTransfer{1};
 
   int maxSendWr{0};
   int maxCqeNum{0};
@@ -69,8 +81,11 @@ struct RdmaBackendConfig : public BackendConfig {
 inline std::ostream& operator<<(std::ostream& os, const RdmaBackendConfig& c) {
   return os << "qpPerTransfer[" << c.qpPerTransfer << "] postBatchSize[" << c.postBatchSize
             << "] numWorkerThreads[" << c.numWorkerThreads << "] enableNotification["
-            << c.enableNotification << "] notifPerQp[" << c.notifPerQp << "] maxSendWr["
-            << c.maxSendWr << "] maxCqeNum[" << c.maxCqeNum << "] maxMsgSge[" << c.maxMsgSge << "]";
+            << c.enableNotification << "] notifPerQp[" << c.notifPerQp
+            << "] enableTransferChunking[" << c.enableTransferChunking << "] chunkBytes["
+            << c.chunkBytes << "] maxChunksPerTransfer[" << c.maxChunksPerTransfer
+            << "] numNicsPerTransfer[" << c.numNicsPerTransfer << "] maxSendWr[" << c.maxSendWr
+            << "] maxCqeNum[" << c.maxCqeNum << "] maxMsgSge[" << c.maxMsgSge << "]";
 }
 
 struct XgmiBackendConfig : public BackendConfig {

--- a/include/mori/io/backend.hpp
+++ b/include/mori/io/backend.hpp
@@ -48,7 +48,7 @@ struct RdmaBackendConfig : public BackendConfig {
   RdmaBackendConfig() : BackendConfig(BackendType::RDMA) {}
   RdmaBackendConfig(int qpPerTransfer_, int postBatchSize_, int numWorkerThreads_,
                     PollCqMode pollCqMode_, bool enableNotification_, uint32_t notifPerQp_ = 1024,
-                    bool enableTransferChunking_ = false, size_t chunkBytes_ = 131072,
+                    bool enableTransferChunking_ = false, size_t chunkBytes_ = 65536,
                     int maxChunksPerTransfer_ = 64, int numNicsPerTransfer_ = 1)
       : BackendConfig(BackendType::RDMA),
         qpPerTransfer(qpPerTransfer_),
@@ -69,7 +69,7 @@ struct RdmaBackendConfig : public BackendConfig {
   bool enableNotification{true};  // Enable/disable notification mechanism for transfer completion
   uint32_t notifPerQp{1024};      // Pre-posted RECV WRs per QP; defines the Zone A boundary
   bool enableTransferChunking{false};
-  size_t chunkBytes{131072};
+  size_t chunkBytes{65536};
   int maxChunksPerTransfer{64};
   int numNicsPerTransfer{1};
 

--- a/include/mori/io/common.hpp
+++ b/include/mori/io/common.hpp
@@ -102,14 +102,15 @@ struct MemoryDesc {
   size_t size{0};
   MemoryLocationType loc;
   std::array<char, kIpcHandleSize> ipcHandle{};
+  int numaNode{-1};
 
   constexpr bool operator==(const MemoryDesc& rhs) const noexcept {
     return (engineKey == rhs.engineKey) && (id == rhs.id) && (deviceId == rhs.deviceId) &&
            (deviceBusId == rhs.deviceBusId) && (data == rhs.data) && (size == rhs.size) &&
-           (loc == rhs.loc);
+           (loc == rhs.loc) && (numaNode == rhs.numaNode);
   }
 
-  MSGPACK_DEFINE(engineKey, id, deviceId, deviceBusId, data, size, loc, ipcHandle);
+  MSGPACK_DEFINE(engineKey, id, deviceId, deviceBusId, data, size, loc, ipcHandle, numaNode);
 };
 
 using TransferUniqueId = uint64_t;

--- a/src/application/topology/system.cpp
+++ b/src/application/topology/system.cpp
@@ -101,6 +101,67 @@ std::string TopoSystem::MatchGpuAndNic(int id) {
   return matches[id];
 }
 
+std::vector<std::string> TopoSystem::MatchGpuAndNics(int id, int k) {
+  if (k <= 0) return {};
+
+  std::vector<Candidate> candidates = CollectAndSortCandidates(this, id);
+  std::vector<std::string> matches;
+  matches.reserve(std::min<int>(k, candidates.size()));
+
+  std::unordered_set<std::string> seen;
+  for (const auto& candidate : candidates) {
+    if (candidate.nic == nullptr) continue;
+    const std::string& name = candidate.nic->name;
+    if (!seen.insert(name).second) continue;
+    matches.push_back(name);
+    if (static_cast<int>(matches.size()) >= k) break;
+  }
+
+  return matches;
+}
+
+std::vector<std::string> TopoSystem::MatchCpuNics(int numaNode, int k) {
+  if (k <= 0) return {};
+
+  TopoSystemPci* pci = GetTopoSystemPci();
+  TopoSystemNet* net = GetTopoSystemNet();
+
+  auto nics = net->GetNics();
+  std::vector<TopoNodeNic*> candidates;
+  candidates.reserve(nics.size());
+  for (auto* nic : nics) {
+    if (nic == nullptr) continue;
+    candidates.push_back(nic);
+  }
+
+  std::sort(candidates.begin(), candidates.end(), [&](TopoNodeNic* a, TopoNodeNic* b) -> bool {
+    if (numaNode >= 0) {
+      TopoNodePci* aNode = pci->Node(a->busId);
+      TopoNodePci* bNode = pci->Node(b->busId);
+      const bool aLocal = (aNode != nullptr) && (aNode->NumaNode() == numaNode);
+      const bool bLocal = (bNode != nullptr) && (bNode->NumaNode() == numaNode);
+      if (aLocal != bLocal) return aLocal;
+    }
+
+    bool tie = (a->totalGbps == b->totalGbps);
+    if (!tie) return a->totalGbps > b->totalGbps;
+
+    return a->name <= b->name;
+  });
+
+  std::vector<std::string> matches;
+  matches.reserve(std::min<int>(k, candidates.size()));
+  std::unordered_set<std::string> seen;
+  for (const auto* nic : candidates) {
+    if (nic == nullptr) continue;
+    if (!seen.insert(nic->name).second) continue;
+    matches.push_back(nic->name);
+    if (static_cast<int>(matches.size()) >= k) break;
+  }
+
+  return matches;
+}
+
 std::vector<std::string> TopoSystem::MatchAllGpusAndNics() {
   int count;
   HIP_RUNTIME_CHECK(hipGetDeviceCount(&count));

--- a/src/io/engine.cpp
+++ b/src/io/engine.cpp
@@ -22,6 +22,8 @@
 #include "mori/io/engine.hpp"
 
 #include <hip/hip_runtime_api.h>
+#include <linux/mempolicy.h>
+#include <sys/syscall.h>
 #include <unistd.h>
 
 #include <cctype>
@@ -82,6 +84,19 @@ std::string QueryDeviceBusId(int deviceId) {
 bool IsAutoXgmiEnabled() {
   const char* v = std::getenv("MORI_DISABLE_AUTO_XGMI");
   return v != nullptr && v[0] == '0';
+}
+
+int DetectNumaNode(void* addr) {
+#if defined(SYS_get_mempolicy)
+  int node = -1;
+  long rc = syscall(SYS_get_mempolicy, &node, nullptr, 0,
+                    reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(addr)),
+                    MPOL_F_NODE | MPOL_F_ADDR);
+  return rc == 0 ? node : -1;
+#else
+  (void)addr;
+  return -1;
+#endif
 }
 
 }  // namespace
@@ -347,6 +362,9 @@ MemoryDesc IOEngine::RegisterMemory(void* data, size_t size, int device, MemoryL
   memDesc.data = reinterpret_cast<uintptr_t>(data);
   memDesc.size = size;
   memDesc.loc = loc;
+  if (loc == MemoryLocationType::CPU && data != nullptr) {
+    memDesc.numaNode = DetectNumaNode(data);
+  }
 
   for (auto& it : backends) {
     it.second->RegisterMemory(memDesc);

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -48,6 +48,30 @@ static void ValidateRdmaNotificationConfig(const RdmaBackendConfig& config) {
   }
 }
 
+void ValidateRdmaTransferConfig(const RdmaBackendConfig& config) {
+  if (config.maxChunksPerTransfer < 1) {
+    MORI_IO_ERROR("Invalid RDMA config: maxChunksPerTransfer must be >= 1; got {}",
+                  config.maxChunksPerTransfer);
+    throw std::runtime_error("Invalid RDMA config: maxChunksPerTransfer must be >= 1");
+  }
+  if (config.numNicsPerTransfer < 1) {
+    MORI_IO_ERROR("Invalid RDMA config: numNicsPerTransfer must be >= 1; got {}",
+                  config.numNicsPerTransfer);
+    throw std::runtime_error("Invalid RDMA config: numNicsPerTransfer must be >= 1");
+  }
+  if (config.enableTransferChunking && config.chunkBytes < 4096) {
+    MORI_IO_ERROR(
+        "Invalid RDMA config: chunkBytes must be >= 4096 when chunking is enabled; got {}",
+        config.chunkBytes);
+    throw std::runtime_error(
+        "Invalid RDMA config: chunkBytes must be >= 4096 when chunking is enabled");
+  }
+}
+
+bool UsesInlineOnly(const RdmaBackendConfig& config) {
+  return config.enableTransferChunking || config.numNicsPerTransfer > 1;
+}
+
 enum class CqeFailureOrigin : uint8_t {
   BatchTransfer = 0,
   NotificationSend,
@@ -172,18 +196,35 @@ RdmaManager::~RdmaManager() {
 
 std::vector<std::pair<int, int>> RdmaManager::Search(TopoKey key) {
   if (key.loc == MemoryLocationType::GPU) {
-    std::string nicName = topo->MatchGpuAndNic(key.deviceId);
-    assert(!nicName.empty());
-    for (int i = 0; i < availDevices.size(); i++) {
-      if (availDevices[i].first->Name() == nicName) {
-        return {{i, 1}};
+    const int requestedNics = std::max(1, config.numNicsPerTransfer);
+    std::vector<std::string> nicNames;
+    if (requestedNics == 1) {
+      std::string nicName = topo->MatchGpuAndNic(key.deviceId);
+      if (!nicName.empty()) nicNames.push_back(std::move(nicName));
+    } else {
+      nicNames = topo->MatchGpuAndNics(key.deviceId, requestedNics);
+    }
+
+    std::vector<std::pair<int, int>> matches;
+    matches.reserve(nicNames.size());
+    for (const auto& nicName : nicNames) {
+      for (int i = 0; i < availDevices.size(); i++) {
+        if (availDevices[i].first->Name() == nicName) {
+          matches.push_back({i, 1});
+          break;
+        }
       }
     }
-    MORI_IO_WARN("No matching NIC found for GPU {}, nicName: {}", key.deviceId, nicName);
+    if (!matches.empty()) return matches;
+    MORI_IO_WARN("No matching NIC found for GPU {}", key.deviceId);
   } else if (key.loc == MemoryLocationType::CPU) {
     if (availDevices.empty()) return {};
+    const int requestedNics = std::max(1, config.numNicsPerTransfer);
     const char* envNic = std::getenv("MORI_IO_RDMA_NIC_IDX");
     if (envNic) {
+      if (requestedNics > 1) {
+        MORI_IO_WARN("MORI_IO_RDMA_NIC_IDX pins a single NIC; multi-NIC selection is disabled");
+      }
       int idx = std::atoi(envNic);
       if (idx >= 0 && idx < static_cast<int>(availDevices.size())) {
         return {{idx, 1}};
@@ -191,8 +232,25 @@ std::vector<std::pair<int, int>> RdmaManager::Search(TopoKey key) {
       MORI_IO_WARN("MORI_IO_RDMA_NIC_IDX={} out of range [0, {}), falling back to round-robin", idx,
                    availDevices.size());
     }
-    int idx = (roundRobinCounter.fetch_add(1, std::memory_order_relaxed) % availDevices.size());
-    return {{idx, 1}};
+
+    if (requestedNics == 1) {
+      int idx = (roundRobinCounter.fetch_add(1, std::memory_order_relaxed) % availDevices.size());
+      return {{idx, 1}};
+    }
+
+    std::vector<std::string> nicNames = topo->MatchCpuNics(key.numaNode, requestedNics);
+    std::vector<std::pair<int, int>> matches;
+    matches.reserve(nicNames.size());
+    for (const auto& nicName : nicNames) {
+      for (int i = 0; i < availDevices.size(); i++) {
+        if (availDevices[i].first->Name() == nicName) {
+          matches.push_back({i, 1});
+          break;
+        }
+      }
+    }
+    if (!matches.empty()) return matches;
+    MORI_IO_WARN("No matching NIC found for CPU numa node {}", key.numaNode);
   }
   MORI_IO_ERROR(
       "topo searching for device other than CPU/GPU is not implemented yet, returning default "
@@ -206,7 +264,7 @@ std::optional<application::RdmaMemoryRegion> RdmaManager::GetLocalMemory(int dev
   std::shared_lock<std::shared_mutex> lock(mu);
   MemoryKey key{devId, id};
   if (mTable.find(key) == mTable.end()) return std::nullopt;
-  return mTable[key];
+  return mTable.at(key);
 }
 
 application::RdmaMemoryRegion RdmaManager::RegisterLocalMemory(int devId, const MemoryDesc& desc) {
@@ -226,17 +284,37 @@ void RdmaManager::DeregisterLocalMemory(int devId, const MemoryDesc& desc) {
   }
 }
 
+void RdmaManager::DeregisterLocalMemory(const MemoryDesc& desc) {
+  std::unique_lock<std::shared_mutex> lock(mu);
+  std::vector<MemoryKey> keysToErase;
+  keysToErase.reserve(mTable.size());
+  for (const auto& [key, _] : mTable) {
+    if (key.id == desc.id) keysToErase.push_back(key);
+  }
+  for (const auto& key : keysToErase) {
+    auto it = mTable.find(key);
+    if (it == mTable.end()) continue;
+    if (key.devId >= 0 && key.devId < static_cast<int>(deviceCtxs.size()) &&
+        deviceCtxs[key.devId] != nullptr) {
+      deviceCtxs[key.devId]->DeregisterRdmaMemoryRegion(reinterpret_cast<void*>(desc.data));
+    }
+    mTable.erase(it);
+  }
+}
+
 /* ---------------------------------- Remote Memory Management ---------------------------------- */
 std::optional<application::RdmaMemoryRegion> RdmaManager::GetRemoteMemory(EngineKey ekey,
                                                                           int remRdmaDevId,
                                                                           MemoryUniqueId id) {
   std::shared_lock<std::shared_mutex> lock(mu);
+  auto remoteIt = remotes.find(ekey);
+  if (remoteIt == remotes.end()) return std::nullopt;
   MemoryKey key{remRdmaDevId, id};
-  RemoteEngineMeta& remote = remotes[ekey];
+  const RemoteEngineMeta& remote = remoteIt->second;
   if (remote.mTable.find(key) == remote.mTable.end()) {
     return std::nullopt;
   }
-  return remote.mTable[key];
+  return remote.mTable.at(key);
 }
 
 void RdmaManager::RegisterRemoteMemory(EngineKey ekey, int remRdmaDevId, MemoryUniqueId id,
@@ -259,12 +337,20 @@ void RdmaManager::DeregisterRemoteMemory(EngineKey ekey, int remRdmaDevId, Memor
 /* ------------------------------------- Endpoint Management ------------------------------------ */
 int RdmaManager::CountEndpoint(EngineKey engine, TopoKeyPair key) {
   std::shared_lock<std::shared_mutex> lock(mu);
-  return remotes[engine].rTable[key].size();
+  auto remoteIt = remotes.find(engine);
+  if (remoteIt == remotes.end()) return 0;
+  auto tableIt = remoteIt->second.rTable.find(key);
+  if (tableIt == remoteIt->second.rTable.end()) return 0;
+  return tableIt->second.size();
 }
 
 EpPairVec RdmaManager::GetAllEndpoint(EngineKey engine, TopoKeyPair key) {
   std::shared_lock<std::shared_mutex> lock(mu);
-  return remotes[engine].rTable[key];
+  auto remoteIt = remotes.find(engine);
+  if (remoteIt == remotes.end()) return {};
+  auto tableIt = remoteIt->second.rTable.find(key);
+  if (tableIt == remoteIt->second.rTable.end()) return {};
+  return tableIt->second;
 }
 
 application::RdmaEndpointConfig RdmaManager::GetRdmaEndpointConfig(int devId) {
@@ -790,7 +876,7 @@ std::optional<int> ControlPlaneServer::TryGetRemoteEnginePort(const EngineKey& e
   return it->second.port;
 }
 
-void ControlPlaneServer::BuildRdmaConn(EngineKey ekey, TopoKeyPair topo) {
+void ControlPlaneServer::BuildRdmaConn(EngineKey ekey, TopoKeyPair topo, int nicRank) {
   application::TCPEndpointHandle tcph;
   {
     std::lock_guard<std::mutex> lock(mu);
@@ -801,12 +887,13 @@ void ControlPlaneServer::BuildRdmaConn(EngineKey ekey, TopoKeyPair topo) {
 
   auto candidates = rdma->Search(topo.local);
   assert(!candidates.empty());
-  auto [devId, weight] = candidates[0];
+  int rank = std::min<int>(nicRank, static_cast<int>(candidates.size()) - 1);
+  auto [devId, weight] = candidates[rank];
 
   application::RdmaEndpoint lep = rdma->CreateEndpoint(devId);
 
   Protocol p(tcph);
-  p.WriteMessageRegEndpoint({myEngKey, topo, devId, lep.handle});
+  p.WriteMessageRegEndpoint({myEngKey, topo, devId, lep.handle, rank});
   MessageHeader hdr = p.ReadMessageHeader();
   assert(hdr.type == MessageType::RegEndpoint);
   MessageRegEndpoint msg = p.ReadMessageRegEndpoint(hdr.len);
@@ -872,13 +959,14 @@ void ControlPlaneServer::HandleControlPlaneProtocol(int fd) {
       auto candidates = rdma->Search(msg.topo.remote);
       assert(!candidates.empty());
       int rdevId = msg.devId;
-      auto [devId, weight] = candidates[0];
+      int rank = std::min<int>(msg.nicRank, static_cast<int>(candidates.size()) - 1);
+      auto [devId, weight] = candidates[rank];
       application::RdmaEndpoint lep = rdma->CreateEndpoint(devId);
       EndpointId eid =
           rdma->ConnectEndpoint(msg.ekey, devId, lep, rdevId, msg.eph, msg.topo, weight);
       auto ert = rdma->GetEndpointRuntime(eid);
       notif->RegisterEndpoint(ert);
-      p.WriteMessageRegEndpoint(MessageRegEndpoint{myEngKey, msg.topo, devId, lep.handle});
+      p.WriteMessageRegEndpoint(MessageRegEndpoint{myEngKey, msg.topo, devId, lep.handle, rank});
       SYSCALL_RETURN_ZERO(epoll_ctl(epfd, EPOLL_CTL_DEL, fd, NULL));
       break;
     }
@@ -959,11 +1047,66 @@ void ControlPlaneServer::Shutdown() {
 /*                                       RdmaBackendSession */
 /* ----------------------------------------------------------------------------------------------
  */
+std::vector<int> BuildDesiredQpCounts(int totalQp, int numRanks) {
+  std::vector<int> counts(numRanks, 0);
+  if (totalQp <= 0 || numRanks <= 0) return counts;
+  const int base = totalQp / numRanks;
+  const int rem = totalQp % numRanks;
+  for (int rank = 0; rank < numRanks; ++rank) {
+    counts[rank] = base + (rank < rem ? 1 : 0);
+  }
+  return counts;
+}
+
+EpPairVec InterleaveEndpointsByLocalDevice(const EpPairVec& eps,
+                                           const std::vector<int>& localDevOrder,
+                                           const std::vector<int>& wantPerRank) {
+  assert(localDevOrder.size() == wantPerRank.size());
+  std::unordered_map<int, size_t> rankByDev;
+  for (size_t rank = 0; rank < localDevOrder.size(); ++rank) {
+    rankByDev[localDevOrder[rank]] = rank;
+  }
+
+  std::vector<EpPairVec> buckets(localDevOrder.size());
+  int wantTotal = 0;
+  for (int want : wantPerRank) wantTotal += want;
+
+  for (const auto& ep : eps) {
+    auto it = rankByDev.find(ep.ldevId);
+    if (it == rankByDev.end()) continue;
+    size_t rank = it->second;
+    if (static_cast<int>(buckets[rank].size()) < wantPerRank[rank]) {
+      buckets[rank].push_back(ep);
+    }
+  }
+
+  EpPairVec interleaved;
+  interleaved.reserve(wantTotal);
+  for (size_t round = 0; interleaved.size() < static_cast<size_t>(wantTotal); ++round) {
+    bool progressed = false;
+    for (size_t rank = 0; rank < buckets.size(); ++rank) {
+      if (round >= buckets[rank].size()) continue;
+      interleaved.push_back(buckets[rank][round]);
+      progressed = true;
+      if (interleaved.size() == static_cast<size_t>(wantTotal)) break;
+    }
+    if (!progressed) break;
+  }
+
+  return interleaved;
+}
+
+/* ----------------------------------------------------------------------------------------------
+ */
 RdmaBackendSession::RdmaBackendSession(const RdmaBackendConfig& config,
-                                       const application::RdmaMemoryRegion& l,
-                                       const application::RdmaMemoryRegion& r, const EpPairVec& e,
-                                       Executor* exec)
-    : config(config), local(l), remote(r), eps(e), executor(exec) {}
+                                       std::vector<application::RdmaMemoryRegion> localMrPerEp,
+                                       std::vector<application::RdmaMemoryRegion> remoteMrPerEp,
+                                       const EpPairVec& e, Executor* exec)
+    : config(config),
+      localMrPerEp(std::move(localMrPerEp)),
+      remoteMrPerEp(std::move(remoteMrPerEp)),
+      eps(e),
+      executor(exec) {}
 
 void RdmaBackendSession::ReadWrite(size_t localOffset, size_t remoteOffset, size_t size,
                                    TransferStatus* status, TransferUniqueId id, bool isRead) {
@@ -972,8 +1115,10 @@ void RdmaBackendSession::ReadWrite(size_t localOffset, size_t remoteOffset, size
   auto callbackMeta = std::make_shared<CqCallbackMeta>(status, id, 1);
   internal::PublishCurrentIoCallDiagnostics(callbackMeta);
 
-  RdmaOpRet ret =
-      RdmaReadWrite(eps, local, localOffset, remote, remoteOffset, size, callbackMeta, id, isRead);
+  RdmaOpRet ret = RdmaBatchReadWrite(eps, localMrPerEp, remoteMrPerEp, {localOffset},
+                                     {remoteOffset}, {size}, callbackMeta, id, isRead, 1,
+                                     config.enableTransferChunking ? config.chunkBytes : 0,
+                                     config.maxChunksPerTransfer, config.enableTransferChunking);
 
   assert(!ret.Init());
   if (ret.Failed() || ret.Succeeded()) {
@@ -996,12 +1141,14 @@ void RdmaBackendSession::BatchReadWrite(const SizeVec& localOffsets, const SizeV
   internal::PublishCurrentIoCallDiagnostics(callbackMeta);
   RdmaOpRet ret;
   if (executor) {
-    ExecutorReq req{eps,          local, localOffsets,         remote, remoteOffsets, sizes,
-                    callbackMeta, id,    config.postBatchSize, isRead};
+    ExecutorReq req{eps,   localMrPerEp.front(), localOffsets, remoteMrPerEp.front(), remoteOffsets,
+                    sizes, callbackMeta,         id,           config.postBatchSize,  isRead};
     ret = executor->RdmaBatchReadWrite(req);
   } else {
-    ret = RdmaBatchReadWrite(eps, local, localOffsets, remote, remoteOffsets, sizes, callbackMeta,
-                             id, isRead, config.postBatchSize);
+    ret = RdmaBatchReadWrite(eps, localMrPerEp, remoteMrPerEp, localOffsets, remoteOffsets, sizes,
+                             callbackMeta, id, isRead, config.postBatchSize,
+                             config.enableTransferChunking ? config.chunkBytes : 0,
+                             config.maxChunksPerTransfer, config.enableTransferChunking);
   }
   assert(!ret.Init());
   if (ret.Failed() || ret.Succeeded()) {
@@ -1033,7 +1180,15 @@ RdmaBackend::RdmaBackend(EngineKey k, const IOEngineConfig& engConfig,
     : myEngKey(k), config(beConfig) {
   env::Override("MORI_IO_ENABLE_NOTIFICATION", config.enableNotification,
                 mori::env::detail::ParseBool);
+  env::Override("MORI_IO_ENABLE_CHUNKING", config.enableTransferChunking,
+                mori::env::detail::ParseBool);
+  env::Override("MORI_IO_CHUNK_BYTES", config.chunkBytes, mori::env::detail::ParsePositiveInt);
+  env::Override("MORI_IO_MAX_CHUNKS", config.maxChunksPerTransfer,
+                mori::env::detail::ParsePositiveInt);
+  env::Override("MORI_IO_NUM_NICS_PER_TRANSFER", config.numNicsPerTransfer,
+                mori::env::detail::ParsePositiveInt);
   ValidateRdmaNotificationConfig(config);
+  ValidateRdmaTransferConfig(config);
 
   auto rdmaCtx = std::make_unique<application::RdmaContext>(application::RdmaBackendType::IBVerbs);
   rdma.reset(new mori::io::RdmaManager(config, rdmaCtx.get()));
@@ -1046,7 +1201,14 @@ RdmaBackend::RdmaBackend(EngineKey k, const IOEngineConfig& engConfig,
       new ControlPlaneServer(myEngKey, engConfig.host, engConfig.port, rdma.get(), notif.get()));
   server->Start();
 
-  if (config.numWorkerThreads > 1) {
+  bool useInlineOnly = UsesInlineOnly(config);
+  if (config.numWorkerThreads > 1 && useInlineOnly) {
+    MORI_IO_WARN(
+        "numWorkerThreads={} is ignored because transfer chunking / multi-NIC is enabled; "
+        "using single-thread inline posting",
+        config.numWorkerThreads);
+  }
+  if (config.numWorkerThreads > 1 && !useInlineOnly) {
     executor.reset(
         new MultithreadExecutor(std::min(config.qpPerTransfer, config.numWorkerThreads)));
     executor->Start();
@@ -1077,6 +1239,7 @@ void RdmaBackend::RegisterMemory(MemoryDesc& desc) { server->RegisterMemory(desc
 
 void RdmaBackend::DeregisterMemory(const MemoryDesc& desc) {
   server->DeregisterMemory(desc);
+  rdma->DeregisterLocalMemory(desc);
   InvalidateSessionsForMemory(desc.id);
 }
 
@@ -1119,39 +1282,105 @@ BackendSession* RdmaBackend::CreateSession(const MemoryDesc& local, const Memory
 
 void RdmaBackend::CreateSession(const MemoryDesc& local, const MemoryDesc& remote,
                                 RdmaBackendSession& sess) {
-  TopoKey localKey{local.deviceId, local.loc};
-  TopoKey remoteKey{remote.deviceId, remote.loc};
+  TopoKey localKey{local.deviceId, local.loc, local.numaNode};
+  TopoKey remoteKey{remote.deviceId, remote.loc, remote.numaNode};
   TopoKeyPair kp{localKey, remoteKey};
 
   EngineKey ekey = remote.engineKey;
 
-  // Create a pair of endpoint if none
-  int epNum = rdma->CountEndpoint(ekey, kp);
-  for (int i = 0; i < (config.qpPerTransfer - epNum); i++) {
-    server->BuildRdmaConn(ekey, kp);
+  auto buildLock = GetConnBuildLock(ekey, kp);
+  std::lock_guard<std::mutex> connGuard(*buildLock);
+
+  std::vector<std::pair<int, int>> localCandidates;
+  int effectiveNumNics = 1;
+  if (config.numNicsPerTransfer > 1) {
+    localCandidates = rdma->Search(kp.local);
+    if (localCandidates.empty()) {
+      throw std::runtime_error("RdmaBackend::CreateSession: no local RDMA candidate found");
+    }
+    effectiveNumNics = std::max(1, std::min({config.numNicsPerTransfer, config.qpPerTransfer,
+                                             static_cast<int>(localCandidates.size())}));
   }
+  std::vector<int> desiredPerRank = BuildDesiredQpCounts(config.qpPerTransfer, effectiveNumNics);
+
+  if (effectiveNumNics == 1) {
+    int epNum = rdma->CountEndpoint(ekey, kp);
+    for (int i = epNum; i < config.qpPerTransfer; ++i) {
+      server->BuildRdmaConn(ekey, kp, 0);
+    }
+  } else {
+    std::unordered_map<int, int> rankByDev;
+    for (int rank = 0; rank < effectiveNumNics; ++rank) {
+      rankByDev[localCandidates[rank].first] = rank;
+    }
+
+    EpPairVec existing = rdma->GetAllEndpoint(ekey, kp);
+    std::vector<int> haveByRank(effectiveNumNics, 0);
+    for (const auto& ep : existing) {
+      auto it = rankByDev.find(ep.ldevId);
+      if (it != rankByDev.end()) haveByRank[it->second] += 1;
+    }
+
+    for (int rank = 0; rank < effectiveNumNics; ++rank) {
+      for (int count = haveByRank[rank]; count < desiredPerRank[rank]; ++count) {
+        server->BuildRdmaConn(ekey, kp, rank);
+      }
+    }
+  }
+
   EpPairVec eps = rdma->GetAllEndpoint(ekey, kp);
-  assert(!eps.empty());
-
-  EpPairVec epSet = {eps.begin(), eps.begin() + config.qpPerTransfer};
-
-  // TODO: we assume all eps is on same device and has same ldevId/rdevId
-  EpPair ep = epSet[0];
-  auto localMr = rdma->GetLocalMemory(ep.ldevId, local.id);
-  if (!localMr.has_value()) {
-    localMr = rdma->RegisterLocalMemory(ep.ldevId, local);
+  if (static_cast<int>(eps.size()) < config.qpPerTransfer) {
+    throw std::runtime_error("RdmaBackend::CreateSession: insufficient RDMA endpoints");
   }
 
-  auto remoteMr = rdma->GetRemoteMemory(ekey, ep.rdevId, remote.id);
-  if (!remoteMr.has_value()) {
-    remoteMr = server->AskRemoteMemoryRegion(ekey, ep.rdevId, remote.id);
-    // TODO: protocol should return status code
-    // Currently we check member equality to ensure correct memory region
-    assert(remoteMr->length == remote.size);
-    rdma->RegisterRemoteMemory(ekey, ep.rdevId, remote.id, remoteMr.value());
+  EpPairVec epSet;
+  if (effectiveNumNics == 1) {
+    epSet = {eps.begin(), eps.begin() + config.qpPerTransfer};
+  } else {
+    std::vector<int> localDevOrder;
+    localDevOrder.reserve(effectiveNumNics);
+    for (int rank = 0; rank < effectiveNumNics; ++rank) {
+      localDevOrder.push_back(localCandidates[rank].first);
+    }
+    epSet = InterleaveEndpointsByLocalDevice(eps, localDevOrder, desiredPerRank);
+    if (static_cast<int>(epSet.size()) != config.qpPerTransfer) {
+      throw std::runtime_error(
+          "RdmaBackend::CreateSession: failed to assemble multi-NIC endpoint set");
+    }
   }
 
-  sess = RdmaBackendSession(config, localMr.value(), remoteMr.value(), epSet, executor.get());
+  std::unordered_map<int, application::RdmaMemoryRegion> localMrByDev;
+  std::unordered_map<int, application::RdmaMemoryRegion> remoteMrByDev;
+  std::vector<application::RdmaMemoryRegion> localMrPerEp;
+  std::vector<application::RdmaMemoryRegion> remoteMrPerEp;
+  localMrPerEp.reserve(epSet.size());
+  remoteMrPerEp.reserve(epSet.size());
+
+  for (const auto& ep : epSet) {
+    if (localMrByDev.find(ep.ldevId) == localMrByDev.end()) {
+      auto localMr = rdma->GetLocalMemory(ep.ldevId, local.id);
+      if (!localMr.has_value()) {
+        localMr = rdma->RegisterLocalMemory(ep.ldevId, local);
+      }
+      localMrByDev[ep.ldevId] = *localMr;
+    }
+
+    if (remoteMrByDev.find(ep.rdevId) == remoteMrByDev.end()) {
+      auto remoteMr = rdma->GetRemoteMemory(ekey, ep.rdevId, remote.id);
+      if (!remoteMr.has_value()) {
+        remoteMr = server->AskRemoteMemoryRegion(ekey, ep.rdevId, remote.id);
+        assert(remoteMr->length == remote.size);
+        rdma->RegisterRemoteMemory(ekey, ep.rdevId, remote.id, remoteMr.value());
+      }
+      remoteMrByDev[ep.rdevId] = *remoteMr;
+    }
+
+    localMrPerEp.push_back(localMrByDev.at(ep.ldevId));
+    remoteMrPerEp.push_back(remoteMrByDev.at(ep.rdevId));
+  }
+
+  sess = RdmaBackendSession(config, std::move(localMrPerEp), std::move(remoteMrPerEp), epSet,
+                            executor.get());
 }
 
 bool RdmaBackend::PopInboundTransferStatus(EngineKey remote, TransferUniqueId id,
@@ -1190,6 +1419,15 @@ void RdmaBackend::InvalidateSessionsForMemory(MemoryUniqueId id) {
       ++it;
     }
   }
+}
+
+std::shared_ptr<std::mutex> RdmaBackend::GetConnBuildLock(const EngineKey& remoteEngineKey,
+                                                          const TopoKeyPair& topo) {
+  std::lock_guard<std::mutex> guard(connBuildMapMu_);
+  ConnBuildKey key{remoteEngineKey, topo};
+  auto& lockPtr = connBuildMu_[key];
+  if (!lockPtr) lockPtr = std::make_shared<std::mutex>();
+  return lockPtr;
 }
 
 }  // namespace io

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -72,6 +72,14 @@ bool UsesInlineOnly(const RdmaBackendConfig& config) {
   return config.enableTransferChunking || config.numNicsPerTransfer > 1;
 }
 
+int ResolveRequestedNics(const RdmaBackendConfig& config, const TopoKey& local,
+                         const TopoKey& remote) {
+  if (local.loc == MemoryLocationType::GPU || remote.loc == MemoryLocationType::GPU) {
+    return 1;
+  }
+  return std::max(1, config.numNicsPerTransfer);
+}
+
 enum class CqeFailureOrigin : uint8_t {
   BatchTransfer = 0,
   NotificationSend,
@@ -194,9 +202,12 @@ RdmaManager::~RdmaManager() {
   }
 }
 
-std::vector<std::pair<int, int>> RdmaManager::Search(TopoKey key) {
+std::vector<std::pair<int, int>> RdmaManager::Search(TopoKey key, int requestedNics) {
+  if (requestedNics <= 0) {
+    requestedNics = std::max(1, config.numNicsPerTransfer);
+  }
+
   if (key.loc == MemoryLocationType::GPU) {
-    const int requestedNics = std::max(1, config.numNicsPerTransfer);
     std::vector<std::string> nicNames;
     if (requestedNics == 1) {
       std::string nicName = topo->MatchGpuAndNic(key.deviceId);
@@ -219,7 +230,6 @@ std::vector<std::pair<int, int>> RdmaManager::Search(TopoKey key) {
     MORI_IO_WARN("No matching NIC found for GPU {}", key.deviceId);
   } else if (key.loc == MemoryLocationType::CPU) {
     if (availDevices.empty()) return {};
-    const int requestedNics = std::max(1, config.numNicsPerTransfer);
     const char* envNic = std::getenv("MORI_IO_RDMA_NIC_IDX");
     if (envNic) {
       if (requestedNics > 1) {
@@ -850,8 +860,9 @@ void NotifManager::Shutdown() {
 /* ----------------------------------------------------------------------------------------------
  */
 ControlPlaneServer::ControlPlaneServer(const std::string& k, const std::string& host, int port,
-                                       RdmaManager* rdmaMgr, NotifManager* notifMgr)
-    : myEngKey(k) {
+                                       const RdmaBackendConfig& cfg, RdmaManager* rdmaMgr,
+                                       NotifManager* notifMgr)
+    : myEngKey(k), config(cfg) {
   ctx.reset(new application::TCPContext(host, port));
   rdma = rdmaMgr;
   notif = notifMgr;
@@ -885,7 +896,8 @@ void ControlPlaneServer::BuildRdmaConn(EngineKey ekey, TopoKeyPair topo, int nic
     tcph = ctx->Connect(rdesc.host, rdesc.port);
   }
 
-  auto candidates = rdma->Search(topo.local);
+  int requestedNics = ResolveRequestedNics(config, topo.local, topo.remote);
+  auto candidates = rdma->Search(topo.local, requestedNics);
   assert(!candidates.empty());
   int rank = std::min<int>(nicRank, static_cast<int>(candidates.size()) - 1);
   auto [devId, weight] = candidates[rank];
@@ -956,7 +968,8 @@ void ControlPlaneServer::HandleControlPlaneProtocol(int fd) {
   switch (hdr.type) {
     case MessageType::RegEndpoint: {
       MessageRegEndpoint msg = p.ReadMessageRegEndpoint(hdr.len);
-      auto candidates = rdma->Search(msg.topo.remote);
+      int requestedNics = ResolveRequestedNics(config, msg.topo.remote, msg.topo.local);
+      auto candidates = rdma->Search(msg.topo.remote, requestedNics);
       assert(!candidates.empty());
       int rdevId = msg.devId;
       int rank = std::min<int>(msg.nicRank, static_cast<int>(candidates.size()) - 1);
@@ -1197,8 +1210,8 @@ RdmaBackend::RdmaBackend(EngineKey k, const IOEngineConfig& engConfig,
   notif.reset(new NotifManager(rdma.get(), config));
   notif->Start();
 
-  server.reset(
-      new ControlPlaneServer(myEngKey, engConfig.host, engConfig.port, rdma.get(), notif.get()));
+  server.reset(new ControlPlaneServer(myEngKey, engConfig.host, engConfig.port, config, rdma.get(),
+                                      notif.get()));
   server->Start();
 
   bool useInlineOnly = UsesInlineOnly(config);
@@ -1293,12 +1306,13 @@ void RdmaBackend::CreateSession(const MemoryDesc& local, const MemoryDesc& remot
 
   std::vector<std::pair<int, int>> localCandidates;
   int effectiveNumNics = 1;
-  if (config.numNicsPerTransfer > 1) {
-    localCandidates = rdma->Search(kp.local);
+  int requestedNics = ResolveRequestedNics(config, kp.local, kp.remote);
+  if (requestedNics > 1) {
+    localCandidates = rdma->Search(kp.local, requestedNics);
     if (localCandidates.empty()) {
       throw std::runtime_error("RdmaBackend::CreateSession: no local RDMA candidate found");
     }
-    effectiveNumNics = std::max(1, std::min({config.numNicsPerTransfer, config.qpPerTransfer,
+    effectiveNumNics = std::max(1, std::min({requestedNics, config.qpPerTransfer,
                                              static_cast<int>(localCandidates.size())}));
   }
   std::vector<int> desiredPerRank = BuildDesiredQpCounts(config.qpPerTransfer, effectiveNumNics);

--- a/src/io/rdma/backend_impl.hpp
+++ b/src/io/rdma/backend_impl.hpp
@@ -53,6 +53,8 @@ inline constexpr uint16_t kXgmiOnlyFallbackPlaceholderPort = 1;
 
 void ValidateRdmaTransferConfig(const RdmaBackendConfig& config);
 bool UsesInlineOnly(const RdmaBackendConfig& config);
+int ResolveRequestedNics(const RdmaBackendConfig& config, const TopoKey& local,
+                         const TopoKey& remote);
 std::vector<int> BuildDesiredQpCounts(int totalQp, int numRanks);
 EpPairVec InterleaveEndpointsByLocalDevice(const EpPairVec& eps,
                                            const std::vector<int>& localDevOrder,
@@ -69,7 +71,7 @@ class RdmaManager {
   application::RdmaEndpointConfig GetRdmaEndpointConfig(int devId);
 
   // Topology APIs
-  std::vector<std::pair<int, int>> Search(TopoKey);
+  std::vector<std::pair<int, int>> Search(TopoKey, int requestedNics = -1);
 
   // Local memory management APIs
   std::optional<application::RdmaMemoryRegion> GetLocalMemory(int ldevId, MemoryUniqueId);
@@ -201,8 +203,8 @@ class NotifManager {
 /* ---------------------------------------------------------------------------------------------- */
 class ControlPlaneServer {
  public:
-  ControlPlaneServer(const std::string& key, const std::string& host, int port, RdmaManager*,
-                     NotifManager*);
+  ControlPlaneServer(const std::string& key, const std::string& host, int port,
+                     const RdmaBackendConfig& config, RdmaManager*, NotifManager*);
   ~ControlPlaneServer();
 
   std::optional<uint16_t> GetListenPort() const {
@@ -234,6 +236,7 @@ class ControlPlaneServer {
 
  private:
   EngineKey myEngKey;
+  RdmaBackendConfig config{};
 
   mutable std::mutex mu;
 

--- a/src/io/rdma/backend_impl.hpp
+++ b/src/io/rdma/backend_impl.hpp
@@ -51,6 +51,13 @@ inline constexpr uint16_t kXgmiOnlyFallbackPlaceholderPort = 1;
 
 }  // namespace internal
 
+void ValidateRdmaTransferConfig(const RdmaBackendConfig& config);
+bool UsesInlineOnly(const RdmaBackendConfig& config);
+std::vector<int> BuildDesiredQpCounts(int totalQp, int numRanks);
+EpPairVec InterleaveEndpointsByLocalDevice(const EpPairVec& eps,
+                                           const std::vector<int>& localDevOrder,
+                                           const std::vector<int>& wantPerRank);
+
 /* ---------------------------------------------------------------------------------------------- */
 /*                                           RdmaManager                                          */
 /* ---------------------------------------------------------------------------------------------- */
@@ -68,6 +75,7 @@ class RdmaManager {
   std::optional<application::RdmaMemoryRegion> GetLocalMemory(int ldevId, MemoryUniqueId);
   application::RdmaMemoryRegion RegisterLocalMemory(int ldevId, const MemoryDesc& desc);
   void DeregisterLocalMemory(int ldevId, const MemoryDesc& desc);
+  void DeregisterLocalMemory(const MemoryDesc& desc);
 
   // Remote memory management APIs
   std::optional<application::RdmaMemoryRegion> GetRemoteMemory(EngineKey, int remRdmaDevId,
@@ -208,7 +216,7 @@ class ControlPlaneServer {
   std::optional<int> TryGetRemoteEnginePort(const EngineKey&) const;
 
   // Endpoint management
-  void BuildRdmaConn(EngineKey, TopoKeyPair);
+  void BuildRdmaConn(EngineKey, TopoKeyPair, int nicRank);
 
   // MemoryRegion management
   void RegisterMemory(MemoryDesc&);
@@ -247,8 +255,9 @@ class ControlPlaneServer {
 class RdmaBackendSession : public BackendSession {
  public:
   RdmaBackendSession() = default;
-  RdmaBackendSession(const RdmaBackendConfig& config, const application::RdmaMemoryRegion& local,
-                     const application::RdmaMemoryRegion& remote, const EpPairVec& eps,
+  RdmaBackendSession(const RdmaBackendConfig& config,
+                     std::vector<application::RdmaMemoryRegion> localMrPerEp,
+                     std::vector<application::RdmaMemoryRegion> remoteMrPerEp, const EpPairVec& eps,
                      Executor* executor);
   ~RdmaBackendSession() = default;
 
@@ -263,8 +272,8 @@ class RdmaBackendSession : public BackendSession {
 
  private:
   RdmaBackendConfig config{};
-  application::RdmaMemoryRegion local{};
-  application::RdmaMemoryRegion remote{};
+  std::vector<application::RdmaMemoryRegion> localMrPerEp{};
+  std::vector<application::RdmaMemoryRegion> remoteMrPerEp{};
   EpPairVec eps{};
   Executor* executor{nullptr};
 };
@@ -326,8 +335,24 @@ class RdmaBackend : public Backend {
       return seed;
     }
   };
+  struct ConnBuildKey {
+    EngineKey remoteEngineKey;
+    TopoKeyPair topo;
+    bool operator==(const ConnBuildKey& o) const {
+      return remoteEngineKey == o.remoteEngineKey && topo == o.topo;
+    }
+  };
+  struct ConnBuildKeyHash {
+    std::size_t operator()(const ConnBuildKey& k) const noexcept {
+      std::size_t topoHash = std::hash<TopoKeyPair>{}(k.topo);
+      std::size_t engineHash = std::hash<std::string>{}(k.remoteEngineKey);
+      return topoHash ^ (engineHash + 0x9e3779b97f4a7c15ULL + (topoHash << 6) + (topoHash >> 2));
+    }
+  };
   RdmaBackendSession* GetOrCreateSessionCached(const MemoryDesc& local, const MemoryDesc& remote);
   void InvalidateSessionsForMemory(MemoryUniqueId id);
+  std::shared_ptr<std::mutex> GetConnBuildLock(const EngineKey& remoteEngineKey,
+                                               const TopoKeyPair& topo);
 
  private:
   EngineKey myEngKey;
@@ -340,6 +365,8 @@ class RdmaBackend : public Backend {
   std::unordered_map<SessionCacheKey, std::unique_ptr<RdmaBackendSession>, SessionCacheKeyHash>
       sessionCache;
   std::mutex sessionCacheMu;
+  std::mutex connBuildMapMu_;
+  std::unordered_map<ConnBuildKey, std::shared_ptr<std::mutex>, ConnBuildKeyHash> connBuildMu_;
 };
 
 }  // namespace io

--- a/src/io/rdma/common.cpp
+++ b/src/io/rdma/common.cpp
@@ -255,6 +255,82 @@ static void ReleaseSqDepth(const EpPair& ep, int wrCount) {
   ep.sqDepth->fetch_sub(wrCount, std::memory_order_relaxed);
 }
 
+std::vector<std::pair<uint64_t, uint32_t>> PlanChunks(uint32_t total, size_t chunkBytes,
+                                                      int maxChunks) {
+  std::vector<std::pair<uint64_t, uint32_t>> plan;
+  if (total == 0) return plan;
+  if (chunkBytes == 0) {
+    plan.push_back({0, total});
+    return plan;
+  }
+  if (maxChunks <= 0) return plan;
+  if (total <= chunkBytes) {
+    plan.push_back({0, total});
+    return plan;
+  }
+
+  size_t chunkCount = (static_cast<size_t>(total) + chunkBytes - 1) / chunkBytes;
+  chunkCount = std::max<size_t>(1, std::min(chunkCount, static_cast<size_t>(maxChunks)));
+  const size_t perChunk = (static_cast<size_t>(total) + chunkCount - 1) / chunkCount;
+
+  plan.reserve(chunkCount);
+  for (size_t offset = 0; offset < total; offset += perChunk) {
+    const uint32_t len =
+        static_cast<uint32_t>(std::min(perChunk, static_cast<size_t>(total) - offset));
+    plan.push_back({offset, len});
+  }
+  return plan;
+}
+
+struct MergedWorkRequest {
+  ibv_send_wr wr{};
+  std::vector<ibv_sge> sges;
+  size_t totalRemoteLength = 0;
+  size_t mergedRequests = 1;
+};
+
+static void ResetMergedWorkRequestPointers(MergedWorkRequest* wr) {
+  if (wr == nullptr) return;
+  wr->wr.sg_list = wr->sges.empty() ? nullptr : wr->sges.data();
+  wr->wr.num_sge = static_cast<int>(wr->sges.size());
+}
+
+static std::vector<MergedWorkRequest> ExpandChunkedWorkRequests(
+    std::vector<MergedWorkRequest> mergedWrs, size_t chunkBytes, int maxChunks) {
+  if (chunkBytes == 0 || maxChunks <= 0) return mergedWrs;
+
+  std::vector<MergedWorkRequest> chunked;
+  chunked.reserve(mergedWrs.size());
+  for (auto& wr : mergedWrs) {
+    if (wr.wr.num_sge != 1 || wr.sges.empty() || wr.sges[0].length <= chunkBytes) {
+      chunked.push_back(std::move(wr));
+      continue;
+    }
+
+    const uint64_t localBase = wr.sges[0].addr;
+    const uint64_t remoteBase = wr.wr.wr.rdma.remote_addr;
+    const uint32_t totalLength = wr.sges[0].length;
+    std::vector<std::pair<uint64_t, uint32_t>> chunkPlan =
+        PlanChunks(totalLength, chunkBytes, maxChunks);
+
+    for (const auto& [offset, len] : chunkPlan) {
+      MergedWorkRequest chunk;
+      chunk.sges.reserve(1);
+      chunk.sges.push_back(ibv_sge{.addr = localBase + offset, .length = len, .lkey = 0});
+      chunk.totalRemoteLength = len;
+      chunk.mergedRequests = 1;
+      chunk.wr.opcode = wr.wr.opcode;
+      chunk.wr.send_flags = 0;
+      chunk.wr.wr.rdma.remote_addr = remoteBase + offset;
+      chunk.wr.wr.rdma.rkey = 0;
+      ResetMergedWorkRequestPointers(&chunk);
+      chunked.push_back(std::move(chunk));
+    }
+  }
+
+  return chunked;
+}
+
 /* ---------------------------------------------------------------------------------------------- */
 /*                                         Rdma Utilities                                         */
 /* ---------------------------------------------------------------------------------------------- */
@@ -310,12 +386,13 @@ RdmaOpRet RdmaNotifyTransfer(const EpPairVec& eps, TransferStatus* status, Trans
   return {StatusCode::IN_PROGRESS, ""};
 }
 
-RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemoryRegion& local,
-                             const SizeVec& localOffsets,
-                             const application::RdmaMemoryRegion& remote,
-                             const SizeVec& remoteOffsets, const SizeVec& sizes,
-                             std::shared_ptr<CqCallbackMeta> callbackMeta, TransferUniqueId id,
-                             bool isRead, int postBatchSize) {
+RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
+                             const std::vector<application::RdmaMemoryRegion>& localMrPerEp,
+                             const std::vector<application::RdmaMemoryRegion>& remoteMrPerEp,
+                             const SizeVec& localOffsets, const SizeVec& remoteOffsets,
+                             const SizeVec& sizes, std::shared_ptr<CqCallbackMeta> callbackMeta,
+                             TransferUniqueId id, bool isRead, int postBatchSize, size_t chunkBytes,
+                             int maxChunks, bool creditByWrCount) {
   MORI_IO_FUNCTION_TIMER;
 
   if ((localOffsets.size() != remoteOffsets.size()) || (sizes.size() != remoteOffsets.size())) {
@@ -328,33 +405,37 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
     return {StatusCode::SUCCESS, ""};
   }
 
-  for (size_t i = 0; i < batchSize; i++) {
-    if (((localOffsets[i] + sizes[i]) > local.length) ||
-        ((remoteOffsets[i] + sizes[i]) > remote.length)) {
-      return {StatusCode::ERR_INVALID_ARGS, "length out of range"};
-    }
-  }
-
   if (eps.empty()) {
     return {StatusCode::ERR_INVALID_ARGS, "no endpoints"};
+  }
+
+  if (localMrPerEp.size() != eps.size() || remoteMrPerEp.size() != eps.size()) {
+    return {StatusCode::ERR_INVALID_ARGS, "memory-region vectors must align with endpoints"};
+  }
+
+  if (maxChunks <= 0) {
+    return {StatusCode::ERR_INVALID_ARGS, "maxChunks must be >= 1"};
+  }
+
+  const application::RdmaMemoryRegion& baseLocalMr = localMrPerEp.front();
+  const application::RdmaMemoryRegion& baseRemoteMr = remoteMrPerEp.front();
+  for (size_t i = 0; i < batchSize; i++) {
+    if (((localOffsets[i] + sizes[i]) > baseLocalMr.length) ||
+        ((remoteOffsets[i] + sizes[i]) > baseRemoteMr.length)) {
+      return {StatusCode::ERR_INVALID_ARGS, "length out of range"};
+    }
   }
 
   std::vector<size_t> indices(batchSize);
   std::iota(indices.begin(), indices.end(), 0);
 
-  if (std::is_sorted(remoteOffsets.begin(), remoteOffsets.end()) == false)
+  if (!std::is_sorted(remoteOffsets.begin(), remoteOffsets.end())) {
     std::sort(indices.begin(), indices.end(),
               [&](size_t a, size_t b) { return remoteOffsets[a] < remoteOffsets[b]; });
+  }
 
-  struct MergedWorkRequest {
-    ibv_send_wr wr{};
-    std::vector<ibv_sge> sges;
-    size_t totalRemoteLength = 0;
-    size_t mergedRequests = 1;
-  };
-
-  const uint64_t localBaseAddr = reinterpret_cast<uint64_t>(local.addr);
-  const uint64_t remoteBaseAddr = reinterpret_cast<uint64_t>(remote.addr);
+  const uint64_t localBaseAddr = reinterpret_cast<uint64_t>(baseLocalMr.addr);
+  const uint64_t remoteBaseAddr = reinterpret_cast<uint64_t>(baseRemoteMr.addr);
   const uint32_t maxSge =
       std::max(eps[0].local.handle.maxSge, 1u);  // We assume all endpoints have the same maxSge
 
@@ -365,15 +446,13 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
     mergedWrs.emplace_back();
     MergedWorkRequest& newWr = mergedWrs.back();
     newWr.sges.reserve(maxSge);  // keep sg_list stable
-    newWr.sges.push_back(ibv_sge{.addr = localAddr, .length = len, .lkey = local.lkey});
+    newWr.sges.push_back(ibv_sge{.addr = localAddr, .length = len, .lkey = 0});
     newWr.totalRemoteLength = len;
-
-    newWr.wr.sg_list = newWr.sges.data();
-    newWr.wr.num_sge = 1;
     newWr.wr.opcode = isRead ? IBV_WR_RDMA_READ : IBV_WR_RDMA_WRITE;
     newWr.wr.send_flags = 0;
     newWr.wr.wr.rdma.remote_addr = remoteAddr;
-    newWr.wr.wr.rdma.rkey = remote.rkey;
+    newWr.wr.wr.rdma.rkey = 0;
+    ResetMergedWorkRequestPointers(&newWr);
   };
 
   for (size_t i = 0; i < batchSize; ++i) {
@@ -387,12 +466,10 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
       MergedWorkRequest& lastWr = mergedWrs.back();
       const uint64_t expectedRemoteAddr = lastWr.wr.wr.rdma.remote_addr + lastWr.totalRemoteLength;
       if (expectedRemoteAddr == currentRemoteAddr) {
-        // Try to merge into last WR
         ibv_sge& lastSge = lastWr.sges.back();
         const bool localContiguous = (lastSge.addr + lastSge.length) == currentLocalAddr;
 
         if (localContiguous) {
-          // Ensure SGE length doesn't overflow uint32_t
           const uint64_t newLen = static_cast<uint64_t>(lastSge.length) + currentSize32;
           if (newLen <= std::numeric_limits<uint32_t>::max()) {
             lastSge.length = static_cast<uint32_t>(newLen);
@@ -401,22 +478,31 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
             merged = true;
           }
         }
-        if (!merged) {
-          if (lastWr.sges.size() < maxSge) {
-            // Append a new SGE into the same WR
-            lastWr.sges.push_back(
-                ibv_sge{.addr = currentLocalAddr, .length = currentSize32, .lkey = local.lkey});
-            lastWr.wr.num_sge = static_cast<int>(lastWr.sges.size());
-            lastWr.mergedRequests += 1;
-            lastWr.totalRemoteLength += currentSize32;
-            merged = true;
-          }
+        if (!merged && lastWr.sges.size() < maxSge) {
+          lastWr.sges.push_back(
+              ibv_sge{.addr = currentLocalAddr, .length = currentSize32, .lkey = 0});
+          ResetMergedWorkRequestPointers(&lastWr);
+          lastWr.mergedRequests += 1;
+          lastWr.totalRemoteLength += currentSize32;
+          merged = true;
         }
       }
     }
     if (!merged) {
       start_new_wr(currentRemoteAddr, currentLocalAddr, currentSize32);
     }
+  }
+
+  if (chunkBytes > 0) {
+    mergedWrs = ExpandChunkedWorkRequests(std::move(mergedWrs), chunkBytes, maxChunks);
+  }
+
+  if (creditByWrCount) {
+    if (mergedWrs.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
+      return {StatusCode::ERR_INVALID_ARGS, "final WR count exceeds int range"};
+    }
+    for (auto& wr : mergedWrs) wr.mergedRequests = 1;
+    callbackMeta->totalBatchSize = static_cast<int>(mergedWrs.size());
   }
 
   size_t mergedWrCount = mergedWrs.size();
@@ -441,8 +527,6 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
   if (postBatchSize <= 0) postBatchSize = 1;
   int numPostBatch = (mergedWrCount + postBatchSize - 1) / postBatchSize;
 
-  // Per-EP state for adaptive signaling: track WRs and merged requests
-  // accumulated since the last signaled WR on each EP.
   std::vector<int> epWrsSinceSignal(epNum, 0);
   std::vector<size_t> epMergedSinceSignal(epNum, 0);
 
@@ -453,8 +537,6 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
     int epId = i % epNum;
     int batchWrNum = end - st;
 
-    // Reserve SQ depth for this batch; blocks with backoff if the SQ is full,
-    // waiting for CQEs from earlier signaled WRs to drain depth.
     std::string reserveErr;
     SqReserveFailureKind reserveFailure = SqReserveFailureKind::None;
     if (!TryReserveSqDepth(eps[epId], batchWrNum, epId, "batch", &reserveErr, &reserveFailure)) {
@@ -463,12 +545,19 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
       return {StatusCode::ERR_RDMA_OP, reserveErr};
     }
 
+    const auto& localMr = localMrPerEp[epId];
+    const auto& remoteMr = remoteMrPerEp[epId];
     size_t mergedReqSize = 0;
     for (int j = st; j < end; j++) {
-      struct ibv_send_wr& wr = mergedWrs[j].wr;
+      MergedWorkRequest& mergedWr = mergedWrs[j];
+      for (auto& sge : mergedWr.sges) sge.lkey = localMr.lkey;
+      mergedWr.wr.wr.rdma.rkey = remoteMr.rkey;
+      ResetMergedWorkRequestPointers(&mergedWr);
+
+      struct ibv_send_wr& wr = mergedWr.wr;
       wr.wr_id = 0;
       wr.next = (j + 1 < end) ? &mergedWrs[j + 1].wr : nullptr;
-      mergedReqSize += mergedWrs[j].mergedRequests;
+      mergedReqSize += mergedWr.mergedRequests;
     }
 
     epWrsSinceSignal[epId] += batchWrNum;
@@ -523,10 +612,7 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
       const bool lastWasPosted = (postedCount == batchWrNum);
       if (needSignal && lastWasPosted) {
         // Signaled WR was posted; CQ path (ledger->ReleaseByCqe) owns the release.
-        // The record inserted above remains in Posted state — nothing to do here.
       } else if (needSignal) {
-        // Signaled WR itself was NOT posted; remove the record we just inserted
-        // and release whatever was actually posted (tracked via unpostedCount above).
         int dummy = 0;
         eps[epId].ledger->ReleaseByCqe(recordId, nullptr, &dummy);
       }
@@ -539,8 +625,6 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
         if (eps[epId].degraded) {
           eps[epId].degraded->store(true, std::memory_order_relaxed);
         }
-        // Ledger record for ALL orphaned posted WRs (including prior unsignaled batches
-        // on this EP): sqDepth held by ledger until recovery.
         if (eps[epId].ledger) {
           eps[epId].ledger->InsertOrphaned(epWrsSinceSignal[epId], callbackMeta,
                                            static_cast<int>(epMergedSinceSignal[epId]));
@@ -583,6 +667,18 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemory
     MORI_IO_TRACE("ibv_post_send ep index {} batch index range [{}, {})", epId, st, end);
   }
   return {StatusCode::IN_PROGRESS, ""};
+}
+
+RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemoryRegion& local,
+                             const SizeVec& localOffsets,
+                             const application::RdmaMemoryRegion& remote,
+                             const SizeVec& remoteOffsets, const SizeVec& sizes,
+                             std::shared_ptr<CqCallbackMeta> callbackMeta, TransferUniqueId id,
+                             bool isRead, int postBatchSize) {
+  std::vector<application::RdmaMemoryRegion> localVec(eps.size(), local);
+  std::vector<application::RdmaMemoryRegion> remoteVec(eps.size(), remote);
+  return RdmaBatchReadWrite(eps, localVec, remoteVec, localOffsets, remoteOffsets, sizes,
+                            callbackMeta, id, isRead, postBatchSize, 0, 1, false);
 }
 
 }  // namespace io

--- a/src/io/rdma/common.cpp
+++ b/src/io/rdma/common.cpp
@@ -49,7 +49,7 @@ enum class PostSendOpKind : uint8_t {
 
 static int GetSqBackoffTimeoutUs() {
   static const int kBackoffTimeoutUs = []() {
-    int v = 10000;
+    int v = 5000000;
     env::Override("MORI_IO_SQ_BACKOFF_TIMEOUT_US", v, mori::env::detail::ParsePositiveInt);
     return v;
   }();

--- a/src/io/rdma/common.hpp
+++ b/src/io/rdma/common.hpp
@@ -27,6 +27,8 @@
 #include <memory>
 #include <mutex>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "mori/io/common.hpp"
 #include "mori/io/enum.hpp"
@@ -42,12 +44,13 @@ namespace io {
 struct TopoKey {
   int deviceId;
   MemoryLocationType loc;
+  int numaNode{-1};
 
   bool operator==(const TopoKey& rhs) const noexcept {
-    return (deviceId == rhs.deviceId) && (loc == rhs.loc);
+    return (deviceId == rhs.deviceId) && (loc == rhs.loc) && (numaNode == rhs.numaNode);
   }
 
-  MSGPACK_DEFINE(deviceId, loc);
+  MSGPACK_DEFINE(deviceId, loc, numaNode);
 };
 
 struct TopoKeyPair {
@@ -79,7 +82,9 @@ struct hash<mori::io::TopoKey> {
   std::size_t operator()(const mori::io::TopoKey& k) const noexcept {
     std::size_t h1 = std::hash<uint32_t>{}(k.deviceId);
     std::size_t h2 = std::hash<uint32_t>{}(static_cast<uint32_t>(k.loc));
-    return h1 ^ (h2 + 0x9e3779b9 + (h1 << 6) + (h1 >> 2));
+    std::size_t h3 = std::hash<int>{}(k.numaNode);
+    std::size_t seed = h1 ^ (h2 + 0x9e3779b9 + (h1 << 6) + (h1 >> 2));
+    return seed ^ (h3 + 0x9e3779b9 + (seed << 6) + (seed >> 2));
   }
 };
 
@@ -125,6 +130,9 @@ inline TransferUniqueId ExtractTransferIdFromWrId(uint64_t wr_id) {
 }
 
 uint64_t MakeNotifSendWrId(TransferUniqueId id);
+
+std::vector<std::pair<uint64_t, uint32_t>> PlanChunks(uint32_t total, size_t chunkBytes,
+                                                      int maxChunks);
 
 struct CqCallbackMeta {
   CqCallbackMeta(TransferStatus* s, TransferUniqueId id_, int n)
@@ -225,6 +233,15 @@ struct RdmaOpRet {
 };
 
 RdmaOpRet RdmaNotifyTransfer(const EpPairVec& eps, TransferStatus* status, TransferUniqueId id);
+
+RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
+                             const std::vector<application::RdmaMemoryRegion>& localMrPerEp,
+                             const std::vector<application::RdmaMemoryRegion>& remoteMrPerEp,
+                             const SizeVec& localOffsets, const SizeVec& remoteOffsets,
+                             const SizeVec& sizes, std::shared_ptr<CqCallbackMeta> callbackMeta,
+                             TransferUniqueId id, bool isRead, int postBatchSize = -1,
+                             size_t chunkBytes = 0, int maxChunks = 1,
+                             bool creditByWrCount = false);
 
 RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemoryRegion& local,
                              const SizeVec& localOffsets,

--- a/src/io/rdma/protocol.hpp
+++ b/src/io/rdma/protocol.hpp
@@ -47,7 +47,8 @@ struct MessageRegEndpoint {
   TopoKeyPair topo;
   int devId;
   application::RdmaEndpointHandle eph;
-  MSGPACK_DEFINE(ekey, topo, devId, eph);
+  int nicRank{0};
+  MSGPACK_DEFINE(ekey, topo, devId, eph, nicRank);
 };
 
 struct MessageAskMemoryRegion {

--- a/src/pybind/pybind_io.cpp
+++ b/src/pybind/pybind_io.cpp
@@ -68,7 +68,7 @@ void RegisterMoriIo(pybind11::module_& m) {
            py::arg("num_worker_threads") = -1,
            py::arg("poll_cq_mode") = mori::io::PollCqMode::POLLING,
            py::arg("enable_notification") = true, py::arg("notif_per_qp") = 1024,
-           py::arg("enable_transfer_chunking") = false, py::arg("chunk_bytes") = 131072,
+           py::arg("enable_transfer_chunking") = false, py::arg("chunk_bytes") = 65536,
            py::arg("max_chunks_per_transfer") = 64, py::arg("num_nics_per_transfer") = 1)
       .def_readwrite("qp_per_transfer", &mori::io::RdmaBackendConfig::qpPerTransfer)
       .def_readwrite("post_batch_size", &mori::io::RdmaBackendConfig::postBatchSize)

--- a/src/pybind/pybind_io.cpp
+++ b/src/pybind/pybind_io.cpp
@@ -63,17 +63,24 @@ void RegisterMoriIo(pybind11::module_& m) {
   py::class_<mori::io::BackendConfig>(m, "BackendConfig");
 
   py::class_<mori::io::RdmaBackendConfig, mori::io::BackendConfig>(m, "RdmaBackendConfig")
-      .def(py::init<int, int, int, mori::io::PollCqMode, bool, uint32_t>(),
+      .def(py::init<int, int, int, mori::io::PollCqMode, bool, uint32_t, bool, size_t, int, int>(),
            py::arg("qp_per_transfer") = 1, py::arg("post_batch_size") = -1,
            py::arg("num_worker_threads") = -1,
            py::arg("poll_cq_mode") = mori::io::PollCqMode::POLLING,
-           py::arg("enable_notification") = true, py::arg("notif_per_qp") = 1024)
+           py::arg("enable_notification") = true, py::arg("notif_per_qp") = 1024,
+           py::arg("enable_transfer_chunking") = false, py::arg("chunk_bytes") = 131072,
+           py::arg("max_chunks_per_transfer") = 64, py::arg("num_nics_per_transfer") = 1)
       .def_readwrite("qp_per_transfer", &mori::io::RdmaBackendConfig::qpPerTransfer)
       .def_readwrite("post_batch_size", &mori::io::RdmaBackendConfig::postBatchSize)
       .def_readwrite("num_worker_threads", &mori::io::RdmaBackendConfig::numWorkerThreads)
       .def_readwrite("poll_cq_mode", &mori::io::RdmaBackendConfig::pollCqMode)
       .def_readwrite("enable_notification", &mori::io::RdmaBackendConfig::enableNotification)
       .def_readwrite("notif_per_qp", &mori::io::RdmaBackendConfig::notifPerQp)
+      .def_readwrite("enable_transfer_chunking",
+                     &mori::io::RdmaBackendConfig::enableTransferChunking)
+      .def_readwrite("chunk_bytes", &mori::io::RdmaBackendConfig::chunkBytes)
+      .def_readwrite("max_chunks_per_transfer", &mori::io::RdmaBackendConfig::maxChunksPerTransfer)
+      .def_readwrite("num_nics_per_transfer", &mori::io::RdmaBackendConfig::numNicsPerTransfer)
       .def_readwrite("max_send_wr", &mori::io::RdmaBackendConfig::maxSendWr)
       .def_readwrite("max_cqe_num", &mori::io::RdmaBackendConfig::maxCqeNum)
       .def_readwrite("max_msg_sge", &mori::io::RdmaBackendConfig::maxMsgSge);
@@ -130,6 +137,7 @@ void RegisterMoriIo(pybind11::module_& m) {
       .def_readonly("id", &mori::io::MemoryDesc::id)
       .def_readonly("device_id", &mori::io::MemoryDesc::deviceId)
       .def_readonly("device_bus_id", &mori::io::MemoryDesc::deviceBusId)
+      .def_readonly("numa_node", &mori::io::MemoryDesc::numaNode)
       .def_property_readonly("data",
                              [](const mori::io::MemoryDesc& desc) -> uintptr_t {
                                return reinterpret_cast<uintptr_t>(desc.data);

--- a/tests/cpp/io/test_engine.cpp
+++ b/tests/cpp/io/test_engine.cpp
@@ -267,6 +267,181 @@ void CaseWrIdNamespaceHelpers() {
   Require(!IsNotifSendWrId(4096), "ledger-range ids without bit 63 should not be SEND-tagged");
 }
 
+void CaseRdmaBackendConfigChunkingFields() {
+  RdmaBackendConfig cfg{4, -1, 2, PollCqMode::POLLING, true, 2048, true, 65536, 32, 2};
+  Require(cfg.qpPerTransfer == 4, "qpPerTransfer constructor field mismatch");
+  Require(cfg.postBatchSize == -1, "postBatchSize constructor field mismatch");
+  Require(cfg.numWorkerThreads == 2, "numWorkerThreads constructor field mismatch");
+  Require(cfg.enableNotification, "enableNotification constructor field mismatch");
+  Require(cfg.notifPerQp == 2048, "notifPerQp constructor field mismatch");
+  Require(cfg.enableTransferChunking, "enableTransferChunking constructor field mismatch");
+  Require(cfg.chunkBytes == 65536, "chunkBytes constructor field mismatch");
+  Require(cfg.maxChunksPerTransfer == 32, "maxChunksPerTransfer constructor field mismatch");
+  Require(cfg.numNicsPerTransfer == 2, "numNicsPerTransfer constructor field mismatch");
+}
+
+void RequireChunkPlanCoverage(const std::vector<std::pair<uint64_t, uint32_t>>& plan,
+                              uint32_t total) {
+  uint64_t expectedOffset = 0;
+  uint64_t totalLength = 0;
+  for (const auto& [offset, length] : plan) {
+    Require(offset == expectedOffset, "chunk plan must be contiguous");
+    expectedOffset += length;
+    totalLength += length;
+  }
+  Require(totalLength == total, "chunk plan total length mismatch");
+}
+
+void CasePlanChunksBoundaries() {
+  {
+    auto plan = PlanChunks(0, 65536, 8);
+    Require(plan.empty(), "zero-length plan should be empty");
+  }
+  {
+    auto plan = PlanChunks(65536, 0, 8);
+    Require(plan.size() == 1, "chunkBytes==0 should disable splitting");
+    Require(plan[0].first == 0 && plan[0].second == 65536, "unsplit plan mismatch");
+  }
+  {
+    auto plan = PlanChunks(65536, 65536, 8);
+    Require(plan.size() == 1, "total==chunkBytes should not split");
+    Require(plan[0].first == 0 && plan[0].second == 65536, "boundary non-split mismatch");
+  }
+  {
+    auto plan = PlanChunks(65537, 65536, 8);
+    Require(plan.size() == 2, "chunkBytes+1 should split into 2 chunks");
+    RequireChunkPlanCoverage(plan, 65537);
+    Require(plan[0].second == 32769 && plan[1].second == 32768,
+            "unexpected chunkBytes+1 split geometry");
+  }
+  {
+    auto plan = PlanChunks(1024 * 1024, 131072, 4);
+    Require(plan.size() == 4, "maxChunks must cap chunk count");
+    RequireChunkPlanCoverage(plan, 1024 * 1024);
+    for (const auto& [_, length] : plan) {
+      Require(length == 262144, "capped chunk plan should rebalance evenly");
+    }
+  }
+  {
+    auto plan = PlanChunks(65536, 65536, 0);
+    Require(plan.empty(), "invalid maxChunks should produce empty plan");
+  }
+}
+
+void CaseBuildDesiredQpCounts() {
+  {
+    auto counts = BuildDesiredQpCounts(4, 3);
+    Require(counts.size() == 3, "counts size mismatch");
+    Require(counts[0] == 2 && counts[1] == 1 && counts[2] == 1,
+            "4 QPs over 3 ranks should distribute as 2/1/1");
+  }
+  {
+    auto counts = BuildDesiredQpCounts(8, 1);
+    Require(counts.size() == 1 && counts[0] == 8, "single-rank distribution mismatch");
+  }
+  {
+    auto counts = BuildDesiredQpCounts(2, 4);
+    Require(counts.size() == 4, "counts size mismatch for sparse distribution");
+    Require(counts[0] == 1 && counts[1] == 1 && counts[2] == 0 && counts[3] == 0,
+            "2 QPs over 4 ranks should distribute as 1/1/0/0");
+  }
+  {
+    auto counts = BuildDesiredQpCounts(0, 4);
+    int total = 0;
+    for (int v : counts) total += v;
+    Require(total == 0, "zero-QP distribution should sum to zero");
+  }
+}
+
+void CaseInterleaveEndpointsByLocalDevice() {
+  EpPairVec eps;
+  auto add = [&](int ldevId) {
+    EpPair ep{};
+    ep.ldevId = ldevId;
+    eps.push_back(ep);
+  };
+  add(0);
+  add(0);
+  add(1);
+  add(1);
+  add(2);
+
+  {
+    auto interleaved = InterleaveEndpointsByLocalDevice(eps, {0, 1, 2}, {2, 1, 1});
+    Require(interleaved.size() == 4, "interleaved endpoint count mismatch");
+    Require(interleaved[0].ldevId == 0 && interleaved[1].ldevId == 1 &&
+                interleaved[2].ldevId == 2 && interleaved[3].ldevId == 0,
+            "unexpected interleave order for 0/1/2 buckets");
+  }
+  {
+    auto interleaved = InterleaveEndpointsByLocalDevice(eps, {1, 0}, {1, 2});
+    Require(interleaved.size() == 3, "rank-limited interleave endpoint count mismatch");
+    Require(interleaved[0].ldevId == 1 && interleaved[1].ldevId == 0 && interleaved[2].ldevId == 0,
+            "unexpected interleave order for reordered buckets");
+  }
+}
+
+void CaseUsesInlineOnly() {
+  RdmaBackendConfig cfg{};
+  Require(!UsesInlineOnly(cfg), "default config should keep executor-compatible path");
+
+  cfg.enableTransferChunking = true;
+  Require(UsesInlineOnly(cfg), "chunking should force inline-only path");
+
+  cfg.enableTransferChunking = false;
+  cfg.numNicsPerTransfer = 2;
+  Require(UsesInlineOnly(cfg), "multi-NIC should force inline-only path");
+}
+
+void CaseValidateRdmaTransferConfig() {
+  {
+    RdmaBackendConfig cfg{};
+    ValidateRdmaTransferConfig(cfg);
+  }
+  {
+    RdmaBackendConfig cfg{};
+    cfg.maxChunksPerTransfer = 0;
+    bool threw = false;
+    try {
+      ValidateRdmaTransferConfig(cfg);
+    } catch (const std::runtime_error&) {
+      threw = true;
+    }
+    Require(threw, "maxChunksPerTransfer<1 should be rejected");
+  }
+  {
+    RdmaBackendConfig cfg{};
+    cfg.numNicsPerTransfer = 0;
+    bool threw = false;
+    try {
+      ValidateRdmaTransferConfig(cfg);
+    } catch (const std::runtime_error&) {
+      threw = true;
+    }
+    Require(threw, "numNicsPerTransfer<1 should be rejected");
+  }
+  {
+    RdmaBackendConfig cfg{};
+    cfg.enableTransferChunking = true;
+    cfg.chunkBytes = 1024;
+    bool threw = false;
+    try {
+      ValidateRdmaTransferConfig(cfg);
+    } catch (const std::runtime_error&) {
+      threw = true;
+    }
+    Require(threw, "chunkBytes<4096 should be rejected when chunking is enabled");
+  }
+  {
+    RdmaBackendConfig cfg{};
+    cfg.enableTransferChunking = true;
+    cfg.chunkBytes = 4096;
+    cfg.maxChunksPerTransfer = 1;
+    cfg.numNicsPerTransfer = 1;
+    ValidateRdmaTransferConfig(cfg);
+  }
+}
+
 void CaseRdmaNotificationRejectsZeroNotifPerQp() {
   if (!RdmaBackend::HasActiveDevices()) {
     throw TestSkip("requires at least one active RDMA device");
@@ -1068,6 +1243,12 @@ int main(int argc, char* argv[]) {
   std::vector<TestCase> cases = {
       {"submission_ledger_basic", CaseSubmissionLedgerBasic},
       {"wr_id_namespace_helpers", CaseWrIdNamespaceHelpers},
+      {"rdma_backend_config_chunking_fields", CaseRdmaBackendConfigChunkingFields},
+      {"plan_chunks_boundaries", CasePlanChunksBoundaries},
+      {"build_desired_qp_counts", CaseBuildDesiredQpCounts},
+      {"interleave_endpoints_by_local_device", CaseInterleaveEndpointsByLocalDevice},
+      {"uses_inline_only", CaseUsesInlineOnly},
+      {"validate_rdma_transfer_config", CaseValidateRdmaTransferConfig},
       {"rdma_notification_rejects_zero_notif_per_qp", CaseRdmaNotificationRejectsZeroNotifPerQp},
       {"rdma_backend_has_active_devices_returns_false_when_no_device",
        CaseRdmaBackendHasActiveDevicesReturnsFalseWhenNoDevice},

--- a/tests/cpp/io/test_engine.cpp
+++ b/tests/cpp/io/test_engine.cpp
@@ -268,6 +268,9 @@ void CaseWrIdNamespaceHelpers() {
 }
 
 void CaseRdmaBackendConfigChunkingFields() {
+  RdmaBackendConfig defaultCfg{};
+  Require(defaultCfg.chunkBytes == 65536, "default chunkBytes should be 64KB");
+
   RdmaBackendConfig cfg{4, -1, 2, PollCqMode::POLLING, true, 2048, true, 65536, 32, 2};
   Require(cfg.qpPerTransfer == 4, "qpPerTransfer constructor field mismatch");
   Require(cfg.postBatchSize == -1, "postBatchSize constructor field mismatch");
@@ -278,6 +281,20 @@ void CaseRdmaBackendConfigChunkingFields() {
   Require(cfg.chunkBytes == 65536, "chunkBytes constructor field mismatch");
   Require(cfg.maxChunksPerTransfer == 32, "maxChunksPerTransfer constructor field mismatch");
   Require(cfg.numNicsPerTransfer == 2, "numNicsPerTransfer constructor field mismatch");
+}
+
+void CaseResolveRequestedNics() {
+  RdmaBackendConfig cfg{};
+  cfg.numNicsPerTransfer = 4;
+
+  TopoKey cpu0{0, MemoryLocationType::CPU, 0};
+  TopoKey cpu1{1, MemoryLocationType::CPU, 1};
+  TopoKey gpu0{0, MemoryLocationType::GPU, -1};
+
+  Require(ResolveRequestedNics(cfg, cpu0, cpu1) == 4,
+          "host-host session should honor configured NIC count");
+  Require(ResolveRequestedNics(cfg, gpu0, cpu0) == 1, "GPU-local session should force single-NIC");
+  Require(ResolveRequestedNics(cfg, cpu0, gpu0) == 1, "GPU-remote session should force single-NIC");
 }
 
 void RequireChunkPlanCoverage(const std::vector<std::pair<uint64_t, uint32_t>>& plan,
@@ -1244,6 +1261,7 @@ int main(int argc, char* argv[]) {
       {"submission_ledger_basic", CaseSubmissionLedgerBasic},
       {"wr_id_namespace_helpers", CaseWrIdNamespaceHelpers},
       {"rdma_backend_config_chunking_fields", CaseRdmaBackendConfigChunkingFields},
+      {"resolve_requested_nics", CaseResolveRequestedNics},
       {"plan_chunks_boundaries", CasePlanChunksBoundaries},
       {"build_desired_qp_counts", CaseBuildDesiredQpCounts},
       {"interleave_endpoints_by_local_device", CaseInterleaveEndpointsByLocalDevice},

--- a/tests/python/io/benchmark.py
+++ b/tests/python/io/benchmark.py
@@ -181,6 +181,13 @@ def parse_args():
         help="Max number of chunks per transfer (default: 64)",
     )
     parser.add_argument(
+        "--mem-type",
+        type=str,
+        default="gpu",
+        choices=["gpu", "cpu"],
+        help="Memory type for transfer buffers: 'gpu' (cuda) or 'cpu' (host) (default: gpu)",
+    )
+    parser.add_argument(
         "--iters",
         type=int,
         default=128,
@@ -258,6 +265,7 @@ class MoriIoBenchmark:
         enable_chunking: bool = True,
         chunk_bytes: int = 65536,
         max_chunks: int = 64,
+        mem_type: str = "gpu",
         src_gpu: int = 0,
         dst_gpu: int = 1,
         num_streams: int = 64,
@@ -294,6 +302,7 @@ class MoriIoBenchmark:
         self.enable_chunking = enable_chunking
         self.chunk_bytes = chunk_bytes
         self.max_chunks = max_chunks
+        self.mem_type = mem_type
 
         self.src_gpu = src_gpu
         self.dst_gpu = dst_gpu
@@ -324,16 +333,20 @@ class MoriIoBenchmark:
             self.global_rank = self.role_rank + self.num_initiator_dev
             self.role = EngineRole.TARGET
 
-        self.device = torch.device("cuda", self.role_rank)
         # When not batch_contiguous, use strided offsets so buffer must fit (buffer_size+1)*transfer_batch_size
         total_elements = (
             (self.buffer_size + 1) * self.transfer_batch_size
             if not self.batch_contiguous
             else self.buffer_size * self.transfer_batch_size
         )
-        self.tensor = torch.randn(total_elements).to(
-            self.device, dtype=torch.float8_e4m3fnuz
-        )
+        if self.mem_type == "cpu":
+            self.device = torch.device("cpu")
+            self.tensor = torch.randint(0, 256, (total_elements,), dtype=torch.uint8)
+        else:
+            self.device = torch.device("cuda", self.role_rank)
+            self.tensor = torch.randn(total_elements).to(
+                self.device, dtype=torch.float8_e4m3fnuz
+            )
 
     def _setup_xgmi(self):
         if self.xgmi_multiprocess:
@@ -391,6 +404,7 @@ class MoriIoBenchmark:
             print(f"  role_rank: {self.role_rank}")
             print(f"  num_initiator_dev: {self.num_initiator_dev}")
             print(f"  num_target_dev: {self.num_target_dev}")
+            print(f"  mem_type: {self.mem_type}")
             print(f"  num_qp_per_transfer: {self.num_qp_per_transfer}")
             print(f"  num_worker_threads: {self.num_worker_threads}")
             print(f"  enable_chunking: {self.enable_chunking}")
@@ -1004,6 +1018,7 @@ def benchmark_engine(local_rank, node_rank, args):
         enable_chunking=not args.disable_chunking,
         chunk_bytes=args.chunk_bytes,
         max_chunks=args.max_chunks,
+        mem_type=args.mem_type,
     )
     bench.print_config()
     bench.run()

--- a/tests/python/io/benchmark.py
+++ b/tests/python/io/benchmark.py
@@ -154,14 +154,31 @@ def parse_args():
     parser.add_argument(
         "--num-qp-per-transfer",
         type=int,
-        default=1,
-        help="Number of QPs for a single transfer",
+        default=4,
+        help="Number of QPs for a single transfer (default: 4)",
     )
     parser.add_argument(
         "--num-worker-threads",
         type=int,
         default=1,
         help="Number of threads used for transfer",
+    )
+    parser.add_argument(
+        "--disable-chunking",
+        action="store_true",
+        help="Disable single-transfer chunking (chunking is enabled by default)",
+    )
+    parser.add_argument(
+        "--chunk-bytes",
+        type=int,
+        default=65536,
+        help="Chunk size in bytes when chunking is enabled (default: 64KB)",
+    )
+    parser.add_argument(
+        "--max-chunks",
+        type=int,
+        default=64,
+        help="Max number of chunks per transfer (default: 64)",
     )
     parser.add_argument(
         "--iters",
@@ -232,12 +249,15 @@ class MoriIoBenchmark:
         rank_in_node: int = 0,
         num_initiator_dev: int = 1,
         num_target_dev: int = 1,
-        num_qp_per_transfer: int = 1,
+        num_qp_per_transfer: int = 4,
         num_worker_threads: int = 1,
         poll_cq_mode: str = "polling",
         max_send_wr: int = 0,
         max_cqe_num: int = 0,
         max_msg_sge: int = 0,
+        enable_chunking: bool = True,
+        chunk_bytes: int = 65536,
+        max_chunks: int = 64,
         src_gpu: int = 0,
         dst_gpu: int = 1,
         num_streams: int = 64,
@@ -271,6 +291,9 @@ class MoriIoBenchmark:
         self.max_send_wr = max_send_wr
         self.max_cqe_num = max_cqe_num
         self.max_msg_sge = max_msg_sge
+        self.enable_chunking = enable_chunking
+        self.chunk_bytes = chunk_bytes
+        self.max_chunks = max_chunks
 
         self.src_gpu = src_gpu
         self.dst_gpu = dst_gpu
@@ -370,6 +393,10 @@ class MoriIoBenchmark:
             print(f"  num_target_dev: {self.num_target_dev}")
             print(f"  num_qp_per_transfer: {self.num_qp_per_transfer}")
             print(f"  num_worker_threads: {self.num_worker_threads}")
+            print(f"  enable_chunking: {self.enable_chunking}")
+            if self.enable_chunking:
+                print(f"  chunk_bytes: {self.chunk_bytes}")
+                print(f"  max_chunks: {self.max_chunks}")
             print(f"  poll_cq_mode: {self.poll_cq_mode}")
             if self.max_send_wr or self.max_cqe_num or self.max_msg_sge:
                 print(
@@ -528,6 +555,9 @@ class MoriIoBenchmark:
             post_batch_size=-1,
             num_worker_threads=self.num_worker_threads,
             poll_cq_mode=self.poll_cq_mode,
+            enable_transfer_chunking=self.enable_chunking,
+            chunk_bytes=self.chunk_bytes,
+            max_chunks_per_transfer=self.max_chunks,
         )
         if self.max_send_wr > 0:
             config.max_send_wr = self.max_send_wr
@@ -971,6 +1001,9 @@ def benchmark_engine(local_rank, node_rank, args):
         max_send_wr=args.max_send_wr,
         max_cqe_num=args.max_cqe_num,
         max_msg_sge=args.max_msg_sge,
+        enable_chunking=not args.disable_chunking,
+        chunk_bytes=args.chunk_bytes,
+        max_chunks=args.max_chunks,
     )
     bench.print_config()
     bench.run()

--- a/tests/python/io/test_engine.py
+++ b/tests/python/io/test_engine.py
@@ -159,6 +159,30 @@ def test_engine_desc_node_id_env_override(monkeypatch):
     assert desc.node_id == "node-id-test"
 
 
+def test_rdma_backend_config_chunking_fields():
+    config = RdmaBackendConfig(
+        qp_per_transfer=4,
+        post_batch_size=-1,
+        num_worker_threads=2,
+        enable_notification=True,
+        notif_per_qp=2048,
+        enable_transfer_chunking=True,
+        chunk_bytes=65536,
+        max_chunks_per_transfer=32,
+        num_nics_per_transfer=2,
+    )
+
+    assert config.qp_per_transfer == 4
+    assert config.post_batch_size == -1
+    assert config.num_worker_threads == 2
+    assert config.enable_notification is True
+    assert config.notif_per_qp == 2048
+    assert config.enable_transfer_chunking is True
+    assert config.chunk_bytes == 65536
+    assert config.max_chunks_per_transfer == 32
+    assert config.num_nics_per_transfer == 2
+
+
 @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="requires GPU")
 def test_rdmabackend_auto_creates_xgmi_backend_for_gpu_mem(monkeypatch):
     monkeypatch.setenv("MORI_DISABLE_AUTO_XGMI", "0")
@@ -236,6 +260,7 @@ def test_mem_desc():
     assert mem_desc.data == tensor.data_ptr()
     assert mem_desc.size == tensor.nelement() * tensor.element_size()
     assert mem_desc.loc == MemoryLocationType.CPU
+    assert mem_desc.numa_node >= -1
 
     # Test gpu tensor
     device = torch.device("cuda", 0)
@@ -248,6 +273,7 @@ def test_mem_desc():
     assert mem_desc.data == tensor.data_ptr()
     assert mem_desc.size == tensor.nelement() * tensor.element_size()
     assert mem_desc.loc == MemoryLocationType.GPU
+    assert mem_desc.numa_node == -1
 
     # TODO: test mem_desc pack / unpack
     packed_desc = mem_desc.pack()

--- a/tests/python/io/test_engine.py
+++ b/tests/python/io/test_engine.py
@@ -160,6 +160,9 @@ def test_engine_desc_node_id_env_override(monkeypatch):
 
 
 def test_rdma_backend_config_chunking_fields():
+    default_config = RdmaBackendConfig()
+    assert default_config.chunk_bytes == 65536
+
     config = RdmaBackendConfig(
         qp_per_transfer=4,
         post_batch_size=-1,

--- a/tools/run_internode_io_benchmark.sh
+++ b/tools/run_internode_io_benchmark.sh
@@ -21,6 +21,7 @@ MASTER_ADDR=""
 MASTER_PORT=1234
 IFNAME=""
 HOST=""
+NUMA_NODE=""
 EXTRA_ARGS=()
 
 while [[ $# -gt 0 ]]; do
@@ -30,6 +31,7 @@ while [[ $# -gt 0 ]]; do
     --master-port)  MASTER_PORT="$2"; shift 2 ;;
     --ifname)       IFNAME="$2";      shift 2 ;;
     --host)         HOST="$2";        shift 2 ;;
+    --numa)         NUMA_NODE="$2";   shift 2 ;;
     --)             shift; EXTRA_ARGS=("$@"); break ;;
     *) echo "Unknown option: $1"; exit 1 ;;
   esac
@@ -73,7 +75,25 @@ cd "$REPO_ROOT"
 
 BENCH_TIMEOUT_SEC="${MORI_IO_BENCH_TIMEOUT_SEC:-600}"
 
-exec timeout "$BENCH_TIMEOUT_SEC" torchrun \
+# Optional NUMA pinning. For host-memory multi-NIC runs this is REQUIRED to stay
+# rail-safe: the multi-NIC pairing matches each side's rank-j NUMA-local NIC, so
+# both nodes must select the SAME NIC subset. Pinning both nodes to the same NUMA
+# node makes MatchCpuNics() return an identical, rail-aligned NIC ordering on both
+# ends; without it the two nodes can land on different NUMA nodes and pair NICs
+# across rails (fails on fabrics where rails are not interconnected).
+NUMACTL=()
+if [[ -n "$NUMA_NODE" ]]; then
+  if command -v numactl >/dev/null 2>&1; then
+    NUMACTL=(numactl --cpunodebind="$NUMA_NODE" --membind="$NUMA_NODE")
+    echo "[run_internode_io_benchmark] NUMA pinned to node $NUMA_NODE: ${NUMACTL[*]}"
+  else
+    echo "[run_internode_io_benchmark] ERROR: --numa $NUMA_NODE requested but numactl not found;" \
+         "refusing to run multi-NIC host benchmark unpinned (cross-rail risk)." >&2
+    exit 1
+  fi
+fi
+
+exec "${NUMACTL[@]}" timeout "$BENCH_TIMEOUT_SEC" torchrun \
   --nnodes=2 \
   --node_rank="$RANK" \
   --nproc_per_node=1 \


### PR DESCRIPTION
## Summary
A single RDMA transfer was posted as one WR on one QP/NIC, capping at single-outstanding bandwidth (~28 GB/s) regardless of message size. This PR:

- **Single-transfer chunking** (size-adaptive): split a transfer into ~`chunkBytes` chunks (default 64KB, capped by `maxChunks`) and round-robin them across the session's QPs to pipeline. Messages ≤ `chunkBytes` are unchanged. Enabling chunking uses the inline post path (single posting thread), avoiding worker-thread handoff latency.
- **Adaptive multi-NIC striping** by memory type: GPU stays single-NIC (PCIe-bound); host memory stripes across NUMA-local NICs.

All new behavior is config/env gated.

## Performance
All numbers: 2 nodes, 400G ionic, **qp_per_transfer=4, op=write** (deployment config).

### GPU memory (single NIC) — before = `main` (4 worker), after = chunking (auto single-worker inline)
| Scenario | Before (main) | After |
|---|---|---|
| 1 MB, single transfer | 76 us / 13.7 GB/s | 38 us / 27.8 GB/s (~2x) |
| 1 GB, single transfer | 25.0 GB/s | 47.2 GB/s (~1.9x) |
| batch (1 MB blocks) | 48.0 GB/s | 47.7 GB/s |

A single QP never saturates the NIC (~28 GB/s) even at GB scale; chunking lifts it to the PCIe/line ceiling (~47 GB/s). GPU multi-NIC is PCIe-bound (single GPU Gen5x16 ≈ one NIC) → defaults to 1.

### Host/CPU memory (chunking on) — multi-NIC + QP-depth scaling
Host DRAM has no single-x16 chokepoint, so throughput scales with both NIC count and QPs-per-NIC across NUMA-local NICs.

**Single transfer (8 MB block):**
| | 1 NIC | NUMA-local 4 NIC |
|---|---|---|
| 8 MB | 44.3 GB/s | 88.9 GB/s (~2x) |

**Batch write (256 × 1 MB blocks), peak BW @ 1 MB block:**
| NICs × QP/NIC (total qp_per_transfer) | Max BW | Avg BW |
|---|---|---|
| 1 NIC × 4 QP (baseline) | 47.2 | 44.8 |
| 4 NIC × 1 QP (qp=4) | 124.3 | 97.2 |
| 4 NIC × 2 QP (qp=8) | 164.7 | 162.7 |
| 4 NIC × 4 QP (qp=16) | 174.7 | 171.9 |
| 4 NIC × 8 QP (qp=32) | 176.1 | 175.0 |
| 8 NIC × 2 QP (qp=16) | 192.8 | 177.1 |
| 8 NIC × 4 QP (qp=32) | 197.6 | 192.1 |

- Multi-NIC striping scales host batch throughput ~4x (47 → 176 GB/s on 4 NICs, → 198 GB/s on 8 NICs).
- For a fixed NIC set the **1→2 QP/NIC step matters most**; ≥4 QP/NIC saturates the links (4-NIC ceiling ≈176, 8-NIC ≈198) and converges Avg→Max (run-to-run stability). The remaining ceiling is NIC count, not QP depth.
- The deployment default `qp_per_transfer=4` over 4 NICs is only 1 QP/NIC; raising `qp_per_transfer` lets chunking spread more QPs/NIC and unlocks the headroom above.

## Tests
- New C++/Python unit tests: chunk planning, QP-count distribution, NIC interleave, memory-type NIC resolution, config validation, defaults.
- Functional byte-for-byte validation across read/write x GPU/CPU x single/multi-NIC; batch and single-transfer.
