### PR TITLE
fix(topo): recognize VGA (0x0300) and 3D (0x0302) PCI classes as GPU for RDNA 4 support

### DIFF
--- a/src/application/topology/pci.cpp
+++ b/src/application/topology/pci.cpp
@@ -265,7 +265,10 @@ TopoNodePci* CreateTopoNodePciFrom(pci_dev* dev) {
     return TopoNodePci::CreateBridge(bus, numa);
   } else if (baseCls == PCI_BASE_CLASS_NETWORK) {
     return TopoNodePci::CreateNet(bus, numa);
-  } else if (cls == 0x1200) {
+  } else if (cls == 0x1200 || cls == 0x0300 || cls == 0x0302) {
+    // 0x1200: Processing Accelerator (data-center GPUs)
+    // 0x0300: VGA compatible controller (RDNA 4 consumer/workstation GPUs, e.g. R9700)
+    // 0x0302: 3D controller (some workstation GPUs)
     return TopoNodePci::CreateGpu(bus, numa);
   }
 


### PR DESCRIPTION
## Summary

- `CreateTopoNodePciFrom()` in `src/application/topology/pci.cpp` only recognized PCI class `0x1200` (Processing Accelerator) as a GPU, causing RDNA 4 consumer/workstation GPUs (e.g. R9700/gfx1201) to be silently skipped during topology discovery
- These GPUs enumerate as PCI class `0x0300` (VGA compatible controller); some workstation GPUs use `0x0302` (3D controller)
- The missing nodes caused `MatchGpuAndNic` to receive a null GPU pointer, triggering a segfault in `RdmaManager::Search` → `ControlPlaneServer::BuildRdmaConn` → `RdmaBackend::CreateSession`
- Added `0x0300` and `0x0302` to the GPU class check so RDNA 4 PCIe GPUs are correctly included in the PCI topology and matched to their local NICs

Fixes #374

## Test plan

- [ ] Build MoRI on a system with R9700 (gfx1201) + Pollara (ionic) NICs
- [ ] Verify `TopoSystem::MatchAllGpusAndNics` completes without segfault
- [ ] Confirm P/D disaggregation works end-to-end (KV transfer succeeds)
- [ ] Verify no regression on data-center GPU hardware (gfx1200/MI300X) where `0x1200` is the class

🤖 Generated with [Claude Code](https://claude.com/claude-code)