### PR TITLE
fix(io): bind worker threads within allowed cpuset

### DIFF
--- a/src/io/rdma/executor.cpp
+++ b/src/io/rdma/executor.cpp
@@ -26,11 +26,31 @@
 
 #include <cstring>
 #include <future>
+#include <vector>
 
 #include "mori/io/logging.hpp"
 
 namespace mori {
 namespace io {
+
+namespace {
+
+// Allowed CPUs of the current process, sorted ascending. Reflects cgroup/cpuset
+// limits. Empty means affinity could not be read.
+std::vector<int> GetAllowedCpus() {
+  cpu_set_t set;
+  CPU_ZERO(&set);
+  std::vector<int> cpus;
+  if (sched_getaffinity(0, sizeof(set), &set) != 0) {
+    return cpus;
+  }
+  for (int cpu = 0; cpu < CPU_SETSIZE; ++cpu) {
+    if (CPU_ISSET(cpu, &set)) cpus.push_back(cpu);
+  }
+  return cpus;
+}
+
+}  // namespace
 
 /* ---------------------------------------------------------------------------------------------- */
 /*                                   MultithreadExecutor::Worker                                  */
@@ -56,25 +76,40 @@ void MultithreadExecutor::Worker::Shutdown() {
 }
 
 void MultithreadExecutor::Worker::MainLoop() {
+  // MORI_CORE_OFFSET is a relative offset into the allowed CPU list, not an
+  // absolute host CPU id, so binding stays within the cpuset.
   int coreOffset = 0;
   const char* env = std::getenv("MORI_CORE_OFFSET");
   if (env) {
     coreOffset = std::stoi(env);
   }
 
-  cpu_set_t cpuset;
-  CPU_ZERO(&cpuset);
-  int targetCore = workerId + coreOffset;
-  CPU_SET(targetCore, &cpuset);
-
-  int rc = pthread_setaffinity_np(thd.native_handle(), sizeof(cpu_set_t), &cpuset);
-  if (rc != 0) {
+  std::vector<int> allowed = GetAllowedCpus();
+  if (allowed.empty()) {
     MORI_IO_WARN(
-        "worker {} failed to set affinity to core {}: errno={} ({}). "
-        "Worker will run on any available core. "
-        "This is usually caused by: CPU not available in cpuset, "
-        "NUMA configuration, or container CPU limits.",
-        workerId, targetCore, rc, strerror(rc));
+        "worker {} could not read allowed CPU set (sched_getaffinity failed); "
+        "worker will run on any available core.",
+        workerId);
+  } else {
+    int n = static_cast<int>(allowed.size());
+    int idx = ((workerId + coreOffset) % n + n) % n;
+    int targetCore = allowed[idx];
+
+    cpu_set_t cpuset;
+    CPU_ZERO(&cpuset);
+    CPU_SET(targetCore, &cpuset);
+
+    int rc = pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
+    if (rc != 0) {
+      MORI_IO_WARN(
+          "worker {} failed to set affinity to core {} (allowed[{}], allowed size {}): "
+          "errno={} ({}). Worker will run on any available core. "
+          "This is usually caused by NUMA configuration or container CPU limits.",
+          workerId, targetCore, idx, n, rc, strerror(rc));
+    } else {
+      MORI_IO_INFO("worker {} bound to core {} (allowed[{}] of {} allowed CPUs, offset {})",
+                   workerId, targetCore, idx, n, coreOffset);
+    }
   }
 
   MORI_IO_INFO("worker {} enter main loop, running on core {}", workerId, sched_getcpu());


### PR DESCRIPTION
## Problem

`MultithreadExecutor::Worker` pinned each IO worker to `workerId + MORI_CORE_OFFSET`,
treating it as an absolute host CPU id. Under Docker/K8s `cpuset` (or any cgroup
CPU limit), the process is only allowed to run on a subset of cores (often not
starting at 0), so these target cores fall outside the allowed set,
`pthread_setaffinity_np` fails with `EINVAL`, and workers fall back to running on
any core — losing affinity and giving unstable performance.

## Fix

Pick the target core from the process's *allowed* CPU set
(`sched_getaffinity`), which already reflects cgroup/cpuset limits:

`core = allowed[(workerId + MORI_CORE_OFFSET) % allowed.size()]`

- `MORI_CORE_OFFSET` is now a relative offset into the allowed CPU list, not an
  absolute host CPU id.
- Falls back gracefully (warn + run on any core) if affinity can't be read.
- Binds via `pthread_self()` from inside the worker thread, avoiding a race on `thd`.
- Logs allowed-CPU count and the `worker -> core` mapping for easier debugging.

## Why not a configurable CPU list?

Intentionally kept minimal. This reuses the existing `MORI_CORE_OFFSET` knob and
introduces no new env vars, so existing offset-based setups keep working (on bare
metal where the allowed set is contiguous `0..N-1`, behavior is unchanged). A
richer interface — explicit `MORI_IO_CPU_LIST`, NUMA-aware selection, strict/disable
modes — can be added later if there's demand, without blocking this cpuset fix.

## Compatibility

- Bare metal, no cpuset: equivalent to previous behavior.
- Bare metal, large offset: wraps instead of going out of range (improvement).
- Container cpuset: now binds inside the allowed set instead of failing.

## Test

Two-node RDMA benchmark under `taskset -c 8-15` with
`--num-worker-threads 4 --disable-chunking`: all workers bound to cores 8-11
(within the allowed set), no affinity failures. Without the fix the old code
targets cores 0-3 and fails with `EINVAL`.