### PR TITLE
fix: detect same physical node by MORI_NODE_ID/boot_id, with hostname fallback

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Keep build outputs, VCS data, and caches out of the docker build context.
+build/
+.git/
+**/__pycache__/
+**/*.egg-info/
+**/*.pyc
+python/mori/_jit-sources/

--- a/include/mori/application/context/context.hpp
+++ b/include/mori/application/context/context.hpp
@@ -70,7 +70,9 @@ class Context {
   void InitializePossibleTransports();
 
   struct PeerInfo {
-    bool sameHost{false};     // on the same node (same hostname+IP)
+    // True if peer is on this rank's physical node. Keyed on node identity, not
+    // raw hostname, so it holds even when all machines share one hostname.
+    bool sameHost{false};
     bool sameProcess{false};  // in the same OS process (same pid + same host)
   };
 

--- a/include/mori/io/engine.hpp
+++ b/include/mori/io/engine.hpp
@@ -146,7 +146,6 @@ class IOEngine {
   void InvalidateRouteCache();
   void UpdateRouteCache(const RouteCacheKey& key, BackendType backendType);
   std::optional<BackendType> QueryRouteCache(const RouteCacheKey& key) const;
-  std::string ResolveNodeId(const std::string& hostname) const;
 
  public:
   IOEngineConfig config;

--- a/include/mori/utils/host_utils.hpp
+++ b/include/mori/utils/host_utils.hpp
@@ -1,0 +1,55 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+#include <cctype>
+#include <fstream>
+#include <string>
+
+#include "mori/utils/env_utils.hpp"
+
+namespace mori {
+
+// Identical for all processes on one physical node, distinct across nodes;
+// empty if unavailable.
+inline std::string ReadKernelBootId() {
+  std::ifstream f("/proc/sys/kernel/random/boot_id");
+  std::string id;
+  if (f && std::getline(f, id)) {
+    while (!id.empty() && std::isspace(static_cast<unsigned char>(id.back()))) id.pop_back();
+    return id;
+  }
+  return {};
+}
+
+// Per-physical-node identity, by priority: MORI_NODE_ID override, boot_id, then
+// hostname. boot_id keeps it correct when machines share one hostname.
+inline std::string ResolveNodeId(const std::string& hostname) {
+  if (auto nodeId = env::GetString("MORI_NODE_ID"); nodeId.has_value()) {
+    return *nodeId;
+  }
+  std::string bootId = ReadKernelBootId();
+  if (!bootId.empty()) return bootId;
+  return hostname;
+}
+
+}  // namespace mori

--- a/src/application/context/context.cpp
+++ b/src/application/context/context.cpp
@@ -36,6 +36,7 @@
 #include "mori/application/transport/sdma/anvil.hpp"
 #include "mori/application/utils/check.hpp"
 #include "mori/utils/env_utils.hpp"
+#include "mori/utils/host_utils.hpp"
 #include "mori/utils/mori_log.hpp"
 
 namespace mori {
@@ -106,35 +107,36 @@ bool Context::SameProcessP2P(int destRank) const {
 void Context::CollectHostNames() {
   char hostname[HOST_NAME_MAX];
   gethostname(hostname, HOST_NAME_MAX);
+  myHostname = std::string(hostname);
 
-  // Keep node identity stable across ranks on the same machine.
-  // Using hostname+IP can split local ranks when different NICs are selected.
+  // Key co-location on node id, not hostname: identical hostnames would mark
+  // cross-node ranks as co-located, over-counting rankInNode (trips assert below).
+  std::string nodeId = ResolveNodeId(myHostname);
 
-  // Pack pid + hostname into a fixed-size buffer for Allgather.
-  // Using a fixed layout avoids string parsing ambiguity.
+  // Allgather a fixed-layout {pid, nodeId} record; fixed size avoids parsing.
   constexpr int kPidSize = sizeof(pid_t);
-  constexpr int kStrMax = HOST_NAME_MAX + 1;  // +1 for '\0'
+  constexpr int kStrMax = 256;  // node id: boot_id, hostname, or override
   constexpr int kRecordSize = kPidSize + kStrMax;
 
   pid_t myPid = getpid();
-  char localBuffer[kRecordSize];
+  char localBuffer[kRecordSize] = {};
   memcpy(localBuffer, &myPid, kPidSize);
-  snprintf(localBuffer + kPidSize, kStrMax, "%s", hostname);
+  snprintf(localBuffer + kPidSize, kStrMax, "%s", nodeId.c_str());
 
   std::vector<char> global(kRecordSize * WorldSize());
   bootNet.Allgather(localBuffer, global.data(), kRecordSize);
 
-  myHostname = std::string(localBuffer + kPidSize);
+  std::string myNodeId(localBuffer + kPidSize);
   peerInfos.resize(WorldSize());
   for (int i = 0; i < WorldSize(); i++) {
     const char* rec = global.data() + i * kRecordSize;
     pid_t peerPid;
     memcpy(&peerPid, rec, kPidSize);
-    std::string peerHost(rec + kPidSize);
-    peerInfos[i].sameHost = (peerHost == myHostname);
+    std::string peerNodeId(rec + kPidSize);
+    peerInfos[i].sameHost = (peerNodeId == myNodeId);
     peerInfos[i].sameProcess = peerInfos[i].sameHost && (peerPid == myPid);
     if (LocalRank() == 0) {
-      MORI_APP_TRACE("rank {} hostname={} pid={} sameHost={} sameProcess={}", i, peerHost, peerPid,
+      MORI_APP_TRACE("rank {} nodeId={} pid={} sameHost={} sameProcess={}", i, peerNodeId, peerPid,
                      peerInfos[i].sameHost, peerInfos[i].sameProcess);
     }
   }

--- a/src/io/engine.cpp
+++ b/src/io/engine.cpp
@@ -36,6 +36,7 @@
 
 #include "mori/io/env.hpp"
 #include "mori/io/logging.hpp"
+#include "mori/utils/host_utils.hpp"
 #include "src/io/call_diagnostics_internal.hpp"
 #include "src/io/rdma/backend_impl.hpp"
 #include "src/io/xgmi/backend_impl.hpp"
@@ -169,7 +170,7 @@ IOEngine::IOEngine(EngineKey key, IOEngineConfig config) : config(config) {
   desc.key = key;
   char hostname[HOST_NAME_MAX];
   gethostname(hostname, HOST_NAME_MAX);
-  desc.nodeId = ResolveNodeId(hostname);
+  desc.nodeId = mori::ResolveNodeId(hostname);
   desc.hostname = std::string(hostname);
   desc.host = config.host;
   desc.port = config.port;
@@ -439,13 +440,6 @@ std::optional<BackendType> IOEngine::QueryRouteCache(const RouteCacheKey& key) c
     return std::nullopt;
   }
   return it->second;
-}
-
-std::string IOEngine::ResolveNodeId(const std::string& hostname) const {
-  if (auto nodeId = mori::env::GetString("MORI_IO_NODE_ID"); nodeId.has_value()) {
-    return *nodeId;
-  }
-  return hostname;
 }
 
 #define SELECT_BACKEND_AND_RETURN_IF_NONE(local, remote, status, backend)     \

--- a/src/io/xgmi/backend_impl.cpp
+++ b/src/io/xgmi/backend_impl.cpp
@@ -39,6 +39,7 @@
 
 #include "mori/io/env.hpp"
 #include "mori/io/logging.hpp"
+#include "mori/utils/host_utils.hpp"
 
 namespace mori {
 namespace io {
@@ -466,15 +467,10 @@ bool XgmiBackendSession::Alive() const { return true; }
 XgmiBackend::XgmiBackend(EngineKey k, const IOEngineConfig& engConfig,
                          const XgmiBackendConfig& beConfig)
     : myEngKey(k), config(beConfig), myPid(static_cast<int>(getpid())) {
-  if (auto nodeId = mori::env::GetString("MORI_IO_NODE_ID"); nodeId.has_value()) {
-    myNodeId = *nodeId;
-  }
   char hostname[HOST_NAME_MAX];
   gethostname(hostname, HOST_NAME_MAX);
   myHostname = std::string(hostname);
-  if (myNodeId.empty()) {
-    myNodeId = myHostname;
-  }
+  myNodeId = mori::ResolveNodeId(myHostname);
 
   streamPool = std::make_unique<StreamPool>(config.numStreams);
   eventPool = std::make_unique<EventPool>(config.numEvents);

--- a/tests/python/io/test_engine.py
+++ b/tests/python/io/test_engine.py
@@ -149,7 +149,7 @@ def test_engine_desc_port_zero_auto_bind():
 
 
 def test_engine_desc_node_id_env_override(monkeypatch):
-    monkeypatch.setenv("MORI_IO_NODE_ID", "node-id-test")
+    monkeypatch.setenv("MORI_NODE_ID", "node-id-test")
     config = IOEngineConfig(
         host="127.0.0.1",
         port=get_free_port(),


### PR DESCRIPTION
## Problem
`Context::CollectHostNames` derived `sameHost` purely from the hostname. On
clusters where every machine shares one hostname, all cross-node ranks are
marked co-located. This over-counts `rankInNode` (tripping
`assert(rankInNode < 8)` on >8-rank multi-node runs) and mis-selects P2P/SDMA
across physical machines.

## Fix
Resolve a per-physical-node identity in priority order:
1. `MORI_NODE_ID` env override (an IP or any unique token)
2. kernel `boot_id` — distinct per physical node even with identical hostnames
3. hostname (fallback)

Shared logic is extracted into `mori/utils/host_utils.hpp` and used from both
the application `Context` and the io engine/xgmi backends. This also unifies
the io module's `MORI_IO_NODE_ID` into `MORI_NODE_ID` and gives the io path the
same `boot_id` fallback. `hostname` is still kept for logging.

## Test
- 2-node, 16-rank `test_dispatch_combine_internode.py` (v1_ll, max-tokens 128,
  num-qp 2): no longer asserts; both XGMI (intra-node) and RDMA (inter-node)
  bandwidth are non-zero, confirming correct `sameHost` classification.
- Verified host vs. container `boot_id` match under docker/runc on both nodes
  (machine-id differed, confirming boot_id is the right key).