### PR TITLE
test(io): add --target-dev-offset to MORI-IO benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,6 +435,7 @@ jobs:
             rdma_sl: 3
             rdma_tc: 104
             ct: podman
+            rail_only: true
           - platform: MI300X_BNXT
             runner: [self-hosted, MI300X-BNXT]
             node1_host: 10.245.128.61
@@ -446,6 +447,7 @@ jobs:
             rdma_sl: 3
             rdma_tc: 104
             ct: docker
+            rail_only: false
     env:
       CT: ${{ matrix.ct }}
       SSH_OPTS: -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
@@ -569,6 +571,36 @@ jobs:
             --enable-batch-transfer --enable-sess --poll_cq_mode event \
             --num-qp-per-transfer 2 \
             --num-initiator-dev 8 --num-target-dev 8
+          wait
+
+      - name: MORI-IO internode cross-rail (nic_select_by_dest_gpu)
+        if: ${{ matrix.rail_only }}
+        run: |
+          SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_io_benchmark.sh"
+          PORT=29123
+          # Rail-only fabric: pair initiator GPU i with target GPU (i+5)%8 so every
+          # transfer crosses rails (e.g. GPU0 -> GPU5). This only succeeds when
+          # MORI_IO_NIC_SELECT_BY_DEST_GPU=1 keeps both ends on the destination GPU's
+          # rail; without it the local NIC follows the source GPU and the QP would span
+          # two rails and fail on this fabric.
+          echo "=== MORI-IO internode benchmark: cross-rail write (offset 5) port=$PORT ==="
+          NODE2_CMD=(
+            $CT exec -e MORI_IO_NIC_SELECT_BY_DEST_GPU=1 $CONTAINER bash $SCRIPT
+            --rank 1 --master-addr $NODE1_HOST --master-port $PORT
+            --ifname $NODE2_IFNAME
+            -- --op-type write --buffer-size 4096 --transfer-batch-size 64 --iters 4
+            --enable-batch-transfer --enable-sess
+            --num-qp-per-transfer 2
+            --num-initiator-dev 8 --num-target-dev 8 --target-dev-offset 5
+          )
+          ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
+          $CT exec -e MORI_IO_NIC_SELECT_BY_DEST_GPU=1 $CONTAINER bash $SCRIPT \
+            --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
+            --ifname $NODE1_IFNAME \
+            -- --op-type write --buffer-size 4096 --transfer-batch-size 64 --iters 4 \
+            --enable-batch-transfer --enable-sess \
+            --num-qp-per-transfer 2 \
+            --num-initiator-dev 8 --num-target-dev 8 --target-dev-offset 5
           wait
 
       - name: MORI-IO internode CPU memory sweep (chunking + 4 NIC x 4 QP)

--- a/docs/MORI-IO-GUIDE.md
+++ b/docs/MORI-IO-GUIDE.md
@@ -173,6 +173,7 @@ See `examples/io/example.py` for more complete examples including batch transfer
 | `RdmaBackendConfig.chunk_bytes` | Chunk size when chunking is on (default `65536` = 64 KB). Messages ≤ this are unchanged. Env: `MORI_IO_CHUNK_BYTES` |
 | `RdmaBackendConfig.max_chunks_per_transfer` | Cap on chunks per transfer to bound WR/SQ usage (default `64`). Env: `MORI_IO_MAX_CHUNKS` |
 | `RdmaBackendConfig.num_nics_per_transfer` | Stripe a transfer across this many NICs (default `1`). Adaptive by memory type: GPU memory stays single-NIC (PCIe-bound); host memory stripes across NUMA-local NICs. Env: `MORI_IO_NUM_NICS_PER_TRANSFER` |
+| `RdmaBackendConfig.nic_select_by_dest_gpu` | Rail-only topology: select the local NIC by the destination GPU id so cross-node QPs stay on the same rail (default `False`). Assumes a uniform physical topology across the cluster. Only affects transfers whose remote memory is on a GPU. Env: `MORI_IO_NIC_SELECT_BY_DEST_GPU` |
 | `IOEngineConfig.port = 0` | Auto-bind to a free port |
 | `MORI_IBVERBS_LIB` | Path/soname of libibverbs to `dlopen` at runtime — MORI-IO loads libibverbs dynamically rather than linking it. Set to point at an out-of-tree libibverbs; defaults to `libibverbs.so` / `libibverbs.so.1`. |
 

--- a/include/mori/io/backend.hpp
+++ b/include/mori/io/backend.hpp
@@ -72,6 +72,9 @@ struct RdmaBackendConfig : public BackendConfig {
   size_t chunkBytes{65536};
   int maxChunksPerTransfer{64};
   int numNicsPerTransfer{1};
+  // Rail-only topology: pick the local NIC by the destination GPU id (assumes a uniform physical
+  // topology across the cluster), so cross-node QPs always stay on the same rail.
+  bool nicSelectByDestGpu{false};
 
   int maxSendWr{0};
   int maxCqeNum{0};
@@ -84,8 +87,9 @@ inline std::ostream& operator<<(std::ostream& os, const RdmaBackendConfig& c) {
             << c.enableNotification << "] notifPerQp[" << c.notifPerQp
             << "] enableTransferChunking[" << c.enableTransferChunking << "] chunkBytes["
             << c.chunkBytes << "] maxChunksPerTransfer[" << c.maxChunksPerTransfer
-            << "] numNicsPerTransfer[" << c.numNicsPerTransfer << "] maxSendWr[" << c.maxSendWr
-            << "] maxCqeNum[" << c.maxCqeNum << "] maxMsgSge[" << c.maxMsgSge << "]";
+            << "] numNicsPerTransfer[" << c.numNicsPerTransfer << "] nicSelectByDestGpu["
+            << c.nicSelectByDestGpu << "] maxSendWr[" << c.maxSendWr << "] maxCqeNum["
+            << c.maxCqeNum << "] maxMsgSge[" << c.maxMsgSge << "]";
 }
 
 struct XgmiBackendConfig : public BackendConfig {

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -483,6 +483,11 @@ application::RdmaDeviceContext* RdmaManager::GetRdmaDeviceContext(int devId) {
   return deviceCtxs[devId];
 }
 
+std::string RdmaManager::GetDeviceName(int devId) {
+  if (devId < 0 || devId >= static_cast<int>(availDevices.size())) return "";
+  return availDevices[devId].first->Name();
+}
+
 std::vector<std::shared_ptr<EndpointRuntime>> RdmaManager::SnapshotEndpointRuntimes() {
   std::shared_lock<std::shared_mutex> lock(mu);
   std::vector<std::shared_ptr<EndpointRuntime>> result;
@@ -897,7 +902,14 @@ void ControlPlaneServer::BuildRdmaConn(EngineKey ekey, TopoKeyPair topo, int nic
   }
 
   int requestedNics = ResolveRequestedNics(config, topo.local, topo.remote);
-  auto candidates = rdma->Search(topo.local, requestedNics);
+  // Rail-only: select the local NIC by the destination GPU id so this QP stays on the same rail as
+  // the remote NIC. The responder picks its NIC from topo.remote (its own GPU), which matches.
+  TopoKey searchKey = topo.local;
+  if (config.nicSelectByDestGpu && topo.remote.loc == MemoryLocationType::GPU) {
+    searchKey.deviceId = topo.remote.deviceId;
+    searchKey.loc = MemoryLocationType::GPU;
+  }
+  auto candidates = rdma->Search(searchKey, requestedNics);
   assert(!candidates.empty());
   int rank = std::min<int>(nicRank, static_cast<int>(candidates.size()) - 1);
   auto [devId, weight] = candidates[rank];
@@ -913,8 +925,9 @@ void ControlPlaneServer::BuildRdmaConn(EngineKey ekey, TopoKeyPair topo, int nic
   EndpointId eid = rdma->ConnectEndpoint(ekey, devId, lep, msg.devId, msg.eph, topo, weight);
   auto ert = rdma->GetEndpointRuntime(eid);
   notif->RegisterEndpoint(ert);
-  MORI_IO_INFO("Built RdmaConn for engine {} with topo local({},{}) remote({},{})", ekey,
-               topo.local.deviceId, topo.local.loc, topo.remote.deviceId, topo.remote.loc);
+  MORI_IO_INFO("Built RdmaConn for engine {} with topo local({},{}) remote({},{}) local nic {}",
+               ekey, topo.local.deviceId, topo.local.loc, topo.remote.deviceId, topo.remote.loc,
+               rdma->GetDeviceName(devId));
   ctx->CloseEndpoint(tcph);
 }
 
@@ -992,6 +1005,10 @@ void ControlPlaneServer::HandleControlPlaneProtocol(int fd) {
           rdma->ConnectEndpoint(msg.ekey, devId, lep, rdevId, msg.eph, msg.topo, weight);
       auto ert = rdma->GetEndpointRuntime(eid);
       notif->RegisterEndpoint(ert);
+      MORI_IO_INFO(
+          "Accepted RdmaConn for engine {} with topo local({},{}) remote({},{}) local nic {}",
+          msg.ekey, msg.topo.local.deviceId, msg.topo.local.loc, msg.topo.remote.deviceId,
+          msg.topo.remote.loc, rdma->GetDeviceName(devId));
       p.WriteMessageRegEndpoint(MessageRegEndpoint{myEngKey, msg.topo, devId, lep.handle, rank});
       SYSCALL_RETURN_ZERO(epoll_ctl(epfd, EPOLL_CTL_DEL, fd, NULL));
       break;
@@ -1213,6 +1230,8 @@ RdmaBackend::RdmaBackend(EngineKey k, const IOEngineConfig& engConfig,
                 mori::env::detail::ParsePositiveInt);
   env::Override("MORI_IO_NUM_NICS_PER_TRANSFER", config.numNicsPerTransfer,
                 mori::env::detail::ParsePositiveInt);
+  env::Override("MORI_IO_NIC_SELECT_BY_DEST_GPU", config.nicSelectByDestGpu,
+                mori::env::detail::ParseBool);
   ValidateRdmaNotificationConfig(config);
   ValidateRdmaTransferConfig(config);
 

--- a/src/io/rdma/backend_impl.hpp
+++ b/src/io/rdma/backend_impl.hpp
@@ -97,6 +97,7 @@ class RdmaManager {
   std::vector<std::shared_ptr<EndpointRuntime>> SnapshotEndpointRuntimes();
 
   application::RdmaDeviceContext* GetRdmaDeviceContext(int devId);
+  std::string GetDeviceName(int devId);
 
  private:
   application::RdmaDeviceContext* GetOrCreateDeviceContext(int devId);

--- a/src/pybind/pybind_io.cpp
+++ b/src/pybind/pybind_io.cpp
@@ -81,6 +81,7 @@ void RegisterMoriIo(pybind11::module_& m) {
       .def_readwrite("chunk_bytes", &mori::io::RdmaBackendConfig::chunkBytes)
       .def_readwrite("max_chunks_per_transfer", &mori::io::RdmaBackendConfig::maxChunksPerTransfer)
       .def_readwrite("num_nics_per_transfer", &mori::io::RdmaBackendConfig::numNicsPerTransfer)
+      .def_readwrite("nic_select_by_dest_gpu", &mori::io::RdmaBackendConfig::nicSelectByDestGpu)
       .def_readwrite("max_send_wr", &mori::io::RdmaBackendConfig::maxSendWr)
       .def_readwrite("max_cqe_num", &mori::io::RdmaBackendConfig::maxCqeNum)
       .def_readwrite("max_msg_sge", &mori::io::RdmaBackendConfig::maxMsgSge);

--- a/tests/python/io/benchmark.py
+++ b/tests/python/io/benchmark.py
@@ -152,6 +152,14 @@ def parse_args():
         help="Number of devices on target side",
     )
     parser.add_argument(
+        "--target-dev-offset",
+        type=int,
+        default=0,
+        help="Shift each target buffer to GPU (role_rank + offset) %% gpu_count, so the "
+        "initiator's GPU i pairs with a different-index target GPU. Used to exercise cross-rail "
+        "transfers on rail-only fabrics (e.g. offset 5 makes GPU0 -> GPU5). GPU memory only.",
+    )
+    parser.add_argument(
         "--num-qp-per-transfer",
         type=int,
         default=4,
@@ -256,6 +264,7 @@ class MoriIoBenchmark:
         rank_in_node: int = 0,
         num_initiator_dev: int = 1,
         num_target_dev: int = 1,
+        target_dev_offset: int = 0,
         num_qp_per_transfer: int = 4,
         num_worker_threads: int = 1,
         poll_cq_mode: str = "polling",
@@ -291,6 +300,7 @@ class MoriIoBenchmark:
         self.role_rank = rank_in_node
         self.num_initiator_dev = num_initiator_dev
         self.num_target_dev = num_target_dev
+        self.target_dev_offset = target_dev_offset
         self.num_qp_per_transfer = num_qp_per_transfer
         self.num_worker_threads = num_worker_threads
         self.poll_cq_mode = (
@@ -343,7 +353,12 @@ class MoriIoBenchmark:
             self.device = torch.device("cpu")
             self.tensor = torch.randint(0, 256, (total_elements,), dtype=torch.uint8)
         else:
-            self.device = torch.device("cuda", self.role_rank)
+            gpu_index = self.role_rank
+            if self.role is EngineRole.TARGET and self.target_dev_offset:
+                gpu_index = (
+                    self.role_rank + self.target_dev_offset
+                ) % torch.cuda.device_count()
+            self.device = torch.device("cuda", gpu_index)
             self.tensor = torch.randn(total_elements).to(
                 self.device, dtype=torch.float8_e4m3fnuz
             )
@@ -404,6 +419,7 @@ class MoriIoBenchmark:
             print(f"  role_rank: {self.role_rank}")
             print(f"  num_initiator_dev: {self.num_initiator_dev}")
             print(f"  num_target_dev: {self.num_target_dev}")
+            print(f"  target_dev_offset: {self.target_dev_offset}")
             print(f"  mem_type: {self.mem_type}")
             print(f"  num_qp_per_transfer: {self.num_qp_per_transfer}")
             print(f"  num_worker_threads: {self.num_worker_threads}")
@@ -1009,6 +1025,7 @@ def benchmark_engine(local_rank, node_rank, args):
         rank_in_node=local_rank,
         num_initiator_dev=args.num_initiator_dev,
         num_target_dev=args.num_target_dev,
+        target_dev_offset=args.target_dev_offset,
         num_qp_per_transfer=args.num_qp_per_transfer,
         num_worker_threads=args.num_worker_threads,
         poll_cq_mode=args.poll_cq_mode,


### PR DESCRIPTION
## What

Add a `--target-dev-offset` option to `tests/python/io/benchmark.py`. The target side places each buffer on GPU `(role_rank + offset) % gpu_count`, so the initiator's GPU `i` pairs with a different-index target GPU (e.g. `--target-dev-offset 5` makes GPU0 -> GPU5).

- GPU memory only; default `0` keeps the existing same-index pairing (no behavior change).
- Lets the benchmark drive **cross-rail** transfers, which is needed to exercise rail-only / rail-affinity code paths on a rail-isolated fabric.
