### PR TITLE
Fix(jit): reuse the already-loaded libamdhip64 to avoid HIP 709 on framework streams

### DIFF
--- a/python/mori/jit/hip_driver.py
+++ b/python/mori/jit/hip_driver.py
@@ -32,13 +32,31 @@ from ctypes import c_char_p, c_uint, c_void_p, POINTER, byref
 _hip: ctypes.CDLL | None = None
 
 
+def _already_loaded_libamdhip64() -> str | None:
+    try:
+        with open("/proc/self/maps", "r") as maps:
+            for line in maps:
+                path = line.rstrip("\n").rsplit(" ", 1)[-1]
+                if path.startswith("/") and os.path.basename(path).startswith(
+                    "libamdhip64.so"
+                ):
+                    return path
+    except OSError:
+        pass
+    return None
+
+
 def _get_hip_lib() -> ctypes.CDLL:
     global _hip
     if _hip is not None:
         return _hip
 
     rocm_path = os.environ.get("ROCM_PATH", "/opt/rocm")
-    candidates = [
+    candidates = []
+    already_loaded = _already_loaded_libamdhip64()
+    if already_loaded is not None:
+        candidates.append(already_loaded)
+    candidates += [
         os.path.join(rocm_path, "lib", "libamdhip64.so"),
         "libamdhip64.so",
     ]


### PR DESCRIPTION
#  Problem

  When mori's EP dispatch/combine is driven from a deep-learning framework (e.g. PyTorch, via SGLang), the first EpDispatchCombineOp kernel launch fails with:
  `RuntimeError: HIP error 709: hipModuleLaunchKernel(EpDispatchIntraNodeKernel_bf16)`
709 is hipErrorContextIsDestroyed. The failure is stream-specific: launching the same kernel on the default/null stream works, while launching on a framework-created non-default stream faults. This is why standalone microbenchmarks (which run on the default stream) pass, but real framework integrations fault on the very first MoE dispatch.

#  Root cause

  mori/jit/hip_driver.py:_get_hip_lib() dlopens $ROCM_PATH/lib/libamdhip64.so by full path. But frameworks ship and load their own bundled libamdhip64 (e.g. torch/lib/libamdhip64.so). The bundled copy and the $ROCM_PATH copy are different shared objects (different files/inodes) even though they share the same SONAME (libamdhip64.so.7), so loading the $ROCM_PATH copy by full path creates a second HIP runtime instance with its own context/stream registry.

Streams are created by the framework's libamdhip64 instance; mori then launches kernels through its own instance, which doesn't recognize the foreign stream handle → hipModuleLaunchKernel returns hipErrorContextIsDestroyed. The null/default stream is valid in any instance, which
  masks the bug in default-stream-only tests.

#  Fix

  Prefer a libamdhip64 that is already mapped into the process (detected via /proc/self/maps) so mori shares the framework's HIP runtime/context. dlopen of an already-mapped file just bumps its refcount and returns the same handle. Falls back to $ROCM_PATH/lib/libamdhip64.so and the bare soname exactly as before.