### PR TITLE
feat(ep): add AccumNum=9 vec8 intranode combine for shared-expert fusion

### DIFF
--- a/include/mori/core/transport/p2p/device_primitives.hpp
+++ b/include/mori/core/transport/p2p/device_primitives.hpp
@@ -1774,13 +1774,12 @@ __device__ __forceinline__ void WarpAccumFp8DequantFullImpl(
   }
 }
 
-template <typename OutT, typename Fp8T, int BlockElems>
+template <typename OutT, typename Fp8T, int BlockElems, int AccumNum = 8>
 __device__ __forceinline__ void WarpAccumFp8DequantFullBlockVec8Top8(
     OutT* __restrict__ dstToken, const Fp8T* const* __restrict__ srcs,
     const float* const* __restrict__ srcScales, int hiddenDim) {
   static_assert(BlockElems > 0 && (BlockElems & (BlockElems - 1)) == 0,
                 "BlockElems must be a positive power of two");
-  constexpr int AccumNum = 8;
 
   const int laneId = threadIdx.x & (warpSize - 1);
   const Fp8T* cachedSrcs[AccumNum];
@@ -2016,13 +2015,12 @@ __device__ __forceinline__ void WarpAccumFp8DequantSegmentImpl(
 }
 
 // Caller must ensure hiddenDimOffset and hiddenDimSize are 8-byte aligned.
-template <typename OutT, typename Fp8T, int BlockElems>
+template <typename OutT, typename Fp8T, int BlockElems, int AccumNum = 8>
 __device__ __forceinline__ void WarpAccumFp8DequantSegmentBlockVec8Top8(
     OutT* __restrict__ dstToken, const Fp8T* const* __restrict__ srcs,
     const float* const* __restrict__ srcScales, int hiddenDimOffset, int hiddenDimSize) {
   static_assert(BlockElems > 0 && (BlockElems & (BlockElems - 1)) == 0,
                 "BlockElems must be a positive power of two");
-  constexpr int AccumNum = 8;
 
   const int laneId = threadIdx.x & (warpSize - 1);
   if (hiddenDimSize <= 0) return;
@@ -2052,16 +2050,15 @@ __device__ __forceinline__ void WarpAccumFp8DequantSegmentBlockVec8Top8(
       /*blockElems=*/BlockElems);
 }
 
-// Scalar fallback for the rare misaligned-segment case in the AccumNum=8 vec8 path. Kept tiny
-// on purpose: delegating to WarpAccumFp8DequantSegmentImpl<...,8> would drag the generic
+// Scalar fallback for the rare misaligned-segment case in the vec8 path. Kept tiny
+// on purpose: delegating to WarpAccumFp8DequantSegmentImpl<...,AccumNum> would drag the generic
 // vec16/vec8/vec4 dispatch tree into the caller and push num_vgpr from 79 back to 128.
-template <typename OutT, typename Fp8T, int BlockElems>
+template <typename OutT, typename Fp8T, int BlockElems, int AccumNum = 8>
 __device__ __forceinline__ void WarpAccumFp8DequantSegmentScalarTop8(
     OutT* __restrict__ dstToken, const Fp8T* const* __restrict__ srcs,
     const float* const* __restrict__ srcScales, int hiddenDimOffset, int hiddenDimSize) {
   static_assert(BlockElems > 0 && (BlockElems & (BlockElems - 1)) == 0,
                 "BlockElems must be a positive power of two");
-  constexpr int AccumNum = 8;
   constexpr int kBlockShift = __builtin_ctz(BlockElems);
 
   const int laneId = threadIdx.x & (warpSize - 1);

--- a/python/mori/ops/dispatch_combine.py
+++ b/python/mori/ops/dispatch_combine.py
@@ -1008,28 +1008,39 @@ class EpDispatchCombineOp:
             EpDispatchCombineKernelType.IntraNodeLL.value,
         ):
             if quant_type == EpDispatchCombineQuantType.Fp8BlockwiseQuant:
-                # Mirror of the AccumNum=8 + VecBytes=8 specialization gating in
-                # LaunchCombine() / launch.cpp. Keep in sync.
+                # Mirror of the AccumNum=8/9 + VecBytes=8 specialization gating in
+                # LaunchCombine() / launch.cpp. top-k==9 covers shared-expert fusion
+                # (8 routed + 1 fused shared). Keep in sync.
                 fp8_scale_dim = self._fp8_blockwise_combine_scale_dim
                 block_elems = (hidden_dim + fp8_scale_dim - 1) // fp8_scale_dim
                 base_vec8_top8_eligible = (
                     weight_ptr == 0
                     and (hidden_dim % 512) == 0
-                    and self.config.num_experts_per_token == 8
+                    and self.config.num_experts_per_token in (8, 9)
                     and self.config.world_size > 4
                 )
+                top9 = self.config.num_experts_per_token == 9
                 kernel_name = "EpCombineIntraNodeKernel_bf16_nop2p_fp8bwq"
                 use_vec8_top8 = False
                 if base_vec8_top8_eligible:
                     if block_elems == 128:
-                        kernel_name = "EpCombineIntraNodeKernel_bf16_nop2p_fp8bwq_noweight_block128_vec8"
+                        kernel_name = (
+                            "EpCombineIntraNodeKernel_bf16_nop2p_fp8bwq_noweight_block128_vec8_top9"
+                            if top9
+                            else "EpCombineIntraNodeKernel_bf16_nop2p_fp8bwq_noweight_block128_vec8"
+                        )
                         use_vec8_top8 = True
                     elif block_elems == 256:
-                        kernel_name = "EpCombineIntraNodeKernel_bf16_nop2p_fp8bwq_noweight_block256_vec8"
+                        kernel_name = (
+                            "EpCombineIntraNodeKernel_bf16_nop2p_fp8bwq_noweight_block256_vec8_top9"
+                            if top9
+                            else "EpCombineIntraNodeKernel_bf16_nop2p_fp8bwq_noweight_block256_vec8"
+                        )
                         use_vec8_top8 = True
                 shared_mem = self._combine_shared_mem(
                     actual_wpb, use_weights=not use_vec8_top8
                 )
+                self._last_combine_kernel_name = kernel_name
                 self._launch(
                     kernel_name,
                     grid,

--- a/src/ops/dispatch_combine/intranode.hpp
+++ b/src/ops/dispatch_combine/intranode.hpp
@@ -470,7 +470,7 @@ __global__ void EpDispatchIntraNodeKernel(EpDispatchCombineArgs<T> args) {
 /* ---------------------------------------------------------------------------------------------- */
 template <typename T, bool UseP2PRead = true, bool EnableStdMoE = false,
           bool UseFp8DirectCast = false, bool UseFp8BlockwiseQuant = false, bool UseWeights = true,
-          int Vec8Top8BlockElems = 0>
+          int Vec8Top8BlockElems = 0, int Vec8AccumNum = 8>
 __device__ __forceinline__ void EpCombineIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   using TokT =
       std::conditional_t<UseFp8DirectCast || UseFp8BlockwiseQuant, core::CombineInternalFp8, T>;
@@ -744,18 +744,18 @@ __device__ __forceinline__ void EpCombineIntraNodeKernel_body(EpDispatchCombineA
       if constexpr (Vec8Top8BlockElems != 0) {
         if (mwIter.warpsPerItem == 1) {
           core::WarpAccumFp8DequantFullBlockVec8Top8<T, core::CombineInternalFp8,
-                                                     Vec8Top8BlockElems>(
+                                                     Vec8Top8BlockElems, Vec8AccumNum>(
               outPtr, reinterpret_cast<const core::CombineInternalFp8* const*>(srcPtrs),
               reinterpret_cast<const float* const*>(srcScalePtrs), hiddenDim);
         } else if ((hiddenDimOffset & 0x7) == 0 && (hiddenDimSize & 0x7) == 0) {
           core::WarpAccumFp8DequantSegmentBlockVec8Top8<T, core::CombineInternalFp8,
-                                                        Vec8Top8BlockElems>(
+                                                        Vec8Top8BlockElems, Vec8AccumNum>(
               outPtr, reinterpret_cast<const core::CombineInternalFp8* const*>(srcPtrs),
               reinterpret_cast<const float* const*>(srcScalePtrs), hiddenDimOffset, hiddenDimSize);
         } else {
           // Misaligned segment: vec8 helper would fault on the load. Tiny scalar fallback.
           core::WarpAccumFp8DequantSegmentScalarTop8<T, core::CombineInternalFp8,
-                                                     Vec8Top8BlockElems>(
+                                                     Vec8Top8BlockElems, Vec8AccumNum>(
               outPtr, reinterpret_cast<const core::CombineInternalFp8* const*>(srcPtrs),
               reinterpret_cast<const float* const*>(srcScalePtrs), hiddenDimOffset, hiddenDimSize);
         }
@@ -796,10 +796,10 @@ __device__ __forceinline__ void EpCombineIntraNodeKernel_body(EpDispatchCombineA
 
 template <typename T, bool UseP2PRead = true, bool EnableStdMoE = false,
           bool UseFp8DirectCast = false, bool UseFp8BlockwiseQuant = false, bool UseWeights = true,
-          int Vec8Top8BlockElems = 0>
+          int Vec8Top8BlockElems = 0, int Vec8AccumNum = 8>
 __global__ void EpCombineIntraNodeKernel(EpDispatchCombineArgs<T> args) {
   EpCombineIntraNodeKernel_body<T, UseP2PRead, EnableStdMoE, UseFp8DirectCast, UseFp8BlockwiseQuant,
-                                UseWeights, Vec8Top8BlockElems>(args);
+                                UseWeights, Vec8Top8BlockElems, Vec8AccumNum>(args);
 }
 
 }  // namespace moe

--- a/src/ops/dispatch_combine/launch.cpp
+++ b/src/ops/dispatch_combine/launch.cpp
@@ -541,15 +541,15 @@ void LaunchCombine(EpDispatchCombineHandle& handle, void* input, void* weights, 
         if (fp8ScaleDim <= 0) {
           throw std::runtime_error("Fp8BlockwiseQuant requires internal combine scaleDim > 0");
         }
-        // Pick the AccumNum=8/9 + VecBytes=8 specialization when (no weights, hidden_dim % 512 == 0,
-        // top-k in {8,9}, EP > 4) and block_elems matches a registered symbol. top-k==9 covers
+        // Pick the AccumNum=8/9 + VecBytes=8 specialization when (no weights, hidden_dim % 512 ==
+        // 0, top-k in {8,9}, EP > 4) and block_elems matches a registered symbol. top-k==9 covers
         // shared-expert fusion (8 routed + 1 fused shared). Keep in sync with the Python launch
         // path in dispatch_combine.py.
         const int block_elems = (args.config.hiddenDim + fp8ScaleDim - 1) / fp8ScaleDim;
-        const bool baseVec8Top8Eligible = !hasWeights && (args.config.hiddenDim % 512 == 0) &&
-                                          (args.config.numExpertPerToken == 8 ||
-                                           args.config.numExpertPerToken == 9) &&
-                                          args.config.worldSize > 4;
+        const bool baseVec8Top8Eligible =
+            !hasWeights && (args.config.hiddenDim % 512 == 0) &&
+            (args.config.numExpertPerToken == 8 || args.config.numExpertPerToken == 9) &&
+            args.config.worldSize > 4;
         const bool top9 = (args.config.numExpertPerToken == 9);
         const char* kernel_name = "EpCombineIntraNodeKernel_bf16_nop2p_fp8bwq";
         bool useVec8Top8 = false;

--- a/src/ops/dispatch_combine/launch.cpp
+++ b/src/ops/dispatch_combine/launch.cpp
@@ -541,21 +541,28 @@ void LaunchCombine(EpDispatchCombineHandle& handle, void* input, void* weights, 
         if (fp8ScaleDim <= 0) {
           throw std::runtime_error("Fp8BlockwiseQuant requires internal combine scaleDim > 0");
         }
-        // Pick the AccumNum=8 + VecBytes=8 specialization when (no weights, hidden_dim % 512 == 0,
-        // top-k == 8, EP > 4) and block_elems matches a registered symbol. Keep in sync with the
-        // Python launch path in dispatch_combine.py.
+        // Pick the AccumNum=8/9 + VecBytes=8 specialization when (no weights, hidden_dim % 512 == 0,
+        // top-k in {8,9}, EP > 4) and block_elems matches a registered symbol. top-k==9 covers
+        // shared-expert fusion (8 routed + 1 fused shared). Keep in sync with the Python launch
+        // path in dispatch_combine.py.
         const int block_elems = (args.config.hiddenDim + fp8ScaleDim - 1) / fp8ScaleDim;
         const bool baseVec8Top8Eligible = !hasWeights && (args.config.hiddenDim % 512 == 0) &&
-                                          args.config.numExpertPerToken == 8 &&
+                                          (args.config.numExpertPerToken == 8 ||
+                                           args.config.numExpertPerToken == 9) &&
                                           args.config.worldSize > 4;
+        const bool top9 = (args.config.numExpertPerToken == 9);
         const char* kernel_name = "EpCombineIntraNodeKernel_bf16_nop2p_fp8bwq";
         bool useVec8Top8 = false;
         if (baseVec8Top8Eligible) {
           if (block_elems == 128) {
-            kernel_name = "EpCombineIntraNodeKernel_bf16_nop2p_fp8bwq_noweight_block128_vec8";
+            kernel_name =
+                top9 ? "EpCombineIntraNodeKernel_bf16_nop2p_fp8bwq_noweight_block128_vec8_top9"
+                     : "EpCombineIntraNodeKernel_bf16_nop2p_fp8bwq_noweight_block128_vec8";
             useVec8Top8 = true;
           } else if (block_elems == 256) {
-            kernel_name = "EpCombineIntraNodeKernel_bf16_nop2p_fp8bwq_noweight_block256_vec8";
+            kernel_name =
+                top9 ? "EpCombineIntraNodeKernel_bf16_nop2p_fp8bwq_noweight_block256_vec8_top9"
+                     : "EpCombineIntraNodeKernel_bf16_nop2p_fp8bwq_noweight_block256_vec8";
             useVec8Top8 = true;
           }
         }

--- a/src/ops/kernels/ep_common.hip
+++ b/src/ops/kernels/ep_common.hip
@@ -104,6 +104,11 @@ using namespace mori::moe;
     kernel##_body<T, B1, B2, B3, B4, B5, B6>(args);                             \
   }
 
+#define WRAP_BOOL7(kernel, suffix, T, B1, B2, B3, B4, B5, B6, B7)               \
+  extern "C" __global__ void kernel##_##suffix(EpDispatchCombineArgs<T> args) { \
+    kernel##_body<T, B1, B2, B3, B4, B5, B6, B7>(args);                         \
+  }
+
 #define WRAP_ALL_TYPES_BOOL3(kernel, bool_suffix, B1, B2, B3)                               \
   WRAP_BOOL3(kernel, bf16##bool_suffix, hip_bfloat16, B1, B2, B3)                           \
   MORI_FP8_FNUZ(WRAP_BOOL3(kernel, fp8_fnuz##bool_suffix, __hip_fp8_e4m3_fnuz, B1, B2, B3)) \

--- a/src/ops/kernels/ep_intranode.hip
+++ b/src/ops/kernels/ep_intranode.hip
@@ -21,6 +21,12 @@ MORI_FP8_ANY(WRAP_BOOL6(EpCombineIntraNodeKernel, bf16_nop2p_fp8bwq_noweight_blo
                         hip_bfloat16, false, false, false, true, false, 128))
 MORI_FP8_ANY(WRAP_BOOL6(EpCombineIntraNodeKernel, bf16_nop2p_fp8bwq_noweight_block256_vec8,
                         hip_bfloat16, false, false, false, true, false, 256))
+// AccumNum=9 variants: shared-expert fusion routes every token through 9 sources
+// (8 routed + 1 fused shared expert, topk 8->9). Same weightless vec8 path as top8.
+MORI_FP8_ANY(WRAP_BOOL7(EpCombineIntraNodeKernel, bf16_nop2p_fp8bwq_noweight_block128_vec8_top9,
+                        hip_bfloat16, false, false, false, true, false, 128, 9))
+MORI_FP8_ANY(WRAP_BOOL7(EpCombineIntraNodeKernel, bf16_nop2p_fp8bwq_noweight_block256_vec8_top9,
+                        hip_bfloat16, false, false, false, true, false, 256, 9))
 
 // Convert (used with ENABLE_STANDARD_MOE_ADAPT)
 extern "C" __global__ void mori_ConvertDispatchOutputKernel(ConvertDispatchOutputArgs args) {

--- a/tests/python/ops/dispatch_combine_test_utils.py
+++ b/tests/python/ops/dispatch_combine_test_utils.py
@@ -668,7 +668,7 @@ class EpDispatchCombineTestCase:
                     )
                 assert weight_match
 
-    def run_test_once(self, op, test_data, check_results=True):
+    def run_test_once(self, op, test_data, check_results=True, weightless=False):
         (
             _,
             all_rank_indices,
@@ -710,7 +710,7 @@ class EpDispatchCombineTestCase:
             )
         combine_output, combine_output_weight = op.combine(
             dispatch_output,
-            dispatch_weights,
+            None if weightless else dispatch_weights,
             all_rank_indices[self.config.rank],
             call_reset=False,
         )
@@ -793,6 +793,8 @@ def run_ep_dispatch_combine_test(
     num_token_override=None,
     check_results=True,
     sentinel_pattern=None,
+    weightless=False,
+    expect_combine_kernel_substr=None,
 ):
     op = mori.ops.EpDispatchCombineOp(config)
     test_case = test_case_cls(config)
@@ -806,4 +808,13 @@ def run_ep_dispatch_combine_test(
     if sentinel_pattern is not None:
         gen_kwargs["sentinel_pattern"] = sentinel_pattern
     test_data = test_case.gen_test_data(**gen_kwargs)
-    test_case.run_test_once(op, test_data, check_results=check_results)
+    test_case.run_test_once(
+        op, test_data, check_results=check_results, weightless=weightless
+    )
+    if expect_combine_kernel_substr is not None:
+        selected = getattr(op, "_last_combine_kernel_name", None)
+        assert selected is not None and expect_combine_kernel_substr in selected, (
+            f"Rank[{config.rank}] expected combine kernel containing "
+            f"{expect_combine_kernel_substr!r} but ran {selected!r} "
+            "(gate fell back to the generic path)"
+        )

--- a/tests/python/ops/dispatch_combine_test_utils.py
+++ b/tests/python/ops/dispatch_combine_test_utils.py
@@ -808,9 +808,13 @@ def run_ep_dispatch_combine_test(
     if sentinel_pattern is not None:
         gen_kwargs["sentinel_pattern"] = sentinel_pattern
     test_data = test_case.gen_test_data(**gen_kwargs)
-    test_case.run_test_once(
-        op, test_data, check_results=check_results, weightless=weightless
-    )
+    # Only forward ``weightless`` when explicitly requested so test case
+    # subclasses that override ``run_test_once`` without the parameter
+    # (e.g. AsyncLLDispatchCombineTestCase) keep working with the default.
+    run_kwargs = {}
+    if weightless:
+        run_kwargs["weightless"] = True
+    test_case.run_test_once(op, test_data, check_results=check_results, **run_kwargs)
     if expect_combine_kernel_substr is not None:
         selected = getattr(op, "_last_combine_kernel_name", None)
         assert selected is not None and expect_combine_kernel_substr in selected, (

--- a/tests/python/ops/test_dispatch_combine_intranode.py
+++ b/tests/python/ops/test_dispatch_combine_intranode.py
@@ -84,6 +84,8 @@ def _test_dispatch_combine(
     use_max_token_num=False,
     check_results=True,
     sentinel_pattern=None,
+    weightless=False,
+    expect_combine_kernel_substr=None,
 ):
     config = _make_intranode_config(
         rank=rank,
@@ -106,6 +108,8 @@ def _test_dispatch_combine(
         use_max_token_num=use_max_token_num,
         routing=routing,
         check_results=check_results,
+        weightless=weightless,
+        expect_combine_kernel_substr=expect_combine_kernel_substr,
     )
 
 
@@ -204,6 +208,64 @@ def test_dispatch_combine(
                     scale_dim,
                     scale_type_size,
                     quant_type,
+                ],
+            )
+        )
+
+    assert_worker_results(torch_dist_process_manager, world_size)
+
+
+# Exercises the fast fp8_blockwise weightless vec8 combine kernels, including the
+# topk=9 (AccumNum=9) shared-experts-fusion specialization. hidden_dim=7168 with the
+# default MORI_FP8_COMBINE_SCALE_DIM=56 yields block_elems=128, so the gate fires and
+# we assert the specialized kernel was actually selected (guards against silent
+# fallback to the generic path, which would produce identical weightless numbers).
+@pytest.mark.parametrize("world_size", (8,))
+@pytest.mark.parametrize("data_type", (torch.bfloat16,))
+@pytest.mark.parametrize("hidden_dim", (7168,))
+@pytest.mark.parametrize("max_num_inp_token_per_rank", (128,))
+@pytest.mark.parametrize("num_experts_per_rank", (32,))
+@pytest.mark.parametrize("num_experts_per_token", (8, 9))
+@pytest.mark.parametrize("use_external_inp_buf", (True,))
+@pytest.mark.parametrize("quant_type", ("fp8_blockwise",))
+def test_dispatch_combine_weightless_vec8(
+    torch_dist_process_manager,
+    world_size,
+    data_type,
+    hidden_dim,
+    max_num_inp_token_per_rank,
+    num_experts_per_rank,
+    num_experts_per_token,
+    use_external_inp_buf,
+    quant_type,
+):
+    expect_combine_kernel_substr = (
+        "noweight_block128_vec8_top9"
+        if num_experts_per_token == 9
+        else "noweight_block128_vec8"
+    )
+    for i in range(world_size):
+        torch_dist_process_manager.task_queue.put(
+            (
+                _test_dispatch_combine,
+                [
+                    world_size,
+                    data_type,
+                    hidden_dim,
+                    max_num_inp_token_per_rank,
+                    num_experts_per_rank,
+                    num_experts_per_token,
+                    use_external_inp_buf,
+                    0,  # scale_dim
+                    1,  # scale_type_size
+                    quant_type,
+                    0,  # max_total_recv_tokens
+                    None,  # routing
+                    False,  # use_max_token_num
+                    True,  # check_results
+                    None,  # sentinel_pattern
+                    True,  # weightless
+                    expect_combine_kernel_substr,
                 ],
             )
         )


### PR DESCRIPTION
# feat(ep): add AccumNum=9 vec8 intranode combine for shared-expert fusion

## Summary

- Adds an **AccumNum=9** specialization of the fast weightless `fp8_blockwise` vec8 intranode combine kernel so **shared-expert fusion (topk 8→9)** can use the fast path instead of falling back to the generic combine.
- Generalizes the existing AccumNum=8 vec8 device helpers + the `EpCombineIntraNodeKernel` template on a new `AccumNum` template parameter (default 8) — no behavior change for existing top-8 callers.
- Relaxes the launch gate (C++ `launch.cpp` **and** the mirrored Python path in `dispatch_combine.py`) from a hardcoded `numExpertPerToken == 8` to `{8, 9}`, selecting the `_vec8_top9` symbol when topk == 9.
- Adds a weightless intranode combine test covering topk=8 and topk=9 that **asserts the specialized kernel was actually selected** (guards against silent fallback).

## Why

Shared-expert fusion folds the always-on shared expert in as an extra grouped-GEMM expert and raises the effective top-k from 8 to 9 (8 routed + 1 fused shared). The fast weightless `fp8_blockwise` vec8 combine path only had an AccumNum=8 specialization that unrolls over exactly 8 accumulation sources, so `numExpertPerToken == 9` failed the gate by construction and dropped to the slower generic combine kernel.

The combine call is already weightless in this path (the caller passes `weights=None`), so the only blocker was the hardcoded top-k. The fix is a new AccumNum=9 kernel instantiation plus the gate relax — the accumulation math is identical to the existing weightless path, just unrolled over 9 sources instead of 8.

## What changed

| File | Change |
|------|--------|
| `include/mori/core/transport/p2p/device_primitives.hpp` | `WarpAccumFp8DequantFullBlockVec8Top8` / `...SegmentBlockVec8Top8` / `...SegmentScalarTop8` gain an `int AccumNum = 8` template param (was `constexpr int AccumNum = 8`). |
| `src/ops/dispatch_combine/intranode.hpp` | `EpCombineIntraNodeKernel` body + global gain `int Vec8AccumNum = 8`, threaded into the three vec8 helper calls. |
| `src/ops/kernels/ep_common.hip` | New `WRAP_BOOL7` wrapper macro (7 non-type template args). |
| `src/ops/kernels/ep_intranode.hip` | Register `..._noweight_block128_vec8_top9` and `..._block256_vec8_top9` (AccumNum=9) symbols. |
| `src/ops/dispatch_combine/launch.cpp` | Gate accepts `numExpertPerToken in {8,9}`; selects `_top9` symbol when topk==9. |
| `python/mori/ops/dispatch_combine.py` | Mirror of the launch gate; records `_last_combine_kernel_name` for test introspection. |
| `tests/python/ops/dispatch_combine_test_utils.py` | `run_test_once` / `run_ep_dispatch_combine_test` gain `weightless` + `expect_combine_kernel_substr`; asserts the selected kernel. |
| `tests/python/ops/test_dispatch_combine_intranode.py` | New `test_dispatch_combine_weightless_vec8` (topk 8 and 9). |

## Trace verification
Before:
<img width="2955" height="81" alt="image" src="https://github.com/user-attachments/assets/461999c4-429c-4b44-8737-caab83695013" />

After:
<img width="3613" height="99" alt="image" src="https://github.com/user-attachments/assets/31d9777f-0ac5-4a26-a924-3987409fff2c" />


## Testing

Validated in a fresh container on MI355X (gfx950) against **current `main` (post-#392, the PR that rewrote the combine body)** — not just the fork base — to confirm the patch still applies and behaves correctly after the recent combine refactor.

- **Build:** C++ extension + JIT `ep_intranode.hsaco` rebuild clean; both `noweight_block128_vec8_top9` and `noweight_block256_vec8_top9` symbols present in the compiled HSACO.
- **New test (`test_dispatch_combine_weightless_vec8`): 2 passed** (topk 8 + topk 9). The topk=9 case asserts the runtime selected `noweight_block128_vec8_top9`, so a silent fallback to the generic path (which would produce identical weightless numbers) fails the test.
- **Top-8 regression (`test_dispatch_combine`): 128 passed, 0 failed** (16 fp8_blockwise + 112 none/fp8_direct_cast; remaining parametrizations skip on existing constraints).

CI note: the `intranode-test` job already runs `pytest tests/python/ops/test_dispatch_combine_intranode.py -v` (timeout 360s). The new test adds ~21s.

## End-to-end impact (DeepSeek-R1 MXFP4, MI355X, EP=8 offline)

Measured in the MLPerf offline harness under shared-expert fusion (topk=9), same RNG seeds and test parameters in both runs (apples-to-apples). The runtime confirmed selecting `EpCombineIntraNodeKernel_bf16_nop2p_fp8bwq_noweight_block128_vec8_top9` (topk=9, block_elems=128) on all 8 ranks. Both results VALID.

| Combine path | Tokens/s | Samples/s |
|--------------|----------|-----------|
| generic (before) | 31579.1 | 8.37529 |
| `vec8_top9` (this PR) | **32166.2** | **8.45422** |
| **Δ** | **+587.1 (+1.86%)** | +0.94% |

Accuracy is unchanged (accumulation math is identical to the generic weightless path).

---

Signed-off-by: Rita Brugarolas Brufau <rita.brugarolasbrufau@amd.com>
