### PR TITLE
fix(ep): add mlx5 collapsed CQ + dedicated dispatch staging buffer for internode-v1

### DIFF
--- a/include/mori/ops/dispatch_combine/dispatch_combine.hpp
+++ b/include/mori/ops/dispatch_combine/dispatch_combine.hpp
@@ -182,6 +182,8 @@ struct ShmemBufsInterNodeV1 {
   mori::application::SymmMemObjPtr dispatchOut;
   mori::application::SymmMemObjPtr combineOut;
   mori::application::SymmMemObjPtr staging;
+  // Dispatch send source, separate from `staging` so combine can't overwrite it.
+  mori::application::SymmMemObjPtr dispatchStaging;
 };
 
 // InterNode / AsyncLL: full 5-buffer set used by the non-V1 RDMA paths.

--- a/include/mori/shmem/shmem_ibgda_kernels.hpp
+++ b/include/mori/shmem/shmem_ibgda_kernels.hpp
@@ -285,98 +285,73 @@ inline __device__ void ShmemQuietThreadKernelPsdImpl(int pe, int qpId) {
   }
 }
 
+// Drain a collapsed CQ (cc=1, oi=1) and advance wq.doneIdx. The NIC keeps the
+// latest completion in CQE[0]; reconstruct the 32-bit completion from the 16-bit
+// wqe_counter against doneIdx (a lower bound, since outstanding < sqWqeNum <
+// 65536). Lock-free / multi-warp safe via atomicMax on doneIdx.
+//
+// DrainToLive=false: exit at a snapshot of dbTouchIdx (recycle gate -- just free
+// some slots). true: re-read the live postIdx and wait until every reserved WQE
+// has completed, so no send can still be reading its source (final quiet).
+template <bool DrainToLive = false>
+inline __device__ void Mlx5CollapsedCqDrain(core::WorkQueueHandle& wq,
+                                            core::CompletionQueueHandle& cq) {
+  uint32_t exitTarget =
+      DrainToLive ? __hip_atomic_load(&wq.postIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT)
+                  : __hip_atomic_load(&wq.dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+  uint32_t cons = __hip_atomic_load(&wq.doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+  if (cons >= exitTarget) return;
+
+  volatile mlx5_cqe64* cqe = reinterpret_cast<volatile mlx5_cqe64*>(cq.cqAddr);
+  // Device scope: CQE read fresh via volatile from the uncached CQ; doneIdx is a
+  // GPU-only counter. Nothing here orders memory the NIC reads.
+  __threadfence();
+
+  do {
+    uint16_t wqeCounter = BE16TOH(cqe->wqe_counter);
+    uint8_t opcode = (reinterpret_cast<volatile uint8_t*>(cq.cqAddr)[sizeof(mlx5_cqe64) - 1]) >> 4;
+    if (opcode == MLX5_CQE_REQ_ERR || opcode == MLX5_CQE_RESP_ERR) {
+      auto error = core::Mlx5HandleErrorCqe(reinterpret_cast<mlx5_err_cqe*>(cq.cqAddr));
+      MORI_PRINTF("(%s:%d) collapsed CQE error: %s\n", __FILE__, __LINE__,
+                  core::IbvWcStatusString(error));
+      assert(false);
+      return;
+    }
+
+    uint16_t comp16 = static_cast<uint16_t>(wqeCounter + 1);
+    uint32_t completed = (cons & ~0xffffu) | comp16;
+    if (completed < cons) completed += 0x10000u;  // low-bit wrap into next 64K block
+
+    __hip_atomic_fetch_max(&wq.doneIdx, completed, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    cons = __hip_atomic_load(&wq.doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    if constexpr (DrainToLive) {
+      exitTarget = __hip_atomic_load(&wq.postIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    }
+  } while (cons < exitTarget);
+  __threadfence();
+}
+
+template <bool DrainToLive = false>
 inline __device__ void ShmemQuietThreadKernelMlnxImpl(int pe, int qpId) {
   GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
   ShmemRdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
   int epIndex = pe * globalGpuStates->numQpPerPe + (qpId % globalGpuStates->numQpPerPe);
   core::WorkQueueHandle& wq = ep[epIndex].wqHandle;
   core::CompletionQueueHandle& cq = ep[epIndex].cqHandle;
-
-  constexpr size_t BROADCAST_SIZE = 1024 / warpSize;
-  __shared__ uint64_t wqe_broadcast[BROADCAST_SIZE];
-  uint8_t warp_id = core::FlatBlockThreadId() / warpSize;
-  wqe_broadcast[warp_id] = 0;
-
-  uint64_t activemask = core::GetActiveLaneMask();
-  uint8_t num_active_lanes = core::GetActiveLaneCount(activemask);
-  uint8_t my_logical_lane_id = core::GetActiveLaneNum(activemask);
-  bool is_leader{my_logical_lane_id == 0};
-  const uint64_t leader_phys_lane_id = core::GetFirstActiveLaneID(activemask);
-
-  while (true) {
-    bool done{false};
-    uint32_t quiet_amount{0};
-    uint32_t warp_cq_consumer{0};
-    while (!done) {
-      uint32_t active =
-          __hip_atomic_load(&cq.activeIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint32_t posted =
-          __hip_atomic_load(&cq.needConsIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint32_t completed =
-          __hip_atomic_load(&cq.consIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      if (!(posted - completed)) {
-        return;
-      }
-      int32_t quiet_val = posted - active;
-      if (quiet_val <= 0) {
-        continue;
-      }
-      quiet_amount = min(num_active_lanes, quiet_val);
-      if (is_leader) {
-        done = __hip_atomic_compare_exchange_strong(&cq.activeIdx, &active, active + quiet_amount,
-                                                    __ATOMIC_RELAXED, __ATOMIC_RELAXED,
-                                                    __HIP_MEMORY_SCOPE_AGENT);
-        if (done) {
-          warp_cq_consumer = __hip_atomic_fetch_add(&cq.cq_consumer, quiet_amount, __ATOMIC_RELAXED,
-                                                    __HIP_MEMORY_SCOPE_AGENT);
-        }
-      }
-      done = __shfl(done, leader_phys_lane_id);
-    }
-    warp_cq_consumer = __shfl(warp_cq_consumer, leader_phys_lane_id);
-    uint32_t my_cq_consumer = warp_cq_consumer + my_logical_lane_id;
-    uint32_t my_cq_index = my_cq_consumer % cq.cqeNum;
-
-    if (my_logical_lane_id < quiet_amount) {
-      uint32_t wqe_counter;
-      int opcode = core::PollCq<core::ProviderType::MLX5>(cq.cqAddr, cq.cqeNum, &my_cq_consumer,
-                                                          &wqe_counter);
-      if (opcode == MLX5_CQE_RESP_ERR || opcode == MLX5_CQE_REQ_ERR) {
-        int rank = globalGpuStates->rank;
-        MORI_PRINTF("rank %d dest pe %d consIdx %d opcode %d\n", rank, pe, my_cq_index, opcode);
-        core::DumpMlx5Wqe(wq.sqAddr, my_cq_index);
-        assert(false);
-      }
-      uint64_t wqe_id = wq.outstandingWqe[wqe_counter];
-      __hip_atomic_fetch_max(&wqe_broadcast[warp_id], wqe_id, __ATOMIC_RELAXED,
-                             __HIP_MEMORY_SCOPE_WORKGROUP);
-      __atomic_signal_fence(__ATOMIC_SEQ_CST);
-    }
-    if (is_leader) {
-      uint64_t completed{0};
-      do {
-        completed = __hip_atomic_load(&cq.consIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      } while (completed != warp_cq_consumer);
-
-      core::UpdateCqDbrRecord<core::ProviderType::MLX5>(
-          cq, (uint32_t)(warp_cq_consumer + quiet_amount));
-
-      __atomic_signal_fence(__ATOMIC_SEQ_CST);
-      uint64_t doneIdx = wqe_broadcast[warp_id];
-      __hip_atomic_fetch_max(&wq.doneIdx, doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      __hip_atomic_fetch_add(&cq.consIdx, quiet_amount, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    }
-  }
+  Mlx5CollapsedCqDrain<DrainToLive>(wq, cq);
 }
 
-template <core::ProviderType PrvdType>
+// DrainToLive=false (recycle gate, per-QP): snapshot drain. The caller holds its
+// own un-doorbelled reservation, so a live (postIdx) drain would self-deadlock.
+// true (final per-pe quiet): wait for the live postIdx -- every reserved WQE done.
+template <core::ProviderType PrvdType, bool DrainToLive = false>
 inline __device__ void ShmemQuietThreadKernelImpl(int pe, int qpId) {
   if constexpr (PrvdType == core::ProviderType::BNXT) {
     ShmemQuietThreadKernelSerialImpl(pe, qpId);
   } else if constexpr (PrvdType == core::ProviderType::PSD) {
     ShmemQuietThreadKernelPsdImpl(pe, qpId);
   } else if constexpr (PrvdType == core::ProviderType::MLX5) {
-    ShmemQuietThreadKernelMlnxImpl(pe, qpId);
+    ShmemQuietThreadKernelMlnxImpl<DrainToLive>(pe, qpId);
   } else {
     static_assert(false);
   }
@@ -396,6 +371,10 @@ inline __device__ void ShmemQuietThreadKernel<application::TransportType::RDMA>(
   }
 }
 
+// Quiet all QPs to `pe`: returns only once every reserved WQE has completed (the
+// live drain, DrainToLive=true -> waits for postIdx). The per-QP recycle gate
+// instead uses ShmemQuietThreadKernelImpl with the default snapshot drain, which
+// must stay snapshot there to avoid self-deadlock.
 template <>
 inline __device__ void ShmemQuietThreadKernel<application::TransportType::RDMA>(int pe) {
   GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
@@ -403,7 +382,13 @@ inline __device__ void ShmemQuietThreadKernel<application::TransportType::RDMA>(
   if (pe == rank) return;
   if (globalGpuStates->transportTypes[pe] != application::TransportType::RDMA) return;
   for (int qpId = 0; qpId < globalGpuStates->numQpPerPe; qpId++) {
-    DISPATCH_PROVIDER_TYPE_COMPILE_TIME(ShmemQuietThreadKernelImpl, pe, qpId);
+    if constexpr (DISPATCH_BNXT == 1) {
+      ShmemQuietThreadKernelImpl<core::ProviderType::BNXT, true>(pe, qpId);
+    } else if constexpr (DISPATCH_PSD == 1) {
+      ShmemQuietThreadKernelImpl<core::ProviderType::PSD, true>(pe, qpId);
+    } else {
+      ShmemQuietThreadKernelImpl<core::ProviderType::MLX5, true>(pe, qpId);
+    }
   }
 }
 
@@ -548,7 +533,6 @@ inline __device__ void ShmemPutMemNbiThreadKernelImpl(const application::SymmMem
 
     uint64_t dbr_val;
     if constexpr (PrvdType == core::ProviderType::MLX5) {
-      wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
       dbr_val =
           core::PostWrite<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter, is_leader,
                                     qpn, srcAddr, lkey, raddr, rkey, transfer_size);
@@ -558,7 +542,6 @@ inline __device__ void ShmemPutMemNbiThreadKernelImpl(const application::SymmMem
           core::PostWrite<PrvdType>(*wq, my_sq_counter, my_msntbl_counter, my_psn_counter,
                                     is_leader, qpn, srcAddr, lkey, raddr, rkey, transfer_size);
     } else if constexpr (PrvdType == core::ProviderType::PSD) {
-      wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
       dbr_val =
           core::PostWrite<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter, is_leader,
                                     qpn, srcAddr, lkey, raddr, rkey, transfer_size);
@@ -734,7 +717,6 @@ inline __device__ void ShmemPutSizeImmNbiThreadKernelImpl(const application::Sym
 
   uint64_t dbr_val;
   if constexpr (PrvdType == core::ProviderType::MLX5) {
-    wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
     dbr_val = core::PostWriteInline<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter,
                                               is_leader, qpn, val, raddr, rkey, bytes);
   } else if constexpr (PrvdType == core::ProviderType::BNXT) {
@@ -742,7 +724,6 @@ inline __device__ void ShmemPutSizeImmNbiThreadKernelImpl(const application::Sym
     dbr_val = core::PostWriteInline<PrvdType>(*wq, my_sq_counter, my_msntbl_counter, my_psn_counter,
                                               is_leader, qpn, val, raddr, rkey, bytes);
   } else if constexpr (PrvdType == core::ProviderType::PSD) {
-    wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
     dbr_val = core::PostWriteInline<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter,
                                               is_leader, qpn, val, raddr, rkey, bytes);
   } else {
@@ -951,7 +932,6 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelImpl(
     // Note: PostWrite always returns a valid doorbell value, regardless of cqeSignal
     uint64_t dbr_val;
     if constexpr (PrvdType == core::ProviderType::MLX5) {
-      wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
       dbr_val = core::PostWrite<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter,
                                           is_leader, qpn, laddr, lkey, raddr, rkey, transfer_size);
     } else if constexpr (PrvdType == core::ProviderType::BNXT) {
@@ -959,7 +939,6 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelImpl(
       dbr_val = core::PostWrite<PrvdType>(*wq, my_sq_counter, my_msntbl_counter, my_psn_counter,
                                           is_leader, qpn, laddr, lkey, raddr, rkey, transfer_size);
     } else if constexpr (PrvdType == core::ProviderType::PSD) {
-      wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
       dbr_val = core::PostWrite<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter,
                                           is_leader, qpn, laddr, lkey, raddr, rkey, transfer_size);
     } else {
@@ -983,7 +962,6 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelImpl(
         bool should_signal = onlyOneSignal ? is_leader : true;
         if (should_signal) {
           if constexpr (PrvdType == core::ProviderType::MLX5) {
-            wq->outstandingWqe[(my_sq_counter + 1) % OUTSTANDING_TABLE_SIZE] = my_sq_counter + 1;
             dbr_val = core::PostWriteInline<PrvdType>(
                 *wq, my_sq_counter + 1, my_sq_counter + 1, my_sq_counter + 1, is_leader, qpn,
                 &signalValue, signalRaddr, signalRkey, sizeof(signalValue));
@@ -993,7 +971,6 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelImpl(
                 *wq, my_sq_counter + 1, my_msntbl_counter + 1, my_psn_counter + psnCnt, is_leader,
                 qpn, &signalValue, signalRaddr, signalRkey, sizeof(signalValue));
           } else if constexpr (PrvdType == core::ProviderType::PSD) {
-            wq->outstandingWqe[(my_sq_counter + 1) % OUTSTANDING_TABLE_SIZE] = my_sq_counter + 1;
             dbr_val = core::PostWriteInline<PrvdType>(
                 *wq, my_sq_counter + 1, my_sq_counter + 1, my_sq_counter + 1, is_leader, qpn,
                 &signalValue, signalRaddr, signalRkey, sizeof(signalValue));
@@ -1005,7 +982,6 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelImpl(
         bool should_signal = onlyOneSignal ? is_leader : true;
         if (should_signal) {
           if constexpr (PrvdType == core::ProviderType::MLX5) {
-            wq->outstandingWqe[(my_sq_counter + 1) % OUTSTANDING_TABLE_SIZE] = my_sq_counter + 1;
             dbr_val = core::PostAtomic<PrvdType>(
                 *wq, my_sq_counter + 1, my_sq_counter + 1, my_sq_counter + 1, is_leader, qpn,
                 ibuf->addr, ibuf->lkey, signalRaddr, signalRkey, &signalValue, &signalValue,
@@ -1017,7 +993,6 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelImpl(
                 qpn, ibuf->addr, ibuf->lkey, signalRaddr, signalRkey, &signalValue, &signalValue,
                 sizeof(signalValue), core::atomicType::AMO_ADD);
           } else if constexpr (PrvdType == core::ProviderType::PSD) {
-            wq->outstandingWqe[(my_sq_counter + 1) % OUTSTANDING_TABLE_SIZE] = my_sq_counter + 1;
             dbr_val = core::PostAtomic<PrvdType>(
                 *wq, my_sq_counter + 1, my_sq_counter + 1, my_sq_counter + 1, is_leader, qpn,
                 ibuf->addr, ibuf->lkey, signalRaddr, signalRkey, &signalValue, &signalValue,
@@ -1251,12 +1226,8 @@ inline __device__ void ShmemAtomicSizeNonFetchThreadKernelImpl(
     ShmemQuietThreadKernelImpl<PrvdType>(pe, qpId);
   }
 
-  if constexpr (PrvdType == core::ProviderType::MLX5) {
-    wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
-  } else if constexpr (PrvdType == core::ProviderType::BNXT) {
+  if constexpr (PrvdType == core::ProviderType::BNXT) {
     wq->outstandingWqe[my_sq_counter % wq->sqWqeNum] = my_sq_counter;
-  } else if constexpr (PrvdType == core::ProviderType::PSD) {
-    wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
   }
 
   uint64_t dbr_val;
@@ -1442,12 +1413,8 @@ inline __device__ T ShmemAtomicTypeFetchThreadKernelImpl(const application::Symm
     ShmemQuietThreadKernelImpl<PrvdType>(pe, qpId);
   }
 
-  if constexpr (PrvdType == core::ProviderType::MLX5) {
-    wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
-  } else if constexpr (PrvdType == core::ProviderType::BNXT) {
+  if constexpr (PrvdType == core::ProviderType::BNXT) {
     wq->outstandingWqe[my_sq_counter % wq->sqWqeNum] = my_sq_counter;
-  } else if constexpr (PrvdType == core::ProviderType::PSD) {
-    wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
   }
 
   uint64_t dbr_val;
@@ -1712,7 +1679,6 @@ inline __device__ void ShmemPutMemNbiThreadKernelAddrImpl(const void* dest, cons
     // Post RDMA write for this chunk
     uint64_t dbr_val;
     if constexpr (PrvdType == core::ProviderType::MLX5) {
-      wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
       dbr_val =
           core::PostWrite<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter, is_leader,
                                     qpn, srcAddr, lkey, raddr, rkey, transfer_size);
@@ -1722,7 +1688,6 @@ inline __device__ void ShmemPutMemNbiThreadKernelAddrImpl(const void* dest, cons
           core::PostWrite<PrvdType>(*wq, my_sq_counter, my_msntbl_counter, my_psn_counter,
                                     is_leader, qpn, srcAddr, lkey, raddr, rkey, transfer_size);
     } else if constexpr (PrvdType == core::ProviderType::PSD) {
-      wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
       dbr_val =
           core::PostWrite<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter, is_leader,
                                     qpn, srcAddr, lkey, raddr, rkey, transfer_size);
@@ -1876,7 +1841,6 @@ inline __device__ void ShmemPutSizeImmNbiThreadKernelAddrImpl(const void* dest, 
 
   uint64_t dbr_val;
   if constexpr (PrvdType == core::ProviderType::MLX5) {
-    wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
     dbr_val = core::PostWriteInline<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter,
                                               is_leader, qpn, val, raddr, rkey, bytes);
   } else if constexpr (PrvdType == core::ProviderType::BNXT) {
@@ -1884,7 +1848,6 @@ inline __device__ void ShmemPutSizeImmNbiThreadKernelAddrImpl(const void* dest, 
     dbr_val = core::PostWriteInline<PrvdType>(*wq, my_sq_counter, my_msntbl_counter, my_psn_counter,
                                               is_leader, qpn, val, raddr, rkey, bytes);
   } else if constexpr (PrvdType == core::ProviderType::PSD) {
-    wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
     dbr_val = core::PostWriteInline<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter,
                                               is_leader, qpn, val, raddr, rkey, bytes);
   } else {
@@ -2090,7 +2053,6 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelAddrImpl(
     // Post RDMA write for this chunk
     uint64_t dbr_val;
     if constexpr (PrvdType == core::ProviderType::MLX5) {
-      wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
       dbr_val = core::PostWrite<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter, false,
                                           qpn, srcAddr, lkey, raddr, rkey, transfer_size);
     } else if constexpr (PrvdType == core::ProviderType::BNXT) {
@@ -2098,7 +2060,6 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelAddrImpl(
       dbr_val = core::PostWrite<PrvdType>(*wq, my_sq_counter, my_msntbl_counter, my_psn_counter,
                                           false, qpn, srcAddr, lkey, raddr, rkey, transfer_size);
     } else if constexpr (PrvdType == core::ProviderType::PSD) {
-      wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
       dbr_val = core::PostWrite<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter, false,
                                           qpn, srcAddr, lkey, raddr, rkey, transfer_size);
     } else {
@@ -2112,7 +2073,6 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelAddrImpl(
         bool should_signal = onlyOneSignal ? is_leader : true;
         if (should_signal) {
           if constexpr (PrvdType == core::ProviderType::MLX5) {
-            wq->outstandingWqe[(my_sq_counter + 1) % OUTSTANDING_TABLE_SIZE] = my_sq_counter + 1;
             dbr_val = core::PostWriteInline<PrvdType>(
                 *wq, my_sq_counter + 1, my_sq_counter + 1, my_sq_counter + 1, is_leader, qpn,
                 &signalValue, signalRaddr, signalRkey, sizeof(signalValue));
@@ -2122,7 +2082,6 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelAddrImpl(
                 *wq, my_sq_counter + 1, my_msntbl_counter + 1, my_psn_counter + psnCnt, is_leader,
                 qpn, &signalValue, signalRaddr, signalRkey, sizeof(signalValue));
           } else if constexpr (PrvdType == core::ProviderType::PSD) {
-            wq->outstandingWqe[(my_sq_counter + 1) % OUTSTANDING_TABLE_SIZE] = my_sq_counter + 1;
             dbr_val = core::PostWriteInline<PrvdType>(
                 *wq, my_sq_counter + 1, my_sq_counter + 1, my_sq_counter + 1, is_leader, qpn,
                 &signalValue, signalRaddr, signalRkey, sizeof(signalValue));
@@ -2134,7 +2093,6 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelAddrImpl(
         bool should_signal = onlyOneSignal ? is_leader : true;
         if (should_signal) {
           if constexpr (PrvdType == core::ProviderType::MLX5) {
-            wq->outstandingWqe[(my_sq_counter + 1) % OUTSTANDING_TABLE_SIZE] = my_sq_counter + 1;
             dbr_val = core::PostAtomic<PrvdType>(
                 *wq, my_sq_counter + 1, my_sq_counter + 1, my_sq_counter + 1, is_leader, qpn,
                 ibuf->addr, ibuf->lkey, signalRaddr, signalRkey, &signalValue, &signalValue,
@@ -2146,7 +2104,6 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelAddrImpl(
                 qpn, ibuf->addr, ibuf->lkey, signalRaddr, signalRkey, &signalValue, &signalValue,
                 sizeof(signalValue), core::atomicType::AMO_ADD);
           } else if constexpr (PrvdType == core::ProviderType::PSD) {
-            wq->outstandingWqe[(my_sq_counter + 1) % OUTSTANDING_TABLE_SIZE] = my_sq_counter + 1;
             dbr_val = core::PostAtomic<PrvdType>(
                 *wq, my_sq_counter + 1, my_sq_counter + 1, my_sq_counter + 1, is_leader, qpn,
                 ibuf->addr, ibuf->lkey, signalRaddr, signalRkey, &signalValue, &signalValue,
@@ -2357,12 +2314,8 @@ inline __device__ void ShmemAtomicSizeNonFetchThreadKernelAddrImpl(const void* d
     ShmemQuietThreadKernelImpl<PrvdType>(pe, qpId);
   }
 
-  if constexpr (PrvdType == core::ProviderType::MLX5) {
-    wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
-  } else if constexpr (PrvdType == core::ProviderType::BNXT) {
+  if constexpr (PrvdType == core::ProviderType::BNXT) {
     wq->outstandingWqe[my_sq_counter % wq->sqWqeNum] = my_sq_counter;
-  } else if constexpr (PrvdType == core::ProviderType::PSD) {
-    wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
   }
 
   uint64_t dbr_val;
@@ -2513,12 +2466,8 @@ inline __device__ T ShmemAtomicTypeFetchThreadKernelAddrImpl(const void* dest, v
     ShmemQuietThreadKernelImpl<PrvdType>(pe, qpId);
   }
 
-  if constexpr (PrvdType == core::ProviderType::MLX5) {
-    wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
-  } else if constexpr (PrvdType == core::ProviderType::BNXT) {
+  if constexpr (PrvdType == core::ProviderType::BNXT) {
     wq->outstandingWqe[my_sq_counter % wq->sqWqeNum] = my_sq_counter;
-  } else if constexpr (PrvdType == core::ProviderType::PSD) {
-    wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
   }
 
   uint64_t dbr_val;
@@ -2736,7 +2685,6 @@ inline __device__ void ShmemGetMemNbiThreadKernelImpl(const application::SymmMem
 
     uint64_t dbr_val;
     if constexpr (PrvdType == core::ProviderType::MLX5) {
-      wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
       dbr_val =
           core::PostRead<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter, is_leader, qpn,
                                    destAddr, lkey, raddr, rkey, transfer_size);
@@ -2746,7 +2694,6 @@ inline __device__ void ShmemGetMemNbiThreadKernelImpl(const application::SymmMem
           core::PostRead<PrvdType>(*wq, my_sq_counter, my_msntbl_counter, my_psn_counter, is_leader,
                                    qpn, destAddr, lkey, raddr, rkey, transfer_size);
     } else if constexpr (PrvdType == core::ProviderType::PSD) {
-      wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
       dbr_val =
           core::PostRead<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter, is_leader, qpn,
                                    destAddr, lkey, raddr, rkey, transfer_size);
@@ -2951,7 +2898,6 @@ inline __device__ void ShmemGetMemNbiThreadKernelAddrImpl(void* dest, const void
 
     uint64_t dbr_val;
     if constexpr (PrvdType == core::ProviderType::MLX5) {
-      wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
       dbr_val =
           core::PostRead<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter, is_leader, qpn,
                                    destAddr, lkey, raddr, rkey, transfer_size);
@@ -2961,7 +2907,6 @@ inline __device__ void ShmemGetMemNbiThreadKernelAddrImpl(void* dest, const void
           core::PostRead<PrvdType>(*wq, my_sq_counter, my_msntbl_counter, my_psn_counter, is_leader,
                                    qpn, destAddr, lkey, raddr, rkey, transfer_size);
     } else if constexpr (PrvdType == core::ProviderType::PSD) {
-      wq->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
       dbr_val =
           core::PostRead<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter, is_leader, qpn,
                                    destAddr, lkey, raddr, rkey, transfer_size);

--- a/src/application/transport/rdma/providers/mlx5/mlx5.cpp
+++ b/src/application/transport/rdma/providers/mlx5/mlx5.cpp
@@ -88,12 +88,14 @@ Mlx5CqContainer::Mlx5CqContainer(ibv_context* context, const RdmaEndpointConfig&
   // TODO: adjust cqe_num after aligning?
   cqSize = (cqSize + config.alignment - 1) / config.alignment * config.alignment;
 
+  // Init CQ buffer to 0xff so wqe_counter reads 0xffff ("nothing completed")
+  // until the NIC writes a real completion (zero-init would look like WQE 0 done).
   if (config.onGpu) {
-    HIP_RUNTIME_CHECK(hipMalloc(&cqUmemAddr, cqSize));
-    HIP_RUNTIME_CHECK(hipMemset(cqUmemAddr, 0, cqSize));
+    HIP_RUNTIME_CHECK(hipExtMallocWithFlags(&cqUmemAddr, cqSize, hipDeviceMallocUncached));
+    HIP_RUNTIME_CHECK(hipMemset(cqUmemAddr, 0xff, cqSize));
   } else {
     int status = posix_memalign(&cqUmemAddr, config.alignment, cqSize);
-    memset(cqUmemAddr, 0, cqSize);
+    memset(cqUmemAddr, 0xff, cqSize);
     assert(!status);
   }
 
@@ -102,7 +104,7 @@ Mlx5CqContainer::Mlx5CqContainer(ibv_context* context, const RdmaEndpointConfig&
 
   // Allocate user memory for CQ DBR (doorbell?)
   if (config.onGpu) {
-    HIP_RUNTIME_CHECK(hipMalloc(&cqDbrUmemAddr, 8));
+    HIP_RUNTIME_CHECK(hipExtMallocWithFlags(&cqDbrUmemAddr, 8, hipDeviceMallocUncached));
     HIP_RUNTIME_CHECK(hipMemset(cqDbrUmemAddr, 0, 8));
   } else {
     int status = posix_memalign(&cqDbrUmemAddr, 8, 8);
@@ -126,6 +128,12 @@ Mlx5CqContainer::Mlx5CqContainer(ibv_context* context, const RdmaEndpointConfig&
   void* cq_context = DEVX_ADDR_OF(create_cq_in, cmd_in, cq_context);
   DEVX_SET(cqc, cq_context, dbr_umem_valid, 0x1);
   DEVX_SET(cqc, cq_context, dbr_umem_id, cqDbrUmem->umem_id);
+  // Collapsed CQ: cc=1 collapses all completions into CQE slot 0, oi=1 ignores
+  // overrun (no CQ consumer doorbell); progress is tracked via CQE[0].wqe_counter.
+  // cqe_sz=0 selects 64B CQEs.
+  DEVX_SET(cqc, cq_context, cqe_sz, 0x0);
+  DEVX_SET(cqc, cq_context, cc, 0x1);
+  DEVX_SET(cqc, cq_context, oi, 0x1);
   DEVX_SET(cqc, cq_context, log_cq_size, LogCeil2(cqeNum));
   DEVX_SET(cqc, cq_context, uar_page, uar->page_id);
 
@@ -225,7 +233,7 @@ void Mlx5QpContainer::CreateQueuePair(uint32_t cqn, uint32_t pdn) {
   // Allocate user memory for QP
 
   if (config.onGpu) {
-    HIP_RUNTIME_CHECK(hipMalloc(&qpUmemAddr, qpTotalSize));
+    HIP_RUNTIME_CHECK(hipExtMallocWithFlags(&qpUmemAddr, qpTotalSize, hipDeviceMallocUncached));
     HIP_RUNTIME_CHECK(hipMemset(qpUmemAddr, 0, qpTotalSize));
   } else {
     status = posix_memalign(&qpUmemAddr, config.alignment, qpTotalSize);
@@ -239,7 +247,7 @@ void Mlx5QpContainer::CreateQueuePair(uint32_t cqn, uint32_t pdn) {
 
   // Allocate user memory for DBR (doorbell?)
   if (config.onGpu) {
-    HIP_RUNTIME_CHECK(hipMalloc(&qpDbrUmemAddr, 8));
+    HIP_RUNTIME_CHECK(hipExtMallocWithFlags(&qpDbrUmemAddr, 8, hipDeviceMallocUncached));
     HIP_RUNTIME_CHECK(hipMemset(qpDbrUmemAddr, 0, 8));
   } else {
     status = posix_memalign(&qpDbrUmemAddr, 8, 8);
@@ -254,7 +262,8 @@ void Mlx5QpContainer::CreateQueuePair(uint32_t cqn, uint32_t pdn) {
   // Allocate and register atomic internal buffer (ibuf)
   atomicIbufSize = (RoundUpPowOfTwo(config.atomicIbufSlots) + 1) * ATOMIC_IBUF_SLOT_SIZE;
   if (config.onGpu) {
-    HIP_RUNTIME_CHECK(hipMalloc(&atomicIbufAddr, atomicIbufSize));
+    HIP_RUNTIME_CHECK(
+        hipExtMallocWithFlags(&atomicIbufAddr, atomicIbufSize, hipDeviceMallocUncached));
     HIP_RUNTIME_CHECK(hipMemset(atomicIbufAddr, 0, atomicIbufSize));
   } else {
     status = posix_memalign(&atomicIbufAddr, config.alignment, atomicIbufSize);
@@ -451,9 +460,8 @@ void Mlx5QpContainer::ModifyInit2Rtr(const RdmaEndpointHandle& local_handle,
            sizeof(remote_handle.eth.mac));
     DEVX_SET(qpc, qpc, primary_address_path.hop_limit, 64);
     DEVX_SET(qpc, qpc, primary_address_path.src_addr_index, local_handle.eth.gidIdx);
-    // UDP sport: default to a single fixed RoCEv2 sport (NVSHMEM-style, == 0xC000
-    // on RoCE). MORI_MLX5_ENABLE_UDP_SPORT=1 rotates per-qpId (GetUdpSport) for
-    // ECMP spread.
+    // UDP sport: default to a single fixed RoCEv2 sport (== 0xC000 on RoCE).
+    // MORI_MLX5_ENABLE_UDP_SPORT=1 rotates per-qpId (GetUdpSport) for ECMP spread.
     static const bool enableUdpSport = []() {
       const char* e = std::getenv("MORI_MLX5_ENABLE_UDP_SPORT");
       return e != nullptr && std::atoi(e) != 0;

--- a/src/ops/dispatch_combine/dispatch_combine.cpp
+++ b/src/ops/dispatch_combine/dispatch_combine.cpp
@@ -218,11 +218,15 @@ void EpDispatchCombineHandle::InitializeShmemBuf() {
                              config.MaxXferBytesPerToken();
     size_t stagingSize = static_cast<ssize_t>(2 * nNodes) * config.MaxNumTokensToSendPerRank() *
                          config.MaxXferBytesPerToken();
+    size_t dispatchStagingSize =
+        static_cast<ssize_t>(config.MaxNumTokensToSendPerRank()) * config.MaxXferBytesPerToken();
     bufs.dispatchInp = ShmemMallocAndReturnMemObjPtr(dispatchInpSize, hipDeviceMallocUncached);
     bufs.combineInp = ShmemMallocAndReturnMemObjPtr(maxStagingSize, hipDeviceMallocUncached);
     bufs.staging = ShmemMallocAndReturnMemObjPtr(stagingSize, hipDeviceMallocUncached);
     bufs.dispatchOut = ShmemMallocAndReturnMemObjPtr(dispatchOutSize, hipDeviceMallocUncached);
     bufs.combineOut = ShmemMallocAndReturnMemObjPtr(combineOutSize, hipDeviceMallocUncached);
+    bufs.dispatchStaging =
+        ShmemMallocAndReturnMemObjPtr(dispatchStagingSize, hipDeviceMallocUncached);
   } else {
     auto& bufs = shmemTokBufs.emplace<ShmemBufsInterNode>();
     // NOTE(ditian12): no overflow protection for dispatchInp/combinInp/staging in async kernel,
@@ -291,6 +295,7 @@ void EpDispatchCombineHandle::FinalizeShmemBuf() {
     ShmemFree(bufs.dispatchOut->localPtr);
     ShmemFree(bufs.combineOut->localPtr);
     ShmemFree(bufs.staging->localPtr);
+    ShmemFree(bufs.dispatchStaging->localPtr);
   } else {
     auto& bufs = std::get<ShmemBufsInterNode>(shmemTokBufs);
     ShmemFree(bufs.dispatchInp->localPtr);

--- a/src/ops/dispatch_combine/internode_v1.cpp
+++ b/src/ops/dispatch_combine/internode_v1.cpp
@@ -200,7 +200,7 @@ inline __device__ void DispatchInterNodeSend(EpDispatchCombineArgs<T>& args) {
             int qpId = (tokenId / warpSize) % config.numQpPerPe;
             shmem::ShmemPutMemNbiSignalThread(
                 args.interNodeV1TokBufs.dispatchInp, remoteIdx * xferBytes,
-                args.interNodeV1TokBufs.staging, stagingTokOffset, count * xferBytes,
+                args.interNodeV1TokBufs.dispatchStaging, stagingTokOffset, count * xferBytes,
                 args.interNodeChunkFlagMemObj,
                 (myNode * maxChunkNum + flagSlotId) * sizeof(uint64_t), flag,
                 core::atomicType::AMO_ADD, proxyPe, qpId);
@@ -236,7 +236,7 @@ inline __device__ void DispatchInterNodeSend(EpDispatchCombineArgs<T>& args) {
           int qpId = (tokenId / warpSize) % config.numQpPerPe;
           shmem::ShmemPutMemNbiSignalThread(
               args.interNodeV1TokBufs.dispatchInp, remoteIdx * xferBytes,
-              args.interNodeV1TokBufs.staging, stagingTokOffset, tokenNum * xferBytes,
+              args.interNodeV1TokBufs.dispatchStaging, stagingTokOffset, tokenNum * xferBytes,
               args.interNodeChunkFlagMemObj, (myNode * maxChunkNum + flagSlotId) * sizeof(uint64_t),
               tokenNum + 1, core::atomicType::AMO_ADD, proxyPe, qpId);
         }
@@ -308,7 +308,7 @@ inline __device__ void DispatchInterNodeLLSend(EpDispatchCombineArgs<T>& args) {
 
         shmem::ShmemPutMemNbiSignalThread(
             args.interNodeV1TokBufs.dispatchInp, remoteIdx * xferBytes,
-            args.interNodeV1TokBufs.staging, stagingTokOffset, tokenNum * xferBytes,
+            args.interNodeV1TokBufs.dispatchStaging, stagingTokOffset, tokenNum * xferBytes,
             args.interNodeChunkFlagMemObj, (myNode * maxChunkNum + flagSlotId) * sizeof(uint64_t),
             tokenNum + 1, core::atomicType::AMO_ADD, proxyPe, qpId);
       }
@@ -624,7 +624,7 @@ __device__ void EpDispatchCopyToStaging_body(EpDispatchCombineArgs<T> args) {
     size_t hiddenDimOffset, hiddenDimSize;
     mwIter.Decode(i, tokenId, inTokenPartId, hiddenDimOffset, hiddenDimSize);
 
-    uint8_t* stagingPtr = args.interNodeV1TokBufs.staging->template GetAs<uint8_t*>();
+    uint8_t* stagingPtr = args.interNodeV1TokBufs.dispatchStaging->template GetAs<uint8_t*>();
     size_t stagingTokOffset = tokenId * xferBytes;
     core::WarpCopy<uint8_t, 4>(stagingPtr + stagingTokOffset + hiddenDimOffset * sizeof(T),
                                reinterpret_cast<uint8_t*>(args.inpTokenBuf) +


### PR DESCRIPTION
## Summary

Two related changes to the mlx5 internode-v1 dispatch/combine path: a collapsed-CQ completion path for the IBGDA quiet, and a fix for a silent data-corruption bug that only showed up on mlx5 under high pressure.

## 1. Collapsed CQ (cc=1 / oi=1) completion tracking

The NIC collapses every completion into a single CQE slot (overrun ignored, so there is no per-CQE consumer ring and no CQ consumer doorbell to maintain). The device advances `wq.doneIdx` purely from `CQE[0].wqe_counter`, reconstructing the 32-bit completion from the 16-bit counter against `doneIdx` (a guaranteed lower bound, since outstanding < sqWqeNum < 65536). `atomicMax` on `doneIdx` keeps it lock-free and multi-warp safe.

- Final per-pe quiet waits for the live `postIdx` (every reserved WQE completed); the SQ recycle gate keeps a cheap snapshot drain (a live drain there would self-deadlock, since the gated warp already holds its own un-doorbelled reservation).
- CQ buffer is initialized to `0xff` so `wqe_counter` reads `0xffff` ("nothing completed") until the NIC writes a real completion.
- The GPU-resident control structures (CQ, both doorbell records, QP, atomic ibuf) are allocated uncached for NIC↔GPU coherence.
- Device-scope fences in the drain (it only touches the uncached CQ and the GPU-only `doneIdx`); dead `outstandingWqe` writes removed on the mlx5/psd providers.

## 2. Fix silent data corruption

The inter-node dispatch send is non-blocking and reads its payload from `staging`. The same iteration's combine phase then writes its accumulation results back into `staging` (an overlapping region). Under load the NIC could still be DMA-reading `staging` for the dispatch send when combine overwrote it, so combine's activation data was sent into a peer's `dispatchInp` — silent corruption (zero CQE errors, no loss/reorder), reproducible only on mlx5-RoCE under high pressure (qp1 and qp4), independent of congestion (persisted even at zero ECN).

Fix: dispatch gets its own send-source buffer `dispatchStaging`, filled by `EpDispatchCopyToStaging` and read by the send, which combine never writes — removing the reuse hazard entirely.

## Validation

- 2-node mlx5-RoCE, EP16 bench/stress mode, SL=0 / TC=41: qp1 / qp2 / qp4 all PASS at 50000 iterations 