### PR TITLE
feat(rdma): load libibverbs at runtime via dlopen instead of linking

### DIFF
--- a/docs/MORI-IO-GUIDE.md
+++ b/docs/MORI-IO-GUIDE.md
@@ -174,6 +174,7 @@ See `examples/io/example.py` for more complete examples including batch transfer
 | `RdmaBackendConfig.max_chunks_per_transfer` | Cap on chunks per transfer to bound WR/SQ usage (default `64`). Env: `MORI_IO_MAX_CHUNKS` |
 | `RdmaBackendConfig.num_nics_per_transfer` | Stripe a transfer across this many NICs (default `1`). Adaptive by memory type: GPU memory stays single-NIC (PCIe-bound); host memory stripes across NUMA-local NICs. Env: `MORI_IO_NUM_NICS_PER_TRANSFER` |
 | `IOEngineConfig.port = 0` | Auto-bind to a free port |
+| `MORI_IBVERBS_LIB` | Path/soname of libibverbs to `dlopen` at runtime — MORI-IO loads libibverbs dynamically rather than linking it. Set to point at an out-of-tree libibverbs; defaults to `libibverbs.so` / `libibverbs.so.1`. |
 
 UMBP (the upper-layer cache pool) exposes a separate set of runtime-tunable
 env vars for distributed master / pool client / SPDK proxy timing. Those are

--- a/docs/MORI-SHMEM-GUIDE.md
+++ b/docs/MORI-SHMEM-GUIDE.md
@@ -295,6 +295,7 @@ This copies the current GPU states to the `globalGpuStates` symbol in the dynami
 | `MORI_SHMEM_VMM_CHUNK_SIZE` | VMM mode chunk size in bytes | Auto |
 | `MORI_SOCKET_IFNAME` | Network interface for shmem bootstrap TCP connections (e.g., `"lo"`, `"eth0"`) | Auto-detect |
 | `MORI_RDMA_DEVICES` | RDMA NIC selection. Include: `mlx5_0,mlx5_1`. Exclude: `^mlx5_2,mlx5_3` | All available |
+| `MORI_IBVERBS_LIB` | Path/soname of libibverbs to `dlopen` at runtime (mori loads libibverbs dynamically instead of linking it). Set this to point at an out-of-tree libibverbs. | `libibverbs.so` / `libibverbs.so.1` |
 | `MORI_NUM_QP_PER_PE` | Number of RDMA queue pairs per PE | `1` |
 | `MORI_IB_GID_INDEX` | InfiniBand GID index for RDMA connections | Auto-detect |
 | `MORI_RDMA_SL` | RDMA service level | Auto |

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -152,8 +152,8 @@ add_library(
 target_include_directories(
   mori_shmem_for_siof_static PUBLIC ${CMAKE_SOURCE_DIR}/include
                                     ${CMAKE_SOURCE_DIR})
-target_link_libraries(mori_shmem_for_siof_static
-                      PUBLIC mori_application mori_logging ibverbs hip::host)
+target_link_libraries(mori_shmem_for_siof_static PUBLIC mori_application
+                                                        mori_logging hip::host)
 
 add_executable(static_link_siof_test shmem/static_link_siof_test.cpp)
 

--- a/src/application/CMakeLists.txt
+++ b/src/application/CMakeLists.txt
@@ -67,6 +67,20 @@ list(
   topology/pci.cpp
   topology/system.cpp)
 
+# libibverbs is loaded at runtime via dlopen (see ibv_shim.cpp), not linked. The
+# shim is built as an object library with hidden visibility so every mori shared
+# object that touches the verbs API embeds its own private copy and never
+# interposes a real libibverbs that may also be present in the process.
+add_library(mori_ibv_shim OBJECT transport/rdma/providers/ibverbs/ibv_shim.cpp)
+set_source_files_properties(transport/rdma/providers/ibverbs/ibv_shim.cpp
+                            PROPERTIES LANGUAGE CXX)
+target_include_directories(mori_ibv_shim PRIVATE ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(mori_ibv_shim PRIVATE mori_logging)
+target_link_libraries(mori_ibv_shim PRIVATE dl)
+target_compile_options(mori_ibv_shim PRIVATE -fvisibility=hidden
+                                             -fvisibility-inlines-hidden)
+set_target_properties(mori_ibv_shim PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 set_source_files_properties(${MORI_APP_SOURCES} PROPERTIES LANGUAGE CXX)
 add_library(mori_application SHARED ${MORI_APP_SOURCES})
 
@@ -76,14 +90,15 @@ find_library(ROCM_SMI_LIB rocm_smi64 HINTS /opt/rocm/lib REQUIRED)
 find_library(HSA_RUNTIME_LIB hsa-runtime64 HINTS /opt/rocm/lib REQUIRED)
 target_link_libraries(
   mori_application
-  PUBLIC ibverbs
-         hip::host
+  PUBLIC hip::host
          dl
          ${ROCM_SMI_LIB}
          pci
          mori_logging
          ${HSA_RUNTIME_LIB}
          hsakmt::hsakmt)
+# Embed the libibverbs dlopen shim (object library, hidden visibility).
+target_link_libraries(mori_application PRIVATE mori_ibv_shim)
 
 if(WITH_MPI)
   target_compile_definitions(mori_application PUBLIC MORI_WITH_MPI)

--- a/src/application/transport/rdma/providers/ibverbs/ibv_shim.cpp
+++ b/src/application/transport/rdma/providers/ibverbs/ibv_shim.cpp
@@ -1,0 +1,259 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Runtime shim for the core libibverbs API.
+//
+// Historically mori linked libibverbs at build time (-libverbs). This file
+// removes that link-time dependency: it defines every core ibv_* symbol that
+// mori references and forwards each call to libibverbs.so.1, which is dlopen()ed
+// lazily on first use. This mirrors the dlopen approach already used for the
+// vendor direct-verbs libraries (libmlx5 / libbnxt_re / libionic) in
+// dv_loader.cpp.
+//
+// Why this works without touching any call site:
+//   * The plain ibv_* functions mori calls (ibv_alloc_pd, ibv_create_qp, ...)
+//     resolve to the definitions below.
+//   * The static-inline / macro wrappers in <infiniband/verbs.h>
+//     (ibv_reg_mr, ibv_query_port, ibv_query_gid_ex, ibv_create_qp_ex,
+//     ibv_query_device_ex, ...) ultimately call a handful of real symbols
+//     (ibv_reg_mr, ibv_reg_mr_iova2, ibv_query_port, _ibv_query_gid_ex,
+//     ibv_create_qp, ibv_query_device); those are provided here too.
+//   * The remaining inline helpers (ibv_post_send, ibv_poll_cq, ...) dispatch
+//     through context/qp op tables and need no external symbol at all.
+//
+// All symbols defined here are compiled with hidden visibility (see CMake) so
+// each mori shared object carries its own private copy and we never interpose a
+// real libibverbs that may also be present in the process (e.g. via RCCL).
+
+// dlvsym() (used to pin the libibverbs ABI version, see IbvSym) is a GNU
+// extension and is only declared by <dlfcn.h> when _GNU_SOURCE is set.
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <dlfcn.h>
+#include <infiniband/verbs.h>
+
+#include <cerrno>
+#include <cstdlib>
+
+#include "mori/utils/mori_log.hpp"
+
+// <infiniband/verbs.h> defines ibv_reg_mr and ibv_query_port as function-like
+// macros. Undefine them so we can define the underlying real symbols that those
+// macros (and the header's inline wrappers) expand to.
+#undef ibv_reg_mr
+#undef ibv_query_port
+
+namespace {
+
+// Lazily dlopen libibverbs once. Order (mirrors NCCL): MORI_IBVERBS_LIB override,
+// then the unversioned and versioned sonames. Returns nullptr if none is found,
+// in which case every shim degrades to a failure return so that RDMA discovery /
+// setup fails gracefully instead of crashing on a host without RDMA.
+void* IbvHandle() {
+  static void* handle = [] {
+    const char* libs[] = {std::getenv("MORI_IBVERBS_LIB"), "libibverbs.so", "libibverbs.so.1"};
+    for (const char* lib : libs) {
+      if (!lib || !*lib) continue;
+      void* h = dlopen(lib, RTLD_LAZY | RTLD_LOCAL);
+      if (h) {
+        MORI_APP_TRACE("dlopen({}) succeeded", lib);
+        return h;
+      }
+      MORI_APP_TRACE("dlopen({}) failed: {}", lib, dlerror());
+    }
+    MORI_APP_WARN("failed to dlopen libibverbs (set MORI_IBVERBS_LIB to override)");
+    return static_cast<void*>(nullptr);
+  }();
+  return handle;
+}
+
+// Resolve a symbol, preferring the exact ABI version (like NCCL's dlvsym usage)
+// for determinism across libibverbs revisions, and falling back to the default /
+// unversioned symbol so we never regress when a version string does not match
+// (e.g. ibv_create_comp_channel only exists as IBVERBS_1.0 on some builds).
+void* IbvSym(const char* name, const char* version) {
+  void* h = IbvHandle();
+  if (!h) return nullptr;
+  dlerror();  // clear any stale error before the lookups (dl* API contract)
+  void* sym = dlvsym(h, name, version);
+  if (!sym) sym = dlsym(h, name);
+  if (!sym) {
+    const char* err = dlerror();
+    MORI_APP_WARN("failed to resolve {}: {}", name, err ? err : "symbol not found");
+  }
+  return sym;
+}
+
+// Failure value for a shim whose symbol could not be resolved. Set errno so
+// callers that log it (e.g. RDMA MR registration paths) get an explicit reason
+// instead of a stale/irrelevant value, mirroring how libibverbs reports errors.
+template <typename T>
+T IbvUnavailable(T fail) {
+  errno = ENOSYS;
+  return fail;
+}
+
+}  // namespace
+
+// Resolve a symbol once per shim (function-local static init is thread-safe) and
+// reuse the cached pointer. decltype(&name) yields the exact function-pointer
+// type from the verbs.h declaration, so the forwarding stays type-checked. The
+// version string is the symbol's libibverbs ABI version (see IbvSym).
+#define MORI_IBV_RESOLVE(name, version) \
+  static auto fn = reinterpret_cast<decltype(&name)>(IbvSym(#name, version))
+
+extern "C" {
+
+// ---- device enumeration -----------------------------------------------------
+struct ibv_device** ibv_get_device_list(int* num_devices) {
+  MORI_IBV_RESOLVE(ibv_get_device_list, "IBVERBS_1.1");
+  if (!fn) {
+    // Match libibverbs: report zero devices so callers reading the out-param
+    // (e.g. RdmaContext::nums_device) don't observe an uninitialized count.
+    if (num_devices) *num_devices = 0;
+    return IbvUnavailable<struct ibv_device**>(nullptr);
+  }
+  return fn(num_devices);
+}
+void ibv_free_device_list(struct ibv_device** list) {
+  MORI_IBV_RESOLVE(ibv_free_device_list, "IBVERBS_1.1");
+  if (fn) fn(list);
+}
+struct ibv_context* ibv_open_device(struct ibv_device* device) {
+  MORI_IBV_RESOLVE(ibv_open_device, "IBVERBS_1.1");
+  return fn ? fn(device) : IbvUnavailable<struct ibv_context*>(nullptr);
+}
+int ibv_close_device(struct ibv_context* context) {
+  MORI_IBV_RESOLVE(ibv_close_device, "IBVERBS_1.1");
+  return fn ? fn(context) : IbvUnavailable(-1);
+}
+
+// ---- protection domains -----------------------------------------------------
+struct ibv_pd* ibv_alloc_pd(struct ibv_context* context) {
+  MORI_IBV_RESOLVE(ibv_alloc_pd, "IBVERBS_1.1");
+  return fn ? fn(context) : IbvUnavailable<struct ibv_pd*>(nullptr);
+}
+int ibv_dealloc_pd(struct ibv_pd* pd) {
+  MORI_IBV_RESOLVE(ibv_dealloc_pd, "IBVERBS_1.1");
+  return fn ? fn(pd) : IbvUnavailable(-1);
+}
+
+// ---- memory regions ---------------------------------------------------------
+struct ibv_mr* ibv_reg_mr(struct ibv_pd* pd, void* addr, size_t length, int access) {
+  MORI_IBV_RESOLVE(ibv_reg_mr, "IBVERBS_1.1");
+  return fn ? fn(pd, addr, length, access) : IbvUnavailable<struct ibv_mr*>(nullptr);
+}
+struct ibv_mr* ibv_reg_mr_iova2(struct ibv_pd* pd, void* addr, size_t length, uint64_t iova,
+                                unsigned int access) {
+  MORI_IBV_RESOLVE(ibv_reg_mr_iova2, "IBVERBS_1.8");
+  return fn ? fn(pd, addr, length, iova, access) : IbvUnavailable<struct ibv_mr*>(nullptr);
+}
+struct ibv_mr* ibv_reg_dmabuf_mr(struct ibv_pd* pd, uint64_t offset, size_t length, uint64_t iova,
+                                 int fd, int access) {
+  MORI_IBV_RESOLVE(ibv_reg_dmabuf_mr, "IBVERBS_1.12");
+  return fn ? fn(pd, offset, length, iova, fd, access) : IbvUnavailable<struct ibv_mr*>(nullptr);
+}
+int ibv_dereg_mr(struct ibv_mr* mr) {
+  MORI_IBV_RESOLVE(ibv_dereg_mr, "IBVERBS_1.1");
+  return fn ? fn(mr) : IbvUnavailable(-1);
+}
+
+// ---- completion channels / queues -------------------------------------------
+// NB: ibv_create/destroy_comp_channel are only versioned IBVERBS_1.0.
+struct ibv_comp_channel* ibv_create_comp_channel(struct ibv_context* context) {
+  MORI_IBV_RESOLVE(ibv_create_comp_channel, "IBVERBS_1.0");
+  return fn ? fn(context) : IbvUnavailable<struct ibv_comp_channel*>(nullptr);
+}
+int ibv_destroy_comp_channel(struct ibv_comp_channel* channel) {
+  MORI_IBV_RESOLVE(ibv_destroy_comp_channel, "IBVERBS_1.0");
+  return fn ? fn(channel) : IbvUnavailable(-1);
+}
+struct ibv_cq* ibv_create_cq(struct ibv_context* context, int cqe, void* cq_context,
+                             struct ibv_comp_channel* channel, int comp_vector) {
+  MORI_IBV_RESOLVE(ibv_create_cq, "IBVERBS_1.1");
+  return fn ? fn(context, cqe, cq_context, channel, comp_vector)
+            : IbvUnavailable<struct ibv_cq*>(nullptr);
+}
+int ibv_destroy_cq(struct ibv_cq* cq) {
+  MORI_IBV_RESOLVE(ibv_destroy_cq, "IBVERBS_1.1");
+  return fn ? fn(cq) : IbvUnavailable(-1);
+}
+int ibv_get_cq_event(struct ibv_comp_channel* channel, struct ibv_cq** cq, void** cq_context) {
+  MORI_IBV_RESOLVE(ibv_get_cq_event, "IBVERBS_1.1");
+  return fn ? fn(channel, cq, cq_context) : IbvUnavailable(-1);
+}
+void ibv_ack_cq_events(struct ibv_cq* cq, unsigned int nevents) {
+  MORI_IBV_RESOLVE(ibv_ack_cq_events, "IBVERBS_1.1");
+  if (fn) fn(cq, nevents);
+}
+
+// ---- queue pairs / shared receive queues ------------------------------------
+struct ibv_qp* ibv_create_qp(struct ibv_pd* pd, struct ibv_qp_init_attr* qp_init_attr) {
+  MORI_IBV_RESOLVE(ibv_create_qp, "IBVERBS_1.1");
+  return fn ? fn(pd, qp_init_attr) : IbvUnavailable<struct ibv_qp*>(nullptr);
+}
+int ibv_destroy_qp(struct ibv_qp* qp) {
+  MORI_IBV_RESOLVE(ibv_destroy_qp, "IBVERBS_1.1");
+  return fn ? fn(qp) : IbvUnavailable(-1);
+}
+int ibv_modify_qp(struct ibv_qp* qp, struct ibv_qp_attr* attr, int attr_mask) {
+  MORI_IBV_RESOLVE(ibv_modify_qp, "IBVERBS_1.1");
+  return fn ? fn(qp, attr, attr_mask) : IbvUnavailable(-1);
+}
+struct ibv_srq* ibv_create_srq(struct ibv_pd* pd, struct ibv_srq_init_attr* srq_init_attr) {
+  MORI_IBV_RESOLVE(ibv_create_srq, "IBVERBS_1.1");
+  return fn ? fn(pd, srq_init_attr) : IbvUnavailable<struct ibv_srq*>(nullptr);
+}
+int ibv_destroy_srq(struct ibv_srq* srq) {
+  MORI_IBV_RESOLVE(ibv_destroy_srq, "IBVERBS_1.1");
+  return fn ? fn(srq) : IbvUnavailable(-1);
+}
+
+// ---- device / port / gid queries --------------------------------------------
+int ibv_query_device(struct ibv_context* context, struct ibv_device_attr* device_attr) {
+  MORI_IBV_RESOLVE(ibv_query_device, "IBVERBS_1.1");
+  return fn ? fn(context, device_attr) : IbvUnavailable(-1);
+}
+int ibv_query_port(struct ibv_context* context, uint8_t port_num,
+                   struct _compat_ibv_port_attr* port_attr) {
+  MORI_IBV_RESOLVE(ibv_query_port, "IBVERBS_1.1");
+  return fn ? fn(context, port_num, port_attr) : IbvUnavailable(-1);
+}
+int ibv_query_gid(struct ibv_context* context, uint8_t port_num, int index, union ibv_gid* gid) {
+  MORI_IBV_RESOLVE(ibv_query_gid, "IBVERBS_1.1");
+  return fn ? fn(context, port_num, index, gid) : IbvUnavailable(-1);
+}
+int _ibv_query_gid_ex(struct ibv_context* context, uint32_t port_num, uint32_t gid_index,
+                      struct ibv_gid_entry* entry, uint32_t flags, size_t entry_size) {
+  MORI_IBV_RESOLVE(_ibv_query_gid_ex, "IBVERBS_1.11");
+  return fn ? fn(context, port_num, gid_index, entry, flags, entry_size) : IbvUnavailable(-1);
+}
+
+// ---- misc -------------------------------------------------------------------
+const char* ibv_wc_status_str(enum ibv_wc_status status) {
+  MORI_IBV_RESOLVE(ibv_wc_status_str, "IBVERBS_1.1");
+  return fn ? fn(status) : IbvUnavailable<const char*>("unknown (libibverbs unavailable)");
+}
+
+}  // extern "C"

--- a/src/application/transport/rdma/rdma.cpp
+++ b/src/application/transport/rdma/rdma.cpp
@@ -515,7 +515,12 @@ ActiveDevicePortList GetActiveDevicePortList(const RdmaDeviceList& devices) {
 RdmaContext::RdmaContext(RdmaBackendType backendType) : backendType(backendType) {
   deviceList = ibv_get_device_list(&nums_device);
   MORI_APP_TRACE("ibv_get_device_list nums_device: {}", nums_device);
-  Initialize();
+  // ibv_get_device_list returns nullptr when libibverbs cannot be loaded (see
+  // ibv_shim.cpp) or device enumeration fails. Treat this the same as "no RDMA
+  // devices": leave rdmaDeviceList empty instead of dereferencing a null array
+  // in Initialize(). Single-node / intranode runs need no RDMA device and the
+  // upper layers already handle an empty list gracefully.
+  if (deviceList != nullptr) Initialize();
 }
 
 RdmaContext::~RdmaContext() {

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -15,7 +15,10 @@ target_include_directories(mori_io PUBLIC ${CMAKE_SOURCE_DIR}/include)
 target_include_directories(mori_io PUBLIC ${CMAKE_SOURCE_DIR})
 target_include_directories(
   mori_io PUBLIC ${CMAKE_SOURCE_DIR}/3rdparty/msgpack-c/include)
-target_link_libraries(mori_io mori_application ibverbs hip::host mori_logging)
+# libibverbs is loaded at runtime via dlopen; embed the shim (hidden visibility)
+# so mori_io's own ibv_* references resolve without linking libibverbs.
+target_link_libraries(mori_io mori_application hip::host mori_logging
+                      mori_ibv_shim)
 target_compile_definitions(mori_io PUBLIC MSGPACK_NO_BOOST)
 set_target_properties(
   mori_io

--- a/src/shmem/CMakeLists.txt
+++ b/src/shmem/CMakeLists.txt
@@ -5,8 +5,9 @@ add_library(mori_shmem SHARED ${MORI_SHMEM_SOURCES})
 
 target_include_directories(mori_shmem PUBLIC ${CMAKE_SOURCE_DIR}/include)
 target_include_directories(mori_shmem PUBLIC ${CMAKE_SOURCE_DIR})
-target_link_libraries(mori_shmem PUBLIC mori_application mori_logging ibverbs
-                                        hip::host)
+# libibverbs is no longer linked: mori_shmem makes no direct verbs calls and the
+# dlopen shim is embedded in mori_application.
+target_link_libraries(mori_shmem PUBLIC mori_application mori_logging hip::host)
 
 if(MORI_MULTITHREAD_SUPPORT)
   target_compile_definitions(mori_shmem PUBLIC MORI_MULTITHREAD_SUPPORT)

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -21,7 +21,11 @@ add_executable(test_transport_ibverbs application/test_transport_ibverbs.cpp)
 target_include_directories(test_transport_ibverbs
                            PUBLIC ${CMAKE_SOURCE_DIR}/include)
 target_include_directories(test_transport_ibverbs PUBLIC ${CMAKE_SOURCE_DIR})
-target_link_libraries(test_transport_ibverbs mori_application)
+# This test calls libibverbs directly (e.g. ibv_get_cq_event); mori_application
+# no longer re-exports those symbols (they are dlopen'd internally). Link the
+# dlopen shim instead of the real libibverbs so BUILD_TESTS=ON does not
+# reintroduce a link-time dependency on a host without RDMA installed.
+target_link_libraries(test_transport_ibverbs mori_application mori_ibv_shim)
 
 if(BUILD_IO)
   add_executable(test_engine io/test_engine.cpp)


### PR DESCRIPTION
## What

mori previously linked libibverbs at build time (`-libverbs`). This removes the
link-time dependency so mori's shared objects load on hosts without RDMA
installed, failing only when RDMA is actually exercised.

`ibv_shim.cpp` defines every core `ibv_*` symbol mori references and forwards
each call to `libibverbs.so.1`, dlopen()ed lazily on first use — mirroring the
dlopen approach already used for the vendor direct-verbs libraries
(libmlx5/libbnxt_re/libionic) in `dv_loader.cpp`. **No call sites change**: the
verbs.h inline/macro wrappers resolve to the shim definitions.

Borrowing from NCCL's `ibvsymbols` loader:
- resolve each symbol with `dlvsym()` pinned to its exact libibverbs ABI version
  (IBVERBS_1.0/1.1/1.8/1.11/1.12), falling back to `dlsym()` so a version
  mismatch never regresses;
- honor a `MORI_IBVERBS_LIB` override;
- degrade gracefully when the library is absent.

The shim is built as an object library with **hidden visibility** and embedded
into `mori_application` and `mori_io`, so each `.so` carries its own private copy
and never interposes a real libibverbs that may also be present in the process
(e.g. via RCCL). Dropped the `ibverbs` link from `mori_application`, `mori_io`
and `mori_shmem`; the `test_transport_ibverbs` C++ test calls libibverbs
directly and now links it explicitly.

## Verification (Broadcom bnxt host, CI docker image)

- All three `libmori_*.so` have **no `NEEDED libibverbs`**, **no undefined
  `ibv_*` symbols**, and the 26 shims are **local/hidden** (none exported).
- `pip install .` succeeds; `import mori` OK; installed `.so` carry no libibverbs
  dependency.
- Runtime: RDMA device discovery finds all bnxt_re0–9 (dlvsym path, no fallback
  warnings); `MORI_DISABLE_P2P=ON mpirun -np 2 p2p_put_bw / p2p_get_bw` run the
  full RDMA data path at ~37 GB/s.
