### PR TITLE
refactor(bnxt): collapsed-CQ drain, drop outstandingWqe, fix per-lane PSN

### DIFF
--- a/examples/dist_rdma_ops/dist_write.cpp
+++ b/examples/dist_rdma_ops/dist_write.cpp
@@ -59,6 +59,15 @@ void VerifyBuffer(void* buffer, size_t maxSize, char expected) {
   HIP_RUNTIME_CHECK(hipDeviceSynchronize());
 }
 
+// Largest V <= dbTouchIdx with V % modulus == wrapped % modulus (modulus =
+// sqWqeNum for bnxt/psd, 2^16 for mlx5). Replaces the outstandingWqe[] table.
+__device__ inline uint32_t ReconstructDone(uint32_t wrapped, uint32_t modulus,
+                                           uint32_t dbTouchIdx) {
+  uint32_t v = (dbTouchIdx - (dbTouchIdx % modulus)) + (wrapped % modulus);
+  if (v > dbTouchIdx) v -= modulus;
+  return v;
+}
+
 template <ProviderType P>
 inline __device__ void QuietSerial(RdmaEndpoint* endpoint) {
   if (GetActiveLaneNum() != 0) return;
@@ -92,21 +101,19 @@ inline __device__ void QuietSerial(RdmaEndpoint* endpoint) {
         core::DumpMlx5Wqe(wq.sqAddr, my_cq_index);
         assert(false);
       }
-      wqe_id = wq.outstandingWqe[wqe_counter];
+      wqe_id = ReconstructDone(wqe_counter, 1u << 16, dbTouchIdx);
     } else if constexpr (P == core::ProviderType::BNXT) {
       if (opcode != BNXT_RE_REQ_ST_OK) {
         uint32_t my_cq_index = my_cq_consumer % cq.cqeNum;
         assert(false);
       }
-      wqe_counter = (wqe_counter + wq.sqWqeNum - 1) % wq.sqWqeNum;
-      wqe_id = wq.outstandingWqe[wqe_counter] + 1;
+      wqe_id = ReconstructDone(wqe_counter, wq.sqWqeNum, dbTouchIdx);
     } else if constexpr (P == core::ProviderType::PSD) {
       if (opcode != 0) {
         uint32_t my_cq_index = my_cq_consumer % cq.cqeNum;
         assert(false);
       }
-      wqe_counter = (wqe_counter + wq.sqWqeNum - 1) % wq.sqWqeNum;
-      wqe_id = wq.outstandingWqe[wqe_counter] + 1;
+      wqe_id = ReconstructDone(wqe_counter, wq.sqWqeNum, dbTouchIdx);
     }
 
     // core::UpdateCqDbrRecord<P>(cq, cq.dbrRecAddr, (uint32_t)(my_cq_consumer + 1), cq.cqeNum);
@@ -171,7 +178,9 @@ __device__ void Quiet(RdmaEndpoint* endpoint) {
       uint32_t wqe_counter;
       PollCq<P>(cqHandle->cqAddr, cqHandle->cqeNum, &my_cq_consumer, &wqe_counter);
       __threadfence_system();
-      wqe_id = endpoint->wqHandle.outstandingWqe[wqe_counter];
+      uint32_t dbTouchIdx = __hip_atomic_load(&endpoint->wqHandle.dbTouchIdx, __ATOMIC_RELAXED,
+                                              __HIP_MEMORY_SCOPE_AGENT);
+      wqe_id = ReconstructDone(wqe_counter, 1u << 16, dbTouchIdx);
       __hip_atomic_fetch_max(&wqe_broadcast[warp_id], wqe_id, __ATOMIC_RELAXED,
                              __HIP_MEMORY_SCOPE_WORKGROUP);
       __atomic_signal_fence(__ATOMIC_SEQ_CST);
@@ -340,17 +349,14 @@ __device__ void Write(RdmaEndpoint* endpoint, RdmaMemoryRegion localMr, RdmaMemo
   uintptr_t dstAddr = remoteMr.addr + FlatThreadId() * msg_size;
   uint64_t dbr_val;
   if constexpr (P == ProviderType::MLX5) {
-    wqHandle->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
     dbr_val =
         PostWrite<P>(*wqHandle, my_sq_counter, my_sq_counter, my_sq_counter, is_leader,
                      endpoint->handle.qpn, srcAddr, localMr.lkey, dstAddr, remoteMr.rkey, msg_size);
   } else if constexpr (P == ProviderType::BNXT) {
-    wqHandle->outstandingWqe[my_sq_counter % wqHandle->sqWqeNum] = my_sq_counter;
     dbr_val =
         PostWrite<P>(*wqHandle, my_sq_counter, my_msntbl_counter, my_psn_counter, is_leader,
                      endpoint->handle.qpn, srcAddr, localMr.lkey, dstAddr, remoteMr.rkey, msg_size);
   } else if constexpr (P == ProviderType::PSD) {
-    wqHandle->outstandingWqe[my_sq_counter % OUTSTANDING_TABLE_SIZE] = my_sq_counter;
     dbr_val =
         PostWrite<P>(*wqHandle, my_sq_counter, my_sq_counter, my_sq_counter, is_leader,
                      endpoint->handle.qpn, srcAddr, localMr.lkey, dstAddr, remoteMr.rkey, msg_size);
@@ -624,16 +630,6 @@ void distRdmaOps(int argc, char* argv[]) {
   std::vector<RdmaMemoryRegion> global_mr_handles(world_size);
   bootNet.Allgather(&mr_handle, global_mr_handles.data(), sizeof(mr_handle));
   global_mr_handles[local_rank] = mr_handle;
-  // WorkQueueHandle::outstandingWqe is now a pointer (mori_shmem leaves it null and
-  // reconstructs completions arithmetically). This example's quiet still uses the
-  // slot->counter table, so allocate one device buffer per QP and attach it before
-  // the handles are copied to the device.
-  for (int i = 0; i < num_qp; ++i) {
-    uint64_t* outstandingWqeBuf = nullptr;
-    HIP_RUNTIME_CHECK(hipMalloc(&outstandingWqeBuf, OUTSTANDING_TABLE_SIZE * sizeof(uint64_t)));
-    HIP_RUNTIME_CHECK(hipMemset(outstandingWqeBuf, 0, OUTSTANDING_TABLE_SIZE * sizeof(uint64_t)));
-    endpoints[i].wqHandle.outstandingWqe = outstandingWqeBuf;
-  }
   RdmaEndpoint* devEndpoints;
   HIP_RUNTIME_CHECK(hipMalloc(&devEndpoints, num_qp * sizeof(RdmaEndpoint)));
   HIP_RUNTIME_CHECK(hipMemcpy(devEndpoints, endpoints.data(), num_qp * sizeof(RdmaEndpoint),

--- a/examples/dist_rdma_ops/dist_write.cpp
+++ b/examples/dist_rdma_ops/dist_write.cpp
@@ -624,6 +624,16 @@ void distRdmaOps(int argc, char* argv[]) {
   std::vector<RdmaMemoryRegion> global_mr_handles(world_size);
   bootNet.Allgather(&mr_handle, global_mr_handles.data(), sizeof(mr_handle));
   global_mr_handles[local_rank] = mr_handle;
+  // WorkQueueHandle::outstandingWqe is now a pointer (mori_shmem leaves it null and
+  // reconstructs completions arithmetically). This example's quiet still uses the
+  // slot->counter table, so allocate one device buffer per QP and attach it before
+  // the handles are copied to the device.
+  for (int i = 0; i < num_qp; ++i) {
+    uint64_t* outstandingWqeBuf = nullptr;
+    HIP_RUNTIME_CHECK(hipMalloc(&outstandingWqeBuf, OUTSTANDING_TABLE_SIZE * sizeof(uint64_t)));
+    HIP_RUNTIME_CHECK(hipMemset(outstandingWqeBuf, 0, OUTSTANDING_TABLE_SIZE * sizeof(uint64_t)));
+    endpoints[i].wqHandle.outstandingWqe = outstandingWqeBuf;
+  }
   RdmaEndpoint* devEndpoints;
   HIP_RUNTIME_CHECK(hipMalloc(&devEndpoints, num_qp * sizeof(RdmaEndpoint)));
   HIP_RUNTIME_CHECK(hipMemcpy(devEndpoints, endpoints.data(), num_qp * sizeof(RdmaEndpoint),

--- a/include/mori/core/transport/rdma/core_device_types.hpp
+++ b/include/mori/core/transport/rdma/core_device_types.hpp
@@ -68,7 +68,6 @@ typedef enum {
   AMO_OP_SENTINEL = INT_MAX,
 } atomicType;
 
-#define OUTSTANDING_TABLE_SIZE (65536)
 struct WorkQueueHandle {
   uint32_t postIdx{0};     // numbers of wqe that post to work queue
   uint32_t dbTouchIdx{0};  // numbers of wqe that touched doorbell
@@ -92,7 +91,6 @@ struct WorkQueueHandle {
   uint32_t msntblNum{0};
   uint32_t rqWqeNum{0};
   uint32_t postSendLock{0};
-  uint64_t outstandingWqe[OUTSTANDING_TABLE_SIZE]{0};
   bool color;
   uint64_t sq_dbval{0};
   uint64_t rq_dbval{0};

--- a/include/mori/core/transport/rdma/core_device_types.hpp
+++ b/include/mori/core/transport/rdma/core_device_types.hpp
@@ -68,6 +68,10 @@ typedef enum {
   AMO_OP_SENTINEL = INT_MAX,
 } atomicType;
 
+// Size of the optional slot->counter table some callers attach to
+// WorkQueueHandle::outstandingWqe (see below).
+#define OUTSTANDING_TABLE_SIZE (65536)
+
 struct WorkQueueHandle {
   uint32_t postIdx{0};     // numbers of wqe that post to work queue
   uint32_t dbTouchIdx{0};  // numbers of wqe that touched doorbell
@@ -91,6 +95,11 @@ struct WorkQueueHandle {
   uint32_t msntblNum{0};
   uint32_t rqWqeNum{0};
   uint32_t postSendLock{0};
+  // Optional slot->counter table for completion tracking. mori_shmem reconstructs
+  // doneIdx arithmetically and leaves this null (so the GPU-resident handle no
+  // longer carries a 512 KB inline array). Callers that still want a table -- e.g.
+  // the dist_rdma_ops example -- allocate a device buffer and assign it here.
+  uint64_t* outstandingWqe{nullptr};
   bool color;
   uint64_t sq_dbval{0};
   uint64_t rq_dbval{0};

--- a/include/mori/core/transport/rdma/core_device_types.hpp
+++ b/include/mori/core/transport/rdma/core_device_types.hpp
@@ -68,10 +68,6 @@ typedef enum {
   AMO_OP_SENTINEL = INT_MAX,
 } atomicType;
 
-// Size of the optional slot->counter table some callers attach to
-// WorkQueueHandle::outstandingWqe (see below).
-#define OUTSTANDING_TABLE_SIZE (65536)
-
 struct WorkQueueHandle {
   uint32_t postIdx{0};     // numbers of wqe that post to work queue
   uint32_t dbTouchIdx{0};  // numbers of wqe that touched doorbell
@@ -95,11 +91,6 @@ struct WorkQueueHandle {
   uint32_t msntblNum{0};
   uint32_t rqWqeNum{0};
   uint32_t postSendLock{0};
-  // Optional slot->counter table for completion tracking. mori_shmem reconstructs
-  // doneIdx arithmetically and leaves this null (so the GPU-resident handle no
-  // longer carries a 512 KB inline array). Callers that still want a table -- e.g.
-  // the dist_rdma_ops example -- allocate a device buffer and assign it here.
-  uint64_t* outstandingWqe{nullptr};
   bool color;
   uint64_t sq_dbval{0};
   uint64_t rq_dbval{0};

--- a/include/mori/shmem/shmem_ibgda_kernels.hpp
+++ b/include/mori/shmem/shmem_ibgda_kernels.hpp
@@ -236,7 +236,24 @@ inline __device__ void ShmemQuietThreadKernelSerialImpl(int pe, int qpId) {
   int epIndex = pe * globalGpuStates->numQpPerPe + (qpId % globalGpuStates->numQpPerPe);
   core::WorkQueueHandle& wq = ep[epIndex].wqHandle;
   core::CompletionQueueHandle& cq = ep[epIndex].cqHandle;
-  BnxtCollapsedCqDrain<DrainToLive>(wq, cq);
+
+  // One warp owns the drain; losers spin on cacheable reads and only CAS the lock
+  // when it looks free. Recycle (DrainToLive=false) losers return; final-quiet
+  // losers wait until doneIdx >= postIdx.
+  while (true) {
+    if constexpr (DrainToLive) {
+      uint32_t done = __hip_atomic_load(&wq.doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      uint32_t post = __hip_atomic_load(&wq.postIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      if (done >= post) return;
+    }
+    if (__hip_atomic_load(&cq.pollCqLock, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT) == 0 &&
+        core::AcquireLockOnce(&cq.pollCqLock)) {
+      BnxtCollapsedCqDrain<DrainToLive>(wq, cq);
+      core::ReleaseLock(&cq.pollCqLock);
+      return;
+    }
+    if constexpr (!DrainToLive) return;
+  }
 }
 
 inline __device__ void ShmemQuietThreadKernelPsdImpl(int pe, int qpId) {

--- a/include/mori/shmem/shmem_ibgda_kernels.hpp
+++ b/include/mori/shmem/shmem_ibgda_kernels.hpp
@@ -171,6 +171,57 @@ inline __device__ void VmmLookupRemote(uintptr_t addr, int pe, uintptr_t& out_ra
 /* ---------------------------------------------------------------------------------------------- */
 /*                                         Synchronization                                        */
 /* ---------------------------------------------------------------------------------------------- */
+// Drain a collapsed (one-CQE, cqeNum==1) bnxt CQ and advance wq.doneIdx. The NIC
+// keeps the latest completion in CQE[0]; its 16-bit con_indx gives the completed
+// WQE slot (con_indx % sqWqeNum == completed-count % sqWqeNum, the same identity
+// the old outstandingWqe[] table relied on). Reconstruct the 32-bit monotonic
+// completed count by anchoring on dbTouchIdx (the true upper bound of completions):
+// the unique value V <= dbTouchIdx with V % sqWqeNum == con_indx % sqWqeNum, which
+// is unambiguous because outstanding (dbTouchIdx - doneIdx) <= sqWqeNum. This
+// removes the per-WQE wq.outstandingWqe[] slot->counter table entirely. sqWqeNum is
+// a power of two, so the modulus is a mask. Lock-free / multi-warp safe via
+// atomicMax on doneIdx, mirroring Mlx5CollapsedCqDrain.
+//
+// DrainToLive=false: exit at a snapshot of dbTouchIdx (recycle gate -- just free
+// some slots). true: re-read the live postIdx and wait until every reserved WQE
+// has completed, so no send can still be reading its source (final quiet).
+template <bool DrainToLive = false>
+inline __device__ void BnxtCollapsedCqDrain(core::WorkQueueHandle& wq,
+                                            core::CompletionQueueHandle& cq) {
+  uint32_t exitTarget =
+      DrainToLive ? __hip_atomic_load(&wq.postIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT)
+                  : __hip_atomic_load(&wq.dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+  uint32_t cons = __hip_atomic_load(&wq.doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+  if (cons >= exitTarget) return;
+
+  const uint32_t mask = wq.sqWqeNum - 1;  // sqWqeNum is a power of two
+  __threadfence();
+  do {
+    uint32_t consIdxIgnored = 0;  // collapsed CQ (cqeNum==1) always reads CQE[0]
+    uint32_t wqeCounter = 0;
+    int opcode =
+        core::PollCq<core::ProviderType::BNXT>(cq.cqAddr, cq.cqeNum, &consIdxIgnored, &wqeCounter);
+    if (opcode != BNXT_RE_REQ_ST_OK) {
+      assert(false);
+      return;
+    }
+
+    // Largest V <= dbTouchIdx with V % sqWqeNum == con_indx % sqWqeNum.
+    uint32_t dbTouch =
+        __hip_atomic_load(&wq.dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    uint32_t completed = (dbTouch & ~mask) | (wqeCounter & mask);
+    if (completed > dbTouch) completed -= wq.sqWqeNum;
+
+    __hip_atomic_fetch_max(&wq.doneIdx, completed, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    cons = __hip_atomic_load(&wq.doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    if constexpr (DrainToLive) {
+      exitTarget = __hip_atomic_load(&wq.postIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    }
+  } while (cons < exitTarget);
+  __threadfence();
+}
+
+template <bool DrainToLive = false>
 inline __device__ void ShmemQuietThreadKernelSerialImpl(int pe, int qpId) {
   if (core::GetActiveLaneNum() != 0) return;
   GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
@@ -178,34 +229,7 @@ inline __device__ void ShmemQuietThreadKernelSerialImpl(int pe, int qpId) {
   int epIndex = pe * globalGpuStates->numQpPerPe + (qpId % globalGpuStates->numQpPerPe);
   core::WorkQueueHandle& wq = ep[epIndex].wqHandle;
   core::CompletionQueueHandle& cq = ep[epIndex].cqHandle;
-  if (!core::AcquireLockOnce(&cq.pollCqLock)) return;
-  while (true) {
-    uint32_t dbTouchIdx =
-        __hip_atomic_load(&wq.dbTouchIdx, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
-    uint32_t doneIdx = __hip_atomic_load(&wq.doneIdx, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_AGENT);
-    if (dbTouchIdx == doneIdx) {
-      break;
-    }
-
-    uint32_t my_cq_consumer =
-        __hip_atomic_fetch_add(&cq.cq_consumer, 1, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-
-    uint32_t wqe_counter;
-    int opcode =
-        core::PollCq<core::ProviderType::BNXT>(cq.cqAddr, cq.cqeNum, &my_cq_consumer, &wqe_counter);
-    if (opcode != BNXT_RE_REQ_ST_OK) {
-      int rank = globalGpuStates->rank;
-      uint32_t my_cq_index = my_cq_consumer % cq.cqeNum;
-      MORI_PRINTF("rank %d dest pe %d consIdx %d opcode %d\n", rank, pe, my_cq_index, opcode);
-      assert(false);
-    }
-    wqe_counter = (wqe_counter + wq.sqWqeNum - 1) % wq.sqWqeNum;
-    uint64_t wqe_id = wq.outstandingWqe[wqe_counter] + 1;
-
-    __atomic_signal_fence(__ATOMIC_SEQ_CST);
-    __hip_atomic_fetch_max(&wq.doneIdx, wqe_id, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-  }
-  core::ReleaseLock(&cq.pollCqLock);
+  BnxtCollapsedCqDrain<DrainToLive>(wq, cq);
 }
 
 inline __device__ void ShmemQuietThreadKernelPsdImpl(int pe, int qpId) {
@@ -347,7 +371,7 @@ inline __device__ void ShmemQuietThreadKernelMlnxImpl(int pe, int qpId) {
 template <core::ProviderType PrvdType, bool DrainToLive = false>
 inline __device__ void ShmemQuietThreadKernelImpl(int pe, int qpId) {
   if constexpr (PrvdType == core::ProviderType::BNXT) {
-    ShmemQuietThreadKernelSerialImpl(pe, qpId);
+    ShmemQuietThreadKernelSerialImpl<DrainToLive>(pe, qpId);
   } else if constexpr (PrvdType == core::ProviderType::PSD) {
     ShmemQuietThreadKernelPsdImpl(pe, qpId);
   } else if constexpr (PrvdType == core::ProviderType::MLX5) {
@@ -537,7 +561,6 @@ inline __device__ void ShmemPutMemNbiThreadKernelImpl(const application::SymmMem
           core::PostWrite<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter, is_leader,
                                     qpn, srcAddr, lkey, raddr, rkey, transfer_size);
     } else if constexpr (PrvdType == core::ProviderType::BNXT) {
-      wq->outstandingWqe[my_sq_counter % wq->sqWqeNum] = my_sq_counter;
       dbr_val =
           core::PostWrite<PrvdType>(*wq, my_sq_counter, my_msntbl_counter, my_psn_counter,
                                     is_leader, qpn, srcAddr, lkey, raddr, rkey, transfer_size);
@@ -720,7 +743,6 @@ inline __device__ void ShmemPutSizeImmNbiThreadKernelImpl(const application::Sym
     dbr_val = core::PostWriteInline<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter,
                                               is_leader, qpn, val, raddr, rkey, bytes);
   } else if constexpr (PrvdType == core::ProviderType::BNXT) {
-    wq->outstandingWqe[my_sq_counter % wq->sqWqeNum] = my_sq_counter;
     dbr_val = core::PostWriteInline<PrvdType>(*wq, my_sq_counter, my_msntbl_counter, my_psn_counter,
                                               is_leader, qpn, val, raddr, rkey, bytes);
   } else if constexpr (PrvdType == core::ProviderType::PSD) {
@@ -935,7 +957,6 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelImpl(
       dbr_val = core::PostWrite<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter,
                                           is_leader, qpn, laddr, lkey, raddr, rkey, transfer_size);
     } else if constexpr (PrvdType == core::ProviderType::BNXT) {
-      wq->outstandingWqe[my_sq_counter % wq->sqWqeNum] = my_sq_counter;
       dbr_val = core::PostWrite<PrvdType>(*wq, my_sq_counter, my_msntbl_counter, my_psn_counter,
                                           is_leader, qpn, laddr, lkey, raddr, rkey, transfer_size);
     } else if constexpr (PrvdType == core::ProviderType::PSD) {
@@ -966,7 +987,6 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelImpl(
                 *wq, my_sq_counter + 1, my_sq_counter + 1, my_sq_counter + 1, is_leader, qpn,
                 &signalValue, signalRaddr, signalRkey, sizeof(signalValue));
           } else if constexpr (PrvdType == core::ProviderType::BNXT) {
-            wq->outstandingWqe[(my_sq_counter + 1) % wq->sqWqeNum] = my_sq_counter + 1;
             dbr_val = core::PostWriteInline<PrvdType>(
                 *wq, my_sq_counter + 1, my_msntbl_counter + 1, my_psn_counter + psnCnt, is_leader,
                 qpn, &signalValue, signalRaddr, signalRkey, sizeof(signalValue));
@@ -987,7 +1007,6 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelImpl(
                 ibuf->addr, ibuf->lkey, signalRaddr, signalRkey, &signalValue, &signalValue,
                 sizeof(signalValue), core::atomicType::AMO_ADD);
           } else if constexpr (PrvdType == core::ProviderType::BNXT) {
-            wq->outstandingWqe[(my_sq_counter + 1) % wq->sqWqeNum] = my_sq_counter + 1;
             dbr_val = core::PostAtomic<PrvdType>(
                 *wq, my_sq_counter + 1, my_msntbl_counter + 1, my_psn_counter + psnCnt, is_leader,
                 qpn, ibuf->addr, ibuf->lkey, signalRaddr, signalRkey, &signalValue, &signalValue,
@@ -1226,10 +1245,6 @@ inline __device__ void ShmemAtomicSizeNonFetchThreadKernelImpl(
     ShmemQuietThreadKernelImpl<PrvdType>(pe, qpId);
   }
 
-  if constexpr (PrvdType == core::ProviderType::BNXT) {
-    wq->outstandingWqe[my_sq_counter % wq->sqWqeNum] = my_sq_counter;
-  }
-
   uint64_t dbr_val;
   if constexpr (PrvdType == core::ProviderType::MLX5) {
     dbr_val =
@@ -1411,10 +1426,6 @@ inline __device__ T ShmemAtomicTypeFetchThreadKernelImpl(const application::Symm
     uint64_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
     if (num_free_entries > num_entries_until_warp_last_entry) break;
     ShmemQuietThreadKernelImpl<PrvdType>(pe, qpId);
-  }
-
-  if constexpr (PrvdType == core::ProviderType::BNXT) {
-    wq->outstandingWqe[my_sq_counter % wq->sqWqeNum] = my_sq_counter;
   }
 
   uint64_t dbr_val;
@@ -1683,7 +1694,6 @@ inline __device__ void ShmemPutMemNbiThreadKernelAddrImpl(const void* dest, cons
           core::PostWrite<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter, is_leader,
                                     qpn, srcAddr, lkey, raddr, rkey, transfer_size);
     } else if constexpr (PrvdType == core::ProviderType::BNXT) {
-      wq->outstandingWqe[my_sq_counter % wq->sqWqeNum] = my_sq_counter;
       dbr_val =
           core::PostWrite<PrvdType>(*wq, my_sq_counter, my_msntbl_counter, my_psn_counter,
                                     is_leader, qpn, srcAddr, lkey, raddr, rkey, transfer_size);
@@ -1844,7 +1854,6 @@ inline __device__ void ShmemPutSizeImmNbiThreadKernelAddrImpl(const void* dest, 
     dbr_val = core::PostWriteInline<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter,
                                               is_leader, qpn, val, raddr, rkey, bytes);
   } else if constexpr (PrvdType == core::ProviderType::BNXT) {
-    wq->outstandingWqe[my_sq_counter % wq->sqWqeNum] = my_sq_counter;
     dbr_val = core::PostWriteInline<PrvdType>(*wq, my_sq_counter, my_msntbl_counter, my_psn_counter,
                                               is_leader, qpn, val, raddr, rkey, bytes);
   } else if constexpr (PrvdType == core::ProviderType::PSD) {
@@ -2056,7 +2065,6 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelAddrImpl(
       dbr_val = core::PostWrite<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter, false,
                                           qpn, srcAddr, lkey, raddr, rkey, transfer_size);
     } else if constexpr (PrvdType == core::ProviderType::BNXT) {
-      wq->outstandingWqe[my_sq_counter % wq->sqWqeNum] = my_sq_counter;
       dbr_val = core::PostWrite<PrvdType>(*wq, my_sq_counter, my_msntbl_counter, my_psn_counter,
                                           false, qpn, srcAddr, lkey, raddr, rkey, transfer_size);
     } else if constexpr (PrvdType == core::ProviderType::PSD) {
@@ -2077,7 +2085,6 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelAddrImpl(
                 *wq, my_sq_counter + 1, my_sq_counter + 1, my_sq_counter + 1, is_leader, qpn,
                 &signalValue, signalRaddr, signalRkey, sizeof(signalValue));
           } else if constexpr (PrvdType == core::ProviderType::BNXT) {
-            wq->outstandingWqe[(my_sq_counter + 1) % wq->sqWqeNum] = my_sq_counter + 1;
             dbr_val = core::PostWriteInline<PrvdType>(
                 *wq, my_sq_counter + 1, my_msntbl_counter + 1, my_psn_counter + psnCnt, is_leader,
                 qpn, &signalValue, signalRaddr, signalRkey, sizeof(signalValue));
@@ -2098,7 +2105,6 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelAddrImpl(
                 ibuf->addr, ibuf->lkey, signalRaddr, signalRkey, &signalValue, &signalValue,
                 sizeof(signalValue), core::atomicType::AMO_ADD);
           } else if constexpr (PrvdType == core::ProviderType::BNXT) {
-            wq->outstandingWqe[(my_sq_counter + 1) % wq->sqWqeNum] = my_sq_counter + 1;
             dbr_val = core::PostAtomic<PrvdType>(
                 *wq, my_sq_counter + 1, my_msntbl_counter + 1, my_psn_counter + psnCnt, is_leader,
                 qpn, ibuf->addr, ibuf->lkey, signalRaddr, signalRkey, &signalValue, &signalValue,
@@ -2314,10 +2320,6 @@ inline __device__ void ShmemAtomicSizeNonFetchThreadKernelAddrImpl(const void* d
     ShmemQuietThreadKernelImpl<PrvdType>(pe, qpId);
   }
 
-  if constexpr (PrvdType == core::ProviderType::BNXT) {
-    wq->outstandingWqe[my_sq_counter % wq->sqWqeNum] = my_sq_counter;
-  }
-
   uint64_t dbr_val;
   if constexpr (PrvdType == core::ProviderType::MLX5) {
     dbr_val =
@@ -2464,10 +2466,6 @@ inline __device__ T ShmemAtomicTypeFetchThreadKernelAddrImpl(const void* dest, v
     uint64_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
     if (num_free_entries > num_entries_until_warp_last_entry) break;
     ShmemQuietThreadKernelImpl<PrvdType>(pe, qpId);
-  }
-
-  if constexpr (PrvdType == core::ProviderType::BNXT) {
-    wq->outstandingWqe[my_sq_counter % wq->sqWqeNum] = my_sq_counter;
   }
 
   uint64_t dbr_val;
@@ -2689,7 +2687,6 @@ inline __device__ void ShmemGetMemNbiThreadKernelImpl(const application::SymmMem
           core::PostRead<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter, is_leader, qpn,
                                    destAddr, lkey, raddr, rkey, transfer_size);
     } else if constexpr (PrvdType == core::ProviderType::BNXT) {
-      wq->outstandingWqe[my_sq_counter % wq->sqWqeNum] = my_sq_counter;
       dbr_val =
           core::PostRead<PrvdType>(*wq, my_sq_counter, my_msntbl_counter, my_psn_counter, is_leader,
                                    qpn, destAddr, lkey, raddr, rkey, transfer_size);
@@ -2902,7 +2899,6 @@ inline __device__ void ShmemGetMemNbiThreadKernelAddrImpl(void* dest, const void
           core::PostRead<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter, is_leader, qpn,
                                    destAddr, lkey, raddr, rkey, transfer_size);
     } else if constexpr (PrvdType == core::ProviderType::BNXT) {
-      wq->outstandingWqe[my_sq_counter % wq->sqWqeNum] = my_sq_counter;
       dbr_val =
           core::PostRead<PrvdType>(*wq, my_sq_counter, my_msntbl_counter, my_psn_counter, is_leader,
                                    qpn, destAddr, lkey, raddr, rkey, transfer_size);

--- a/include/mori/shmem/shmem_ibgda_kernels.hpp
+++ b/include/mori/shmem/shmem_ibgda_kernels.hpp
@@ -104,6 +104,24 @@ namespace shmem {
     }                                                                       \
   } while (0)
 
+// Exclusive prefix sum of per-lane psnCnt over active lanes; warp-wide total via
+// outTotal. Used for bnxt PSN accounting when lanes transfer different sizes.
+inline __device__ uint32_t WarpActivePsnPrefix(uint32_t psnCnt, uint64_t activemask,
+                                               uint32_t* outTotal) {
+  const uint32_t myPhys = static_cast<uint32_t>(core::WarpLaneId());
+  uint32_t excl = 0, total = 0;
+  uint64_t m = activemask;
+  while (m) {
+    int l = __ffsll(static_cast<unsigned long long>(m)) - 1;
+    uint32_t v = __shfl(psnCnt, l);
+    total += v;
+    if (static_cast<uint32_t>(l) < myPhys) excl += v;
+    m &= m - 1;
+  }
+  *outTotal = total;
+  return excl;
+}
+
 /* ---------------------------------------------------------------------------------------------- */
 /*                                    VMM Heap Helper Functions                                   */
 /* ---------------------------------------------------------------------------------------------- */
@@ -504,18 +522,19 @@ inline __device__ void ShmemPutMemNbiThreadKernelImpl(const application::SymmMem
     uint32_t warp_msntbl_counter{0}, warp_psn_counter{0};
     uint32_t my_sq_counter{0}, my_msntbl_counter{0}, my_psn_counter{0};
     uint32_t psnCnt = 0;
+    uint32_t warp_total_psn = 0, my_psn_excl = 0;
 
     if constexpr (PrvdType == core::ProviderType::BNXT) {
       psnCnt = (transfer_size + wq->mtuSize - 1) / wq->mtuSize;
+      my_psn_excl = WarpActivePsnPrefix(psnCnt, activemask, &warp_total_psn);
     }
     if (is_leader) {
       if constexpr (PrvdType == core::ProviderType::MLX5) {
         warp_sq_counter = __hip_atomic_fetch_add(&wq->postIdx, num_active_lanes, __ATOMIC_RELAXED,
                                                  __HIP_MEMORY_SCOPE_AGENT);
       } else if constexpr (PrvdType == core::ProviderType::BNXT) {
-        core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_active_lanes,
-                                            psnCnt * num_active_lanes, &warp_msntbl_counter,
-                                            &warp_psn_counter);
+        core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_active_lanes, warp_total_psn,
+                                            &warp_msntbl_counter, &warp_psn_counter);
         warp_sq_counter = warp_msntbl_counter;
         __hip_atomic_fetch_max(&wq->postIdx, warp_sq_counter + num_active_lanes, __ATOMIC_RELAXED,
                                __HIP_MEMORY_SCOPE_AGENT);
@@ -534,7 +553,7 @@ inline __device__ void ShmemPutMemNbiThreadKernelImpl(const application::SymmMem
       warp_psn_counter = __shfl(warp_psn_counter, leader_phys_lane_id);
       my_sq_counter = warp_sq_counter + my_logical_lane_id;
       my_msntbl_counter = warp_msntbl_counter + my_logical_lane_id;
-      my_psn_counter = warp_psn_counter + psnCnt * my_logical_lane_id;
+      my_psn_counter = warp_psn_counter + my_psn_excl;
     } else if constexpr (PrvdType == core::ProviderType::PSD) {
       my_sq_counter = warp_sq_counter + my_logical_lane_id;
     } else {
@@ -886,24 +905,25 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelImpl(
     uint32_t warp_msntbl_counter{0}, warp_psn_counter{0};
     uint32_t my_sq_counter{0}, my_msntbl_counter{0}, my_psn_counter{0};
     uint32_t psnCnt = 0;
+    uint32_t warp_total_psn = 0, my_psn_excl = 0;
     // For last chunk: add 1 WQE for signal; for other chunks: just put
     uint32_t num_wqes = isLastChunk ? (onlyOneSignal ? num_active_lanes + 1 : num_active_lanes * 2)
                                     : num_active_lanes;
 
     if constexpr (PrvdType == core::ProviderType::BNXT) {
       psnCnt = (transfer_size + wq->mtuSize - 1) / wq->mtuSize;
+      // Per-lane PSN unit includes this lane's signal WQE when each lane signals.
+      uint32_t psnUnit = (isLastChunk && !onlyOneSignal) ? (psnCnt + 1) : psnCnt;
+      my_psn_excl = WarpActivePsnPrefix(psnUnit, activemask, &warp_total_psn);
+      if (isLastChunk && onlyOneSignal) warp_total_psn += 1;
     }
     if (is_leader) {
       if constexpr (PrvdType == core::ProviderType::MLX5) {
         warp_sq_counter = __hip_atomic_fetch_add(&wq->postIdx, num_wqes, __ATOMIC_RELAXED,
                                                  __HIP_MEMORY_SCOPE_AGENT);
       } else if constexpr (PrvdType == core::ProviderType::BNXT) {
-        uint32_t total_psn = psnCnt * num_active_lanes;
-        if (isLastChunk) {
-          total_psn += (onlyOneSignal ? 1 : num_active_lanes);
-        }
-        core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_wqes, total_psn, &warp_msntbl_counter,
-                                            &warp_psn_counter);
+        core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_wqes, warp_total_psn,
+                                            &warp_msntbl_counter, &warp_psn_counter);
         warp_sq_counter = warp_msntbl_counter;
         __hip_atomic_fetch_max(&wq->postIdx, warp_sq_counter + num_wqes, __ATOMIC_RELAXED,
                                __HIP_MEMORY_SCOPE_AGENT);
@@ -926,9 +946,7 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelImpl(
       my_msntbl_counter =
           warp_msntbl_counter +
           (isLastChunk && !onlyOneSignal ? my_logical_lane_id * 2 : my_logical_lane_id);
-      my_psn_counter =
-          warp_psn_counter + (isLastChunk && !onlyOneSignal ? (psnCnt + 1) * my_logical_lane_id
-                                                            : psnCnt * my_logical_lane_id);
+      my_psn_counter = warp_psn_counter + my_psn_excl;
     } else if constexpr (PrvdType == core::ProviderType::PSD) {
       my_sq_counter = warp_sq_counter +
                       (isLastChunk && !onlyOneSignal ? my_logical_lane_id * 2 : my_logical_lane_id);
@@ -1636,18 +1654,19 @@ inline __device__ void ShmemPutMemNbiThreadKernelAddrImpl(const void* dest, cons
     uint32_t warp_msntbl_counter{0}, warp_psn_counter{0};
     uint32_t my_sq_counter{0}, my_msntbl_counter{0}, my_psn_counter{0};
     uint32_t psnCnt = 0;
+    uint32_t warp_total_psn = 0, my_psn_excl = 0;
 
     if constexpr (PrvdType == core::ProviderType::BNXT) {
       psnCnt = (transfer_size + wq->mtuSize - 1) / wq->mtuSize;
+      my_psn_excl = WarpActivePsnPrefix(psnCnt, activemask, &warp_total_psn);
     }
     if (is_leader) {
       if constexpr (PrvdType == core::ProviderType::MLX5) {
         warp_sq_counter = __hip_atomic_fetch_add(&wq->postIdx, num_active_lanes, __ATOMIC_RELAXED,
                                                  __HIP_MEMORY_SCOPE_AGENT);
       } else if constexpr (PrvdType == core::ProviderType::BNXT) {
-        core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_active_lanes,
-                                            psnCnt * num_active_lanes, &warp_msntbl_counter,
-                                            &warp_psn_counter);
+        core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_active_lanes, warp_total_psn,
+                                            &warp_msntbl_counter, &warp_psn_counter);
         warp_sq_counter = warp_msntbl_counter;
         __hip_atomic_fetch_max(&wq->postIdx, warp_sq_counter + num_active_lanes, __ATOMIC_RELAXED,
                                __HIP_MEMORY_SCOPE_AGENT);
@@ -1666,7 +1685,7 @@ inline __device__ void ShmemPutMemNbiThreadKernelAddrImpl(const void* dest, cons
       warp_psn_counter = __shfl(warp_psn_counter, leader_phys_lane_id);
       my_sq_counter = warp_sq_counter + my_logical_lane_id;
       my_msntbl_counter = warp_msntbl_counter + my_logical_lane_id;
-      my_psn_counter = warp_psn_counter + my_logical_lane_id * psnCnt;
+      my_psn_counter = warp_psn_counter + my_psn_excl;
     } else if constexpr (PrvdType == core::ProviderType::PSD) {
       my_sq_counter = warp_sq_counter + my_logical_lane_id;
     } else {
@@ -1995,24 +2014,25 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelAddrImpl(
     uint32_t warp_msntbl_counter{0}, warp_psn_counter{0};
     uint32_t my_sq_counter{0}, my_msntbl_counter{0}, my_psn_counter{0};
     uint32_t psnCnt = 0;
+    uint32_t warp_total_psn = 0, my_psn_excl = 0;
     // For last chunk: add 1 WQE for signal; for other chunks: just put
     uint32_t num_wqes = isLastChunk ? (onlyOneSignal ? num_active_lanes + 1 : num_active_lanes * 2)
                                     : num_active_lanes;
 
     if constexpr (PrvdType == core::ProviderType::BNXT) {
       psnCnt = (transfer_size + wq->mtuSize - 1) / wq->mtuSize;
+      // Per-lane PSN unit includes this lane's signal WQE when each lane signals.
+      uint32_t psnUnit = (isLastChunk && !onlyOneSignal) ? (psnCnt + 1) : psnCnt;
+      my_psn_excl = WarpActivePsnPrefix(psnUnit, activemask, &warp_total_psn);
+      if (isLastChunk && onlyOneSignal) warp_total_psn += 1;
     }
     if (is_leader) {
       if constexpr (PrvdType == core::ProviderType::MLX5) {
         warp_sq_counter = __hip_atomic_fetch_add(&wq->postIdx, num_wqes, __ATOMIC_RELAXED,
                                                  __HIP_MEMORY_SCOPE_AGENT);
       } else if constexpr (PrvdType == core::ProviderType::BNXT) {
-        uint32_t total_psn = psnCnt * num_active_lanes;
-        if (isLastChunk) {
-          total_psn += (onlyOneSignal ? 1 : num_active_lanes);
-        }
-        core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_wqes, total_psn, &warp_msntbl_counter,
-                                            &warp_psn_counter);
+        core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_wqes, warp_total_psn,
+                                            &warp_msntbl_counter, &warp_psn_counter);
         warp_sq_counter = warp_msntbl_counter;
         __hip_atomic_fetch_max(&wq->postIdx, warp_sq_counter + num_wqes, __ATOMIC_RELAXED,
                                __HIP_MEMORY_SCOPE_AGENT);
@@ -2035,9 +2055,7 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelAddrImpl(
       my_msntbl_counter =
           warp_msntbl_counter +
           (isLastChunk && !onlyOneSignal ? my_logical_lane_id * 2 : my_logical_lane_id);
-      my_psn_counter =
-          warp_psn_counter + (isLastChunk && !onlyOneSignal ? (psnCnt + 1) * my_logical_lane_id
-                                                            : psnCnt * my_logical_lane_id);
+      my_psn_counter = warp_psn_counter + my_psn_excl;
     } else if constexpr (PrvdType == core::ProviderType::PSD) {
       my_sq_counter = warp_sq_counter +
                       (isLastChunk && !onlyOneSignal ? my_logical_lane_id * 2 : my_logical_lane_id);
@@ -2630,18 +2648,19 @@ inline __device__ void ShmemGetMemNbiThreadKernelImpl(const application::SymmMem
     uint32_t warp_msntbl_counter{0}, warp_psn_counter{0};
     uint32_t my_sq_counter{0}, my_msntbl_counter{0}, my_psn_counter{0};
     uint32_t psnCnt = 0;
+    uint32_t warp_total_psn = 0, my_psn_excl = 0;
 
     if constexpr (PrvdType == core::ProviderType::BNXT) {
       psnCnt = (transfer_size + wq->mtuSize - 1) / wq->mtuSize;
+      my_psn_excl = WarpActivePsnPrefix(psnCnt, activemask, &warp_total_psn);
     }
     if (is_leader) {
       if constexpr (PrvdType == core::ProviderType::MLX5) {
         warp_sq_counter = __hip_atomic_fetch_add(&wq->postIdx, num_active_lanes, __ATOMIC_RELAXED,
                                                  __HIP_MEMORY_SCOPE_AGENT);
       } else if constexpr (PrvdType == core::ProviderType::BNXT) {
-        core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_active_lanes,
-                                            psnCnt * num_active_lanes, &warp_msntbl_counter,
-                                            &warp_psn_counter);
+        core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_active_lanes, warp_total_psn,
+                                            &warp_msntbl_counter, &warp_psn_counter);
         warp_sq_counter = warp_msntbl_counter;
         __hip_atomic_fetch_max(&wq->postIdx, warp_sq_counter + num_active_lanes, __ATOMIC_RELAXED,
                                __HIP_MEMORY_SCOPE_AGENT);
@@ -2660,7 +2679,7 @@ inline __device__ void ShmemGetMemNbiThreadKernelImpl(const application::SymmMem
       warp_psn_counter = __shfl(warp_psn_counter, leader_phys_lane_id);
       my_sq_counter = warp_sq_counter + my_logical_lane_id;
       my_msntbl_counter = warp_msntbl_counter + my_logical_lane_id;
-      my_psn_counter = warp_psn_counter + psnCnt * my_logical_lane_id;
+      my_psn_counter = warp_psn_counter + my_psn_excl;
     } else if constexpr (PrvdType == core::ProviderType::PSD) {
       my_sq_counter = warp_sq_counter + my_logical_lane_id;
     } else {
@@ -2842,18 +2861,19 @@ inline __device__ void ShmemGetMemNbiThreadKernelAddrImpl(void* dest, const void
     uint32_t warp_msntbl_counter{0}, warp_psn_counter{0};
     uint32_t my_sq_counter{0}, my_msntbl_counter{0}, my_psn_counter{0};
     uint32_t psnCnt = 0;
+    uint32_t warp_total_psn = 0, my_psn_excl = 0;
 
     if constexpr (PrvdType == core::ProviderType::BNXT) {
       psnCnt = (transfer_size + wq->mtuSize - 1) / wq->mtuSize;
+      my_psn_excl = WarpActivePsnPrefix(psnCnt, activemask, &warp_total_psn);
     }
     if (is_leader) {
       if constexpr (PrvdType == core::ProviderType::MLX5) {
         warp_sq_counter = __hip_atomic_fetch_add(&wq->postIdx, num_active_lanes, __ATOMIC_RELAXED,
                                                  __HIP_MEMORY_SCOPE_AGENT);
       } else if constexpr (PrvdType == core::ProviderType::BNXT) {
-        core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_active_lanes,
-                                            psnCnt * num_active_lanes, &warp_msntbl_counter,
-                                            &warp_psn_counter);
+        core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_active_lanes, warp_total_psn,
+                                            &warp_msntbl_counter, &warp_psn_counter);
         warp_sq_counter = warp_msntbl_counter;
         __hip_atomic_fetch_max(&wq->postIdx, warp_sq_counter + num_active_lanes, __ATOMIC_RELAXED,
                                __HIP_MEMORY_SCOPE_AGENT);
@@ -2872,7 +2892,7 @@ inline __device__ void ShmemGetMemNbiThreadKernelAddrImpl(void* dest, const void
       warp_psn_counter = __shfl(warp_psn_counter, leader_phys_lane_id);
       my_sq_counter = warp_sq_counter + my_logical_lane_id;
       my_msntbl_counter = warp_msntbl_counter + my_logical_lane_id;
-      my_psn_counter = warp_psn_counter + my_logical_lane_id * psnCnt;
+      my_psn_counter = warp_psn_counter + my_psn_excl;
     } else if constexpr (PrvdType == core::ProviderType::PSD) {
       my_sq_counter = warp_sq_counter + my_logical_lane_id;
     } else {

--- a/include/mori/shmem/shmem_ibgda_kernels.hpp
+++ b/include/mori/shmem/shmem_ibgda_kernels.hpp
@@ -189,20 +189,9 @@ inline __device__ void VmmLookupRemote(uintptr_t addr, int pe, uintptr_t& out_ra
 /* ---------------------------------------------------------------------------------------------- */
 /*                                         Synchronization                                        */
 /* ---------------------------------------------------------------------------------------------- */
-// Drain a collapsed (one-CQE, cqeNum==1) bnxt CQ and advance wq.doneIdx. The NIC
-// keeps the latest completion in CQE[0]; its 16-bit con_indx gives the completed
-// WQE slot (con_indx % sqWqeNum == completed-count % sqWqeNum, the same identity
-// the old outstandingWqe[] table relied on). Reconstruct the 32-bit monotonic
-// completed count by anchoring on dbTouchIdx (the true upper bound of completions):
-// the unique value V <= dbTouchIdx with V % sqWqeNum == con_indx % sqWqeNum, which
-// is unambiguous because outstanding (dbTouchIdx - doneIdx) <= sqWqeNum. This
-// removes the per-WQE wq.outstandingWqe[] slot->counter table entirely. sqWqeNum is
-// a power of two, so the modulus is a mask. Lock-free / multi-warp safe via
-// atomicMax on doneIdx, mirroring Mlx5CollapsedCqDrain.
-//
-// DrainToLive=false: exit at a snapshot of dbTouchIdx (recycle gate -- just free
-// some slots). true: re-read the live postIdx and wait until every reserved WQE
-// has completed, so no send can still be reading its source (final quiet).
+// Drain a collapsed (cqeNum==1) bnxt CQ and advance wq.doneIdx, reconstructing the
+// completed count from CQE[0].con_indx (lock-free, mirrors Mlx5CollapsedCqDrain).
+// DrainToLive=false drains to a dbTouchIdx snapshot; true waits for the live postIdx.
 template <bool DrainToLive = false>
 inline __device__ void BnxtCollapsedCqDrain(core::WorkQueueHandle& wq,
                                             core::CompletionQueueHandle& cq) {


### PR DESCRIPTION
Apply the mlx5 collapsed-CQ approach to bnxt (one-CQE mode) and fix two related issues.

- Add BnxtCollapsedCqDrain (DrainToLive): reconstruct doneIdx from CQE[0].con_indx instead of the outstandingWqe[] table; lock-free, mirrors Mlx5CollapsedCqDrain.
- Remove the outstandingWqe[65536] member from WorkQueueHandle (512 KB per WQ, GPU-resident); dist_rdma_ops reconstructs completions the same way.
- Fix bnxt MSN/PSN accounting in put/get/putSignal thread kernels: lanes can transfer different sizes, so reserve the warp-wide sum of per-lane psnCnt and place each lane at the exclusive prefix sum (was psnCnt*laneId, which gaps/overlaps when sizes differ). Identical for uniform sizes; correct when they vary.

Validated on MI300X + bnxt: IBGDA put/get/imm/signal/atomic, p2p bandwidth/latency, and EP internode_v1 (113 passed).
