### PR TITLE
fix(topo): avoid infinite loop on PCI bridge with subordinate bus 0xff

### DIFF
--- a/src/application/topology/pci.cpp
+++ b/src/application/topology/pci.cpp
@@ -297,9 +297,12 @@ void TopoSystemPci::Load() {
     pcis.emplace(node->BusId().packed, node);
 
     if (headerType == PCI_HEADER_TYPE_BRIDGE) {
-      uint8_t secondary = pci_read_byte(dev, PCI_SECONDARY_BUS);
-      uint8_t subordinate = pci_read_byte(dev, PCI_SUBORDINATE_BUS);
-      for (uint8_t i = secondary; i <= subordinate; i++) {
+      // Use a wider counter than the bus numbers themselves: a bridge may report
+      // a subordinate bus of 0xff (e.g. empty downstream ports on some NICs), and
+      // a uint8_t loop variable would wrap from 0xff back to 0 and spin forever.
+      uint32_t secondary = pci_read_byte(dev, PCI_SECONDARY_BUS);
+      uint32_t subordinate = pci_read_byte(dev, PCI_SUBORDINATE_BUS);
+      for (uint32_t i = secondary; i <= subordinate; i++) {
         uint64_t dspBusId = PciBusId(dev->domain, i, 0, 0).packed;
         if (dsp2dev.find(dspBusId) != dsp2dev.end()) {
           struct pci_dev* lastDev = dsp2dev[dspBusId];


### PR DESCRIPTION
## Problem

`TopoSystemPci::Load()` hangs (100% CPU, never returns) during shmem initialization on hosts that have a PCI bridge reporting a subordinate bus number of `0xff` (e.g. empty/disabled downstream ports, seen on AMD Pensando NICs).

The bus-range loop used a `uint8_t` counter:

```cpp
uint8_t subordinate = pci_read_byte(dev, PCI_SUBORDINATE_BUS);
for (uint8_t i = secondary; i <= subordinate; i++) { ... }
```

When `subordinate == 0xff`, `i <= 0xff` is always true and `i++` wraps `255 -> 0`, so the loop never terminates. Every rank spins forever in PCI topology detection and the process makes no progress.

## Fix

Use a wider (`uint32_t`) loop counter so `i` can exceed `0xff` and the loop exits normally. Bus numbers stay in range; only the counter width changes.

## Test

`tests/python/ops/test_dispatch_combine_intranode.py` previously hung on an affected host; with this change it completes:

```
315 passed, 528 skipped
```
