### PR TITLE
fix(io): make io worker cpu pinning opt-in via MORI_CORE_OFFSET

### DIFF
--- a/include/mori/utils/env_utils.hpp
+++ b/include/mori/utils/env_utils.hpp
@@ -89,6 +89,17 @@ inline std::optional<int> ParsePositiveInt(const char* raw) {
   return static_cast<int>(parsed);
 }
 
+inline std::optional<int> ParseInt(const char* raw) {
+  errno = 0;
+  char* end = nullptr;
+  long parsed = std::strtol(raw, &end, 10);
+  if (end == raw || *end != '\0' || errno != 0 || parsed < std::numeric_limits<int>::min() ||
+      parsed > std::numeric_limits<int>::max()) {
+    return std::nullopt;
+  }
+  return static_cast<int>(parsed);
+}
+
 }  // namespace detail
 
 /// Check if an environment variable is set and enabled.
@@ -109,6 +120,14 @@ inline int GetPositiveIntOr(const char* varName, int defaultValue) {
   if (val == nullptr || val[0] == '\0') return defaultValue;
   auto parsed = detail::ParsePositiveInt(val);
   return parsed.value_or(defaultValue);
+}
+
+/// Read an int env var (any value, including 0 and negative). Returns nullopt
+/// when unset, empty, or not parseable.
+inline std::optional<int> GetInt(const char* varName) {
+  const char* val = Get(varName);
+  if (val == nullptr || val[0] == '\0') return std::nullopt;
+  return detail::ParseInt(val);
 }
 
 }  // namespace env

--- a/src/io/rdma/executor.cpp
+++ b/src/io/rdma/executor.cpp
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "mori/io/logging.hpp"
+#include "mori/utils/env_utils.hpp"
 
 namespace mori {
 namespace io {
@@ -76,39 +77,34 @@ void MultithreadExecutor::Worker::Shutdown() {
 }
 
 void MultithreadExecutor::Worker::MainLoop() {
-  // MORI_CORE_OFFSET is a relative offset into the allowed CPU list, not an
-  // absolute host CPU id, so binding stays within the cpuset.
-  int coreOffset = 0;
-  const char* env = std::getenv("MORI_CORE_OFFSET");
-  if (env) {
-    coreOffset = std::stoi(env);
-  }
-
-  std::vector<int> allowed = GetAllowedCpus();
-  if (allowed.empty()) {
-    MORI_IO_WARN(
-        "worker {} could not read allowed CPU set (sched_getaffinity failed); "
-        "worker will run on any available core.",
-        workerId);
-  } else {
-    int n = static_cast<int>(allowed.size());
-    int idx = ((workerId + coreOffset) % n + n) % n;
-    int targetCore = allowed[idx];
-
-    cpu_set_t cpuset;
-    CPU_ZERO(&cpuset);
-    CPU_SET(targetCore, &cpuset);
-
-    int rc = pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
-    if (rc != 0) {
+  // MORI_CORE_OFFSET is relative to the allowed CPU list, so binding stays within the cpuset.
+  if (auto coreOffset = mori::env::GetInt("MORI_CORE_OFFSET")) {
+    std::vector<int> allowed = GetAllowedCpus();
+    if (allowed.empty()) {
       MORI_IO_WARN(
-          "worker {} failed to set affinity to core {} (allowed[{}], allowed size {}): "
-          "errno={} ({}). Worker will run on any available core. "
-          "This is usually caused by NUMA configuration or container CPU limits.",
-          workerId, targetCore, idx, n, rc, strerror(rc));
+          "worker {} could not read allowed CPU set (sched_getaffinity failed); "
+          "worker will run on any available core.",
+          workerId);
     } else {
-      MORI_IO_INFO("worker {} bound to core {} (allowed[{}] of {} allowed CPUs, offset {})",
-                   workerId, targetCore, idx, n, coreOffset);
+      int n = static_cast<int>(allowed.size());
+      int idx = ((workerId + *coreOffset) % n + n) % n;
+      int targetCore = allowed[idx];
+
+      cpu_set_t cpuset;
+      CPU_ZERO(&cpuset);
+      CPU_SET(targetCore, &cpuset);
+
+      int rc = pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
+      if (rc != 0) {
+        MORI_IO_WARN(
+            "worker {} failed to set affinity to core {} (allowed[{}], allowed size {}): "
+            "errno={} ({}). Worker will run on any available core. "
+            "This is usually caused by NUMA configuration or container CPU limits.",
+            workerId, targetCore, idx, n, rc, strerror(rc));
+      } else {
+        MORI_IO_INFO("worker {} bound to core {} (allowed[{}] of {} allowed CPUs, offset {})",
+                     workerId, targetCore, idx, n, *coreOffset);
+      }
     }
   }
 


### PR DESCRIPTION
Follow-up to #358 (cpuset-aware worker pinning).

## Changes
- IO worker CPU pinning is now **opt-in**: workers are only pinned when
  `MORI_CORE_OFFSET` is set. When it is unset, workers inherit the process
  cpuset and the scheduler places them (matches the default no-explicit-pin
  behavior used elsewhere, e.g. SGLang's opt-in `SGLANG_SET_CPU_AFFINITY`).
- Parse `MORI_CORE_OFFSET` via `mori::env::GetInt` instead of `std::stoi`,
  so an invalid value is ignored (treated as unset) instead of throwing and
  terminating the worker thread. Added a small signed-int helper
  (`ParseInt` / `GetInt`) alongside the existing `ParsePositiveInt` /
  `GetPositiveIntOr` in `env_utils.hpp`.

## Why opt-in
Implicitly pinning every worker to `allowed[0..n]` can collide with other hot
threads sharing the same cpuset (e.g. the SGLang scheduler/compute threads).
Pinning is a tuning decision, so the default is now neutral; operators opt in
when they have a deliberate core layout.

## Test
On 086/087 under `taskset -c 8-15` with `--num-worker-threads 4 --disable-chunking`:
- `MORI_CORE_OFFSET=0`: workers bound to cores 8-11 (within the allowed set).
- unset: no pinning, workers run on scheduler-chosen allowed cores (e.g. 11-14).
- `MORI_CORE_OFFSET=abc` (invalid): no crash, treated as unset, workers run normally.
Plus a unit check of `GetInt` parsing (valid / 0 / negative / garbage / overflow).