### PR TITLE
(bench) add CCO api bench, similar to shmem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,18 @@ option(USE_ROCM "Whether to use rocm" ON)
 option(USE_BNXT "Whether to use BNXT NIC" OFF)
 option(USE_IONIC "Whether to use IONIC" OFF)
 option(BUILD_EXAMPLES "Whether to build examples" ON)
+option(BUILD_BENCHMARK "Whether to build benchmark targets" OFF)
+# MPI is required by mpi_bootstrap, the C++ examples, and every benchmark
+# target (all use the MPI multi-rank launcher), so default it on whenever
+# either is enabled.
+if(BUILD_EXAMPLES OR BUILD_BENCHMARK)
+  set(_with_mpi_default ON)
+else()
+  set(_with_mpi_default OFF)
+endif()
 option(WITH_MPI
-       "Enable MPI support (required for mpi_bootstrap and C++ examples)"
-       ${BUILD_EXAMPLES})
+       "Enable MPI support (required for mpi_bootstrap, C++ examples, benchmarks)"
+       ${_with_mpi_default})
 option(BUILD_APPLICATION "Whether to build application library" ON)
 option(BUILD_SHMEM "Whether to build shmem library" ON)
 option(BUILD_CCO "Whether to build cco library" ON)
@@ -36,7 +45,6 @@ option(BUILD_PYBINDS "Whether to build mori python bindings" ON)
 option(BUILD_XLA_FFI_OPS "Whether to build mori xla ffi python bindings" OFF)
 option(BUILD_UMBP "Whether to build UMBP (Unified Memory/Bandwidth Pool)" OFF)
 option(BUILD_TESTS "Whether to build mori CPP tests" ON)
-option(BUILD_BENCHMARK "Whether to build benchmark targets" OFF)
 option(ENABLE_PROFILER "Enable kernel profiling" OFF)
 option(ENABLE_DEBUG_PRINTF "Enable debug printf in device kernels" OFF)
 option(ENABLE_STANDARD_MOE_ADAPT "Enable standard moe adapt" OFF)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -44,6 +44,33 @@ function(add_mori_benchmark_app name)
   endif()
 endfunction()
 
+# --- CCO benchmark: HIP kernel TU + a shared host-CXX control-plane lib ---
+# CCO makes `ccoComm` host-only (opaque under __HIPCC__). util.cpp touches its
+# members, so it must compile as plain CXX, never as HIP. Putting it in its own
+# CXX static library guarantees that regardless of the per-target HIP language of
+# the kernel TUs. Each benchmark = one HIP kernel .cpp + this lib.
+function(add_mori_benchmark_cco name)
+  cmake_parse_arguments(ARG "" "" "SOURCES;LIBS;INCLUDES" ${ARGN})
+  if(NOT ARG_SOURCES)
+    message(FATAL_ERROR "add_mori_benchmark_cco(${name}): SOURCES required")
+  endif()
+  add_executable(${name} ${ARG_SOURCES})
+  set_source_files_properties(${ARG_SOURCES} PROPERTIES LANGUAGE HIP)
+  target_link_libraries(${name} PRIVATE cco_bench_util mori_cco mori_application
+                                        ibverbs hip::host hip::device ${ARG_LIBS})
+  target_include_directories(${name} PRIVATE ${CMAKE_SOURCE_DIR}/include
+                                             ${CMAKE_CURRENT_SOURCE_DIR}/cco)
+  if(DEFINED GPU_TARGETS)
+    set_target_properties(${name} PROPERTIES HIP_ARCHITECTURES "${GPU_TARGETS}")
+  endif()
+  if(MORI_DEVICE_NIC_DEFINE)
+    target_compile_definitions(${name} PRIVATE ${MORI_DEVICE_NIC_DEFINE})
+  endif()
+  if(ARG_INCLUDES)
+    target_include_directories(${name} PRIVATE ${ARG_INCLUDES})
+  endif()
+endfunction()
+
 # ---------------------------------------------------------------------------
 # Registered benchmark targets
 # ---------------------------------------------------------------------------
@@ -61,4 +88,34 @@ if(WITH_MPI)
                            shmem/util.cpp LIBS stdc++fs)
   add_mori_benchmark_shmem(p2p_get_latency SOURCES shmem/p2p_get_latency.cpp
                            shmem/util.cpp LIBS stdc++fs)
+endif()
+
+# --- CCO p2p benchmarks (LSA + IGBDA transports, MPI 2-rank launcher) ---
+if(WITH_MPI AND BUILD_CCO)
+  # Host control-plane (MPI + ccoComm lifecycle) as a plain CXX static lib, so it
+  # never gets the kernel TUs' HIP language (which would make ccoComm opaque).
+  add_library(cco_bench_util STATIC cco/util.cpp)
+  set_source_files_properties(cco/util.cpp PROPERTIES LANGUAGE CXX)
+  target_include_directories(cco_bench_util PRIVATE ${CMAKE_SOURCE_DIR}/include
+                                                    ${CMAKE_CURRENT_SOURCE_DIR}/cco
+                                                    ${MPI_CXX_INCLUDE_DIRS})
+  target_link_libraries(cco_bench_util PRIVATE mori_cco mori_application
+                                               hip::host ${MPI_CXX_LIBRARIES})
+  set_target_properties(cco_bench_util PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+  add_mori_benchmark_cco(cco_p2p_put_bw SOURCES cco/p2p_put_bw.cpp
+                         LIBS stdc++fs ${MPI_CXX_LIBRARIES}
+                         INCLUDES ${MPI_CXX_INCLUDE_DIRS})
+  add_mori_benchmark_cco(cco_p2p_put_latency SOURCES cco/p2p_put_latency.cpp
+                         LIBS stdc++fs ${MPI_CXX_LIBRARIES}
+                         INCLUDES ${MPI_CXX_INCLUDE_DIRS})
+  add_mori_benchmark_cco(cco_p2p_get_bw SOURCES cco/p2p_get_bw.cpp
+                         LIBS stdc++fs ${MPI_CXX_LIBRARIES}
+                         INCLUDES ${MPI_CXX_INCLUDE_DIRS})
+  add_mori_benchmark_cco(cco_p2p_get_latency SOURCES cco/p2p_get_latency.cpp
+                         LIBS stdc++fs ${MPI_CXX_LIBRARIES}
+                         INCLUDES ${MPI_CXX_INCLUDE_DIRS})
+elseif(WITH_MPI AND NOT BUILD_CCO)
+  message(WARNING
+    "BUILD_BENCHMARK=ON with BUILD_CCO=OFF: CCO p2p benchmark targets skipped")
 endif()

--- a/benchmark/cco/device_utils.hpp
+++ b/benchmark/cco/device_utils.hpp
@@ -1,0 +1,52 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Device-side helpers shared across the CCO p2p benchmark kernels. Include only
+// from HIP translation units.
+
+#pragma once
+
+#include "mori/cco/cco_scale_out.hpp"
+#include "util.hpp"
+
+namespace mori::cco::benchmark {
+
+// Intra-block linear thread index.
+__device__ inline int linear_tid() {
+  return threadIdx.x * blockDim.y * blockDim.z + threadIdx.y * blockDim.z + threadIdx.z;
+}
+
+// Strided element copy across [lane, nlanes): dst[i] = src[i] for i in [0, n).
+template <typename T>
+__device__ inline void lsa_copy_strided(T* __restrict__ dst, const T* __restrict__ src, size_t n,
+                                        int lane, int nlanes) {
+  for (size_t i = lane; i < n; i += static_cast<size_t>(nlanes)) {
+    dst[i] = src[i];
+  }
+}
+
+}  // namespace mori::cco::benchmark
+
+// CCO_GDA_DISPATCH is provided by mori/cco/cco_scale_out.hpp: GDA provider is
+// fixed at build time (per-NIC, from MORI_DEVICE_NIC_*), so the macro just binds
+// `constexpr auto P = CCO_GDA_BUILD_PROVIDER` and runs the statement — no
+// runtime provider argument.

--- a/benchmark/cco/p2p_get_bw.cpp
+++ b/benchmark/cco/p2p_get_bw.cpp
@@ -1,0 +1,196 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// CCO p2p get bandwidth — PE 0 pulls from PE 1's send window into its recv
+// window.
+//
+//   -T lsa   : intra-node flat-VA load loop (read peer slot → local).
+//   -T igbda : cross-node one-sided RDMA read via ccoGda<PrvdType>.
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#include "device_utils.hpp"
+#include "hip/hip_runtime.h"
+#include "mori/application/utils/check.hpp"
+#include "mori/cco/cco_scale_out.hpp"
+#include "util.hpp"
+
+namespace mori::cco::benchmark {
+
+// LSA: each block reads its chunk from the peer's send window into the local
+// recv window.
+__global__ void lsa_get_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin, size_t len_doubles,
+                           int peerLsa, int iter, int lanes) {
+  const int bid = blockIdx.x;
+  const int nblocks = gridDim.x;
+  const int tid = linear_tid();
+  if (tid >= lanes) return;
+
+  const size_t chunk = len_doubles / static_cast<size_t>(nblocks);
+  const size_t off_bytes = static_cast<size_t>(bid) * chunk * sizeof(double);
+
+  const double* src =
+      reinterpret_cast<const double*>(ccoGetLsaPeerPtr(sendWin, peerLsa, off_bytes));
+  double* dst = reinterpret_cast<double*>(ccoGetLocalPtr(recvWin, off_bytes));
+
+  for (int i = 0; i < iter; i++) {
+    lsa_copy_strided(dst, src, chunk, tid, lanes);
+    // Per-iteration system fence — see p2p_put_bw for the cache-absorption
+    // rationale (repeated same-region traffic otherwise measures cache BW).
+    __threadfence_system();
+  }
+}
+
+// IGBDA: one RDMA read per coop unit of its chunk.
+template <core::ProviderType PrvdType, typename Coop>
+__global__ void igbda_get_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin, size_t len_doubles,
+                             ccoDevComm devComm, int iter) {
+  Coop coop;
+  const int bid = blockIdx.x;
+  const int nblocks = gridDim.x;
+  ccoGda<PrvdType> gda{devComm, /*ginContext=*/bid};  // one QP context per block
+  const int peer = !devComm.rank;
+  const size_t chunk = len_doubles / static_cast<size_t>(nblocks);
+
+  const int tid = linear_tid();
+  const int unit = tid / coop.size();
+  const int nunits = (blockDim.x * blockDim.y * blockDim.z) / coop.size();
+  const size_t per_unit = chunk / static_cast<size_t>(nunits);
+  const size_t base = static_cast<size_t>(bid) * chunk + static_cast<size_t>(unit) * per_unit;
+  const size_t off_bytes = base * sizeof(double);
+  const size_t bytes = per_unit * sizeof(double);
+
+  // RDMA read completions are self-confirming (data has landed locally when the
+  // CQE is reaped). Pipeline the reads, one end flush drains the whole batch.
+  for (int i = 0; i < iter; i++) {
+    gda.get(peer, reinterpret_cast<ccoWindow_t>(sendWin), off_bytes,
+            reinterpret_cast<ccoWindow_t>(recvWin), off_bytes, bytes, coop);
+  }
+  gda.flush(ccoCoopBlock{});
+}
+
+static void launch_lsa(PutScope scope, dim3 grid, dim3 block, ccoWindow_t sendWin,
+                       ccoWindow_t recvWin, size_t len_doubles, int peerLsa, int count,
+                       int warp_size) {
+  int lanes = block.x;
+  if (scope == PutScope::kWarp) lanes = warp_size;
+  if (scope == PutScope::kThread) lanes = 1;
+  hipLaunchKernelGGL(lsa_get_bw, grid, block, 0, 0, sendWin, recvWin, len_doubles, peerLsa, count,
+                     lanes);
+}
+
+template <core::ProviderType PrvdType>
+static void launch_igbda(PutScope scope, dim3 grid, dim3 block, ccoWindow_t sendWin,
+                         ccoWindow_t recvWin, size_t len_doubles, ccoDevComm devComm, int count) {
+  switch (scope) {
+    case PutScope::kBlock:
+      hipLaunchKernelGGL((igbda_get_bw<PrvdType, ccoCoopBlock>), grid, block, 0, 0, sendWin,
+                         recvWin, len_doubles, devComm, count);
+      break;
+    case PutScope::kWarp:
+      hipLaunchKernelGGL((igbda_get_bw<PrvdType, ccoCoopWarp>), grid, block, 0, 0, sendWin, recvWin,
+                         len_doubles, devComm, count);
+      break;
+    case PutScope::kThread:
+      hipLaunchKernelGGL((igbda_get_bw<PrvdType, ccoCoopThread>), grid, block, 0, 0, sendWin,
+                         recvWin, len_doubles, devComm, count);
+      break;
+  }
+}
+
+}  // namespace mori::cco::benchmark
+
+int main(int argc, char** argv) {
+  using namespace mori::cco;
+  using namespace mori::cco::benchmark;
+
+  PerfContext ctx{};
+  const int init_rc = PerfInit(argc, argv, &ctx);
+  if (init_rc != 0) {
+    return init_rc == 2 ? 0 : 1;
+  }
+
+  PerfArgs& args = ctx.args;
+  const int my_pe = ctx.my_pe;
+  const bool run_kernels = (my_pe == 0);  // unidirectional: PE 0 pulls
+
+  const dim3 grid(args.nblocks, 1, 1);
+  const dim3 block(args.threads_per_block, 1, 1);
+
+  PerfRes res;
+  if (run_kernels) {
+    PerfResAlloc(&res);
+  }
+
+  std::vector<PerfTableRow> table;
+  if (my_pe == 0) {
+    table.reserve(64);
+  }
+
+  for (size_t size_bytes = args.min_size; size_bytes <= args.max_size;
+       size_bytes *= args.step_factor) {
+    if (size_bytes % sizeof(double) != 0) continue;
+    const size_t len_doubles = size_bytes / sizeof(double);
+
+    if (!size_ok(args.put_scope, size_bytes, args.nblocks, args.threads_per_block,
+                 ctx.device_warp_size)) {
+      if (my_pe == 0) table.push_back(PerfTableRow{size_bytes, true, 0.0});
+      ccoBarrierAll(ctx.comm);
+      continue;
+    }
+
+    if (run_kernels) {
+      const float ms = RunWarmupAndTimed(res, args.warmup, args.iters, [&](int count) {
+        if (args.transport == Transport::kLsa) {
+          launch_lsa(args.put_scope, grid, block, ctx.send_win, ctx.recv_win, len_doubles,
+                     ctx.peer_lsa_rank, count, ctx.device_warp_size);
+        } else {
+          CCO_GDA_DISPATCH(launch_igbda<P>(args.put_scope, grid, block, ctx.send_win, ctx.recv_win,
+                                           len_doubles, ctx.devComm, count));
+        }
+        HIP_RUNTIME_CHECK(hipGetLastError());
+      });
+
+      const double gbps = static_cast<double>(size_bytes) /
+                          (static_cast<double>(ms) * (kBToGb / (args.iters * kMsToS)));
+      table.push_back(PerfTableRow{size_bytes, false, gbps});
+    }
+
+    ccoBarrierAll(ctx.comm);
+  }
+
+  ccoBarrierAll(ctx.comm);
+  if (my_pe == 0) {
+    PrintPerfTable("p2p_get_bw unidirection", TransportToChar(args.transport),
+                   ScopeToChar(args.put_scope), args.nblocks, args.threads_per_block,
+                   ctx.device_warp_size, args.iters, args.warmup, PerfTableMetric::kBandwidthGbps,
+                   table);
+  }
+
+  if (run_kernels) {
+    PerfResFree(&res);
+  }
+  PerfFinalize(&ctx);
+  return 0;
+}

--- a/benchmark/cco/p2p_get_latency.cpp
+++ b/benchmark/cco/p2p_get_latency.cpp
@@ -1,0 +1,147 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// CCO p2p get latency — PE 0 pulls from PE 1, one op per iteration.
+//
+//   -T lsa   : single flat-VA load of the whole buffer per iteration.
+//   -T igbda : single RDMA read + flush per iteration.
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#include "device_utils.hpp"
+#include "hip/hip_runtime.h"
+#include "mori/application/utils/check.hpp"
+#include "mori/cco/cco_scale_out.hpp"
+#include "util.hpp"
+
+namespace mori::cco::benchmark {
+
+// LSA: one block reads the whole buffer from the peer's send window.
+__global__ void lsa_get_lat(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin, size_t len_doubles,
+                            int peerLsa, int iter) {
+  if (blockIdx.x != 0) return;
+  const int tid = linear_tid();
+  const int lanes = blockDim.x * blockDim.y * blockDim.z;
+
+  const double* src = reinterpret_cast<const double*>(ccoGetLsaPeerPtr(sendWin, peerLsa, 0));
+  double* dst = reinterpret_cast<double*>(ccoGetLocalPtr(recvWin, 0));
+
+  for (int i = 0; i < iter; i++) {
+    lsa_copy_strided(dst, src, len_doubles, tid, lanes);
+    __syncthreads();
+  }
+}
+
+// IGBDA: one block issues a single RDMA read of the whole buffer + flush per
+// iteration.
+template <core::ProviderType PrvdType>
+__global__ void igbda_get_lat(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
+                              size_t len_doubles, ccoDevComm devComm, int iter) {
+  if (blockIdx.x != 0) return;
+  ccoGda<PrvdType> gda{devComm, /*ginContext=*/0};
+  const int peer = !devComm.rank;
+  const size_t bytes = len_doubles * sizeof(double);
+
+  for (int i = 0; i < iter; i++) {
+    gda.get(peer, reinterpret_cast<ccoWindow_t>(sendWin), 0, reinterpret_cast<ccoWindow_t>(recvWin),
+            0, bytes, ccoCoopBlock{});
+    gda.flush(ccoCoopWarp{});
+  }
+}
+
+}  // namespace mori::cco::benchmark
+
+int main(int argc, char** argv) {
+  using namespace mori::cco;
+  using namespace mori::cco::benchmark;
+
+  PerfContext ctx{};
+  const int init_rc = PerfInit(argc, argv, &ctx);
+  if (init_rc != 0) {
+    return init_rc == 2 ? 0 : 1;
+  }
+
+  PerfArgs& args = ctx.args;
+  const int my_pe = ctx.my_pe;
+  const bool run_kernels = (my_pe == 0);
+
+  const int block_threads =
+      LatencyBlockThreads(args.put_scope, args.threads_per_block, ctx.device_warp_size);
+  const dim3 grid(1, 1, 1);
+  const dim3 block(block_threads, 1, 1);
+
+  PerfRes res;
+  if (run_kernels) {
+    PerfResAlloc(&res);
+  }
+
+  std::vector<PerfTableRow> table;
+  if (my_pe == 0) {
+    table.reserve(64);
+  }
+
+  for (size_t size_bytes = args.min_size; size_bytes <= args.max_size;
+       size_bytes *= args.step_factor) {
+    if (size_bytes % sizeof(double) != 0) continue;
+    const size_t len_doubles = size_bytes / sizeof(double);
+
+    if (!latency_size_ok(len_doubles)) {
+      if (my_pe == 0) table.push_back(PerfTableRow{size_bytes, true, 0.0});
+      ccoBarrierAll(ctx.comm);
+      continue;
+    }
+
+    if (run_kernels) {
+      const float ms = RunWarmupAndTimed(res, args.warmup, args.iters, [&](int count) {
+        if (args.transport == Transport::kLsa) {
+          hipLaunchKernelGGL(lsa_get_lat, grid, block, 0, 0, ctx.send_win, ctx.recv_win,
+                             len_doubles, ctx.peer_lsa_rank, count);
+        } else {
+          CCO_GDA_DISPATCH(hipLaunchKernelGGL((igbda_get_lat<P>), grid, block, 0, 0, ctx.send_win,
+                                              ctx.recv_win, len_doubles, ctx.devComm, count));
+        }
+        HIP_RUNTIME_CHECK(hipGetLastError());
+      });
+
+      const double latency_us = (static_cast<double>(ms) * static_cast<double>(kMsToUs)) /
+                                static_cast<double>(args.iters);
+      table.push_back(PerfTableRow{size_bytes, false, latency_us});
+    }
+
+    ccoBarrierAll(ctx.comm);
+  }
+
+  ccoBarrierAll(ctx.comm);
+  if (my_pe == 0) {
+    PrintPerfTable("p2p_get_latency unidirection", TransportToChar(args.transport),
+                   ScopeToChar(args.put_scope), 1, block_threads, ctx.device_warp_size, args.iters,
+                   args.warmup, PerfTableMetric::kLatencyUs, table);
+  }
+
+  if (run_kernels) {
+    PerfResFree(&res);
+  }
+  PerfFinalize(&ctx);
+  return 0;
+}

--- a/benchmark/cco/p2p_put_bw.cpp
+++ b/benchmark/cco/p2p_put_bw.cpp
@@ -1,0 +1,216 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// CCO p2p put bandwidth — unidirectional, PE 0 → PE 1.
+//
+//   -T lsa   : intra-node flat-VA store loop (no NIC).
+//   -T igbda : cross-node one-sided RDMA write via ccoGda<PrvdType>.
+//
+// The buffer is split into `nblocks` chunks (one per block); scope controls
+// the per-chunk cooperation granularity (block/warp/thread).
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#include "device_utils.hpp"
+#include "hip/hip_runtime.h"
+#include "mori/application/utils/check.hpp"
+#include "mori/cco/cco_scale_out.hpp"
+#include "util.hpp"
+
+namespace mori::cco::benchmark {
+
+// ── LSA: flat-VA store loop. Each block copies its chunk into the peer's recv
+// window. `lanes`/`lane0` select how many threads of the block participate
+// (block: all, warp: first warp, thread: thread 0). ──
+__global__ void lsa_put_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin, size_t len_doubles,
+                           int peerLsa, int iter, int lanes) {
+  const int bid = blockIdx.x;
+  const int nblocks = gridDim.x;
+  const int tid = linear_tid();
+  if (tid >= lanes) return;
+
+  const size_t chunk = len_doubles / static_cast<size_t>(nblocks);
+  const size_t off_bytes = static_cast<size_t>(bid) * chunk * sizeof(double);
+
+  double* dst = reinterpret_cast<double*>(ccoGetLsaPeerPtr(recvWin, peerLsa, off_bytes));
+  const double* src = reinterpret_cast<const double*>(ccoGetLocalPtr(sendWin, off_bytes));
+
+  for (int i = 0; i < iter; i++) {
+    lsa_copy_strided(dst, src, chunk, tid, lanes);
+    // Per-iteration system fence: every iteration writes the SAME src->dst, so
+    // without forcing each round's stores out to the peer they get absorbed by
+    // L2/Infinity cache and the timer measures cache bandwidth, not real P2P
+    // (symptom: mid-size BW spikes far above the NIC/xGMI limit, then drops to
+    // the true rate once the buffer exceeds cache). The fence makes each round's
+    // writes visible to the peer before the next round reuses the same region.
+    __threadfence_system();
+  }
+}
+
+// ── IGBDA: perftest ib_write_bw model. Each block owns a QP context and
+// pipelines `iter` RDMA writes of its chunk back-to-back (no per-op flush), then
+// the final write carries a SignalInc — an RDMA atomic whose completion only
+// fires after the remote read-modify-write round-trip. RC same-QP ordering means
+// that completion also guarantees every preceding write landed remotely. One
+// end flush waits the whole pipeline. This is what makes the host timer span
+// real wire throughput; a write-only flush returns on the local send-CQE before
+// data lands (intra-node loopback), inflating bandwidth to bogus TB/s. ──
+template <core::ProviderType PrvdType, typename Coop>
+__global__ void igbda_put_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin, size_t len_doubles,
+                             ccoDevComm devComm, int iter) {
+  Coop coop;
+  const int bid = blockIdx.x;
+  const int nblocks = gridDim.x;
+  ccoGda<PrvdType> gda{devComm, /*ginContext=*/bid};  // one QP context per block
+  const int peer = !devComm.rank;
+  const size_t chunk = len_doubles / static_cast<size_t>(nblocks);
+
+  // Sub-divide the block's chunk across coop units (warps for warp scope, the
+  // whole block for block scope, the lane for thread scope).
+  const int tid = linear_tid();
+  const int unit = tid / coop.size();
+  const int nunits = (blockDim.x * blockDim.y * blockDim.z) / coop.size();
+  const size_t per_unit = chunk / static_cast<size_t>(nunits);
+  const size_t base = static_cast<size_t>(bid) * chunk + static_cast<size_t>(unit) * per_unit;
+  const size_t off_bytes = base * sizeof(double);
+  const size_t bytes = per_unit * sizeof(double);
+
+  const auto sig = ccoGda_SignalInc{static_cast<ccoGdaSignal_t>(bid)};
+  for (int i = 0; i < iter; i++) {
+    if (i == iter - 1) {
+      // Last op carries the signal; its atomic round-trip confirms landing.
+      gda.put(peer, reinterpret_cast<ccoWindow_t>(recvWin), off_bytes,
+              reinterpret_cast<ccoWindow_t>(sendWin), off_bytes, bytes, sig, coop);
+    } else {
+      gda.put(peer, reinterpret_cast<ccoWindow_t>(recvWin), off_bytes,
+              reinterpret_cast<ccoWindow_t>(sendWin), off_bytes, bytes, ccoGda_NoSignal{}, coop);
+    }
+  }
+  gda.flush(ccoCoopBlock{});
+}
+
+static void launch_lsa(PutScope scope, dim3 grid, dim3 block, ccoWindow_t sendWin,
+                       ccoWindow_t recvWin, size_t len_doubles, int peerLsa, int count,
+                       int warp_size) {
+  int lanes = block.x;
+  if (scope == PutScope::kWarp) lanes = warp_size;
+  if (scope == PutScope::kThread) lanes = 1;
+  hipLaunchKernelGGL(lsa_put_bw, grid, block, 0, 0, sendWin, recvWin, len_doubles, peerLsa, count,
+                     lanes);
+}
+
+template <core::ProviderType PrvdType>
+static void launch_igbda(PutScope scope, dim3 grid, dim3 block, ccoWindow_t sendWin,
+                         ccoWindow_t recvWin, size_t len_doubles, ccoDevComm devComm, int count) {
+  switch (scope) {
+    case PutScope::kBlock:
+      hipLaunchKernelGGL((igbda_put_bw<PrvdType, ccoCoopBlock>), grid, block, 0, 0, sendWin,
+                         recvWin, len_doubles, devComm, count);
+      break;
+    case PutScope::kWarp:
+      hipLaunchKernelGGL((igbda_put_bw<PrvdType, ccoCoopWarp>), grid, block, 0, 0, sendWin, recvWin,
+                         len_doubles, devComm, count);
+      break;
+    case PutScope::kThread:
+      hipLaunchKernelGGL((igbda_put_bw<PrvdType, ccoCoopThread>), grid, block, 0, 0, sendWin,
+                         recvWin, len_doubles, devComm, count);
+      break;
+  }
+}
+
+}  // namespace mori::cco::benchmark
+
+int main(int argc, char** argv) {
+  using namespace mori::cco;
+  using namespace mori::cco::benchmark;
+
+  PerfContext ctx{};
+  const int init_rc = PerfInit(argc, argv, &ctx);
+  if (init_rc != 0) {
+    return init_rc == 2 ? 0 : 1;
+  }
+
+  PerfArgs& args = ctx.args;
+  const int my_pe = ctx.my_pe;
+  const bool run_kernels = (my_pe == 0);  // unidirectional: PE 0 issues
+
+  const dim3 grid(args.nblocks, 1, 1);
+  const dim3 block(args.threads_per_block, 1, 1);
+
+  PerfRes res;
+  if (run_kernels) {
+    PerfResAlloc(&res);
+  }
+
+  std::vector<PerfTableRow> table;
+  if (my_pe == 0) {
+    table.reserve(64);
+  }
+
+  for (size_t size_bytes = args.min_size; size_bytes <= args.max_size;
+       size_bytes *= args.step_factor) {
+    if (size_bytes % sizeof(double) != 0) continue;
+    const size_t len_doubles = size_bytes / sizeof(double);
+
+    if (!size_ok(args.put_scope, size_bytes, args.nblocks, args.threads_per_block,
+                 ctx.device_warp_size)) {
+      if (my_pe == 0) table.push_back(PerfTableRow{size_bytes, true, 0.0});
+      ccoBarrierAll(ctx.comm);
+      continue;
+    }
+
+    if (run_kernels) {
+      const float ms = RunWarmupAndTimed(res, args.warmup, args.iters, [&](int count) {
+        if (args.transport == Transport::kLsa) {
+          launch_lsa(args.put_scope, grid, block, ctx.send_win, ctx.recv_win, len_doubles,
+                     ctx.peer_lsa_rank, count, ctx.device_warp_size);
+        } else {
+          CCO_GDA_DISPATCH(launch_igbda<P>(args.put_scope, grid, block, ctx.send_win, ctx.recv_win,
+                                           len_doubles, ctx.devComm, count));
+        }
+        HIP_RUNTIME_CHECK(hipGetLastError());
+      });
+
+      const double gbps = static_cast<double>(size_bytes) /
+                          (static_cast<double>(ms) * (kBToGb / (args.iters * kMsToS)));
+      table.push_back(PerfTableRow{size_bytes, false, gbps});
+    }
+
+    ccoBarrierAll(ctx.comm);
+  }
+
+  ccoBarrierAll(ctx.comm);
+  if (my_pe == 0) {
+    PrintPerfTable("p2p_put_bw unidirection", TransportToChar(args.transport),
+                   ScopeToChar(args.put_scope), args.nblocks, args.threads_per_block,
+                   ctx.device_warp_size, args.iters, args.warmup, PerfTableMetric::kBandwidthGbps,
+                   table);
+  }
+
+  if (run_kernels) {
+    PerfResFree(&res);
+  }
+  PerfFinalize(&ctx);
+  return 0;
+}

--- a/benchmark/cco/p2p_put_latency.cpp
+++ b/benchmark/cco/p2p_put_latency.cpp
@@ -1,0 +1,150 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// CCO p2p put latency — unidirectional, PE 0 → PE 1, one op per iteration.
+//
+//   -T lsa   : single flat-VA store of the whole buffer + system fence.
+//   -T igbda : single RDMA write + flush per iteration.
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#include "device_utils.hpp"
+#include "hip/hip_runtime.h"
+#include "mori/application/utils/check.hpp"
+#include "mori/cco/cco_scale_out.hpp"
+#include "util.hpp"
+
+namespace mori::cco::benchmark {
+
+// LSA: one block stores the whole buffer to the peer, fences, each iteration.
+__global__ void lsa_put_lat(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin, size_t len_doubles,
+                            int peerLsa, int iter) {
+  if (blockIdx.x != 0) return;
+  const int tid = linear_tid();
+  const int lanes = blockDim.x * blockDim.y * blockDim.z;
+
+  double* dst = reinterpret_cast<double*>(ccoGetLsaPeerPtr(recvWin, peerLsa, 0));
+  const double* src = reinterpret_cast<const double*>(ccoGetLocalPtr(sendWin, 0));
+
+  for (int i = 0; i < iter; i++) {
+    lsa_copy_strided(dst, src, len_doubles, tid, lanes);
+    __syncthreads();
+    if (tid == 0) __threadfence_system();
+    __syncthreads();
+  }
+}
+
+// IGBDA: one block issues a single RDMA write of the whole buffer + flush per
+// iteration (mirrors shmem's lat_block put_nbi + quiet). flush drains the local
+// CQ each iteration, so on real hardware the per-op time tracks wire latency.
+template <core::ProviderType PrvdType>
+__global__ void igbda_put_lat(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
+                              size_t len_doubles, ccoDevComm devComm, int iter) {
+  if (blockIdx.x != 0) return;
+  ccoGda<PrvdType> gda{devComm, /*ginContext=*/0};
+  const int peer = !devComm.rank;
+  const size_t bytes = len_doubles * sizeof(double);
+
+  for (int i = 0; i < iter; i++) {
+    gda.put(peer, reinterpret_cast<ccoWindow_t>(recvWin), 0, reinterpret_cast<ccoWindow_t>(sendWin),
+            0, bytes, ccoGda_NoSignal{}, ccoCoopBlock{});
+    gda.flush(ccoCoopWarp{});
+  }
+}
+
+}  // namespace mori::cco::benchmark
+
+int main(int argc, char** argv) {
+  using namespace mori::cco;
+  using namespace mori::cco::benchmark;
+
+  PerfContext ctx{};
+  const int init_rc = PerfInit(argc, argv, &ctx);
+  if (init_rc != 0) {
+    return init_rc == 2 ? 0 : 1;
+  }
+
+  PerfArgs& args = ctx.args;
+  const int my_pe = ctx.my_pe;
+  const bool run_kernels = (my_pe == 0);
+
+  const int block_threads =
+      LatencyBlockThreads(args.put_scope, args.threads_per_block, ctx.device_warp_size);
+  const dim3 grid(1, 1, 1);
+  const dim3 block(block_threads, 1, 1);
+
+  PerfRes res;
+  if (run_kernels) {
+    PerfResAlloc(&res);
+  }
+
+  std::vector<PerfTableRow> table;
+  if (my_pe == 0) {
+    table.reserve(64);
+  }
+
+  for (size_t size_bytes = args.min_size; size_bytes <= args.max_size;
+       size_bytes *= args.step_factor) {
+    if (size_bytes % sizeof(double) != 0) continue;
+    const size_t len_doubles = size_bytes / sizeof(double);
+
+    if (!latency_size_ok(len_doubles)) {
+      if (my_pe == 0) table.push_back(PerfTableRow{size_bytes, true, 0.0});
+      ccoBarrierAll(ctx.comm);
+      continue;
+    }
+
+    if (run_kernels) {
+      const float ms = RunWarmupAndTimed(res, args.warmup, args.iters, [&](int count) {
+        if (args.transport == Transport::kLsa) {
+          hipLaunchKernelGGL(lsa_put_lat, grid, block, 0, 0, ctx.send_win, ctx.recv_win,
+                             len_doubles, ctx.peer_lsa_rank, count);
+        } else {
+          CCO_GDA_DISPATCH(hipLaunchKernelGGL((igbda_put_lat<P>), grid, block, 0, 0, ctx.send_win,
+                                              ctx.recv_win, len_doubles, ctx.devComm, count));
+        }
+        HIP_RUNTIME_CHECK(hipGetLastError());
+      });
+
+      const double latency_us = (static_cast<double>(ms) * static_cast<double>(kMsToUs)) /
+                                static_cast<double>(args.iters);
+      table.push_back(PerfTableRow{size_bytes, false, latency_us});
+    }
+
+    ccoBarrierAll(ctx.comm);
+  }
+
+  ccoBarrierAll(ctx.comm);
+  if (my_pe == 0) {
+    PrintPerfTable("p2p_put_latency unidirection", TransportToChar(args.transport),
+                   ScopeToChar(args.put_scope), 1, block_threads, ctx.device_warp_size, args.iters,
+                   args.warmup, PerfTableMetric::kLatencyUs, table);
+  }
+
+  if (run_kernels) {
+    PerfResFree(&res);
+  }
+  PerfFinalize(&ctx);
+  return 0;
+}

--- a/benchmark/cco/util.cpp
+++ b/benchmark/cco/util.cpp
@@ -1,0 +1,401 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "util.hpp"
+
+#include <cstring>
+#include <string>
+
+#include "hip/hip_runtime.h"
+#include "mori/application/bootstrap/mpi_bootstrap.hpp"
+#include "mori/application/utils/check.hpp"
+#include "mori/utils/env_utils.hpp"
+
+namespace mori::cco::benchmark {
+
+void PrintUsage(const char* program) {
+  std::fprintf(stderr,
+               "Usage: %s [options]\n"
+               "  transport is selected by env MORI_DISABLE_P2P:\n"
+               "    unset / on / 1  -> igbda (RDMA)   [default]\n"
+               "    off / 0 / false -> lsa   (intra-node P2P)\n"
+               "  -b min_bytes   minimum message size\n"
+               "  -e max_bytes   maximum message size\n"
+               "  -f step        multiply size by this factor each step\n"
+               "  -n iters       timed iterations\n"
+               "  -w warmup      warmup iterations\n"
+               "  -c grid_x      HIP grid x (blocks)\n"
+               "  -t threads     threads per block\n"
+               "  -s scope       thread | warp | block (default block)\n"
+               "  -h             this help\n",
+               program != nullptr ? program : "program");
+}
+
+int ParseArgs(int argc, char** argv, PerfArgs* out_args) {
+  if (out_args == nullptr) {
+    return 1;
+  }
+
+  *out_args = PerfArgs{};
+
+  auto parse_size = [](const char* s) -> std::size_t {
+    char* end = nullptr;
+    std::size_t val = std::strtoul(s, &end, 0);
+    if (end && *end != '\0') {
+      switch (*end | 0x20) {  // tolower
+        case 'k':
+          val <<= 10;
+          break;
+        case 'm':
+          val <<= 20;
+          break;
+        case 'g':
+          val <<= 30;
+          break;
+      }
+    }
+    return val;
+  };
+
+  int opt = 0;
+  while ((opt = getopt(argc, argv, "hb:e:f:n:w:c:t:s:")) != -1) {
+    switch (opt) {
+      case 'h':
+        return 2;
+      case 'b':
+        out_args->min_size = parse_size(optarg);
+        break;
+      case 'e':
+        out_args->max_size = parse_size(optarg);
+        break;
+      case 'f':
+        out_args->step_factor = static_cast<std::size_t>(std::strtoul(optarg, nullptr, 0));
+        break;
+      case 'n':
+        out_args->iters = static_cast<std::size_t>(std::strtoul(optarg, nullptr, 0));
+        break;
+      case 'w':
+        out_args->warmup = static_cast<std::size_t>(std::strtoul(optarg, nullptr, 0));
+        break;
+      case 'c':
+        out_args->nblocks = std::atoi(optarg);
+        break;
+      case 't':
+        out_args->threads_per_block = std::atoi(optarg);
+        break;
+      case 's':
+        if (std::strcmp(optarg, "thread") == 0) {
+          out_args->put_scope = PutScope::kThread;
+        } else if (std::strcmp(optarg, "warp") == 0) {
+          out_args->put_scope = PutScope::kWarp;
+        } else if (std::strcmp(optarg, "block") == 0) {
+          out_args->put_scope = PutScope::kBlock;
+        } else {
+          return 1;
+        }
+        break;
+      default:
+        return 1;
+    }
+  }
+
+  return 0;
+}
+
+static std::string fmt_size(std::size_t bytes) {
+  char buf[16];
+  std::size_t val;
+  const char* unit;
+  if (bytes >= (1ULL << 30)) {
+    val = bytes >> 30;
+    unit = "GB";
+  } else if (bytes >= (1ULL << 20)) {
+    val = bytes >> 20;
+    unit = "MB";
+  } else if (bytes >= (1ULL << 10)) {
+    val = bytes >> 10;
+    unit = "KB";
+  } else {
+    val = bytes;
+    unit = "B ";
+  }
+  std::snprintf(buf, sizeof(buf), "%3zu %s", val, unit);
+  return buf;
+}
+
+void PrintPerfTable(const char* test_name, const char* transport_name, const char* scope_name,
+                    int grid_x, int block_threads, int warp_size, std::size_t iters,
+                    std::size_t warmup, PerfTableMetric metric,
+                    const std::vector<PerfTableRow>& rows) {
+  const char* scope_col = (scope_name != nullptr && scope_name[0] != '\0') ? scope_name : "none";
+  const char* tag = (test_name != nullptr && test_name[0] != '\0') ? test_name : "p2p";
+
+  std::printf("# %s transport=%s scope=%s grid=%d block=%d warpSize=%d iters=%zu warmup=%zu\n", tag,
+              transport_name, scope_col, grid_x, block_threads, warp_size, iters, warmup);
+
+  constexpr int kWSize = 10;
+  constexpr int kWScope = 8;
+  constexpr int kWNum = 12;
+
+  const bool is_bw = (metric == PerfTableMetric::kBandwidthGbps);
+  const char* num_header = is_bw ? "Bandwidth" : "Latency";
+  const char* unit_str = is_bw ? "GB/s" : "us";
+
+  std::printf("%-*s %-*s %*s %s\n", kWSize, "size", kWScope, "scope", kWNum, num_header, unit_str);
+
+  for (const PerfTableRow& r : rows) {
+    std::string sz = fmt_size(r.size_bytes);
+    if (r.skipped) {
+      std::printf("%-*s %-*s %*s\n", kWSize, sz.c_str(), kWScope, scope_col, kWNum, "skip");
+    } else {
+      std::printf("%-*s %-*s %*.3f %s\n", kWSize, sz.c_str(), kWScope, scope_col, kWNum, r.value,
+                  unit_str);
+    }
+  }
+  std::fflush(stdout);
+}
+
+int PerfInit(int argc, char** argv, PerfContext* ctx) {
+  std::memset(&ctx->devComm, 0, sizeof(ctx->devComm));
+  ctx->comm = nullptr;
+  ctx->send_win = nullptr;
+  ctx->recv_win = nullptr;
+  ctx->send_buf = nullptr;
+  ctx->recv_buf = nullptr;
+
+  MPI_Init(&argc, &argv);
+  MPI_Comm_rank(MPI_COMM_WORLD, &ctx->world_rank);
+
+  PerfArgs& args = ctx->args;
+  int rc = ParseArgs(argc, argv, &args);
+  if (rc) {
+    if (ctx->world_rank == 0) {
+      PrintUsage(argv[0]);
+    }
+    MPI_Finalize();
+    return rc;  // 2 = help, 1 = bad args; caller must NOT call PerfFinalize
+  }
+
+  if (args.min_size > args.max_size || args.step_factor < 2 || args.iters < 1 || args.nblocks < 1 ||
+      args.threads_per_block < 1) {
+    if (ctx->world_rank == 0) {
+      std::fprintf(stderr,
+                   "Invalid arguments (need iters >= 1, nblocks/threads >= 1, step >= 2).\n");
+    }
+    MPI_Finalize();
+    return 1;
+  }
+  if (args.min_size % sizeof(double) != 0) {
+    args.min_size = (args.min_size + sizeof(double) - 1) / sizeof(double) * sizeof(double);
+  }
+
+  // Transport from MORI_DISABLE_P2P. Default (unset) is IBGDA (P2P disabled);
+  // an explicit false value ("0"/"false"/"off"/"no") selects LSA. This mirrors
+  // mori::env::IsEnvVarEnabled's parsing but defaults to enabled when unset.
+  {
+    const char* v = std::getenv("MORI_DISABLE_P2P");
+    bool p2p_disabled = true;  // default: IBGDA
+    if (v != nullptr && v[0] != '\0') {
+      p2p_disabled = env::detail::ParseBool(v).value_or(true);
+    }
+    args.transport = p2p_disabled ? Transport::kIgbda : Transport::kLsa;
+  }
+
+  // Local communicator → local rank → device binding. CCO pins the device at
+  // ccoCommCreate, so hipSetDevice must happen first.
+  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &ctx->local_comm);
+  MPI_Comm_rank(ctx->local_comm, &ctx->local_rank);
+
+  HIP_RUNTIME_CHECK(hipGetDeviceCount(&ctx->device_count));
+  assert(ctx->device_count);
+  const int device_id = ctx->local_rank % ctx->device_count;
+  HIP_RUNTIME_CHECK(hipSetDevice(device_id));
+  HIP_RUNTIME_CHECK(
+      hipDeviceGetAttribute(&ctx->device_warp_size, hipDeviceAttributeWarpSize, device_id));
+
+  // Enable peer access for LSA flat-VA loopback / import where available.
+  for (int i = 0; i < ctx->device_count; i++) {
+    if (i == device_id) continue;
+    int can_access = 0;
+    HIP_RUNTIME_CHECK(hipDeviceCanAccessPeer(&can_access, device_id, i));
+    if (can_access) (void)hipDeviceEnablePeerAccess(i, 0);
+  }
+
+  // CCO comm. bootNet ownership transfers to comm (freed in ccoCommDestroy).
+  auto* bootNet = new application::MpiBootstrapNetwork(MPI_COMM_WORLD);
+  const std::size_t per_rank_vmm = 2 * args.max_size + kVmmSlack;
+  if (ccoCommCreate(bootNet, per_rank_vmm, &ctx->comm) != 0) {
+    if (ctx->world_rank == 0) std::fprintf(stderr, "ccoCommCreate failed\n");
+    PerfFinalize(ctx);
+    return 1;
+  }
+
+  ctx->my_pe = ctx->comm->rank;
+  ctx->npes = ctx->comm->worldSize;
+  if (ctx->npes != 2) {
+    if (ctx->my_pe == 0) {
+      std::fprintf(stderr, "CCO p2p benchmark requires exactly 2 PEs (npes=%d)\n", ctx->npes);
+    }
+    PerfFinalize(ctx);
+    return 1;
+  }
+
+  // Register send/recv windows (overload A: internal VMM alloc + P2P + RDMA MR).
+  if (ccoWindowRegister(ctx->comm, args.max_size, &ctx->send_win, &ctx->send_buf) != 0 ||
+      ccoWindowRegister(ctx->comm, args.max_size, &ctx->recv_win, &ctx->recv_buf) != 0) {
+    if (ctx->my_pe == 0) std::fprintf(stderr, "ccoWindowRegister failed\n");
+    PerfFinalize(ctx);
+    return 1;
+  }
+
+  // DevComm tuned to the chosen transport.
+  ccoDevCommRequirements reqs = CCO_DEV_COMM_REQUIREMENTS_INITIALIZER;
+  if (args.transport == Transport::kLsa) {
+    reqs.gdaConnectionType = CCO_GDA_CONNECTION_NONE;
+    reqs.gdaSignalCount = 0;
+    reqs.gdaCounterCount = 0;
+    // Unidirectional bw/lat: only PE 0 writes, host ccoBarrierAll provides
+    // cross-rank sync — no device barrier session needed.
+    reqs.lsaBarrierCount = 0;
+  } else {
+    reqs.gdaConnectionType = CCO_GDA_CONNECTION_FULL;
+    // perftest ib_write_bw model: pipeline writes, confirm landing via a
+    // GIN signal (RDMA atomic) on the last op — its completion only fires
+    // after the remote read-modify-write round-trip, and same-QP RC ordering
+    // guarantees the preceding writes landed too. One QP context per block; one
+    // signal slot per block. (GDA rail barrier is unavailable single-node, and
+    // counter polls the same early-completing CQ — only the atomic round-trip
+    // forces true remote landing on intra-node loopback.)
+    reqs.gdaContextCount = args.nblocks;
+    reqs.gdaSignalCount = args.nblocks;
+    reqs.gdaCounterCount = 0;
+    reqs.lsaBarrierCount = 0;
+  }
+
+  if (ccoDevCommCreate(ctx->comm, &reqs, &ctx->devComm) != 0) {
+    if (ctx->my_pe == 0) std::fprintf(stderr, "ccoDevCommCreate failed\n");
+    PerfFinalize(ctx);
+    return 1;
+  }
+
+  // Transport feasibility checks.
+  if (args.transport == Transport::kLsa) {
+    if (ctx->devComm.lsaSize < 2) {
+      if (ctx->my_pe == 0) {
+        std::fprintf(stderr,
+                     "LSA transport requires both PEs on the same node (lsaSize=%d). "
+                     "Run -T igbda for cross-node.\n",
+                     ctx->devComm.lsaSize);
+      }
+      PerfFinalize(ctx);
+      return 1;
+    }
+    // The other PE's index within the LSA team.
+    ctx->peer_lsa_rank = ctx->devComm.lsaRank ^ 1;
+  } else {
+    if (ctx->devComm.gdaConnType == CCO_GDA_CONNECTION_NONE) {
+      if (ctx->my_pe == 0) {
+        std::fprintf(stderr,
+                     "IGBDA transport collapsed to NONE — RDMA loopback unsupported on a single "
+                     "node? Run across 2 nodes.\n");
+      }
+      PerfFinalize(ctx);
+      return 1;
+    }
+  }
+
+  // Announce the resolved transport up front (PE 0 only) so the run is
+  // self-identifying without parsing the table header.
+  if (ctx->my_pe == 0) {
+    if (args.transport == Transport::kLsa) {
+      std::printf("[cco-bench] transport = LSA  (intra-node P2P, flat-VA load/store; lsaSize=%d)\n",
+                  ctx->devComm.lsaSize);
+    } else {
+      std::printf(
+          "[cco-bench] transport = IGBDA (cross-node RDMA via ccoGda; gdaConnType=%d)\n"
+          "            set MORI_DISABLE_P2P=0 to switch to LSA\n",
+          static_cast<int>(ctx->devComm.gdaConnType));
+    }
+    std::fflush(stdout);
+  }
+
+  return 0;
+}
+
+void PerfFinalize(PerfContext* ctx) {
+  // Free our local communicator first: ccoCommDestroy below calls
+  // bootNet->Finalize(), which invokes MPI_Finalize — any MPI_Comm_free after
+  // that is illegal and aborts the job.
+  if (ctx->local_comm != MPI_COMM_NULL) {
+    MPI_Comm_free(&ctx->local_comm);
+    ctx->local_comm = MPI_COMM_NULL;
+  }
+  if (ctx->comm != nullptr) {
+    ccoDevCommDestroy(ctx->comm, &ctx->devComm);
+    // Windows came from the combined ccoWindowRegister(size, &win, &buf)
+    // overload, which internally does ccoMemAlloc. Deregister only releases the
+    // RDMA MR / GPU structs / peer P2P slots — the local VMM mapping must be
+    // freed with ccoMemFree, else the flat VA still has live maps and
+    // ccoCommDestroy's hipMemAddressFree fails.
+    if (ctx->recv_win) ccoWindowDeregister(ctx->comm, ctx->recv_win);
+    if (ctx->send_win) ccoWindowDeregister(ctx->comm, ctx->send_win);
+    if (ctx->recv_buf) ccoMemFree(ctx->comm, ctx->recv_buf);
+    if (ctx->send_buf) ccoMemFree(ctx->comm, ctx->send_buf);
+    // ccoCommDestroy finalizes MPI via bootNet->Finalize().
+    ccoCommDestroy(ctx->comm);
+    ctx->comm = nullptr;
+  } else {
+    int finalized = 0;
+    MPI_Finalized(&finalized);
+    if (!finalized) {
+      MPI_Finalize();
+    }
+  }
+}
+
+void PerfResAlloc(PerfRes* res) {
+  HIP_RUNTIME_CHECK(hipEventCreate(&res->start));
+  HIP_RUNTIME_CHECK(hipEventCreate(&res->stop));
+}
+
+void PerfResFree(PerfRes* res) {
+  HIP_RUNTIME_CHECK(hipEventDestroy(res->start));
+  HIP_RUNTIME_CHECK(hipEventDestroy(res->stop));
+}
+
+float RunWarmupAndTimed(PerfRes& res, std::size_t warmup, std::size_t iters, LaunchFn launch) {
+  launch(static_cast<int>(warmup));
+  HIP_RUNTIME_CHECK(hipGetLastError());
+  HIP_RUNTIME_CHECK(hipDeviceSynchronize());
+
+  HIP_RUNTIME_CHECK(hipEventRecord(res.start, nullptr));
+  launch(static_cast<int>(iters));
+  HIP_RUNTIME_CHECK(hipGetLastError());
+  HIP_RUNTIME_CHECK(hipEventRecord(res.stop, nullptr));
+  HIP_RUNTIME_CHECK(hipEventSynchronize(res.stop));
+
+  float ms = 0.f;
+  HIP_RUNTIME_CHECK(hipEventElapsedTime(&ms, res.start, res.stop));
+  return ms;
+}
+
+}  // namespace mori::cco::benchmark

--- a/benchmark/cco/util.hpp
+++ b/benchmark/cco/util.hpp
@@ -1,0 +1,202 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <mpi.h>
+#include <unistd.h>
+
+#include <cassert>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <functional>
+#include <vector>
+
+#include "hip/hip_runtime.h"
+// Host control-plane types only (ccoComm / ccoDevComm / ccoWindow_t). The GDA
+// device layer (ccoGda) lives in cco_scale_out.hpp and is included directly by
+// the kernel TUs that need it — util.cpp is host CXX and must not pull it in.
+#include "mori/cco/cco.hpp"
+
+namespace mori::cco::benchmark {
+
+// Cooperation granularity of the kernel transfer loop / RDMA op.
+enum class PutScope { kThread, kWarp, kBlock };
+
+// Which CCO p2p transport to exercise. Selected by the MORI_DISABLE_P2P env
+// var (consistent with the rest of mori): unset or enabled → kIgbda (P2P
+// disabled, use RDMA); explicitly disabled (0/false/off/no) → kLsa.
+//   kLsa   — intra-node flat-VA load/store (no NIC), requires same-node peer.
+//   kIgbda — cross-node one-sided RDMA via ccoGda<PrvdType>.
+enum class Transport { kLsa, kIgbda };
+
+inline constexpr std::size_t kDefaultMinSize = 8;
+inline constexpr std::size_t kDefaultMaxSize = 64ULL * 1024ULL * 1024ULL;
+inline constexpr std::size_t kDefaultStepFactor = 2;
+inline constexpr std::size_t kDefaultIters = 10;
+inline constexpr std::size_t kDefaultWarmup = 5;
+inline constexpr int kDefaultNumBlocks = 32;
+inline constexpr int kDefaultThreadsPerBlock = 256;
+
+inline constexpr float kMsToS = 1000.0f;
+inline constexpr float kMsToUs = 1000.0f;
+inline constexpr double kBToGb = 1e9;
+
+// Per-rank VMM reservation for the CCO flat address space. 0 lets CCO pick a
+// default sized from the registered windows; we pass an explicit size so two
+// max_size windows always fit.
+inline constexpr std::size_t kVmmSlack = 64ULL * 1024ULL * 1024ULL;
+
+struct PerfArgs {
+  std::size_t min_size = kDefaultMinSize;
+  std::size_t max_size = kDefaultMaxSize;
+  std::size_t step_factor = kDefaultStepFactor;
+  std::size_t iters = kDefaultIters;
+  std::size_t warmup = kDefaultWarmup;
+  int nblocks = kDefaultNumBlocks;
+  int threads_per_block = kDefaultThreadsPerBlock;
+  PutScope put_scope = PutScope::kBlock;
+  // Default IBGDA; overridden in PerfInit from MORI_DISABLE_P2P.
+  Transport transport = Transport::kIgbda;
+};
+
+// Holds MPI + CCO state for the lifetime of a benchmark run. PerfInit registers
+// two windows (send/recv) of max_size and a DevComm matching the transport.
+struct PerfContext {
+  // MPI / topology.
+  int world_rank = 0;
+  int local_rank = 0;
+  MPI_Comm local_comm = MPI_COMM_NULL;
+  int device_count = 0;
+  int device_warp_size = 0;
+  int my_pe = 0;  // CCO rank
+  int npes = 0;   // CCO world size
+
+  PerfArgs args;
+
+  // CCO handles (owned; released by PerfFinalize).
+  ccoComm* comm = nullptr;
+  ccoDevComm devComm{};
+  ccoWindow_t send_win = nullptr;
+  ccoWindow_t recv_win = nullptr;
+  void* send_buf = nullptr;  // local pointer into send window
+  void* recv_buf = nullptr;  // local pointer into recv window
+
+  // Peer's LSA rank (the other PE on the node). Valid only when lsaSize >= 2.
+  int peer_lsa_rank = 0;
+};
+
+// Returns 0 on success, 1 on bad args / setup failure, 2 when help was shown
+// (caller should exit 0 without calling PerfFinalize).
+int PerfInit(int argc, char** argv, PerfContext* ctx);
+void PerfFinalize(PerfContext* ctx);
+
+using LaunchFn = std::function<void(int /*count*/)>;
+
+struct PerfRes {
+  hipEvent_t start{};
+  hipEvent_t stop{};
+};
+
+void PerfResAlloc(PerfRes* res);
+void PerfResFree(PerfRes* res);
+float RunWarmupAndTimed(PerfRes& res, std::size_t warmup, std::size_t iters, LaunchFn launch);
+
+int ParseArgs(int argc, char** argv, PerfArgs* out_args);
+void PrintUsage(const char* program);
+
+enum class PerfTableMetric { kBandwidthGbps, kLatencyUs };
+
+struct PerfTableRow {
+  std::size_t size_bytes{};
+  bool skipped{};
+  double value{};
+};
+
+void PrintPerfTable(const char* test_name, const char* transport_name, const char* scope_name,
+                    int grid_x, int block_threads, int warp_size, std::size_t iters,
+                    std::size_t warmup, PerfTableMetric metric,
+                    const std::vector<PerfTableRow>& rows);
+
+inline const char* ScopeToChar(PutScope scope) {
+  switch (scope) {
+    case PutScope::kThread:
+      return "thread";
+    case PutScope::kWarp:
+      return "warp";
+    case PutScope::kBlock:
+      return "block";
+  }
+  return "none";
+}
+
+inline const char* TransportToChar(Transport t) {
+  switch (t) {
+    case Transport::kLsa:
+      return "lsa";
+    case Transport::kIgbda:
+      return "igbda";
+  }
+  return "none";
+}
+
+// Block-scope bandwidth kernels split the buffer into nblocks chunks, and warp/
+// thread scope split each chunk further; require even divisibility so every
+// lane gets equal work.
+inline bool size_ok(PutScope scope, std::size_t size_bytes, int nblocks, int threads_per_block,
+                    int device_warp_size) {
+  if (size_bytes == 0 || size_bytes % sizeof(double) != 0) {
+    return false;
+  }
+  const std::size_t len = size_bytes / sizeof(double);
+  if (len % static_cast<std::size_t>(nblocks) != 0) {
+    return false;
+  }
+  const std::size_t per_block = len / static_cast<std::size_t>(nblocks);
+  if (scope == PutScope::kThread) {
+    return per_block % static_cast<std::size_t>(threads_per_block) == 0;
+  }
+  if (scope == PutScope::kWarp) {
+    if (threads_per_block % device_warp_size != 0) {
+      return false;
+    }
+    const int nw = threads_per_block / device_warp_size;
+    if (nw <= 0) {
+      return false;
+    }
+    return per_block % static_cast<std::size_t>(nw) == 0;
+  }
+  return true;  // block scope: per_block already integral
+}
+
+// Latency kernels issue a single op for the whole buffer — no per-lane split.
+inline bool latency_size_ok(std::size_t len_doubles) { return len_doubles > 0; }
+
+// Latency block width by scope (mirrors shmem util).
+inline int LatencyBlockThreads(PutScope scope, int threads_per_block, int device_warp_size) {
+  if (scope == PutScope::kWarp) return device_warp_size;
+  if (scope == PutScope::kBlock) return threads_per_block;
+  return 1;
+}
+
+}  // namespace mori::cco::benchmark

--- a/setup.py
+++ b/setup.py
@@ -371,6 +371,7 @@ class CMakeBuild(build_ext):
             "ON"
             if (
                 build_examples.upper() == "ON"
+                or build_benchmark.upper() == "ON"
                 or os.environ.get("MORI_WITH_MPI", "OFF").upper() == "ON"
             )
             else "OFF"
@@ -419,6 +420,18 @@ class CMakeBuild(build_ext):
         subprocess.check_call(
             ["cmake", "--build", ".", "-j", f"{os.cpu_count()}"], cwd=str(build_dir)
         )
+
+        # When benchmarks are off, the shared libs are rebuilt without MPI but a
+        # previous BUILD_BENCHMARK=ON run may have left benchmark executables in
+        # build/benchmark/. Running those stale binaries fails with an
+        # undefined MpiBootstrapNetwork symbol. Remove them so the build dir
+        # stays self-consistent.
+        if build_benchmark.upper() != "ON":
+            bench_dir = build_dir / "benchmark"
+            if bench_dir.is_dir():
+                for exe in bench_dir.iterdir():
+                    if exe.is_file() and os.access(exe, os.X_OK):
+                        exe.unlink()
 
         files_to_copy = [
             (


### PR DESCRIPTION
# Motivation
Add a CCO p2p microbenchmark suite (put/get × bw/latency) mirroring benchmark/shmem/, covering both transports: LSA (intra-node P2P) and IGBDA (cross-node RDMA).

# Technical Details
New benchmark/cco/ with 4 binaries; transport chosen via MORI_DISABLE_P2P. Issues found & fixed:

quietUntil (PSD) returned mid-transfer — unconditional break abandoned the CQ wait, inflating BW to multi-TB/s. Now breaks only on error.
LSA bw cache absorption — added per-iter __threadfence_system().
32-QP doorbell contention destabilized mid-size BW.
Build: BUILD_BENCHMARK now implies MPI; util.cpp builds as CXX.

# Test Result
LSA/IGBDA saturate near NIC limit; GDA tests pas