### PR TITLE
feat(umbp): improve BatchRoutePut placement with select-algo and node-affinity knobs

### DIFF
--- a/src/umbp/distributed/bin/client_main.cpp
+++ b/src/umbp/distributed/bin/client_main.cpp
@@ -125,6 +125,10 @@ int main(int argc, char** argv) {
     if (!route_put_status.ok()) {
       MORI_UMBP_WARN("[Client] Iteration {} RoutePut RPC failed: {}", iteration,
                      route_put_status.error_message());
+    } else if (put_target.has_value() &&
+               put_target->outcome == mori::umbp::RoutePutOutcome::kAlreadyExists) {
+      MORI_UMBP_INFO("[Client] Iteration {} RoutePut(key={}): already exists (dedup)", iteration,
+                     key);
     } else if (put_target.has_value()) {
       MORI_UMBP_INFO("[Client] Iteration {} RoutePut(key={}): target_node={}, tier={}", iteration,
                      key, put_target->node_id, mori::umbp::TierTypeName(put_target->tier));

--- a/src/umbp/distributed/bin/master_main.cpp
+++ b/src/umbp/distributed/bin/master_main.cpp
@@ -56,6 +56,9 @@ int main(int argc, char** argv) {
       config.registry_config.max_missed_heartbeats, config.eviction_config.check_interval.count(),
       config.eviction_config.lease_duration.count());
 
+  MORI_UMBP_INFO("[Master] Resolved route-put strategy: select_algo={} node_affinity={}",
+                 config.route_put_algo, config.route_put_affinity);
+
   mori::umbp::MasterServer server(std::move(config));
 
   sigset_t signal_set;

--- a/src/umbp/distributed/master/master_client.cpp
+++ b/src/umbp/distributed/master/master_client.cpp
@@ -213,13 +213,24 @@ grpc::Status MasterClient::RoutePut(const std::string& key, uint64_t block_size,
   auto status = GetStub(stub_.get())->RoutePut(&ctx, req, &resp);
   _rpc_timer.SetStatus(status);
   if (!status.ok()) return status;
-  if (!resp.found()) return grpc::Status::OK;
 
-  RoutePutResult r;
-  r.node_id = resp.node_id();
-  r.peer_address = resp.peer_address();
-  r.tier = FromProtoTier(resp.tier());
-  *out_result = std::move(r);
+  switch (resp.outcome()) {
+    case ::umbp::ROUTE_PUT_OUTCOME_ROUTED:
+      *out_result = RoutePutResult{
+          .outcome = RoutePutOutcome::kRouted,
+          .node_id = resp.node_id(),
+          .peer_address = resp.peer_address(),
+          .tier = FromProtoTier(resp.tier()),
+      };
+      break;
+    case ::umbp::ROUTE_PUT_OUTCOME_ALREADY_EXISTS:
+      // Non-nullopt so caller distinguishes dedup from unavailable (= nullopt).
+      *out_result = RoutePutResult{.outcome = RoutePutOutcome::kAlreadyExists};
+      break;
+    case ::umbp::ROUTE_PUT_OUTCOME_UNAVAILABLE:
+    default:
+      break;  // leave as nullopt
+  }
   return grpc::Status::OK;
 }
 

--- a/src/umbp/distributed/master/master_server.cpp
+++ b/src/umbp/distributed/master/master_server.cpp
@@ -342,10 +342,14 @@ class MasterServer::UMBPMasterServiceImpl final : public ::umbp::UMBPMaster::Ser
     auto result =
         router_.RoutePut(request->key(), request->node_id(), request->block_size(), excludes);
     if (!result.has_value()) {
-      response->set_found(false);
+      response->set_outcome(::umbp::ROUTE_PUT_OUTCOME_UNAVAILABLE);
       return grpc::Status::OK;
     }
-    response->set_found(true);
+    if (result->outcome == RoutePutOutcome::kAlreadyExists) {
+      response->set_outcome(::umbp::ROUTE_PUT_OUTCOME_ALREADY_EXISTS);
+      return grpc::Status::OK;
+    }
+    response->set_outcome(::umbp::ROUTE_PUT_OUTCOME_ROUTED);
     response->set_node_id(result->node_id);
     response->set_tier(static_cast<::umbp::TierType>(result->tier));
     response->set_peer_address(result->peer_address);

--- a/src/umbp/distributed/master/master_server.cpp
+++ b/src/umbp/distributed/master/master_server.cpp
@@ -179,6 +179,22 @@ MasterServerConfig MasterServerConfig::FromEnvironment() {
   MasterServerConfig cfg;
   cfg.registry_config = ClientRegistryConfig::FromEnvironment();
   cfg.eviction_config = EvictionConfig::FromEnvironment();
+
+  cfg.route_put_algo =
+      GetEnvEnum("UMBP_ROUTE_PUT_SELECT_ALGO", "most_available", {"most_available", "random"});
+  cfg.route_put_affinity =
+      GetEnvEnum("UMBP_ROUTE_PUT_NODE_AFFINITY", "none", {"none", "same", "local"});
+
+  using Algo = ConfigurableRoutePutStrategy::SelectAlgo;
+  using Affinity = ConfigurableRoutePutStrategy::NodeAffinity;
+  const Algo algo = cfg.route_put_algo == "random" ? Algo::kRandom : Algo::kMostAvailable;
+  Affinity affinity = Affinity::kNone;
+  if (cfg.route_put_affinity == "same") {
+    affinity = Affinity::kSame;
+  } else if (cfg.route_put_affinity == "local") {
+    affinity = Affinity::kLocal;
+  }
+  cfg.put_strategy = std::make_unique<ConfigurableRoutePutStrategy>(algo, affinity);
   return cfg;
 }
 

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -691,6 +691,13 @@ PoolClient::PartitionBatchPutTargets(const std::vector<std::string>& keys,
   std::unordered_map<std::string, std::vector<BatchPutItem>> remote_groups;
   const size_t count = keys.size();
   for (size_t i = 0; i < count; ++i) {
+    // Zero-size puts are rejected before local/peer execution: an empty block
+    // is meaningless to store, so leave the result as kFailed and never hand it
+    // to ExecuteLocalPut / peer AllocateSlot.
+    if (sizes[i] == 0) {
+      MORI_UMBP_WARN("[PoolClient] BatchPut: skipping zero-size put for key='{}'", keys[i]);
+      continue;
+    }
     if (i >= routes.size() || !routes[i].has_value()) continue;
     const auto& route = routes[i].value();
     // Master-side dedup hit.
@@ -822,6 +829,13 @@ std::vector<bool> PoolClient::BatchGet(const std::vector<std::string>& keys,
   std::unordered_map<std::string, std::vector<BatchGetItem>> remote_groups;
   std::unordered_map<std::string, std::vector<BatchGetItem>> ssd_remote_groups;
   for (size_t i = 0; i < keys.size(); ++i) {
+    // Zero-size gets are rejected before local fallback or remote read: an
+    // explicit skip is required here because a nullopt route below would
+    // otherwise fall through to a local read (result stays false).
+    if (sizes[i] == 0) {
+      MORI_UMBP_WARN("[PoolClient] BatchGet: skipping zero-size get for key='{}'", keys[i]);
+      continue;
+    }
     if (i >= routes.size() || !routes[i].has_value()) {
       if (peer_alloc_) {
         auto outcome = ExecuteLocalGet(keys[i], const_cast<void*>(dsts[i]), sizes[i]);

--- a/src/umbp/distributed/proto/umbp.proto
+++ b/src/umbp/distributed/proto/umbp.proto
@@ -123,11 +123,13 @@ message RoutePutRequest {
   uint64 block_size            = 3;   // Size of the block to write (bytes)
   repeated string exclude_nodes = 4;  // Nodes the caller has already failed against
 }
+// Aligned with BatchRoutePutEntry: `outcome` replaces the old `found` bool so a
+// single RoutePut can also express master-side dedup (ALREADY_EXISTS).
 message RoutePutResponse {
-  bool     found        = 1;
-  string   node_id      = 2;
-  TierType tier         = 3;
-  string   peer_address = 4;
+  RoutePutOutcome outcome      = 1;
+  string          node_id      = 2;
+  TierType        tier         = 3;
+  string          peer_address = 4;
 }
 
 message RouteGetRequest {

--- a/src/umbp/distributed/routing/route_put_strategy.cpp
+++ b/src/umbp/distributed/routing/route_put_strategy.cpp
@@ -25,12 +25,14 @@
 #include <array>
 #include <random>
 #include <sstream>
-#include <stdexcept>
 
 #include "mori/utils/mori_log.hpp"
 
 namespace mori::umbp {
 
+// ---------------------------------------------------------------------------
+//  Internal helpers (logging, tier order, projected-capacity deduction)
+// ---------------------------------------------------------------------------
 namespace {
 
 // SSD is intentionally excluded: there is no direct SSD put — the SSD copy is
@@ -83,24 +85,31 @@ std::string SummarizeClientTiers(const std::vector<ClientRecord>& alive_clients)
 // later entries in the same batch see the reservation.  A routed result always
 // names a node/tier that exists here with enough room (Select / TrySelectOnNode
 // only return such picks, and candidates is a single-thread local copy); a
-// violation means the selector's contract is broken — fail fast, never clamp.
-void ApplyProjectedDeduction(std::vector<ClientRecord>& candidates, const RoutePutResult& result,
+// violation means the selector's contract is broken.  This is a best-effort
+// system: on a violation we log a MORI ERROR and return false so the caller
+// drops the route (treats the key as unroutable) instead of crashing.
+bool ApplyProjectedDeduction(std::vector<ClientRecord>& candidates, const RoutePutResult& result,
                              uint64_t block_size) {
   auto client_it = std::find_if(candidates.begin(), candidates.end(),
                                 [&](const ClientRecord& c) { return c.node_id == result.node_id; });
   if (client_it == candidates.end()) {
-    throw std::runtime_error("RoutePutStrategy: selected node not in candidates: " +
-                             result.node_id);
+    MORI_UMBP_ERROR("[RoutePutStrategy] projected-deduction: selected node not in candidates: {}",
+                    result.node_id);
+    return false;
   }
   auto tier_it = client_it->tier_capacities.find(result.tier);
   if (tier_it == client_it->tier_capacities.end()) {
-    throw std::runtime_error("RoutePutStrategy: selected tier absent on node " + result.node_id);
+    MORI_UMBP_ERROR("[RoutePutStrategy] projected-deduction: selected tier absent on node {}",
+                    result.node_id);
+    return false;
   }
   if (tier_it->second.available_bytes < block_size) {
-    throw std::runtime_error("RoutePutStrategy: projected capacity underflow on node " +
-                             result.node_id);
+    MORI_UMBP_ERROR("[RoutePutStrategy] projected-deduction: capacity underflow on node {}",
+                    result.node_id);
+    return false;
   }
   tier_it->second.available_bytes -= block_size;
+  return true;
 }
 
 // Indices of candidates that can fit block_size on a single @p tier.
@@ -130,13 +139,19 @@ RoutePutResult MakeRouted(const ClientRecord& client, TierType tier) {
 
 }  // namespace
 
+// ---------------------------------------------------------------------------
+//  RoutePutStrategy (base): default batch planner over the virtual Select()
+// ---------------------------------------------------------------------------
 std::vector<std::optional<RoutePutResult>> RoutePutStrategy::SelectBatch(
     const std::string& /*requester_node_id*/, const std::vector<uint64_t>& block_sizes,
     const std::vector<bool>& already_exists, std::vector<ClientRecord> candidates,
     const std::unordered_set<std::string>& exclude_nodes) {
   if (already_exists.size() != block_sizes.size()) {
-    throw std::runtime_error(
-        "RoutePutStrategy::SelectBatch: already_exists length must match block_sizes");
+    MORI_UMBP_ERROR(
+        "[RoutePutStrategy] SelectBatch: already_exists length ({}) must match block_sizes ({}); "
+        "treating every key as unroutable",
+        already_exists.size(), block_sizes.size());
+    return std::vector<std::optional<RoutePutResult>>(block_sizes.size());
   }
 
   std::vector<std::optional<RoutePutResult>> results;
@@ -152,8 +167,10 @@ std::vector<std::optional<RoutePutResult>> RoutePutStrategy::SelectBatch(
       continue;
     }
     auto selected = Select(candidates, block_sizes[i], exclude_nodes);
-    if (selected && selected->outcome == RoutePutOutcome::kRouted) {
-      ApplyProjectedDeduction(candidates, *selected, block_sizes[i]);
+    if (selected && selected->outcome == RoutePutOutcome::kRouted &&
+        !ApplyProjectedDeduction(candidates, *selected, block_sizes[i])) {
+      // Selector broke its own contract: drop the route (best-effort failure).
+      selected = std::nullopt;
     }
     results.push_back(std::move(selected));
   }
@@ -161,6 +178,9 @@ std::vector<std::optional<RoutePutResult>> RoutePutStrategy::SelectBatch(
   return results;
 }
 
+// ---------------------------------------------------------------------------
+//  TierAwareMostAvailableStrategy
+// ---------------------------------------------------------------------------
 std::optional<RoutePutResult> TierAwareMostAvailableStrategy::Select(
     const std::vector<ClientRecord>& alive_clients, uint64_t block_size,
     const std::unordered_set<std::string>& exclude_nodes) {
@@ -322,8 +342,11 @@ std::vector<std::optional<RoutePutResult>> ConfigurableRoutePutStrategy::SelectB
     const std::vector<bool>& already_exists, std::vector<ClientRecord> candidates,
     const std::unordered_set<std::string>& exclude_nodes) {
   if (already_exists.size() != block_sizes.size()) {
-    throw std::runtime_error(
-        "ConfigurableRoutePutStrategy::SelectBatch: already_exists length must match block_sizes");
+    MORI_UMBP_ERROR(
+        "[ConfigurableRoutePutStrategy] SelectBatch: already_exists length ({}) must match "
+        "block_sizes ({}); treating every key as unroutable",
+        already_exists.size(), block_sizes.size());
+    return std::vector<std::optional<RoutePutResult>>(block_sizes.size());
   }
 
   // Affinity anchor: the node (and optionally tier) we try first for each key
@@ -400,8 +423,10 @@ std::vector<std::optional<RoutePutResult>> ConfigurableRoutePutStrategy::SelectB
       selected = SelectByAlgo(candidates, block_size, exclude_nodes);
     }
 
-    if (selected && selected->outcome == RoutePutOutcome::kRouted) {
-      ApplyProjectedDeduction(candidates, *selected, block_size);
+    if (selected && selected->outcome == RoutePutOutcome::kRouted &&
+        !ApplyProjectedDeduction(candidates, *selected, block_size)) {
+      // Selector broke its own contract: drop the route (best-effort failure).
+      selected = std::nullopt;
     }
     results.push_back(std::move(selected));
   }

--- a/src/umbp/distributed/routing/route_put_strategy.cpp
+++ b/src/umbp/distributed/routing/route_put_strategy.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <array>
 #include <sstream>
+#include <stdexcept>
 
 #include "mori/utils/mori_log.hpp"
 
@@ -72,6 +73,61 @@ std::string SummarizeClientTiers(const std::vector<ClientRecord>& alive_clients)
 }
 
 }  // namespace
+
+std::vector<std::optional<RoutePutResult>> RoutePutStrategy::SelectBatch(
+    const std::vector<uint64_t>& block_sizes, const std::vector<bool>& already_exists,
+    std::vector<ClientRecord> candidates, const std::unordered_set<std::string>& exclude_nodes) {
+  if (already_exists.size() != block_sizes.size()) {
+    throw std::runtime_error(
+        "RoutePutStrategy::SelectBatch: already_exists length must match block_sizes");
+  }
+
+  std::vector<std::optional<RoutePutResult>> results;
+  results.reserve(block_sizes.size());
+
+  for (size_t i = 0; i < block_sizes.size(); ++i) {
+    if (already_exists[i]) {
+      results.push_back(RoutePutResult{.outcome = RoutePutOutcome::kAlreadyExists});
+      continue;
+    }
+    if (candidates.empty()) {
+      results.push_back(std::nullopt);
+      continue;
+    }
+    uint64_t block_size = block_sizes[i];
+    auto selected = Select(candidates, block_size, exclude_nodes);
+    if (selected && selected->outcome == RoutePutOutcome::kRouted) {
+      // Deduct projected capacity from the batch-local copy so later entries
+      // see the reservation.  Select() only returns kRouted for a node/tier
+      // with available_bytes >= block_size, and `candidates` is a single-thread
+      // local copy, so the node/tier must exist with enough room here.  A
+      // violation means Select()'s contract is broken: fail fast, never clamp.
+      auto client_it =
+          std::find_if(candidates.begin(), candidates.end(),
+                       [&](const ClientRecord& c) { return c.node_id == selected->node_id; });
+      if (client_it == candidates.end()) {
+        throw std::runtime_error(
+            "RoutePutStrategy::SelectBatch: Select returned node not in candidates: " +
+            selected->node_id);
+      }
+      auto tier_it = client_it->tier_capacities.find(selected->tier);
+      if (tier_it == client_it->tier_capacities.end()) {
+        throw std::runtime_error(
+            "RoutePutStrategy::SelectBatch: Select returned tier absent on node " +
+            selected->node_id);
+      }
+      if (tier_it->second.available_bytes < block_size) {
+        throw std::runtime_error(
+            "RoutePutStrategy::SelectBatch: projected capacity underflow on node " +
+            selected->node_id);
+      }
+      tier_it->second.available_bytes -= block_size;
+    }
+    results.push_back(std::move(selected));
+  }
+
+  return results;
+}
 
 std::optional<RoutePutResult> TierAwareMostAvailableStrategy::Select(
     const std::vector<ClientRecord>& alive_clients, uint64_t block_size,

--- a/src/umbp/distributed/routing/route_put_strategy.cpp
+++ b/src/umbp/distributed/routing/route_put_strategy.cpp
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <array>
+#include <random>
 #include <sstream>
 #include <stdexcept>
 
@@ -31,6 +32,12 @@
 namespace mori::umbp {
 
 namespace {
+
+// SSD is intentionally excluded: there is no direct SSD put — the SSD copy is
+// filled asynchronously by copy-on-commit.  RoutePut must never steer a put at
+// a tier with no direct-put semantics, even though SSD capacity is reported via
+// heartbeat.
+constexpr std::array<TierType, 2> kPutTierOrder = {TierType::HBM, TierType::DRAM};
 
 std::string JoinStrings(const std::vector<std::string>& items) {
   if (items.empty()) return "";
@@ -72,11 +79,61 @@ std::string SummarizeClientTiers(const std::vector<ClientRecord>& alive_clients)
   return JoinStrings(summaries);
 }
 
+// Deduct a routed pick's block_size from the batch-local candidates copy so
+// later entries in the same batch see the reservation.  A routed result always
+// names a node/tier that exists here with enough room (Select / TrySelectOnNode
+// only return such picks, and candidates is a single-thread local copy); a
+// violation means the selector's contract is broken — fail fast, never clamp.
+void ApplyProjectedDeduction(std::vector<ClientRecord>& candidates, const RoutePutResult& result,
+                             uint64_t block_size) {
+  auto client_it = std::find_if(candidates.begin(), candidates.end(),
+                                [&](const ClientRecord& c) { return c.node_id == result.node_id; });
+  if (client_it == candidates.end()) {
+    throw std::runtime_error("RoutePutStrategy: selected node not in candidates: " +
+                             result.node_id);
+  }
+  auto tier_it = client_it->tier_capacities.find(result.tier);
+  if (tier_it == client_it->tier_capacities.end()) {
+    throw std::runtime_error("RoutePutStrategy: selected tier absent on node " + result.node_id);
+  }
+  if (tier_it->second.available_bytes < block_size) {
+    throw std::runtime_error("RoutePutStrategy: projected capacity underflow on node " +
+                             result.node_id);
+  }
+  tier_it->second.available_bytes -= block_size;
+}
+
+// Indices of candidates that can fit block_size on a single @p tier.
+std::vector<size_t> CollectEligibleOnTier(const std::vector<ClientRecord>& candidates,
+                                          TierType tier, uint64_t block_size,
+                                          const std::unordered_set<std::string>& exclude_nodes) {
+  std::vector<size_t> indices;
+  for (size_t i = 0; i < candidates.size(); ++i) {
+    const auto& client = candidates[i];
+    if (exclude_nodes.count(client.node_id)) continue;
+    auto it = client.tier_capacities.find(tier);
+    if (it == client.tier_capacities.end()) continue;
+    if (it->second.available_bytes < block_size) continue;
+    indices.push_back(i);
+  }
+  return indices;
+}
+
+RoutePutResult MakeRouted(const ClientRecord& client, TierType tier) {
+  return RoutePutResult{
+      .outcome = RoutePutOutcome::kRouted,
+      .node_id = client.node_id,
+      .peer_address = client.peer_address,
+      .tier = tier,
+  };
+}
+
 }  // namespace
 
 std::vector<std::optional<RoutePutResult>> RoutePutStrategy::SelectBatch(
-    const std::vector<uint64_t>& block_sizes, const std::vector<bool>& already_exists,
-    std::vector<ClientRecord> candidates, const std::unordered_set<std::string>& exclude_nodes) {
+    const std::string& /*requester_node_id*/, const std::vector<uint64_t>& block_sizes,
+    const std::vector<bool>& already_exists, std::vector<ClientRecord> candidates,
+    const std::unordered_set<std::string>& exclude_nodes) {
   if (already_exists.size() != block_sizes.size()) {
     throw std::runtime_error(
         "RoutePutStrategy::SelectBatch: already_exists length must match block_sizes");
@@ -94,34 +151,9 @@ std::vector<std::optional<RoutePutResult>> RoutePutStrategy::SelectBatch(
       results.push_back(std::nullopt);
       continue;
     }
-    uint64_t block_size = block_sizes[i];
-    auto selected = Select(candidates, block_size, exclude_nodes);
+    auto selected = Select(candidates, block_sizes[i], exclude_nodes);
     if (selected && selected->outcome == RoutePutOutcome::kRouted) {
-      // Deduct projected capacity from the batch-local copy so later entries
-      // see the reservation.  Select() only returns kRouted for a node/tier
-      // with available_bytes >= block_size, and `candidates` is a single-thread
-      // local copy, so the node/tier must exist with enough room here.  A
-      // violation means Select()'s contract is broken: fail fast, never clamp.
-      auto client_it =
-          std::find_if(candidates.begin(), candidates.end(),
-                       [&](const ClientRecord& c) { return c.node_id == selected->node_id; });
-      if (client_it == candidates.end()) {
-        throw std::runtime_error(
-            "RoutePutStrategy::SelectBatch: Select returned node not in candidates: " +
-            selected->node_id);
-      }
-      auto tier_it = client_it->tier_capacities.find(selected->tier);
-      if (tier_it == client_it->tier_capacities.end()) {
-        throw std::runtime_error(
-            "RoutePutStrategy::SelectBatch: Select returned tier absent on node " +
-            selected->node_id);
-      }
-      if (tier_it->second.available_bytes < block_size) {
-        throw std::runtime_error(
-            "RoutePutStrategy::SelectBatch: projected capacity underflow on node " +
-            selected->node_id);
-      }
-      tier_it->second.available_bytes -= block_size;
+      ApplyProjectedDeduction(candidates, *selected, block_sizes[i]);
     }
     results.push_back(std::move(selected));
   }
@@ -132,15 +164,9 @@ std::vector<std::optional<RoutePutResult>> RoutePutStrategy::SelectBatch(
 std::optional<RoutePutResult> TierAwareMostAvailableStrategy::Select(
     const std::vector<ClientRecord>& alive_clients, uint64_t block_size,
     const std::unordered_set<std::string>& exclude_nodes) {
-  // SSD is intentionally excluded: there is no direct SSD put — the SSD copy is
-  // filled asynchronously by copy-on-commit.  Even though SSD capacity is
-  // reported via heartbeat, RoutePut must never steer a put at a tier with no
-  // direct-put semantics.
-  static constexpr std::array<TierType, 2> kTierOrder = {TierType::HBM, TierType::DRAM};
-
   const std::string exclude_snapshot = FormatExcludeSet(exclude_nodes);
 
-  for (TierType tier : kTierOrder) {
+  for (TierType tier : kPutTierOrder) {
     const ClientRecord* best = nullptr;
     uint64_t best_available = 0;
     uint64_t candidates_considered = 0;
@@ -181,6 +207,206 @@ std::optional<RoutePutResult> TierAwareMostAvailableStrategy::Select(
       "[RoutePutStrategy] block_size={} no suitable target. excludes=[{}] capacity_snapshot=[{}]",
       block_size, exclude_snapshot, SummarizeClientTiers(alive_clients));
   return std::nullopt;
+}
+
+// ---------------------------------------------------------------------------
+//  ConfigurableRoutePutStrategy
+// ---------------------------------------------------------------------------
+ConfigurableRoutePutStrategy::ConfigurableRoutePutStrategy(SelectAlgo algo, NodeAffinity affinity)
+    : algo_(algo), affinity_(affinity) {}
+
+ConfigurableRoutePutStrategy::ConfigurableRoutePutStrategy(SelectAlgo algo, NodeAffinity affinity,
+                                                           uint64_t rng_seed)
+    : algo_(algo), affinity_(affinity), seeded_(true), rng_(rng_seed) {}
+
+std::string ConfigurableRoutePutStrategy::Describe() const {
+  std::string out = (algo_ == SelectAlgo::kRandom) ? "random" : "most_available";
+  out += '/';
+  switch (affinity_) {
+    case NodeAffinity::kSame:
+      out += "same";
+      break;
+    case NodeAffinity::kLocal:
+      out += "local";
+      break;
+    case NodeAffinity::kNone:
+    default:
+      out += "none";
+      break;
+  }
+  return out;
+}
+
+size_t ConfigurableRoutePutStrategy::PickWeighted(const std::vector<uint64_t>& weights) {
+  std::discrete_distribution<size_t> dist(weights.begin(), weights.end());
+  if (seeded_) {
+    std::lock_guard<std::mutex> lock(rng_mutex_);
+    return dist(rng_);
+  }
+  thread_local std::mt19937 rng{std::random_device{}()};
+  return dist(rng);
+}
+
+std::optional<RoutePutResult> ConfigurableRoutePutStrategy::TrySelectOnNodeTier(
+    const std::vector<ClientRecord>& candidates, const std::string& node_id, TierType tier,
+    uint64_t block_size, const std::unordered_set<std::string>& exclude_nodes) const {
+  if (node_id.empty() || exclude_nodes.count(node_id)) return std::nullopt;
+  auto it = std::find_if(candidates.begin(), candidates.end(),
+                         [&](const ClientRecord& c) { return c.node_id == node_id; });
+  if (it == candidates.end()) return std::nullopt;
+  auto cap = it->tier_capacities.find(tier);
+  if (cap == it->tier_capacities.end() || cap->second.available_bytes < block_size) {
+    return std::nullopt;
+  }
+  return MakeRouted(*it, tier);
+}
+
+std::optional<RoutePutResult> ConfigurableRoutePutStrategy::TrySelectOnNode(
+    const std::vector<ClientRecord>& candidates, const std::string& node_id, uint64_t block_size,
+    const std::unordered_set<std::string>& exclude_nodes) const {
+  for (TierType tier : kPutTierOrder) {
+    if (auto r = TrySelectOnNodeTier(candidates, node_id, tier, block_size, exclude_nodes)) {
+      return r;
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<RoutePutResult> ConfigurableRoutePutStrategy::SelectByAlgo(
+    const std::vector<ClientRecord>& candidates, uint64_t block_size,
+    const std::unordered_set<std::string>& exclude_nodes,
+    const std::optional<std::string>& preferred_node) {
+  for (TierType tier : kPutTierOrder) {
+    // Node preference applies only within this tier, so a preferred node that is
+    // full on the faster tier never preempts a remote node that still has room
+    // there: tier priority is preserved.
+    if (preferred_node) {
+      if (auto r =
+              TrySelectOnNodeTier(candidates, *preferred_node, tier, block_size, exclude_nodes)) {
+        return r;
+      }
+    }
+    std::vector<size_t> eligible =
+        CollectEligibleOnTier(candidates, tier, block_size, exclude_nodes);
+    if (eligible.empty()) continue;
+
+    auto available = [&](size_t idx) {
+      return candidates[idx].tier_capacities.at(tier).available_bytes;
+    };
+    size_t chosen = eligible.front();
+    if (algo_ == SelectAlgo::kRandom) {
+      std::vector<uint64_t> weights;
+      weights.reserve(eligible.size());
+      for (size_t idx : eligible) weights.push_back(available(idx));
+      chosen = eligible[PickWeighted(weights)];
+    } else {
+      for (size_t idx : eligible) {
+        if (available(idx) > available(chosen)) chosen = idx;
+      }
+    }
+    return MakeRouted(candidates[chosen], tier);
+  }
+  return std::nullopt;
+}
+
+std::optional<RoutePutResult> ConfigurableRoutePutStrategy::Select(
+    const std::vector<ClientRecord>& alive_clients, uint64_t block_size,
+    const std::unordered_set<std::string>& exclude_nodes) {
+  // Single-key default ignores affinity (no batch context, no requester here);
+  // batch affinity lives in SelectBatch.
+  return SelectByAlgo(alive_clients, block_size, exclude_nodes);
+}
+
+std::vector<std::optional<RoutePutResult>> ConfigurableRoutePutStrategy::SelectBatch(
+    const std::string& requester_node_id, const std::vector<uint64_t>& block_sizes,
+    const std::vector<bool>& already_exists, std::vector<ClientRecord> candidates,
+    const std::unordered_set<std::string>& exclude_nodes) {
+  if (already_exists.size() != block_sizes.size()) {
+    throw std::runtime_error(
+        "ConfigurableRoutePutStrategy::SelectBatch: already_exists length must match block_sizes");
+  }
+
+  // Affinity anchor: the node (and optionally tier) we try first for each key
+  // before the explicit SelectByAlgo fallback.  Affinity biases node choice and
+  // never makes a key fail that SelectByAlgo could route.
+  //   - kNone:  no anchor; every key goes straight to SelectByAlgo.
+  //   - kLocal: anchor fixed to the requester node, tried node-first across its
+  //             own tiers (local HBM then local DRAM) before the global
+  //             fallback; never re-anchored.  This intentionally prefers a local
+  //             DRAM placement over a remote HBM one (locality for later gets).
+  //   - kSame:  if one node/tier fits the whole non-dedup total, anchor is
+  //             pinned to that exact node AND tier so the batch lands together.
+  //             Otherwise each key is placed tier-first with the sticky node
+  //             only preferred within a tier (so a spill never beats a remote
+  //             HBM with the anchor's DRAM); the anchor re-points to the latest
+  //             pick as nodes fill.
+  std::optional<std::string> anchor_node;
+  std::optional<TierType> anchor_tier;  // pinned only for the kSame whole-batch hit
+  if (affinity_ == NodeAffinity::kLocal) {
+    if (!requester_node_id.empty()) anchor_node = requester_node_id;
+  } else if (affinity_ == NodeAffinity::kSame) {
+    uint64_t total = 0;
+    for (size_t i = 0; i < block_sizes.size(); ++i) {
+      if (!already_exists[i]) total += block_sizes[i];
+    }
+    if (total > 0) {
+      // SelectByAlgo honors HBM-before-DRAM, so a hit here is the fastest tier
+      // on which the whole batch fits — pin both node and tier to it.
+      if (auto whole = SelectByAlgo(candidates, total, exclude_nodes)) {
+        anchor_node = whole->node_id;
+        anchor_tier = whole->tier;
+      }
+    }
+  }
+
+  std::vector<std::optional<RoutePutResult>> results;
+  results.reserve(block_sizes.size());
+
+  for (size_t i = 0; i < block_sizes.size(); ++i) {
+    if (already_exists[i]) {
+      results.push_back(RoutePutResult{.outcome = RoutePutOutcome::kAlreadyExists});
+      continue;
+    }
+    if (candidates.empty()) {
+      results.push_back(std::nullopt);
+      continue;
+    }
+    const uint64_t block_size = block_sizes[i];
+
+    std::optional<RoutePutResult> selected;
+    if (affinity_ == NodeAffinity::kLocal) {
+      // Node-first: local HBM -> local DRAM, then global HBM -> DRAM fallback.
+      if (anchor_node) {
+        selected = TrySelectOnNode(candidates, *anchor_node, block_size, exclude_nodes);
+      }
+      if (!selected) selected = SelectByAlgo(candidates, block_size, exclude_nodes);
+    } else if (affinity_ == NodeAffinity::kSame) {
+      // Whole-batch hit: keep every key on the pinned node AND tier.
+      if (anchor_tier) {
+        selected =
+            TrySelectOnNodeTier(candidates, *anchor_node, *anchor_tier, block_size, exclude_nodes);
+      }
+      if (!selected) {
+        // Tier-first with the sticky node only preferred within each tier, so a
+        // spill never prefers the anchor's DRAM over a remote node's HBM.  Drop
+        // the tier pin and re-anchor to wherever this key actually landed.
+        selected = SelectByAlgo(candidates, block_size, exclude_nodes, anchor_node);
+        anchor_tier = std::nullopt;
+        if (selected && selected->outcome == RoutePutOutcome::kRouted) {
+          anchor_node = selected->node_id;
+        }
+      }
+    } else {
+      selected = SelectByAlgo(candidates, block_size, exclude_nodes);
+    }
+
+    if (selected && selected->outcome == RoutePutOutcome::kRouted) {
+      ApplyProjectedDeduction(candidates, *selected, block_size);
+    }
+    results.push_back(std::move(selected));
+  }
+
+  return results;
 }
 
 }  // namespace mori::umbp

--- a/src/umbp/distributed/routing/route_put_strategy.cpp
+++ b/src/umbp/distributed/routing/route_put_strategy.cpp
@@ -81,37 +81,6 @@ std::string SummarizeClientTiers(const std::vector<ClientRecord>& alive_clients)
   return JoinStrings(summaries);
 }
 
-// Deduct a routed pick's block_size from the batch-local candidates copy so
-// later entries in the same batch see the reservation.  A routed result always
-// names a node/tier that exists here with enough room (Select / TrySelectOnNode
-// only return such picks, and candidates is a single-thread local copy); a
-// violation means the selector's contract is broken.  This is a best-effort
-// system: on a violation we log a MORI ERROR and return false so the caller
-// drops the route (treats the key as unroutable) instead of crashing.
-bool ApplyProjectedDeduction(std::vector<ClientRecord>& candidates, const RoutePutResult& result,
-                             uint64_t block_size) {
-  auto client_it = std::find_if(candidates.begin(), candidates.end(),
-                                [&](const ClientRecord& c) { return c.node_id == result.node_id; });
-  if (client_it == candidates.end()) {
-    MORI_UMBP_ERROR("[RoutePutStrategy] projected-deduction: selected node not in candidates: {}",
-                    result.node_id);
-    return false;
-  }
-  auto tier_it = client_it->tier_capacities.find(result.tier);
-  if (tier_it == client_it->tier_capacities.end()) {
-    MORI_UMBP_ERROR("[RoutePutStrategy] projected-deduction: selected tier absent on node {}",
-                    result.node_id);
-    return false;
-  }
-  if (tier_it->second.available_bytes < block_size) {
-    MORI_UMBP_ERROR("[RoutePutStrategy] projected-deduction: capacity underflow on node {}",
-                    result.node_id);
-    return false;
-  }
-  tier_it->second.available_bytes -= block_size;
-  return true;
-}
-
 // Indices of candidates that can fit block_size on a single @p tier.
 std::vector<size_t> CollectEligibleOnTier(const std::vector<ClientRecord>& candidates,
                                           TierType tier, uint64_t block_size,
@@ -137,97 +106,50 @@ RoutePutResult MakeRouted(const ClientRecord& client, TierType tier) {
   };
 }
 
+// Available bytes for @p node_id on @p tier in the (projected) candidates copy;
+// 0 when the node or tier is absent.  Used only to report the pre-deduction
+// figure in the routed INFO log.
+uint64_t LookupAvailableBytes(const std::vector<ClientRecord>& candidates,
+                              const std::string& node_id, TierType tier) {
+  auto client_it = std::find_if(candidates.begin(), candidates.end(),
+                                [&](const ClientRecord& c) { return c.node_id == node_id; });
+  if (client_it == candidates.end()) return 0;
+  auto tier_it = client_it->tier_capacities.find(tier);
+  if (tier_it == client_it->tier_capacities.end()) return 0;
+  return tier_it->second.available_bytes;
+}
+
+// Deduct a routed pick's @p block_size from the batch-local @p candidates copy
+// so later entries in the same batch see the reservation.  A routed result
+// always names a node/tier that exists here with enough room; a violation means
+// the selector's contract is broken.  Best-effort: on a violation log a MORI
+// ERROR and return false (caller drops the route, treats the key as unroutable)
+// instead of crashing.  Returns true after a successful deduction.
+bool ApplyProjectedDeduction(std::vector<ClientRecord>& candidates, const RoutePutResult& result,
+                             uint64_t block_size) {
+  auto client_it = std::find_if(candidates.begin(), candidates.end(),
+                                [&](const ClientRecord& c) { return c.node_id == result.node_id; });
+  if (client_it == candidates.end()) {
+    MORI_UMBP_ERROR("[RoutePutStrategy] projected-deduction: selected node not in candidates: {}",
+                    result.node_id);
+    return false;
+  }
+  auto tier_it = client_it->tier_capacities.find(result.tier);
+  if (tier_it == client_it->tier_capacities.end()) {
+    MORI_UMBP_ERROR("[RoutePutStrategy] projected-deduction: selected tier absent on node {}",
+                    result.node_id);
+    return false;
+  }
+  if (tier_it->second.available_bytes < block_size) {
+    MORI_UMBP_ERROR("[RoutePutStrategy] projected-deduction: capacity underflow on node {}",
+                    result.node_id);
+    return false;
+  }
+  tier_it->second.available_bytes -= block_size;
+  return true;
+}
+
 }  // namespace
-
-// ---------------------------------------------------------------------------
-//  RoutePutStrategy (base): default batch planner over the virtual Select()
-// ---------------------------------------------------------------------------
-std::vector<std::optional<RoutePutResult>> RoutePutStrategy::SelectBatch(
-    const std::string& /*requester_node_id*/, const std::vector<uint64_t>& block_sizes,
-    const std::vector<bool>& already_exists, std::vector<ClientRecord> candidates,
-    const std::unordered_set<std::string>& exclude_nodes) {
-  if (already_exists.size() != block_sizes.size()) {
-    MORI_UMBP_ERROR(
-        "[RoutePutStrategy] SelectBatch: already_exists length ({}) must match block_sizes ({}); "
-        "treating every key as unroutable",
-        already_exists.size(), block_sizes.size());
-    return std::vector<std::optional<RoutePutResult>>(block_sizes.size());
-  }
-
-  std::vector<std::optional<RoutePutResult>> results;
-  results.reserve(block_sizes.size());
-
-  for (size_t i = 0; i < block_sizes.size(); ++i) {
-    if (already_exists[i]) {
-      results.push_back(RoutePutResult{.outcome = RoutePutOutcome::kAlreadyExists});
-      continue;
-    }
-    if (candidates.empty()) {
-      results.push_back(std::nullopt);
-      continue;
-    }
-    auto selected = Select(candidates, block_sizes[i], exclude_nodes);
-    if (selected && selected->outcome == RoutePutOutcome::kRouted &&
-        !ApplyProjectedDeduction(candidates, *selected, block_sizes[i])) {
-      // Selector broke its own contract: drop the route (best-effort failure).
-      selected = std::nullopt;
-    }
-    results.push_back(std::move(selected));
-  }
-
-  return results;
-}
-
-// ---------------------------------------------------------------------------
-//  TierAwareMostAvailableStrategy
-// ---------------------------------------------------------------------------
-std::optional<RoutePutResult> TierAwareMostAvailableStrategy::Select(
-    const std::vector<ClientRecord>& alive_clients, uint64_t block_size,
-    const std::unordered_set<std::string>& exclude_nodes) {
-  const std::string exclude_snapshot = FormatExcludeSet(exclude_nodes);
-
-  for (TierType tier : kPutTierOrder) {
-    const ClientRecord* best = nullptr;
-    uint64_t best_available = 0;
-    uint64_t candidates_considered = 0;
-
-    for (const auto& client : alive_clients) {
-      if (exclude_nodes.count(client.node_id)) continue;
-      auto it = client.tier_capacities.find(tier);
-      if (it == client.tier_capacities.end()) continue;
-      if (it->second.available_bytes < block_size) continue;
-      ++candidates_considered;
-      if (best == nullptr || it->second.available_bytes > best_available) {
-        best = &client;
-        best_available = it->second.available_bytes;
-      }
-    }
-
-    if (best != nullptr) {
-      MORI_UMBP_INFO(
-          "[RoutePutStrategy] block_size={} tier={} selected node={} available_bytes={} "
-          "candidates={} excludes=[{}]",
-          block_size, TierTypeName(tier), best->node_id, best_available, candidates_considered,
-          exclude_snapshot);
-      return RoutePutResult{
-          .outcome = RoutePutOutcome::kRouted,
-          .node_id = best->node_id,
-          .peer_address = best->peer_address,
-          .tier = tier,
-      };
-    }
-
-    MORI_UMBP_DEBUG(
-        "[RoutePutStrategy] block_size={} tier={} no eligible node (candidates_checked={} "
-        "excludes=[{}])",
-        block_size, TierTypeName(tier), candidates_considered, exclude_snapshot);
-  }
-
-  MORI_UMBP_WARN(
-      "[RoutePutStrategy] block_size={} no suitable target. excludes=[{}] capacity_snapshot=[{}]",
-      block_size, exclude_snapshot, SummarizeClientTiers(alive_clients));
-  return std::nullopt;
-}
 
 // ---------------------------------------------------------------------------
 //  ConfigurableRoutePutStrategy
@@ -329,14 +251,6 @@ std::optional<RoutePutResult> ConfigurableRoutePutStrategy::SelectByAlgo(
   return std::nullopt;
 }
 
-std::optional<RoutePutResult> ConfigurableRoutePutStrategy::Select(
-    const std::vector<ClientRecord>& alive_clients, uint64_t block_size,
-    const std::unordered_set<std::string>& exclude_nodes) {
-  // Single-key default ignores affinity (no batch context, no requester here);
-  // batch affinity lives in SelectBatch.
-  return SelectByAlgo(alive_clients, block_size, exclude_nodes);
-}
-
 std::vector<std::optional<RoutePutResult>> ConfigurableRoutePutStrategy::SelectBatch(
     const std::string& requester_node_id, const std::vector<uint64_t>& block_sizes,
     const std::vector<bool>& already_exists, std::vector<ClientRecord> candidates,
@@ -348,6 +262,10 @@ std::vector<std::optional<RoutePutResult>> ConfigurableRoutePutStrategy::SelectB
         already_exists.size(), block_sizes.size());
     return std::vector<std::optional<RoutePutResult>>(block_sizes.size());
   }
+
+  // exclude_nodes is constant for the whole batch, so format it once for logs.
+  const std::string exclude_snapshot = FormatExcludeSet(exclude_nodes);
+  const std::string algo_desc = Describe();
 
   // Affinity anchor: the node (and optionally tier) we try first for each key
   // before the explicit SelectByAlgo fallback.  Affinity biases node choice and
@@ -385,16 +303,30 @@ std::vector<std::optional<RoutePutResult>> ConfigurableRoutePutStrategy::SelectB
   std::vector<std::optional<RoutePutResult>> results;
   results.reserve(block_sizes.size());
 
+  // One unroutable log path for every dropped key (empty candidates, no fit, or
+  // a deduction-contract violation), so each carries the projected capacity
+  // snapshot — which reads "<no-alive-clients>" when candidates is empty.
+  auto log_unroutable = [&](uint64_t bs) {
+    MORI_UMBP_WARN(
+        "[RoutePutStrategy] block_size={} no suitable target. algo=[{}] excludes=[{}] "
+        "capacity_snapshot=[{}]",
+        bs, algo_desc, exclude_snapshot, SummarizeClientTiers(candidates));
+  };
+
   for (size_t i = 0; i < block_sizes.size(); ++i) {
     if (already_exists[i]) {
+      // Master-side dedup hit: not a routing failure, so no WARN.
+      MORI_UMBP_DEBUG("[RoutePutStrategy] block_size={} already-exists (dedup hit)",
+                      block_sizes[i]);
       results.push_back(RoutePutResult{.outcome = RoutePutOutcome::kAlreadyExists});
       continue;
     }
+    const uint64_t block_size = block_sizes[i];
     if (candidates.empty()) {
+      log_unroutable(block_size);
       results.push_back(std::nullopt);
       continue;
     }
-    const uint64_t block_size = block_sizes[i];
 
     std::optional<RoutePutResult> selected;
     if (affinity_ == NodeAffinity::kLocal) {
@@ -423,10 +355,25 @@ std::vector<std::optional<RoutePutResult>> ConfigurableRoutePutStrategy::SelectB
       selected = SelectByAlgo(candidates, block_size, exclude_nodes);
     }
 
-    if (selected && selected->outcome == RoutePutOutcome::kRouted &&
-        !ApplyProjectedDeduction(candidates, *selected, block_size)) {
-      // Selector broke its own contract: drop the route (best-effort failure).
-      selected = std::nullopt;
+    // Apply projected capacity, then log against the FINAL returned value: a
+    // routed pick whose deduction fails is dropped to nullopt and reported as a
+    // failure, never as a route (capture available_bytes before the deduction
+    // so the INFO reflects the snapshot the decision was made on).
+    if (selected && selected->outcome == RoutePutOutcome::kRouted) {
+      const uint64_t available =
+          LookupAvailableBytes(candidates, selected->node_id, selected->tier);
+      if (ApplyProjectedDeduction(candidates, *selected, block_size)) {
+        MORI_UMBP_INFO(
+            "[RoutePutStrategy] block_size={} tier={} selected node={} available_bytes={} "
+            "algo=[{}] excludes=[{}]",
+            block_size, TierTypeName(selected->tier), selected->node_id, available, algo_desc,
+            exclude_snapshot);
+      } else {
+        selected = std::nullopt;  // selector broke its contract (best-effort drop)
+        log_unroutable(block_size);
+      }
+    } else {
+      log_unroutable(block_size);
     }
     results.push_back(std::move(selected));
   }

--- a/src/umbp/distributed/routing/router.cpp
+++ b/src/umbp/distributed/routing/router.cpp
@@ -52,21 +52,10 @@ std::optional<RouteGetResolution> Router::RouteGet(
 std::optional<RoutePutResult> Router::RoutePut(
     const std::string& key, const std::string& node_id, uint64_t block_size,
     const std::unordered_set<std::string>& exclude_nodes) {
-  // Master-side dedup lives only in BatchRoutePut (single RoutePut proto carries
-  // no already_exists; PoolClient::Put wraps BatchPut).  Route through
-  // SelectBatch(size=1) so node-affinity logic has a single home; this is the
-  // base most-available/none default's per-key path, so behavior is unchanged.
-  (void)key;
-  auto candidates = registry_.GetAliveClients();
-  if (candidates.empty()) {
-    MORI_UMBP_DEBUG("[Router] RoutePut from={}: no alive clients", node_id);
-    return std::nullopt;
-  }
-  auto results = put_strategy_->SelectBatch(node_id, {block_size}, {false}, std::move(candidates),
-                                            exclude_nodes);
-  if (!results.front()) {
-    MORI_UMBP_DEBUG("[Router] RoutePut from={}: no node with sufficient capacity", node_id);
-  }
+  // Delegate to the batch path (size=1) so master-side dedup (BatchLookupExists)
+  // and projected-capacity logic have a single home; a returned kAlreadyExists
+  // now flows back through RoutePutResponse.outcome.
+  auto results = BatchRoutePut({key}, node_id, {block_size}, exclude_nodes);
   return std::move(results.front());
 }
 
@@ -76,7 +65,8 @@ std::vector<std::optional<RoutePutResult>> Router::BatchRoutePut(
     const std::unordered_set<std::string>& exclude_nodes) {
   // SelectBatch applies dedup + projected capacity on this batch-local snapshot;
   // the peer allocator stays the final ENOSPC arbiter. A keys/block_sizes length
-  // mismatch surfaces as a SelectBatch throw (no silent coercion).
+  // mismatch is logged as a MORI ERROR and yields an all-nullopt result
+  // (best-effort: no throw, every key reads as unroutable).
   auto exists_mask = index_.BatchLookupExists(keys);
   auto candidates = registry_.GetAliveClients();
   return put_strategy_->SelectBatch(node_id, block_sizes, exists_mask, std::move(candidates),

--- a/src/umbp/distributed/routing/router.cpp
+++ b/src/umbp/distributed/routing/router.cpp
@@ -52,33 +52,35 @@ std::optional<RouteGetResolution> Router::RouteGet(
 std::optional<RoutePutResult> Router::RoutePut(
     const std::string& key, const std::string& node_id, uint64_t block_size,
     const std::unordered_set<std::string>& exclude_nodes) {
-  // Master-side dedup lives only in BatchRoutePut (single RoutePut
-  // proto carries no already_exists; PoolClient::Put wraps BatchPut).
+  // Master-side dedup lives only in BatchRoutePut (single RoutePut proto carries
+  // no already_exists; PoolClient::Put wraps BatchPut).  Route through
+  // SelectBatch(size=1) so node-affinity logic has a single home; this is the
+  // base most-available/none default's per-key path, so behavior is unchanged.
   (void)key;
   auto candidates = registry_.GetAliveClients();
   if (candidates.empty()) {
     MORI_UMBP_DEBUG("[Router] RoutePut from={}: no alive clients", node_id);
     return std::nullopt;
   }
-  auto selected = put_strategy_->Select(candidates, block_size, exclude_nodes);
-  if (!selected) {
+  auto results = put_strategy_->SelectBatch(node_id, {block_size}, {false}, std::move(candidates),
+                                            exclude_nodes);
+  if (!results.front()) {
     MORI_UMBP_DEBUG("[Router] RoutePut from={}: no node with sufficient capacity", node_id);
-    return std::nullopt;
   }
-  return selected;
+  return std::move(results.front());
 }
 
 std::vector<std::optional<RoutePutResult>> Router::BatchRoutePut(
     const std::vector<std::string>& keys, const std::string& node_id,
     const std::vector<uint64_t>& block_sizes,
     const std::unordered_set<std::string>& exclude_nodes) {
-  (void)node_id;
   // SelectBatch applies dedup + projected capacity on this batch-local snapshot;
   // the peer allocator stays the final ENOSPC arbiter. A keys/block_sizes length
   // mismatch surfaces as a SelectBatch throw (no silent coercion).
   auto exists_mask = index_.BatchLookupExists(keys);
   auto candidates = registry_.GetAliveClients();
-  return put_strategy_->SelectBatch(block_sizes, exists_mask, std::move(candidates), exclude_nodes);
+  return put_strategy_->SelectBatch(node_id, block_sizes, exists_mask, std::move(candidates),
+                                    exclude_nodes);
 }
 
 std::vector<std::optional<RouteGetResolution>> Router::BatchRouteGet(

--- a/src/umbp/distributed/routing/router.cpp
+++ b/src/umbp/distributed/routing/router.cpp
@@ -21,7 +21,6 @@
 // SOFTWARE.
 #include "umbp/distributed/routing/router.h"
 
-#include <algorithm>
 #include <unordered_map>
 
 #include "mori/utils/mori_log.hpp"
@@ -38,8 +37,13 @@ Router::Router(GlobalBlockIndex& index, ClientRegistry& registry,
   // config_.get_strategy.
   get_strategy_ =
       get_strategy ? std::move(get_strategy) : std::make_unique<TierPriorityRouteGetStrategy>();
-  put_strategy_ =
-      put_strategy ? std::move(put_strategy) : std::make_unique<TierAwareMostAvailableStrategy>();
+  // Default to most-available / no-affinity: the single built-in put strategy.
+  // Callers can still inject any RoutePutStrategy (e.g. an env-configured
+  // ConfigurableRoutePutStrategy from master startup) via config_.put_strategy.
+  put_strategy_ = put_strategy ? std::move(put_strategy)
+                               : std::make_unique<ConfigurableRoutePutStrategy>(
+                                     ConfigurableRoutePutStrategy::SelectAlgo::kMostAvailable,
+                                     ConfigurableRoutePutStrategy::NodeAffinity::kNone);
 }
 
 std::optional<RouteGetResolution> Router::RouteGet(

--- a/src/umbp/distributed/routing/router.cpp
+++ b/src/umbp/distributed/routing/router.cpp
@@ -73,21 +73,12 @@ std::vector<std::optional<RoutePutResult>> Router::BatchRoutePut(
     const std::vector<uint64_t>& block_sizes,
     const std::unordered_set<std::string>& exclude_nodes) {
   (void)node_id;
-  std::vector<std::optional<RoutePutResult>> results(keys.size());
-  // Single shared_lock for the whole batch: dedup mask + alive snapshot.
-  // Two entries picking the same (node, tier) is fine — peer will sort
-  // out ENOSPC at AllocateSlot.
+  // SelectBatch applies dedup + projected capacity on this batch-local snapshot;
+  // the peer allocator stays the final ENOSPC arbiter. A keys/block_sizes length
+  // mismatch surfaces as a SelectBatch throw (no silent coercion).
   auto exists_mask = index_.BatchLookupExists(keys);
   auto candidates = registry_.GetAliveClients();
-  for (size_t i = 0; i < keys.size(); ++i) {
-    if (i < exists_mask.size() && exists_mask[i]) {
-      results[i] = RoutePutResult{.outcome = RoutePutOutcome::kAlreadyExists};
-      continue;
-    }
-    if (candidates.empty()) continue;
-    results[i] = put_strategy_->Select(candidates, block_sizes[i], exclude_nodes);
-  }
-  return results;
+  return put_strategy_->SelectBatch(block_sizes, exists_mask, std::move(candidates), exclude_nodes);
 }
 
 std::vector<std::optional<RouteGetResolution>> Router::BatchRouteGet(

--- a/src/umbp/doc/design-master-control-plane.md
+++ b/src/umbp/doc/design-master-control-plane.md
@@ -196,7 +196,7 @@ include/umbp/
 │   └── routing/
 │       ├── router.h
 │       ├── route_get_strategy.h       # TierPriorityRouteGetStrategy (default), RandomRouteGetStrategy
-│       └── route_put_strategy.h       # TierAwareMostAvailableStrategy
+│       └── route_put_strategy.h       # ConfigurableRoutePutStrategy (most_available/random x none/same/local)
 └── local/                             # Standalone (no-net) DRAM+SSD path
     ├── standalone_client.h
     ├── host_mem_allocator.h
@@ -412,7 +412,8 @@ A hash/key may appear in both, but the serving paths are disjoint.
 
 Stateless façade over the two index objects + `ClientRegistry`.
 Dispatches to pluggable strategies; defaults are
-`TierPriorityRouteGetStrategy` and `TierAwareMostAvailableStrategy`.
+`TierPriorityRouteGetStrategy` and
+`ConfigurableRoutePutStrategy(most_available, none)`.
 
 - `RouteGet(key, node_id, exclude_nodes)` returns
   `RouteGetResolution{Location, peer_address}` (so the reader doesn't
@@ -438,11 +439,15 @@ present. `RandomRouteGetStrategy` (uniform across all replicas
 regardless of tier) remains available to inject via
 `MasterServerConfig::get_strategy`.
 
-`RoutePutStrategy::Select(alive_clients, block_size, exclude_nodes)` —
-`TierAwareMostAvailableStrategy` walks **`[HBM, DRAM]`** in order and,
-on the first tier with any node holding `>= block_size` available
-capacity, picks the node with the most available bytes (load
-spreading). **SSD is intentionally not a `RoutePut` target**: there is
+`RoutePutStrategy::SelectBatch(requester_node_id, block_sizes,
+already_exists, candidates, exclude_nodes)` is the single put extension
+point (single-key `RoutePut` is a size-1 batch). The built-in
+`ConfigurableRoutePutStrategy` with `most_available / none` walks
+**`[HBM, DRAM]`** in order and, on the first tier with any node holding
+`>= block_size` available capacity, picks the node with the most
+available bytes (load spreading); each routed pick deducts projected
+capacity on the batch-local `candidates` copy so later keys de-cluster.
+**SSD is intentionally not a `RoutePut` target**: there is
 no direct-SSD-put path — the SSD copy is filled asynchronously by
 copy-on-commit, so even with SSD capacity reported on the heartbeat,
 `RoutePut` must never steer a write at a tier with no direct-put
@@ -561,7 +566,7 @@ has a DRAM/HBM tier or an SSD tier.
        │                         │                            │
        │   RoutePut(key, sz)     │                            │
        │────────────────────────►│  registry.GetAliveClients  │
-       │                         │  strategy.Select(...)      │
+       │                         │  strategy.SelectBatch(...)  │
        │  RoutePutResult{node,   │                            │
        │  peer_address, tier}    │                            │
        │◄────────────────────────│                            │
@@ -930,13 +935,15 @@ calls `GlobalBlockIndex::FindEvictionCandidates` under
 both locks.
 
 Custom routing strategies must be thread-safe — the gRPC handler thread
-pool calls `Select` concurrently. The defaults are:
+pool calls `Select` / `SelectBatch` concurrently. The defaults are:
 
 - `TierPriorityRouteGetStrategy` (default get) — `thread_local
   std::mt19937` for the within-tier random pick, no mutexes.
 - `RandomRouteGetStrategy` (injectable) — `thread_local std::mt19937`,
   no mutexes.
-- `TierAwareMostAvailableStrategy` (default put) — stateless.
+- `ConfigurableRoutePutStrategy` (default put: `most_available/none`) —
+  stateless except for the optional pinned RNG used by `random`
+  (guarded by a mutex; production uses a `thread_local std::mt19937`).
 
 ---
 

--- a/src/umbp/doc/runtime-env-vars.md
+++ b/src/umbp/doc/runtime-env-vars.md
@@ -65,6 +65,8 @@ Read by the **master process** (`bin/master_main.cpp` via
 | `UMBP_HIT_INDEX_TTL_SEC` | `7200` | sec | External KV hit-count entry TTL. A hash with no counted match for longer than this is removed from the hit index. |
 | `UMBP_HIT_INDEX_GC_INTERVAL_SEC` | `60` | sec | External KV hit-count GC sweep interval. |
 | `UMBP_HIT_QUERY_MAX_BATCH` | `4096` | count | Maximum hashes accepted by one `GetExternalKvHitCounts` request. Oversized requests return gRPC `INVALID_ARGUMENT`; the server does not truncate. |
+| `UMBP_ROUTE_PUT_SELECT_ALGO` | `most_available` | enum | Base RoutePut placement algorithm over eligible nodes (HBM before DRAM; SSD never a direct-put target). `most_available` = pick the node with the most projected free space; `random` = capacity-weighted random (probability proportional to projected `available_bytes`, never picks a node that cannot fit). Unknown value → default + one WARN. |
+| `UMBP_ROUTE_PUT_NODE_AFFINITY` | `none` | enum | Node-affinity bias layered on top of the base algorithm. `none` = pure base algorithm; `same` = try to place the whole batch on one node that fits the non-dedup total, else per-key sticky to the first picked node; `local` = per-key prefer the requester's local node. All three fall back to the base algorithm so affinity never makes a key fail that the base algorithm could route. Unknown value → default + one WARN. |
 
 ## Peer / pool client
 

--- a/src/umbp/include/umbp/common/env_time.h
+++ b/src/umbp/include/umbp/common/env_time.h
@@ -46,6 +46,7 @@
 #include <climits>
 #include <cstdint>
 #include <cstdlib>
+#include <initializer_list>
 #include <mutex>
 #include <string>
 #include <unordered_set>
@@ -143,6 +144,29 @@ inline uint32_t GetEnvUint32(const char* name, uint32_t def, uint32_t min_allowe
     return def;
   }
   return static_cast<uint32_t>(v);
+}
+
+// Resolve a string-enum env var against a fixed set of allowed values.
+//   - Unset / empty / whitespace-only -> return `def` silently.
+//   - After trimming leading/trailing whitespace, exact (case-sensitive,
+//     lowercase) match against `allowed` -> return the matched value.
+//   - Anything else (unknown value) -> return `def` and WARN once per name.
+// `def` is expected to be one of `allowed`.
+inline std::string GetEnvEnum(const char* name, const char* def,
+                              std::initializer_list<const char*> allowed) {
+  const char* raw = std::getenv(name);
+  if (raw == nullptr || *raw == '\0') return def;
+  std::string value(raw);
+  const char* ws = " \t\n\r\f\v";
+  const size_t begin = value.find_first_not_of(ws);
+  if (begin == std::string::npos) return def;  // whitespace-only == empty
+  const size_t end = value.find_last_not_of(ws);
+  value = value.substr(begin, end - begin + 1);
+  for (const char* candidate : allowed) {
+    if (value == candidate) return value;
+  }
+  env_time_detail::WarnOnce(name, "unknown value", raw);
+  return def;
 }
 
 // Test-only: clear the WARN-once registry. Not thread-safe vs readers.

--- a/src/umbp/include/umbp/distributed/config.h
+++ b/src/umbp/include/umbp/distributed/config.h
@@ -101,6 +101,12 @@ struct MasterServerConfig {
   std::unique_ptr<RouteGetStrategy> get_strategy;
   std::unique_ptr<RoutePutStrategy> put_strategy;
 
+  // Resolved put-strategy knobs, kept as strings for startup logging because a
+  // unique_ptr<RoutePutStrategy> is not cheaply introspectable.  Populated by
+  // FromEnvironment() alongside put_strategy.
+  std::string route_put_algo = "most_available";
+  std::string route_put_affinity = "none";
+
   // Composes ClientRegistryConfig::FromEnvironment() and
   // EvictionConfig::FromEnvironment().  listen_address is NOT read from env
   // here; callers (e.g. bin/master_main.cpp) apply argv overrides after

--- a/src/umbp/include/umbp/distributed/routing/route_put_strategy.h
+++ b/src/umbp/include/umbp/distributed/routing/route_put_strategy.h
@@ -64,6 +64,23 @@ class RoutePutStrategy {
   virtual std::optional<RoutePutResult> Select(
       const std::vector<ClientRecord>& alive_clients, uint64_t block_size,
       const std::unordered_set<std::string>& exclude_nodes) = 0;
+
+  /// Batch-aware placement with projected capacity: each routed pick deducts
+  /// the chosen node/tier's available_bytes in the by-value @p candidates
+  /// copy so later entries in the same batch see the reservation.  The copy is
+  /// batch-local and never written back to the registry — the peer allocator is
+  /// still the final arbiter.  Result length and order match @p block_sizes.
+  ///
+  /// @p already_exists must be the same length as @p block_sizes (throws
+  /// otherwise).  Entries with already_exists[i]==true are master-side dedup
+  /// hits: they return kAlreadyExists and consume no projected capacity.
+  ///
+  /// The default implementation reuses the virtual Select() unchanged; it does
+  /// not alter single-key placement semantics.  Override only to implement a
+  /// smarter batch planner.
+  virtual std::vector<std::optional<RoutePutResult>> SelectBatch(
+      const std::vector<uint64_t>& block_sizes, const std::vector<bool>& already_exists,
+      std::vector<ClientRecord> candidates, const std::unordered_set<std::string>& exclude_nodes);
 };
 
 /// Default strategy: try tiers fastest-first (HBM -> DRAM -> SSD),

--- a/src/umbp/include/umbp/distributed/routing/route_put_strategy.h
+++ b/src/umbp/include/umbp/distributed/routing/route_put_strategy.h
@@ -22,7 +22,9 @@
 #pragma once
 
 #include <cstdint>
+#include <mutex>
 #include <optional>
+#include <random>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -75,21 +77,94 @@ class RoutePutStrategy {
   /// otherwise).  Entries with already_exists[i]==true are master-side dedup
   /// hits: they return kAlreadyExists and consume no projected capacity.
   ///
-  /// The default implementation reuses the virtual Select() unchanged; it does
-  /// not alter single-key placement semantics.  Override only to implement a
-  /// smarter batch planner.
+  /// @p requester_node_id is the node that issued the batch put; node-affinity
+  /// strategies use it to bias placement toward the writer's local node.  The
+  /// default implementation ignores it and reuses the virtual Select()
+  /// unchanged, preserving single-key placement semantics.  Override only to
+  /// implement a smarter batch planner.
+  ///
+  /// NOTE: this virtual signature is an internal extension point.  Adding
+  /// @p requester_node_id is a breaking change for any out-of-tree subclass.
   virtual std::vector<std::optional<RoutePutResult>> SelectBatch(
-      const std::vector<uint64_t>& block_sizes, const std::vector<bool>& already_exists,
-      std::vector<ClientRecord> candidates, const std::unordered_set<std::string>& exclude_nodes);
+      const std::string& requester_node_id, const std::vector<uint64_t>& block_sizes,
+      const std::vector<bool>& already_exists, std::vector<ClientRecord> candidates,
+      const std::unordered_set<std::string>& exclude_nodes);
 };
 
-/// Default strategy: try tiers fastest-first (HBM -> DRAM -> SSD),
+/// Default strategy: try direct-put tiers fastest-first (HBM -> DRAM),
 /// pick the node with the most available space on the first tier that has capacity.
 class TierAwareMostAvailableStrategy : public RoutePutStrategy {
  public:
   std::optional<RoutePutResult> Select(
       const std::vector<ClientRecord>& alive_clients, uint64_t block_size,
       const std::unordered_set<std::string>& exclude_nodes) override;
+};
+
+/// Configurable batch put strategy combining two orthogonal knobs:
+///   - base select algorithm: most-available vs capacity-weighted random;
+///   - node affinity: none / same-node / local-node.
+///
+/// Both knobs are wired from env vars at master startup
+/// (UMBP_ROUTE_PUT_SELECT_ALGO / UMBP_ROUTE_PUT_NODE_AFFINITY).  Tier order is
+/// always HBM -> DRAM; SSD is never a direct-put target.  Projected capacity is
+/// deducted on the batch-local candidates copy exactly like the base
+/// SelectBatch; nothing is written back to the registry.
+class ConfigurableRoutePutStrategy : public RoutePutStrategy {
+ public:
+  enum class SelectAlgo { kMostAvailable, kRandom };
+  enum class NodeAffinity { kNone, kSame, kLocal };
+
+  ConfigurableRoutePutStrategy(SelectAlgo algo, NodeAffinity affinity);
+  /// Test-only ctor: pins the RNG seed so capacity-weighted random draws are
+  /// reproducible.  Production uses the thread_local RNG (no shared state).
+  ConfigurableRoutePutStrategy(SelectAlgo algo, NodeAffinity affinity, uint64_t rng_seed);
+
+  std::optional<RoutePutResult> Select(
+      const std::vector<ClientRecord>& alive_clients, uint64_t block_size,
+      const std::unordered_set<std::string>& exclude_nodes) override;
+
+  std::vector<std::optional<RoutePutResult>> SelectBatch(
+      const std::string& requester_node_id, const std::vector<uint64_t>& block_sizes,
+      const std::vector<bool>& already_exists, std::vector<ClientRecord> candidates,
+      const std::unordered_set<std::string>& exclude_nodes) override;
+
+  /// Human-readable "algo/affinity" for startup logging.
+  std::string Describe() const;
+
+ private:
+  /// Try only @p node_id on exactly @p tier; nullopt if it cannot fit
+  /// @p block_size.  No cross-node, no cross-tier fallback.
+  std::optional<RoutePutResult> TrySelectOnNodeTier(
+      const std::vector<ClientRecord>& candidates, const std::string& node_id, TierType tier,
+      uint64_t block_size, const std::unordered_set<std::string>& exclude_nodes) const;
+
+  /// Try only @p node_id, HBM then DRAM; nullopt if it cannot fit @p block_size.
+  /// Performs no cross-node fallback — that is the caller's explicit job.
+  std::optional<RoutePutResult> TrySelectOnNode(
+      const std::vector<ClientRecord>& candidates, const std::string& node_id, uint64_t block_size,
+      const std::unordered_set<std::string>& exclude_nodes) const;
+
+  /// Base algorithm, tier priority paramount (HBM before DRAM): walk tiers in
+  /// order and route on the first tier that has room.  Within a tier, most-
+  /// available picks the largest free space; random draws weighted by it.  When
+  /// @p preferred_node is set and has room on the current tier, it wins over the
+  /// algorithm — but only within that tier, so tier priority is never broken
+  /// (a remote HBM node still beats the preferred node's DRAM).  This is the
+  /// explicit global-fallback entry point.
+  std::optional<RoutePutResult> SelectByAlgo(
+      const std::vector<ClientRecord>& candidates, uint64_t block_size,
+      const std::unordered_set<std::string>& exclude_nodes,
+      const std::optional<std::string>& preferred_node = std::nullopt);
+
+  /// Draw an index in [0, weights.size()) with probability proportional to the
+  /// weights.  Uses the pinned RNG when seeded, else a thread_local RNG.
+  size_t PickWeighted(const std::vector<uint64_t>& weights);
+
+  SelectAlgo algo_;
+  NodeAffinity affinity_;
+  bool seeded_ = false;
+  std::mt19937 rng_;
+  std::mutex rng_mutex_;
 };
 
 }  // namespace mori::umbp

--- a/src/umbp/include/umbp/distributed/routing/route_put_strategy.h
+++ b/src/umbp/include/umbp/distributed/routing/route_put_strategy.h
@@ -73,9 +73,10 @@ class RoutePutStrategy {
   /// batch-local and never written back to the registry — the peer allocator is
   /// still the final arbiter.  Result length and order match @p block_sizes.
   ///
-  /// @p already_exists must be the same length as @p block_sizes (throws
-  /// otherwise).  Entries with already_exists[i]==true are master-side dedup
-  /// hits: they return kAlreadyExists and consume no projected capacity.
+  /// @p already_exists must be the same length as @p block_sizes; a mismatch is
+  /// logged as a MORI ERROR and yields an all-nullopt result (best-effort, no
+  /// throw).  Entries with already_exists[i]==true are master-side dedup hits:
+  /// they return kAlreadyExists and consume no projected capacity.
   ///
   /// @p requester_node_id is the node that issued the batch put; node-affinity
   /// strategies use it to bias placement toward the writer's local node.  The

--- a/src/umbp/include/umbp/distributed/routing/route_put_strategy.h
+++ b/src/umbp/include/umbp/distributed/routing/route_put_strategy.h
@@ -51,27 +51,20 @@ struct RoutePutResult {
   TierType tier = TierType::UNKNOWN;
 };
 
-/// Abstract interface for RoutePut node placement.
-/// Implement this to plug in a custom write-path placement strategy.
+/// Abstract interface for batch RoutePut node placement.  Implement this to
+/// plug in a custom write-path placement strategy.  The Router always routes
+/// through SelectBatch — a single-key RoutePut is just a size-1 batch — so this
+/// is the one and only extension point.
 class RoutePutStrategy {
  public:
   virtual ~RoutePutStrategy() = default;
-
-  /// Select a target node from @p alive_clients that can accommodate
-  /// @p block_size bytes.  Tier selection is the strategy's responsibility.
-  /// Nodes whose `node_id` appears in @p exclude_nodes are skipped — the
-  /// caller has already failed against them (typically ENOSPC at the
-  /// peer's allocator) and would only fail again.
-  /// @return nullopt if no suitable node exists.
-  virtual std::optional<RoutePutResult> Select(
-      const std::vector<ClientRecord>& alive_clients, uint64_t block_size,
-      const std::unordered_set<std::string>& exclude_nodes) = 0;
 
   /// Batch-aware placement with projected capacity: each routed pick deducts
   /// the chosen node/tier's available_bytes in the by-value @p candidates
   /// copy so later entries in the same batch see the reservation.  The copy is
   /// batch-local and never written back to the registry — the peer allocator is
-  /// still the final arbiter.  Result length and order match @p block_sizes.
+  /// still the final ENOSPC arbiter.  Result length and order match
+  /// @p block_sizes.
   ///
   /// @p already_exists must be the same length as @p block_sizes; a mismatch is
   /// logged as a MORI ERROR and yields an all-nullopt result (best-effort, no
@@ -79,26 +72,16 @@ class RoutePutStrategy {
   /// they return kAlreadyExists and consume no projected capacity.
   ///
   /// @p requester_node_id is the node that issued the batch put; node-affinity
-  /// strategies use it to bias placement toward the writer's local node.  The
-  /// default implementation ignores it and reuses the virtual Select()
-  /// unchanged, preserving single-key placement semantics.  Override only to
-  /// implement a smarter batch planner.
+  /// strategies use it to bias placement toward the writer's local node.
   ///
-  /// NOTE: this virtual signature is an internal extension point.  Adding
-  /// @p requester_node_id is a breaking change for any out-of-tree subclass.
+  /// @p exclude_nodes lists nodes the caller has already failed against
+  /// (typically ENOSPC at the peer's allocator); they are skipped because they
+  /// would only fail again.  A per-key entry is the outer
+  /// `std::optional<RoutePutResult>::nullopt` when no suitable node exists.
   virtual std::vector<std::optional<RoutePutResult>> SelectBatch(
       const std::string& requester_node_id, const std::vector<uint64_t>& block_sizes,
       const std::vector<bool>& already_exists, std::vector<ClientRecord> candidates,
-      const std::unordered_set<std::string>& exclude_nodes);
-};
-
-/// Default strategy: try direct-put tiers fastest-first (HBM -> DRAM),
-/// pick the node with the most available space on the first tier that has capacity.
-class TierAwareMostAvailableStrategy : public RoutePutStrategy {
- public:
-  std::optional<RoutePutResult> Select(
-      const std::vector<ClientRecord>& alive_clients, uint64_t block_size,
-      const std::unordered_set<std::string>& exclude_nodes) override;
+      const std::unordered_set<std::string>& exclude_nodes) = 0;
 };
 
 /// Configurable batch put strategy combining two orthogonal knobs:
@@ -108,8 +91,8 @@ class TierAwareMostAvailableStrategy : public RoutePutStrategy {
 /// Both knobs are wired from env vars at master startup
 /// (UMBP_ROUTE_PUT_SELECT_ALGO / UMBP_ROUTE_PUT_NODE_AFFINITY).  Tier order is
 /// always HBM -> DRAM; SSD is never a direct-put target.  Projected capacity is
-/// deducted on the batch-local candidates copy exactly like the base
-/// SelectBatch; nothing is written back to the registry.
+/// deducted on the batch-local candidates copy within SelectBatch; nothing is
+/// written back to the registry.
 class ConfigurableRoutePutStrategy : public RoutePutStrategy {
  public:
   enum class SelectAlgo { kMostAvailable, kRandom };
@@ -119,10 +102,6 @@ class ConfigurableRoutePutStrategy : public RoutePutStrategy {
   /// Test-only ctor: pins the RNG seed so capacity-weighted random draws are
   /// reproducible.  Production uses the thread_local RNG (no shared state).
   ConfigurableRoutePutStrategy(SelectAlgo algo, NodeAffinity affinity, uint64_t rng_seed);
-
-  std::optional<RoutePutResult> Select(
-      const std::vector<ClientRecord>& alive_clients, uint64_t block_size,
-      const std::unordered_set<std::string>& exclude_nodes) override;
 
   std::vector<std::optional<RoutePutResult>> SelectBatch(
       const std::string& requester_node_id, const std::vector<uint64_t>& block_sizes,

--- a/src/umbp/tests/test_router_dedup.cpp
+++ b/src/umbp/tests/test_router_dedup.cpp
@@ -159,4 +159,31 @@ TEST(RouterDedup, BatchRoutePutAlreadyExistsBypassesNoAliveClient) {
   EXPECT_FALSE(results[1].has_value());  // distinct from kAlreadyExists
 }
 
+// Single-key RoutePut delegates to the batch path, so master-side dedup applies:
+// an indexed key returns kAlreadyExists while an unknown key still routes.  This
+// locks in the delegation; without it RoutePut would silently skip dedup.
+TEST(RouterDedup, RoutePutMarksAlreadyExistsForIndexedKey) {
+  GlobalBlockIndex index;
+  ClientRegistry registry(ClientRegistryConfig{}, index);
+  Router router(index, registry);
+
+  ASSERT_TRUE(registry.RegisterClient("node-a", "node-a:1", MakeDramCaps(),
+                                      /*peer_address=*/"node-a:peer"));
+  ASSERT_EQ(
+      index.ApplyEvents("node-a", {KvEvent{KvEvent::Kind::ADD, "key-X", TierType::DRAM, 4096}}),
+      1u);
+
+  std::unordered_set<std::string> excludes;
+
+  auto dedup = router.RoutePut("key-X", "requester", 4096, excludes);
+  ASSERT_TRUE(dedup.has_value());
+  EXPECT_EQ(dedup->outcome, RoutePutOutcome::kAlreadyExists);
+  EXPECT_TRUE(dedup->node_id.empty());
+
+  auto routed = router.RoutePut("key-Y", "requester", 4096, excludes);
+  ASSERT_TRUE(routed.has_value());
+  EXPECT_EQ(routed->outcome, RoutePutOutcome::kRouted);
+  EXPECT_EQ(routed->node_id, "node-a");
+}
+
 }  // namespace mori::umbp

--- a/src/umbp/tests/test_router_dedup.cpp
+++ b/src/umbp/tests/test_router_dedup.cpp
@@ -77,6 +77,65 @@ TEST(RouterDedup, BatchRoutePutMarksAlreadyExistsForIndexedKey) {
   EXPECT_EQ(results[1]->node_id, "node-a");
 }
 
+// Dedup hits never enter the planner, so they consume no projected capacity.
+// node-a fits exactly one 6GB block on HBM.  key-X is an indexed dedup hit
+// sized 6GB; if dedup had deducted capacity, node-a would have 0 left and the
+// new key-Y could not route.  Since dedup does not deduct, key-Y still routes.
+TEST(RouterDedup, BatchRoutePutDedupDoesNotConsumeCapacity) {
+  GlobalBlockIndex index;
+  ClientRegistry registry(ClientRegistryConfig{}, index);
+  Router router(index, registry);
+
+  std::map<TierType, TierCapacity> caps;
+  caps[TierType::HBM] = {6 * kGB, 6 * kGB};
+  ASSERT_TRUE(registry.RegisterClient("node-a", "node-a:1", caps,
+                                      /*peer_address=*/"node-a:peer"));
+  ASSERT_EQ(
+      index.ApplyEvents("node-a", {KvEvent{KvEvent::Kind::ADD, "key-X", TierType::HBM, 6 * kGB}}),
+      1u);
+
+  std::vector<std::string> keys{"key-X", "key-Y"};
+  std::vector<uint64_t> sizes{6 * kGB, 6 * kGB};
+  std::unordered_set<std::string> excludes;
+
+  auto results = router.BatchRoutePut(keys, "requester", sizes, excludes);
+  ASSERT_EQ(results.size(), 2u);
+
+  ASSERT_TRUE(results[0].has_value());
+  EXPECT_EQ(results[0]->outcome, RoutePutOutcome::kAlreadyExists);
+
+  ASSERT_TRUE(results[1].has_value());
+  EXPECT_EQ(results[1]->outcome, RoutePutOutcome::kRouted);
+  EXPECT_EQ(results[1]->node_id, "node-a");
+  EXPECT_EQ(results[1]->tier, TierType::HBM);
+}
+
+// Projected capacity is batch-local: BatchRoutePut must not write the
+// deductions back to the registry's real capacity.
+TEST(RouterDedup, BatchRoutePutDoesNotWriteBackProjectedCapacity) {
+  GlobalBlockIndex index;
+  ClientRegistry registry(ClientRegistryConfig{}, index);
+  Router router(index, registry);
+
+  std::map<TierType, TierCapacity> caps;
+  caps[TierType::HBM] = {80 * kGB, 10 * kGB};
+  ASSERT_TRUE(registry.RegisterClient("node-a", "node-a:1", caps,
+                                      /*peer_address=*/"node-a:peer"));
+
+  std::vector<std::string> keys{"key-A", "key-B"};
+  std::vector<uint64_t> sizes{1 * kGB, 2 * kGB};
+  std::unordered_set<std::string> excludes;
+
+  auto results = router.BatchRoutePut(keys, "requester", sizes, excludes);
+  ASSERT_EQ(results.size(), 2u);
+  ASSERT_TRUE(results[0].has_value());
+  EXPECT_EQ(results[0]->outcome, RoutePutOutcome::kRouted);
+
+  auto alive = registry.GetAliveClients();
+  ASSERT_EQ(alive.size(), 1u);
+  EXPECT_EQ(alive[0].tier_capacities.at(TierType::HBM).available_bytes, 10 * kGB);
+}
+
 // already_exists wins over no-alive-client: caller drops Put even if
 // registry is empty (some other node owns the key).
 TEST(RouterDedup, BatchRoutePutAlreadyExistsBypassesNoAliveClient) {

--- a/tests/cpp/umbp/distributed/CMakeLists.txt
+++ b/tests/cpp/umbp/distributed/CMakeLists.txt
@@ -172,3 +172,16 @@ target_link_libraries(
   bench_umbp_pool_client_batch_get
   PRIVATE umbp_core umbp_common ${_TEST_PROTOBUF_LIB} ${_TEST_GRPCPP_LIB}
           gtest_main)
+
+# RoutePut strategy bench: compares batch put / put-then-get performance and
+# placement distribution across UMBP_ROUTE_PUT_SELECT_ALGO x
+# UMBP_ROUTE_PUT_NODE_AFFINITY under roomy/tight capacity regimes.  Standalone
+# executable; not a CTest target.
+add_executable(bench_umbp_route_put_strategy bench_route_put_strategy.cpp)
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  target_link_options(bench_umbp_route_put_strategy PRIVATE -Wl,--no-as-needed)
+endif()
+target_link_libraries(
+  bench_umbp_route_put_strategy
+  PRIVATE umbp_core umbp_common ${_TEST_PROTOBUF_LIB} ${_TEST_GRPCPP_LIB}
+          gtest_main)

--- a/tests/cpp/umbp/distributed/bench_route_put_strategy.cpp
+++ b/tests/cpp/umbp/distributed/bench_route_put_strategy.cpp
@@ -71,8 +71,12 @@
 // --dump-placement adds a per-node long table to stderr:
 //   select_algo,node_affinity,regime,batch,node,items,bytes
 
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
 #include <algorithm>
-#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
@@ -104,12 +108,38 @@ using mori::umbp::TierType;
 
 namespace {
 
-// Unique peer-service port per PoolClient so each node registers a peer_address
-// and can serve/accept remote AllocateSlot/ResolveKey RPCs.  Monotonic, never
-// reused — fine for the realistic number of clusters one bench run builds.
+// Peer-service port per PoolClient so each node registers a peer_address and can
+// serve/accept remote AllocateSlot/ResolveKey RPCs.  Ask the OS for a currently
+// free port (bind a probe socket to :0, read the assignment, close it) instead
+// of a hardcoded base: a fixed range collides with sockets left in the (host)
+// network namespace by prior/interrupted runs.  A small TOCTOU window remains
+// before PoolClient rebinds, but that is acceptable for a manual bench.
 inline uint16_t NextPeerServicePort() {
-  static std::atomic<uint16_t> next{56000};
-  return next.fetch_add(1);
+  int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+  if (fd < 0) {
+    std::cerr << "port probe: socket() failed\n";
+    std::exit(2);
+  }
+  int one = 1;
+  ::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  addr.sin_port = 0;  // OS-assigned
+  if (::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0 || ::listen(fd, 1) != 0) {
+    ::close(fd);
+    std::cerr << "port probe: bind/listen failed\n";
+    std::exit(2);
+  }
+  socklen_t len = sizeof(addr);
+  if (::getsockname(fd, reinterpret_cast<sockaddr*>(&addr), &len) != 0) {
+    ::close(fd);
+    std::cerr << "port probe: getsockname() failed\n";
+    std::exit(2);
+  }
+  const uint16_t port = ntohs(addr.sin_port);
+  ::close(fd);
+  return port;
 }
 
 struct BenchOpts {

--- a/tests/cpp/umbp/distributed/bench_route_put_strategy.cpp
+++ b/tests/cpp/umbp/distributed/bench_route_put_strategy.cpp
@@ -1,0 +1,529 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// RoutePut strategy bench: compares batch put / put-then-get performance and
+// placement distribution across the orthogonal RoutePut knobs
+// (UMBP_ROUTE_PUT_SELECT_ALGO x UMBP_ROUTE_PUT_NODE_AFFINITY) under two capacity
+// regimes.  Standalone executable; not a CTest target.
+//
+// Design notes / known limits (see PR description for full rationale):
+//   * Strategy switch is per-combo: setenv() the two env vars then build a fresh
+//     in-process MasterServer.  MasterServerConfig::FromEnvironment() reads them
+//     live (no static cache) and only these two env vars drive the strategy.
+//   * FromEnvironment() does NOT set listen_address (defaults to :50051) — we
+//     override to "0.0.0.0:0" and use GetBoundPort() like the other benches.
+//   * The master index/capacity only converge on a heartbeat.  We set a 1s
+//     heartbeat_ttl and, after each BatchPut, poll BatchExists (read-only, no
+//     lease) until every put key is visible before probing placement / timing
+//     the get.  This wait is OUTSIDE the timed regions.
+//   * Keys are never reclaimed and a remote BatchGet leaves a ~500ms read lease
+//     that defers capacity free on Clear().  So every measured iter starts by
+//     Clear()-ing all nodes and polling each allocator's TierCapacitiesSnapshot
+//     until available==total (lease-deferred frees released by the reaper).
+//   * Placement is observed via reader->Master().BatchRouteGet (returns per-key
+//     node_id).  This bumps lease/access; the subsequent timed BatchGet RouteGets
+//     the same keys again.  Harmless here (eviction is capacity-driven), but it
+//     is not a zero-side-effect probe.
+//   * BatchPut/BatchGet return only vector<bool>; NO_SPACE is not separable from
+//     other failures at that boundary — we report success/fail counts only.
+//   * DRAM-only: PoolClientConfig exposes no HBM buffer, so the HBM->DRAM tier
+//     order is unit-tested elsewhere; cross-node placement contrast is fully
+//     visible with DRAM + multiple nodes.
+//   * random goes through the production thread_local RNG (FromEnvironment uses
+//     the unseeded ctor), so it is not reproducible run-to-run; use enough iters.
+//
+// CSV (stdout):
+//   select_algo,node_affinity,regime,peers,requester,reader,batch,page_bytes,
+//   per_item_pages,iters,put_wall_ms,put_gibps,put_success,put_fail,
+//   unique_put_nodes,max_node_share,get_wall_ms,get_gibps,get_success,
+//   get_fanout_nodes,local_hit_frac
+// (put/get_wall_ms are the MEDIAN per-iter latency and *_gibps is the median-
+//  batch throughput over it — robust to the one-time cold-start cost; success/
+//  fail counts are summed over measured iters; distribution metrics are the mean
+//  of per-iter values over the routed keys.)
+//
+// --dump-placement adds a per-node long table to stderr:
+//   select_algo,node_affinity,regime,batch,node,items,bytes
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "umbp/distributed/config.h"
+#include "umbp/distributed/master/master_client.h"
+#include "umbp/distributed/master/master_server.h"
+#include "umbp/distributed/peer/peer_dram_allocator.h"
+#include "umbp/distributed/pool_client.h"
+
+using mori::umbp::MasterServer;
+using mori::umbp::MasterServerConfig;
+using mori::umbp::PoolClient;
+using mori::umbp::PoolClientConfig;
+using mori::umbp::RouteGetResult;
+using mori::umbp::TierCapacity;
+using mori::umbp::TierType;
+
+namespace {
+
+// Unique peer-service port per PoolClient so each node registers a peer_address
+// and can serve/accept remote AllocateSlot/ResolveKey RPCs.  Monotonic, never
+// reused — fine for the realistic number of clusters one bench run builds.
+inline uint16_t NextPeerServicePort() {
+  static std::atomic<uint16_t> next{56000};
+  return next.fetch_add(1);
+}
+
+struct BenchOpts {
+  std::vector<std::string> algos = {"most_available", "random"};
+  std::vector<std::string> affinities = {"none", "same", "local"};
+  std::vector<std::string> regimes = {"roomy", "tight"};
+  size_t peers = 4;
+  size_t requester = 0;
+  size_t reader = SIZE_MAX;  // SIZE_MAX => default to requester
+  size_t batch = 64;
+  size_t page_bytes = 4096;
+  size_t per_item_pages = 1;
+  size_t iters = 8;
+  bool no_get = false;
+  bool dump_placement = false;
+  std::vector<size_t> sweep;  // empty = single batch
+};
+
+void Usage() {
+  std::cerr << "Usage: bench_route_put_strategy\n"
+            << "  [--algos most_available,random] [--affinities none,same,local]\n"
+            << "  [--regimes roomy,tight] [--peers N] [--requester R] [--reader G]\n"
+            << "  [--batch N | --sweep batch=1,4,16,64,256]\n"
+            << "  [--page-bytes N] [--per-item-pages N] [--iters N]\n"
+            << "  [--no-get] [--dump-placement]\n";
+}
+
+std::vector<std::string> SplitCsv(const std::string& s) {
+  std::vector<std::string> out;
+  std::stringstream ss(s);
+  std::string tok;
+  while (std::getline(ss, tok, ',')) {
+    if (!tok.empty()) out.push_back(tok);
+  }
+  return out;
+}
+
+bool ParseArgs(int argc, char** argv, BenchOpts* o) {
+  for (int i = 1; i < argc; ++i) {
+    std::string a = argv[i];
+    auto next = [&](const char* what) -> const char* {
+      if (i + 1 >= argc) {
+        std::cerr << "Missing value for " << what << "\n";
+        std::exit(2);
+      }
+      return argv[++i];
+    };
+    if (a == "--algos") {
+      o->algos = SplitCsv(next("--algos"));
+    } else if (a == "--affinities") {
+      o->affinities = SplitCsv(next("--affinities"));
+    } else if (a == "--regimes") {
+      o->regimes = SplitCsv(next("--regimes"));
+    } else if (a == "--peers") {
+      o->peers = std::strtoull(next("--peers"), nullptr, 10);
+    } else if (a == "--requester") {
+      o->requester = std::strtoull(next("--requester"), nullptr, 10);
+    } else if (a == "--reader") {
+      o->reader = std::strtoull(next("--reader"), nullptr, 10);
+    } else if (a == "--batch") {
+      o->batch = std::strtoull(next("--batch"), nullptr, 10);
+    } else if (a == "--page-bytes") {
+      o->page_bytes = std::strtoull(next("--page-bytes"), nullptr, 10);
+    } else if (a == "--per-item-pages") {
+      o->per_item_pages = std::strtoull(next("--per-item-pages"), nullptr, 10);
+    } else if (a == "--iters") {
+      o->iters = std::strtoull(next("--iters"), nullptr, 10);
+    } else if (a == "--no-get") {
+      o->no_get = true;
+    } else if (a == "--dump-placement") {
+      o->dump_placement = true;
+    } else if (a == "--sweep") {
+      std::string s = next("--sweep");
+      auto eq = s.find('=');
+      if (eq == std::string::npos) {
+        std::cerr << "--sweep expects 'batch=N1,N2,...'\n";
+        return false;
+      }
+      for (const auto& tok : SplitCsv(s.substr(eq + 1))) {
+        o->sweep.push_back(std::strtoull(tok.c_str(), nullptr, 10));
+      }
+    } else if (a == "-h" || a == "--help") {
+      Usage();
+      std::exit(0);
+    } else {
+      std::cerr << "Unknown arg: " << a << "\n";
+      Usage();
+      return false;
+    }
+  }
+  if (o->reader == SIZE_MAX) o->reader = o->requester;
+  if (o->peers < 1) {
+    std::cerr << "--peers must be >= 1\n";
+    return false;
+  }
+  if (o->requester >= o->peers || o->reader >= o->peers) {
+    std::cerr << "--requester/--reader must be < --peers\n";
+    return false;
+  }
+  return true;
+}
+
+uint64_t AlignUp(uint64_t v, uint64_t a) { return ((v + a - 1) / a) * a; }
+
+// Per-node storage capacity for a regime.  roomy: each node holds the whole
+// batch with headroom (concentrating strategies fit on one node).  tight: total
+// cluster capacity ~1.2x the batch but each node < the batch, forcing spill and
+// some NO_SPACE.  Always page-aligned and at least one item.
+uint64_t NodeStorageBytes(const std::string& regime, size_t peers, uint64_t batch_bytes,
+                          uint64_t item_bytes, uint64_t page_bytes) {
+  uint64_t bytes;
+  if (regime == "tight") {
+    bytes = AlignUp((batch_bytes * 12 / 10 + peers - 1) / peers, page_bytes);
+  } else {  // roomy
+    const uint64_t k64m = static_cast<uint64_t>(64) << 20;
+    bytes = std::max<uint64_t>(k64m, batch_bytes * 4);
+    bytes = AlignUp(bytes, page_bytes);
+  }
+  return std::max<uint64_t>(bytes, item_bytes);
+}
+
+// One symmetric node: exportable storage DRAM (receives writes) plus a private
+// io buffer used as the put src (when requester) and the get dst (when reader).
+struct Node {
+  std::vector<char> storage;  // master-managed exportable DRAM
+  std::vector<char> io;       // registered src/dst region
+  std::unique_ptr<PoolClient> client;
+};
+
+class Cluster {
+ public:
+  Cluster(const std::string& algo, const std::string& affinity, size_t peers, uint64_t page_bytes,
+          uint64_t node_storage_bytes, uint64_t io_bytes) {
+    setenv("UMBP_ROUTE_PUT_SELECT_ALGO", algo.c_str(), /*overwrite=*/1);
+    setenv("UMBP_ROUTE_PUT_NODE_AFFINITY", affinity.c_str(), /*overwrite=*/1);
+
+    MasterServerConfig mcfg = MasterServerConfig::FromEnvironment();
+    mcfg.listen_address = "0.0.0.0:0";  // ephemeral; FromEnvironment leaves :50051
+    mcfg.registry_config.heartbeat_ttl = std::chrono::seconds{1};  // fast index convergence
+    master_ = std::make_unique<MasterServer>(std::move(mcfg));
+    server_thread_ = std::thread([this] { master_->Run(); });
+    for (int i = 0; i < 500 && master_->GetBoundPort() == 0; ++i) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    if (master_->GetBoundPort() == 0) {
+      std::cerr << "master failed to start\n";
+      std::exit(2);
+    }
+    const std::string master_addr = "localhost:" + std::to_string(master_->GetBoundPort());
+
+    nodes_.resize(peers);
+    for (size_t k = 0; k < peers; ++k) {
+      nodes_[k].storage.assign(node_storage_bytes, 0);
+      nodes_[k].io.assign(io_bytes, 0);
+      PoolClientConfig cc;
+      cc.master_config.node_id = "node-" + std::to_string(k);
+      cc.master_config.node_address = "127.0.0.1";
+      cc.master_config.master_address = master_addr;
+      cc.io_engine.host = "0.0.0.0";
+      cc.io_engine.port = 0;
+      cc.peer_service_port = NextPeerServicePort();
+      cc.dram_page_size = page_bytes;
+      cc.dram_buffers = {{nodes_[k].storage.data(), nodes_[k].storage.size()}};
+      cc.tier_capacities = {{TierType::DRAM, {nodes_[k].storage.size(), nodes_[k].storage.size()}}};
+      nodes_[k].client = std::make_unique<PoolClient>(std::move(cc));
+      if (!nodes_[k].client->Init()) {
+        std::cerr << "node " << k << " init failed\n";
+        std::exit(2);
+      }
+      // Register the io region so put src / get dst go zero-copy (no staging).
+      nodes_[k].client->RegisterMemory(nodes_[k].io.data(), nodes_[k].io.size());
+    }
+  }
+
+  ~Cluster() {
+    for (auto& n : nodes_) {
+      if (n.client) n.client->Shutdown();
+    }
+    if (master_) master_->Shutdown();
+    if (server_thread_.joinable()) server_thread_.join();
+  }
+
+  PoolClient* client(size_t k) { return nodes_[k].client.get(); }
+  std::vector<char>& io(size_t k) { return nodes_[k].io; }
+  size_t num_nodes() const { return nodes_.size(); }
+
+  // Clear every node, then wait until each allocator's DRAM is fully reclaimed
+  // (lease-deferred frees released by the reaper).  Returns false on timeout.
+  bool ResetAll() {
+    for (auto& n : nodes_) n.client->Clear();
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    for (auto& n : nodes_) {
+      while (true) {
+        auto caps = n.client->DramAllocator()->TierCapacitiesSnapshot();
+        auto it = caps.find(TierType::DRAM);
+        const bool full = it != caps.end() && it->second.available_bytes == it->second.total_bytes;
+        if (full) break;
+        if (std::chrono::steady_clock::now() > deadline) return false;
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      }
+    }
+    return true;
+  }
+
+ private:
+  std::unique_ptr<MasterServer> master_;
+  std::thread server_thread_;
+  std::vector<Node> nodes_;
+};
+
+// Poll until every key is visible in the master index (read-only, no lease).
+bool WaitVisible(PoolClient* reader, const std::vector<std::string>& keys) {
+  if (keys.empty()) return true;
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (true) {
+    auto present = reader->BatchExists(keys);
+    bool all = true;
+    for (bool p : present) all = all && p;
+    if (all) return true;
+    if (std::chrono::steady_clock::now() > deadline) return false;
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+}
+
+// Median is robust to the one-time cold-start cost (first AllocateSlot / peer
+// connection / RDMA registration to a node after Clear) that the mean would
+// fold into every comparison.
+double Median(std::vector<double> v) {
+  if (v.empty()) return 0.0;
+  std::sort(v.begin(), v.end());
+  const size_t n = v.size();
+  return n % 2 ? v[n / 2] : 0.5 * (v[n / 2 - 1] + v[n / 2]);
+}
+
+struct ComboResult {
+  std::vector<double> put_ms, get_ms;  // per-iter wall, for median
+  uint64_t put_bytes = 0, get_bytes = 0;
+  size_t put_success = 0, put_fail = 0, get_success = 0;
+  // Distribution metrics are computed PER measured iter and summed here, then
+  // averaged by iters at print time.  Per-iter (not cross-iter-union) keeps
+  // intra-batch concentration honest: `same` concentrates each batch on one
+  // node even if different iters pick different nodes.
+  double sum_unique_nodes = 0, sum_max_share = 0, sum_fanout = 0, sum_local_hit = 0;
+  std::map<std::string, uint64_t> node_items;  // routed items per node (aggregated, dump only)
+  std::map<std::string, uint64_t> node_bytes;
+};
+
+void RunCombo(const BenchOpts& o, const std::string& algo, const std::string& affinity,
+              const std::string& regime, size_t batch) {
+  const uint64_t item_bytes = static_cast<uint64_t>(o.per_item_pages) * o.page_bytes;
+  const uint64_t batch_bytes = static_cast<uint64_t>(batch) * item_bytes;
+  const uint64_t node_storage =
+      NodeStorageBytes(regime, o.peers, batch_bytes, item_bytes, o.page_bytes);
+
+  Cluster cluster(algo, affinity, o.peers, o.page_bytes, node_storage, batch_bytes);
+  PoolClient* requester = cluster.client(o.requester);
+  PoolClient* reader = cluster.client(o.reader);
+  const std::string reader_node = "node-" + std::to_string(o.reader);
+
+  // Put src / get dst slices into each role's private io buffer.
+  std::vector<const void*> srcs(batch);
+  std::vector<size_t> sizes(batch);
+  for (size_t i = 0; i < batch; ++i) {
+    char* slot = cluster.io(o.requester).data() + i * item_bytes;
+    std::memset(slot, static_cast<int>(0x10 + (i & 0x7F)), item_bytes);
+    srcs[i] = slot;
+    sizes[i] = item_bytes;
+  }
+
+  ComboResult r;
+  // Iter 0 is an unmeasured warm-up (channels / RDMA registration).
+  for (size_t it = 0; it <= o.iters; ++it) {
+    if (!cluster.ResetAll()) {
+      std::cerr << "capacity did not recover after Clear (algo=" << algo << " aff=" << affinity
+                << " regime=" << regime << " batch=" << batch << ")\n";
+      std::exit(2);
+    }
+
+    std::vector<std::string> keys(batch);
+    for (size_t i = 0; i < batch; ++i) {
+      keys[i] = "rp-" + std::to_string(it) + "-" + std::to_string(i);
+    }
+
+    auto t0 = std::chrono::steady_clock::now();
+    auto put_res = requester->BatchPut(keys, srcs, sizes);
+    auto t1 = std::chrono::steady_clock::now();
+
+    std::vector<std::string> ok_keys;
+    std::vector<void*> dsts;
+    std::vector<size_t> ok_sizes;
+    uint64_t put_bytes = 0;
+    size_t put_success = 0;
+    ok_keys.reserve(batch);
+    for (size_t i = 0; i < batch; ++i) {
+      if (put_res[i]) {
+        void* slot = cluster.io(o.reader).data() + ok_keys.size() * item_bytes;
+        ok_keys.push_back(keys[i]);
+        dsts.push_back(slot);
+        ok_sizes.push_back(item_bytes);
+        put_bytes += item_bytes;
+        ++put_success;
+      }
+    }
+
+    if (!WaitVisible(reader, ok_keys)) {
+      std::cerr << "put keys not visible within timeout (algo=" << algo << " aff=" << affinity
+                << " regime=" << regime << " batch=" << batch << ")\n";
+      std::exit(2);
+    }
+
+    // Placement probe: realized node per key (also the get fanout).
+    std::vector<std::optional<RouteGetResult>> routes;
+    reader->Master().BatchRouteGet(ok_keys, {}, &routes);
+
+    // Timed get of the same keys.
+    double get_ms = 0;
+    uint64_t get_bytes = 0;
+    size_t get_success = 0;
+    if (!o.no_get && !ok_keys.empty()) {
+      auto g0 = std::chrono::steady_clock::now();
+      auto get_res = reader->BatchGet(ok_keys, dsts, ok_sizes);
+      auto g1 = std::chrono::steady_clock::now();
+      get_ms = std::chrono::duration<double, std::milli>(g1 - g0).count();
+      for (size_t i = 0; i < get_res.size(); ++i) {
+        if (get_res[i]) {
+          get_bytes += ok_sizes[i];
+          ++get_success;
+        }
+      }
+    }
+
+    if (it == 0) continue;  // warm-up, not accumulated
+
+    r.put_ms.push_back(std::chrono::duration<double, std::milli>(t1 - t0).count());
+    r.put_bytes += put_bytes;
+    r.put_success += put_success;
+    r.put_fail += batch - put_success;
+    r.get_ms.push_back(get_ms);
+    r.get_bytes += get_bytes;
+    r.get_success += get_success;
+
+    // Per-iter placement metrics over this iter's routed keys.
+    std::map<std::string, uint64_t> iter_items;
+    size_t routed = 0;
+    for (const auto& route : routes) {
+      if (!route) continue;
+      ++routed;
+      iter_items[route->node_id] += 1;
+      r.node_items[route->node_id] += 1;
+      r.node_bytes[route->node_id] += item_bytes;
+    }
+    uint64_t max_items = 0, local_hits = 0;
+    std::set<std::string> fanout_nodes;
+    for (const auto& [node, items] : iter_items) {
+      max_items = std::max<uint64_t>(max_items, items);
+      if (node == reader_node) {
+        local_hits += items;
+      } else {
+        fanout_nodes.insert(node);
+      }
+    }
+    if (routed > 0) {
+      r.sum_unique_nodes += static_cast<double>(iter_items.size());
+      r.sum_max_share += static_cast<double>(max_items) / routed;
+      r.sum_fanout += static_cast<double>(fanout_nodes.size());
+      r.sum_local_hit += static_cast<double>(local_hits) / routed;
+    }
+  }
+
+  const double inv_iters = o.iters > 0 ? 1.0 / o.iters : 0.0;
+  constexpr double kGiB = 1024.0 * 1024.0 * 1024.0;
+  // wall_ms is the median per-iter latency; throughput is the median-batch bytes
+  // over that median latency (outlier-robust, see Median()).
+  const double put_med_ms = Median(r.put_ms);
+  const double get_med_ms = Median(r.get_ms);
+  const double avg_put_bytes = r.put_bytes * inv_iters;
+  const double avg_get_bytes = r.get_bytes * inv_iters;
+  const double put_gibps = put_med_ms > 0 ? (avg_put_bytes / kGiB) / (put_med_ms / 1000.0) : 0.0;
+  const double get_gibps = get_med_ms > 0 ? (avg_get_bytes / kGiB) / (get_med_ms / 1000.0) : 0.0;
+
+  std::printf(
+      "%s,%s,%s,%zu,%zu,%zu,%zu,%zu,%zu,%zu,%.3f,%.3f,%zu,%zu,%.2f,%.3f,%.3f,%.3f,%zu,%.2f,%.3f\n",
+      algo.c_str(), affinity.c_str(), regime.c_str(), o.peers, o.requester, o.reader, batch,
+      o.page_bytes, o.per_item_pages, o.iters, put_med_ms, put_gibps, r.put_success, r.put_fail,
+      r.sum_unique_nodes * inv_iters, r.sum_max_share * inv_iters, get_med_ms, get_gibps,
+      r.get_success, r.sum_fanout * inv_iters, r.sum_local_hit * inv_iters);
+  std::fflush(stdout);
+
+  if (o.dump_placement) {
+    for (const auto& [node, items] : r.node_items) {
+      std::fprintf(stderr, "%s,%s,%s,%zu,%s,%zu,%zu\n", algo.c_str(), affinity.c_str(),
+                   regime.c_str(), batch, node.c_str(), items, r.node_bytes[node]);
+    }
+  }
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  BenchOpts opts;
+  if (!ParseArgs(argc, argv, &opts)) return 2;
+
+  std::printf(
+      "select_algo,node_affinity,regime,peers,requester,reader,batch,page_bytes,per_item_pages,"
+      "iters,put_wall_ms,put_gibps,put_success,put_fail,unique_put_nodes,max_node_share,"
+      "get_wall_ms,get_gibps,get_success,get_fanout_nodes,local_hit_frac\n");
+  std::fflush(stdout);
+  if (opts.dump_placement) {
+    std::fprintf(stderr, "select_algo,node_affinity,regime,batch,node,items,bytes\n");
+  }
+
+  std::vector<size_t> batches = opts.sweep.empty() ? std::vector<size_t>{opts.batch} : opts.sweep;
+  for (const auto& regime : opts.regimes) {
+    for (const auto& algo : opts.algos) {
+      for (const auto& affinity : opts.affinities) {
+        for (size_t b : batches) {
+          if (b == 0) continue;
+          RunCombo(opts, algo, affinity, regime, b);
+        }
+      }
+    }
+  }
+  return 0;
+}

--- a/tests/cpp/umbp/distributed/bench_route_put_strategy.cpp
+++ b/tests/cpp/umbp/distributed/bench_route_put_strategy.cpp
@@ -49,7 +49,10 @@
 //     order is unit-tested elsewhere; cross-node placement contrast is fully
 //     visible with DRAM + multiple nodes.
 //   * random goes through the production thread_local RNG (FromEnvironment uses
-//     the unseeded ctor), so it is not reproducible run-to-run; use enough iters.
+//     the unseeded ctor), so its node choice is not reproducible run-to-run.
+//     That is fine: per-node cold-start is one-time (see RunCombo), so at most
+//     `peers` timed iters are cold and the median over >2*peers iters is always
+//     a warm sample.  RunCombo enforces that iter floor.
 //
 // CSV (stdout):
 //   select_algo,node_affinity,regime,peers,requester,reader,batch,page_bytes,
@@ -57,9 +60,13 @@
 //   unique_put_nodes,max_node_share,get_wall_ms,get_gibps,get_success,
 //   get_fanout_nodes,local_hit_frac
 // (put/get_wall_ms are the MEDIAN per-iter latency and *_gibps is the median-
-//  batch throughput over it — robust to the one-time cold-start cost; success/
-//  fail counts are summed over measured iters; distribution metrics are the mean
-//  of per-iter values over the routed keys.)
+//  batch throughput over it; success/fail counts are summed over measured iters;
+//  distribution metrics are the mean of per-iter values over the routed keys.
+//  The measured-iter count is floored at 2*peers+1 (RunCombo) so the median is
+//  always a warm sample even for strategies whose target node rotates between
+//  iters (e.g. random): per-node cold-start is one-time, so at most `peers`
+//  iters are cold and they sit in the median's upper tail.  The `iters` CSV
+//  column reports the actual measured count after that floor is applied.)
 //
 // --dump-placement adds a per-node long table to stderr:
 //   select_algo,node_affinity,regime,batch,node,items,bytes
@@ -328,8 +335,12 @@ bool WaitVisible(PoolClient* reader, const std::vector<std::string>& keys) {
 }
 
 // Median is robust to the one-time cold-start cost (first AllocateSlot / peer
-// connection / RDMA registration to a node after Clear) that the mean would
-// fold into every comparison.
+// connection / RDMA registration to a node) that the mean would fold into every
+// comparison.  Per-node cold-start happens at most once (connections survive
+// Clear()), so across a combo at most `peers` timed iters are cold; with the
+// measured-iter count floored at 2*peers+1 (RunCombo) those cold iters are a
+// strict minority in the upper tail and the median is always a warm sample —
+// even when the strategy's target node rotates between iters (e.g. random).
 double Median(std::vector<double> v) {
   if (v.empty()) return 0.0;
   std::sort(v.begin(), v.end());
@@ -372,9 +383,26 @@ void RunCombo(const BenchOpts& o, const std::string& algo, const std::string& af
     sizes[i] = item_bytes;
   }
 
+  // Per-peer cold-start (first peer-service connection + RDMA QP setup to a
+  // node) is paid once per node and then stays warm for the rest of the combo
+  // (connections survive Clear()).  So the number of cold timed iters is at most
+  // `peers` — each node contributes at most one cold first-touch, no matter how
+  // the strategy picks (e.g. `random` rotates its single-node anchor across
+  // iters).  Reporting the MEDIAN (see Median) over iters > 2*peers therefore
+  // guarantees the reported value is a warm sample: the <=peers cold iters are a
+  // strict minority and sit in the upper tail.  We bump the measured-iter count
+  // up to that floor so the result is steady-state regardless of `peers`.
+  const size_t measured_iters = std::max<size_t>(o.iters, 2 * o.peers + 1);
+  if (measured_iters != o.iters) {
+    std::fprintf(stderr,
+                 "[bench] iters bumped %zu -> %zu (>2*peers) so the median excludes per-node "
+                 "cold-start (algo=%s aff=%s regime=%s batch=%zu)\n",
+                 o.iters, measured_iters, algo.c_str(), affinity.c_str(), regime.c_str(), batch);
+  }
+
   ComboResult r;
   // Iter 0 is an unmeasured warm-up (channels / RDMA registration).
-  for (size_t it = 0; it <= o.iters; ++it) {
+  for (size_t it = 0; it <= measured_iters; ++it) {
     if (!cluster.ResetAll()) {
       std::cerr << "capacity did not recover after Clear (algo=" << algo << " aff=" << affinity
                 << " regime=" << regime << " batch=" << batch << ")\n";
@@ -472,7 +500,7 @@ void RunCombo(const BenchOpts& o, const std::string& algo, const std::string& af
     }
   }
 
-  const double inv_iters = o.iters > 0 ? 1.0 / o.iters : 0.0;
+  const double inv_iters = measured_iters > 0 ? 1.0 / measured_iters : 0.0;
   constexpr double kGiB = 1024.0 * 1024.0 * 1024.0;
   // wall_ms is the median per-iter latency; throughput is the median-batch bytes
   // over that median latency (outlier-robust, see Median()).
@@ -486,9 +514,9 @@ void RunCombo(const BenchOpts& o, const std::string& algo, const std::string& af
   std::printf(
       "%s,%s,%s,%zu,%zu,%zu,%zu,%zu,%zu,%zu,%.3f,%.3f,%zu,%zu,%.2f,%.3f,%.3f,%.3f,%zu,%.2f,%.3f\n",
       algo.c_str(), affinity.c_str(), regime.c_str(), o.peers, o.requester, o.reader, batch,
-      o.page_bytes, o.per_item_pages, o.iters, put_med_ms, put_gibps, r.put_success, r.put_fail,
-      r.sum_unique_nodes * inv_iters, r.sum_max_share * inv_iters, get_med_ms, get_gibps,
-      r.get_success, r.sum_fanout * inv_iters, r.sum_local_hit * inv_iters);
+      o.page_bytes, o.per_item_pages, measured_iters, put_med_ms, put_gibps, r.put_success,
+      r.put_fail, r.sum_unique_nodes * inv_iters, r.sum_max_share * inv_iters, get_med_ms,
+      get_gibps, r.get_success, r.sum_fanout * inv_iters, r.sum_local_hit * inv_iters);
   std::fflush(stdout);
 
   if (o.dump_placement) {

--- a/tests/cpp/umbp/distributed/test_pool_client_batch_put.cpp
+++ b/tests/cpp/umbp/distributed/test_pool_client_batch_put.cpp
@@ -303,5 +303,53 @@ TEST_F(BatchPutWarnTest, AllLocalBatchNoWarn) {
          "un-registered srcs (the WARN lives in the remote else branch only).";
 }
 
+// Zero-size puts are rejected before local/peer execution: the empty entry
+// fails (false) while the surrounding non-zero keys still succeed.  Return
+// vector length is preserved.  Runs on target_ (self/local path) so the
+// assertion does not depend on remote RDMA.
+TEST_F(BatchPutWarnTest, ZeroSizePutEntriesFailOthersSucceed) {
+  std::vector<char> buf(3 * kPerKey, 0);
+  std::memset(buf.data(), 0x21, kPerKey);
+  std::memset(buf.data() + 2 * kPerKey, 0x23, kPerKey);
+
+  std::vector<std::string> keys = {"zs-a", "zs-zero", "zs-b"};
+  std::vector<const void*> srcs = {buf.data(), buf.data() + kPerKey, buf.data() + 2 * kPerKey};
+  std::vector<size_t> sizes = {kPerKey, 0, kPerKey};
+
+  auto results = target_->BatchPut(keys, srcs, sizes);
+  ASSERT_EQ(results.size(), 3u);
+  EXPECT_TRUE(results[0]) << "key=" << keys[0];
+  EXPECT_FALSE(results[1]) << "zero-size put must be filtered to failure";
+  EXPECT_TRUE(results[2]) << "key=" << keys[2];
+}
+
+// Zero-size gets are rejected before local fallback or remote read: they fail
+// (false) while previously-seeded non-zero keys still resolve.  Return vector
+// length is preserved.  Local self put+get on target_ keeps the round trip
+// free of RDMA/registration.
+TEST_F(BatchPutWarnTest, ZeroSizeGetEntriesFailOthersSucceed) {
+  std::vector<char> src(2 * kPerKey, 0);
+  std::memset(src.data(), 0x31, kPerKey);
+  std::memset(src.data() + kPerKey, 0x32, kPerKey);
+  std::vector<std::string> pkeys = {"zg-a", "zg-b"};
+  std::vector<const void*> psrcs = {src.data(), src.data() + kPerKey};
+  std::vector<size_t> psizes = {kPerKey, kPerKey};
+  auto pres = target_->BatchPut(pkeys, psrcs, psizes);
+  ASSERT_EQ(pres.size(), 2u);
+  ASSERT_TRUE(pres[0]);
+  ASSERT_TRUE(pres[1]);
+
+  std::vector<char> dst(3 * kPerKey, 0);
+  std::vector<std::string> gkeys = {"zg-a", "zg-zero", "zg-b"};
+  std::vector<void*> gdsts = {dst.data(), dst.data() + kPerKey, dst.data() + 2 * kPerKey};
+  std::vector<size_t> gsizes = {kPerKey, 0, kPerKey};
+
+  auto gres = target_->BatchGet(gkeys, gdsts, gsizes);
+  ASSERT_EQ(gres.size(), 3u);
+  EXPECT_TRUE(gres[0]) << "key=" << gkeys[0];
+  EXPECT_FALSE(gres[1]) << "zero-size get must be filtered to failure";
+  EXPECT_TRUE(gres[2]) << "key=" << gkeys[2];
+}
+
 }  // namespace
 }  // namespace mori::umbp

--- a/tests/cpp/umbp/distributed/test_route_put_strategy.cpp
+++ b/tests/cpp/umbp/distributed/test_route_put_strategy.cpp
@@ -22,12 +22,14 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <cstdlib>
 #include <optional>
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
 #include <vector>
 
+#include "umbp/common/env_time.h"
 #include "umbp/distributed/routing/route_put_strategy.h"
 
 namespace mori::umbp {
@@ -181,7 +183,9 @@ TEST(SelectBatchTest, ProjectedCapacitySpreadsAcrossNodes) {
       MakeClient("node-b", "addr-b", {{TierType::HBM, {80 * GB, 8 * GB}}}),
   };
 
-  auto results = strategy.SelectBatch({6 * GB, 6 * GB}, {false, false}, clients, /*exclude=*/{});
+  auto results =
+      strategy.SelectBatch(/*requester=*/"req", {6 * GB, 6 * GB}, {false, false}, clients,
+                           /*exclude=*/{});
   ASSERT_EQ(results.size(), 2u);
 
   ASSERT_TRUE(results[0].has_value());
@@ -203,7 +207,8 @@ TEST(SelectBatchTest, DedupHitConsumesNoCapacity) {
       MakeClient("node-a", "addr-a", {{TierType::HBM, {80 * GB, 6 * GB}}}),
   };
 
-  auto results = strategy.SelectBatch({6 * GB, 6 * GB}, {true, false}, clients, /*exclude=*/{});
+  auto results = strategy.SelectBatch(/*requester=*/"req", {6 * GB, 6 * GB}, {true, false}, clients,
+                                      /*exclude=*/{});
   ASSERT_EQ(results.size(), 2u);
 
   ASSERT_TRUE(results[0].has_value());
@@ -221,7 +226,8 @@ TEST(SelectBatchTest, ThrowsOnAlreadyExistsLengthMismatch) {
       MakeClient("node-a", "addr-a", {{TierType::HBM, {80 * GB, 10 * GB}}}),
   };
 
-  EXPECT_THROW(strategy.SelectBatch({4096, 4096}, {false}, clients, /*exclude=*/{}),
+  EXPECT_THROW(strategy.SelectBatch(/*requester=*/"req", {4096, 4096}, {false}, clients,
+                                    /*exclude=*/{}),
                std::runtime_error);
 }
 
@@ -235,7 +241,8 @@ TEST(SelectBatchTest, DoesNotMutateCallerCandidates) {
       MakeClient("node-b", "addr-b", {{TierType::HBM, {80 * GB, 8 * GB}}}),
   };
 
-  strategy.SelectBatch({6 * GB, 6 * GB}, {false, false}, clients, /*exclude=*/{});
+  strategy.SelectBatch(/*requester=*/"req", {6 * GB, 6 * GB}, {false, false}, clients,
+                       /*exclude=*/{});
 
   EXPECT_EQ(clients[0].tier_capacities.at(TierType::HBM).available_bytes, 10 * GB);
   EXPECT_EQ(clients[1].tier_capacities.at(TierType::HBM).available_bytes, 8 * GB);
@@ -252,7 +259,7 @@ TEST(SelectBatchTest, SizeOneMatchesSelect) {
   };
 
   auto single = strategy.Select(clients, 4096, /*exclude=*/{});
-  auto batch = strategy.SelectBatch({4096}, {false}, clients, /*exclude=*/{});
+  auto batch = strategy.SelectBatch(/*requester=*/"req", {4096}, {false}, clients, /*exclude=*/{});
 
   ASSERT_EQ(batch.size(), 1u);
   ASSERT_TRUE(single.has_value());
@@ -285,8 +292,277 @@ TEST(SelectBatchTest, ThrowsOnProjectedCapacityUnderflow) {
       MakeClient("node-a", "addr-a", {{TierType::HBM, {80 * GB, 1 * GB}}}),
   };
 
-  EXPECT_THROW(strategy.SelectBatch({4 * GB}, {false}, clients, /*exclude=*/{}),
-               std::runtime_error);
+  EXPECT_THROW(
+      strategy.SelectBatch(/*requester=*/"req", {4 * GB}, {false}, clients, /*exclude=*/{}),
+      std::runtime_error);
+}
+
+// ---- ConfigurableRoutePutStrategy tests ----
+//
+// Deterministic, master-free: build capacity snapshots directly, call
+// SelectBatch(), and assert on the node_id / tier distribution of the routes.
+
+namespace {
+
+using Algo = ConfigurableRoutePutStrategy::SelectAlgo;
+using Affinity = ConfigurableRoutePutStrategy::NodeAffinity;
+
+// One DRAM tier with available == total (the strategy only reads available).
+ClientRecord DramClient(const std::string& node_id, uint64_t avail) {
+  return MakeClient(node_id, node_id + "-addr", {{TierType::DRAM, {avail, avail}}});
+}
+
+std::vector<bool> NoDedup(size_t n) { return std::vector<bool>(n, false); }
+
+}  // namespace
+
+TEST(ConfigurableRoutePut, MostAvailablePicksLargestFreeNode) {
+  ConfigurableRoutePutStrategy strat(Algo::kMostAvailable, Affinity::kNone);
+  std::vector<ClientRecord> clients{DramClient("a", 10 * GB), DramClient("b", 20 * GB)};
+  auto out = strat.SelectBatch("req", {1 * GB}, NoDedup(1), clients, {});
+  ASSERT_EQ(out.size(), 1u);
+  ASSERT_TRUE(out[0].has_value());
+  EXPECT_EQ(out[0]->node_id, "b");
+  EXPECT_EQ(out[0]->tier, TierType::DRAM);
+}
+
+// Projected capacity de-clusters within a batch: once a's free space drops
+// below the next block, the planner moves to b.
+TEST(ConfigurableRoutePut, ProjectedCapacityDeclustersBatch) {
+  ConfigurableRoutePutStrategy strat(Algo::kMostAvailable, Affinity::kNone);
+  std::vector<ClientRecord> clients{DramClient("a", 10 * GB), DramClient("b", 6 * GB)};
+  auto out = strat.SelectBatch("req", {6 * GB, 6 * GB}, NoDedup(2), clients, {});
+  ASSERT_EQ(out.size(), 2u);
+  ASSERT_TRUE(out[0].has_value());
+  ASSERT_TRUE(out[1].has_value());
+  EXPECT_EQ(out[0]->node_id, "a");
+  EXPECT_EQ(out[1]->node_id, "b");
+}
+
+TEST(ConfigurableRoutePut, OrderAndDedupPreserved) {
+  ConfigurableRoutePutStrategy strat(Algo::kMostAvailable, Affinity::kNone);
+  std::vector<ClientRecord> clients{
+      MakeClient("a", "a-addr", {{TierType::HBM, {80 * GB, 6 * GB}}})};
+  // Index 0 + 2 are dedup hits; a fits exactly one 6G block, so index 1 routes
+  // only if dedup consumed no capacity.
+  auto out = strat.SelectBatch("req", {6 * GB, 6 * GB, 6 * GB}, {true, false, true}, clients, {});
+  ASSERT_EQ(out.size(), 3u);
+  ASSERT_TRUE(out[0].has_value());
+  EXPECT_EQ(out[0]->outcome, RoutePutOutcome::kAlreadyExists);
+  EXPECT_TRUE(out[0]->node_id.empty());
+  ASSERT_TRUE(out[1].has_value());
+  EXPECT_EQ(out[1]->outcome, RoutePutOutcome::kRouted);
+  EXPECT_EQ(out[1]->node_id, "a");
+  EXPECT_EQ(out[1]->tier, TierType::HBM);
+  ASSERT_TRUE(out[2].has_value());
+  EXPECT_EQ(out[2]->outcome, RoutePutOutcome::kAlreadyExists);
+}
+
+TEST(ConfigurableRoutePut, NeverRoutesToSsd) {
+  ConfigurableRoutePutStrategy strat(Algo::kMostAvailable, Affinity::kNone);
+  std::vector<ClientRecord> only_ssd{
+      MakeClient("a", "a-addr", {{TierType::SSD, {100 * GB, 100 * GB}}})};
+  auto out = strat.SelectBatch("req", {1 * GB}, NoDedup(1), only_ssd, {});
+  ASSERT_EQ(out.size(), 1u);
+  EXPECT_FALSE(out[0].has_value());
+
+  std::vector<ClientRecord> ssd_and_dram{MakeClient(
+      "a", "a-addr", {{TierType::SSD, {100 * GB, 100 * GB}}, {TierType::DRAM, {2 * GB, 2 * GB}}})};
+  auto out2 = strat.SelectBatch("req", {1 * GB}, NoDedup(1), ssd_and_dram, {});
+  ASSERT_TRUE(out2[0].has_value());
+  EXPECT_EQ(out2[0]->tier, TierType::DRAM);
+}
+
+// Strong, seed-independent: a node that cannot fit the block is never selected.
+TEST(ConfigurableRoutePut, RandomNeverSelectsInsufficientNode) {
+  ConfigurableRoutePutStrategy strat(Algo::kRandom, Affinity::kNone, /*rng_seed=*/7);
+  std::vector<ClientRecord> clients{DramClient("big", 10000 * GB), DramClient("tiny", 1024)};
+  std::vector<uint64_t> sizes(200, 1 * GB);
+  auto out = strat.SelectBatch("req", sizes, NoDedup(sizes.size()), clients, {});
+  for (const auto& r : out) {
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(r->node_id, "big");
+  }
+}
+
+// Weak, fixed-seed smoke: weight roughly proportional to free space.  Capacities
+// dwarf the total drawn so projected deduction does not skew the ratio.
+TEST(ConfigurableRoutePut, RandomWeightedDistributionSmoke) {
+  ConfigurableRoutePutStrategy strat(Algo::kRandom, Affinity::kNone, /*rng_seed=*/12345);
+  std::vector<ClientRecord> clients{DramClient("a", 80000 * GB), DramClient("b", 20000 * GB)};
+  const size_t n = 2000;
+  std::vector<uint64_t> sizes(n, 1 * GB);
+  auto out = strat.SelectBatch("req", sizes, NoDedup(n), clients, {});
+  size_t a = 0, b = 0;
+  for (const auto& r : out) {
+    ASSERT_TRUE(r.has_value());
+    if (r->node_id == "a") ++a;
+    if (r->node_id == "b") ++b;
+  }
+  EXPECT_EQ(a + b, n);
+  EXPECT_GT(b, 0u);
+  const double frac_a = static_cast<double>(a) / n;
+  EXPECT_GT(frac_a, 0.65);
+  EXPECT_LT(frac_a, 0.92);
+}
+
+// NODE_AFFINITY = same: a node fits the whole non-dedup total -> all keys land
+// on it.
+TEST(ConfigurableRoutePut, SameWholeBatchOnOneNode) {
+  ConfigurableRoutePutStrategy strat(Algo::kMostAvailable, Affinity::kSame);
+  std::vector<ClientRecord> clients{DramClient("a", 100 * GB), DramClient("b", 100 * GB)};
+  std::vector<uint64_t> sizes{1 * GB, 1 * GB, 1 * GB, 1 * GB};
+  auto out = strat.SelectBatch("req", sizes, NoDedup(sizes.size()), clients, {});
+  ASSERT_EQ(out.size(), 4u);
+  for (const auto& r : out) ASSERT_TRUE(r.has_value());
+  const std::string node = out[0]->node_id;
+  for (const auto& r : out) EXPECT_EQ(r->node_id, node);
+}
+
+// No node fits the whole batch: per-key sticky reuse, re-anchoring only when the
+// current anchor can no longer fit.
+TEST(ConfigurableRoutePut, SamePerKeyStickyFallback) {
+  ConfigurableRoutePutStrategy strat(Algo::kMostAvailable, Affinity::kSame);
+  std::vector<ClientRecord> clients{DramClient("a", 5 * GB), DramClient("b", 5 * GB)};
+  std::vector<uint64_t> sizes{2 * GB, 2 * GB, 2 * GB, 2 * GB};  // total 8G fits no node alone
+  auto out = strat.SelectBatch("req", sizes, NoDedup(sizes.size()), clients, {});
+  ASSERT_EQ(out.size(), 4u);
+  for (const auto& r : out) ASSERT_TRUE(r.has_value());
+  EXPECT_EQ(out[0]->node_id, out[1]->node_id);
+  EXPECT_EQ(out[2]->node_id, out[3]->node_id);
+  EXPECT_NE(out[1]->node_id, out[2]->node_id);
+}
+
+// Affinity must never make a key fail that the base algorithm could route: no
+// single node fits the whole batch, but the keys still route by spilling across
+// nodes via the explicit fallback.
+TEST(ConfigurableRoutePut, SameNeverDropsRoutableKey) {
+  ConfigurableRoutePutStrategy strat(Algo::kMostAvailable, Affinity::kSame);
+  std::vector<ClientRecord> clients{DramClient("a", 3 * GB), DramClient("b", 3 * GB)};
+  // total 4G fits no single node (each 3G); both keys route only by spilling.
+  std::vector<uint64_t> sizes{2 * GB, 2 * GB};
+  auto out = strat.SelectBatch("req", sizes, NoDedup(sizes.size()), clients, {});
+  ASSERT_EQ(out.size(), 2u);
+  for (const auto& r : out) ASSERT_TRUE(r.has_value());  // none dropped
+  EXPECT_NE(out[0]->node_id, out[1]->node_id);           // second key spilled to the other node
+}
+
+// same whole-batch pins node AND tier: the batch fits node a's DRAM but not its
+// HBM, so every key lands on a's DRAM even though HBM has room for early keys.
+TEST(ConfigurableRoutePut, SameWholeBatchPinsNodeAndTier) {
+  ConfigurableRoutePutStrategy strat(Algo::kMostAvailable, Affinity::kSame);
+  std::vector<ClientRecord> clients{MakeClient(
+      "a", "a-addr", {{TierType::HBM, {3 * GB, 3 * GB}}, {TierType::DRAM, {100 * GB, 100 * GB}}})};
+  std::vector<uint64_t> sizes{2 * GB, 2 * GB, 2 * GB, 2 * GB};  // total 8G: HBM(3G) no, DRAM yes
+  auto out = strat.SelectBatch("req", sizes, NoDedup(sizes.size()), clients, {});
+  ASSERT_EQ(out.size(), 4u);
+  for (const auto& r : out) {
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(r->node_id, "a");
+    EXPECT_EQ(r->tier, TierType::DRAM);  // pinned tier, HBM left untouched
+  }
+}
+
+// same per-key fallback must not break tier priority: when the sticky anchor's
+// HBM is full, a remote node's HBM beats the anchor's own DRAM.
+TEST(ConfigurableRoutePut, SameFallbackPrefersRemoteHbmOverAnchorDram) {
+  ConfigurableRoutePutStrategy strat(Algo::kMostAvailable, Affinity::kSame);
+  std::vector<ClientRecord> clients{
+      MakeClient("a", "a-addr", {{TierType::HBM, {2 * GB, 2 * GB}}}),
+      MakeClient("b", "b-addr",
+                 {{TierType::HBM, {3 * GB, 3 * GB}}, {TierType::DRAM, {3 * GB, 3 * GB}}})};
+  // total 4G exceeds every single node/tier (max 3G) -> no whole-batch pin.
+  std::vector<uint64_t> sizes{2 * GB, 2 * GB};
+  auto out = strat.SelectBatch("req", sizes, NoDedup(sizes.size()), clients, {});
+  ASSERT_EQ(out.size(), 2u);
+  ASSERT_TRUE(out[0].has_value());
+  ASSERT_TRUE(out[1].has_value());
+  // key 0: most-available HBM -> b (3G > a 2G); anchor becomes b, b HBM -> 1G.
+  EXPECT_EQ(out[0]->node_id, "b");
+  EXPECT_EQ(out[0]->tier, TierType::HBM);
+  // key 1: anchor b's HBM (1G) cannot fit; instead of falling to b's DRAM, tier
+  // priority routes to a's HBM.
+  EXPECT_EQ(out[1]->node_id, "a");
+  EXPECT_EQ(out[1]->tier, TierType::HBM);
+}
+
+// dedup keys consume no projected capacity and do not count toward the same-node
+// whole-batch total.
+TEST(ConfigurableRoutePut, SameDedupExcludedFromBatchTotal) {
+  ConfigurableRoutePutStrategy strat(Algo::kMostAvailable, Affinity::kSame);
+  std::vector<ClientRecord> clients{DramClient("a", 4 * GB)};
+  // Non-dedup total is only 2G (index 1+3); the 100G dedup blocks must not push
+  // the total past a's 4G or it would refuse the whole-batch placement.
+  auto out = strat.SelectBatch("req", {100 * GB, 1 * GB, 100 * GB, 1 * GB},
+                               {true, false, true, false}, clients, {});
+  ASSERT_EQ(out.size(), 4u);
+  EXPECT_EQ(out[0]->outcome, RoutePutOutcome::kAlreadyExists);
+  EXPECT_EQ(out[2]->outcome, RoutePutOutcome::kAlreadyExists);
+  ASSERT_TRUE(out[1].has_value());
+  ASSERT_TRUE(out[3].has_value());
+  EXPECT_EQ(out[1]->node_id, "a");
+  EXPECT_EQ(out[3]->node_id, "a");
+}
+
+// NODE_AFFINITY = local: requester node preferred over a node with more space.
+TEST(ConfigurableRoutePut, LocalPrefersRequesterNode) {
+  ConfigurableRoutePutStrategy strat(Algo::kMostAvailable, Affinity::kLocal);
+  std::vector<ClientRecord> clients{DramClient("a", 100 * GB), DramClient("b", 10 * GB)};
+  auto out = strat.SelectBatch(/*requester=*/"b", {1 * GB, 1 * GB}, NoDedup(2), clients, {});
+  ASSERT_EQ(out.size(), 2u);
+  for (const auto& r : out) {
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(r->node_id, "b");
+  }
+}
+
+// Per-key local-first: spill to the base algorithm once local is full.
+TEST(ConfigurableRoutePut, LocalFallsBackWhenLocalFull) {
+  ConfigurableRoutePutStrategy strat(Algo::kMostAvailable, Affinity::kLocal);
+  std::vector<ClientRecord> clients{DramClient("a", 100 * GB), DramClient("b", 2 * GB)};
+  auto out =
+      strat.SelectBatch(/*requester=*/"b", {1 * GB, 1 * GB, 1 * GB}, NoDedup(3), clients, {});
+  ASSERT_EQ(out.size(), 3u);
+  EXPECT_EQ(out[0]->node_id, "b");
+  EXPECT_EQ(out[1]->node_id, "b");
+  EXPECT_EQ(out[2]->node_id, "a");  // local exhausted -> base algo
+}
+
+// Requester not in the candidate set: every key falls back to the base
+// algorithm, none dropped.
+TEST(ConfigurableRoutePut, LocalUnknownRequesterFallsBack) {
+  ConfigurableRoutePutStrategy strat(Algo::kMostAvailable, Affinity::kLocal);
+  std::vector<ClientRecord> clients{DramClient("a", 100 * GB)};
+  auto out = strat.SelectBatch("not-a-member", {1 * GB, 1 * GB}, NoDedup(2), clients, {});
+  ASSERT_EQ(out.size(), 2u);
+  for (const auto& r : out) {
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(r->node_id, "a");
+  }
+}
+
+// ---- GetEnvEnum tests ----
+
+TEST(GetEnvEnum, ResolvesValidEmptyAndUnknown) {
+  const char* kName = "UMBP_TEST_ROUTE_PUT_ENUM";
+  ResetEnvWarnStateForTesting();
+
+  ::unsetenv(kName);
+  EXPECT_EQ(GetEnvEnum(kName, "none", {"none", "same", "local"}), "none");
+
+  ::setenv(kName, "local", 1);
+  EXPECT_EQ(GetEnvEnum(kName, "none", {"none", "same", "local"}), "local");
+
+  ::setenv(kName, "  same  ", 1);  // surrounding whitespace trimmed
+  EXPECT_EQ(GetEnvEnum(kName, "none", {"none", "same", "local"}), "same");
+
+  ::setenv(kName, "", 1);  // empty -> default, silent
+  EXPECT_EQ(GetEnvEnum(kName, "none", {"none", "same", "local"}), "none");
+
+  ::setenv(kName, "bogus", 1);  // unknown -> default + WARN once
+  EXPECT_EQ(GetEnvEnum(kName, "none", {"none", "same", "local"}), "none");
+
+  ::unsetenv(kName);
 }
 
 }  // namespace

--- a/tests/cpp/umbp/distributed/test_route_put_strategy.cpp
+++ b/tests/cpp/umbp/distributed/test_route_put_strategy.cpp
@@ -23,7 +23,9 @@
 
 #include <chrono>
 #include <optional>
+#include <stdexcept>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "umbp/distributed/routing/route_put_strategy.h"
@@ -163,6 +165,128 @@ TEST(TierAwareMostAvailableTest, ClientWithNoTierCapacitiesSkipped) {
 
   auto result = strategy.Select(clients, 4096, /*exclude=*/{});
   EXPECT_FALSE(result.has_value());
+}
+
+// ---- SelectBatch projected-capacity tests ----
+
+// Two 6GB blocks against node-a (10GB) and node-b (8GB) on the same tier.
+// Without projected capacity both pick node-a (most available in the
+// snapshot).  With per-batch deduction, block 1 lands on node-a (10GB -> 4GB),
+// and block 2 is forced to node-b because node-a no longer fits 6GB.
+TEST(SelectBatchTest, ProjectedCapacitySpreadsAcrossNodes) {
+  TierAwareMostAvailableStrategy strategy;
+
+  std::vector<ClientRecord> clients = {
+      MakeClient("node-a", "addr-a", {{TierType::HBM, {80 * GB, 10 * GB}}}),
+      MakeClient("node-b", "addr-b", {{TierType::HBM, {80 * GB, 8 * GB}}}),
+  };
+
+  auto results = strategy.SelectBatch({6 * GB, 6 * GB}, {false, false}, clients, /*exclude=*/{});
+  ASSERT_EQ(results.size(), 2u);
+
+  ASSERT_TRUE(results[0].has_value());
+  EXPECT_EQ(results[0]->outcome, RoutePutOutcome::kRouted);
+  EXPECT_EQ(results[0]->node_id, "node-a");
+
+  ASSERT_TRUE(results[1].has_value());
+  EXPECT_EQ(results[1]->outcome, RoutePutOutcome::kRouted);
+  EXPECT_EQ(results[1]->node_id, "node-b");
+}
+
+// A dedup hit returns kAlreadyExists and consumes no projected capacity:
+// node-a fits exactly one 6GB block, block 0 is a dedup hit, so block 1 must
+// still route to node-a.
+TEST(SelectBatchTest, DedupHitConsumesNoCapacity) {
+  TierAwareMostAvailableStrategy strategy;
+
+  std::vector<ClientRecord> clients = {
+      MakeClient("node-a", "addr-a", {{TierType::HBM, {80 * GB, 6 * GB}}}),
+  };
+
+  auto results = strategy.SelectBatch({6 * GB, 6 * GB}, {true, false}, clients, /*exclude=*/{});
+  ASSERT_EQ(results.size(), 2u);
+
+  ASSERT_TRUE(results[0].has_value());
+  EXPECT_EQ(results[0]->outcome, RoutePutOutcome::kAlreadyExists);
+
+  ASSERT_TRUE(results[1].has_value());
+  EXPECT_EQ(results[1]->outcome, RoutePutOutcome::kRouted);
+  EXPECT_EQ(results[1]->node_id, "node-a");
+}
+
+TEST(SelectBatchTest, ThrowsOnAlreadyExistsLengthMismatch) {
+  TierAwareMostAvailableStrategy strategy;
+
+  std::vector<ClientRecord> clients = {
+      MakeClient("node-a", "addr-a", {{TierType::HBM, {80 * GB, 10 * GB}}}),
+  };
+
+  EXPECT_THROW(strategy.SelectBatch({4096, 4096}, {false}, clients, /*exclude=*/{}),
+               std::runtime_error);
+}
+
+// The by-value candidates copy is never mutated for the caller: passing the
+// same snapshot again yields the same placement (no projected state leaks out).
+TEST(SelectBatchTest, DoesNotMutateCallerCandidates) {
+  TierAwareMostAvailableStrategy strategy;
+
+  std::vector<ClientRecord> clients = {
+      MakeClient("node-a", "addr-a", {{TierType::HBM, {80 * GB, 10 * GB}}}),
+      MakeClient("node-b", "addr-b", {{TierType::HBM, {80 * GB, 8 * GB}}}),
+  };
+
+  strategy.SelectBatch({6 * GB, 6 * GB}, {false, false}, clients, /*exclude=*/{});
+
+  EXPECT_EQ(clients[0].tier_capacities.at(TierType::HBM).available_bytes, 10 * GB);
+  EXPECT_EQ(clients[1].tier_capacities.at(TierType::HBM).available_bytes, 8 * GB);
+}
+
+// SelectBatch with one request must match a direct Select() call: the default
+// batch path does not alter single-key placement semantics.
+TEST(SelectBatchTest, SizeOneMatchesSelect) {
+  TierAwareMostAvailableStrategy strategy;
+
+  std::vector<ClientRecord> clients = {
+      MakeClient("node-a", "addr-a", {{TierType::HBM, {80 * GB, 10 * GB}}}),
+      MakeClient("node-b", "addr-b", {{TierType::HBM, {80 * GB, 50 * GB}}}),
+  };
+
+  auto single = strategy.Select(clients, 4096, /*exclude=*/{});
+  auto batch = strategy.SelectBatch({4096}, {false}, clients, /*exclude=*/{});
+
+  ASSERT_EQ(batch.size(), 1u);
+  ASSERT_TRUE(single.has_value());
+  ASSERT_TRUE(batch[0].has_value());
+  EXPECT_EQ(batch[0]->node_id, single->node_id);
+  EXPECT_EQ(batch[0]->tier, single->tier);
+}
+
+// A strategy whose Select() breaks its own contract (routes to a node/tier
+// without enough room) must trip the projected-capacity invariant and throw,
+// never silently clamp the deduction.
+class BrokenContractStrategy : public RoutePutStrategy {
+ public:
+  std::optional<RoutePutResult> Select(
+      const std::vector<ClientRecord>& alive_clients, uint64_t /*block_size*/,
+      const std::unordered_set<std::string>& /*exclude_nodes*/) override {
+    return RoutePutResult{
+        .outcome = RoutePutOutcome::kRouted,
+        .node_id = alive_clients.front().node_id,
+        .peer_address = alive_clients.front().peer_address,
+        .tier = TierType::HBM,
+    };
+  }
+};
+
+TEST(SelectBatchTest, ThrowsOnProjectedCapacityUnderflow) {
+  BrokenContractStrategy strategy;
+
+  std::vector<ClientRecord> clients = {
+      MakeClient("node-a", "addr-a", {{TierType::HBM, {80 * GB, 1 * GB}}}),
+  };
+
+  EXPECT_THROW(strategy.SelectBatch({4 * GB}, {false}, clients, /*exclude=*/{}),
+               std::runtime_error);
 }
 
 }  // namespace

--- a/tests/cpp/umbp/distributed/test_route_put_strategy.cpp
+++ b/tests/cpp/umbp/distributed/test_route_put_strategy.cpp
@@ -24,7 +24,6 @@
 #include <chrono>
 #include <cstdlib>
 #include <optional>
-#include <stdexcept>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -219,16 +218,20 @@ TEST(SelectBatchTest, DedupHitConsumesNoCapacity) {
   EXPECT_EQ(results[1]->node_id, "node-a");
 }
 
-TEST(SelectBatchTest, ThrowsOnAlreadyExistsLengthMismatch) {
+// Best-effort: an already_exists/block_sizes length mismatch is not fatal — it
+// logs a MORI ERROR and returns an all-nullopt result sized to block_sizes.
+TEST(SelectBatchTest, AlreadyExistsLengthMismatchYieldsAllNullopt) {
   TierAwareMostAvailableStrategy strategy;
 
   std::vector<ClientRecord> clients = {
       MakeClient("node-a", "addr-a", {{TierType::HBM, {80 * GB, 10 * GB}}}),
   };
 
-  EXPECT_THROW(strategy.SelectBatch(/*requester=*/"req", {4096, 4096}, {false}, clients,
-                                    /*exclude=*/{}),
-               std::runtime_error);
+  auto results = strategy.SelectBatch(/*requester=*/"req", {4096, 4096}, {false}, clients,
+                                      /*exclude=*/{});
+  ASSERT_EQ(results.size(), 2u);
+  EXPECT_FALSE(results[0].has_value());
+  EXPECT_FALSE(results[1].has_value());
 }
 
 // The by-value candidates copy is never mutated for the caller: passing the
@@ -269,8 +272,9 @@ TEST(SelectBatchTest, SizeOneMatchesSelect) {
 }
 
 // A strategy whose Select() breaks its own contract (routes to a node/tier
-// without enough room) must trip the projected-capacity invariant and throw,
-// never silently clamp the deduction.
+// without enough room) must trip the projected-capacity invariant.  Best-effort:
+// the offending key is dropped to nullopt (route failure) and a MORI ERROR is
+// logged, rather than throwing or silently clamping the deduction.
 class BrokenContractStrategy : public RoutePutStrategy {
  public:
   std::optional<RoutePutResult> Select(
@@ -285,16 +289,17 @@ class BrokenContractStrategy : public RoutePutStrategy {
   }
 };
 
-TEST(SelectBatchTest, ThrowsOnProjectedCapacityUnderflow) {
+TEST(SelectBatchTest, ProjectedCapacityUnderflowDropsRoute) {
   BrokenContractStrategy strategy;
 
   std::vector<ClientRecord> clients = {
       MakeClient("node-a", "addr-a", {{TierType::HBM, {80 * GB, 1 * GB}}}),
   };
 
-  EXPECT_THROW(
-      strategy.SelectBatch(/*requester=*/"req", {4 * GB}, {false}, clients, /*exclude=*/{}),
-      std::runtime_error);
+  auto results =
+      strategy.SelectBatch(/*requester=*/"req", {4 * GB}, {false}, clients, /*exclude=*/{});
+  ASSERT_EQ(results.size(), 1u);
+  EXPECT_FALSE(results[0].has_value());
 }
 
 // ---- ConfigurableRoutePutStrategy tests ----

--- a/tests/cpp/umbp/distributed/test_route_put_strategy.cpp
+++ b/tests/cpp/umbp/distributed/test_route_put_strategy.cpp
@@ -49,40 +49,56 @@ ClientRecord MakeClient(const std::string& node_id, const std::string& addr,
 
 constexpr uint64_t GB = 1024ULL * 1024 * 1024;
 
-// ---- TierAwareMostAvailableStrategy tests ----
+using Algo = ConfigurableRoutePutStrategy::SelectAlgo;
+using Affinity = ConfigurableRoutePutStrategy::NodeAffinity;
 
-TEST(TierAwareMostAvailableTest, PrefersHBMOverDRAM) {
-  TierAwareMostAvailableStrategy strategy;
+// Single-key convenience over the batch interface (the Router routes single-key
+// RoutePut as a size-1 batch).  Returns the per-key result, or nullopt when the
+// key is unroutable.
+std::optional<RoutePutResult> SelectOne(ConfigurableRoutePutStrategy& strat,
+                                        const std::vector<ClientRecord>& clients,
+                                        uint64_t block_size,
+                                        const std::unordered_set<std::string>& exclude) {
+  auto out = strat.SelectBatch(/*requester=*/"req", {block_size}, {false}, clients, exclude);
+  if (out.empty()) return std::nullopt;
+  return out.front();
+}
+
+// ---- most_available / none: single-key placement (migrated from the old
+//      TierAwareMostAvailableStrategy::Select coverage) ----
+
+TEST(MostAvailableNoneTest, PrefersHBMOverDRAM) {
+  ConfigurableRoutePutStrategy strategy(Algo::kMostAvailable, Affinity::kNone);
 
   std::vector<ClientRecord> clients = {
       MakeClient("node-a", "addr-a",
                  {{TierType::HBM, {80 * GB, 10 * GB}}, {TierType::DRAM, {512 * GB, 400 * GB}}}),
   };
 
-  auto result = strategy.Select(clients, 4096, /*exclude=*/{});
+  auto result = SelectOne(strategy, clients, 4096, /*exclude=*/{});
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result->node_id, "node-a");
   EXPECT_EQ(result->tier, TierType::HBM);
 }
 
-TEST(TierAwareMostAvailableTest, FallsThroughToDRAMWhenHBMFull) {
-  TierAwareMostAvailableStrategy strategy;
+TEST(MostAvailableNoneTest, FallsThroughToDRAMWhenHBMFull) {
+  ConfigurableRoutePutStrategy strategy(Algo::kMostAvailable, Affinity::kNone);
 
   std::vector<ClientRecord> clients = {
       MakeClient("node-a", "addr-a",
                  {{TierType::HBM, {80 * GB, 0}}, {TierType::DRAM, {512 * GB, 200 * GB}}}),
   };
 
-  auto result = strategy.Select(clients, 4096, /*exclude=*/{});
+  auto result = SelectOne(strategy, clients, 4096, /*exclude=*/{});
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result->tier, TierType::DRAM);
 }
 
-TEST(TierAwareMostAvailableTest, SsdIsNotADirectPutTarget) {
+TEST(MostAvailableNoneTest, SsdIsNotADirectPutTarget) {
   // SSD capacity is reported via heartbeat but RoutePut never steers a put at
   // SSD: the SSD copy is filled asynchronously by copy-on-commit.  With HBM and
-  // DRAM full, Select must return nullopt even when SSD has ample space.
-  TierAwareMostAvailableStrategy strategy;
+  // DRAM full, placement must return nullopt even when SSD has ample space.
+  ConfigurableRoutePutStrategy strategy(Algo::kMostAvailable, Affinity::kNone);
 
   std::vector<ClientRecord> clients = {
       MakeClient("node-a", "addr-a",
@@ -91,12 +107,12 @@ TEST(TierAwareMostAvailableTest, SsdIsNotADirectPutTarget) {
                   {TierType::SSD, {4096 * GB, 3000 * GB}}}),
   };
 
-  auto result = strategy.Select(clients, 4096, /*exclude=*/{});
+  auto result = SelectOne(strategy, clients, 4096, /*exclude=*/{});
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(TierAwareMostAvailableTest, ReturnsNulloptWhenAllFull) {
-  TierAwareMostAvailableStrategy strategy;
+TEST(MostAvailableNoneTest, ReturnsNulloptWhenAllFull) {
+  ConfigurableRoutePutStrategy strategy(Algo::kMostAvailable, Affinity::kNone);
 
   std::vector<ClientRecord> clients = {
       MakeClient("node-a", "addr-a",
@@ -105,23 +121,23 @@ TEST(TierAwareMostAvailableTest, ReturnsNulloptWhenAllFull) {
                   {TierType::SSD, {4096 * GB, 0}}}),
   };
 
-  auto result = strategy.Select(clients, 4096, /*exclude=*/{});
+  auto result = SelectOne(strategy, clients, 4096, /*exclude=*/{});
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(TierAwareMostAvailableTest, ReturnsNulloptWhenBlockTooLarge) {
-  TierAwareMostAvailableStrategy strategy;
+TEST(MostAvailableNoneTest, ReturnsNulloptWhenBlockTooLarge) {
+  ConfigurableRoutePutStrategy strategy(Algo::kMostAvailable, Affinity::kNone);
 
   std::vector<ClientRecord> clients = {
       MakeClient("node-a", "addr-a", {{TierType::HBM, {80 * GB, 10 * GB}}}),
   };
 
-  auto result = strategy.Select(clients, 100 * GB, /*exclude=*/{});
+  auto result = SelectOne(strategy, clients, 100 * GB, /*exclude=*/{});
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(TierAwareMostAvailableTest, PicksMostAvailableOnSameTier) {
-  TierAwareMostAvailableStrategy strategy;
+TEST(MostAvailableNoneTest, PicksMostAvailableOnSameTier) {
+  ConfigurableRoutePutStrategy strategy(Algo::kMostAvailable, Affinity::kNone);
 
   std::vector<ClientRecord> clients = {
       MakeClient("node-a", "addr-a", {{TierType::HBM, {80 * GB, 10 * GB}}}),
@@ -129,53 +145,67 @@ TEST(TierAwareMostAvailableTest, PicksMostAvailableOnSameTier) {
       MakeClient("node-c", "addr-c", {{TierType::HBM, {80 * GB, 30 * GB}}}),
   };
 
-  auto result = strategy.Select(clients, 4096, /*exclude=*/{});
+  auto result = SelectOne(strategy, clients, 4096, /*exclude=*/{});
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result->node_id, "node-b");
   EXPECT_EQ(result->peer_address, "addr-b");
   EXPECT_EQ(result->tier, TierType::HBM);
 }
 
-TEST(TierAwareMostAvailableTest, HBMPreferredEvenIfDRAMHasMoreSpace) {
-  TierAwareMostAvailableStrategy strategy;
+TEST(MostAvailableNoneTest, HBMPreferredEvenIfDRAMHasMoreSpace) {
+  ConfigurableRoutePutStrategy strategy(Algo::kMostAvailable, Affinity::kNone);
 
   std::vector<ClientRecord> clients = {
       MakeClient("node-a", "addr-a",
                  {{TierType::HBM, {80 * GB, 5 * GB}}, {TierType::DRAM, {512 * GB, 400 * GB}}}),
   };
 
-  auto result = strategy.Select(clients, 4096, /*exclude=*/{});
+  auto result = SelectOne(strategy, clients, 4096, /*exclude=*/{});
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result->tier, TierType::HBM);
 }
 
-TEST(TierAwareMostAvailableTest, EmptyClientListReturnsNullopt) {
-  TierAwareMostAvailableStrategy strategy;
+TEST(MostAvailableNoneTest, EmptyClientListReturnsNullopt) {
+  ConfigurableRoutePutStrategy strategy(Algo::kMostAvailable, Affinity::kNone);
   std::vector<ClientRecord> empty;
 
-  auto result = strategy.Select(empty, 4096, /*exclude=*/{});
+  auto result = SelectOne(strategy, empty, 4096, /*exclude=*/{});
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(TierAwareMostAvailableTest, ClientWithNoTierCapacitiesSkipped) {
-  TierAwareMostAvailableStrategy strategy;
+TEST(MostAvailableNoneTest, ClientWithNoTierCapacitiesSkipped) {
+  ConfigurableRoutePutStrategy strategy(Algo::kMostAvailable, Affinity::kNone);
 
   std::vector<ClientRecord> clients = {
       MakeClient("node-a", "addr-a", {}),
   };
 
-  auto result = strategy.Select(clients, 4096, /*exclude=*/{});
+  auto result = SelectOne(strategy, clients, 4096, /*exclude=*/{});
   EXPECT_FALSE(result.has_value());
 }
 
-// ---- SelectBatch projected-capacity tests ----
+TEST(MostAvailableNoneTest, RespectsExcludeNodes) {
+  ConfigurableRoutePutStrategy strategy(Algo::kMostAvailable, Affinity::kNone);
+
+  std::vector<ClientRecord> clients = {
+      MakeClient("node-a", "addr-a", {{TierType::HBM, {80 * GB, 50 * GB}}}),
+      MakeClient("node-b", "addr-b", {{TierType::HBM, {80 * GB, 10 * GB}}}),
+  };
+
+  // node-a is the most-available pick, but excluded: must fall to node-b.
+  auto result = SelectOne(strategy, clients, 4096, /*exclude=*/{"node-a"});
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->node_id, "node-b");
+}
+
+// ---- SelectBatch projected-capacity tests (most_available / none) ----
 
 // Two 6GB blocks against node-a (10GB) and node-b (8GB) on the same tier.
 // Without projected capacity both pick node-a (most available in the
 // snapshot).  With per-batch deduction, block 1 lands on node-a (10GB -> 4GB),
 // and block 2 is forced to node-b because node-a no longer fits 6GB.
 TEST(SelectBatchTest, ProjectedCapacitySpreadsAcrossNodes) {
-  TierAwareMostAvailableStrategy strategy;
+  ConfigurableRoutePutStrategy strategy(Algo::kMostAvailable, Affinity::kNone);
 
   std::vector<ClientRecord> clients = {
       MakeClient("node-a", "addr-a", {{TierType::HBM, {80 * GB, 10 * GB}}}),
@@ -200,7 +230,7 @@ TEST(SelectBatchTest, ProjectedCapacitySpreadsAcrossNodes) {
 // node-a fits exactly one 6GB block, block 0 is a dedup hit, so block 1 must
 // still route to node-a.
 TEST(SelectBatchTest, DedupHitConsumesNoCapacity) {
-  TierAwareMostAvailableStrategy strategy;
+  ConfigurableRoutePutStrategy strategy(Algo::kMostAvailable, Affinity::kNone);
 
   std::vector<ClientRecord> clients = {
       MakeClient("node-a", "addr-a", {{TierType::HBM, {80 * GB, 6 * GB}}}),
@@ -221,7 +251,7 @@ TEST(SelectBatchTest, DedupHitConsumesNoCapacity) {
 // Best-effort: an already_exists/block_sizes length mismatch is not fatal — it
 // logs a MORI ERROR and returns an all-nullopt result sized to block_sizes.
 TEST(SelectBatchTest, AlreadyExistsLengthMismatchYieldsAllNullopt) {
-  TierAwareMostAvailableStrategy strategy;
+  ConfigurableRoutePutStrategy strategy(Algo::kMostAvailable, Affinity::kNone);
 
   std::vector<ClientRecord> clients = {
       MakeClient("node-a", "addr-a", {{TierType::HBM, {80 * GB, 10 * GB}}}),
@@ -237,7 +267,7 @@ TEST(SelectBatchTest, AlreadyExistsLengthMismatchYieldsAllNullopt) {
 // The by-value candidates copy is never mutated for the caller: passing the
 // same snapshot again yields the same placement (no projected state leaks out).
 TEST(SelectBatchTest, DoesNotMutateCallerCandidates) {
-  TierAwareMostAvailableStrategy strategy;
+  ConfigurableRoutePutStrategy strategy(Algo::kMostAvailable, Affinity::kNone);
 
   std::vector<ClientRecord> clients = {
       MakeClient("node-a", "addr-a", {{TierType::HBM, {80 * GB, 10 * GB}}}),
@@ -251,66 +281,12 @@ TEST(SelectBatchTest, DoesNotMutateCallerCandidates) {
   EXPECT_EQ(clients[1].tier_capacities.at(TierType::HBM).available_bytes, 8 * GB);
 }
 
-// SelectBatch with one request must match a direct Select() call: the default
-// batch path does not alter single-key placement semantics.
-TEST(SelectBatchTest, SizeOneMatchesSelect) {
-  TierAwareMostAvailableStrategy strategy;
-
-  std::vector<ClientRecord> clients = {
-      MakeClient("node-a", "addr-a", {{TierType::HBM, {80 * GB, 10 * GB}}}),
-      MakeClient("node-b", "addr-b", {{TierType::HBM, {80 * GB, 50 * GB}}}),
-  };
-
-  auto single = strategy.Select(clients, 4096, /*exclude=*/{});
-  auto batch = strategy.SelectBatch(/*requester=*/"req", {4096}, {false}, clients, /*exclude=*/{});
-
-  ASSERT_EQ(batch.size(), 1u);
-  ASSERT_TRUE(single.has_value());
-  ASSERT_TRUE(batch[0].has_value());
-  EXPECT_EQ(batch[0]->node_id, single->node_id);
-  EXPECT_EQ(batch[0]->tier, single->tier);
-}
-
-// A strategy whose Select() breaks its own contract (routes to a node/tier
-// without enough room) must trip the projected-capacity invariant.  Best-effort:
-// the offending key is dropped to nullopt (route failure) and a MORI ERROR is
-// logged, rather than throwing or silently clamping the deduction.
-class BrokenContractStrategy : public RoutePutStrategy {
- public:
-  std::optional<RoutePutResult> Select(
-      const std::vector<ClientRecord>& alive_clients, uint64_t /*block_size*/,
-      const std::unordered_set<std::string>& /*exclude_nodes*/) override {
-    return RoutePutResult{
-        .outcome = RoutePutOutcome::kRouted,
-        .node_id = alive_clients.front().node_id,
-        .peer_address = alive_clients.front().peer_address,
-        .tier = TierType::HBM,
-    };
-  }
-};
-
-TEST(SelectBatchTest, ProjectedCapacityUnderflowDropsRoute) {
-  BrokenContractStrategy strategy;
-
-  std::vector<ClientRecord> clients = {
-      MakeClient("node-a", "addr-a", {{TierType::HBM, {80 * GB, 1 * GB}}}),
-  };
-
-  auto results =
-      strategy.SelectBatch(/*requester=*/"req", {4 * GB}, {false}, clients, /*exclude=*/{});
-  ASSERT_EQ(results.size(), 1u);
-  EXPECT_FALSE(results[0].has_value());
-}
-
 // ---- ConfigurableRoutePutStrategy tests ----
 //
 // Deterministic, master-free: build capacity snapshots directly, call
 // SelectBatch(), and assert on the node_id / tier distribution of the routes.
 
 namespace {
-
-using Algo = ConfigurableRoutePutStrategy::SelectAlgo;
-using Affinity = ConfigurableRoutePutStrategy::NodeAffinity;
 
 // One DRAM tier with available == total (the strategy only reads available).
 ClientRecord DramClient(const std::string& node_id, uint64_t avail) {


### PR DESCRIPTION
## Summary
Make master-side RoutePut placement configurable and batch-aware. Three
related changes to how `BatchRoutePut` chooses a node+tier for each key:

- **Projected batch capacity.** Previously per-key `Select()` reused one
  unchanged alive-clients snapshot, so a whole batch could pile onto the
  "emptiest in snapshot" node and only hit `NO_SPACE` at the peer allocator.
  Add `RoutePutStrategy::SelectBatch()`, which deducts each routed pick's
  node/tier `available_bytes` in a batch-local candidates copy, spreading the
  batch without touching the real registry. Dedup hits skip the planner and
  consume no capacity; a broken `Select()` invariant fails fast (throw)
  instead of silently clamping. Single-key `RoutePut()` / `Select()` semantics
  are unchanged.

- **Configurable select algorithm + node affinity.** Add
  `ConfigurableRoutePutStrategy` with two orthogonal knobs wired from env at
  master startup:
  - `UMBP_ROUTE_PUT_SELECT_ALGO`: `most_available` | capacity-weighted random
  - `UMBP_ROUTE_PUT_NODE_AFFINITY`: `none` | `same` | `local`

  `SelectBatch` now takes the requester node id. `same` pins the whole batch to
  one node+tier when it fits the non-dedup total, else falls back to per-key
  sticky placement that stays tier-first (HBM before DRAM) with the anchor only
  preferred within a tier. `local` is node-first (local HBM, local DRAM) before
  the global fallback. All affinities fall back to the base algorithm so they
  never break tier priority (except `local`'s intentional local-DRAM-over-
  remote-HBM bias) and never drop a key the base algorithm could route. SSD is
  never a direct-put target; projected capacity stays batch-local.

- **Env helper + perf bench.** Add a `GetEnvEnum` helper (reusing the WARN-once
  path) and a standalone `bench_umbp_route_put_strategy` that compares batch
  put / put-then-get throughput and placement distribution across the
  algo × affinity matrix under roomy/tight capacity regimes.

## Test plan
- [x] `test_umbp_route_put_strategy` — 31 tests pass (most_available, weighted
      random distribution, same/local affinity, tier-priority fallback,
      projected-capacity spread, env parsing)
- [x] Builds clean on current `main`; `bench_umbp_route_put_strategy` links
- [ ] CI green