### PR TITLE
Perf/umbp dram parallel copy

### DIFF
--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -32,6 +32,9 @@
 #include <string>
 #include <string_view>
 #include <thread>
+#if defined(__x86_64__) || defined(__i386__)
+#include <immintrin.h>
+#endif
 #include <unordered_map>
 
 #include "mori/io/backend.hpp"
@@ -105,6 +108,86 @@ void ObserveBatchBandwidth(MasterClient& master_client, double bytes, double sec
 
 // Bytes belonging to the i-th logical page of a Put/Get spread across
 // `num_pages` pages of `page_size` bytes.  Last page may be partial.
+// --- Parallel + AVX2 NT block copy for self-target (local) pages. ----------
+// In distributed mode 1 key == 1 page (master page_size == KV block size), so
+// the distributed self-target path copies one ~4 MiB block per call. The local
+// tier's (DRAMTier) multi-thread/AVX2 optimization never applied here because
+// it parallelizes *within* a call's pages (always 1). We instead parallelize
+// across the many keys of one BatchPut/BatchGet (different threads -> different
+// keys); per-key NT-AVX2 copy gives the cache-bypass win. Threads via
+// UMBP_DRAM_{READ,WRITE}_THREADS (same envs as DRAMTier).
+#if defined(__x86_64__) || defined(__i386__)
+__attribute__((target("avx2"))) inline void LocalNtCopyAvx2(char* d, const char* s, size_t n) {
+  size_t head = (32 - (reinterpret_cast<uintptr_t>(d) & 31)) & 31;
+  if (head > n) head = n;
+  std::memcpy(d, s, head);
+  size_t i = head;
+  for (; i + 128 <= n; i += 128) {
+    __m256i a = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + i));
+    __m256i b = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + i + 32));
+    __m256i c = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + i + 64));
+    __m256i e = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + i + 96));
+    _mm256_stream_si256(reinterpret_cast<__m256i*>(d + i), a);
+    _mm256_stream_si256(reinterpret_cast<__m256i*>(d + i + 32), b);
+    _mm256_stream_si256(reinterpret_cast<__m256i*>(d + i + 64), c);
+    _mm256_stream_si256(reinterpret_cast<__m256i*>(d + i + 96), e);
+  }
+  for (; i + 32 <= n; i += 32) {
+    __m256i a = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + i));
+    _mm256_stream_si256(reinterpret_cast<__m256i*>(d + i), a);
+  }
+  if (i < n) std::memcpy(d + i, s + i, n - i);
+  _mm_sfence();
+}
+inline bool LocalAvx2Supported() { return __builtin_cpu_supports("avx2"); }
+#else
+inline void LocalNtCopyAvx2(char* d, const char* s, size_t n) { std::memcpy(d, s, n); }
+inline bool LocalAvx2Supported() { return false; }
+#endif
+
+inline void LocalCopyBlock(void* dst, const void* src, size_t size) {
+  static const bool kNt =
+      LocalAvx2Supported() &&
+      !(std::getenv("UMBP_DRAM_NT_COPY") && std::getenv("UMBP_DRAM_NT_COPY")[0] == '0');
+  static const size_t kNtMinBytes = 256ull << 10;
+  if (kNt && size >= kNtMinBytes) {
+    LocalNtCopyAvx2(static_cast<char*>(dst), static_cast<const char*>(src), size);
+  } else {
+    std::memcpy(dst, src, size);
+  }
+}
+
+inline int LocalCopyThreads(const char* env_name) {
+  int t = 4;
+  if (const char* e = std::getenv(env_name)) {
+    int x = std::atoi(e);
+    if (x >= 1) t = x;
+  }
+  unsigned hc = std::thread::hardware_concurrency();
+  if (hc > 0 && t > static_cast<int>(hc)) t = static_cast<int>(hc);
+  if (t < 1) t = 1;
+  return t;
+}
+
+template <typename Fn>
+inline void LocalParallelFor(size_t n, int num_threads, Fn&& fn) {
+  if (n == 0) return;
+  if (num_threads > static_cast<int>(n)) num_threads = static_cast<int>(n);
+  if (num_threads <= 1) {
+    for (size_t i = 0; i < n; ++i) fn(i);
+    return;
+  }
+  std::atomic<size_t> next{0};
+  auto worker = [&]() {
+    size_t i;
+    while ((i = next.fetch_add(1)) < n) fn(i);
+  };
+  std::vector<std::thread> pool;
+  pool.reserve(num_threads);
+  for (int t = 0; t < num_threads; ++t) pool.emplace_back(worker);
+  for (auto& th : pool) th.join();
+}
+
 inline uint64_t LogicalPageBytes(size_t i, size_t num_pages, uint64_t page_size,
                                  size_t total_size) {
   return (i + 1 == num_pages) ? (total_size - i * page_size) : page_size;
@@ -558,7 +641,7 @@ bool PoolClient::LocalPutPages(const std::vector<PageLocation>& pages, uint64_t 
       return false;
     }
     const uint64_t bytes = LogicalPageBytes(i, pages.size(), page_size, size);
-    std::memcpy(static_cast<char*>(dram.buffer) + off, src_bytes + i * page_size, bytes);
+    LocalCopyBlock(static_cast<char*>(dram.buffer) + off, src_bytes + i * page_size, bytes);
   }
   return true;
 }
@@ -579,7 +662,7 @@ bool PoolClient::LocalGetPages(const std::vector<PageLocation>& pages, uint64_t 
       return false;
     }
     const uint64_t bytes = LogicalPageBytes(i, pages.size(), page_size, size);
-    std::memcpy(dst_bytes + i * page_size, static_cast<const char*>(dram.buffer) + off, bytes);
+    LocalCopyBlock(dst_bytes + i * page_size, static_cast<const char*>(dram.buffer) + off, bytes);
   }
   return true;
 }
@@ -689,6 +772,7 @@ PoolClient::PartitionBatchPutTargets(const std::vector<std::string>& keys,
                                      const std::vector<std::optional<RoutePutResult>>& routes,
                                      std::vector<PutEntryOutcome>* results) {
   std::unordered_map<std::string, std::vector<BatchPutItem>> remote_groups;
+  std::vector<size_t> local_idx;
   const size_t count = keys.size();
   for (size_t i = 0; i < count; ++i) {
     if (i >= routes.size() || !routes[i].has_value()) continue;
@@ -699,7 +783,22 @@ PoolClient::PartitionBatchPutTargets(const std::vector<std::string>& keys,
       continue;
     }
     if (route.node_id == config_.master_config.node_id) {
-      switch (ExecuteLocalPut(keys[i], srcs[i], sizes[i], route.tier)) {
+      local_idx.push_back(i);
+      continue;
+    }
+    if (route.tier != TierType::DRAM && route.tier != TierType::HBM) continue;
+    remote_groups[route.node_id].push_back(BatchPutItem{
+        .index = i, .key = &keys[i], .src = srcs[i], .size = sizes[i], .route = route});
+  }
+  // Parallel local writes: different threads handle different keys. The
+  // PeerDramAllocator serializes Allocate/Commit internally (mutex); the heavy
+  // per-key memcpy in ExecuteLocalPut->LocalPutPages runs lock-free in parallel.
+  if (!local_idx.empty()) {
+    const int nthr = LocalCopyThreads("UMBP_DRAM_WRITE_THREADS");
+    const auto t0 = std::chrono::steady_clock::now();
+    LocalParallelFor(local_idx.size(), nthr, [&](size_t k) {
+      const size_t i = local_idx[k];
+      switch (ExecuteLocalPut(keys[i], srcs[i], sizes[i], routes[i]->tier)) {
         case PutAttemptOutcome::kSuccess:
           (*results)[i] = PutEntryOutcome::kSucceeded;
           break;
@@ -708,13 +807,18 @@ PoolClient::PartitionBatchPutTargets(const std::vector<std::string>& keys,
           break;
         case PutAttemptOutcome::kRetry:
         case PutAttemptOutcome::kFatal:
-          break;  // default kFailed
+          break;
       }
-      continue;
+    });
+    if (std::getenv("UMBP_LOCAL_COPY_TIMING")) {
+      double sec = std::chrono::duration_cast<std::chrono::duration<double>>(
+                       std::chrono::steady_clock::now() - t0).count();
+      size_t tot = 0;
+      for (size_t k : local_idx) tot += sizes[k];
+      MORI_UMBP_INFO("[LocalCopy] PUT keys={} bytes={} threads={} elapsed_ms={:.3f} GiB_s={:.2f}",
+                     local_idx.size(), tot, nthr, sec * 1000.0,
+                     tot / (sec > 0 ? sec : 1e-12) / (1024.0 * 1024 * 1024));
     }
-    if (route.tier != TierType::DRAM && route.tier != TierType::HBM) continue;
-    remote_groups[route.node_id].push_back(BatchPutItem{
-        .index = i, .key = &keys[i], .src = srcs[i], .size = sizes[i], .route = route});
   }
   return remote_groups;
 }
@@ -821,25 +925,23 @@ std::vector<bool> PoolClient::BatchGet(const std::vector<std::string>& keys,
   // because each needs its own peer-side staging slot + lease.
   std::unordered_map<std::string, std::vector<BatchGetItem>> remote_groups;
   std::unordered_map<std::string, std::vector<BatchGetItem>> ssd_remote_groups;
+  std::vector<size_t> local_get_idx;
   for (size_t i = 0; i < keys.size(); ++i) {
     if (i >= routes.size() || !routes[i].has_value()) {
-      if (peer_alloc_) {
-        auto outcome = ExecuteLocalGet(keys[i], const_cast<void*>(dsts[i]), sizes[i]);
-        if (outcome == GetAttemptOutcome::kSuccess) {
-          results[i] = true;
-        }
-      }
+      if (peer_alloc_) local_get_idx.push_back(i);
       continue;
     }
     const auto& route = routes[i].value();
     if (route.node_id == config_.master_config.node_id) {
-      // Self-target fast path: SSD via PeerSsdManager, DRAM/HBM via the allocator.
-      GetAttemptOutcome outcome =
-          route.tier == TierType::SSD
-              ? ExecuteLocalSsdGet(keys[i], const_cast<void*>(dsts[i]), sizes[i])
-              : ExecuteLocalGet(keys[i], const_cast<void*>(dsts[i]), sizes[i]);
-      if (outcome == GetAttemptOutcome::kSuccess) {
-        results[i] = true;
+      // Self-target fast path: SSD via PeerSsdManager (inline); DRAM/HBM via the
+      // allocator, deferred for batch-parallel copy across keys.
+      if (route.tier == TierType::SSD) {
+        if (ExecuteLocalSsdGet(keys[i], const_cast<void*>(dsts[i]), sizes[i]) ==
+            GetAttemptOutcome::kSuccess) {
+          results[i] = true;
+        }
+      } else {
+        local_get_idx.push_back(i);
       }
       continue;
     }
@@ -852,6 +954,37 @@ std::vector<bool> PoolClient::BatchGet(const std::vector<std::string>& keys,
       ssd_remote_groups[route.node_id].push_back(std::move(item));
     } else {
       remote_groups[route.node_id].push_back(std::move(item));
+    }
+  }
+
+  // Parallel local DRAM reads: different threads handle different keys. Resolve
+  // is mutex-serialized in the allocator; the per-key memcpy in
+  // ExecuteLocalGet->LocalGetPages runs lock-free in parallel. results is
+  // std::vector<bool> (bit-packed) so threads write a temp buffer; merge serially.
+  if (!local_get_idx.empty()) {
+    const int nthr = LocalCopyThreads("UMBP_DRAM_READ_THREADS");
+    const auto t0 = std::chrono::steady_clock::now();
+    std::vector<char> ok(local_get_idx.size(), 0);
+    LocalParallelFor(local_get_idx.size(), nthr, [&](size_t k) {
+      const size_t i = local_get_idx[k];
+      if (ExecuteLocalGet(keys[i], const_cast<void*>(dsts[i]), sizes[i]) ==
+          GetAttemptOutcome::kSuccess) {
+        ok[k] = 1;
+      }
+    });
+    size_t tot = 0;
+    for (size_t k = 0; k < local_get_idx.size(); ++k) {
+      if (ok[k]) {
+        results[local_get_idx[k]] = true;
+        tot += sizes[local_get_idx[k]];
+      }
+    }
+    if (std::getenv("UMBP_LOCAL_COPY_TIMING")) {
+      double sec = std::chrono::duration_cast<std::chrono::duration<double>>(
+                       std::chrono::steady_clock::now() - t0).count();
+      MORI_UMBP_INFO("[LocalCopy] GET keys={} bytes={} threads={} elapsed_ms={:.3f} GiB_s={:.2f}",
+                     local_get_idx.size(), tot, nthr, sec * 1000.0,
+                     tot / (sec > 0 ? sec : 1e-12) / (1024.0 * 1024 * 1024));
     }
   }
 

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -146,9 +146,8 @@ inline bool LocalAvx2Supported() { return false; }
 #endif
 
 inline void LocalCopyBlock(void* dst, const void* src, size_t size) {
-  static const bool kNt =
-      LocalAvx2Supported() &&
-      !(std::getenv("UMBP_DRAM_NT_COPY") && std::getenv("UMBP_DRAM_NT_COPY")[0] == '0');
+  static const bool kNt = LocalAvx2Supported() && !(std::getenv("UMBP_DRAM_NT_COPY") &&
+                                                    std::getenv("UMBP_DRAM_NT_COPY")[0] == '0');
   static const size_t kNtMinBytes = 256ull << 10;
   if (kNt && size >= kNtMinBytes) {
     LocalNtCopyAvx2(static_cast<char*>(dst), static_cast<const char*>(src), size);
@@ -812,7 +811,8 @@ PoolClient::PartitionBatchPutTargets(const std::vector<std::string>& keys,
     });
     if (std::getenv("UMBP_LOCAL_COPY_TIMING")) {
       double sec = std::chrono::duration_cast<std::chrono::duration<double>>(
-                       std::chrono::steady_clock::now() - t0).count();
+                       std::chrono::steady_clock::now() - t0)
+                       .count();
       size_t tot = 0;
       for (size_t k : local_idx) tot += sizes[k];
       MORI_UMBP_INFO("[LocalCopy] PUT keys={} bytes={} threads={} elapsed_ms={:.3f} GiB_s={:.2f}",
@@ -981,7 +981,8 @@ std::vector<bool> PoolClient::BatchGet(const std::vector<std::string>& keys,
     }
     if (std::getenv("UMBP_LOCAL_COPY_TIMING")) {
       double sec = std::chrono::duration_cast<std::chrono::duration<double>>(
-                       std::chrono::steady_clock::now() - t0).count();
+                       std::chrono::steady_clock::now() - t0)
+                       .count();
       MORI_UMBP_INFO("[LocalCopy] GET keys={} bytes={} threads={} elapsed_ms={:.3f} GiB_s={:.2f}",
                      local_get_idx.size(), tot, nthr, sec * 1000.0,
                      tot / (sec > 0 ? sec : 1e-12) / (1024.0 * 1024 * 1024));

--- a/src/umbp/include/umbp/local/tiers/dram_tier.h
+++ b/src/umbp/include/umbp/local/tiers/dram_tier.h
@@ -131,12 +131,12 @@ class DRAMTier : public TierBackend {
   // Threads used by ReadBatchIntoPtr for parallel CopyBlock. Default 8, override
   // via env UMBP_DRAM_READ_THREADS, capped to hardware concurrency. >1 breaks
   // the single-core memcpy ceiling on cold DRAM.
-  int read_threads_ = 8;
+  int read_threads_ = 4;
 
   // Threads used by BatchWrite for parallel CopyBlock. Default 8, override via
   // env UMBP_DRAM_WRITE_THREADS, capped to hardware concurrency. >1 breaks the
   // single-core memcpy ceiling on the PUT (backup) path.
-  int write_threads_ = 8;
+  int write_threads_ = 4;
 
   size_t Allocate(size_t size);                 // Allocate from free_list_
   void Deallocate(size_t offset, size_t size);  // Return to free_list_

--- a/src/umbp/include/umbp/local/tiers/dram_tier.h
+++ b/src/umbp/include/umbp/local/tiers/dram_tier.h
@@ -60,6 +60,13 @@ class DRAMTier : public TierBackend {
   // Upper layer (LocalStorageManager) is responsible for demoting keys.
   bool Write(const std::string& key, const void* data, size_t size) override;
   bool ReadIntoPtr(const std::string& key, uintptr_t dst_ptr, size_t size) override;
+  // Multi-threaded batch read: parallel CopyBlock of many KV blocks to break
+  // the single-core memcpy ceiling on cold DRAM. Holds mu_ for the whole batch
+  // (consistent with this tier's single-mutex model: serializes against other
+  // reads/writes), while the per-block copies run in parallel within the batch.
+  std::vector<bool> ReadBatchIntoPtr(const std::vector<std::string>& keys,
+                                     const std::vector<uintptr_t>& dst_ptrs,
+                                     const std::vector<size_t>& sizes) override;
   bool Exists(const std::string& key) const override;
   bool Evict(const std::string& key) override;
   std::pair<size_t, size_t> Capacity() const override;
@@ -112,6 +119,11 @@ class DRAMTier : public TierBackend {
   std::list<FreeBlock> free_list_;
 
   mutable std::mutex mu_;
+
+  // Threads used by ReadBatchIntoPtr for parallel CopyBlock. Default 8, override
+  // via env UMBP_DRAM_READ_THREADS, capped to hardware concurrency. >1 breaks
+  // the single-core memcpy ceiling on cold DRAM.
+  int read_threads_ = 8;
 
   size_t Allocate(size_t size);                 // Allocate from free_list_
   void Deallocate(size_t offset, size_t size);  // Return to free_list_

--- a/src/umbp/include/umbp/local/tiers/dram_tier.h
+++ b/src/umbp/include/umbp/local/tiers/dram_tier.h
@@ -67,6 +67,14 @@ class DRAMTier : public TierBackend {
   std::vector<bool> ReadBatchIntoPtr(const std::vector<std::string>& keys,
                                      const std::vector<uintptr_t>& dst_ptrs,
                                      const std::vector<size_t>& sizes) override;
+  // Multi-threaded batch write: serial slot allocation (mutates free_list_)
+  // followed by parallel non-temporal CopyBlock of each payload into its slot.
+  // Mirrors ReadBatchIntoPtr to break the single-core memcpy ceiling on the
+  // L2->L3 backup (PUT) path. Does NOT self-evict — keys that don't fit are
+  // left false so the upper layer can demote and retry per-key.
+  std::vector<bool> BatchWrite(const std::vector<std::string>& keys,
+                               const std::vector<const void*>& data_ptrs,
+                               const std::vector<size_t>& sizes) override;
   bool Exists(const std::string& key) const override;
   bool Evict(const std::string& key) override;
   std::pair<size_t, size_t> Capacity() const override;
@@ -124,6 +132,11 @@ class DRAMTier : public TierBackend {
   // via env UMBP_DRAM_READ_THREADS, capped to hardware concurrency. >1 breaks
   // the single-core memcpy ceiling on cold DRAM.
   int read_threads_ = 8;
+
+  // Threads used by BatchWrite for parallel CopyBlock. Default 8, override via
+  // env UMBP_DRAM_WRITE_THREADS, capped to hardware concurrency. >1 breaks the
+  // single-core memcpy ceiling on the PUT (backup) path.
+  int write_threads_ = 8;
 
   size_t Allocate(size_t size);                 // Allocate from free_list_
   void Deallocate(size_t offset, size_t size);  // Return to free_list_

--- a/src/umbp/include/umbp/local/tiers/local_storage_manager.h
+++ b/src/umbp/include/umbp/local/tiers/local_storage_manager.h
@@ -65,6 +65,13 @@ class LocalStorageManager {
   // depth == -1 means no metadata (degenerates to plain LRU eviction).
   bool WriteFromPtrWithDepth(const std::string& key, uintptr_t src, size_t size, int depth,
                              StorageTier tier = StorageTier::CPU_DRAM);
+  // Batch counterpart of WriteFromPtr. When the target tier advertises
+  // batch_write, payloads are copied in parallel via TierBackend::BatchWrite;
+  // any key that doesn't fit falls back to a per-key Write() with LRU demotion.
+  std::vector<bool> WriteBatchFromPtr(const std::vector<std::string>& keys,
+                                      const std::vector<uintptr_t>& srcs,
+                                      const std::vector<size_t>& sizes,
+                                      StorageTier tier = StorageTier::CPU_DRAM);
 
   bool ReadIntoPtr(const std::string& key, uintptr_t dst, size_t size);
   bool ReadIntoPtrNoPromote(const std::string& key, uintptr_t dst, size_t size);

--- a/src/umbp/local/standalone_client.cpp
+++ b/src/umbp/local/standalone_client.cpp
@@ -136,22 +136,46 @@ bool StandaloneClient::Exists(const std::string& key) const {
 std::vector<bool> StandaloneClient::BatchPut(const std::vector<std::string>& keys,
                                              const std::vector<uintptr_t>& srcs,
                                              const std::vector<size_t>& sizes) {
-  std::vector<bool> results(keys.size(), false);
+  const size_t n = keys.size();
+  std::vector<bool> results(n, false);
+  // Followers never write; keep results all-false (and skip leader SSD copy).
+  if (role_ == UMBPRole::SharedSSDFollower) return results;
 
-  for (size_t i = 0; i < keys.size(); ++i) {
-    if (role_ == UMBPRole::SharedSSDFollower) continue;
+  // Collect keys needing an actual write (skip ones already present), then issue
+  // a single batched write so the payload copies run in parallel inside the tier
+  // (mirrors BatchGet's single ReadBatchIntoPtr dispatch).
+  std::vector<size_t> wmap;
+  std::vector<std::string> wkeys;
+  std::vector<uintptr_t> wsrcs;
+  std::vector<size_t> wsizes;
+  wmap.reserve(n);
+  wkeys.reserve(n);
+  wsrcs.reserve(n);
+  wsizes.reserve(n);
+  for (size_t i = 0; i < n; ++i) {
     if (index_.MayExist(keys[i])) {
       results[i] = true;
       continue;
     }
-    if (!storage_.WriteFromPtr(keys[i], srcs[i], sizes[i])) continue;
-    index_.Insert(keys[i], {StorageTier::CPU_DRAM, 0, sizes[i]});
-    results[i] = true;
+    wmap.push_back(i);
+    wkeys.push_back(keys[i]);
+    wsrcs.push_back(srcs[i]);
+    wsizes.push_back(sizes[i]);
+  }
+
+  if (!wkeys.empty()) {
+    auto wres = storage_.WriteBatchFromPtr(wkeys, wsrcs, wsizes);
+    for (size_t j = 0; j < wkeys.size(); ++j) {
+      if (!wres[j]) continue;
+      size_t i = wmap[j];
+      index_.Insert(keys[i], {StorageTier::CPU_DRAM, 0, sizes[i]});
+      results[i] = true;
+    }
   }
 
   if (role_ == UMBPRole::SharedSSDLeader) {
     std::vector<std::string> ssd_keys;
-    for (size_t i = 0; i < keys.size(); ++i) {
+    for (size_t i = 0; i < n; ++i) {
       if (results[i]) ssd_keys.push_back(keys[i]);
     }
     copy_pipeline_->MaybeBatchCopyToSharedSSD(ssd_keys);

--- a/src/umbp/local/tiers/dram_tier.cpp
+++ b/src/umbp/local/tiers/dram_tier.cpp
@@ -89,9 +89,8 @@ bool Avx2Supported() { return false; }
 // fall back to glibc memcpy (its small-copy path is faster and they may be hot).
 // Disable NT via UMBP_DRAM_NT_COPY=0.
 inline void CopyBlock(void* dst, const void* src, size_t size) {
-  static const bool kNt =
-      Avx2Supported() &&
-      !(std::getenv("UMBP_DRAM_NT_COPY") && std::getenv("UMBP_DRAM_NT_COPY")[0] == '0');
+  static const bool kNt = Avx2Supported() && !(std::getenv("UMBP_DRAM_NT_COPY") &&
+                                               std::getenv("UMBP_DRAM_NT_COPY")[0] == '0');
   static const size_t kNtMinBytes = 256ull << 10;
   if (kNt && size >= kNtMinBytes) {
     NtCopyAvx2(static_cast<char*>(dst), static_cast<const char*>(src), size);

--- a/src/umbp/local/tiers/dram_tier.cpp
+++ b/src/umbp/local/tiers/dram_tier.cpp
@@ -156,9 +156,15 @@ DRAMTier::DRAMTier(size_t capacity, bool use_shm, const std::string& shm_name, b
     int v = std::atoi(e);
     if (v >= 1) read_threads_ = v;
   }
+  if (const char* e = std::getenv("UMBP_DRAM_WRITE_THREADS")) {
+    int v = std::atoi(e);
+    if (v >= 1) write_threads_ = v;
+  }
   unsigned hc = std::thread::hardware_concurrency();
   if (hc > 0 && read_threads_ > static_cast<int>(hc)) read_threads_ = static_cast<int>(hc);
   if (read_threads_ < 1) read_threads_ = 1;
+  if (hc > 0 && write_threads_ > static_cast<int>(hc)) write_threads_ = static_cast<int>(hc);
+  if (write_threads_ < 1) write_threads_ = 1;
 }
 
 DRAMTier::~DRAMTier() {
@@ -344,6 +350,79 @@ std::vector<bool> DRAMTier::ReadBatchIntoPtr(const std::vector<std::string>& key
   return results;
 }
 
+std::vector<bool> DRAMTier::BatchWrite(const std::vector<std::string>& keys,
+                                       const std::vector<const void*>& data_ptrs,
+                                       const std::vector<size_t>& sizes) {
+  const size_t n = keys.size();
+  std::vector<bool> results(n, false);
+  if (n == 0) return results;
+
+  // Hold mu_ for the whole batch (single-mutex model: serializes against other
+  // reads/writes). Slot allocation mutates free_list_/slots_ and must be serial;
+  // only the per-block payload copies run in parallel, which is what breaks the
+  // single-core memcpy ceiling on the backup path.
+  std::lock_guard<std::mutex> lock(mu_);
+
+  struct Job {
+    void* dst;
+    const void* src;
+    size_t size;
+    size_t idx;
+    size_t offset;
+  };
+  std::vector<Job> jobs;
+  jobs.reserve(n);
+
+  // Phase 1 (serial): free any existing slot for the key, then allocate. Does
+  // NOT self-evict — a key that doesn't fit is left false so the upper layer
+  // (LocalStorageManager) can demote LRU keys and retry per-key.
+  for (size_t i = 0; i < n; ++i) {
+    auto existing = slots_.find(keys[i]);
+    if (existing != slots_.end()) {
+      Deallocate(existing->second.offset, existing->second.size);
+      used_ -= existing->second.size;
+      slots_.erase(existing);
+      auto lru_it = lru_map_.find(keys[i]);
+      if (lru_it != lru_map_.end()) {
+        lru_list_.erase(lru_it->second);
+        lru_map_.erase(lru_it);
+      }
+    }
+    size_t offset = Allocate(sizes[i]);
+    if (offset == static_cast<size_t>(-1)) continue;
+    jobs.push_back({static_cast<char*>(base_ptr_) + offset, data_ptrs[i], sizes[i], i, offset});
+  }
+
+  // Phase 2 (parallel): non-temporal CopyBlock each payload into its slot.
+  int num_threads = write_threads_;
+  if (num_threads > static_cast<int>(jobs.size())) num_threads = static_cast<int>(jobs.size());
+
+  if (num_threads <= 1) {
+    for (const auto& j : jobs) CopyBlock(j.dst, j.src, j.size);
+  } else {
+    std::atomic<size_t> next{0};
+    auto worker = [&]() {
+      size_t i;
+      while ((i = next.fetch_add(1)) < jobs.size()) {
+        CopyBlock(jobs[i].dst, jobs[i].src, jobs[i].size);
+      }
+    };
+    std::vector<std::thread> pool;
+    pool.reserve(num_threads);
+    for (int t = 0; t < num_threads; ++t) pool.emplace_back(worker);
+    for (auto& th : pool) th.join();
+  }
+
+  // Phase 3 (serial): register slots + LRU, mark successes.
+  for (const auto& j : jobs) {
+    slots_[keys[j.idx]] = {j.offset, j.size};
+    used_ += j.size;
+    TouchLRU(keys[j.idx]);
+    results[j.idx] = true;
+  }
+  return results;
+}
+
 const void* DRAMTier::ReadPtr(const std::string& key, size_t* out_size) {
   std::lock_guard<std::mutex> lock(mu_);
 
@@ -371,7 +450,8 @@ std::vector<char> DRAMTier::Read(const std::string& key) {
 TierCapabilities DRAMTier::Capabilities() const {
   TierCapabilities caps;
   caps.zero_copy_read = true;
-  caps.batch_read = true;  // use the multi-threaded ReadBatchIntoPtr above
+  caps.batch_read = true;   // use the multi-threaded ReadBatchIntoPtr above
+  caps.batch_write = true;  // use the multi-threaded BatchWrite below
   return caps;
 }
 

--- a/src/umbp/local/tiers/dram_tier.cpp
+++ b/src/umbp/local/tiers/dram_tier.cpp
@@ -26,10 +26,81 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <atomic>
+#include <cstdlib>
 #include <cstring>
 #include <stdexcept>
+#include <thread>
+
+#if defined(__x86_64__) || defined(__i386__)
+#include <immintrin.h>
+#endif
 
 namespace mori::umbp {
+
+namespace {
+
+#if defined(__x86_64__) || defined(__i386__)
+// Non-temporal AVX2 (256-bit) copy: streaming stores bypass the cache and skip
+// the read-for-ownership (RFO) on dst. This is the right choice for the real
+// batch-get path, where each KV block is read ONCE from cold DRAM and the
+// working set far exceeds L3: a cached copy moves 3x the block bytes through
+// memory (read src + RFO dst + writeback dst), NT moves only 2x (read src +
+// stream-write dst).
+//
+// Width: AVX2 (256-bit), not AVX-512. On Zen4 the 512-bit datapath is
+// double-pumped over 256-bit units, so 512-bit stream stores give no real
+// width advantage and can trip AVX-512 frequency throttling; the NT bottleneck
+// is the write-combining buffer drain rate, which 256-bit already saturates.
+// Measured cold 4 MiB blocks, 8 threads (no pinning) on Zen4 EPYC:
+//   avx2_nt ~134  >  avx512_nt ~130  >  glibc memcpy ~88  >  cached storeu ~77.
+// dst is a host pinned buffer; sfence orders the streaming stores before the
+// subsequent host->device DMA reads it.
+__attribute__((target("avx2"))) void NtCopyAvx2(char* d, const char* s, size_t n) {
+  size_t head = (32 - (reinterpret_cast<uintptr_t>(d) & 31)) & 31;
+  if (head > n) head = n;
+  std::memcpy(d, s, head);
+  size_t i = head;
+  for (; i + 128 <= n; i += 128) {
+    __m256i a = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + i));
+    __m256i b = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + i + 32));
+    __m256i c = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + i + 64));
+    __m256i e = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + i + 96));
+    _mm256_stream_si256(reinterpret_cast<__m256i*>(d + i), a);
+    _mm256_stream_si256(reinterpret_cast<__m256i*>(d + i + 32), b);
+    _mm256_stream_si256(reinterpret_cast<__m256i*>(d + i + 64), c);
+    _mm256_stream_si256(reinterpret_cast<__m256i*>(d + i + 96), e);
+  }
+  for (; i + 32 <= n; i += 32) {
+    __m256i a = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(s + i));
+    _mm256_stream_si256(reinterpret_cast<__m256i*>(d + i), a);
+  }
+  if (i < n) std::memcpy(d + i, s + i, n - i);
+  _mm_sfence();
+}
+bool Avx2Supported() { return __builtin_cpu_supports("avx2"); }
+#else
+void NtCopyAvx2(char* d, const char* s, size_t n) { std::memcpy(d, s, n); }
+bool Avx2Supported() { return false; }
+#endif
+
+// Copy one KV block. Large blocks (>= 256 KiB, the real KV-page regime, always
+// cold DRAM) use non-temporal stores (~1.5x over memcpy on Zen4). Tiny blocks
+// fall back to glibc memcpy (its small-copy path is faster and they may be hot).
+// Disable NT via UMBP_DRAM_NT_COPY=0.
+inline void CopyBlock(void* dst, const void* src, size_t size) {
+  static const bool kNt =
+      Avx2Supported() &&
+      !(std::getenv("UMBP_DRAM_NT_COPY") && std::getenv("UMBP_DRAM_NT_COPY")[0] == '0');
+  static const size_t kNtMinBytes = 256ull << 10;
+  if (kNt && size >= kNtMinBytes) {
+    NtCopyAvx2(static_cast<char*>(dst), static_cast<const char*>(src), size);
+  } else {
+    std::memcpy(dst, src, size);
+  }
+}
+
+}  // namespace
 
 DRAMTier::DRAMTier(size_t capacity, bool use_shm, const std::string& shm_name, bool use_hugepages,
                    size_t hugepage_size, int numa_node, bool prefault)
@@ -78,6 +149,16 @@ DRAMTier::DRAMTier(size_t capacity, bool use_shm, const std::string& shm_name, b
 
   // Initialize free list with entire capacity
   free_list_.push_back({0, capacity_});
+
+  // Threads for parallel batch-read CopyBlock. Default 8, override via env,
+  // capped to hardware concurrency. >1 breaks the single-core memcpy ceiling.
+  if (const char* e = std::getenv("UMBP_DRAM_READ_THREADS")) {
+    int v = std::atoi(e);
+    if (v >= 1) read_threads_ = v;
+  }
+  unsigned hc = std::thread::hardware_concurrency();
+  if (hc > 0 && read_threads_ > static_cast<int>(hc)) read_threads_ = static_cast<int>(hc);
+  if (read_threads_ < 1) read_threads_ = 1;
 }
 
 DRAMTier::~DRAMTier() {
@@ -206,6 +287,63 @@ bool DRAMTier::ReadIntoPtr(const std::string& key, uintptr_t dst_ptr, size_t siz
   return true;
 }
 
+std::vector<bool> DRAMTier::ReadBatchIntoPtr(const std::vector<std::string>& keys,
+                                             const std::vector<uintptr_t>& dst_ptrs,
+                                             const std::vector<size_t>& sizes) {
+  const size_t n = keys.size();
+  std::vector<bool> results(n, false);
+  if (n == 0) return results;
+
+  // Hold mu_ for the whole batch. This tier uses a single mutex (reads and
+  // writes are mutually exclusive), so holding it keeps slot offsets valid
+  // during the parallel copy without a use-after-free against Write/Evict/
+  // Clear. The per-block copies still run in parallel within the batch, which
+  // is what breaks the single-core memcpy ceiling on cold DRAM.
+  std::lock_guard<std::mutex> lock(mu_);
+
+  struct Job {
+    void* dst;
+    const void* src;
+    size_t size;
+    size_t idx;
+  };
+  std::vector<Job> jobs;
+  jobs.reserve(n);
+  for (size_t i = 0; i < n; ++i) {
+    auto it = slots_.find(keys[i]);
+    if (it == slots_.end()) continue;
+    if (sizes[i] != it->second.size) continue;
+    jobs.push_back({reinterpret_cast<void*>(dst_ptrs[i]),
+                    static_cast<char*>(base_ptr_) + it->second.offset, sizes[i], i});
+  }
+
+  int num_threads = read_threads_;
+  if (num_threads > static_cast<int>(jobs.size())) num_threads = static_cast<int>(jobs.size());
+
+  if (num_threads <= 1) {
+    for (const auto& j : jobs) {
+      CopyBlock(j.dst, j.src, j.size);
+      results[j.idx] = true;
+    }
+  } else {
+    std::atomic<size_t> next{0};
+    auto worker = [&]() {
+      size_t i;
+      while ((i = next.fetch_add(1)) < jobs.size()) {
+        CopyBlock(jobs[i].dst, jobs[i].src, jobs[i].size);
+      }
+    };
+    std::vector<std::thread> pool;
+    pool.reserve(num_threads);
+    for (int t = 0; t < num_threads; ++t) pool.emplace_back(worker);
+    for (auto& th : pool) th.join();
+    for (const auto& j : jobs) results[j.idx] = true;
+  }
+
+  for (const auto& j : jobs) TouchLRU(keys[j.idx]);
+  return results;
+}
+
 const void* DRAMTier::ReadPtr(const std::string& key, size_t* out_size) {
   std::lock_guard<std::mutex> lock(mu_);
 
@@ -233,6 +371,7 @@ std::vector<char> DRAMTier::Read(const std::string& key) {
 TierCapabilities DRAMTier::Capabilities() const {
   TierCapabilities caps;
   caps.zero_copy_read = true;
+  caps.batch_read = true;  // use the multi-threaded ReadBatchIntoPtr above
   return caps;
 }
 

--- a/src/umbp/local/tiers/local_storage_manager.cpp
+++ b/src/umbp/local/tiers/local_storage_manager.cpp
@@ -676,6 +676,40 @@ bool LocalStorageManager::WriteFromPtr(const std::string& key, uintptr_t src, si
   return Write(key, reinterpret_cast<const void*>(src), size, tier);
 }
 
+std::vector<bool> LocalStorageManager::WriteBatchFromPtr(const std::vector<std::string>& keys,
+                                                         const std::vector<uintptr_t>& srcs,
+                                                         const std::vector<size_t>& sizes,
+                                                         StorageTier tier) {
+  const size_t n = keys.size();
+  std::vector<bool> results(n, false);
+  if (n == 0) return results;
+
+  TierBackend* target = GetTier(tier);
+  if (!target) return results;
+
+  // Fast path: parallel batch write when the tier supports it. BatchWrite does
+  // not self-evict, so keys that don't fit come back false; retry those per-key
+  // through Write() which demotes LRU victims to make room.
+  if (target->Capabilities().batch_write && n > 1) {
+    std::vector<const void*> ptrs;
+    ptrs.reserve(n);
+    for (size_t i = 0; i < n; ++i) ptrs.push_back(reinterpret_cast<const void*>(srcs[i]));
+    results = target->BatchWrite(keys, ptrs, sizes);
+    for (size_t i = 0; i < n; ++i) {
+      if (!results[i]) {
+        results[i] = Write(keys[i], reinterpret_cast<const void*>(srcs[i]), sizes[i], tier);
+      }
+    }
+    return results;
+  }
+
+  // Slow path: per-key (also covers single-element batches).
+  for (size_t i = 0; i < n; ++i) {
+    results[i] = Write(keys[i], reinterpret_cast<const void*>(srcs[i]), sizes[i], tier);
+  }
+  return results;
+}
+
 bool LocalStorageManager::ReadIntoPtr(const std::string& key, uintptr_t dst, size_t size) {
   bool ok = ReadIntoPtrNoPromote(key, dst, size);
   if (ok && config_.eviction.auto_promote_on_read) {


### PR DESCRIPTION
## What
Multi-threaded + AVX2 non-temporal copy on the UMBP DRAM-tier KV copy paths,
for both the standalone (DRAMTier) and distributed (PoolClient self-target) paths.

## Why / Design
- DRAMTier (standalone): parallel CopyBlock across a batch's KV blocks + AVX2 NT stores.
- Distributed self-target: previously a single-threaded std::memcpy. The DRAMTier
  optimization never applied because in distributed mode 1 key == 1 page
  (master page_size == KV block size), so per-call page parallelism never engaged
  (verified: T=1 == T=8, ~23 GiB/s). Fix: parallelize across the many keys of a
  BatchPut/BatchGet — different threads handle different keys. PeerDramAllocator
  serializes Allocate/Commit/Resolve (mutex); per-key memcpy runs lock-free into
  distinct slots.
- Tunables: UMBP_DRAM_{READ,WRITE}_THREADS (default 4), UMBP_DRAM_NT_COPY=0 to disable NT.

## Data (skyriver07, DP8 distributed case3, per-rank local-copy GiB/s)
| op | T=1 | T=4 (default) | T=8 |
|----|-----|---------------|-----|
| PUT local | 23.1 | 54.8 (2.4x) | 57.2 |
| GET local | 19.9 | 46.2 (2.3x) | 47.1 |

## Correctness
test_umbp_e2e (Put/Get round-trip + memcmp + multi-process verify) PASS at threads=1/4/8.
Clean build off current ROCm/mori main.