### PR TITLE
feat(rdma): add dmabuf-first MR registration with MORI_DISABLE_DMABUF_REG

### DIFF
--- a/include/mori/application/transport/rdma/rdma.hpp
+++ b/include/mori/application/transport/rdma/rdma.hpp
@@ -205,6 +205,9 @@ class RdmaDeviceContext {
                                                     int accessFlag = MR_DEFAULT_ACCESS_FLAG);
   virtual RdmaMemoryRegion RegisterRdmaMemoryRegionDmabuf(void* ptr, size_t size, int dmabuf_fd,
                                                           int accessFlag = MR_DEFAULT_ACCESS_FLAG);
+  // dmabuf-first registration; falls back to ibv_reg_mr. Disable via MORI_DISABLE_DMABUF_REG.
+  virtual RdmaMemoryRegion RegisterRdmaMemoryRegionAuto(void* ptr, size_t size,
+                                                        int accessFlag = MR_DEFAULT_ACCESS_FLAG);
   virtual void DeregisterRdmaMemoryRegion(void* ptr);
 
   // TODO: query gid entry by ibv_query_gid_table
@@ -242,6 +245,7 @@ class RdmaDeviceContext {
  private:
   RdmaDevice* device;
   std::unordered_map<void*, ibv_mr*> mrPool;
+  bool dmabufRegDisabled{false};
 };
 
 /* -------------------------------------------------------------------------- */

--- a/src/application/memory/symmetric_memory.cpp
+++ b/src/application/memory/symmetric_memory.cpp
@@ -195,7 +195,8 @@ SymmMemObjPtr SymmMemManager::RegisterSymmMemObj(void* localPtr, size_t size, bo
     }
   }
   if (rdmaDeviceContext && anyRdmaPeer) {
-    application::RdmaMemoryRegion mr = rdmaDeviceContext->RegisterRdmaMemoryRegion(localPtr, size);
+    application::RdmaMemoryRegion mr =
+        rdmaDeviceContext->RegisterRdmaMemoryRegionAuto(localPtr, size);
     cpuMemObj->lkey = mr.lkey;
     cpuMemObj->peerRkeys[rank] = mr.rkey;
   }

--- a/src/application/transport/rdma/rdma.cpp
+++ b/src/application/transport/rdma/rdma.cpp
@@ -38,6 +38,8 @@
 #include "mori/application/transport/rdma/providers/ibverbs/ibverbs.hpp"
 #include "mori/application/transport/rdma/providers/ionic/ionic.hpp"
 #include "mori/application/transport/rdma/providers/mlx5/mlx5.hpp"
+#include "mori/hip_compat.hpp"
+#include "mori/utils/env_utils.hpp"
 #include "mori/utils/mori_log.hpp"
 
 namespace mori {
@@ -315,6 +317,7 @@ int MaybeAddRelaxedOrderingFlag(int accessFlag) {
 /* ---------------------------------------------------------------------------------------------- */
 RdmaDeviceContext::RdmaDeviceContext(RdmaDevice* device, ibv_pd* inPd) : device(device), pd(inPd) {
   InitializeUdpSportConfiguration();
+  dmabufRegDisabled = env::IsEnvVarEnabled("MORI_DISABLE_DMABUF_REG");
 }
 
 RdmaDeviceContext::~RdmaDeviceContext() {
@@ -376,6 +379,50 @@ application::RdmaMemoryRegion RdmaDeviceContext::RegisterRdmaMemoryRegionDmabuf(
   handle.rkey = mr->rkey;
   handle.length = mr->length;
   return handle;
+}
+
+namespace {
+// Export a dmabuf fd for the GPU buffer at `ptr`. Returns -1 if unsupported.
+int TryExportDmabufFd(void* ptr, size_t size) {
+  int fd = -1;
+  hipError_t err = hipMemGetHandleForAddressRange(
+      &fd, reinterpret_cast<hipDeviceptr_t>(ptr), size, hipMemRangeHandleTypeDmaBufFd, 0);
+  if (err != hipSuccess) {
+    (void)hipGetLastError();
+    return -1;
+  }
+  return fd;
+}
+}  // namespace
+
+application::RdmaMemoryRegion RdmaDeviceContext::RegisterRdmaMemoryRegionAuto(void* ptr,
+                                                                              size_t size,
+                                                                              int accessFlag) {
+  if (!dmabufRegDisabled) {
+    int dmabufFd = TryExportDmabufFd(ptr, size);
+    if (dmabufFd >= 0) {
+      int effectiveAccessFlag = MaybeAddRelaxedOrderingFlag(accessFlag);
+      ibv_mr* mr = ibv_reg_dmabuf_mr(pd, 0, size, reinterpret_cast<uint64_t>(ptr), dmabufFd,
+                                     effectiveAccessFlag);
+      close(dmabufFd);
+      if (mr) {
+        MORI_APP_TRACE("RegisterRdmaMemoryRegionAuto[dmabuf], addr:{}, size:{}, lkey:{}, rkey:{}",
+                       ptr, size, mr->lkey, mr->rkey);
+        mrPool.insert({ptr, mr});
+        application::RdmaMemoryRegion handle;
+        handle.addr = reinterpret_cast<uintptr_t>(ptr);
+        handle.lkey = mr->lkey;
+        handle.rkey = mr->rkey;
+        handle.length = mr->length;
+        return handle;
+      }
+      MORI_APP_WARN(
+          "ibv_reg_dmabuf_mr failed (addr:{}, size:{}, errno:{} ({})), falling back to "
+          "ibv_reg_mr",
+          ptr, size, errno, strerror(errno));
+    }
+  }
+  return RegisterRdmaMemoryRegion(ptr, size, accessFlag);
 }
 
 void RdmaDeviceContext::DeregisterRdmaMemoryRegion(void* ptr) {

--- a/src/application/transport/rdma/rdma.cpp
+++ b/src/application/transport/rdma/rdma.cpp
@@ -381,9 +381,8 @@ application::RdmaMemoryRegion RdmaDeviceContext::RegisterRdmaMemoryRegionDmabuf(
   return handle;
 }
 
-namespace {
 // Export a dmabuf fd for the GPU buffer at `ptr`. Returns -1 if unsupported.
-int TryExportDmabufFd(void* ptr, size_t size) {
+static int TryExportDmabufFd(void* ptr, size_t size) {
   int fd = -1;
   hipError_t err = hipMemGetHandleForAddressRange(&fd, reinterpret_cast<hipDeviceptr_t>(ptr), size,
                                                   hipMemRangeHandleTypeDmaBufFd, 0);
@@ -393,7 +392,6 @@ int TryExportDmabufFd(void* ptr, size_t size) {
   }
   return fd;
 }
-}  // namespace
 
 application::RdmaMemoryRegion RdmaDeviceContext::RegisterRdmaMemoryRegionAuto(void* ptr,
                                                                               size_t size,

--- a/src/application/transport/rdma/rdma.cpp
+++ b/src/application/transport/rdma/rdma.cpp
@@ -385,8 +385,8 @@ namespace {
 // Export a dmabuf fd for the GPU buffer at `ptr`. Returns -1 if unsupported.
 int TryExportDmabufFd(void* ptr, size_t size) {
   int fd = -1;
-  hipError_t err = hipMemGetHandleForAddressRange(
-      &fd, reinterpret_cast<hipDeviceptr_t>(ptr), size, hipMemRangeHandleTypeDmaBufFd, 0);
+  hipError_t err = hipMemGetHandleForAddressRange(&fd, reinterpret_cast<hipDeviceptr_t>(ptr), size,
+                                                  hipMemRangeHandleTypeDmaBufFd, 0);
   if (err != hipSuccess) {
     (void)hipGetLastError();
     return -1;


### PR DESCRIPTION
## Summary

Introduce `RdmaDeviceContext::RegisterRdmaMemoryRegionAuto`, a dmabuf-first MR registration path that falls back to classic `ibv_reg_mr` when the HIP driver can't export a dmabuf fd or `ibv_reg_dmabuf_mr` fails. The non-VMM symmetric memory allocator switches to this wrapper.

### Why

- Classic `ibv_reg_mr` on large GPU heaps occasionally hits `EINVAL` on hosts where the peermem kernel module is missing / unhappy or where `RLIMIT_MEMLOCK` is too low. The dmabuf path bypasses both: the kernel pins the dmabuf object, not user pages.
- This is the same direction NVSHMEM took (`transport_ib_common.cpp` tries `ibv_reg_dmabuf_mr` first, falls back silently). rocSHMEM still uses classic `ibv_reg_mr` only, so adopting dmabuf moves mori ahead on the AMD side.

### Behavior

| Path | Before | After |
|---|---|---|
| Non-VMM symmetric memory MR | `ibv_reg_mr` (pinned) | dmabuf-first, fallback to `ibv_reg_mr` |
| VMM `RegisterRdmaChunks` | dmabuf (existing) | unchanged |
| `MORI_DISABLE_DMABUF_REG=1/true/on/yes` | n/a | forces classic `ibv_reg_mr` |

### Design notes

- The env var is snapshotted into a `RdmaDeviceContext` member at construction (mirrors the `Context::sdmaEnabled`/`p2pDisabled` cache). All MRs on the same context pick the same path, avoiding hard-to-debug mixed-mode states from late env mutations.
- On `ibv_reg_dmabuf_mr` failure we log a `MORI_APP_WARN` once per call and silently fall back to `ibv_reg_mr` — same policy as NVSHMEM.
- The dmabuf fd is closed immediately after registration (kernel holds its own ref via the MR).

## Test plan

- [x] Existing CI green (build + smoke)
- [x] Multi-node RDMA dispatch/combine still passes with default (dmabuf) path
- [ ] `MORI_DISABLE_DMABUF_REG=1` forces classic path and still passes
- [x] On a host without dmabuf support, init falls back to `ibv_reg_mr` without aborting