### PR TITLE
feat(cco): self-contained cco.hpp + compile-time per-NIC GDA dispatch

### DIFF
--- a/include/mori/cco/cco.hpp
+++ b/include/mori/cco/cco.hpp
@@ -47,37 +47,124 @@
 #include <stddef.h>
 #include <stdint.h>
 
-// application::RdmaEndpointDevice + the device-safe transport types it carries.
-// This header also transitively provides anvil_device (anvil::SdmaQueueDeviceHandle,
-// HSAuint64), core_device_types, and hip_compat (__device__, hipMem* handles),
-// which the structs below rely on — so they are not included separately here.
-#include "mori/application/application_device_types.hpp"
-
-// NOTE: the GDA (RDMA) device layer — the only consumer of the provider RDMA
-// core — now lives in cco_scale_out.hpp, so this header pulls in no RDMA
-// headers. Include cco_scale_out.hpp (which includes this file) for GDA.
-
+// HIP/host compatibility shim — keeps this header self-contained:
+//   * Device/kernel TUs (hipcc, -x hip): NO <hip/hip_runtime.h> is pulled in.
+//     The device code uses clang AMDGCN builtins directly (wrapped below in
+//     _cco* helpers), plus __hip_atomic_* builtins / __HIP_MEMORY_SCOPE_*
+//     predefined macros. __device__ / __host__ are provided as attribute-macro
+//     fallbacks (#ifndef-guarded, like aiter's opus/hip_minimal.hpp) so cco.hpp
+//     compiles even with no HIP runtime header AND no hipcc auto-wrapper
+//     (-nogpuinc, or a DSL/JIT front-end) — and still coexists with the real
+//     HIP headers when they ARE present.
+//   * Pure-host TUs (plain g++/clang, no hipcc) get __device__/__host__ as
+//     empty macros so the few __device__ helpers in the shared region compile
+//     as host no-ops, plus the STL used by the host control-plane structs.
+#if defined(__HIPCC__) || defined(__CUDACC__)
+#ifndef __device__
+#define __device__ __attribute__((device))
+#endif
+#ifndef __host__
+#define __host__ __attribute__((host))
+#endif
+#else
+#ifndef __device__
+#define __device__
+#endif
+#ifndef __host__
+#define __host__
+#endif
+// Host-only: STL containers/smart-pointers used by the host control-plane
+// structs (ccoComm / ccoWindowHost) defined further down. System headers only —
+// they keep cco.hpp self-contained (no mori headers) while these structs stay in
+// this file. Device/kernel TUs skip both the includes and the structs.
 #include <memory>
 #include <mutex>
 #include <unordered_map>
 #include <vector>
+#endif
 
-#include "mori/application/application.hpp"
-#include "mori/application/memory/va_manager.hpp"
-
-// BootstrapNetwork is referenced only by pointer (host API prototypes + ccoComm),
-// so a forward declaration is enough. This keeps the heavy mpi/torch/socket
-// bootstrap headers out of every TU that includes cco.hpp — especially device
-// TUs, which never touch bootstrap. The full definition reaches the host
-// implementation (cco_init.cpp) via application.hpp.
+// SELF-CONTAINED: this header pulls in NO other mori headers. A user needs only
+// this file + the host .so to drive the CCO host API and write LSA device
+// kernels.
+//   * Device kernels get HIP builtins (__device__, __hip_atomic_*, threadIdx,
+//     __syncthreads, ...) from hipcc — no header needed.
+//   * The few external types referenced below appear ONLY as pointers, so they
+//     are forward-declared (their full definitions are never needed here).
+//   * The host control-plane structs (ccoComm, ccoWindowHost) ARE defined here
+//     (host-only, under #if !defined(__HIPCC__)), but reference the application
+//     layer only through forward-declared pointers / unique_ptr (PImpl dtor), so
+//     no application headers are pulled in — only system STL. Their member
+//     functions live in src/cco/cco_init.cpp. Users treat ccoComm as opaque.
+//   * The GDA (RDMA) device layer — the only consumer of the provider RDMA core
+//     — lives in cco_scale_out.hpp (include that, not this, for GDA).
+//
+// Forward declarations (referenced only via pointer / unique_ptr below):
 namespace mori {
 namespace application {
+// BootstrapNetwork / Context: ccoComm members (pointer only).
 class BootstrapNetwork;
-}
-}
+class Context;
+// HeapVAManager: ccoComm::vaManager (unique_ptr; ccoComm has an out-of-line
+// dtor in cco_init.cpp so the incomplete type is fine here).
+class HeapVAManager;
+// RdmaEndpointDevice: ccoIbgdaContext::endpoints (pointer only). Full definition
+// reaches GDA device code via cco_scale_out.hpp, and the host impl via
+// application_device_types.hpp.
+struct RdmaEndpointDevice;
+}  // namespace application
+}  // namespace mori
+namespace anvil {
+// SdmaQueueDeviceHandle: ccoSdmaContext / ccoComm (pointer only).
+struct SdmaQueueDeviceHandle;
+}  // namespace anvil
+// hipMemGenericAllocationHandle_t is an opaque pointer typedef from
+// <hip/hip_runtime_api.h>. Replicated here (identical definition) so ccoComm can
+// name it without pulling the ROCm header into host TUs that include cco.hpp.
+struct ihipMemGenericAllocationHandle;
+typedef struct ihipMemGenericAllocationHandle* hipMemGenericAllocationHandle_t;
 
 namespace mori {
 namespace cco {
+
+/* ════════════════════════════════════════════════════════════════════════════
+ *  0. Device intrinsic wrappers (clang AMDGCN builtins)
+ *
+ *  The reason this header needs NO <hip/hip_runtime.h>: the device code below
+ *  goes through these thin wrappers instead of HIP's threadIdx / __syncthreads /
+ *  __syncwarp / __threadfence_system / clock64. That avoids pulling in and
+ *  parsing the full HIP runtime header (faster compile, minimal dependency),
+ *  mirroring aiter's opus.hpp. Bodies copy HIP's amd_detail definitions
+ *  verbatim. (__hip_atomic_* used elsewhere are clang builtins and
+ *  __HIP_MEMORY_SCOPE_* are compiler-predefined macros under -x hip, so those
+ *  need no header either.) Device-only.
+ * ════════════════════════════════════════════════════════════════════════════ */
+#if defined(__HIPCC__) || defined(__CUDACC__)
+// Internal — not part of the cco API. Kept in mori::cco::impl (the same internal
+// namespace as the GDA provider primitives in cco_scale_out.hpp) so cco's public
+// surface (mori::cco::*) stays free of these generic device-compat helpers.
+namespace impl {
+__device__ inline unsigned threadIdxX() { return __builtin_amdgcn_workitem_id_x(); }
+__device__ inline unsigned blockDimX() { return __builtin_amdgcn_workgroup_size_x(); }
+__device__ inline int warpSize() { return __builtin_amdgcn_wavefrontsize(); }
+// HIP __syncwarp (amd_warp_sync_functions.h)
+__device__ inline void syncWarp() {
+  __builtin_amdgcn_fence(__ATOMIC_RELEASE, "wavefront");
+  __builtin_amdgcn_wave_barrier();
+  __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "wavefront");
+}
+// HIP __syncthreads = __work_group_barrier(global|local fence); conservative
+// SEQ_CST workgroup fence around the execution barrier matches its guarantees.
+__device__ inline void syncThreads() {
+  __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "workgroup");
+  __builtin_amdgcn_s_barrier();
+  __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "workgroup");
+}
+// HIP __threadfence_system (amd_device_functions.h)
+__device__ inline void threadFenceSystem() { __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, ""); }
+// HIP clock64 (amd_device_functions.h): cycle counter for the barrier timeout.
+__device__ inline long long clock64() { return (long long)__builtin_readcyclecounter(); }
+}  // namespace impl
+#endif  // defined(__HIPCC__) || defined(__CUDACC__)
 
 /* ════════════════════════════════════════════════════════════════════════════
  *  1. Shared types (device-safe; host-only structs guarded)
@@ -89,6 +176,18 @@ namespace cco {
 // with INITIALIZER defaults.
 static constexpr uint32_t CCO_API_MAGIC = 0x0CC0AAAA;
 static constexpr uint32_t CCO_API_VERSION = 1;
+
+// RDMA backend provider of the GDA endpoints. Mirrors core::ProviderType values
+// 1:1, but is cco's OWN type so this header needs no core header (and so the
+// host impl, which also includes core_device_types.hpp, gets no enum-redefinition
+// conflict). cco_init.cpp maps core::ProviderType -> ccoProviderType.
+enum ccoProviderType {
+  CCO_PROVIDER_UNKNOWN = 0,
+  CCO_PROVIDER_MLX5 = 1,  // Mellanox
+  CCO_PROVIDER_BNXT = 2,  // Broadcom
+  CCO_PROVIDER_PSD = 3,   // Pensando
+  CCO_PROVIDER_IBVERBS = 4,
+};
 
 // GDA backend QP allocation strategy.
 enum ccoGdaConnectionType {
@@ -177,7 +276,7 @@ struct ccoIbgdaContext {
   // valid endpoint's vendorId; host-readable so a launcher can dispatch to the
   // matching ccoGda<PrvdType> kernel instantiation without hardcoding it.
   // Unknown when gdaConnType==NONE (no endpoints).
-  core::ProviderType providerType{core::ProviderType::Unknown};
+  ccoProviderType providerType{CCO_PROVIDER_UNKNOWN};
 
   // Signal: remote peers atomic +1 here after put completes.
   int signalCount;
@@ -231,9 +330,9 @@ struct ccoGdaBarrierHandle {
 struct ccoSdmaContext {
   uint32_t sdmaNumQueue;                         // 0 when SDMA disabled
   anvil::SdmaQueueDeviceHandle** deviceHandles;  // [lsaSize * sdmaNumQueue], shared from comm
-  HSAuint64* signalBuf;                          // [lsaSize * sdmaNumQueue], local pool
-  HSAuint64* expectSignals;                      // [lsaSize * sdmaNumQueue], local
-  HSAuint64** peerSignalPtrs;                    // [lsaSize], peer signalBuf via IPC
+  uint64_t* signalBuf;                           // [lsaSize * sdmaNumQueue], local pool (HSAuint64)
+  uint64_t* expectSignals;                       // [lsaSize * sdmaNumQueue], local
+  uint64_t** peerSignalPtrs;                     // [lsaSize], peer signalBuf via IPC
 };
 
 struct ccoDevComm {
@@ -417,15 +516,15 @@ struct ccoCoopThread {
 };
 
 struct ccoCoopWarp {
-  __device__ int thread_rank() const { return threadIdx.x % warpSize; }
-  __device__ int size() const { return warpSize; }
-  __device__ void sync() { __syncwarp(); }
+  __device__ int thread_rank() const { return impl::threadIdxX() % impl::warpSize(); }
+  __device__ int size() const { return impl::warpSize(); }
+  __device__ void sync() { impl::syncWarp(); }
 };
 
 struct ccoCoopBlock {
-  __device__ int thread_rank() const { return threadIdx.x; }
-  __device__ int size() const { return blockDim.x; }
-  __device__ void sync() { __syncthreads(); }
+  __device__ int thread_rank() const { return impl::threadIdxX(); }
+  __device__ int size() const { return impl::blockDimX(); }
+  __device__ void sync() { impl::syncThreads(); }
 };
 
 /* ════════════════════════════════════════════════════════════════════════════
@@ -581,7 +680,9 @@ __device__ inline ccoLsaBarrierSession<Coop>::ccoLsaBarrierSession(Coop coop, cc
                                                                    ccoLsaBarrierHandle h,
                                                                    uint32_t idx)
     : coop(coop), team(team), comm(comm), handle(h), index(idx) {
-  assert(idx < h.nBarriers);
+  // Precondition: idx < h.nBarriers (caller passes a valid barrier slot). No
+  // device-side assert() here — it would require <hip/hip_runtime.h> for the
+  // HIP device __assert_fail, which this header deliberately avoids.
 
   // Restore epoch persisted by the previous session's destructor.
   // Inbox slots are never zeroed, so epoch must be monotonically increasing
@@ -618,7 +719,7 @@ __device__ inline void ccoLsaBarrierSession<Coop>::arrive(Coop) {
   // System-scope fence so any prior payload writes from this coop are
   // observable to peers before the relaxed inbox stores below land.
   if (nranks > 1) {
-    __threadfence_system();
+    impl::threadFenceSystem();
   }
 
   for (int i = this->coop.thread_rank(); i < nranks - 1; i += this->coop.size()) {
@@ -637,7 +738,7 @@ __device__ inline int ccoLsaBarrierSession<Coop>::waitInternal(Coop, uint64_t ti
 
   uint64_t startCycle;
   if constexpr (EnableTimeout) {
-    startCycle = (uint64_t)clock64();
+    startCycle = (uint64_t)impl::clock64();
   }
 
   for (int i = this->coop.thread_rank(); i < nranks - 1; i += this->coop.size()) {
@@ -650,7 +751,7 @@ __device__ inline int ccoLsaBarrierSession<Coop>::waitInternal(Coop, uint64_t ti
       if ((got - (uint32_t)(this->epoch + 1)) <= ((uint32_t)-1 >> 1)) break;
 
       if constexpr (EnableTimeout) {
-        if ((uint64_t)clock64() - startCycle >= timeoutCycles) {
+        if ((uint64_t)impl::clock64() - startCycle >= timeoutCycles) {
           ret = 1;
           goto done;
         }
@@ -690,11 +791,17 @@ __device__ inline int ccoLsaBarrierSession<Coop>::sync(Coop coop, uint64_t timeo
 #endif  // defined(__HIPCC__) || defined(__CUDACC__)  — end device-side API
 
 /* ════════════════════════════════════════════════════════════════════════════
- *  5. Host control-plane Structure & API
+ *  5. Host control-plane structs & API
  *
- *  Implemented in src/cco/cco_init.cpp. The full ccoComm definition is
- *  host-only (guarded above); device/kernel TUs see only this forward decl.
+ *  ccoWindowHost / ccoComm are host-only (device/kernel TUs see ccoComm only as
+ *  an opaque forward declaration). They reference the application layer purely
+ *  through forward-declared pointers / unique_ptr, so this header still pulls in
+ *  no application headers — only system STL. Member functions and the
+ *  out-of-line ccoComm destructor live in src/cco/cco_init.cpp. To callers,
+ *  ccoComm is an opaque handle obtained from ccoCommCreate.
  * ════════════════════════════════════════════════════════════════════════════ */
+
+#if !defined(__HIPCC__) && !defined(__CUDACC__)
 
 struct ccoWindowHost {
   void* localPtr;
@@ -767,7 +874,15 @@ struct ccoComm {
     ccoWindowDevice* devPtr;
   };
   std::vector<WindowTableEntry> windowTableEntries;
+
+  // Out-of-line (defined in cco_init.cpp where HeapVAManager is complete) so the
+  // unique_ptr<HeapVAManager> member works with only a forward declaration here.
+  ~ccoComm();
 };
+
+#else
+struct ccoComm;  // device/kernel TUs: opaque handle only
+#endif  // !defined(__HIPCC__) && !defined(__CUDACC__)
 
 // ── Phase 1: Communicator ──
 //

--- a/include/mori/cco/cco.hpp
+++ b/include/mori/cco/cco.hpp
@@ -271,13 +271,6 @@ struct ccoIbgdaContext {
   application::RdmaEndpointDevice* endpoints;  // [worldSize * numQpPerPe]
   int numQpPerPe;
 
-  // RDMA backend provider of the endpoints above (all peers on a node share
-  // the same NIC vendor). Resolved once at DevComm creation from the first
-  // valid endpoint's vendorId; host-readable so a launcher can dispatch to the
-  // matching ccoGda<PrvdType> kernel instantiation without hardcoding it.
-  // Unknown when gdaConnType==NONE (no endpoints).
-  ccoProviderType providerType{CCO_PROVIDER_UNKNOWN};
-
   // Signal: remote peers atomic +1 here after put completes.
   int signalCount;
   uint64_t* signalBuf;      // [signalCount]  — sub-ptr into resourceWindow
@@ -848,6 +841,11 @@ struct ccoComm {
   // Default # of QPs per peer (from Context). Per-DevComm may override via reqs.
   int defaultNumQpPerPe{4};
   bool iovaZeroMode{true};
+
+  // GDA backend provider of this comm's NICs; resolved at the first
+  // ccoDevCommCreate (CCO_PROVIDER_UNKNOWN until then / when GDA is off).
+  // Informational host-side parameter — GDA dispatch is compile-time per-NIC.
+  ccoProviderType providerType{CCO_PROVIDER_UNKNOWN};
 
   // SDMA queue handles (per-comm, sized lsaSize * sdmaNumQueue, indexed by lsaRank).
   anvil::SdmaQueueDeviceHandle** sdmaDevHandles{nullptr};

--- a/include/mori/cco/cco_scale_out.hpp
+++ b/include/mori/cco/cco_scale_out.hpp
@@ -54,6 +54,26 @@ namespace cco {
  *  device-only (uses RDMA core + device builtins).
  * ════════════════════════════════════════════════════════════════════════════ */
 
+// ── Compile-time GDA provider dispatch (per-NIC build, like shmem) ───────────
+// Provider is fixed at build time from the NIC auto-detected by
+// cmake/MoriDetectDevice.cmake (MORI_DEVICE_NIC_*; the python/mori/jit path
+// mirrors it), so only the one ccoGda<P> specialization is built.
+#if defined(MORI_DEVICE_NIC_BNXT)
+#define CCO_GDA_BUILD_PROVIDER ::mori::core::ProviderType::BNXT
+#elif defined(MORI_DEVICE_NIC_IONIC)
+#define CCO_GDA_BUILD_PROVIDER ::mori::core::ProviderType::PSD
+#else
+#define CCO_GDA_BUILD_PROVIDER ::mori::core::ProviderType::MLX5  // default
+#endif
+
+// Launch a GDA kernel against the build's provider; `P` is a constexpr provider:
+//   CCO_GDA_DISPATCH(MyKernel<P, float><<<g, b, 0, s>>>(win, win, n, devComm));
+#define CCO_GDA_DISPATCH(...)                  \
+  do {                                         \
+    constexpr auto P = CCO_GDA_BUILD_PROVIDER; \
+    __VA_ARGS__;                               \
+  } while (0)
+
 // ── low-level type aliases / enums + ccoGda<PrvdType> class declaration ──
 // Window handles use the shared ccoWindow_t (= ccoWindowDevice*) declared above.
 typedef struct {

--- a/src/cco/cco_init.cpp
+++ b/src/cco/cco_init.cpp
@@ -26,22 +26,32 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
+#include <memory>
+#include <mutex>
 #include <random>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "hip/hip_runtime_api.h"
+#include "mori/application/application.hpp"  // Context, BootstrapNetwork
 #include "mori/application/bootstrap/local_bootstrap.hpp"
 #include "mori/application/bootstrap/socket_bootstrap.hpp"
+#include "mori/application/memory/va_manager.hpp"  // HeapVAManager
 #include "mori/application/transport/rdma/rdma.hpp"
 #include "mori/application/transport/sdma/anvil.hpp"
 #include "mori/application/utils/check.hpp"
-#include "mori/cco/cco.hpp"
+#include "mori/cco/cco.hpp"  // public, self-contained (opaque ccoComm fwd-decl)
 #include "mori/utils/hip_compat.hpp"
 #include "mori/utils/mori_log.hpp"
 
 namespace mori {
 namespace cco {
+
+// Out-of-line dtor for the unique_ptr<HeapVAManager> member: ccoComm is defined
+// in cco.hpp with HeapVAManager only forward-declared, so its destruction must
+// be emitted here where HeapVAManager (va_manager.hpp) is complete.
+ccoComm::~ccoComm() = default;
 
 static size_t AlignUp(size_t x, size_t align) { return (x + align - 1) & ~(align - 1); }
 
@@ -960,10 +970,11 @@ int ccoDevCommCreate(ccoComm* comm, const ccoDevCommRequirements* reqs, ccoDevCo
       epsHost[i].cqHandle = newEps[i].cqHandle;
       epsHost[i].atomicIbuf = newEps[i].atomicIbuf;
       // Resolve the GDA backend provider from the first connected endpoint
-      // (empty slots for peers without a QP keep vendorId==Unknown).
-      if (ibgda.providerType == core::ProviderType::Unknown) {
+      // (empty slots for peers without a QP keep vendorId==Unknown). cco's own
+      // ccoProviderType mirrors core::ProviderType values 1:1.
+      if (ibgda.providerType == CCO_PROVIDER_UNKNOWN) {
         core::ProviderType p = epsHost[i].GetProviderType();
-        if (p != core::ProviderType::Unknown) ibgda.providerType = p;
+        if (p != core::ProviderType::Unknown) ibgda.providerType = static_cast<ccoProviderType>(p);
       }
     }
 

--- a/src/cco/cco_init.cpp
+++ b/src/cco/cco_init.cpp
@@ -48,6 +48,19 @@
 namespace mori {
 namespace cco {
 
+// ccoProviderType is cco's self-contained copy of core::ProviderType; the cast
+// below relies on a 1:1 mapping, so guard it (this TU sees both enums).
+static_assert(static_cast<int>(CCO_PROVIDER_UNKNOWN) == static_cast<int>(core::ProviderType::Unknown),
+              "ccoProviderType drifted from core::ProviderType");
+static_assert(static_cast<int>(CCO_PROVIDER_MLX5) == static_cast<int>(core::ProviderType::MLX5),
+              "ccoProviderType drifted from core::ProviderType");
+static_assert(static_cast<int>(CCO_PROVIDER_BNXT) == static_cast<int>(core::ProviderType::BNXT),
+              "ccoProviderType drifted from core::ProviderType");
+static_assert(static_cast<int>(CCO_PROVIDER_PSD) == static_cast<int>(core::ProviderType::PSD),
+              "ccoProviderType drifted from core::ProviderType");
+static_assert(static_cast<int>(CCO_PROVIDER_IBVERBS) == static_cast<int>(core::ProviderType::IBVERBS),
+              "ccoProviderType drifted from core::ProviderType");
+
 // Out-of-line dtor for the unique_ptr<HeapVAManager> member: ccoComm is defined
 // in cco.hpp with HeapVAManager only forward-declared, so its destruction must
 // be emitted here where HeapVAManager (va_manager.hpp) is complete.
@@ -969,12 +982,11 @@ int ccoDevCommCreate(ccoComm* comm, const ccoDevCommRequirements* reqs, ccoDevCo
       epsHost[i].wqHandle = newEps[i].wqHandle;
       epsHost[i].cqHandle = newEps[i].cqHandle;
       epsHost[i].atomicIbuf = newEps[i].atomicIbuf;
-      // Resolve the GDA backend provider from the first connected endpoint
-      // (empty slots for peers without a QP keep vendorId==Unknown). cco's own
-      // ccoProviderType mirrors core::ProviderType values 1:1.
-      if (ibgda.providerType == CCO_PROVIDER_UNKNOWN) {
+      // Cache the GDA provider from the first connected endpoint (empty peer
+      // slots keep vendorId==Unknown) as an informational parameter on the comm.
+      if (comm->providerType == CCO_PROVIDER_UNKNOWN) {
         core::ProviderType p = epsHost[i].GetProviderType();
-        if (p != core::ProviderType::Unknown) ibgda.providerType = static_cast<ccoProviderType>(p);
+        if (p != core::ProviderType::Unknown) comm->providerType = static_cast<ccoProviderType>(p);
       }
     }
 

--- a/tests/cpp/cco/CMakeLists.txt
+++ b/tests/cpp/cco/CMakeLists.txt
@@ -50,6 +50,11 @@ function(add_cco_test src)
       set_target_properties(${target} PROPERTIES HIP_ARCHITECTURES
                                                  "${GPU_TARGETS}")
     endif()
+    # Compile-time GDA provider dispatch (CCO_GDA_DISPATCH in cco_scale_out.hpp)
+    # keys off the auto-detected NIC; without this a BNXT/ionic host defaults to mlx5.
+    if(MORI_DEVICE_NIC_DEFINE)
+      target_compile_definitions(${target} PRIVATE ${MORI_DEVICE_NIC_DEFINE})
+    endif()
   else()
     set_source_files_properties(${src} PROPERTIES LANGUAGE CXX)
   endif()

--- a/tests/cpp/cco/cco_test_harness.hpp
+++ b/tests/cpp/cco/cco_test_harness.hpp
@@ -47,7 +47,6 @@
 
 #include "hip/hip_runtime.h"
 #include "mori/application/bootstrap/socket_bootstrap.hpp"
-#include "mori/core/transport/rdma/core_device_types.hpp"  // mori::core::ProviderType
 
 // Current rank, set at the top of each run_test; used by HIP_CHECK diagnostics.
 inline int g_rank = 0;
@@ -62,30 +61,9 @@ inline int g_rank = 0;
     }                                                                                            \
   } while (0)
 
-// Run a kernel-launch (or any statement) against the ccoGda<PrvdType> provider
-// matching the DevComm's RDMA backend, resolved at runtime. `prvd` is the
-// DevComm's ccoProviderType (devComm.ibgda.providerType); inside __VA_ARGS__,
-// `P` is a constexpr mori::core::ProviderType usable as a template argument.
-#define CCO_GDA_DISPATCH(prvd, ...)                                                              \
-  do {                                                                                           \
-    switch (prvd) {                                                                              \
-      case mori::cco::CCO_PROVIDER_BNXT: {                                                       \
-        constexpr auto P = mori::core::ProviderType::BNXT;                                       \
-        __VA_ARGS__;                                                                             \
-      } break;                                                                                   \
-      case mori::cco::CCO_PROVIDER_MLX5: {                                                       \
-        constexpr auto P = mori::core::ProviderType::MLX5;                                       \
-        __VA_ARGS__;                                                                             \
-      } break;                                                                                   \
-      case mori::cco::CCO_PROVIDER_PSD: {                                                        \
-        constexpr auto P = mori::core::ProviderType::PSD;                                        \
-        __VA_ARGS__;                                                                             \
-      } break;                                                                                   \
-      default:                                                                                   \
-        fprintf(stderr, "[cco gda test] unsupported GDA provider %d\n", static_cast<int>(prvd)); \
-        _exit(1);                                                                                \
-    }                                                                                            \
-  } while (0)
+// GDA provider dispatch (CCO_GDA_DISPATCH) lives in mori/cco/cco_scale_out.hpp
+// now — it is compile-time (per-NIC build), so GDA tests include that header and
+// call CCO_GDA_DISPATCH(Kernel<P, ...><<<...>>>(...)) with no runtime provider.
 
 // Each test implements this; the harness invokes it for every rank.
 int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet);

--- a/tests/cpp/cco/cco_test_harness.hpp
+++ b/tests/cpp/cco/cco_test_harness.hpp
@@ -63,20 +63,21 @@ inline int g_rank = 0;
   } while (0)
 
 // Run a kernel-launch (or any statement) against the ccoGda<PrvdType> provider
-// matching the DevComm's RDMA backend, resolved at runtime. Inside __VA_ARGS__,
+// matching the DevComm's RDMA backend, resolved at runtime. `prvd` is the
+// DevComm's ccoProviderType (devComm.ibgda.providerType); inside __VA_ARGS__,
 // `P` is a constexpr mori::core::ProviderType usable as a template argument.
 #define CCO_GDA_DISPATCH(prvd, ...)                                                              \
   do {                                                                                           \
     switch (prvd) {                                                                              \
-      case mori::core::ProviderType::BNXT: {                                                     \
+      case mori::cco::CCO_PROVIDER_BNXT: {                                                       \
         constexpr auto P = mori::core::ProviderType::BNXT;                                       \
         __VA_ARGS__;                                                                             \
       } break;                                                                                   \
-      case mori::core::ProviderType::MLX5: {                                                     \
+      case mori::cco::CCO_PROVIDER_MLX5: {                                                       \
         constexpr auto P = mori::core::ProviderType::MLX5;                                       \
         __VA_ARGS__;                                                                             \
       } break;                                                                                   \
-      case mori::core::ProviderType::PSD: {                                                      \
+      case mori::cco::CCO_PROVIDER_PSD: {                                                        \
         constexpr auto P = mori::core::ProviderType::PSD;                                        \
         __VA_ARGS__;                                                                             \
       } break;                                                                                   \

--- a/tests/cpp/cco/test_gda_barrier.cpp
+++ b/tests/cpp/cco/test_gda_barrier.cpp
@@ -37,7 +37,7 @@
 static const size_t PER_RANK_VMM_SIZE = 256ULL * 1024 * 1024;
 static const size_t COUNT = 256;
 
-static constexpr mori::core::ProviderType kPrvdType = mori::core::ProviderType::PSD;
+static constexpr mori::core::ProviderType kPrvdType = CCO_GDA_BUILD_PROVIDER;  // per-NIC build
 
 // BASIC: every rank does one sync(). If any rank hangs, the test times out.
 template <mori::core::ProviderType PrvdType>

--- a/tests/cpp/cco/test_gda_counter.cpp
+++ b/tests/cpp/cco/test_gda_counter.cpp
@@ -46,7 +46,7 @@
 static const size_t PER_RANK_VMM_SIZE = 256ULL * 1024 * 1024;
 static const size_t COUNT = 256;  // float elements per rank-pair slice
 
-static constexpr mori::core::ProviderType kPrvdType = mori::core::ProviderType::PSD;
+static constexpr mori::core::ProviderType kPrvdType = CCO_GDA_BUILD_PROVIDER;  // per-NIC build
 
 // SEND: each thread issues `putsPerPeer` puts to a distinct peer (no counter
 // on put — counter is a separate API). After all puts + flush, one counter()

--- a/tests/cpp/cco/test_gda_flush_async.cpp
+++ b/tests/cpp/cco/test_gda_flush_async.cpp
@@ -179,7 +179,7 @@ int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet)
 
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
-  CCO_GDA_DISPATCH(devComm.ibgda.providerType, GdaAlltoAllFlushAsyncKernel<P, float>
+  CCO_GDA_DISPATCH(GdaAlltoAllFlushAsyncKernel<P, float>
                    <<<1, blockDim, 0, stream>>>(sendWin, recvWin, COUNT, devComm));
   HIP_CHECK(hipStreamSynchronize(stream));
   printf("[rank %d] kernel completed\n", rank);

--- a/tests/cpp/cco/test_gda_get.cpp
+++ b/tests/cpp/cco/test_gda_get.cpp
@@ -149,7 +149,7 @@ int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet)
   // launch
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
-  CCO_GDA_DISPATCH(devComm.ibgda.providerType, GdaAlltoAllGetKernel<P, float>
+  CCO_GDA_DISPATCH(GdaAlltoAllGetKernel<P, float>
                    <<<1, 64, 0, stream>>>(sendWin, recvWin, COUNT, devComm));
   HIP_CHECK(hipStreamSynchronize(stream));
   printf("[rank %d] kernel completed\n", rank);

--- a/tests/cpp/cco/test_gda_modes.cpp
+++ b/tests/cpp/cco/test_gda_modes.cpp
@@ -39,6 +39,7 @@
 #include <vector>
 
 #include "hip/hip_runtime.h"
+#include "mori/application/application_device_types.hpp"  // white-box: RdmaEndpointDevice (count QPs)
 #include "mori/application/bootstrap/socket_bootstrap.hpp"
 #include "mori/cco/cco.hpp"
 #include "mori/utils/mori_log.hpp"
@@ -269,11 +270,11 @@ static void run_rank(int rank, int nranks, const mori::application::UniqueId& ui
   //   FULL : (worldSize - 1) * qpsPerPe
   //   RAIL : (nNodes - 1) * qpsPerPe  (one peer per other node at same lsaRank)
   // On single-node (nNodes == 1), RAIL collapses to NONE: expected 0.
-  const int nNodes = comm->worldSize / comm->lsaSize;
-  const int qpsNone = CountQpsFor(dcNone, comm->worldSize);
-  const int qpsFull = CountQpsFor(dcFull, comm->worldSize);
-  const int qpsRail = CountQpsFor(dcRail, comm->worldSize);
-  const int expectedFull = (comm->worldSize - 1) * numQpPerPe;
+  const int nNodes = dcFull.worldSize / dcFull.lsaSize;
+  const int qpsNone = CountQpsFor(dcNone, dcFull.worldSize);
+  const int qpsFull = CountQpsFor(dcFull, dcFull.worldSize);
+  const int qpsRail = CountQpsFor(dcRail, dcFull.worldSize);
+  const int expectedFull = (dcFull.worldSize - 1) * numQpPerPe;
   const int expectedRail = (nNodes - 1) * numQpPerPe;
 
   bool ok = true;
@@ -291,7 +292,7 @@ static void run_rank(int rank, int nranks, const mori::application::UniqueId& ui
     snprintf(r->detail, sizeof(r->detail),
              "alloc/register/devcomm OK; NONE=0 FULL=%d RAIL=%d (worldSize=%d lsaSize=%d "
              "nNodes=%d qpsPerPe=%d)",
-             qpsFull, qpsRail, comm->worldSize, comm->lsaSize, nNodes, numQpPerPe);
+             qpsFull, qpsRail, dcFull.worldSize, dcFull.lsaSize, nNodes, numQpPerPe);
   }
 
   printf("[rank %d] NONE=%d FULL=%d RAIL=%d (expected: 0 / %d / %d)\n", rank, qpsNone, qpsFull,

--- a/tests/cpp/cco/test_gda_multi_context.cpp
+++ b/tests/cpp/cco/test_gda_multi_context.cpp
@@ -45,7 +45,7 @@ static const size_t COUNT = 256;  // float elements per (peer, context) slice
 static const int NCTX = 4;        // GDA contexts == gdaContextCount == QPs/peer
 static const int ITERS = 8;       // DevComm create/destroy cycles
 
-static constexpr mori::core::ProviderType kPrvdType = mori::core::ProviderType::PSD;
+static constexpr mori::core::ProviderType kPrvdType = CCO_GDA_BUILD_PROVIDER;  // per-NIC build
 
 // All-to-all where each GDA context sends its own payload slice over its own QP.
 //

--- a/tests/cpp/cco/test_gda_put.cpp
+++ b/tests/cpp/cco/test_gda_put.cpp
@@ -146,7 +146,7 @@ int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet)
   // launch
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
-  CCO_GDA_DISPATCH(devComm.ibgda.providerType, GdaAlltoAllKernel<P, float>
+  CCO_GDA_DISPATCH(GdaAlltoAllKernel<P, float>
                    <<<1, 64, 0, stream>>>(sendWin, recvWin, COUNT, devComm));
   HIP_CHECK(hipStreamSynchronize(stream));
   printf("[rank %d] kernel completed\n", rank);

--- a/tests/cpp/cco/test_gda_signal_ut.cpp
+++ b/tests/cpp/cco/test_gda_signal_ut.cpp
@@ -45,7 +45,7 @@
 
 static const size_t PER_RANK_VMM_SIZE = 256ULL * 1024 * 1024;
 
-static constexpr mori::core::ProviderType kPrvdType = mori::core::ProviderType::PSD;
+static constexpr mori::core::ProviderType kPrvdType = CCO_GDA_BUILD_PROVIDER;  // per-NIC build
 
 // ── shared op/check descriptors ──────────────────────────────────────────────
 //

--- a/tests/cpp/cco/test_multiprocess.cpp
+++ b/tests/cpp/cco/test_multiprocess.cpp
@@ -39,6 +39,7 @@
 #include <vector>
 
 #include "hip/hip_runtime.h"
+#include "mori/application/application_device_types.hpp"  // white-box: RdmaEndpointDevice (count QPs)
 #include "mori/application/bootstrap/socket_bootstrap.hpp"
 #include "mori/cco/cco.hpp"
 


### PR DESCRIPTION
## Summary

- **`cco.hpp` self-contained & HIP-runtime-free**: copy just `cco.hpp` (+ `libmori_cco.so`) — no other mori header, no `<hip/hip_runtime.h>`. External types via forward-decls; `ccoProviderType` replaces `core::ProviderType`; device code uses `mori::cco::impl` AMDGCN-builtin wrappers (mirrors aiter `opus/hip_minimal.hpp`).
- **Compile-time per-NIC GDA dispatch**: was a runtime provider switch, now compile-time like shmem — a build targets one NIC, only that `ccoGda<P>` is instantiated. `cco_scale_out.hpp` adds `CCO_GDA_BUILD_PROVIDER`/`CCO_GDA_DISPATCH` keyed on `MORI_DEVICE_NIC_*` (auto-detected by `cmake/MoriDetectDevice.cmake`); tests wire `MORI_DEVICE_NIC_DEFINE`. Also fixes the hardcoded-PSD constant that hung `test_gda_barrier` / failed `test_gda_signal_ut` on BNXT.
- **GDA provider → informational `ccoComm` field**: device never read it; moved off the by-value `ccoDevComm` to the host comm, with `static_assert`s guarding the `ccoProviderType`↔`core::ProviderType` 1:1 cast.

## Testing

In-container on BNXT (MI300X gfx942), fork 8 ranks: GDA put/get/flush_async/counter/barrier/signal_ut/multi_context **8/8 each**, LSA barrier **8/8**, full suite builds clean.
