### PR TITLE
fix(mlx5): program RoCE QoS and make UDP sport selectable on DEVX QPs

### DIFF
--- a/src/application/transport/rdma/providers/mlx5/mlx5.cpp
+++ b/src/application/transport/rdma/providers/mlx5/mlx5.cpp
@@ -145,10 +145,31 @@ Mlx5CqContainer::Mlx5CqContainer(ibv_context* context, const RdmaEndpointConfig&
 }
 
 Mlx5CqContainer::~Mlx5CqContainer() {
-  Mlx5DvApi::Instance().devx_umem_dereg(cqUmem);
-  Mlx5DvApi::Instance().devx_umem_dereg(cqDbrUmem);
-  Mlx5DvApi::Instance().devx_free_uar(uar);
-  Mlx5DvApi::Instance().devx_obj_destroy(cq);
+  // Destroy the firmware CQ before releasing the UMEM/UAR it references, then free
+  // the CQ/DBR backing memory (previously leaked on every endpoint teardown).
+  if (cq) {
+    Mlx5DvApi::Instance().devx_obj_destroy(cq);
+    cq = nullptr;
+  }
+  if (cqUmem) Mlx5DvApi::Instance().devx_umem_dereg(cqUmem);
+  if (cqDbrUmem) Mlx5DvApi::Instance().devx_umem_dereg(cqDbrUmem);
+  if (uar) Mlx5DvApi::Instance().devx_free_uar(uar);
+  if (cqUmemAddr) {
+    if (config.onGpu) {
+      HIP_RUNTIME_CHECK(hipFree(cqUmemAddr));
+    } else {
+      free(cqUmemAddr);
+    }
+    cqUmemAddr = nullptr;
+  }
+  if (cqDbrUmemAddr) {
+    if (config.onGpu) {
+      HIP_RUNTIME_CHECK(hipFree(cqDbrUmemAddr));
+    } else {
+      free(cqDbrUmemAddr);
+    }
+    cqDbrUmemAddr = nullptr;
+  }
 }
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -311,6 +332,13 @@ void Mlx5QpContainer::CreateQueuePair(uint32_t cqn, uint32_t pdn) {
 }
 
 void Mlx5QpContainer::DestroyQueuePair() {
+  // Destroy the firmware QP first, so the NIC stops referencing the SQ/DBR UMEMs,
+  // UAR and atomic MR before we release them (avoids leak + NIC DMA into freed mem).
+  if (qp) {
+    Mlx5DvApi::Instance().devx_obj_destroy(qp);
+    qp = nullptr;
+  }
+
   if (atomicIbufMr) {
     ibv_dereg_mr(atomicIbufMr);
     atomicIbufMr = nullptr;
@@ -351,7 +379,6 @@ void Mlx5QpContainer::DestroyQueuePair() {
     }
     Mlx5DvApi::Instance().devx_free_uar(qpUar);
   }
-  if (qp) Mlx5DvApi::Instance().devx_obj_destroy(qp);
 }
 
 void* Mlx5QpContainer::GetSqAddress() { return static_cast<char*>(qpUmemAddr) + sqAttrs.offset; }
@@ -403,7 +430,14 @@ void Mlx5QpContainer::ModifyInit2Rtr(const RdmaEndpointHandle& local_handle,
   DEVX_SET(qpc, qpc, remote_qpn, remote_handle.qpn);
   DEVX_SET(qpc, qpc, next_rcv_psn, remote_handle.psn);
   DEVX_SET(qpc, qpc, min_rnr_nak, 12);
-  DEVX_SET(qpc, qpc, log_rra_max, 20);
+  // log_rra_max: clamp to floor(log2(max_qp_rd_atom)) instead of a hardcoded 20,
+  // which exceeds the HCA cap and can corrupt atomic (flag) delivery.
+  {
+    const ibv_device_attr_ex* devAttr = device_context->GetRdmaDevice()->GetDeviceAttr();
+    uint32_t rraCap =
+        (devAttr && devAttr->orig_attr.max_qp_rd_atom > 0) ? devAttr->orig_attr.max_qp_rd_atom : 1;
+    DEVX_SET(qpc, qpc, log_rra_max, static_cast<uint32_t>(log2(static_cast<double>(rraCap))));
+  }
 
   qpc = DEVX_ADDR_OF(init2rtr_qp_in, init2rtr_cmd_in, qpc);
   DEVX_SET(qpc, qpc, primary_address_path.vhca_port_num, config.portId);
@@ -417,9 +451,27 @@ void Mlx5QpContainer::ModifyInit2Rtr(const RdmaEndpointHandle& local_handle,
            sizeof(remote_handle.eth.mac));
     DEVX_SET(qpc, qpc, primary_address_path.hop_limit, 64);
     DEVX_SET(qpc, qpc, primary_address_path.src_addr_index, local_handle.eth.gidIdx);
-    // Use shared UDP sport configuration with qpId-based selection
-    uint16_t selected_udp_sport = device_context->GetUdpSport(qpId);
-    DEVX_SET(qpc, qpc, primary_address_path.udp_sport, selected_udp_sport | 0xC000);
+    // UDP sport: default to a single fixed RoCEv2 sport (NVSHMEM-style, == 0xC000
+    // on RoCE). MORI_MLX5_ENABLE_UDP_SPORT=1 rotates per-qpId (GetUdpSport) for
+    // ECMP spread.
+    static const bool enableUdpSport = []() {
+      const char* e = std::getenv("MORI_MLX5_ENABLE_UDP_SPORT");
+      return e != nullptr && std::atoi(e) != 0;
+    }();
+    uint16_t selected_udp_sport =
+        enableUdpSport ? static_cast<uint16_t>(device_context->GetUdpSport(qpId) | 0xC000)
+                       : static_cast<uint16_t>(portAttr.lid | 0xC000);
+    DEVX_SET(qpc, qpc, primary_address_path.udp_sport, selected_udp_sport);
+    // RoCE QoS: DEVX QPs ignore MORI_RDMA_TC/SL unless dscp/eth_prio are set here
+    // (traffic_class = DSCP << 2 | ECN, so DSCP = TC >> 2).
+    std::optional<uint8_t> roceTc = ReadRdmaTrafficClassEnv();
+    std::optional<uint8_t> roceSl = ReadRdmaServiceLevelEnv();
+    if (roceTc.has_value()) {
+      DEVX_SET(qpc, qpc, primary_address_path.dscp, roceTc.value() >> 2);
+    }
+    if (roceSl.has_value()) {
+      DEVX_SET(qpc, qpc, primary_address_path.eth_prio, roceSl.value() & 0x7);
+    }
     MORI_APP_TRACE("MLX5 QP {} using UDP sport {} (qpId={}, index={})", qpn, selected_udp_sport,
                    qpId, qpId % RDMA_UDP_SPORT_ARRAY_SIZE);
   } else if (portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND) {
@@ -445,7 +497,13 @@ void Mlx5QpContainer::ModifyRtr2Rts(const RdmaEndpointHandle& local_handle) {
   DEVX_SET(rtr2rts_qp_in, rtr2rts_cmd_in, qpn, qpn);
 
   void* qpc = DEVX_ADDR_OF(rtr2rts_qp_in, rtr2rts_cmd_in, qpc);
-  DEVX_SET(qpc, qpc, log_sra_max, 20);
+  // log_sra_max: clamp to floor(log2(max_qp_rd_atom)) (same rationale as log_rra_max).
+  {
+    const ibv_device_attr_ex* devAttr = device_context->GetRdmaDevice()->GetDeviceAttr();
+    uint32_t sraCap =
+        (devAttr && devAttr->orig_attr.max_qp_rd_atom > 0) ? devAttr->orig_attr.max_qp_rd_atom : 1;
+    DEVX_SET(qpc, qpc, log_sra_max, static_cast<uint32_t>(log2(static_cast<double>(sraCap))));
+  }
   DEVX_SET(qpc, qpc, next_send_psn, local_handle.psn);
   DEVX_SET(qpc, qpc, retry_count, 7);
   DEVX_SET(qpc, qpc, rnr_retry, 7);


### PR DESCRIPTION
## Summary

The mlx5 provider modifies QPs through DEVX, which bypasses rdma-core. As a result the RoCE address path was never given an egress DSCP/priority, so `MORI_RDMA_TC` / `MORI_RDMA_SL` were silently ignored and all RoCE traffic fell onto DSCP/prio 0. The bnxt, ionic and ibverbs providers already program SL/TC; this brings the mlx5 RoCE path in line.

## Changes

- **RoCE QoS**: program `primary_address_path.dscp` (`= MORI_RDMA_TC >> 2`) and `eth_prio` (`= MORI_RDMA_SL & 0x7`) on Init2Rtr so traffic uses the configured (lossless) class instead of defaulting to prio 0.
- **UDP source port**: default to a single fixed RoCEv2 sport (`LID | 0xC000`, NVSHMEM-style). Set `MORI_MLX5_ENABLE_UDP_SPORT=1` to rotate per-qpId (`GetUdpSport`) for ECMP spreading. Naming mirrors `MORI_BNXT_ENABLE_UDP_SPORT`.
- **Endpoint teardown**: destroy the firmware CQ/QP object *before* releasing the UMEM/UAR/atomic-MR it references. The previous order made `devx_obj_destroy` / `devx_umem_dereg` fail — leaking the NIC object and risking the NIC DMAing into freed memory — and the CQ/DBR backing buffers were leaked on every teardown.
- **log_rra_max / log_sra_max**: clamp to `floor(log2(max_qp_rd_atom))` instead of a hardcoded `20`, which exceeds the HCA per-QP cap.

## Testing

- 2-node × 8-GPU MI300X (ConnectX-7, RoCEv2). Verified the QPC now carries the intended DSCP/priority and that traffic lands on the configured class (per-priority NIC counters confirm prio assignment).
- `examples/ops/dispatch_combine` InterNode v1 dispatch/combine bench passes across `--num-qp 1/2/4`.
- Endpoint create/destroy cycles no longer leak the firmware CQ/QP or backing buffers.

## Notes

- On fabrics where the switch ECN/lossless config is tuned for a specific traffic class (e.g. OCI's `NCCL_IB_TC=41`), set `MORI_RDMA_TC` to the matching value so traffic lands on the tuned queue.
- Default behavior with `MORI_RDMA_TC` / `MORI_RDMA_SL` unset is unchanged (fields left at firmware default).