### PR TITLE
ci: add CodeQL SAST workflow and fix all high-severity findings

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,21 @@
+# CodeQL scan configuration for MoRI.
+#
+# Scope the SAST scan to MoRI's own, shippable code: third-party libraries
+# (vendored/submodule under 3rdparty/), test code, and out-of-tree build
+# artifacts (e.g. googletest compiled into the CMake build dir) are not part
+# of the deliverable and are excluded so their alerts don't show up as MoRI
+# findings. This mirrors the pre-commit config, which already excludes 3rdparty/.
+name: "MoRI CodeQL config"
+
+paths-ignore:
+  - "3rdparty"
+  - "3rdparty/**"
+  - "tests"
+  - "tests/**"
+  - "build"
+  - "build/**"
+  - "**/build/**"
+  - "**/_skbuild/**"
+  - "**/googletest/**"
+  - "**/gtest/**"
+  - "**/gmock/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -91,11 +91,14 @@ jobs:
             rm -rf "$OUT" && mkdir -p "$OUT"
 
             # --- build CodeQL database(s). For cpp, CodeQL traces the real
-            #     compiler calls made by `pip install .`; python needs no build. ---
+            #     compiler calls made by `pip install .`; python needs no build.
+            #     The config file scopes results to MoRI's own code (excludes
+            #     3rdparty/, tests, and build artifacts). ---
             codeql database create "$OUT/db" \
               --db-cluster \
               --language="$LANGUAGES" \
               --command="pip install . -v" \
+              --codescanning-config="$GITHUB_WORKSPACE/.github/codeql/codeql-config.yml" \
               --overwrite
 
             # --- analyze each language with the security-and-quality suite ---

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,129 @@
+# Manual SAST scan with CodeQL.
+#
+# Compilation happens *inside* the CI docker container (same image as ci.yml),
+# so CodeQL must run inside that container too: its C/C++ analysis works by
+# tracing real compiler invocations, which it cannot do across `docker exec`.
+# The CodeQL CLI bundle is therefore downloaded and driven from within the
+# container, wrapping the project's normal `pip install .` build.
+#
+# Results are written as SARIF, uploaded to the repo's Security > Code scanning
+# tab, and also attached as a build artifact (the report to hand to Security).
+name: CodeQL (manual SAST)
+
+on:
+  workflow_dispatch:
+    inputs:
+      languages:
+        description: "Languages to scan"
+        type: choice
+        default: "cpp,python"
+        options:
+          - "cpp,python"
+          - "cpp"
+          - "python"
+
+permissions:
+  contents: read
+  security-events: write   # required to upload SARIF to the Security tab
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE: rocm/mori:ci
+  BASE_IMAGE: rocm/pytorch:rocm7.2.1_ubuntu24.04_py3.12_pytorch_release_2.8.0
+  CONTAINER: mori_codeql_${{ github.run_id }}
+  CT: docker
+  LANGUAGES: ${{ inputs.languages }}
+
+jobs:
+  codeql:
+    name: CodeQL scan (MI355X_AINIC)
+    runs-on: [self-hosted, MI355X-AINIC-TW]
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Build CI image
+        run: $CT build --network=host --build-arg BASE_IMAGE=$BASE_IMAGE -t $IMAGE -f docker/Dockerfile.dev .
+
+      - name: Start container
+        run: |
+          $CT rm -f $CONTAINER 2>/dev/null || true
+          CONTAINER_RUNTIME=$CT ./docker/ci_run.sh --name $CONTAINER \
+            -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
+            -w $GITHUB_WORKSPACE \
+            $IMAGE sleep infinity
+          $CT exec $CONTAINER \
+            git config --global --add safe.directory $GITHUB_WORKSPACE
+
+      - name: Run CodeQL (build + analyze) inside container
+        run: |
+          $CT exec \
+            -e GITHUB_WORKSPACE=$GITHUB_WORKSPACE \
+            -e LANGUAGES="$LANGUAGES" \
+            -e HOST_UID=$(id -u) \
+            -e HOST_GID=$(id -g) \
+            $CONTAINER bash -euo pipefail -c '
+            cd "$GITHUB_WORKSPACE"
+
+            # --- tooling: ensure curl/tar, then fetch the CodeQL CLI bundle ---
+            command -v curl >/dev/null 2>&1 || (apt-get update && apt-get install -y --no-install-recommends curl ca-certificates)
+            mkdir -p /opt/codeql-bundle
+            curl -fsSL -o /tmp/codeql-bundle.tar.gz \
+              https://github.com/github/codeql-action/releases/latest/download/codeql-bundle-linux64.tar.gz
+            tar -xzf /tmp/codeql-bundle.tar.gz -C /opt/codeql-bundle
+            export PATH="/opt/codeql-bundle/codeql:$PATH"
+            codeql --version
+
+            OUT="$GITHUB_WORKSPACE/codeql-results"
+            rm -rf "$OUT" && mkdir -p "$OUT"
+
+            # --- build CodeQL database(s). For cpp, CodeQL traces the real
+            #     compiler calls made by `pip install .`; python needs no build. ---
+            codeql database create "$OUT/db" \
+              --db-cluster \
+              --language="$LANGUAGES" \
+              --command="pip install . -v" \
+              --overwrite
+
+            # --- analyze each language with the security-and-quality suite ---
+            IFS=, read -ra LANGS <<< "$LANGUAGES"
+            for lang in "${LANGS[@]}"; do
+              codeql database analyze "$OUT/db/$lang" \
+                "codeql/${lang}-queries:codeql-suites/${lang}-security-and-quality.qls" \
+                --format=sarif-latest \
+                --output="$OUT/mori-${lang}.sarif" \
+                --sarif-category="$lang"
+            done
+
+            # --- make results readable/owned by the runner user on the host ---
+            chown -R "$HOST_UID:$HOST_GID" "$OUT"
+            ls -la "$OUT"
+          '
+
+      - name: Upload SARIF to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: codeql-results
+          wait-for-processing: true
+
+      - name: Upload SARIF as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codeql-sarif-${{ github.run_id }}
+          path: codeql-results/*.sarif
+          if-no-files-found: warn
+
+      - name: Cleanup
+        if: always()
+        run: |
+          $CT rm -f $CONTAINER || true
+          $CT run --rm -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE $BASE_IMAGE \
+              chown -R $(id -u):$(id -g) $GITHUB_WORKSPACE 2>/dev/null || true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,12 @@
 name: CodeQL (manual SAST)
 
 on:
+  # TEMPORARY: lets this workflow run on push to the feature branch so it can be
+  # validated before merging (workflow_dispatch's "Run workflow" button only
+  # appears once the file is on the default branch). Remove this `push:` block
+  # before merging — keep only workflow_dispatch.
+  push:
+    branches: [jiahzhou/codeql-sast]
   workflow_dispatch:
     inputs:
       languages:
@@ -35,7 +41,8 @@ env:
   BASE_IMAGE: rocm/pytorch:rocm7.2.1_ubuntu24.04_py3.12_pytorch_release_2.8.0
   CONTAINER: mori_codeql_${{ github.run_id }}
   CT: docker
-  LANGUAGES: ${{ inputs.languages }}
+  # falls back to cpp,python on push events (where inputs.languages is empty)
+  LANGUAGES: ${{ inputs.languages || 'cpp,python' }}
 
 jobs:
   codeql:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -92,8 +92,8 @@ jobs:
 
             # --- build CodeQL database(s). For cpp, CodeQL traces the real
             #     compiler calls made by `pip install .`; python needs no build.
-            #     The config file scopes results to MoRI's own code (excludes
-            #     3rdparty/, tests, and build artifacts). ---
+            #     The config scopes results to MoRI code only, excluding
+            #     3rdparty, tests, and build artifacts. ---
             codeql database create "$OUT/db" \
               --db-cluster \
               --language="$LANGUAGES" \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,12 +11,6 @@
 name: CodeQL (manual SAST)
 
 on:
-  # TEMPORARY: lets this workflow run on push to the feature branch so it can be
-  # validated before merging (workflow_dispatch's "Run workflow" button only
-  # appears once the file is on the default branch). Remove this `push:` block
-  # before merging — keep only workflow_dispatch.
-  push:
-    branches: [jiahzhou/codeql-sast]
   workflow_dispatch:
     inputs:
       languages:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -111,6 +111,11 @@ jobs:
                 --sarif-category="$lang"
             done
 
+            # --- drop third-party/test/build results. CodeQL paths-ignore is
+            #     not reliably applied to compiled C++, so filter the SARIF
+            #     directly to keep only MoRI code. ---
+            python3 "$GITHUB_WORKSPACE/tools/codeql/filter_sarif.py" "$OUT"/*.sarif
+
             # --- make results readable/owned by the runner user on the host ---
             chown -R "$HOST_UID:$HOST_GID" "$OUT"
             ls -la "$OUT"

--- a/docs/MORI-IO-GUIDE.md
+++ b/docs/MORI-IO-GUIDE.md
@@ -174,7 +174,7 @@ See `examples/io/example.py` for more complete examples including batch transfer
 | `RdmaBackendConfig.max_chunks_per_transfer` | Cap on chunks per transfer to bound WR/SQ usage (default `64`). Env: `MORI_IO_MAX_CHUNKS` |
 | `RdmaBackendConfig.num_nics_per_transfer` | Stripe a transfer across this many NICs (default `1`). Adaptive by memory type: GPU memory stays single-NIC (PCIe-bound); host memory stripes across NUMA-local NICs. Env: `MORI_IO_NUM_NICS_PER_TRANSFER` |
 | `IOEngineConfig.port = 0` | Auto-bind to a free port |
-| `MORI_IBVERBS_LIB` | soname of libibverbs to `dlopen` at runtime — MORI-IO loads libibverbs dynamically rather than linking it. Must be a bare soname (no path); to use an out-of-tree libibverbs, set `LD_LIBRARY_PATH`. Defaults to `libibverbs.so` / `libibverbs.so.1`. |
+| `LD_LIBRARY_PATH` | MORI-IO loads libibverbs dynamically at runtime (`dlopen` of `libibverbs.so` / `libibverbs.so.1`) rather than linking it. To use an out-of-tree libibverbs, put its directory on `LD_LIBRARY_PATH`. |
 
 UMBP (the upper-layer cache pool) exposes a separate set of runtime-tunable
 env vars for distributed master / pool client / SPDK proxy timing. Those are

--- a/docs/MORI-IO-GUIDE.md
+++ b/docs/MORI-IO-GUIDE.md
@@ -174,7 +174,7 @@ See `examples/io/example.py` for more complete examples including batch transfer
 | `RdmaBackendConfig.max_chunks_per_transfer` | Cap on chunks per transfer to bound WR/SQ usage (default `64`). Env: `MORI_IO_MAX_CHUNKS` |
 | `RdmaBackendConfig.num_nics_per_transfer` | Stripe a transfer across this many NICs (default `1`). Adaptive by memory type: GPU memory stays single-NIC (PCIe-bound); host memory stripes across NUMA-local NICs. Env: `MORI_IO_NUM_NICS_PER_TRANSFER` |
 | `IOEngineConfig.port = 0` | Auto-bind to a free port |
-| `MORI_IBVERBS_LIB` | Path/soname of libibverbs to `dlopen` at runtime — MORI-IO loads libibverbs dynamically rather than linking it. Set to point at an out-of-tree libibverbs; defaults to `libibverbs.so` / `libibverbs.so.1`. |
+| `MORI_IBVERBS_LIB` | soname of libibverbs to `dlopen` at runtime — MORI-IO loads libibverbs dynamically rather than linking it. Must be a bare soname (no path); to use an out-of-tree libibverbs, set `LD_LIBRARY_PATH`. Defaults to `libibverbs.so` / `libibverbs.so.1`. |
 
 UMBP (the upper-layer cache pool) exposes a separate set of runtime-tunable
 env vars for distributed master / pool client / SPDK proxy timing. Those are

--- a/docs/MORI-SHMEM-GUIDE.md
+++ b/docs/MORI-SHMEM-GUIDE.md
@@ -295,7 +295,7 @@ This copies the current GPU states to the `globalGpuStates` symbol in the dynami
 | `MORI_SHMEM_VMM_CHUNK_SIZE` | VMM mode chunk size in bytes | Auto |
 | `MORI_SOCKET_IFNAME` | Network interface for shmem bootstrap TCP connections (e.g., `"lo"`, `"eth0"`) | Auto-detect |
 | `MORI_RDMA_DEVICES` | RDMA NIC selection. Include: `mlx5_0,mlx5_1`. Exclude: `^mlx5_2,mlx5_3` | All available |
-| `MORI_IBVERBS_LIB` | soname of libibverbs to `dlopen` at runtime (mori loads libibverbs dynamically instead of linking it). Must be a bare soname (no path); to use an out-of-tree libibverbs, set `LD_LIBRARY_PATH`. | `libibverbs.so` / `libibverbs.so.1` |
+| `LD_LIBRARY_PATH` | mori loads libibverbs dynamically at runtime (`dlopen`) instead of linking it; to use an out-of-tree libibverbs, put its directory here. | `libibverbs.so` / `libibverbs.so.1` |
 | `MORI_NUM_QP_PER_PE` | Number of RDMA queue pairs per PE | `1` |
 | `MORI_IB_GID_INDEX` | InfiniBand GID index for RDMA connections | Auto-detect |
 | `MORI_RDMA_SL` | RDMA service level | Auto |

--- a/docs/MORI-SHMEM-GUIDE.md
+++ b/docs/MORI-SHMEM-GUIDE.md
@@ -295,7 +295,7 @@ This copies the current GPU states to the `globalGpuStates` symbol in the dynami
 | `MORI_SHMEM_VMM_CHUNK_SIZE` | VMM mode chunk size in bytes | Auto |
 | `MORI_SOCKET_IFNAME` | Network interface for shmem bootstrap TCP connections (e.g., `"lo"`, `"eth0"`) | Auto-detect |
 | `MORI_RDMA_DEVICES` | RDMA NIC selection. Include: `mlx5_0,mlx5_1`. Exclude: `^mlx5_2,mlx5_3` | All available |
-| `MORI_IBVERBS_LIB` | Path/soname of libibverbs to `dlopen` at runtime (mori loads libibverbs dynamically instead of linking it). Set this to point at an out-of-tree libibverbs. | `libibverbs.so` / `libibverbs.so.1` |
+| `MORI_IBVERBS_LIB` | soname of libibverbs to `dlopen` at runtime (mori loads libibverbs dynamically instead of linking it). Must be a bare soname (no path); to use an out-of-tree libibverbs, set `LD_LIBRARY_PATH`. | `libibverbs.so` / `libibverbs.so.1` |
 | `MORI_NUM_QP_PER_PE` | Number of RDMA queue pairs per PE | `1` |
 | `MORI_IB_GID_INDEX` | InfiniBand GID index for RDMA connections | Auto-detect |
 | `MORI_RDMA_SL` | RDMA service level | Auto |

--- a/include/mori/ops/dispatch_combine/dispatch_combine.hpp
+++ b/include/mori/ops/dispatch_combine/dispatch_combine.hpp
@@ -168,7 +168,9 @@ struct EpDispatchCombineConfig {
     return numExpertPerToken * sizeof(float);
   }
   inline __host__ __device__ size_t SrcTokenIdBytes() const { return sizeof(index_t); }
-  inline __host__ __device__ size_t ScaleBytes() const { return scaleDim * scaleTypeSize; }
+  inline __host__ __device__ size_t ScaleBytes() const {
+    return static_cast<size_t>(scaleDim) * scaleTypeSize;
+  }
   // Size_t accessors for fields used in token-offset arithmetic.
   // Use these instead of the raw int members to avoid int32 overflow when
   // multiplying by token counts (e.g. tokenId * HiddenDimSz() is size_t * size_t).

--- a/setup.py
+++ b/setup.py
@@ -475,7 +475,7 @@ class CMakeBuild(build_ext):
         spdk_proxy_dst = root_dir / "python/mori/spdk_proxy"
         if build_umbp_spdk_enabled and spdk_proxy_src.exists():
             shutil.copyfile(spdk_proxy_src, spdk_proxy_dst)
-            os.chmod(spdk_proxy_dst, 0o755)
+            os.chmod(spdk_proxy_dst, 0o700)
         elif spdk_proxy_dst.exists():
             spdk_proxy_dst.unlink()
 
@@ -483,7 +483,7 @@ class CMakeBuild(build_ext):
         umbp_master_dst = root_dir / "python/mori/umbp_master"
         if umbp_master_src.exists():
             shutil.copyfile(umbp_master_src, umbp_master_dst)
-            os.chmod(umbp_master_dst, 0o755)
+            os.chmod(umbp_master_dst, 0o700)
         elif umbp_master_dst.exists():
             umbp_master_dst.unlink()
 

--- a/src/application/bootstrap/local_bootstrap.cpp
+++ b/src/application/bootstrap/local_bootstrap.cpp
@@ -104,7 +104,7 @@ void LocalBootstrapNetwork::Barrier() {
 
   // Phase 1: All processes arrive
   std::string arriveFile = socketBasePath_ + "barrier_arrive_" + std::to_string(localRank);
-  int fd = open(arriveFile.c_str(), O_CREAT | O_WRONLY, 0666);
+  int fd = open(arriveFile.c_str(), O_CREAT | O_WRONLY, 0600);
   if (fd >= 0) {
     close(fd);
   }
@@ -139,7 +139,7 @@ void LocalBootstrapNetwork::Barrier() {
 
   // Phase 2: Signal departure (safe to proceed)
   std::string departFile = socketBasePath_ + "barrier_depart_" + std::to_string(localRank);
-  fd = open(departFile.c_str(), O_CREAT | O_WRONLY, 0666);
+  fd = open(departFile.c_str(), O_CREAT | O_WRONLY, 0600);
   if (fd >= 0) {
     close(fd);
   }

--- a/src/application/memory/symmetric_memory.cpp
+++ b/src/application/memory/symmetric_memory.cpp
@@ -240,7 +240,7 @@ SymmMemObjPtr SymmMemManager::RegisterSymmMemObj(void* localPtr, size_t size, bo
       for (size_t q = 0; q < numOfQueuesPerDevice; q++) {
         auto* anvilHandle = anvil::anvil.getSdmaQueue(srcDeviceId, dstDeviceId, q)->deviceHandle();
         HIP_RUNTIME_CHECK(
-            hipMemcpy(&gpuMemObj->deviceHandles_d[dstDeviceId * numOfQueuesPerDevice + q],
+            hipMemcpy(&gpuMemObj->deviceHandles_d[static_cast<size_t>(dstDeviceId) * numOfQueuesPerDevice + q],
                       &anvilHandle, sizeof(anvilHandle), hipMemcpyHostToDevice));
       }
     }

--- a/src/application/memory/symmetric_memory.cpp
+++ b/src/application/memory/symmetric_memory.cpp
@@ -239,9 +239,10 @@ SymmMemObjPtr SymmMemManager::RegisterSymmMemObj(void* localPtr, size_t size, bo
     for (auto& dstDeviceId : dstDeviceIds) {
       for (size_t q = 0; q < numOfQueuesPerDevice; q++) {
         auto* anvilHandle = anvil::anvil.getSdmaQueue(srcDeviceId, dstDeviceId, q)->deviceHandle();
-        HIP_RUNTIME_CHECK(
-            hipMemcpy(&gpuMemObj->deviceHandles_d[static_cast<size_t>(dstDeviceId) * numOfQueuesPerDevice + q],
-                      &anvilHandle, sizeof(anvilHandle), hipMemcpyHostToDevice));
+        HIP_RUNTIME_CHECK(hipMemcpy(
+            &gpuMemObj
+                 ->deviceHandles_d[static_cast<size_t>(dstDeviceId) * numOfQueuesPerDevice + q],
+            &anvilHandle, sizeof(anvilHandle), hipMemcpyHostToDevice));
       }
     }
 

--- a/src/application/transport/rdma/providers/ibverbs/ibv_shim.cpp
+++ b/src/application/transport/rdma/providers/ibverbs/ibv_shim.cpp
@@ -54,8 +54,6 @@
 #include <infiniband/verbs.h>
 
 #include <cerrno>
-#include <cstdlib>
-#include <cstring>
 
 #include "mori/utils/mori_log.hpp"
 
@@ -67,25 +65,15 @@
 
 namespace {
 
-// Lazily dlopen libibverbs once. Order: MORI_IBVERBS_LIB override (restricted to
-// a bare soname), then the unversioned and versioned sonames. Returns nullptr if
-// none is found, in which case every shim degrades to a failure return so that
-// RDMA discovery / setup fails gracefully instead of crashing on a host without
-// RDMA.
+// Lazily dlopen libibverbs once, trying the unversioned then the versioned
+// soname. Returns nullptr if neither is found, in which case every shim degrades
+// to a failure return so that RDMA discovery / setup fails gracefully instead of
+// crashing on a host without RDMA. To use an out-of-tree libibverbs, point
+// LD_LIBRARY_PATH at it.
 void* IbvHandle() {
   static void* handle = [] {
-    // MORI_IBVERBS_LIB may override the soname, but reject any value containing a
-    // path separator: a bare soname is resolved only via the trusted dynamic
-    // linker search path, so the override cannot load a library from an
-    // attacker-chosen directory.
-    const char* envLib = std::getenv("MORI_IBVERBS_LIB");
-    if (envLib && std::strchr(envLib, '/') != nullptr) {
-      MORI_APP_WARN("ignoring MORI_IBVERBS_LIB='{}': must be a bare soname, not a path", envLib);
-      envLib = nullptr;
-    }
-    const char* libs[] = {envLib, "libibverbs.so", "libibverbs.so.1"};
+    const char* libs[] = {"libibverbs.so", "libibverbs.so.1"};
     for (const char* lib : libs) {
-      if (!lib || !*lib) continue;
       void* h = dlopen(lib, RTLD_LAZY | RTLD_LOCAL);
       if (h) {
         MORI_APP_TRACE("dlopen({}) succeeded", lib);
@@ -93,7 +81,7 @@ void* IbvHandle() {
       }
       MORI_APP_TRACE("dlopen({}) failed: {}", lib, dlerror());
     }
-    MORI_APP_WARN("failed to dlopen libibverbs (set MORI_IBVERBS_LIB to override)");
+    MORI_APP_WARN("failed to dlopen libibverbs (set LD_LIBRARY_PATH if it is out-of-tree)");
     return static_cast<void*>(nullptr);
   }();
   return handle;

--- a/src/application/transport/rdma/providers/ibverbs/ibv_shim.cpp
+++ b/src/application/transport/rdma/providers/ibverbs/ibv_shim.cpp
@@ -55,6 +55,7 @@
 
 #include <cerrno>
 #include <cstdlib>
+#include <cstring>
 
 #include "mori/utils/mori_log.hpp"
 
@@ -66,13 +67,23 @@
 
 namespace {
 
-// Lazily dlopen libibverbs once. Order (mirrors NCCL): MORI_IBVERBS_LIB override,
-// then the unversioned and versioned sonames. Returns nullptr if none is found,
-// in which case every shim degrades to a failure return so that RDMA discovery /
-// setup fails gracefully instead of crashing on a host without RDMA.
+// Lazily dlopen libibverbs once. Order: MORI_IBVERBS_LIB override (restricted to
+// a bare soname), then the unversioned and versioned sonames. Returns nullptr if
+// none is found, in which case every shim degrades to a failure return so that
+// RDMA discovery / setup fails gracefully instead of crashing on a host without
+// RDMA.
 void* IbvHandle() {
   static void* handle = [] {
-    const char* libs[] = {std::getenv("MORI_IBVERBS_LIB"), "libibverbs.so", "libibverbs.so.1"};
+    // MORI_IBVERBS_LIB may override the soname, but reject any value containing a
+    // path separator: a bare soname is resolved only via the trusted dynamic
+    // linker search path, so the override cannot load a library from an
+    // attacker-chosen directory.
+    const char* envLib = std::getenv("MORI_IBVERBS_LIB");
+    if (envLib && std::strchr(envLib, '/') != nullptr) {
+      MORI_APP_WARN("ignoring MORI_IBVERBS_LIB='{}': must be a bare soname, not a path", envLib);
+      envLib = nullptr;
+    }
+    const char* libs[] = {envLib, "libibverbs.so", "libibverbs.so.1"};
     for (const char* lib : libs) {
       if (!lib || !*lib) continue;
       void* h = dlopen(lib, RTLD_LAZY | RTLD_LOCAL);

--- a/src/ops/dispatch_combine/dispatch_combine.cpp
+++ b/src/ops/dispatch_combine/dispatch_combine.cpp
@@ -242,7 +242,8 @@ void EpDispatchCombineHandle::InitializeShmemBuf() {
     bufs.combineOut = ShmemMallocAndReturnMemObjPtr(combineOutSize, hipDeviceMallocUncached);
   }
 
-  size_t maxWeightSize = config.MaxNumTokensToRecv() * config.numExpertPerToken * sizeof(float);
+  size_t maxWeightSize =
+      static_cast<size_t>(config.MaxNumTokensToRecv()) * config.numExpertPerToken * sizeof(float);
   shmemInpWeightsMemObj = ShmemMallocAndReturnMemObjPtr(maxWeightSize, hipDeviceMallocUncached);
   shmemDispatchOutWeightsMemObj =
       ShmemMallocAndReturnMemObjPtr(maxWeightSize, hipDeviceMallocUncached);
@@ -267,7 +268,8 @@ void EpDispatchCombineHandle::InitializeShmemBuf() {
     shmemOutScalesMemObj = ShmemMallocAndReturnMemObjPtr(userScaleSize, hipDeviceMallocUncached);
   }
 
-  size_t maxIndicesSize = config.MaxNumTokensToRecv() * config.numExpertPerToken * sizeof(index_t);
+  size_t maxIndicesSize =
+      static_cast<size_t>(config.MaxNumTokensToRecv()) * config.numExpertPerToken * sizeof(index_t);
   shmemInpIndicesMemObj = ShmemMallocAndReturnMemObjPtr(maxIndicesSize, hipDeviceMallocUncached);
   shmemOutIndicesMemObj = ShmemMallocAndReturnMemObjPtr(maxIndicesSize, hipDeviceMallocUncached);
 
@@ -342,7 +344,8 @@ void EpDispatchCombineHandle::FinalizeTokenNumSignalBuf() {
 }
 
 void EpDispatchCombineHandle::InitializeOrderMapBuf() {
-  size_t maxNumOutToken = config.MaxNumTokensToSend() * config.numExpertPerRank;
+  size_t maxNumOutToken =
+      static_cast<size_t>(config.MaxNumTokensToSend()) * config.numExpertPerRank;
   HIP_RUNTIME_CHECK(hipMalloc(&dispReceiverIdxMap, maxNumOutToken * sizeof(index_t)));
   HIP_RUNTIME_CHECK(hipMemset(dispReceiverIdxMap, 0, maxNumOutToken * sizeof(index_t)));
 
@@ -373,7 +376,7 @@ void EpDispatchCombineHandle::InitializeOrderMapBuf() {
   HIP_RUNTIME_CHECK(hipMalloc(&dispDestTokIdMap, maxNumOutToken * sizeof(index_t)));
   HIP_RUNTIME_CHECK(hipMemset(dispDestTokIdMap, 0, maxNumOutToken * sizeof(index_t)));
 
-  size_t maxNumInterNodeToken = config.worldSize / config.gpuPerNode *
+  size_t maxNumInterNodeToken = static_cast<size_t>(config.worldSize) / config.gpuPerNode *
                                 config.MaxNumTokensToSendPerRank() * config.numExpertPerToken;
   HIP_RUNTIME_CHECK(hipMalloc(&interNodeDispDestTokIdMap, maxNumInterNodeToken * sizeof(index_t)));
   HIP_RUNTIME_CHECK(
@@ -384,8 +387,8 @@ void EpDispatchCombineHandle::InitializeOrderMapBuf() {
   HIP_RUNTIME_CHECK(
       hipMemset(blockFlagCounter, 0, config.worldSize / config.gpuPerNode * sizeof(index_t)));
 
-  size_t interNodeDispSendMapSize =
-      config.worldSize / config.gpuPerNode * config.MaxNumTokensToSendPerRank() * sizeof(index_t);
+  size_t interNodeDispSendMapSize = static_cast<size_t>(config.worldSize) / config.gpuPerNode *
+                                    config.MaxNumTokensToSendPerRank() * sizeof(index_t);
   HIP_RUNTIME_CHECK(hipMalloc(&interNodeDispSendMap, interNodeDispSendMapSize));
   HIP_RUNTIME_CHECK(hipMemset(interNodeDispSendMap, 0, interNodeDispSendMapSize));
 
@@ -435,8 +438,8 @@ void EpDispatchCombineHandle::InitializeBarrier() {
   crossDeviceBarrierMemObj =
       ShmemMallocAndReturnMemObjPtr(barrierSize * 2 * sizeof(uint64_t), hipDeviceMallocUncached);
 
-  size_t interNodeChunkFlagSize =
-      config.worldSize / config.gpuPerNode * config.MaxNumTokensToSendPerRank() * sizeof(uint64_t);
+  size_t interNodeChunkFlagSize = static_cast<size_t>(config.worldSize) / config.gpuPerNode *
+                                  config.MaxNumTokensToSendPerRank() * sizeof(uint64_t);
   interNodeChunkFlagMemObj =
       ShmemMallocAndReturnMemObjPtr(interNodeChunkFlagSize, hipDeviceMallocUncached);
 

--- a/src/shmem/init.cpp
+++ b/src/shmem/init.cpp
@@ -397,7 +397,7 @@ static void CopyRdmaEndpointsToGpu(ShmemStates* states) {
     return;
   }
 
-  size_t numEndpoints = gpuStates->worldSize * gpuStates->numQpPerPe;
+  size_t numEndpoints = static_cast<size_t>(gpuStates->worldSize) * gpuStates->numQpPerPe;
 
   // Allocate and copy endpoints.
   // Convert from host-side application::RdmaEndpoint (which contains ibverbs handles and QP

--- a/src/umbp/local/tiers/local_storage_manager.cpp
+++ b/src/umbp/local/tiers/local_storage_manager.cpp
@@ -274,7 +274,7 @@ class ScopedBootstrapLock {
  public:
   explicit ScopedBootstrapLock(const std::string& shm_name) {
     path_ = ::umbp::proxy::ProxyShmRegion::BootstrapLockPath(shm_name);
-    fd_ = open(path_.c_str(), O_CREAT | O_RDWR, 0666);
+    fd_ = open(path_.c_str(), O_CREAT | O_RDWR, 0600);
     if (fd_ < 0) {
       MORI_UMBP_ERROR("LSM: open bootstrap lock '{}' failed: {}", path_, strerror(errno));
       return;

--- a/src/umbp/storage/spdk/proxy/spdk_proxy_shm.cpp
+++ b/src/umbp/storage/spdk/proxy/spdk_proxy_shm.cpp
@@ -166,7 +166,7 @@ int ProxyShmRegion::Create(const std::string& name, uint32_t max_channels, uint3
 
     unlink(hp_path_.c_str());
 
-    fd_ = open(hp_path_.c_str(), O_CREAT | O_RDWR | O_TRUNC, 0666);
+    fd_ = open(hp_path_.c_str(), O_CREAT | O_RDWR | O_TRUNC, 0600);
     if (fd_ >= 0) {
       if (ftruncate(fd_, static_cast<off_t>(hp_size)) == 0) {
         base_ = mmap(nullptr, hp_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE, fd_, 0);
@@ -190,7 +190,7 @@ int ProxyShmRegion::Create(const std::string& name, uint32_t max_channels, uint3
 
   if (!is_hugepage_) {
     shm_unlink(name_.c_str());
-    fd_ = shm_open(name_.c_str(), O_CREAT | O_RDWR | O_EXCL, 0666);
+    fd_ = shm_open(name_.c_str(), O_CREAT | O_RDWR | O_EXCL, 0600);
     if (fd_ < 0) return -errno;
 
     if (ftruncate(fd_, static_cast<off_t>(size_)) != 0) {
@@ -314,7 +314,7 @@ int ProxyShmRegion::Attach(const std::string& name) {
     is_hugepage_ = true;
   } else {
     hp_path_.clear();
-    fd_ = shm_open(name_.c_str(), O_RDWR, 0666);
+    fd_ = shm_open(name_.c_str(), O_RDWR, 0600);
     if (fd_ < 0) return -errno;
   }
 

--- a/tools/codeql/filter_sarif.py
+++ b/tools/codeql/filter_sarif.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# Drop CodeQL results located in third-party / test / build-artifact paths.
+#
+# CodeQL's `paths-ignore` config is not reliably applied to *compiled* languages
+# (C/C++): the extractor still compiles vendored/test sources pulled into the
+# build, so their alerts appear in the SARIF. This post-processes the SARIF to
+# remove any result whose location falls under an excluded path prefix, so the
+# uploaded report reflects MoRI's own shippable code only.
+#
+# Usage: filter_sarif.py FILE.sarif [FILE2.sarif ...]   (edits files in place)
+
+import json
+import sys
+
+# Repo-root-relative path prefixes / substrings that are not MoRI's own code.
+EXCLUDE_PREFIXES = ("3rdparty/", "build/", "tests/")
+EXCLUDE_SUBSTRINGS = ("/_deps/", "/googletest", "/3rdparty/")
+
+
+def is_excluded(uri: str) -> bool:
+    u = uri.lstrip("./")
+    if u.startswith(EXCLUDE_PREFIXES):
+        return True
+    return any(s in u for s in EXCLUDE_SUBSTRINGS)
+
+
+def result_uri(result: dict) -> str:
+    try:
+        return result["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+    except (KeyError, IndexError, TypeError):
+        return ""
+
+
+def main(paths):
+    for path in paths:
+        with open(path) as f:
+            sarif = json.load(f)
+
+        removed = 0
+        for run in sarif.get("runs", []):
+            kept = []
+            for res in run.get("results", []):
+                if is_excluded(result_uri(res)):
+                    removed += 1
+                else:
+                    kept.append(res)
+            run["results"] = kept
+
+        with open(path, "w") as f:
+            json.dump(sarif, f)
+        print(f"{path}: removed {removed} third-party/test/build result(s)")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("usage: filter_sarif.py FILE.sarif [...]", file=sys.stderr)
+        sys.exit(2)
+    main(sys.argv[1:])

--- a/tools/codeql/filter_sarif.py
+++ b/tools/codeql/filter_sarif.py
@@ -1,4 +1,25 @@
 #!/usr/bin/env python3
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 # Drop CodeQL results located in third-party / test / build-artifact paths.
 #
 # CodeQL's `paths-ignore` config is not reliably applied to *compiled* languages


### PR DESCRIPTION
## Summary

Adds a CodeQL SAST scan for MoRI (for the OSRB SAST requirement) and fixes every
high-severity finding it reported. Final result: **0 Critical, 0 High**.

## Changes

- **`codeql.yml`** — manual (`workflow_dispatch`) CodeQL scan for C/C++ and Python,
  compiled inside the CI docker image on the self-hosted runner. Results go to
  Security → Code scanning and a SARIF artifact.
- **Scan scoping** (`codeql-config.yml` + `filter_sarif.py`) — exclude
  3rdparty/, tests, and build artifacts so the report covers MoRI's own code.
- **Fixes**: integer overflow in size math (size_t casts), world-writable files
  (0600), exec perms (0700), and removal of the `MORI_IBVERBS_LIB` dlopen override
  (use `LD_LIBRARY_PATH` instead).

CodeQL went from 0 Critical / 25 High → **0 Critical / 0 High**.