### PR TITLE
perf(umbp): optimize PoolClient BatchPut/BatchGet

### DIFF
--- a/docs/MORI-IO-GUIDE.md
+++ b/docs/MORI-IO-GUIDE.md
@@ -166,9 +166,11 @@ See `examples/io/example.py` for more complete examples including batch transfer
 | Setting | Description |
 |---------|-------------|
 | `set_log_level(level)` | Set MORI-IO log verbosity level |
-| `RdmaBackendConfig.qp_per_transfer` | Queue pairs per transfer (default 1, increase for higher bandwidth; with multi-NIC these QPs are spread across NICs, so aim for ≥2 QP per NIC) |
-| `RdmaBackendConfig.poll_cq_mode` | CQ polling mode: `POLLING` (busy-wait, lower latency) or `EVENT` (interrupt-driven) |
-| `RdmaBackendConfig.enable_notification` | Enable target-side completion notifications (default `True`) |
+| `RdmaBackendConfig.qp_per_transfer` | Queue pairs per transfer (default 1, increase for higher bandwidth; with multi-NIC these QPs are spread across NICs, so aim for ≥2 QP per NIC). Env: `MORI_IO_QP_PER_TRANSFER` |
+| `RdmaBackendConfig.poll_cq_mode` | CQ polling mode: `POLLING` (busy-wait, lower latency) or `EVENT` (interrupt-driven). Env: `MORI_IO_POLL_CQ_MODE` (`0`/`polling`, `1`/`event`) |
+| `RdmaBackendConfig.post_batch_size` | WRs per `ibv_post_send` chain (default `-1` = auto). Env: `MORI_IO_POST_BATCH_SIZE` |
+| `RdmaBackendConfig.num_worker_threads` | Worker threads for batch posting (default `1`; ignored when chunking / multi-NIC forces inline posting). Env: `MORI_IO_NUM_WORKER_THREADS` |
+| `RdmaBackendConfig.enable_notification` | Enable target-side completion notifications (default `True`). Env: `MORI_IO_ENABLE_NOTIFICATION` |
 | `RdmaBackendConfig.enable_transfer_chunking` | Split a large single transfer into `chunk_bytes` chunks pipelined across QPs (default `False`). Lifts single-transfer bandwidth from single-outstanding (~28 GB/s) to NIC line rate. Forces single-thread inline posting (ignores `num_worker_threads`). Env: `MORI_IO_ENABLE_CHUNKING` |
 | `RdmaBackendConfig.chunk_bytes` | Chunk size when chunking is on (default `65536` = 64 KB). Messages ≤ this are unchanged. Env: `MORI_IO_CHUNK_BYTES` |
 | `RdmaBackendConfig.max_chunks_per_transfer` | Cap on chunks per transfer to bound WR/SQ usage (default `64`). Env: `MORI_IO_MAX_CHUNKS` |

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -25,8 +25,10 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <cstring>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <shared_mutex>
 #include <stdexcept>
 #include <string>
@@ -70,6 +72,27 @@ void ValidateRdmaTransferConfig(const RdmaBackendConfig& config) {
 
 bool UsesInlineOnly(const RdmaBackendConfig& config) {
   return config.enableTransferChunking || config.numNicsPerTransfer > 1;
+}
+
+// Parse MORI_IO_POLL_CQ_MODE: "0"/"polling" or "1"/"event" (case-insensitive).
+// Returns nullopt for anything else so env::Override warns and keeps the
+// config value (no silent fallback).
+std::optional<PollCqMode> ParsePollCqMode(const char* raw) {
+  if (std::strcmp(raw, "0") == 0 || mori::env::detail::EqualsIgnoreCase(raw, "polling")) {
+    return PollCqMode::POLLING;
+  }
+  if (std::strcmp(raw, "1") == 0 || mori::env::detail::EqualsIgnoreCase(raw, "event")) {
+    return PollCqMode::EVENT;
+  }
+  return std::nullopt;
+}
+
+// Parse MORI_IO_POST_BATCH_SIZE: only -1 (auto) or a positive int are valid.
+// Rejects 0 / negatives (which the post path would silently clamp to 1) so
+// env::Override warns and keeps the config value.
+std::optional<int> ParsePostBatchSize(const char* raw) {
+  if (std::strcmp(raw, "-1") == 0) return -1;
+  return mori::env::detail::ParsePositiveInt(raw);
 }
 
 int ResolveRequestedNics(const RdmaBackendConfig& config, const TopoKey& local,
@@ -1234,6 +1257,14 @@ RdmaBackend::RdmaBackend(EngineKey k, const IOEngineConfig& engConfig,
                 mori::env::detail::ParsePositiveInt);
   env::Override("MORI_IO_NUM_NICS_PER_TRANSFER", config.numNicsPerTransfer,
                 mori::env::detail::ParsePositiveInt);
+  // Perf-sweep / ops overrides for knobs that otherwise only have a config
+  // field.  postBatchSize accepts any int (-1 = auto), the rest are positive.
+  env::Override("MORI_IO_QP_PER_TRANSFER", config.qpPerTransfer,
+                mori::env::detail::ParsePositiveInt);
+  env::Override("MORI_IO_POST_BATCH_SIZE", config.postBatchSize, ParsePostBatchSize);
+  env::Override("MORI_IO_NUM_WORKER_THREADS", config.numWorkerThreads,
+                mori::env::detail::ParsePositiveInt);
+  env::Override("MORI_IO_POLL_CQ_MODE", config.pollCqMode, ParsePollCqMode);
   ValidateRdmaNotificationConfig(config);
   ValidateRdmaTransferConfig(config);
 

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -282,44 +282,6 @@ bool SsdStartupDiscardEnabled() {
   return !(s == "0" || s == "false" || s == "FALSE" || s == "off");
 }
 
-// BatchGet local/SSD-in-window overlap switch (default on).  Zero-copy remote
-// DRAM always submits all peers before waiting (multi-peer overlap); this knob
-// only controls whether local DRAM/SSD + remote SSD additionally run INSIDE that
-// in-flight window (see ExecuteBatchGetPlan).  Set UMBP_BATCHGET_OVERLAP=0/false/
-// off to keep local/SSD out of the window (A/B + rollback hook).
-bool BatchGetOverlapEnabled() {
-  static const bool v = []() -> bool {
-    const char* e = std::getenv("UMBP_BATCHGET_OVERLAP");
-    if (e == nullptr) return true;
-    const std::string s(e);
-    return !(s == "0" || s == "false" || s == "FALSE" || s == "off");
-  }();
-  return v;
-}
-
-// Max BatchGet size (key count) for which local DRAM/SSD + remote SSD run INSIDE
-// the zero-copy remote-DRAM in-flight window.  Above it, local/SSD run before the
-// submit instead (out of the window) — but zero-copy remote DRAM still does
-// submit-all/wait-all, so this is NOT a full fall-back to a synchronous baseline.
-// Rationale: overlapping local DRAM memcpy with the remote DRAM RDMA wire is a
-// net win at small/medium batch (latency-bound) but a small net loss at large
-// batch, where the local copy threads contend with the RDMA DMA for host
-// memory / PCIe bandwidth and the hidden local time is tiny relative to the wire
-// time (see docs/perf/overlap/NOTES.md, mixed_tier: +4-5% <=128, -3% at 256).
-// Default 128 (solidly positive; the +/-0 crossover is ~192-224).  Set
-// UMBP_BATCHGET_OVERLAP_MAX_BATCH=0 (or negative) for no limit.
-int64_t BatchGetOverlapMaxBatch() {
-  static const int64_t v = [] {
-    const char* e = std::getenv("UMBP_BATCHGET_OVERLAP_MAX_BATCH");
-    if (e == nullptr) return static_cast<int64_t>(128);
-    char* end = nullptr;
-    const long long parsed = std::strtoll(e, &end, 10);
-    if (end == e) return static_cast<int64_t>(128);  // unparseable -> default
-    return static_cast<int64_t>(parsed);
-  }();
-  return v;
-}
-
 // Total attempts for a remote SSD get.  Retryable outcomes (kRetry) are
 // NO_SLOT (transient slot exhaustion, no slot claimed) and a reader-local lease
 // expiry.  Defaults to 1 (no retry); operators opt into bounded retry to absorb
@@ -1153,25 +1115,16 @@ void PoolClient::ExecuteBatchGetPlan(const BatchGetPlan& plan, const std::vector
     return;
   }
 
-  // Zero-copy remote DRAM: submit every peer (posted, not waited) before waiting
-  // any, so multi-peer wire time overlaps.  Overlap eligibility (S2: also put
-  // local DRAM/SSD + remote SSD INSIDE the in-flight window) requires the env on
-  // and the batch not larger than the max-batch threshold — large batches
-  // regress because the local copy contends with the RDMA DMA for memory/PCIe
-  // bandwidth (see BatchGetOverlapMaxBatch).  Below threshold the window is used;
-  // above it local/SSD run first (out of the window) but remote DRAM still does
-  // submit-all/wait-all.
-  bool overlap_window = false;
-  if (BatchGetOverlapEnabled()) {
-    const int64_t max_batch = BatchGetOverlapMaxBatch();
-    overlap_window = max_batch <= 0 || static_cast<int64_t>(keys.size()) <= max_batch;
-  }
-
+  // Zero-copy remote DRAM: submit every peer (posted, not waited) so multi-peer
+  // wire time overlaps, run local DRAM/SSD + remote SSD INSIDE that in-flight
+  // window (local memcpy / SSD use CPU / local-mem / SSD resources disjoint from
+  // the NIC, so they overlap the DRAM wire), then wait all peers.
   std::vector<std::unique_ptr<RemoteDramGetInFlight>> inflights;
   inflights.reserve(remote_dram_groups.size());
-  // RAII drain: guarantee every posted in-flight is waited even on an
-  // exceptional/early exit (e.g. std::bad_alloc), so no posted TransferStatus is
-  // left referenced by the backend CQ callback after this scope.
+  // Cleanup-only RAII: on an exceptional/early exit, Wait() any still-in-flight
+  // status so the backend CQ callback isn't left referencing freed memory.  It
+  // does NOT do failure mapping or result backfill (the normal path's
+  // WaitRemoteBatchGet does that) — it only makes status lifetime safe.
   struct InFlightDrainGuard {
     std::vector<std::unique_ptr<RemoteDramGetInFlight>>& v;
     ~InFlightDrainGuard() {
@@ -1184,30 +1137,16 @@ void PoolClient::ExecuteBatchGetPlan(const BatchGetPlan& plan, const std::vector
     }
   } drain_guard{inflights};
 
-  if (overlap_window) {
-    // Submit every peer, run local/SSD inside the in-flight window, then wait all.
-    for (const auto& [node_id, items] : remote_dram_groups) {
-      if (auto f = SubmitRemoteBatchGet(items, results, /*permit_staging=*/false)) {
-        inflights.push_back(std::move(f));
-      }
+  for (const auto& [node_id, items] : remote_dram_groups) {
+    if (auto f = SubmitRemoteBatchGet(items, results, /*permit_staging=*/false)) {
+      inflights.push_back(std::move(f));
     }
-    run_local_dram();
-    run_local_ssd();
-    run_remote_ssd();
-    for (auto& f : inflights) WaitRemoteBatchGet(*f, results);
-  } else {
-    // Local/SSD run BEFORE the submit (out of the window), but remote DRAM still
-    // submits all peers before waiting any (multi-peer overlap, no contention).
-    run_local_ssd();
-    run_local_dram();
-    for (const auto& [node_id, items] : remote_dram_groups) {
-      if (auto f = SubmitRemoteBatchGet(items, results, /*permit_staging=*/false)) {
-        inflights.push_back(std::move(f));
-      }
-    }
-    for (auto& f : inflights) WaitRemoteBatchGet(*f, results);
-    run_remote_ssd();
   }
+  run_local_dram();
+  run_local_ssd();
+  // TODO(perf): remote SSD is still per-key serial (not yet optimized).
+  run_remote_ssd();
+  for (auto& f : inflights) WaitRemoteBatchGet(*f, results);
 }
 
 void PoolClient::ProcessRemoteBatchPut(const std::vector<BatchPutItem>& items,
@@ -1557,7 +1496,7 @@ void PoolClient::ExecuteRemotePutTransfers(std::vector<RemotePutEntry>& entries,
   // groups return immediately.  A non-success group fails ALL its
   // contributing keys (per-item AND semantics — a key fails if any of its
   // pairs fail).  NOTE: this does not by itself prove safety of backend
-  // partial-post / status-lifetime corner cases (see docs/perf NOTES).
+  // partial-post / status-lifetime corner cases.
   for (size_t g = 0; g < G; ++g) {
     statuses[g].Wait();
     if (statuses[g].Succeeded()) continue;

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -282,6 +282,44 @@ bool SsdStartupDiscardEnabled() {
   return !(s == "0" || s == "false" || s == "FALSE" || s == "off");
 }
 
+// BatchGet local/SSD-in-window overlap switch (default on).  Zero-copy remote
+// DRAM always submits all peers before waiting (multi-peer overlap); this knob
+// only controls whether local DRAM/SSD + remote SSD additionally run INSIDE that
+// in-flight window (see ExecuteBatchGetPlan).  Set UMBP_BATCHGET_OVERLAP=0/false/
+// off to keep local/SSD out of the window (A/B + rollback hook).
+bool BatchGetOverlapEnabled() {
+  static const bool v = []() -> bool {
+    const char* e = std::getenv("UMBP_BATCHGET_OVERLAP");
+    if (e == nullptr) return true;
+    const std::string s(e);
+    return !(s == "0" || s == "false" || s == "FALSE" || s == "off");
+  }();
+  return v;
+}
+
+// Max BatchGet size (key count) for which local DRAM/SSD + remote SSD run INSIDE
+// the zero-copy remote-DRAM in-flight window.  Above it, local/SSD run before the
+// submit instead (out of the window) — but zero-copy remote DRAM still does
+// submit-all/wait-all, so this is NOT a full fall-back to a synchronous baseline.
+// Rationale: overlapping local DRAM memcpy with the remote DRAM RDMA wire is a
+// net win at small/medium batch (latency-bound) but a small net loss at large
+// batch, where the local copy threads contend with the RDMA DMA for host
+// memory / PCIe bandwidth and the hidden local time is tiny relative to the wire
+// time (see docs/perf/overlap/NOTES.md, mixed_tier: +4-5% <=128, -3% at 256).
+// Default 128 (solidly positive; the +/-0 crossover is ~192-224).  Set
+// UMBP_BATCHGET_OVERLAP_MAX_BATCH=0 (or negative) for no limit.
+int64_t BatchGetOverlapMaxBatch() {
+  static const int64_t v = [] {
+    const char* e = std::getenv("UMBP_BATCHGET_OVERLAP_MAX_BATCH");
+    if (e == nullptr) return static_cast<int64_t>(128);
+    char* end = nullptr;
+    const long long parsed = std::strtoll(e, &end, 10);
+    if (end == e) return static_cast<int64_t>(128);  // unparseable -> default
+    return static_cast<int64_t>(parsed);
+  }();
+  return v;
+}
+
 // Total attempts for a remote SSD get.  Retryable outcomes (kRetry) are
 // NO_SLOT (transient slot exhaustion, no slot claimed) and a reader-local lease
 // expiry.  Defaults to 1 (no retry); operators opt into bounded retry to absorb
@@ -973,93 +1011,8 @@ std::vector<bool> PoolClient::BatchGet(const std::vector<std::string>& keys,
     routes.resize(keys.size());
   }
 
-  // DRAM/HBM remote reads go through the batched RDMA path (remote_groups);
-  // remote SSD reads go through a per-key staging path (ssd_remote_groups)
-  // because each needs its own peer-side staging slot + lease.
-  std::unordered_map<std::string, std::vector<BatchGetItem>> remote_groups;
-  std::unordered_map<std::string, std::vector<BatchGetItem>> ssd_remote_groups;
-  std::vector<size_t> local_get_idx;
-  for (size_t i = 0; i < keys.size(); ++i) {
-    // Zero-size gets are rejected before local fallback or remote read: an
-    // explicit skip is required here because a nullopt route below would
-    // otherwise fall through to a local read (result stays false).
-    if (sizes[i] == 0) {
-      MORI_UMBP_WARN("[PoolClient] BatchGet: skipping zero-size get for key='{}'", keys[i]);
-      continue;
-    }
-    if (i >= routes.size() || !routes[i].has_value()) {
-      if (peer_alloc_) local_get_idx.push_back(i);
-      continue;
-    }
-    const auto& route = routes[i].value();
-    if (route.node_id == config_.master_config.node_id) {
-      // Self-target fast path: SSD via PeerSsdManager (inline); DRAM/HBM via the
-      // allocator, deferred for batch-parallel copy across keys.
-      if (route.tier == TierType::SSD) {
-        if (ExecuteLocalSsdGet(keys[i], const_cast<void*>(dsts[i]), sizes[i]) ==
-            GetAttemptOutcome::kSuccess) {
-          results[i] = true;
-        }
-      } else {
-        local_get_idx.push_back(i);
-      }
-      continue;
-    }
-    BatchGetItem item{.index = i,
-                      .key = &keys[i],
-                      .dst = const_cast<void*>(dsts[i]),
-                      .size = sizes[i],
-                      .route = route};
-    if (route.tier == TierType::SSD) {
-      ssd_remote_groups[route.node_id].push_back(std::move(item));
-    } else {
-      remote_groups[route.node_id].push_back(std::move(item));
-    }
-  }
-
-  // Parallel local DRAM reads: different threads handle different keys. Resolve
-  // is mutex-serialized in the allocator; the per-key memcpy in
-  // ExecuteLocalGet->LocalGetPages runs lock-free in parallel. results is
-  // std::vector<bool> (bit-packed) so threads write a temp buffer; merge serially.
-  if (!local_get_idx.empty()) {
-    const int nthr = LocalCopyThreads("UMBP_DRAM_READ_THREADS");
-    const auto t0 = std::chrono::steady_clock::now();
-    std::vector<char> ok(local_get_idx.size(), 0);
-    LocalParallelFor(local_get_idx.size(), nthr, [&](size_t k) {
-      const size_t i = local_get_idx[k];
-      if (ExecuteLocalGet(keys[i], const_cast<void*>(dsts[i]), sizes[i]) ==
-          GetAttemptOutcome::kSuccess) {
-        ok[k] = 1;
-      }
-    });
-    size_t tot = 0;
-    for (size_t k = 0; k < local_get_idx.size(); ++k) {
-      if (ok[k]) {
-        results[local_get_idx[k]] = true;
-        tot += sizes[local_get_idx[k]];
-      }
-    }
-    if (std::getenv("UMBP_LOCAL_COPY_TIMING")) {
-      double sec = std::chrono::duration_cast<std::chrono::duration<double>>(
-                       std::chrono::steady_clock::now() - t0)
-                       .count();
-      MORI_UMBP_INFO("[LocalCopy] GET keys={} bytes={} threads={} elapsed_ms={:.3f} GiB_s={:.2f}",
-                     local_get_idx.size(), tot, nthr, sec * 1000.0,
-                     tot / (sec > 0 ? sec : 1e-12) / (1024.0 * 1024 * 1024));
-    }
-  }
-
-  for (auto& [node_id, items] : remote_groups) {
-    ProcessRemoteBatchGet(items, &results);
-  }
-  for (auto& [node_id, items] : ssd_remote_groups) {
-    ProcessRemoteSsdBatchGet(items, &results);
-  }
-
-  for (size_t i = 0; i < keys.size(); ++i) {
-    if (results[i]) continue;
-    results[i] = false;
-  }
+  BatchGetPlan plan = PartitionBatchGetTargets(keys, dsts, sizes, routes);
+  ExecuteBatchGetPlan(plan, keys, dsts, sizes, &results);
 
   const auto call_end = std::chrono::steady_clock::now();
   const double seconds =
@@ -1074,6 +1027,187 @@ std::vector<bool> PoolClient::BatchGet(const std::vector<std::string>& keys,
                           MORI_UMBP_METRIC_CLIENT_BATCH_GET_BANDWIDTH_HELP, "remote");
   }
   return results;
+}
+
+PoolClient::BatchGetPlan PoolClient::PartitionBatchGetTargets(
+    const std::vector<std::string>& keys, const std::vector<void*>& dsts,
+    const std::vector<size_t>& sizes, const std::vector<std::optional<RouteGetResult>>& routes) {
+  BatchGetPlan plan;
+  for (size_t i = 0; i < keys.size(); ++i) {
+    // Zero-size gets are rejected before local fallback or remote read: an
+    // explicit skip is required here because a nullopt route below would
+    // otherwise fall through to a local read (result stays false).
+    if (sizes[i] == 0) {
+      MORI_UMBP_WARN("[PoolClient] BatchGet: skipping zero-size get for key='{}'", keys[i]);
+      continue;
+    }
+    if (i >= routes.size() || !routes[i].has_value()) {
+      if (peer_alloc_) plan.local_dram_indices.push_back(i);
+      continue;
+    }
+    const auto& route = routes[i].value();
+    if (route.node_id == config_.master_config.node_id) {
+      // Self-target: both DRAM/HBM and SSD are deferred (collected as indices)
+      // so ExecuteBatchGetPlan can place them inside the remote-DRAM in-flight
+      // window in the overlap path.
+      if (route.tier == TierType::SSD) {
+        plan.local_ssd_indices.push_back(i);
+      } else {
+        plan.local_dram_indices.push_back(i);
+      }
+      continue;
+    }
+    BatchGetItem item{.index = i,
+                      .key = &keys[i],
+                      .dst = const_cast<void*>(dsts[i]),
+                      .size = sizes[i],
+                      .route = route};
+    if (route.tier == TierType::SSD) {
+      plan.remote_ssd_groups[route.node_id].push_back(std::move(item));
+    } else {
+      plan.remote_dram_groups[route.node_id].push_back(std::move(item));
+    }
+  }
+  return plan;
+}
+
+void PoolClient::ExecuteBatchGetPlan(const BatchGetPlan& plan, const std::vector<std::string>& keys,
+                                     const std::vector<void*>& dsts,
+                                     const std::vector<size_t>& sizes, std::vector<bool>* results) {
+  // Parallel local DRAM reads: different threads handle different keys. Resolve
+  // is mutex-serialized in the allocator; the per-key memcpy in
+  // ExecuteLocalGet->LocalGetPages runs lock-free in parallel. results is
+  // std::vector<bool> (bit-packed) so threads write a temp buffer; merge serially.
+  auto run_local_dram = [&]() {
+    const auto& idx = plan.local_dram_indices;
+    if (idx.empty()) return;
+    const int nthr = LocalCopyThreads("UMBP_DRAM_READ_THREADS");
+    const auto t0 = std::chrono::steady_clock::now();
+    std::vector<char> ok(idx.size(), 0);
+    LocalParallelFor(idx.size(), nthr, [&](size_t k) {
+      const size_t i = idx[k];
+      if (ExecuteLocalGet(keys[i], const_cast<void*>(dsts[i]), sizes[i]) ==
+          GetAttemptOutcome::kSuccess) {
+        ok[k] = 1;
+      }
+    });
+    size_t tot = 0;
+    for (size_t k = 0; k < idx.size(); ++k) {
+      if (ok[k]) {
+        (*results)[idx[k]] = true;
+        tot += sizes[idx[k]];
+      }
+    }
+    if (std::getenv("UMBP_LOCAL_COPY_TIMING")) {
+      double sec = std::chrono::duration_cast<std::chrono::duration<double>>(
+                       std::chrono::steady_clock::now() - t0)
+                       .count();
+      MORI_UMBP_INFO("[LocalCopy] GET keys={} bytes={} threads={} elapsed_ms={:.3f} GiB_s={:.2f}",
+                     idx.size(), tot, nthr, sec * 1000.0,
+                     tot / (sec > 0 ? sec : 1e-12) / (1024.0 * 1024 * 1024));
+    }
+  };
+
+  // Local SSD self-target reads (deferred from partition): serial on this
+  // thread, reading straight into the user buffer (no staging / RDMA / lease).
+  // Independent per key, so its position in the schedule is correctness-neutral.
+  auto run_local_ssd = [&]() {
+    for (size_t i : plan.local_ssd_indices) {
+      if (ExecuteLocalSsdGet(keys[i], const_cast<void*>(dsts[i]), sizes[i]) ==
+          GetAttemptOutcome::kSuccess) {
+        (*results)[i] = true;
+      }
+    }
+  };
+
+  auto run_remote_ssd = [&]() {
+    for (const auto& [node_id, items] : plan.remote_ssd_groups) {
+      ProcessRemoteSsdBatchGet(items, results);
+    }
+  };
+
+  const auto& remote_dram_groups = plan.remote_dram_groups;
+
+  // Zero-copy? The upper layer guarantees a batch is all-ZC or all-staging, so
+  // probe one remote-DRAM item's dst registration (unordered_map order is
+  // unspecified, but any item answers the all-or-nothing question).
+  const bool is_zc = !remote_dram_groups.empty() &&
+                     FindRegisteredMemory(remote_dram_groups.begin()->second.front().dst,
+                                          remote_dram_groups.begin()->second.front().size)
+                         .has_value();
+
+  if (!is_zc) {
+    // Staging (non-zero-copy), or no remote DRAM at all.  Order: local SSD, local
+    // DRAM, staging remote DRAM (per peer), remote SSD.  Staging must submit then
+    // IMMEDIATELY wait per peer: the in-flight holds staging_mutex_ from submit
+    // until the wait copies out of the shared staging_buffer_, so accumulating
+    // staging in-flights into a submit-all list would deadlock on that lock.
+    run_local_ssd();
+    run_local_dram();
+    for (const auto& [node_id, items] : remote_dram_groups) {
+      if (auto f = SubmitRemoteBatchGet(items, results, /*permit_staging=*/true)) {
+        WaitRemoteBatchGet(*f, results);  // immediate; releases staging_mutex_
+      }
+    }
+    run_remote_ssd();
+    return;
+  }
+
+  // Zero-copy remote DRAM: submit every peer (posted, not waited) before waiting
+  // any, so multi-peer wire time overlaps.  Overlap eligibility (S2: also put
+  // local DRAM/SSD + remote SSD INSIDE the in-flight window) requires the env on
+  // and the batch not larger than the max-batch threshold — large batches
+  // regress because the local copy contends with the RDMA DMA for memory/PCIe
+  // bandwidth (see BatchGetOverlapMaxBatch).  Below threshold the window is used;
+  // above it local/SSD run first (out of the window) but remote DRAM still does
+  // submit-all/wait-all.
+  bool overlap_window = false;
+  if (BatchGetOverlapEnabled()) {
+    const int64_t max_batch = BatchGetOverlapMaxBatch();
+    overlap_window = max_batch <= 0 || static_cast<int64_t>(keys.size()) <= max_batch;
+  }
+
+  std::vector<std::unique_ptr<RemoteDramGetInFlight>> inflights;
+  inflights.reserve(remote_dram_groups.size());
+  // RAII drain: guarantee every posted in-flight is waited even on an
+  // exceptional/early exit (e.g. std::bad_alloc), so no posted TransferStatus is
+  // left referenced by the backend CQ callback after this scope.
+  struct InFlightDrainGuard {
+    std::vector<std::unique_ptr<RemoteDramGetInFlight>>& v;
+    ~InFlightDrainGuard() {
+      for (auto& f : v) {
+        if (f && !f->waited) {
+          for (auto& s : f->statuses) s.Wait();
+          f->waited = true;
+        }
+      }
+    }
+  } drain_guard{inflights};
+
+  if (overlap_window) {
+    // Submit every peer, run local/SSD inside the in-flight window, then wait all.
+    for (const auto& [node_id, items] : remote_dram_groups) {
+      if (auto f = SubmitRemoteBatchGet(items, results, /*permit_staging=*/false)) {
+        inflights.push_back(std::move(f));
+      }
+    }
+    run_local_dram();
+    run_local_ssd();
+    run_remote_ssd();
+    for (auto& f : inflights) WaitRemoteBatchGet(*f, results);
+  } else {
+    // Local/SSD run BEFORE the submit (out of the window), but remote DRAM still
+    // submits all peers before waiting any (multi-peer overlap, no contention).
+    run_local_ssd();
+    run_local_dram();
+    for (const auto& [node_id, items] : remote_dram_groups) {
+      if (auto f = SubmitRemoteBatchGet(items, results, /*permit_staging=*/false)) {
+        inflights.push_back(std::move(f));
+      }
+    }
+    for (auto& f : inflights) WaitRemoteBatchGet(*f, results);
+    run_remote_ssd();
+  }
 }
 
 void PoolClient::ProcessRemoteBatchPut(const std::vector<BatchPutItem>& items,
@@ -1507,68 +1641,6 @@ void PoolClient::FinalizeRemotePutEntries(std::vector<RemotePutEntry>& entries,
   }
 }
 
-void PoolClient::ProcessRemoteBatchGet(const std::vector<BatchGetItem>& items,
-                                       std::vector<bool>* results) {
-  if (items.empty()) return;
-  if (!io_engine_) {
-    MORI_UMBP_ERROR("[PoolClient] ProcessRemoteBatchGet: io_engine_ not initialized (items={})",
-                    items.size());
-    for (const auto& item : items) {
-      (*results)[item.index] = false;
-    }
-    return;
-  }
-
-  const auto& first = items.front();
-  auto& peer = GetOrConnectPeer(first.route.node_id, first.route.peer_address);
-  if (!EnsurePeerServiceConnection(peer)) {
-    MORI_UMBP_WARN(
-        "[PoolClient] ProcessRemoteBatchGet: peer service connection unavailable, node='{}' "
-        "addr='{}' items={}",
-        first.route.node_id, first.route.peer_address, items.size());
-    for (const auto& item : items) {
-      (*results)[item.index] = false;
-    }
-    return;
-  }
-
-  auto* stub = static_cast<::umbp::UMBPPeer::Stub*>(peer.peer_stub.get());
-  ExecuteRemoteBatchGet(items, results, peer, stub);
-}
-
-void PoolClient::ExecuteRemoteBatchGet(const std::vector<BatchGetItem>& items,
-                                       std::vector<bool>* results, PeerConnection& peer,
-                                       ::umbp::UMBPPeer::Stub* stub) {
-  if (items.empty()) return;
-  if (!io_engine_) {
-    for (const auto& item : items) {
-      (*results)[item.index] = false;
-    }
-    return;
-  }
-
-  std::vector<RemoteGetEntry> entries;
-  if (!PrepareRemoteGetEntries(items, stub, &entries, results)) {
-    return;
-  }
-
-  std::vector<TransferInstruction> transfers;
-  uint64_t staging_bytes = 0;
-  if (!BuildRemoteGetTransfers(entries, peer, &transfers, &staging_bytes)) {
-    MORI_UMBP_WARN(
-        "[PoolClient] ExecuteRemoteBatchGet: BuildRemoteGetTransfers failed, node='{}' "
-        "entries={} staging_bytes={}",
-        items.front().route.node_id, entries.size(), staging_bytes);
-    for (auto& entry : entries) {
-      (*results)[entry.result_index] = false;
-    }
-    return;
-  }
-
-  ExecuteRemoteGetTransfers(entries, transfers, staging_bytes);
-  FinalizeRemoteGetEntries(entries, results);
-}
-
 bool PoolClient::PrepareRemoteGetEntries(const std::vector<BatchGetItem>& items,
                                          ::umbp::UMBPPeer::Stub* stub,
                                          std::vector<RemoteGetEntry>* entries,
@@ -1706,81 +1778,6 @@ bool PoolClient::BuildRemoteGetTransfers(std::vector<RemoteGetEntry>& entries, P
   return true;
 }
 
-void PoolClient::ExecuteRemoteGetTransfers(std::vector<RemoteGetEntry>& entries,
-                                           std::vector<TransferInstruction>& transfers,
-                                           uint64_t staging_bytes) {
-  std::unique_lock<std::mutex> staging_lock(staging_mutex_, std::defer_lock);
-  if (staging_bytes > 0) staging_lock.lock();
-
-  std::vector<TransferInstruction> active_transfers;
-  active_transfers.reserve(transfers.size());
-  for (const auto& transfer : transfers) {
-    if (!entries[transfer.entry_index].failed) {
-      active_transfers.push_back(transfer);
-    }
-  }
-  if (active_transfers.empty()) {
-    if (staging_lock.owns_lock()) staging_lock.unlock();
-    return;
-  }
-
-  // Symmetric with the Put path: collapse same-(localMR, remoteMR) pages
-  // into one outer transfer with per-pair status/uid.
-  auto groups = GroupTransfersByPair(active_transfers);
-  const size_t G = groups.size();
-  mori::io::MemDescVec local_descs(G), remote_descs(G);
-  mori::io::BatchSizeVec local_offsets(G), remote_offsets(G), sizes_v(G);
-  std::vector<mori::io::TransferStatus> statuses(G);  // built once at final size
-  mori::io::TransferStatusPtrVec status_ptrs(G);
-  mori::io::TransferUniqueIdVec ids(G);
-  for (size_t g = 0; g < G; ++g) {
-    local_descs[g] = groups[g].local_desc;
-    remote_descs[g] = groups[g].remote_desc;
-    local_offsets[g] = std::move(groups[g].local_offsets);
-    remote_offsets[g] = std::move(groups[g].remote_offsets);
-    sizes_v[g] = std::move(groups[g].sizes);
-    status_ptrs[g] = &statuses[g];
-    ids[g] = io_engine_->AllocateTransferUniqueId();
-  }
-
-  io_engine_->BatchRead(local_descs, local_offsets, remote_descs, remote_offsets, sizes_v,
-                        status_ptrs, ids);
-  // Wait every group (never break early): IN_PROGRESS groups complete here;
-  // INIT/terminal return immediately.  A non-success group fails all of its
-  // contributing keys (per-item AND semantics).  See the Put path / docs
-  // NOTES re: backend partial-post / status-lifetime caveats.
-  for (size_t g = 0; g < G; ++g) {
-    statuses[g].Wait();
-    if (statuses[g].Succeeded()) continue;
-    for (size_t ei : groups[g].entry_indices) {
-      auto& entry = entries[ei];
-      MORI_UMBP_ERROR(
-          "RemoteGet BatchRead failed: code={} msg='{}' peer_engine='{}' key='{}' use_staging={}",
-          statuses[g].CodeUint32(), statuses[g].Message(), groups[g].remote_desc.engineKey,
-          (entry.item && entry.item->key) ? *entry.item->key : std::string{"<null>"},
-          entry.use_staging);
-      entry.failed = true;
-    }
-  }
-
-  if (staging_lock.owns_lock()) {
-    for (auto& entry : entries) {
-      if (entry.failed || !entry.use_staging) continue;
-      if (entry.staging_offset + entry.item->size > config_.staging_buffer_size) {
-        MORI_UMBP_ERROR(
-            "[PoolClient] ExecuteRemoteGetTransfers: staging offset overflow (should not happen), "
-            "key='{}' staging_offset={} size={} cap={}",
-            (entry.item && entry.item->key) ? *entry.item->key : std::string{"<null>"},
-            entry.staging_offset, entry.item ? entry.item->size : 0, config_.staging_buffer_size);
-        entry.failed = true;
-        continue;
-      }
-      std::memcpy(entry.item->dst, staging_buffer_.get() + entry.staging_offset, entry.item->size);
-    }
-    staging_lock.unlock();
-  }
-}
-
 void PoolClient::FinalizeRemoteGetEntries(std::vector<RemoteGetEntry>& entries,
                                           std::vector<bool>* results) {
   for (auto& entry : entries) {
@@ -1796,6 +1793,159 @@ void PoolClient::FinalizeRemoteGetEntries(std::vector<RemoteGetEntry>& entries,
                                {{"traffic", "remote"}}, static_cast<double>(entry.item->size));
     (*results)[entry.result_index] = true;
   }
+}
+
+std::unique_ptr<PoolClient::RemoteDramGetInFlight> PoolClient::SubmitRemoteBatchGet(
+    const std::vector<BatchGetItem>& items, std::vector<bool>* results, bool permit_staging) {
+  if (items.empty()) return nullptr;
+  auto fail_all = [&] {
+    for (const auto& item : items) (*results)[item.index] = false;
+  };
+  if (!io_engine_) {
+    MORI_UMBP_ERROR("[PoolClient] SubmitRemoteBatchGet: io_engine_ not initialized (items={})",
+                    items.size());
+    fail_all();
+    return nullptr;
+  }
+
+  const auto& first = items.front();
+  auto& peer = GetOrConnectPeer(first.route.node_id, first.route.peer_address);
+  if (!EnsurePeerServiceConnection(peer)) {
+    MORI_UMBP_WARN(
+        "[PoolClient] SubmitRemoteBatchGet: peer service connection unavailable, node='{}' "
+        "addr='{}' items={}",
+        first.route.node_id, first.route.peer_address, items.size());
+    fail_all();
+    return nullptr;
+  }
+  auto* stub = static_cast<::umbp::UMBPPeer::Stub*>(peer.peer_stub.get());
+
+  auto inflight = std::make_unique<RemoteDramGetInFlight>();
+  inflight->peer = &peer;
+
+  // resolve RPC + per-key validation; failed keys already written to *results.
+  if (!PrepareRemoteGetEntries(items, stub, &inflight->entries, results)) {
+    return nullptr;
+  }
+
+  std::vector<TransferInstruction> transfers;
+  uint64_t staging_bytes = 0;
+  if (!BuildRemoteGetTransfers(inflight->entries, peer, &transfers, &staging_bytes)) {
+    MORI_UMBP_WARN(
+        "[PoolClient] SubmitRemoteBatchGet: BuildRemoteGetTransfers failed, node='{}' entries={}",
+        first.route.node_id, inflight->entries.size());
+    for (auto& entry : inflight->entries) (*results)[entry.result_index] = false;
+    return nullptr;
+  }
+  inflight->staging_bytes = staging_bytes;
+  // Staging needs the shared staging_buffer_, which a cross-peer submit-all
+  // window cannot serialize on the single staging_mutex_ without deadlocking.
+  // So the zero-copy submit-all caller passes permit_staging=false: a batch that
+  // unexpectedly needs staging (upper layer guarantees all-zc or all-staging) is
+  // failed rather than risking a deadlock.  The serial staging caller passes
+  // true and we park staging_mutex_ in the in-flight until the wait copies out.
+  if (staging_bytes > 0) {
+    if (!permit_staging) {
+      MORI_UMBP_ERROR(
+          "[PoolClient] SubmitRemoteBatchGet: unexpected staging_bytes={} on zero-copy path "
+          "node='{}' -> failing batch",
+          staging_bytes, first.route.node_id);
+      for (auto& entry : inflight->entries) (*results)[entry.result_index] = false;
+      return nullptr;
+    }
+    inflight->staging_lock = std::unique_lock<std::mutex>(staging_mutex_);
+  }
+
+  // Drop transfers whose entry failed during build (invalid remote desc etc.).
+  std::vector<TransferInstruction> active_transfers;
+  active_transfers.reserve(transfers.size());
+  for (const auto& t : transfers) {
+    if (!inflight->entries[t.entry_index].failed) active_transfers.push_back(t);
+  }
+  if (active_transfers.empty()) {
+    for (auto& entry : inflight->entries) {
+      if (entry.failed) (*results)[entry.result_index] = false;
+    }
+    return nullptr;  // staging_lock (if held) released by the in-flight's destruction
+  }
+
+  // Collapse same-(localMR, remoteMR) pages into one outer transfer per pair,
+  // then materialise the BatchRead args INTO the in-flight struct so they outlive
+  // the post.
+  inflight->groups = GroupTransfersByPair(active_transfers);
+  const size_t G = inflight->groups.size();
+  inflight->local_descs.resize(G);
+  inflight->remote_descs.resize(G);
+  inflight->local_offsets.resize(G);
+  inflight->remote_offsets.resize(G);
+  inflight->sizes_v.resize(G);
+  // Build statuses at final size once and never resize/move (backend holds raw
+  // TransferStatus*); status_ptrs alias into it.  vector move-assign steals the
+  // buffer (default allocator), so elements are not moved and addresses are
+  // stable for the in-flight lifetime.
+  inflight->statuses = std::vector<mori::io::TransferStatus>(G);
+  inflight->status_ptrs.resize(G);
+  inflight->ids.resize(G);
+  for (size_t g = 0; g < G; ++g) {
+    inflight->local_descs[g] = inflight->groups[g].local_desc;
+    inflight->remote_descs[g] = inflight->groups[g].remote_desc;
+    inflight->local_offsets[g] = std::move(inflight->groups[g].local_offsets);
+    inflight->remote_offsets[g] = std::move(inflight->groups[g].remote_offsets);
+    inflight->sizes_v[g] = std::move(inflight->groups[g].sizes);
+    inflight->status_ptrs[g] = &inflight->statuses[g];
+    inflight->ids[g] = io_engine_->AllocateTransferUniqueId();
+  }
+
+  // POST the reads; do NOT wait.  Everything BatchRead may reference is owned by
+  // *inflight; no allocation happens after this point in the submit window.  For
+  // staging, the RDMA lands in staging_buffer_ under the held staging_lock.
+  io_engine_->BatchRead(inflight->local_descs, inflight->local_offsets, inflight->remote_descs,
+                        inflight->remote_offsets, inflight->sizes_v, inflight->status_ptrs,
+                        inflight->ids);
+  return inflight;
+}
+
+void PoolClient::WaitRemoteBatchGet(RemoteDramGetInFlight& f, std::vector<bool>* results) {
+  if (f.waited) return;
+  f.waited = true;
+  // Wait every group (never break early): IN_PROGRESS groups complete here;
+  // INIT/terminal return immediately.  A non-success group fails all of its
+  // contributing keys (per-item AND).
+  const size_t G = f.groups.size();
+  for (size_t g = 0; g < G; ++g) {
+    f.statuses[g].Wait();
+    if (f.statuses[g].Succeeded()) continue;
+    for (size_t ei : f.groups[g].entry_indices) {
+      auto& entry = f.entries[ei];
+      MORI_UMBP_ERROR(
+          "RemoteGet BatchRead failed: code={} msg='{}' peer_engine='{}' key='{}' use_staging={}",
+          f.statuses[g].CodeUint32(), f.statuses[g].Message(), f.groups[g].remote_desc.engineKey,
+          (entry.item && entry.item->key) ? *entry.item->key : std::string{"<null>"},
+          entry.use_staging);
+      entry.failed = true;
+    }
+  }
+
+  // Staging (non-zero-copy): RDMA landed in staging_buffer_; copy each surviving
+  // entry out to its user dst, then release staging_mutex_ (held since submit).
+  if (f.staging_lock.owns_lock()) {
+    for (auto& entry : f.entries) {
+      if (entry.failed || !entry.use_staging) continue;
+      if (entry.staging_offset + entry.item->size > config_.staging_buffer_size) {
+        MORI_UMBP_ERROR(
+            "[PoolClient] WaitRemoteBatchGet: staging offset overflow (should not happen), "
+            "key='{}' staging_offset={} size={} cap={}",
+            (entry.item && entry.item->key) ? *entry.item->key : std::string{"<null>"},
+            entry.staging_offset, entry.item ? entry.item->size : 0, config_.staging_buffer_size);
+        entry.failed = true;
+        continue;
+      }
+      std::memcpy(entry.item->dst, staging_buffer_.get() + entry.staging_offset, entry.item->size);
+    }
+    f.staging_lock.unlock();
+  }
+
+  FinalizeRemoteGetEntries(f.entries, results);
 }
 
 bool PoolClient::Exists(const std::string& key) {

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -25,8 +25,11 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <functional>
+#include <limits>
 #include <msgpack.hpp>
 #include <numeric>
 #include <string>
@@ -38,7 +41,6 @@
 #include <unordered_map>
 
 #include "mori/io/backend.hpp"
-#include "mori/utils/env_utils.hpp"
 #include "mori/utils/mori_log.hpp"
 #include "umbp/common/env_time.h"
 #include "umbp/distributed/master/master_metrics.h"
@@ -54,6 +56,34 @@ namespace mori::umbp {
 namespace {
 
 bool IsValidMemoryDesc(const mori::io::MemoryDesc& desc) { return desc.size > 0; }
+
+// Key for grouping page transfers by their (local MR, remote MR) pair.
+struct PairKey {
+  mori::io::MemoryUniqueId local;
+  mori::io::MemoryUniqueId remote;
+  bool operator==(const PairKey& o) const noexcept {
+    return local == o.local && remote == o.remote;
+  }
+};
+struct PairKeyHash {
+  size_t operator()(const PairKey& k) const noexcept {
+    // hash_combine (boost-style): independent of size_t width.
+    size_t h = std::hash<mori::io::MemoryUniqueId>{}(k.local);
+    h ^= std::hash<mori::io::MemoryUniqueId>{}(k.remote) + 0x9e3779b97f4a7c15ULL + (h << 6) +
+         (h >> 2);
+    return h;
+  }
+};
+
+// True iff [next, ...) is exactly adjacent after [base, base+len), with no
+// size_t overflow in base+len.  Used to coalesce contiguous SG segments.
+inline bool AdjacentNoOverflow(size_t base, size_t len, size_t next) {
+  return len <= std::numeric_limits<size_t>::max() - base && base + len == next;
+}
+
+// ---------------------------------------------------------------------------
+//  Bandwidth metrics
+// ---------------------------------------------------------------------------
 
 constexpr double kGiB = 1024.0 * 1024.0 * 1024.0;
 
@@ -105,6 +135,10 @@ void ObserveBatchBandwidth(MasterClient& master_client, double bytes, double sec
   master_client.Observe(metric_name, metric_help, std::move(labels), BatchBandwidthBucketsGiBps(),
                         gibps);
 }
+
+// ---------------------------------------------------------------------------
+//  Page / size math
+// ---------------------------------------------------------------------------
 
 // Bytes belonging to the i-th logical page of a Put/Get spread across
 // `num_pages` pages of `page_size` bytes.  Last page may be partial.
@@ -228,6 +262,10 @@ std::vector<ScatterGroup> GroupPagesByBuffer(const std::vector<PageLocation>& pa
   return groups;
 }
 
+// ---------------------------------------------------------------------------
+//  SSD / lease env knobs
+// ---------------------------------------------------------------------------
+
 uint32_t ReleaseLeaseMaxRetries() {
   static const uint32_t v = GetEnvUint32("UMBP_RELEASE_LEASE_MAX_RETRIES", 2, /*min_allowed=*/1);
   return v;
@@ -283,6 +321,10 @@ std::chrono::milliseconds ReleaseLeaseRpcTimeout() {
                                            std::chrono::milliseconds(1000), /*min_allowed=*/1);
   return v;
 }
+
+// ---------------------------------------------------------------------------
+//  Config / proto translation
+// ---------------------------------------------------------------------------
 
 // Build a TierConfig from the PoolClientConfig (DRAM only — HBM
 // support requires per-tier buffer plumbing the upper layers don't
@@ -360,9 +402,13 @@ bool PoolClient::Init() {
     io_engine_ = std::make_unique<mori::io::IOEngine>(config_.master_config.node_id, io_cfg);
     mori::io::RdmaBackendConfig rdma_cfg;
 
-    rdma_cfg.qpPerTransfer = mori::env::GetPositiveIntOr("MORI_UMBP_QP_PER_TRANSFER", 4);
+    rdma_cfg.qpPerTransfer = 4;
     rdma_cfg.enableTransferChunking = true;
     rdma_cfg.numNicsPerTransfer = 4;
+    // UMBP only sets the config defaults above.  All RDMA knobs (qpPerTransfer
+    // / postBatchSize / numWorkerThreads / pollCqMode / chunking / numNics /
+    // ...) are overridable via MORI_IO_* env in the RDMA backend ctor, shared
+    // by every IO backend user; no UMBP-specific entry points.
     io_engine_->CreateBackend(mori::io::BackendType::RDMA, rdma_cfg);
 
     staging_buffer_ = std::make_unique<char[]>(config_.staging_buffer_size);
@@ -1177,6 +1223,60 @@ bool PoolClient::AllocateRemotePutEntries(const std::vector<BatchPutItem>& items
   return true;
 }
 
+std::vector<PoolClient::PairGroup> PoolClient::GroupTransfersByPair(
+    const std::vector<TransferInstruction>& active) {
+  std::vector<PairGroup> groups;
+  groups.reserve(active.size());
+  // Group by (local MR id, remote MR id); first appearance defines order.
+  std::unordered_map<PairKey, size_t, PairKeyHash> pair_to_group;
+  pair_to_group.reserve(active.size() * 2);
+
+  for (const auto& t : active) {
+    const PairKey key{t.local_desc.id, t.remote_desc.id};
+    auto it = pair_to_group.find(key);
+    size_t gi;
+    if (it == pair_to_group.end()) {
+      gi = groups.size();
+      pair_to_group.emplace(key, gi);
+      PairGroup g;
+      g.local_desc = t.local_desc;
+      g.remote_desc = t.remote_desc;
+      groups.push_back(std::move(g));
+    } else {
+      gi = it->second;
+    }
+    PairGroup& g = groups[gi];
+    const size_t lo = static_cast<size_t>(t.local_offset);
+    const size_t ro = static_cast<size_t>(t.remote_offset);
+    const size_t sz = static_cast<size_t>(t.size);
+    // Coalesce with the previous segment when BOTH local and remote are
+    // exactly contiguous.  This is NOT redundant with the backend's WR
+    // merging: the backend would fold these into the same WR either way, but
+    // doing it here shrinks the inner SG vector it has to sort/merge
+    // (O(M log M)) and allocate, which matters when M is large (big batch x
+    // pages).  Same bytes, so per-pair failure granularity is unchanged.
+    // The merged size must stay within uint32_t since the backend stores it
+    // in ibv_sge.length (matches its own WR-merge cap in common.cpp).
+    const bool can_coalesce =
+        !g.sizes.empty() && AdjacentNoOverflow(g.local_offsets.back(), g.sizes.back(), lo) &&
+        AdjacentNoOverflow(g.remote_offsets.back(), g.sizes.back(), ro) &&
+        g.sizes.back() <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()) - sz;
+    if (can_coalesce) {
+      g.sizes.back() += sz;
+    } else {
+      g.local_offsets.push_back(lo);
+      g.remote_offsets.push_back(ro);
+      g.sizes.push_back(sz);
+    }
+    // De-dup contributing entries: a single entry's pages arrive
+    // consecutively within a pair, so a back() check suffices.
+    if (g.entry_indices.empty() || g.entry_indices.back() != t.entry_index) {
+      g.entry_indices.push_back(t.entry_index);
+    }
+  }
+  return groups;
+}
+
 bool PoolClient::BuildRemotePutTransfers(std::vector<RemotePutEntry>& entries, PeerConnection& peer,
                                          std::vector<TransferInstruction>* transfers,
                                          uint64_t* staging_bytes) {
@@ -1185,7 +1285,6 @@ bool PoolClient::BuildRemotePutTransfers(std::vector<RemotePutEntry>& entries, P
 
   for (size_t idx = 0; idx < entries.size(); ++idx) {
     auto& entry = entries[idx];
-    EnsureBufferDescsCached(peer, entry.plan.descs);
 
     auto zero_copy = FindRegisteredMemory(entry.item->src, entry.item->size);
     if (zero_copy.has_value()) {
@@ -1220,30 +1319,38 @@ bool PoolClient::BuildRemotePutTransfers(std::vector<RemotePutEntry>& entries, P
       base_offset = entry.zero_copy->second;
     }
 
+    // Hydrate + snapshot remote descs inside ONE peers_mutex_ window: a
+    // concurrent EnsureBufferDescsCached may resize dram_memories, so the
+    // reads below must not race it.  zero_copy/staging above touch no peer
+    // state and stay outside the lock.
     std::vector<TransferInstruction> entry_transfers;
     entry_transfers.reserve(entry.plan.pages.size());
-    for (size_t p = 0; p < entry.plan.pages.size(); ++p) {
-      const auto& page = entry.plan.pages[p];
-      if (page.buffer_index >= peer.dram_memories.size() ||
-          !IsValidMemoryDesc(peer.dram_memories[page.buffer_index])) {
-        MORI_UMBP_ERROR(
-            "[PoolClient] BuildRemotePutTransfers: invalid peer dram_memories slot, "
-            "key='{}' buffer_index={} peer_dram_size={} page_index={}",
-            (entry.item && entry.item->key) ? *entry.item->key : std::string{"<null>"},
-            page.buffer_index, peer.dram_memories.size(), page.page_index);
-        entry.failed = true;
-        entry_transfers.clear();
-        break;
+    {
+      std::lock_guard<std::mutex> lock(peers_mutex_);
+      EnsureBufferDescsCachedLocked(peer, entry.plan.descs);
+      for (size_t p = 0; p < entry.plan.pages.size(); ++p) {
+        const auto& page = entry.plan.pages[p];
+        if (page.buffer_index >= peer.dram_memories.size() ||
+            !IsValidMemoryDesc(peer.dram_memories[page.buffer_index])) {
+          MORI_UMBP_ERROR(
+              "[PoolClient] BuildRemotePutTransfers: invalid peer dram_memories slot, "
+              "key='{}' buffer_index={} peer_dram_size={} page_index={}",
+              (entry.item && entry.item->key) ? *entry.item->key : std::string{"<null>"},
+              page.buffer_index, peer.dram_memories.size(), page.page_index);
+          entry.failed = true;
+          entry_transfers.clear();
+          break;
+        }
+        TransferInstruction instr;
+        instr.entry_index = idx;
+        instr.local_desc = local_desc;
+        instr.local_offset = base_offset + static_cast<uint64_t>(p) * entry.plan.page_size;
+        instr.remote_desc = peer.dram_memories[page.buffer_index];
+        instr.remote_offset = static_cast<uint64_t>(page.page_index) * entry.plan.page_size;
+        instr.size =
+            LogicalPageBytes(p, entry.plan.pages.size(), entry.plan.page_size, entry.item->size);
+        entry_transfers.push_back(std::move(instr));
       }
-      TransferInstruction instr;
-      instr.entry_index = idx;
-      instr.local_desc = local_desc;
-      instr.local_offset = base_offset + static_cast<uint64_t>(p) * entry.plan.page_size;
-      instr.remote_desc = peer.dram_memories[page.buffer_index];
-      instr.remote_offset = static_cast<uint64_t>(page.page_index) * entry.plan.page_size;
-      instr.size =
-          LogicalPageBytes(p, entry.plan.pages.size(), entry.plan.page_size, entry.item->size);
-      entry_transfers.push_back(std::move(instr));
     }
 
     if (!entry_transfers.empty()) {
@@ -1289,36 +1396,45 @@ void PoolClient::ExecuteRemotePutTransfers(std::vector<RemotePutEntry>& entries,
     return;
   }
 
-  const size_t N = active_transfers.size();
-  mori::io::MemDescVec local_descs(N), remote_descs(N);
-  mori::io::BatchSizeVec local_offsets(N), remote_offsets(N), sizes_v(N);
-  std::vector<mori::io::TransferStatus> statuses(N);
-  mori::io::TransferStatusPtrVec status_ptrs(N);
-  mori::io::TransferUniqueIdVec ids(N);
-  for (size_t i = 0; i < N; ++i) {
-    const auto& transfer = active_transfers[i];
-    local_descs[i] = transfer.local_desc;
-    remote_descs[i] = transfer.remote_desc;
-    local_offsets[i].push_back(transfer.local_offset);
-    remote_offsets[i].push_back(transfer.remote_offset);
-    sizes_v[i].push_back(transfer.size);
-    status_ptrs[i] = &statuses[i];
-    ids[i] = io_engine_->AllocateTransferUniqueId();
+  // Collapse all pages of the same (localMR, remoteMR) pair into one outer
+  // transfer (inner offset/size vectors = scatter-gather segments).  One
+  // TransferStatus and one TransferUniqueId per pair instead of per page.
+  auto groups = GroupTransfersByPair(active_transfers);
+  const size_t G = groups.size();
+  mori::io::MemDescVec local_descs(G), remote_descs(G);
+  mori::io::BatchSizeVec local_offsets(G), remote_offsets(G), sizes_v(G);
+  std::vector<mori::io::TransferStatus> statuses(G);  // built once at final size
+  mori::io::TransferStatusPtrVec status_ptrs(G);
+  mori::io::TransferUniqueIdVec ids(G);
+  for (size_t g = 0; g < G; ++g) {
+    local_descs[g] = groups[g].local_desc;
+    remote_descs[g] = groups[g].remote_desc;
+    local_offsets[g] = std::move(groups[g].local_offsets);
+    remote_offsets[g] = std::move(groups[g].remote_offsets);
+    sizes_v[g] = std::move(groups[g].sizes);
+    status_ptrs[g] = &statuses[g];
+    ids[g] = io_engine_->AllocateTransferUniqueId();
   }
 
   io_engine_->BatchWrite(local_descs, local_offsets, remote_descs, remote_offsets, sizes_v,
                          status_ptrs, ids);
-  for (size_t i = 0; i < active_transfers.size(); ++i) {
-    statuses[i].Wait();
-    if (!statuses[i].Succeeded()) {
-      const auto& tr = active_transfers[i];
-      auto& entry = entries[tr.entry_index];
+  // Wait every group (never break early): IN_PROGRESS groups complete here;
+  // INIT (left unsubmitted by an engine early-return) or already-terminal
+  // groups return immediately.  A non-success group fails ALL its
+  // contributing keys (per-item AND semantics — a key fails if any of its
+  // pairs fail).  NOTE: this does not by itself prove safety of backend
+  // partial-post / status-lifetime corner cases (see docs/perf NOTES).
+  for (size_t g = 0; g < G; ++g) {
+    statuses[g].Wait();
+    if (statuses[g].Succeeded()) continue;
+    for (size_t ei : groups[g].entry_indices) {
+      auto& entry = entries[ei];
       MORI_UMBP_ERROR(
           "RemotePut BatchWrite failed: code={} msg='{}' peer_engine='{}' key='{}' "
-          "slot_id={} size={} local_off={} remote_off={} use_staging={}",
-          statuses[i].CodeUint32(), statuses[i].Message(), tr.remote_desc.engineKey,
+          "slot_id={} use_staging={}",
+          statuses[g].CodeUint32(), statuses[g].Message(), groups[g].remote_desc.engineKey,
           (entry.item && entry.item->key) ? *entry.item->key : std::string{"<null>"}, entry.slot_id,
-          tr.size, tr.local_offset, tr.remote_offset, entry.use_staging);
+          entry.use_staging);
       entry.failed = true;
     }
   }
@@ -1512,7 +1628,6 @@ bool PoolClient::BuildRemoteGetTransfers(std::vector<RemoteGetEntry>& entries, P
 
   for (size_t idx = 0; idx < entries.size(); ++idx) {
     auto& entry = entries[idx];
-    EnsureBufferDescsCached(peer, entry.plan.descs);
 
     auto zero_copy = FindRegisteredMemory(entry.item->dst, entry.item->size);
     if (zero_copy.has_value()) {
@@ -1550,30 +1665,36 @@ bool PoolClient::BuildRemoteGetTransfers(std::vector<RemoteGetEntry>& entries, P
       continue;
     }
 
+    // Hydrate + snapshot remote descs inside ONE peers_mutex_ window (see
+    // BuildRemotePutTransfers).
     std::vector<TransferInstruction> entry_transfers;
     entry_transfers.reserve(entry.plan.pages.size());
-    for (size_t p = 0; p < entry.plan.pages.size(); ++p) {
-      const auto& page = entry.plan.pages[p];
-      if (page.buffer_index >= peer.dram_memories.size() ||
-          !IsValidMemoryDesc(peer.dram_memories[page.buffer_index])) {
-        MORI_UMBP_ERROR(
-            "[PoolClient] BuildRemoteGetTransfers: invalid peer dram_memories slot, "
-            "key='{}' buffer_index={} peer_dram_size={} page_index={}",
-            (entry.item && entry.item->key) ? *entry.item->key : std::string{"<null>"},
-            page.buffer_index, peer.dram_memories.size(), page.page_index);
-        entry.failed = true;
-        entry_transfers.clear();
-        break;
+    {
+      std::lock_guard<std::mutex> lock(peers_mutex_);
+      EnsureBufferDescsCachedLocked(peer, entry.plan.descs);
+      for (size_t p = 0; p < entry.plan.pages.size(); ++p) {
+        const auto& page = entry.plan.pages[p];
+        if (page.buffer_index >= peer.dram_memories.size() ||
+            !IsValidMemoryDesc(peer.dram_memories[page.buffer_index])) {
+          MORI_UMBP_ERROR(
+              "[PoolClient] BuildRemoteGetTransfers: invalid peer dram_memories slot, "
+              "key='{}' buffer_index={} peer_dram_size={} page_index={}",
+              (entry.item && entry.item->key) ? *entry.item->key : std::string{"<null>"},
+              page.buffer_index, peer.dram_memories.size(), page.page_index);
+          entry.failed = true;
+          entry_transfers.clear();
+          break;
+        }
+        TransferInstruction instr;
+        instr.entry_index = idx;
+        instr.local_desc = local_desc;
+        instr.local_offset = base_offset + static_cast<uint64_t>(p) * entry.plan.page_size;
+        instr.remote_desc = peer.dram_memories[page.buffer_index];
+        instr.remote_offset = static_cast<uint64_t>(page.page_index) * entry.plan.page_size;
+        instr.size =
+            LogicalPageBytes(p, entry.plan.pages.size(), entry.plan.page_size, entry.item->size);
+        entry_transfers.push_back(std::move(instr));
       }
-      TransferInstruction instr;
-      instr.entry_index = idx;
-      instr.local_desc = local_desc;
-      instr.local_offset = base_offset + static_cast<uint64_t>(p) * entry.plan.page_size;
-      instr.remote_desc = peer.dram_memories[page.buffer_index];
-      instr.remote_offset = static_cast<uint64_t>(page.page_index) * entry.plan.page_size;
-      instr.size =
-          LogicalPageBytes(p, entry.plan.pages.size(), entry.plan.page_size, entry.item->size);
-      entry_transfers.push_back(std::move(instr));
     }
 
     if (!entry_transfers.empty()) {
@@ -1603,36 +1724,41 @@ void PoolClient::ExecuteRemoteGetTransfers(std::vector<RemoteGetEntry>& entries,
     return;
   }
 
-  const size_t N = active_transfers.size();
-  mori::io::MemDescVec local_descs(N), remote_descs(N);
-  mori::io::BatchSizeVec local_offsets(N), remote_offsets(N), sizes_v(N);
-  std::vector<mori::io::TransferStatus> statuses(N);
-  mori::io::TransferStatusPtrVec status_ptrs(N);
-  mori::io::TransferUniqueIdVec ids(N);
-  for (size_t i = 0; i < N; ++i) {
-    const auto& transfer = active_transfers[i];
-    remote_descs[i] = transfer.remote_desc;
-    local_descs[i] = transfer.local_desc;
-    remote_offsets[i].push_back(transfer.remote_offset);
-    local_offsets[i].push_back(transfer.local_offset);
-    sizes_v[i].push_back(transfer.size);
-    status_ptrs[i] = &statuses[i];
-    ids[i] = io_engine_->AllocateTransferUniqueId();
+  // Symmetric with the Put path: collapse same-(localMR, remoteMR) pages
+  // into one outer transfer with per-pair status/uid.
+  auto groups = GroupTransfersByPair(active_transfers);
+  const size_t G = groups.size();
+  mori::io::MemDescVec local_descs(G), remote_descs(G);
+  mori::io::BatchSizeVec local_offsets(G), remote_offsets(G), sizes_v(G);
+  std::vector<mori::io::TransferStatus> statuses(G);  // built once at final size
+  mori::io::TransferStatusPtrVec status_ptrs(G);
+  mori::io::TransferUniqueIdVec ids(G);
+  for (size_t g = 0; g < G; ++g) {
+    local_descs[g] = groups[g].local_desc;
+    remote_descs[g] = groups[g].remote_desc;
+    local_offsets[g] = std::move(groups[g].local_offsets);
+    remote_offsets[g] = std::move(groups[g].remote_offsets);
+    sizes_v[g] = std::move(groups[g].sizes);
+    status_ptrs[g] = &statuses[g];
+    ids[g] = io_engine_->AllocateTransferUniqueId();
   }
 
   io_engine_->BatchRead(local_descs, local_offsets, remote_descs, remote_offsets, sizes_v,
                         status_ptrs, ids);
-  for (size_t i = 0; i < active_transfers.size(); ++i) {
-    statuses[i].Wait();
-    if (!statuses[i].Succeeded()) {
-      const auto& tr = active_transfers[i];
-      auto& entry = entries[tr.entry_index];
+  // Wait every group (never break early): IN_PROGRESS groups complete here;
+  // INIT/terminal return immediately.  A non-success group fails all of its
+  // contributing keys (per-item AND semantics).  See the Put path / docs
+  // NOTES re: backend partial-post / status-lifetime caveats.
+  for (size_t g = 0; g < G; ++g) {
+    statuses[g].Wait();
+    if (statuses[g].Succeeded()) continue;
+    for (size_t ei : groups[g].entry_indices) {
+      auto& entry = entries[ei];
       MORI_UMBP_ERROR(
-          "RemoteGet BatchRead failed: code={} msg='{}' peer_engine='{}' key='{}' "
-          "size={} local_off={} remote_off={} use_staging={}",
-          statuses[i].CodeUint32(), statuses[i].Message(), tr.remote_desc.engineKey,
-          (entry.item && entry.item->key) ? *entry.item->key : std::string{"<null>"}, tr.size,
-          tr.local_offset, tr.remote_offset, entry.use_staging);
+          "RemoteGet BatchRead failed: code={} msg='{}' peer_engine='{}' key='{}' use_staging={}",
+          statuses[g].CodeUint32(), statuses[g].Message(), groups[g].remote_desc.engineKey,
+          (entry.item && entry.item->key) ? *entry.item->key : std::string{"<null>"},
+          entry.use_staging);
       entry.failed = true;
     }
   }
@@ -1740,10 +1866,10 @@ PoolClient::PeerConnection& PoolClient::GetOrConnectPeer(const std::string& node
   return ref;
 }
 
-void PoolClient::EnsureBufferDescsCached(PeerConnection& peer,
-                                         const std::vector<BufferMemoryDescBytes>& descs) {
+void PoolClient::EnsureBufferDescsCachedLocked(PeerConnection& peer,
+                                               const std::vector<BufferMemoryDescBytes>& descs) {
+  // Caller holds peers_mutex_.
   if (!io_engine_) return;
-  std::lock_guard<std::mutex> lock(peers_mutex_);
   for (const auto& d : descs) {
     if (peer.dram_memories.size() <= d.buffer_index) {
       peer.dram_memories.resize(d.buffer_index + 1);
@@ -1754,6 +1880,12 @@ void PoolClient::EnsureBufferDescsCached(PeerConnection& peer,
         msgpack::unpack(reinterpret_cast<const char*>(d.desc_bytes.data()), d.desc_bytes.size());
     peer.dram_memories[d.buffer_index] = handle.get().as<mori::io::MemoryDesc>();
   }
+}
+
+void PoolClient::EnsureBufferDescsCached(PeerConnection& peer,
+                                         const std::vector<BufferMemoryDescBytes>& descs) {
+  std::lock_guard<std::mutex> lock(peers_mutex_);
+  EnsureBufferDescsCachedLocked(peer, descs);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -810,41 +810,8 @@ PoolClient::GetAttemptOutcome PoolClient::ExecuteLocalSsdGet(const std::string& 
   return GetAttemptOutcome::kSuccess;
 }
 
-PoolClient::BatchPutPlan PoolClient::PartitionBatchPutTargets(
-    const std::vector<std::string>& keys, const std::vector<const void*>& srcs,
-    const std::vector<size_t>& sizes, const std::vector<std::optional<RoutePutResult>>& routes,
-    std::vector<PutEntryOutcome>* results) {
-  BatchPutPlan plan;
-  const size_t count = keys.size();
-  for (size_t i = 0; i < count; ++i) {
-    // Zero-size puts are meaningless: leave the result kFailed, never execute.
-    if (sizes[i] == 0) {
-      MORI_UMBP_WARN("[PoolClient] BatchPut: skipping zero-size put for key='{}'", keys[i]);
-      continue;
-    }
-    if (i >= routes.size() || !routes[i].has_value()) continue;
-    const auto& route = routes[i].value();
-    // Master-side dedup hit.
-    if (route.outcome == RoutePutOutcome::kAlreadyExists) {
-      (*results)[i] = PutEntryOutcome::kAlreadyExists;
-      continue;
-    }
-    if (route.node_id == config_.master_config.node_id) {
-      // Self-target: deferred (with its tier) so ExecuteBatchPutPlan can run the
-      // local memcpy inside the remote-DRAM submit..wait window.
-      plan.local_items.push_back(BatchPutItem{
-          .index = i, .key = &keys[i], .src = srcs[i], .size = sizes[i], .route = route});
-      continue;
-    }
-    if (route.tier != TierType::DRAM && route.tier != TierType::HBM) continue;
-    plan.remote_groups[route.node_id].push_back(BatchPutItem{
-        .index = i, .key = &keys[i], .src = srcs[i], .size = sizes[i], .route = route});
-  }
-  return plan;
-}
-
 // ---------------------------------------------------------------------------
-//  Put / Get hot paths
+//  BatchPut
 // ---------------------------------------------------------------------------
 
 bool PoolClient::Put(const std::string& key, const void* src, size_t size) {
@@ -852,14 +819,6 @@ bool PoolClient::Put(const std::string& key, const void* src, size_t size) {
   std::vector<const void*> srcs{src};
   std::vector<size_t> sizes{size};
   auto results = BatchPut(keys, srcs, sizes);
-  return !results.empty() && results[0];
-}
-
-bool PoolClient::Get(const std::string& key, void* dst, size_t size) {
-  std::vector<std::string> keys{key};
-  std::vector<void*> dsts{dst};
-  std::vector<size_t> sizes{size};
-  auto results = BatchGet(keys, dsts, sizes);
   return !results.empty() && results[0];
 }
 
@@ -917,190 +876,37 @@ std::vector<bool> PoolClient::BatchPut(const std::vector<std::string>& keys,
   return results;
 }
 
-std::vector<bool> PoolClient::BatchGet(const std::vector<std::string>& keys,
-                                       const std::vector<void*>& dsts,
-                                       const std::vector<size_t>& sizes) {
-  const auto call_start = std::chrono::steady_clock::now();
-  std::vector<bool> results(keys.size(), false);
-  if (keys.size() != dsts.size() || keys.size() != sizes.size()) {
-    MORI_UMBP_ERROR("[PoolClient] BatchGet: vector length mismatch");
-    return results;
-  }
-  if (!initialized_) {
-    MORI_UMBP_ERROR("[PoolClient] BatchGet: client not initialized");
-    return results;
-  }
-
-  std::vector<std::optional<RouteGetResult>> routes;
-  std::unordered_set<std::string> excludes;
-  auto status = master_client_->BatchRouteGet(keys, excludes, &routes);
-  if (!status.ok()) {
-    MORI_UMBP_ERROR("[PoolClient] BatchGet: BatchRouteGet failed: {}", status.error_message());
-    return results;
-  }
-  if (routes.size() < keys.size()) {
-    routes.resize(keys.size());
-  }
-
-  BatchGetPlan plan = PartitionBatchGetTargets(keys, dsts, sizes, routes);
-  ExecuteBatchGetPlan(plan, keys, dsts, sizes, &results);
-
-  const auto call_end = std::chrono::steady_clock::now();
-  const double seconds =
-      std::chrono::duration_cast<std::chrono::duration<double>>(call_end - call_start).count();
-  if (seconds > 0.0) {
-    auto split = ComputeBatchBandwidthBytes(results, sizes, routes, config_.master_config.node_id);
-    ObserveBatchBandwidth(*master_client_, split.local, seconds,
-                          MORI_UMBP_METRIC_CLIENT_BATCH_GET_BANDWIDTH,
-                          MORI_UMBP_METRIC_CLIENT_BATCH_GET_BANDWIDTH_HELP, "local");
-    ObserveBatchBandwidth(*master_client_, split.remote, seconds,
-                          MORI_UMBP_METRIC_CLIENT_BATCH_GET_BANDWIDTH,
-                          MORI_UMBP_METRIC_CLIENT_BATCH_GET_BANDWIDTH_HELP, "remote");
-  }
-  return results;
-}
-
-PoolClient::BatchGetPlan PoolClient::PartitionBatchGetTargets(
-    const std::vector<std::string>& keys, const std::vector<void*>& dsts,
-    const std::vector<size_t>& sizes, const std::vector<std::optional<RouteGetResult>>& routes) {
-  BatchGetPlan plan;
-  for (size_t i = 0; i < keys.size(); ++i) {
-    // Zero-size gets are rejected before local fallback or remote read: an
-    // explicit skip is required here because a nullopt route below would
-    // otherwise fall through to a local read (result stays false).
+PoolClient::BatchPutPlan PoolClient::PartitionBatchPutTargets(
+    const std::vector<std::string>& keys, const std::vector<const void*>& srcs,
+    const std::vector<size_t>& sizes, const std::vector<std::optional<RoutePutResult>>& routes,
+    std::vector<PutEntryOutcome>* results) {
+  BatchPutPlan plan;
+  const size_t count = keys.size();
+  for (size_t i = 0; i < count; ++i) {
+    // Zero-size puts are meaningless: leave the result kFailed, never execute.
     if (sizes[i] == 0) {
-      MORI_UMBP_WARN("[PoolClient] BatchGet: skipping zero-size get for key='{}'", keys[i]);
+      MORI_UMBP_WARN("[PoolClient] BatchPut: skipping zero-size put for key='{}'", keys[i]);
       continue;
     }
-    if (i >= routes.size() || !routes[i].has_value()) {
-      if (peer_alloc_) plan.local_dram_indices.push_back(i);
-      continue;
-    }
+    if (i >= routes.size() || !routes[i].has_value()) continue;
     const auto& route = routes[i].value();
-    if (route.node_id == config_.master_config.node_id) {
-      // Self-target: both DRAM/HBM and SSD are deferred (collected as indices)
-      // so ExecuteBatchGetPlan can place them inside the remote-DRAM in-flight
-      // window in the overlap path.
-      if (route.tier == TierType::SSD) {
-        plan.local_ssd_indices.push_back(i);
-      } else {
-        plan.local_dram_indices.push_back(i);
-      }
+    // Master-side dedup hit.
+    if (route.outcome == RoutePutOutcome::kAlreadyExists) {
+      (*results)[i] = PutEntryOutcome::kAlreadyExists;
       continue;
     }
-    BatchGetItem item{.index = i,
-                      .key = &keys[i],
-                      .dst = const_cast<void*>(dsts[i]),
-                      .size = sizes[i],
-                      .route = route};
-    if (route.tier == TierType::SSD) {
-      plan.remote_ssd_groups[route.node_id].push_back(std::move(item));
-    } else {
-      plan.remote_dram_groups[route.node_id].push_back(std::move(item));
+    if (route.node_id == config_.master_config.node_id) {
+      // Self-target: deferred (with its tier) so ExecuteBatchPutPlan can run the
+      // local memcpy inside the remote-DRAM submit..wait window.
+      plan.local_items.push_back(BatchPutItem{
+          .index = i, .key = &keys[i], .src = srcs[i], .size = sizes[i], .route = route});
+      continue;
     }
+    if (route.tier != TierType::DRAM && route.tier != TierType::HBM) continue;
+    plan.remote_groups[route.node_id].push_back(BatchPutItem{
+        .index = i, .key = &keys[i], .src = srcs[i], .size = sizes[i], .route = route});
   }
   return plan;
-}
-
-void PoolClient::ExecuteBatchGetPlan(const BatchGetPlan& plan, const std::vector<std::string>& keys,
-                                     const std::vector<void*>& dsts,
-                                     const std::vector<size_t>& sizes, std::vector<bool>* results) {
-  // Parallel local DRAM reads: different threads handle different keys. Resolve
-  // is mutex-serialized in the allocator; the per-key memcpy in
-  // ExecuteLocalGet->LocalGetPages runs lock-free in parallel. results is
-  // std::vector<bool> (bit-packed) so threads write a temp buffer; merge serially.
-  auto run_local_dram = [&]() {
-    const auto& idx = plan.local_dram_indices;
-    if (idx.empty()) return;
-    const int nthr = LocalCopyThreads("UMBP_DRAM_READ_THREADS");
-    const auto t0 = std::chrono::steady_clock::now();
-    std::vector<char> ok(idx.size(), 0);
-    LocalParallelFor(idx.size(), nthr, [&](size_t k) {
-      const size_t i = idx[k];
-      if (ExecuteLocalGet(keys[i], const_cast<void*>(dsts[i]), sizes[i]) ==
-          GetAttemptOutcome::kSuccess) {
-        ok[k] = 1;
-      }
-    });
-    size_t tot = 0;
-    for (size_t k = 0; k < idx.size(); ++k) {
-      if (ok[k]) {
-        (*results)[idx[k]] = true;
-        tot += sizes[idx[k]];
-      }
-    }
-    if (std::getenv("UMBP_LOCAL_COPY_TIMING")) {
-      double sec = std::chrono::duration_cast<std::chrono::duration<double>>(
-                       std::chrono::steady_clock::now() - t0)
-                       .count();
-      MORI_UMBP_INFO("[LocalCopy] GET keys={} bytes={} threads={} elapsed_ms={:.3f} GiB_s={:.2f}",
-                     idx.size(), tot, nthr, sec * 1000.0,
-                     tot / (sec > 0 ? sec : 1e-12) / (1024.0 * 1024 * 1024));
-    }
-  };
-
-  // Local SSD self-target reads (deferred from partition): serial on this
-  // thread, reading straight into the user buffer (no staging / RDMA / lease).
-  // Independent per key, so its position in the schedule is correctness-neutral.
-  auto run_local_ssd = [&]() {
-    for (size_t i : plan.local_ssd_indices) {
-      if (ExecuteLocalSsdGet(keys[i], const_cast<void*>(dsts[i]), sizes[i]) ==
-          GetAttemptOutcome::kSuccess) {
-        (*results)[i] = true;
-      }
-    }
-  };
-
-  auto run_remote_ssd = [&]() {
-    for (const auto& [node_id, items] : plan.remote_ssd_groups) {
-      ProcessRemoteSsdBatchGet(items, results);
-    }
-  };
-
-  const auto& remote_dram_groups = plan.remote_dram_groups;
-
-  // Zero-copy? The upper layer guarantees a batch is all-ZC or all-staging, so
-  // probe one remote-DRAM item's dst registration (unordered_map order is
-  // unspecified, but any item answers the all-or-nothing question).
-  const bool is_zc = !remote_dram_groups.empty() &&
-                     FindRegisteredMemory(remote_dram_groups.begin()->second.front().dst,
-                                          remote_dram_groups.begin()->second.front().size)
-                         .has_value();
-
-  if (!is_zc) {
-    // Staging (non-zero-copy), or no remote DRAM at all.  Order: local SSD, local
-    // DRAM, staging remote DRAM (per peer), remote SSD.  Staging must submit then
-    // IMMEDIATELY wait per peer: the in-flight holds staging_mutex_ from submit
-    // until the wait copies out of the shared staging_buffer_, so accumulating
-    // staging in-flights into a submit-all list would deadlock on that lock.
-    run_local_ssd();
-    run_local_dram();
-    for (const auto& [node_id, items] : remote_dram_groups) {
-      if (auto f = SubmitRemoteBatchGet(items, results, /*permit_staging=*/true)) {
-        WaitRemoteBatchGet(*f, results);  // immediate; releases staging_mutex_
-      }
-    }
-    run_remote_ssd();
-    return;
-  }
-
-  // Zero-copy remote DRAM: submit every peer (posted, not waited) to overlap
-  // wire time across peers, run local DRAM/SSD + remote SSD in that window, then
-  // wait all. On early/exceptional exit ~RemoteDramGetInFlight drains in-flight
-  // statuses (lifetime safety); the wait loop does failure mapping + backfill.
-  std::vector<std::unique_ptr<RemoteDramGetInFlight>> inflights;
-  inflights.reserve(remote_dram_groups.size());
-
-  for (const auto& [node_id, items] : remote_dram_groups) {
-    if (auto f = SubmitRemoteBatchGet(items, results, /*permit_staging=*/false)) {
-      inflights.push_back(std::move(f));
-    }
-  }
-  run_local_dram();
-  run_local_ssd();
-  // TODO(perf): remote SSD is still per-key serial (not yet optimized).
-  run_remote_ssd();
-  for (auto& f : inflights) WaitRemoteBatchGet(*f, results);
 }
 
 void PoolClient::ExecuteBatchPutPlan(const BatchPutPlan& plan,
@@ -1440,66 +1246,19 @@ bool PoolClient::AllocateRemotePutEntries(const std::vector<BatchPutItem>& items
       for (uint64_t slot_id : *abort_slots) abort_req.add_slot_ids(slot_id);
       ::umbp::BatchAbortSlotsResponse abort_resp;
       grpc::ClientContext abort_ctx;
-      stub->BatchAbortSlots(&abort_ctx, abort_req, &abort_resp);
+      // Best-effort: a failed abort just leaves the slots for the peer reaper to
+      // reclaim at pending_ttl. Warn to aid diagnosis but do not propagate.
+      auto abort_status = stub->BatchAbortSlots(&abort_ctx, abort_req, &abort_resp);
+      if (!abort_status.ok()) {
+        MORI_UMBP_WARN(
+            "[PoolClient] AllocateRemotePutEntries: BatchAbortSlots({} slots) failed: {}",
+            abort_slots->size(), abort_status.error_message());
+      }
       abort_slots->clear();
     }
     return false;
   }
   return true;
-}
-
-std::vector<PoolClient::PairGroup> PoolClient::GroupTransfersByPair(
-    const std::vector<TransferInstruction>& active) {
-  std::vector<PairGroup> groups;
-  groups.reserve(active.size());
-  // Group by (local MR id, remote MR id); first appearance defines order.
-  std::unordered_map<PairKey, size_t, PairKeyHash> pair_to_group;
-  pair_to_group.reserve(active.size() * 2);
-
-  for (const auto& t : active) {
-    const PairKey key{t.local_desc.id, t.remote_desc.id};
-    auto it = pair_to_group.find(key);
-    size_t gi;
-    if (it == pair_to_group.end()) {
-      gi = groups.size();
-      pair_to_group.emplace(key, gi);
-      PairGroup g;
-      g.local_desc = t.local_desc;
-      g.remote_desc = t.remote_desc;
-      groups.push_back(std::move(g));
-    } else {
-      gi = it->second;
-    }
-    PairGroup& g = groups[gi];
-    const size_t lo = static_cast<size_t>(t.local_offset);
-    const size_t ro = static_cast<size_t>(t.remote_offset);
-    const size_t sz = static_cast<size_t>(t.size);
-    // Coalesce with the previous segment when BOTH local and remote are
-    // exactly contiguous.  This is NOT redundant with the backend's WR
-    // merging: the backend would fold these into the same WR either way, but
-    // doing it here shrinks the inner SG vector it has to sort/merge
-    // (O(M log M)) and allocate, which matters when M is large (big batch x
-    // pages).  Same bytes, so per-pair failure granularity is unchanged.
-    // The merged size must stay within uint32_t since the backend stores it
-    // in ibv_sge.length (matches its own WR-merge cap in common.cpp).
-    const bool can_coalesce =
-        !g.sizes.empty() && AdjacentNoOverflow(g.local_offsets.back(), g.sizes.back(), lo) &&
-        AdjacentNoOverflow(g.remote_offsets.back(), g.sizes.back(), ro) &&
-        g.sizes.back() <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()) - sz;
-    if (can_coalesce) {
-      g.sizes.back() += sz;
-    } else {
-      g.local_offsets.push_back(lo);
-      g.remote_offsets.push_back(ro);
-      g.sizes.push_back(sz);
-    }
-    // De-dup contributing entries: a single entry's pages arrive
-    // consecutively within a pair, so a back() check suffices.
-    if (g.entry_indices.empty() || g.entry_indices.back() != t.entry_index) {
-      g.entry_indices.push_back(t.entry_index);
-    }
-  }
-  return groups;
 }
 
 bool PoolClient::BuildRemotePutTransfers(std::vector<RemotePutEntry>& entries, PeerConnection& peer,
@@ -1658,158 +1417,202 @@ void PoolClient::FinalizeRemotePutEntries(std::vector<RemotePutEntry>& entries,
   }
 }
 
-bool PoolClient::PrepareRemoteGetEntries(const std::vector<BatchGetItem>& items,
-                                         ::umbp::UMBPPeer::Stub* stub,
-                                         std::vector<RemoteGetEntry>* entries,
-                                         std::vector<bool>* results) {
-  entries->clear();
-  ::umbp::BatchResolveKeysRequest resolve_req;
-  for (const auto& item : items) resolve_req.add_keys(*item.key);
+// ---------------------------------------------------------------------------
+//  BatchGet
+// ---------------------------------------------------------------------------
 
-  ::umbp::BatchResolveKeysResponse resolve_resp;
-  grpc::ClientContext resolve_ctx;
-  auto resolve_status = stub->BatchResolveKeys(&resolve_ctx, resolve_req, &resolve_resp);
-  if (!resolve_status.ok() || resolve_resp.entries_size() != static_cast<int>(items.size())) {
-    MORI_UMBP_WARN("[PoolClient] BatchResolveKeys failed on {}: {}", items.front().route.node_id,
-                   resolve_status.error_message());
-    for (const auto& item : items) {
-      (*results)[item.index] = false;
-    }
-    return false;
-  }
-
-  entries->reserve(items.size());
-  for (size_t i = 0; i < items.size(); ++i) {
-    const auto& item = items[i];
-    const auto& resp_entry = resolve_resp.entries(static_cast<int>(i));
-    if (!resp_entry.found()) {
-      (*results)[item.index] = false;
-      continue;
-    }
-    if (resp_entry.size() != item.size) {
-      MORI_UMBP_WARN("[PoolClient] BatchGet: size mismatch for key='{}' (wanted {}, got {})",
-                     *item.key, item.size, resp_entry.size());
-      (*results)[item.index] = false;
-      continue;
-    }
-    PoolClient::SlotPlan plan = FromResolveKeyResponse(resp_entry);
-    if (!SizeMatchesAllocation(item.size, plan.pages.size(), plan.page_size)) {
-      MORI_UMBP_ERROR("[PoolClient] BatchGet: malformed slot for key='{}'", *item.key);
-      (*results)[item.index] = false;
-      continue;
-    }
-
-    RemoteGetEntry entry;
-    entry.result_index = item.index;
-    entry.item = &item;
-    entry.plan = std::move(plan);
-    entries->push_back(std::move(entry));
-  }
-
-  return !entries->empty();
+bool PoolClient::Get(const std::string& key, void* dst, size_t size) {
+  std::vector<std::string> keys{key};
+  std::vector<void*> dsts{dst};
+  std::vector<size_t> sizes{size};
+  auto results = BatchGet(keys, dsts, sizes);
+  return !results.empty() && results[0];
 }
 
-bool PoolClient::BuildRemoteGetTransfers(std::vector<RemoteGetEntry>& entries, PeerConnection& peer,
-                                         std::vector<TransferInstruction>* transfers,
-                                         uint64_t* staging_bytes) {
-  transfers->clear();
-  uint64_t cursor = 0;
-
-  for (size_t idx = 0; idx < entries.size(); ++idx) {
-    auto& entry = entries[idx];
-
-    auto zero_copy = FindRegisteredMemory(entry.item->dst, entry.item->size);
-    if (zero_copy.has_value()) {
-      entry.zero_copy = zero_copy;
-      entry.use_staging = false;
-      entry.staging_offset = 0;
-    } else {
-      entry.zero_copy.reset();
-      entry.use_staging = true;
-      cursor = AlignUp(cursor, entry.plan.page_size);
-      const uint64_t aligned_size = AlignUp(entry.item->size, entry.plan.page_size);
-      if (cursor + aligned_size > config_.staging_buffer_size) {
-        MORI_UMBP_WARN(
-            "[PoolClient] BuildRemoteGetTransfers: staging buffer overflow at entry {}/{}, "
-            "key='{}' size={} aligned={} cursor={} cap={}",
-            idx, entries.size(),
-            (entry.item && entry.item->key) ? *entry.item->key : std::string{"<null>"},
-            entry.item ? entry.item->size : 0, aligned_size, cursor, config_.staging_buffer_size);
-        return false;
-      }
-      entry.staging_offset = cursor;
-      cursor += aligned_size;
-    }
-
-    mori::io::MemoryDesc local_desc{};
-    uint64_t base_offset = 0;
-    if (entry.use_staging) {
-      local_desc = staging_mem_;
-      base_offset = entry.staging_offset;
-    } else if (entry.zero_copy.has_value()) {
-      local_desc = entry.zero_copy->first;
-      base_offset = entry.zero_copy->second;
-    } else {
-      entry.failed = true;
-      continue;
-    }
-
-    // Hydrate + snapshot remote descs inside ONE peers_mutex_ window (see
-    // BuildRemotePutTransfers).
-    std::vector<TransferInstruction> entry_transfers;
-    entry_transfers.reserve(entry.plan.pages.size());
-    {
-      std::lock_guard<std::mutex> lock(peers_mutex_);
-      EnsureBufferDescsCachedLocked(peer, entry.plan.descs);
-      for (size_t p = 0; p < entry.plan.pages.size(); ++p) {
-        const auto& page = entry.plan.pages[p];
-        if (page.buffer_index >= peer.dram_memories.size() ||
-            !IsValidMemoryDesc(peer.dram_memories[page.buffer_index])) {
-          MORI_UMBP_ERROR(
-              "[PoolClient] BuildRemoteGetTransfers: invalid peer dram_memories slot, "
-              "key='{}' buffer_index={} peer_dram_size={} page_index={}",
-              (entry.item && entry.item->key) ? *entry.item->key : std::string{"<null>"},
-              page.buffer_index, peer.dram_memories.size(), page.page_index);
-          entry.failed = true;
-          entry_transfers.clear();
-          break;
-        }
-        TransferInstruction instr;
-        instr.entry_index = idx;
-        instr.local_desc = local_desc;
-        instr.local_offset = base_offset + static_cast<uint64_t>(p) * entry.plan.page_size;
-        instr.remote_desc = peer.dram_memories[page.buffer_index];
-        instr.remote_offset = static_cast<uint64_t>(page.page_index) * entry.plan.page_size;
-        instr.size =
-            LogicalPageBytes(p, entry.plan.pages.size(), entry.plan.page_size, entry.item->size);
-        entry_transfers.push_back(std::move(instr));
-      }
-    }
-
-    if (!entry_transfers.empty()) {
-      transfers->insert(transfers->end(), entry_transfers.begin(), entry_transfers.end());
-    }
+std::vector<bool> PoolClient::BatchGet(const std::vector<std::string>& keys,
+                                       const std::vector<void*>& dsts,
+                                       const std::vector<size_t>& sizes) {
+  const auto call_start = std::chrono::steady_clock::now();
+  std::vector<bool> results(keys.size(), false);
+  if (keys.size() != dsts.size() || keys.size() != sizes.size()) {
+    MORI_UMBP_ERROR("[PoolClient] BatchGet: vector length mismatch");
+    return results;
+  }
+  if (!initialized_) {
+    MORI_UMBP_ERROR("[PoolClient] BatchGet: client not initialized");
+    return results;
   }
 
-  *staging_bytes = cursor;
-  return true;
+  std::vector<std::optional<RouteGetResult>> routes;
+  std::unordered_set<std::string> excludes;
+  auto status = master_client_->BatchRouteGet(keys, excludes, &routes);
+  if (!status.ok()) {
+    MORI_UMBP_ERROR("[PoolClient] BatchGet: BatchRouteGet failed: {}", status.error_message());
+    return results;
+  }
+  if (routes.size() < keys.size()) {
+    routes.resize(keys.size());
+  }
+
+  BatchGetPlan plan = PartitionBatchGetTargets(keys, dsts, sizes, routes);
+  ExecuteBatchGetPlan(plan, keys, dsts, sizes, &results);
+
+  const auto call_end = std::chrono::steady_clock::now();
+  const double seconds =
+      std::chrono::duration_cast<std::chrono::duration<double>>(call_end - call_start).count();
+  if (seconds > 0.0) {
+    auto split = ComputeBatchBandwidthBytes(results, sizes, routes, config_.master_config.node_id);
+    ObserveBatchBandwidth(*master_client_, split.local, seconds,
+                          MORI_UMBP_METRIC_CLIENT_BATCH_GET_BANDWIDTH,
+                          MORI_UMBP_METRIC_CLIENT_BATCH_GET_BANDWIDTH_HELP, "local");
+    ObserveBatchBandwidth(*master_client_, split.remote, seconds,
+                          MORI_UMBP_METRIC_CLIENT_BATCH_GET_BANDWIDTH,
+                          MORI_UMBP_METRIC_CLIENT_BATCH_GET_BANDWIDTH_HELP, "remote");
+  }
+  return results;
 }
 
-void PoolClient::FinalizeRemoteGetEntries(std::vector<RemoteGetEntry>& entries,
-                                          std::vector<bool>* results) {
-  for (auto& entry : entries) {
-    if (entry.failed) {
-      (*results)[entry.result_index] = false;
+PoolClient::BatchGetPlan PoolClient::PartitionBatchGetTargets(
+    const std::vector<std::string>& keys, const std::vector<void*>& dsts,
+    const std::vector<size_t>& sizes, const std::vector<std::optional<RouteGetResult>>& routes) {
+  BatchGetPlan plan;
+  for (size_t i = 0; i < keys.size(); ++i) {
+    // Zero-size gets are rejected before local fallback or remote read: an
+    // explicit skip is required here because a nullopt route below would
+    // otherwise fall through to a local read (result stays false).
+    if (sizes[i] == 0) {
+      MORI_UMBP_WARN("[PoolClient] BatchGet: skipping zero-size get for key='{}'", keys[i]);
       continue;
     }
-    master_client_->AddCounter(MORI_UMBP_METRIC_CLIENT_OUTBOUND_GET_BYTES_TOTAL,
-                               MORI_UMBP_METRIC_CLIENT_OUTBOUND_GET_BYTES_TOTAL_HELP,
-                               {{"traffic", "remote"}}, static_cast<double>(entry.item->size));
-    master_client_->AddCounter(MORI_UMBP_METRIC_CLIENT_INBOUND_GET_BYTES_TOTAL,
-                               MORI_UMBP_METRIC_CLIENT_INBOUND_GET_BYTES_TOTAL_HELP,
-                               {{"traffic", "remote"}}, static_cast<double>(entry.item->size));
-    (*results)[entry.result_index] = true;
+    if (i >= routes.size() || !routes[i].has_value()) {
+      if (peer_alloc_) plan.local_dram_indices.push_back(i);
+      continue;
+    }
+    const auto& route = routes[i].value();
+    if (route.node_id == config_.master_config.node_id) {
+      // Self-target: both DRAM/HBM and SSD are deferred (collected as indices)
+      // so ExecuteBatchGetPlan can place them inside the remote-DRAM in-flight
+      // window in the overlap path.
+      if (route.tier == TierType::SSD) {
+        plan.local_ssd_indices.push_back(i);
+      } else {
+        plan.local_dram_indices.push_back(i);
+      }
+      continue;
+    }
+    BatchGetItem item{.index = i,
+                      .key = &keys[i],
+                      .dst = const_cast<void*>(dsts[i]),
+                      .size = sizes[i],
+                      .route = route};
+    if (route.tier == TierType::SSD) {
+      plan.remote_ssd_groups[route.node_id].push_back(std::move(item));
+    } else {
+      plan.remote_dram_groups[route.node_id].push_back(std::move(item));
+    }
   }
+  return plan;
+}
+
+void PoolClient::ExecuteBatchGetPlan(const BatchGetPlan& plan, const std::vector<std::string>& keys,
+                                     const std::vector<void*>& dsts,
+                                     const std::vector<size_t>& sizes, std::vector<bool>* results) {
+  // Parallel local DRAM reads: different threads handle different keys. Resolve
+  // is mutex-serialized in the allocator; the per-key memcpy in
+  // ExecuteLocalGet->LocalGetPages runs lock-free in parallel. results is
+  // std::vector<bool> (bit-packed) so threads write a temp buffer; merge serially.
+  auto run_local_dram = [&]() {
+    const auto& idx = plan.local_dram_indices;
+    if (idx.empty()) return;
+    const int nthr = LocalCopyThreads("UMBP_DRAM_READ_THREADS");
+    const auto t0 = std::chrono::steady_clock::now();
+    std::vector<char> ok(idx.size(), 0);
+    LocalParallelFor(idx.size(), nthr, [&](size_t k) {
+      const size_t i = idx[k];
+      if (ExecuteLocalGet(keys[i], const_cast<void*>(dsts[i]), sizes[i]) ==
+          GetAttemptOutcome::kSuccess) {
+        ok[k] = 1;
+      }
+    });
+    size_t tot = 0;
+    for (size_t k = 0; k < idx.size(); ++k) {
+      if (ok[k]) {
+        (*results)[idx[k]] = true;
+        tot += sizes[idx[k]];
+      }
+    }
+    if (std::getenv("UMBP_LOCAL_COPY_TIMING")) {
+      double sec = std::chrono::duration_cast<std::chrono::duration<double>>(
+                       std::chrono::steady_clock::now() - t0)
+                       .count();
+      MORI_UMBP_INFO("[LocalCopy] GET keys={} bytes={} threads={} elapsed_ms={:.3f} GiB_s={:.2f}",
+                     idx.size(), tot, nthr, sec * 1000.0,
+                     tot / (sec > 0 ? sec : 1e-12) / (1024.0 * 1024 * 1024));
+    }
+  };
+
+  // Local SSD self-target reads (deferred from partition): serial on this
+  // thread, reading straight into the user buffer (no staging / RDMA / lease).
+  // Independent per key, so its position in the schedule is correctness-neutral.
+  auto run_local_ssd = [&]() {
+    for (size_t i : plan.local_ssd_indices) {
+      if (ExecuteLocalSsdGet(keys[i], const_cast<void*>(dsts[i]), sizes[i]) ==
+          GetAttemptOutcome::kSuccess) {
+        (*results)[i] = true;
+      }
+    }
+  };
+
+  auto run_remote_ssd = [&]() {
+    for (const auto& [node_id, items] : plan.remote_ssd_groups) {
+      ProcessRemoteSsdBatchGet(items, results);
+    }
+  };
+
+  const auto& remote_dram_groups = plan.remote_dram_groups;
+
+  // Zero-copy? The upper layer guarantees a batch is all-ZC or all-staging, so
+  // probe one remote-DRAM item's dst registration (unordered_map order is
+  // unspecified, but any item answers the all-or-nothing question).
+  const bool is_zc = !remote_dram_groups.empty() &&
+                     FindRegisteredMemory(remote_dram_groups.begin()->second.front().dst,
+                                          remote_dram_groups.begin()->second.front().size)
+                         .has_value();
+
+  if (!is_zc) {
+    // Staging (non-zero-copy), or no remote DRAM at all.  Order: local SSD, local
+    // DRAM, staging remote DRAM (per peer), remote SSD.  Staging must submit then
+    // IMMEDIATELY wait per peer: the in-flight holds staging_mutex_ from submit
+    // until the wait copies out of the shared staging_buffer_, so accumulating
+    // staging in-flights into a submit-all list would deadlock on that lock.
+    run_local_ssd();
+    run_local_dram();
+    for (const auto& [node_id, items] : remote_dram_groups) {
+      if (auto f = SubmitRemoteBatchGet(items, results, /*permit_staging=*/true)) {
+        WaitRemoteBatchGet(*f, results);  // immediate; releases staging_mutex_
+      }
+    }
+    run_remote_ssd();
+    return;
+  }
+
+  // Zero-copy remote DRAM: submit every peer (posted, not waited) to overlap
+  // wire time across peers, run local DRAM/SSD + remote SSD in that window, then
+  // wait all. On early/exceptional exit ~RemoteDramGetInFlight drains in-flight
+  // statuses (lifetime safety); the wait loop does failure mapping + backfill.
+  std::vector<std::unique_ptr<RemoteDramGetInFlight>> inflights;
+  inflights.reserve(remote_dram_groups.size());
+
+  for (const auto& [node_id, items] : remote_dram_groups) {
+    if (auto f = SubmitRemoteBatchGet(items, results, /*permit_staging=*/false)) {
+      inflights.push_back(std::move(f));
+    }
+  }
+  run_local_dram();
+  run_local_ssd();
+  // TODO(perf): remote SSD is still per-key serial (not yet optimized).
+  run_remote_ssd();
+  for (auto& f : inflights) WaitRemoteBatchGet(*f, results);
 }
 
 std::unique_ptr<PoolClient::RemoteDramGetInFlight> PoolClient::SubmitRemoteBatchGet(
@@ -1964,6 +1767,222 @@ void PoolClient::WaitRemoteBatchGet(RemoteDramGetInFlight& f, std::vector<bool>*
 
   FinalizeRemoteGetEntries(f.entries, results);
 }
+
+bool PoolClient::PrepareRemoteGetEntries(const std::vector<BatchGetItem>& items,
+                                         ::umbp::UMBPPeer::Stub* stub,
+                                         std::vector<RemoteGetEntry>* entries,
+                                         std::vector<bool>* results) {
+  entries->clear();
+  ::umbp::BatchResolveKeysRequest resolve_req;
+  for (const auto& item : items) resolve_req.add_keys(*item.key);
+
+  ::umbp::BatchResolveKeysResponse resolve_resp;
+  grpc::ClientContext resolve_ctx;
+  auto resolve_status = stub->BatchResolveKeys(&resolve_ctx, resolve_req, &resolve_resp);
+  if (!resolve_status.ok() || resolve_resp.entries_size() != static_cast<int>(items.size())) {
+    MORI_UMBP_WARN("[PoolClient] BatchResolveKeys failed on {}: {}", items.front().route.node_id,
+                   resolve_status.error_message());
+    for (const auto& item : items) {
+      (*results)[item.index] = false;
+    }
+    return false;
+  }
+
+  entries->reserve(items.size());
+  for (size_t i = 0; i < items.size(); ++i) {
+    const auto& item = items[i];
+    const auto& resp_entry = resolve_resp.entries(static_cast<int>(i));
+    if (!resp_entry.found()) {
+      (*results)[item.index] = false;
+      continue;
+    }
+    if (resp_entry.size() != item.size) {
+      MORI_UMBP_WARN("[PoolClient] BatchGet: size mismatch for key='{}' (wanted {}, got {})",
+                     *item.key, item.size, resp_entry.size());
+      (*results)[item.index] = false;
+      continue;
+    }
+    PoolClient::SlotPlan plan = FromResolveKeyResponse(resp_entry);
+    if (!SizeMatchesAllocation(item.size, plan.pages.size(), plan.page_size)) {
+      MORI_UMBP_ERROR("[PoolClient] BatchGet: malformed slot for key='{}'", *item.key);
+      (*results)[item.index] = false;
+      continue;
+    }
+
+    RemoteGetEntry entry;
+    entry.result_index = item.index;
+    entry.item = &item;
+    entry.plan = std::move(plan);
+    entries->push_back(std::move(entry));
+  }
+
+  return !entries->empty();
+}
+
+bool PoolClient::BuildRemoteGetTransfers(std::vector<RemoteGetEntry>& entries, PeerConnection& peer,
+                                         std::vector<TransferInstruction>* transfers,
+                                         uint64_t* staging_bytes) {
+  transfers->clear();
+  uint64_t cursor = 0;
+
+  for (size_t idx = 0; idx < entries.size(); ++idx) {
+    auto& entry = entries[idx];
+
+    auto zero_copy = FindRegisteredMemory(entry.item->dst, entry.item->size);
+    if (zero_copy.has_value()) {
+      entry.zero_copy = zero_copy;
+      entry.use_staging = false;
+      entry.staging_offset = 0;
+    } else {
+      entry.zero_copy.reset();
+      entry.use_staging = true;
+      cursor = AlignUp(cursor, entry.plan.page_size);
+      const uint64_t aligned_size = AlignUp(entry.item->size, entry.plan.page_size);
+      if (cursor + aligned_size > config_.staging_buffer_size) {
+        MORI_UMBP_WARN(
+            "[PoolClient] BuildRemoteGetTransfers: staging buffer overflow at entry {}/{}, "
+            "key='{}' size={} aligned={} cursor={} cap={}",
+            idx, entries.size(),
+            (entry.item && entry.item->key) ? *entry.item->key : std::string{"<null>"},
+            entry.item ? entry.item->size : 0, aligned_size, cursor, config_.staging_buffer_size);
+        return false;
+      }
+      entry.staging_offset = cursor;
+      cursor += aligned_size;
+    }
+
+    mori::io::MemoryDesc local_desc{};
+    uint64_t base_offset = 0;
+    if (entry.use_staging) {
+      local_desc = staging_mem_;
+      base_offset = entry.staging_offset;
+    } else if (entry.zero_copy.has_value()) {
+      local_desc = entry.zero_copy->first;
+      base_offset = entry.zero_copy->second;
+    } else {
+      entry.failed = true;
+      continue;
+    }
+
+    // Hydrate + snapshot remote descs inside ONE peers_mutex_ window (see
+    // BuildRemotePutTransfers).
+    std::vector<TransferInstruction> entry_transfers;
+    entry_transfers.reserve(entry.plan.pages.size());
+    {
+      std::lock_guard<std::mutex> lock(peers_mutex_);
+      EnsureBufferDescsCachedLocked(peer, entry.plan.descs);
+      for (size_t p = 0; p < entry.plan.pages.size(); ++p) {
+        const auto& page = entry.plan.pages[p];
+        if (page.buffer_index >= peer.dram_memories.size() ||
+            !IsValidMemoryDesc(peer.dram_memories[page.buffer_index])) {
+          MORI_UMBP_ERROR(
+              "[PoolClient] BuildRemoteGetTransfers: invalid peer dram_memories slot, "
+              "key='{}' buffer_index={} peer_dram_size={} page_index={}",
+              (entry.item && entry.item->key) ? *entry.item->key : std::string{"<null>"},
+              page.buffer_index, peer.dram_memories.size(), page.page_index);
+          entry.failed = true;
+          entry_transfers.clear();
+          break;
+        }
+        TransferInstruction instr;
+        instr.entry_index = idx;
+        instr.local_desc = local_desc;
+        instr.local_offset = base_offset + static_cast<uint64_t>(p) * entry.plan.page_size;
+        instr.remote_desc = peer.dram_memories[page.buffer_index];
+        instr.remote_offset = static_cast<uint64_t>(page.page_index) * entry.plan.page_size;
+        instr.size =
+            LogicalPageBytes(p, entry.plan.pages.size(), entry.plan.page_size, entry.item->size);
+        entry_transfers.push_back(std::move(instr));
+      }
+    }
+
+    if (!entry_transfers.empty()) {
+      transfers->insert(transfers->end(), entry_transfers.begin(), entry_transfers.end());
+    }
+  }
+
+  *staging_bytes = cursor;
+  return true;
+}
+
+void PoolClient::FinalizeRemoteGetEntries(std::vector<RemoteGetEntry>& entries,
+                                          std::vector<bool>* results) {
+  for (auto& entry : entries) {
+    if (entry.failed) {
+      (*results)[entry.result_index] = false;
+      continue;
+    }
+    master_client_->AddCounter(MORI_UMBP_METRIC_CLIENT_OUTBOUND_GET_BYTES_TOTAL,
+                               MORI_UMBP_METRIC_CLIENT_OUTBOUND_GET_BYTES_TOTAL_HELP,
+                               {{"traffic", "remote"}}, static_cast<double>(entry.item->size));
+    master_client_->AddCounter(MORI_UMBP_METRIC_CLIENT_INBOUND_GET_BYTES_TOTAL,
+                               MORI_UMBP_METRIC_CLIENT_INBOUND_GET_BYTES_TOTAL_HELP,
+                               {{"traffic", "remote"}}, static_cast<double>(entry.item->size));
+    (*results)[entry.result_index] = true;
+  }
+}
+
+// ---------------------------------------------------------------------------
+//  Remote DRAM transfer grouping (shared by Put and Get)
+// ---------------------------------------------------------------------------
+
+std::vector<PoolClient::PairGroup> PoolClient::GroupTransfersByPair(
+    const std::vector<TransferInstruction>& active) {
+  std::vector<PairGroup> groups;
+  groups.reserve(active.size());
+  // Group by (local MR id, remote MR id); first appearance defines order.
+  std::unordered_map<PairKey, size_t, PairKeyHash> pair_to_group;
+  pair_to_group.reserve(active.size() * 2);
+
+  for (const auto& t : active) {
+    const PairKey key{t.local_desc.id, t.remote_desc.id};
+    auto it = pair_to_group.find(key);
+    size_t gi;
+    if (it == pair_to_group.end()) {
+      gi = groups.size();
+      pair_to_group.emplace(key, gi);
+      PairGroup g;
+      g.local_desc = t.local_desc;
+      g.remote_desc = t.remote_desc;
+      groups.push_back(std::move(g));
+    } else {
+      gi = it->second;
+    }
+    PairGroup& g = groups[gi];
+    const size_t lo = static_cast<size_t>(t.local_offset);
+    const size_t ro = static_cast<size_t>(t.remote_offset);
+    const size_t sz = static_cast<size_t>(t.size);
+    // Coalesce with the previous segment when BOTH local and remote are
+    // exactly contiguous.  This is NOT redundant with the backend's WR
+    // merging: the backend would fold these into the same WR either way, but
+    // doing it here shrinks the inner SG vector it has to sort/merge
+    // (O(M log M)) and allocate, which matters when M is large (big batch x
+    // pages).  Same bytes, so per-pair failure granularity is unchanged.
+    // The merged size must stay within uint32_t since the backend stores it
+    // in ibv_sge.length (matches its own WR-merge cap in common.cpp).
+    const bool can_coalesce =
+        !g.sizes.empty() && AdjacentNoOverflow(g.local_offsets.back(), g.sizes.back(), lo) &&
+        AdjacentNoOverflow(g.remote_offsets.back(), g.sizes.back(), ro) &&
+        g.sizes.back() <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()) - sz;
+    if (can_coalesce) {
+      g.sizes.back() += sz;
+    } else {
+      g.local_offsets.push_back(lo);
+      g.remote_offsets.push_back(ro);
+      g.sizes.push_back(sz);
+    }
+    // De-dup contributing entries: a single entry's pages arrive
+    // consecutively within a pair, so a back() check suffices.
+    if (g.entry_indices.empty() || g.entry_indices.back() != t.entry_index) {
+      g.entry_indices.push_back(t.entry_index);
+    }
+  }
+  return groups;
+}
+
+// ---------------------------------------------------------------------------
+//  Cluster-wide existence check
+// ---------------------------------------------------------------------------
 
 bool PoolClient::Exists(const std::string& key) {
   auto v = BatchExists({key});

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -810,19 +810,14 @@ PoolClient::GetAttemptOutcome PoolClient::ExecuteLocalSsdGet(const std::string& 
   return GetAttemptOutcome::kSuccess;
 }
 
-std::unordered_map<std::string, std::vector<PoolClient::BatchPutItem>>
-PoolClient::PartitionBatchPutTargets(const std::vector<std::string>& keys,
-                                     const std::vector<const void*>& srcs,
-                                     const std::vector<size_t>& sizes,
-                                     const std::vector<std::optional<RoutePutResult>>& routes,
-                                     std::vector<PutEntryOutcome>* results) {
-  std::unordered_map<std::string, std::vector<BatchPutItem>> remote_groups;
-  std::vector<size_t> local_idx;
+PoolClient::BatchPutPlan PoolClient::PartitionBatchPutTargets(
+    const std::vector<std::string>& keys, const std::vector<const void*>& srcs,
+    const std::vector<size_t>& sizes, const std::vector<std::optional<RoutePutResult>>& routes,
+    std::vector<PutEntryOutcome>* results) {
+  BatchPutPlan plan;
   const size_t count = keys.size();
   for (size_t i = 0; i < count; ++i) {
-    // Zero-size puts are rejected before local/peer execution: an empty block
-    // is meaningless to store, so leave the result as kFailed and never hand it
-    // to ExecuteLocalPut / peer AllocateSlot.
+    // Zero-size puts are meaningless: leave the result kFailed, never execute.
     if (sizes[i] == 0) {
       MORI_UMBP_WARN("[PoolClient] BatchPut: skipping zero-size put for key='{}'", keys[i]);
       continue;
@@ -835,45 +830,17 @@ PoolClient::PartitionBatchPutTargets(const std::vector<std::string>& keys,
       continue;
     }
     if (route.node_id == config_.master_config.node_id) {
-      local_idx.push_back(i);
+      // Self-target: deferred (with its tier) so ExecuteBatchPutPlan can run the
+      // local memcpy inside the remote-DRAM submit..wait window.
+      plan.local_items.push_back(BatchPutItem{
+          .index = i, .key = &keys[i], .src = srcs[i], .size = sizes[i], .route = route});
       continue;
     }
     if (route.tier != TierType::DRAM && route.tier != TierType::HBM) continue;
-    remote_groups[route.node_id].push_back(BatchPutItem{
+    plan.remote_groups[route.node_id].push_back(BatchPutItem{
         .index = i, .key = &keys[i], .src = srcs[i], .size = sizes[i], .route = route});
   }
-  // Parallel local writes: different threads handle different keys. The
-  // PeerDramAllocator serializes Allocate/Commit internally (mutex); the heavy
-  // per-key memcpy in ExecuteLocalPut->LocalPutPages runs lock-free in parallel.
-  if (!local_idx.empty()) {
-    const int nthr = LocalCopyThreads("UMBP_DRAM_WRITE_THREADS");
-    const auto t0 = std::chrono::steady_clock::now();
-    LocalParallelFor(local_idx.size(), nthr, [&](size_t k) {
-      const size_t i = local_idx[k];
-      switch (ExecuteLocalPut(keys[i], srcs[i], sizes[i], routes[i]->tier)) {
-        case PutAttemptOutcome::kSuccess:
-          (*results)[i] = PutEntryOutcome::kSucceeded;
-          break;
-        case PutAttemptOutcome::kSuccessAlreadyExists:
-          (*results)[i] = PutEntryOutcome::kAlreadyExists;
-          break;
-        case PutAttemptOutcome::kRetry:
-        case PutAttemptOutcome::kFatal:
-          break;
-      }
-    });
-    if (std::getenv("UMBP_LOCAL_COPY_TIMING")) {
-      double sec = std::chrono::duration_cast<std::chrono::duration<double>>(
-                       std::chrono::steady_clock::now() - t0)
-                       .count();
-      size_t tot = 0;
-      for (size_t k : local_idx) tot += sizes[k];
-      MORI_UMBP_INFO("[LocalCopy] PUT keys={} bytes={} threads={} elapsed_ms={:.3f} GiB_s={:.2f}",
-                     local_idx.size(), tot, nthr, sec * 1000.0,
-                     tot / (sec > 0 ? sec : 1e-12) / (1024.0 * 1024 * 1024));
-    }
-  }
-  return remote_groups;
+  return plan;
 }
 
 // ---------------------------------------------------------------------------
@@ -899,6 +866,10 @@ bool PoolClient::Get(const std::string& key, void* dst, size_t size) {
 std::vector<bool> PoolClient::BatchPut(const std::vector<std::string>& keys,
                                        const std::vector<const void*>& srcs,
                                        const std::vector<size_t>& sizes) {
+  // NOTE: BatchPut only lands data in the DRAM/HBM tier. The SSD tier copy is
+  // asynchronous and owner-driven: a successful slot Commit (local in
+  // ExecuteLocalPut, remote on the peer's CommitSlot) enqueues the copy onto the
+  // SsdCopyPipeline. There is no explicit SSD write on this path.
   const auto call_start = std::chrono::steady_clock::now();
   if (keys.size() != srcs.size() || keys.size() != sizes.size()) {
     MORI_UMBP_ERROR("[PoolClient] BatchPut: vector length mismatch");
@@ -923,10 +894,8 @@ std::vector<bool> PoolClient::BatchPut(const std::vector<std::string>& keys,
   }
   if (routes.size() < keys.size()) routes.resize(keys.size());
 
-  auto remote_groups = PartitionBatchPutTargets(keys, srcs, sizes, routes, &outcomes);
-  for (auto& [node_id, items] : remote_groups) {
-    ProcessRemoteBatchPut(items, &outcomes);
-  }
+  BatchPutPlan plan = PartitionBatchPutTargets(keys, srcs, sizes, routes, &outcomes);
+  ExecuteBatchPutPlan(plan, &outcomes);
 
   const auto call_end = std::chrono::steady_clock::now();
   const double seconds =
@@ -1115,27 +1084,12 @@ void PoolClient::ExecuteBatchGetPlan(const BatchGetPlan& plan, const std::vector
     return;
   }
 
-  // Zero-copy remote DRAM: submit every peer (posted, not waited) so multi-peer
-  // wire time overlaps, run local DRAM/SSD + remote SSD INSIDE that in-flight
-  // window (local memcpy / SSD use CPU / local-mem / SSD resources disjoint from
-  // the NIC, so they overlap the DRAM wire), then wait all peers.
+  // Zero-copy remote DRAM: submit every peer (posted, not waited) to overlap
+  // wire time across peers, run local DRAM/SSD + remote SSD in that window, then
+  // wait all. On early/exceptional exit ~RemoteDramGetInFlight drains in-flight
+  // statuses (lifetime safety); the wait loop does failure mapping + backfill.
   std::vector<std::unique_ptr<RemoteDramGetInFlight>> inflights;
   inflights.reserve(remote_dram_groups.size());
-  // Cleanup-only RAII: on an exceptional/early exit, Wait() any still-in-flight
-  // status so the backend CQ callback isn't left referencing freed memory.  It
-  // does NOT do failure mapping or result backfill (the normal path's
-  // WaitRemoteBatchGet does that) — it only makes status lifetime safe.
-  struct InFlightDrainGuard {
-    std::vector<std::unique_ptr<RemoteDramGetInFlight>>& v;
-    ~InFlightDrainGuard() {
-      for (auto& f : v) {
-        if (f && !f->waited) {
-          for (auto& s : f->statuses) s.Wait();
-          f->waited = true;
-        }
-      }
-    }
-  } drain_guard{inflights};
 
   for (const auto& [node_id, items] : remote_dram_groups) {
     if (auto f = SubmitRemoteBatchGet(items, results, /*permit_staging=*/false)) {
@@ -1149,68 +1103,266 @@ void PoolClient::ExecuteBatchGetPlan(const BatchGetPlan& plan, const std::vector
   for (auto& f : inflights) WaitRemoteBatchGet(*f, results);
 }
 
-void PoolClient::ProcessRemoteBatchPut(const std::vector<BatchPutItem>& items,
-                                       std::vector<PutEntryOutcome>* results) {
-  if (items.empty()) return;
+void PoolClient::ExecuteBatchPutPlan(const BatchPutPlan& plan,
+                                     std::vector<PutEntryOutcome>* results) {
+  // Deferred local puts, parallel: per-key memcpy is lock-free (the allocator
+  // serializes Allocate/Commit); results is not vector<bool>-bit-packed, so
+  // workers write distinct indices directly. AddCounter / timing stay here.
+  auto run_local_put = [&]() {
+    const auto& local = plan.local_items;
+    if (local.empty()) return;
+    const int nthr = LocalCopyThreads("UMBP_DRAM_WRITE_THREADS");
+    const auto t0 = std::chrono::steady_clock::now();
+    LocalParallelFor(local.size(), nthr, [&](size_t k) {
+      const auto& item = local[k];
+      switch (ExecuteLocalPut(*item.key, item.src, item.size, item.route.tier)) {
+        case PutAttemptOutcome::kSuccess:
+          (*results)[item.index] = PutEntryOutcome::kSucceeded;
+          break;
+        case PutAttemptOutcome::kSuccessAlreadyExists:
+          (*results)[item.index] = PutEntryOutcome::kAlreadyExists;
+          break;
+        case PutAttemptOutcome::kRetry:
+        case PutAttemptOutcome::kFatal:
+          break;
+      }
+    });
+    if (std::getenv("UMBP_LOCAL_COPY_TIMING")) {
+      double sec = std::chrono::duration_cast<std::chrono::duration<double>>(
+                       std::chrono::steady_clock::now() - t0)
+                       .count();
+      size_t tot = 0;
+      for (const auto& item : local) tot += item.size;
+      MORI_UMBP_INFO("[LocalCopy] PUT keys={} bytes={} threads={} elapsed_ms={:.3f} GiB_s={:.2f}",
+                     local.size(), tot, nthr, sec * 1000.0,
+                     tot / (sec > 0 ? sec : 1e-12) / (1024.0 * 1024 * 1024));
+    }
+  };
+
+  const auto& remote_groups = plan.remote_groups;
+
+  // All-ZC or all-staging (upper-layer invariant): probe one item's src.
+  const bool is_zc =
+      !remote_groups.empty() && FindRegisteredMemory(remote_groups.begin()->second.front().src,
+                                                     remote_groups.begin()->second.front().size)
+                                    .has_value();
+
+  if (!is_zc) {
+    // Staging / no remote: each peer submits then IMMEDIATELY waits. The
+    // in-flight holds staging_mutex_ submit..wait, so a submit-all over multiple
+    // staging peers would deadlock on the single lock.
+    run_local_put();
+    for (const auto& [node_id, items] : remote_groups) {
+      if (auto f = SubmitRemoteBatchPut(items, results, /*permit_staging=*/true)) {
+        WaitRemoteBatchPut(*f, results);
+      }
+    }
+    return;
+  }
+
+  // Zero-copy: submit every peer (not waited) to overlap the wire across peers,
+  // run local puts in that window, then wait all + commit. On early exit
+  // ~RemoteDramPutInFlight drains statuses; the wait does mapping + commit/abort.
+  std::vector<std::unique_ptr<RemoteDramPutInFlight>> inflights;
+  inflights.reserve(remote_groups.size());
+  for (const auto& [node_id, items] : remote_groups) {
+    if (auto f = SubmitRemoteBatchPut(items, results, /*permit_staging=*/false)) {
+      inflights.push_back(std::move(f));
+    }
+  }
+  run_local_put();
+  for (auto& f : inflights) WaitRemoteBatchPut(*f, results);
+}
+
+std::unique_ptr<PoolClient::RemoteDramPutInFlight> PoolClient::SubmitRemoteBatchPut(
+    const std::vector<BatchPutItem>& items, std::vector<PutEntryOutcome>* results,
+    bool permit_staging) {
+  if (items.empty()) return nullptr;
   auto fail_all = [&] {
     for (const auto& item : items) (*results)[item.index] = PutEntryOutcome::kFailed;
   };
   if (!io_engine_) {
-    MORI_UMBP_ERROR("[PoolClient] ProcessRemoteBatchPut: io_engine_ not initialized (items={})",
+    MORI_UMBP_ERROR("[PoolClient] SubmitRemoteBatchPut: io_engine_ not initialized (items={})",
                     items.size());
     fail_all();
-    return;
+    return nullptr;
   }
+
   const auto& first = items.front();
   auto& peer = GetOrConnectPeer(first.route.node_id, first.route.peer_address);
   if (!EnsurePeerServiceConnection(peer)) {
     MORI_UMBP_WARN(
-        "[PoolClient] ProcessRemoteBatchPut: peer service connection unavailable, node='{}' "
+        "[PoolClient] SubmitRemoteBatchPut: peer service connection unavailable, node='{}' "
         "addr='{}' items={}",
         first.route.node_id, first.route.peer_address, items.size());
     fail_all();
-    return;
+    return nullptr;
   }
   auto* stub = static_cast<::umbp::UMBPPeer::Stub*>(peer.peer_stub.get());
-  ExecuteRemoteBatchPut(items, results, peer, stub);
-}
 
-void PoolClient::ExecuteRemoteBatchPut(const std::vector<BatchPutItem>& items,
-                                       std::vector<PutEntryOutcome>* results, PeerConnection& peer,
-                                       ::umbp::UMBPPeer::Stub* stub) {
-  if (items.empty()) return;
-  if (!io_engine_) {
-    for (const auto& item : items) (*results)[item.index] = PutEntryOutcome::kFailed;
-    return;
+  auto inflight = std::make_unique<RemoteDramPutInFlight>();
+  inflight->peer = &peer;
+  inflight->stub = stub;
+
+  // Abort already-allocated slots on a synchronous failure that returns nullptr
+  // (no WaitRemoteBatchPut/finalize will run for them).
+  auto abort_now = [&](std::vector<uint64_t> slot_ids) {
+    if (slot_ids.empty()) return;
+    ::umbp::BatchAbortSlotsRequest abort_req;
+    for (uint64_t slot_id : slot_ids) abort_req.add_slot_ids(slot_id);
+    ::umbp::BatchAbortSlotsResponse abort_resp;
+    grpc::ClientContext abort_ctx;
+    // Best-effort: a failed abort just leaves the slots for the peer reaper to
+    // reclaim at pending_ttl. Warn to aid diagnosis but do not propagate.
+    auto s = stub->BatchAbortSlots(&abort_ctx, abort_req, &abort_resp);
+    if (!s.ok()) {
+      MORI_UMBP_WARN(
+          "[PoolClient] SubmitRemoteBatchPut: BatchAbortSlots({} slots) failed on {}: {}",
+          slot_ids.size(), first.route.node_id, s.error_message());
+    }
+  };
+
+  // Allocate RPC + per-key dedup/failure mapping; malformed slots go to
+  // inflight->abort_slots. On total failure results are written and the
+  // malformed list already aborted inside the callee — nothing left in flight.
+  if (!AllocateRemotePutEntries(items, stub, &inflight->entries, &inflight->abort_slots, results)) {
+    return nullptr;
   }
-
-  std::vector<RemotePutEntry> entries;
-  std::vector<uint64_t> abort_slots;
-  if (!AllocateRemotePutEntries(items, stub, &entries, &abort_slots, results)) return;
 
   std::vector<TransferInstruction> transfers;
   uint64_t staging_bytes = 0;
-  if (!BuildRemotePutTransfers(entries, peer, &transfers, &staging_bytes)) {
+  if (!BuildRemotePutTransfers(inflight->entries, peer, &transfers, &staging_bytes)) {
     MORI_UMBP_WARN(
-        "[PoolClient] ExecuteRemoteBatchPut: BuildRemotePutTransfers failed, node='{}' "
-        "entries={} staging_bytes={} -> aborting all slots",
-        items.front().route.node_id, entries.size(), staging_bytes);
-    for (auto& entry : entries) {
-      abort_slots.push_back(entry.slot_id);
+        "[PoolClient] SubmitRemoteBatchPut: BuildRemotePutTransfers failed, node='{}' entries={} "
+        "-> aborting all slots",
+        first.route.node_id, inflight->entries.size());
+    // Build failed wholesale: abort everything allocated.
+    std::vector<uint64_t> all = std::move(inflight->abort_slots);
+    for (auto& entry : inflight->entries) {
+      all.push_back(entry.slot_id);
       (*results)[entry.result_index] = PutEntryOutcome::kFailed;
     }
-    if (!abort_slots.empty()) {
-      ::umbp::BatchAbortSlotsRequest abort_req;
-      for (uint64_t slot_id : abort_slots) abort_req.add_slot_ids(slot_id);
-      ::umbp::BatchAbortSlotsResponse abort_resp;
-      grpc::ClientContext abort_ctx;
-      stub->BatchAbortSlots(&abort_ctx, abort_req, &abort_resp);
+    abort_now(std::move(all));
+    return nullptr;
+  }
+  inflight->staging_bytes = staging_bytes;
+
+  // Staging uses the shared staging_buffer_, so a cross-peer submit-all cannot
+  // serialize on the single staging_mutex_ without deadlocking: the zero-copy
+  // path passes permit_staging=false and fails such a batch (contract: a batch
+  // is all-zc or all-staging). The serial staging path acquires staging_mutex_,
+  // copies src->staging here (BEFORE BatchWrite, opposite of Get), and parks the
+  // lock in the in-flight until WaitRemoteBatchPut releases it.
+  if (staging_bytes > 0) {
+    if (!permit_staging) {
+      MORI_UMBP_ERROR(
+          "[PoolClient] SubmitRemoteBatchPut: unexpected staging_bytes={} on zero-copy path "
+          "node='{}' -> failing batch",
+          staging_bytes, first.route.node_id);
+      std::vector<uint64_t> all = std::move(inflight->abort_slots);
+      for (auto& entry : inflight->entries) {
+        all.push_back(entry.slot_id);
+        (*results)[entry.result_index] = PutEntryOutcome::kFailed;
+      }
+      abort_now(std::move(all));
+      return nullptr;
     }
-    return;
+    inflight->staging_lock = std::unique_lock<std::mutex>(staging_mutex_);
+    for (auto& entry : inflight->entries) {
+      if (entry.failed || !entry.use_staging) continue;
+      // Defensive re-check before the memcpy (build already validated the cursor).
+      if (entry.staging_offset + entry.item->size > config_.staging_buffer_size) {
+        MORI_UMBP_ERROR(
+            "[PoolClient] SubmitRemoteBatchPut: staging offset overflow (should not happen), "
+            "key='{}' staging_offset={} size={} cap={}",
+            (entry.item && entry.item->key) ? *entry.item->key : std::string{"<null>"},
+            entry.staging_offset, entry.item ? entry.item->size : 0, config_.staging_buffer_size);
+        entry.failed = true;
+        continue;
+      }
+      std::memcpy(staging_buffer_.get() + entry.staging_offset, entry.item->src, entry.item->size);
+    }
   }
 
-  ExecuteRemotePutTransfers(entries, transfers, staging_bytes);
-  FinalizeRemotePutEntries(entries, abort_slots, results, stub);
+  // Drop transfers whose entry failed during build. Those failed entries ride in
+  // inflight->entries and are aborted by FinalizeRemotePutEntries at wait time —
+  // do NOT early-abort them here (they're not a whole-batch failure).
+  std::vector<TransferInstruction> active_transfers;
+  active_transfers.reserve(transfers.size());
+  for (const auto& t : transfers) {
+    if (!inflight->entries[t.entry_index].failed) active_transfers.push_back(t);
+  }
+  if (active_transfers.empty()) {
+    // Nothing to post: no in-flight returned, so finalize never runs. Release
+    // staging_mutex_ before the abort RPC (no need to hold it over the wire),
+    // then abort every allocated slot and fail every key.
+    if (inflight->staging_lock.owns_lock()) inflight->staging_lock.unlock();
+    std::vector<uint64_t> all = std::move(inflight->abort_slots);
+    for (auto& entry : inflight->entries) {
+      all.push_back(entry.slot_id);
+      (*results)[entry.result_index] = PutEntryOutcome::kFailed;
+    }
+    abort_now(std::move(all));
+    return nullptr;
+  }
+
+  // Collapse same-pair pages into one outer transfer, materialised INTO the
+  // in-flight so the args outlive the post (see RemoteDramGetInFlight).
+  inflight->groups = GroupTransfersByPair(active_transfers);
+  const size_t G = inflight->groups.size();
+  inflight->local_descs.resize(G);
+  inflight->remote_descs.resize(G);
+  inflight->local_offsets.resize(G);
+  inflight->remote_offsets.resize(G);
+  inflight->sizes_v.resize(G);
+  inflight->statuses = std::vector<mori::io::TransferStatus>(G);  // built once, never resized/moved
+  inflight->status_ptrs.resize(G);
+  inflight->ids.resize(G);
+  for (size_t g = 0; g < G; ++g) {
+    inflight->local_descs[g] = inflight->groups[g].local_desc;
+    inflight->remote_descs[g] = inflight->groups[g].remote_desc;
+    inflight->local_offsets[g] = std::move(inflight->groups[g].local_offsets);
+    inflight->remote_offsets[g] = std::move(inflight->groups[g].remote_offsets);
+    inflight->sizes_v[g] = std::move(inflight->groups[g].sizes);
+    inflight->status_ptrs[g] = &inflight->statuses[g];
+    inflight->ids[g] = io_engine_->AllocateTransferUniqueId();
+  }
+
+  // POST the writes; do NOT wait. All args are owned by *inflight; for staging
+  // the src bytes are already in staging_buffer_ under staging_lock.
+  io_engine_->BatchWrite(inflight->local_descs, inflight->local_offsets, inflight->remote_descs,
+                         inflight->remote_offsets, inflight->sizes_v, inflight->status_ptrs,
+                         inflight->ids);
+  return inflight;
+}
+
+void PoolClient::WaitRemoteBatchPut(RemoteDramPutInFlight& f,
+                                    std::vector<PutEntryOutcome>* results) {
+  if (f.drained) return;
+  f.drained = true;  // set early (mirror Get) so the destructor never re-waits.
+  // Wait every group (never break early); a non-success group fails all of its
+  // contributing keys (per-item AND).
+  const size_t G = f.groups.size();
+  for (size_t g = 0; g < G; ++g) {
+    f.statuses[g].Wait();
+    if (f.statuses[g].Succeeded()) continue;
+    for (size_t ei : f.groups[g].entry_indices) {
+      auto& entry = f.entries[ei];
+      MORI_UMBP_ERROR(
+          "RemotePut BatchWrite failed: code={} msg='{}' peer_engine='{}' key='{}' slot_id={} "
+          "use_staging={}",
+          f.statuses[g].CodeUint32(), f.statuses[g].Message(), f.groups[g].remote_desc.engineKey,
+          (entry.item && entry.item->key) ? *entry.item->key : std::string{"<null>"}, entry.slot_id,
+          entry.use_staging);
+      entry.failed = true;
+    }
+  }
+
+  // RDMA has consumed staging_buffer_; release staging_mutex_ (Put has no
+  // staging->dst copy-out — the data went to the peer).
+  if (f.staging_lock.owns_lock()) f.staging_lock.unlock();
+
+  FinalizeRemotePutEntries(f.entries, f.abort_slots, results, f.stub);
 }
 
 bool PoolClient::AllocateRemotePutEntries(const std::vector<BatchPutItem>& items,
@@ -1435,86 +1587,6 @@ bool PoolClient::BuildRemotePutTransfers(std::vector<RemotePutEntry>& entries, P
   return true;
 }
 
-void PoolClient::ExecuteRemotePutTransfers(std::vector<RemotePutEntry>& entries,
-                                           std::vector<TransferInstruction>& transfers,
-                                           uint64_t staging_bytes) {
-  std::unique_lock<std::mutex> staging_lock(staging_mutex_, std::defer_lock);
-  if (staging_bytes > 0) staging_lock.lock();
-
-  for (auto& entry : entries) {
-    if (entry.failed) continue;
-    if (entry.use_staging) {
-      if (entry.staging_offset + entry.item->size > config_.staging_buffer_size) {
-        MORI_UMBP_ERROR(
-            "[PoolClient] ExecuteRemotePutTransfers: staging offset overflow (should not happen), "
-            "key='{}' staging_offset={} size={} cap={}",
-            (entry.item && entry.item->key) ? *entry.item->key : std::string{"<null>"},
-            entry.staging_offset, entry.item ? entry.item->size : 0, config_.staging_buffer_size);
-        entry.failed = true;
-        continue;
-      }
-      std::memcpy(staging_buffer_.get() + entry.staging_offset, entry.item->src, entry.item->size);
-    }
-  }
-
-  std::vector<TransferInstruction> active_transfers;
-  active_transfers.reserve(transfers.size());
-  for (const auto& transfer : transfers) {
-    if (!entries[transfer.entry_index].failed) {
-      active_transfers.push_back(transfer);
-    }
-  }
-  if (active_transfers.empty()) {
-    if (staging_lock.owns_lock()) staging_lock.unlock();
-    return;
-  }
-
-  // Collapse all pages of the same (localMR, remoteMR) pair into one outer
-  // transfer (inner offset/size vectors = scatter-gather segments).  One
-  // TransferStatus and one TransferUniqueId per pair instead of per page.
-  auto groups = GroupTransfersByPair(active_transfers);
-  const size_t G = groups.size();
-  mori::io::MemDescVec local_descs(G), remote_descs(G);
-  mori::io::BatchSizeVec local_offsets(G), remote_offsets(G), sizes_v(G);
-  std::vector<mori::io::TransferStatus> statuses(G);  // built once at final size
-  mori::io::TransferStatusPtrVec status_ptrs(G);
-  mori::io::TransferUniqueIdVec ids(G);
-  for (size_t g = 0; g < G; ++g) {
-    local_descs[g] = groups[g].local_desc;
-    remote_descs[g] = groups[g].remote_desc;
-    local_offsets[g] = std::move(groups[g].local_offsets);
-    remote_offsets[g] = std::move(groups[g].remote_offsets);
-    sizes_v[g] = std::move(groups[g].sizes);
-    status_ptrs[g] = &statuses[g];
-    ids[g] = io_engine_->AllocateTransferUniqueId();
-  }
-
-  io_engine_->BatchWrite(local_descs, local_offsets, remote_descs, remote_offsets, sizes_v,
-                         status_ptrs, ids);
-  // Wait every group (never break early): IN_PROGRESS groups complete here;
-  // INIT (left unsubmitted by an engine early-return) or already-terminal
-  // groups return immediately.  A non-success group fails ALL its
-  // contributing keys (per-item AND semantics — a key fails if any of its
-  // pairs fail).  NOTE: this does not by itself prove safety of backend
-  // partial-post / status-lifetime corner cases.
-  for (size_t g = 0; g < G; ++g) {
-    statuses[g].Wait();
-    if (statuses[g].Succeeded()) continue;
-    for (size_t ei : groups[g].entry_indices) {
-      auto& entry = entries[ei];
-      MORI_UMBP_ERROR(
-          "RemotePut BatchWrite failed: code={} msg='{}' peer_engine='{}' key='{}' "
-          "slot_id={} use_staging={}",
-          statuses[g].CodeUint32(), statuses[g].Message(), groups[g].remote_desc.engineKey,
-          (entry.item && entry.item->key) ? *entry.item->key : std::string{"<null>"}, entry.slot_id,
-          entry.use_staging);
-      entry.failed = true;
-    }
-  }
-
-  if (staging_lock.owns_lock()) staging_lock.unlock();
-}
-
 void PoolClient::FinalizeRemotePutEntries(std::vector<RemotePutEntry>& entries,
                                           std::vector<uint64_t>& abort_slots,
                                           std::vector<PutEntryOutcome>* results,
@@ -1575,7 +1647,13 @@ void PoolClient::FinalizeRemotePutEntries(std::vector<RemotePutEntry>& entries,
     for (uint64_t slot_id : abort_slots) abort_req.add_slot_ids(slot_id);
     ::umbp::BatchAbortSlotsResponse abort_resp;
     grpc::ClientContext abort_ctx;
-    stub->BatchAbortSlots(&abort_ctx, abort_req, &abort_resp);
+    // Best-effort: a failed abort just leaves the slots for the peer reaper to
+    // reclaim at pending_ttl. Warn to aid diagnosis but do not propagate.
+    auto abort_status = stub->BatchAbortSlots(&abort_ctx, abort_req, &abort_resp);
+    if (!abort_status.ok()) {
+      MORI_UMBP_WARN("[PoolClient] FinalizeRemotePutEntries: BatchAbortSlots({} slots) failed: {}",
+                     abort_slots.size(), abort_status.error_message());
+    }
     abort_slots.clear();
   }
 }
@@ -1845,8 +1923,8 @@ std::unique_ptr<PoolClient::RemoteDramGetInFlight> PoolClient::SubmitRemoteBatch
 }
 
 void PoolClient::WaitRemoteBatchGet(RemoteDramGetInFlight& f, std::vector<bool>* results) {
-  if (f.waited) return;
-  f.waited = true;
+  if (f.drained) return;
+  f.drained = true;
   // Wait every group (never break early): IN_PROGRESS groups complete here;
   // INIT/terminal return immediately.  A non-success group fails all of its
   // contributing keys (per-item AND).

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -292,10 +292,25 @@ class PoolClient {
     std::vector<size_t> local_ssd_indices;
   };
 
-  std::unordered_map<std::string, std::vector<BatchPutItem>> PartitionBatchPutTargets(
-      const std::vector<std::string>& keys, const std::vector<const void*>& srcs,
-      const std::vector<size_t>& sizes, const std::vector<std::optional<RoutePutResult>>& routes,
-      std::vector<PutEntryOutcome>* results);
+  // Pure grouping for one BatchPut (no IO, no local put executed; mirrors
+  // BatchGetPlan).  Put has no remote-SSD target.  local_items hold full items
+  // (not bare indices) so the deferred local memcpy keeps its route tier.
+  struct BatchPutPlan {
+    std::unordered_map<std::string, std::vector<BatchPutItem>> remote_groups;
+    std::vector<BatchPutItem> local_items;
+  };
+
+  // Group a BatchPut's routes into a BatchPutPlan; master-side dedup and
+  // zero-size skips are projected straight into *results.
+  BatchPutPlan PartitionBatchPutTargets(const std::vector<std::string>& keys,
+                                        const std::vector<const void*>& srcs,
+                                        const std::vector<size_t>& sizes,
+                                        const std::vector<std::optional<RoutePutResult>>& routes,
+                                        std::vector<PutEntryOutcome>* results);
+  // Execute a BatchPutPlan.  Zero-copy submits all peers (not waited), runs the
+  // deferred local puts in that window, then waits all + commits; staging runs
+  // per peer serially.  Writes per-key outcomes into *results.
+  void ExecuteBatchPutPlan(const BatchPutPlan& plan, std::vector<PutEntryOutcome>* results);
 
   // Group a BatchGet's routes into a BatchGetPlan (no IO issued).  Mirrors
   // PartitionBatchPutTargets, but deliberately does NOT execute local reads:
@@ -364,8 +379,6 @@ class PoolClient {
     bool failed = false;
   };
 
-  void ProcessRemoteBatchPut(const std::vector<BatchPutItem>& items,
-                             std::vector<PutEntryOutcome>* results);
   // Remote SSD reads (one staging slot + lease per key) with bounded retry
   // (default off) on transient NO_SLOT / reader-local lease expiry; an rpc
   // failure is hard not-served, and a NOT_FOUND short-circuits as a miss.
@@ -387,9 +400,6 @@ class PoolClient {
     uint64_t staging_expired_reclaims = 0, staging_slot_full_rejects = 0;
   };
   SsdMetricsLastShipped ssd_metrics_last_;
-  void ExecuteRemoteBatchPut(const std::vector<BatchPutItem>& items,
-                             std::vector<PutEntryOutcome>* results, PeerConnection& peer,
-                             ::umbp::UMBPPeer::Stub* stub);
 
   bool AllocateRemotePutEntries(const std::vector<BatchPutItem>& items,
                                 ::umbp::UMBPPeer::Stub* stub, std::vector<RemotePutEntry>* entries,
@@ -398,9 +408,6 @@ class PoolClient {
   bool BuildRemotePutTransfers(std::vector<RemotePutEntry>& entries, PeerConnection& peer,
                                std::vector<TransferInstruction>* transfers,
                                uint64_t* staging_bytes);
-  void ExecuteRemotePutTransfers(std::vector<RemotePutEntry>& entries,
-                                 std::vector<TransferInstruction>& transfers,
-                                 uint64_t staging_bytes);
   void FinalizeRemotePutEntries(std::vector<RemotePutEntry>& entries,
                                 std::vector<uint64_t>& abort_slots,
                                 std::vector<PutEntryOutcome>* results,
@@ -413,24 +420,10 @@ class PoolClient {
                                uint64_t* staging_bytes);
   void FinalizeRemoteGetEntries(std::vector<RemoteGetEntry>& entries, std::vector<bool>* results);
 
-  // One posted-but-not-yet-waited remote-DRAM read for a single peer.  Submit
-  // builds + posts (BatchRead, no wait) and returns this; the scheduler waits
-  // it later.  Used by BOTH paths:
-  //   * zero-copy: the scheduler submits every peer first, then waits all, so
-  //     wire time overlaps across peers (and optionally with local/SSD work).
-  //   * staging (non-zc): the scheduler submits then waits ONE peer at a time
-  //     (serial); RDMA lands in the shared staging_buffer_, so `staging_lock`
-  //     holds staging_mutex_ across submit -> wait -> memcpy to serialize use of
-  //     the buffer, and WaitRemoteBatchGet copies staging -> user dst.  Staging
-  //     deliberately does NOT join the cross-peer in-flight window.
-  //
-  // Lifetime contract (why it is owned by a unique_ptr and not moved after
-  // submit): the RDMA backend keeps a RAW TransferStatus* in its CQ callback
-  // meta, so `statuses` must outlive the BatchRead and never move.  It is sized
-  // once to G groups and never resized; `status_ptrs[g]` alias &statuses[g].  The
-  // BatchRead arg vectors are kept alive here too (the multithread-executor path
-  // may read offsets/sizes after the call returns; the default chunking-on path
-  // consumes them synchronously, but keeping them is free and config-robust).
+  // One posted-but-not-yet-waited remote-DRAM read for a single peer; the
+  // scheduler waits it later. Owned by a unique_ptr and never moved after
+  // submit: the RDMA backend keeps a RAW TransferStatus* into `statuses`, so it
+  // must outlive BatchRead and never move (sized once to G, never resized).
   struct RemoteDramGetInFlight {
     PeerConnection* peer = nullptr;
     std::vector<RemoteGetEntry> entries;
@@ -443,10 +436,19 @@ class PoolClient {
     std::vector<mori::io::TransferStatus> statuses;  // size G; built once, never resized/moved
     mori::io::TransferStatusPtrVec status_ptrs;      // &statuses[g]
     mori::io::TransferUniqueIdVec ids;
-    bool waited = false;  // set by WaitRemoteBatchGet so the RAII guard skips it
+    bool drained = false;  // set once statuses have been Wait()ed (drain or WaitRemoteBatchGet)
     // Staging (non-zero-copy) state; zero / unlocked for the zero-copy path.
     uint64_t staging_bytes = 0;
     std::unique_lock<std::mutex> staging_lock;  // holds staging_mutex_ submit..memcpy
+
+    // Safety net: BatchRead is posted (not waited) and the backend CQ callback
+    // holds raw TransferStatus* into `statuses`. On an early/exceptional destroy
+    // (before WaitRemoteBatchGet), drain so the callback never writes freed
+    // memory. No failure mapping / result backfill — that's WaitRemoteBatchGet.
+    ~RemoteDramGetInFlight() {
+      if (drained) return;
+      for (auto& s : statuses) s.Wait();
+    }
   };
 
   // Submit half: GetOrConnectPeer + EnsurePeerServiceConnection +
@@ -465,6 +467,58 @@ class PoolClient {
   // back to per-key (per-item AND); for a staging in-flight, copy staging_buffer_
   // -> user dst and release staging_mutex_; then FinalizeRemoteGetEntries.
   void WaitRemoteBatchGet(RemoteDramGetInFlight& inflight, std::vector<bool>* results);
+
+  // One posted-but-not-yet-waited remote-DRAM write for a single peer (same
+  // lifetime contract as RemoteDramGetInFlight: unique_ptr-owned, never moved
+  // after submit; the backend holds raw TransferStatus* into `statuses`, sized
+  // once to G).  Put also carries the slot lifecycle: `entries`/`abort_slots`
+  // feed FinalizeRemotePutEntries and `stub` issues its commit/abort RPCs.
+  struct RemoteDramPutInFlight {
+    PeerConnection* peer = nullptr;
+    ::umbp::UMBPPeer::Stub* stub = nullptr;
+    std::vector<RemotePutEntry> entries;
+    // Malformed slots from Allocate (not in `entries`); Finalize appends
+    // entry.failed slots and aborts the union (peer Abort is idempotent).
+    std::vector<uint64_t> abort_slots;
+    std::vector<PairGroup> groups;
+    mori::io::MemDescVec local_descs;
+    mori::io::MemDescVec remote_descs;
+    mori::io::BatchSizeVec local_offsets;
+    mori::io::BatchSizeVec remote_offsets;
+    mori::io::BatchSizeVec sizes_v;
+    std::vector<mori::io::TransferStatus> statuses;  // size G; built once, never resized/moved
+    mori::io::TransferStatusPtrVec status_ptrs;      // &statuses[g]
+    mori::io::TransferUniqueIdVec ids;
+    bool drained = false;
+    uint64_t staging_bytes = 0;
+    std::unique_lock<std::mutex> staging_lock;  // holds staging_mutex_ submit(memcpy)..wait
+
+    // Safety net (mirror Get): drain posted statuses on an early destroy so the
+    // backend CQ callback never writes freed memory. Slots are NOT committed/
+    // aborted here — an un-committed slot never enters the master index, so it is
+    // correctness-neutral and the peer reaper reclaims it at pending_ttl.
+    ~RemoteDramPutInFlight() {
+      if (drained) return;
+      for (auto& s : statuses) s.Wait();
+    }
+  };
+
+  // Submit half: allocate + build + (staging: memcpy src -> staging_buffer_ under
+  // staging_mutex_) + group + BatchWrite (NOT waited).  Returns the in-flight, or
+  // nullptr if nothing is posted — in which case any allocated slots are aborted
+  // and the keys written kFailed here.  Entries that fail during build but still
+  // post ride in the in-flight and are aborted by FinalizeRemotePutEntries at
+  // wait time (no early abort, avoids double-abort).  permit_staging=false on the
+  // zero-copy submit-all path (staging would deadlock the single lock); true on
+  // the serial staging path, which parks staging_mutex_ in the in-flight.
+  std::unique_ptr<RemoteDramPutInFlight> SubmitRemoteBatchPut(
+      const std::vector<BatchPutItem>& items, std::vector<PutEntryOutcome>* results,
+      bool permit_staging);
+  // Wait half: wait every group (never break early), aggregate per-pair failure
+  // back to per-key (per-item AND), release staging_mutex_ (Put has no
+  // staging->dst copy-out), then FinalizeRemotePutEntries (commit survivors,
+  // abort failures + malformed slots).
+  void WaitRemoteBatchPut(RemoteDramPutInFlight& inflight, std::vector<PutEntryOutcome>* results);
 };
 
 }  // namespace mori::umbp

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -306,12 +306,10 @@ class PoolClient {
                                         const std::vector<size_t>& sizes,
                                         const std::vector<std::optional<RouteGetResult>>& routes);
   // Execute a BatchGetPlan: local DRAM/SSD, remote SSD, and the remote-DRAM
-  // submit/wait arrangement.  Zero-copy remote DRAM always submits all peers then
-  // waits all (multi-peer overlap); the overlap window (local DRAM/SSD + remote
-  // SSD run INSIDE that submit..wait gap) is used only when overlap is enabled
-  // and the batch is within the max-batch threshold, otherwise local/SSD run
-  // first.  Staging (non-zero-copy) runs per peer serially (submit -> wait).
-  // Reads the plan; writes per-key outcomes into *results.
+  // submit/wait arrangement.  Zero-copy remote DRAM submits all peers, runs local
+  // DRAM/SSD + remote SSD INSIDE that submit..wait gap (so they overlap the DRAM
+  // wire), then waits all peers.  Staging (non-zero-copy) runs per peer serially
+  // (submit -> wait).  Reads the plan; writes per-key outcomes into *results.
   void ExecuteBatchGetPlan(const BatchGetPlan& plan, const std::vector<std::string>& keys,
                            const std::vector<void*>& dsts, const std::vector<size_t>& sizes,
                            std::vector<bool>* results);

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -279,10 +279,42 @@ class PoolClient {
     RouteGetResult route;
   };
 
+  // Routing plan for one BatchGet: which keys go to which tier/target.  Pure
+  // grouping — no IO is issued here.  Remote DRAM/HBM reads go through the
+  // batched RDMA path (remote_dram_groups); remote SSD reads through a per-key
+  // staging+lease path (remote_ssd_groups); self-target DRAM and SSD reads are
+  // deferred (collected as indices) so ExecuteBatchGetPlan can place them inside
+  // the remote-DRAM in-flight window when overlapping.
+  struct BatchGetPlan {
+    std::unordered_map<std::string, std::vector<BatchGetItem>> remote_dram_groups;
+    std::unordered_map<std::string, std::vector<BatchGetItem>> remote_ssd_groups;
+    std::vector<size_t> local_dram_indices;
+    std::vector<size_t> local_ssd_indices;
+  };
+
   std::unordered_map<std::string, std::vector<BatchPutItem>> PartitionBatchPutTargets(
       const std::vector<std::string>& keys, const std::vector<const void*>& srcs,
       const std::vector<size_t>& sizes, const std::vector<std::optional<RoutePutResult>>& routes,
       std::vector<PutEntryOutcome>* results);
+
+  // Group a BatchGet's routes into a BatchGetPlan (no IO issued).  Mirrors
+  // PartitionBatchPutTargets, but deliberately does NOT execute local reads:
+  // ExecuteBatchGetPlan decides where the local reads run so they can overlap
+  // the remote-DRAM RDMA in-flight window.
+  BatchGetPlan PartitionBatchGetTargets(const std::vector<std::string>& keys,
+                                        const std::vector<void*>& dsts,
+                                        const std::vector<size_t>& sizes,
+                                        const std::vector<std::optional<RouteGetResult>>& routes);
+  // Execute a BatchGetPlan: local DRAM/SSD, remote SSD, and the remote-DRAM
+  // submit/wait arrangement.  Zero-copy remote DRAM always submits all peers then
+  // waits all (multi-peer overlap); the overlap window (local DRAM/SSD + remote
+  // SSD run INSIDE that submit..wait gap) is used only when overlap is enabled
+  // and the batch is within the max-batch threshold, otherwise local/SSD run
+  // first.  Staging (non-zero-copy) runs per peer serially (submit -> wait).
+  // Reads the plan; writes per-key outcomes into *results.
+  void ExecuteBatchGetPlan(const BatchGetPlan& plan, const std::vector<std::string>& keys,
+                           const std::vector<void*>& dsts, const std::vector<size_t>& sizes,
+                           std::vector<bool>* results);
 
   struct TransferInstruction {
     size_t entry_index;
@@ -336,7 +368,6 @@ class PoolClient {
 
   void ProcessRemoteBatchPut(const std::vector<BatchPutItem>& items,
                              std::vector<PutEntryOutcome>* results);
-  void ProcessRemoteBatchGet(const std::vector<BatchGetItem>& items, std::vector<bool>* results);
   // Remote SSD reads (one staging slot + lease per key) with bounded retry
   // (default off) on transient NO_SLOT / reader-local lease expiry; an rpc
   // failure is hard not-served, and a NOT_FOUND short-circuits as a miss.
@@ -361,8 +392,6 @@ class PoolClient {
   void ExecuteRemoteBatchPut(const std::vector<BatchPutItem>& items,
                              std::vector<PutEntryOutcome>* results, PeerConnection& peer,
                              ::umbp::UMBPPeer::Stub* stub);
-  void ExecuteRemoteBatchGet(const std::vector<BatchGetItem>& items, std::vector<bool>* results,
-                             PeerConnection& peer, ::umbp::UMBPPeer::Stub* stub);
 
   bool AllocateRemotePutEntries(const std::vector<BatchPutItem>& items,
                                 ::umbp::UMBPPeer::Stub* stub, std::vector<RemotePutEntry>* entries,
@@ -384,10 +413,60 @@ class PoolClient {
   bool BuildRemoteGetTransfers(std::vector<RemoteGetEntry>& entries, PeerConnection& peer,
                                std::vector<TransferInstruction>* transfers,
                                uint64_t* staging_bytes);
-  void ExecuteRemoteGetTransfers(std::vector<RemoteGetEntry>& entries,
-                                 std::vector<TransferInstruction>& transfers,
-                                 uint64_t staging_bytes);
   void FinalizeRemoteGetEntries(std::vector<RemoteGetEntry>& entries, std::vector<bool>* results);
+
+  // One posted-but-not-yet-waited remote-DRAM read for a single peer.  Submit
+  // builds + posts (BatchRead, no wait) and returns this; the scheduler waits
+  // it later.  Used by BOTH paths:
+  //   * zero-copy: the scheduler submits every peer first, then waits all, so
+  //     wire time overlaps across peers (and optionally with local/SSD work).
+  //   * staging (non-zc): the scheduler submits then waits ONE peer at a time
+  //     (serial); RDMA lands in the shared staging_buffer_, so `staging_lock`
+  //     holds staging_mutex_ across submit -> wait -> memcpy to serialize use of
+  //     the buffer, and WaitRemoteBatchGet copies staging -> user dst.  Staging
+  //     deliberately does NOT join the cross-peer in-flight window.
+  //
+  // Lifetime contract (why it is owned by a unique_ptr and not moved after
+  // submit): the RDMA backend keeps a RAW TransferStatus* in its CQ callback
+  // meta, so `statuses` must outlive the BatchRead and never move.  It is sized
+  // once to G groups and never resized; `status_ptrs[g]` alias &statuses[g].  The
+  // BatchRead arg vectors are kept alive here too (the multithread-executor path
+  // may read offsets/sizes after the call returns; the default chunking-on path
+  // consumes them synchronously, but keeping them is free and config-robust).
+  struct RemoteDramGetInFlight {
+    PeerConnection* peer = nullptr;
+    std::vector<RemoteGetEntry> entries;
+    std::vector<PairGroup> groups;
+    mori::io::MemDescVec local_descs;
+    mori::io::MemDescVec remote_descs;
+    mori::io::BatchSizeVec local_offsets;
+    mori::io::BatchSizeVec remote_offsets;
+    mori::io::BatchSizeVec sizes_v;
+    std::vector<mori::io::TransferStatus> statuses;  // size G; built once, never resized/moved
+    mori::io::TransferStatusPtrVec status_ptrs;      // &statuses[g]
+    mori::io::TransferUniqueIdVec ids;
+    bool waited = false;  // set by WaitRemoteBatchGet so the RAII guard skips it
+    // Staging (non-zero-copy) state; zero / unlocked for the zero-copy path.
+    uint64_t staging_bytes = 0;
+    std::unique_lock<std::mutex> staging_lock;  // holds staging_mutex_ submit..memcpy
+  };
+
+  // Submit half: GetOrConnectPeer + EnsurePeerServiceConnection +
+  // PrepareRemoteGetEntries + BuildRemoteGetTransfers + GroupTransfersByPair +
+  // BatchRead (NOT waited).  Returns the in-flight handle, or nullptr if nothing
+  // is in flight (peer unreachable / resolve / build failure — failed keys
+  // already written to *results).  When `permit_staging` is false (the zero-copy
+  // submit-all path), a batch that needs staging is treated as a contract
+  // violation and failed rather than acquiring staging_mutex_ (a submit-all over
+  // multiple staging peers would deadlock on the single lock).  When true (the
+  // serial staging path), staging_mutex_ is acquired here and parked in the
+  // in-flight until WaitRemoteBatchGet copies staging -> dst.
+  std::unique_ptr<RemoteDramGetInFlight> SubmitRemoteBatchGet(
+      const std::vector<BatchGetItem>& items, std::vector<bool>* results, bool permit_staging);
+  // Wait half: wait every group (never break early), aggregate per-pair failure
+  // back to per-key (per-item AND); for a staging in-flight, copy staging_buffer_
+  // -> user dst and release staging_mutex_; then FinalizeRemoteGetEntries.
+  void WaitRemoteBatchGet(RemoteDramGetInFlight& inflight, std::vector<bool>* results);
 };
 
 }  // namespace mori::umbp

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -206,6 +206,12 @@ class PoolClient {
   // `descs`.  Idempotent.  Acquires peers_mutex_ internally.
   void EnsureBufferDescsCached(PeerConnection& peer,
                                const std::vector<BufferMemoryDescBytes>& descs);
+  // Same as above, but the caller MUST already hold peers_mutex_.  Lets the
+  // Build* helpers hydrate AND snapshot remote descs inside a single lock
+  // window so a concurrent hydrate (which may resize dram_memories) cannot
+  // race the reads.
+  void EnsureBufferDescsCachedLocked(PeerConnection& peer,
+                                     const std::vector<BufferMemoryDescBytes>& descs);
 
   // Same-tier RDMA scatter helpers (keep as much of the prior impl as
   // possible — the IO engine call shape is unchanged).
@@ -286,6 +292,26 @@ class PoolClient {
     uint64_t remote_offset;
     uint64_t size;
   };
+
+  // A set of page transfers sharing the same (localMR, remoteMR) pair.  All
+  // its pages collapse into ONE outer IO transfer whose inner offset/size
+  // vectors are scatter-gather segments, cutting CQE/status/post count vs
+  // one-transfer-per-page.  `entry_indices` is the de-duplicated list of
+  // entries contributing pages to this group (for per-key failure mapping).
+  struct PairGroup {
+    mori::io::MemoryDesc local_desc;
+    mori::io::MemoryDesc remote_desc;
+    std::vector<size_t> local_offsets;
+    std::vector<size_t> remote_offsets;
+    std::vector<size_t> sizes;
+    std::vector<size_t> entry_indices;
+  };
+  // Group `active` page transfers by (local_desc.id, remote_desc.id),
+  // preserving first-appearance order (stable).  Assumes a fixed page size
+  // per (localMR, remoteMR) pair (1 buffer == 1 page size in the current
+  // model); mixed page sizes would require folding page size into the key.
+  static std::vector<PairGroup> GroupTransfersByPair(
+      const std::vector<TransferInstruction>& active);
 
   struct RemotePutEntry {
     size_t result_index;

--- a/tests/cpp/umbp/distributed/bench_pool_client_batch_get.cpp
+++ b/tests/cpp/umbp/distributed/bench_pool_client_batch_get.cpp
@@ -37,6 +37,8 @@
 // CSV (stdout):
 //   scenario,batch,page_bytes,iters,wall_ms,gibps
 
+#include <unistd.h>
+
 #include <atomic>
 #include <chrono>
 #include <cstdint>
@@ -64,8 +66,12 @@ namespace {
 
 // Unique peer-service port per PoolClient: required so each node registers a
 // peer_address and can serve/accept remote AllocateSlot/ResolveKey RPCs.
+// The base is seeded from the pid so rapidly-restarted bench processes (e.g.
+// a per-(pip,batch) sweep) don't collide on a port left in TIME_WAIT by a
+// prior process.
 inline uint16_t NextPeerServicePort() {
-  static std::atomic<uint16_t> next{55000};
+  static std::atomic<uint16_t> next{
+      static_cast<uint16_t>(20000 + (static_cast<unsigned>(::getpid()) * 16u) % 40000u)};
   return next.fetch_add(1);
 }
 
@@ -150,6 +156,12 @@ class Cluster {
       : page_bytes_(page_bytes), caller_buf_(caller_buf_bytes), caller_local_(caller_local_bytes) {
     MasterServerConfig mcfg;
     mcfg.listen_address = "0.0.0.0:0";
+    // The master index is eventually consistent: a committed key becomes
+    // visible only after the owning peer ships its ADD event on the next
+    // heartbeat (interval = heartbeat_ttl / divisor).  Shorten the TTL so
+    // seeded keys converge in ~0.5s instead of the 5s default, keeping the
+    // pre-Get visibility barrier (WaitAllVisible) cheap.
+    mcfg.registry_config.heartbeat_ttl = std::chrono::seconds{1};
     master_ = std::make_unique<MasterServer>(std::move(mcfg));
     server_thread_ = std::thread([this] { master_->Run(); });
     for (int i = 0; i < 200 && master_->GetBoundPort() == 0; ++i) {
@@ -242,6 +254,32 @@ std::pair<double, size_t> RunOnce(PoolClient* client, const std::vector<std::str
   return {ms, bytes};
 }
 
+// Barrier: block until every key is visible to `client` via the master
+// index.  Committed keys propagate on the owning peer's next heartbeat, so
+// a BatchGet issued immediately after seeding would otherwise route-miss.
+// This runs OUTSIDE the timed BatchGet and never counts toward throughput.
+void WaitAllVisible(PoolClient* client, const std::vector<std::string>& keys,
+                    std::chrono::milliseconds timeout = std::chrono::seconds{10}) {
+  if (keys.empty()) return;
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  for (;;) {
+    auto present = client->BatchExists(keys);
+    bool all = true;
+    for (bool p : present) {
+      if (!p) {
+        all = false;
+        break;
+      }
+    }
+    if (all) return;
+    if (std::chrono::steady_clock::now() >= deadline) {
+      std::cerr << "WaitAllVisible: keys not visible before timeout\n";
+      std::exit(2);
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+}
+
 // Seed `n` keys onto target peer `k` via that peer's BatchPut.  Returns
 // the list of seeded keys parallel to caller's dsts/sizes.
 void SeedPeer(Cluster& cluster, size_t peer_idx, size_t n, size_t bytes_per_item,
@@ -274,8 +312,12 @@ void RunScenario(const BenchOpts& base, size_t batch_override) {
   size_t num_peers = (o.scenario == "multi_peer") ? std::max<size_t>(o.peers, 2) : 1;
   size_t bytes_per_item = o.per_item_pages * o.page_bytes;
   size_t per_peer_items = (o.batch + num_peers - 1) / num_peers;
-  size_t target_dram =
-      std::max<size_t>(static_cast<size_t>(64) << 20, per_peer_items * bytes_per_item * 4);
+  // Each iter seeds a fresh, unique key set that stays resident in the peer
+  // DRAM pool (no eviction between iters), so the target must hold warmup +
+  // all measured iters' keys plus slack — otherwise late-iter seed Puts hit
+  // ENOSPC.  (+2 = warmup + headroom.)
+  size_t target_dram = std::max<size_t>(static_cast<size_t>(64) << 20,
+                                        per_peer_items * bytes_per_item * (o.iters + 2));
   size_t seed_bytes = per_peer_items * bytes_per_item;
   size_t caller_buf_bytes = o.batch * bytes_per_item;
   // Caller_local: tiny (forces all routes to remote in master placement
@@ -335,6 +377,9 @@ void RunScenario(const BenchOpts& base, size_t batch_override) {
       (*dsts)[i] = cluster.caller_buf().data() + i * bytes_per_item;
       (*sizes)[i] = bytes_per_item;
     }
+    // Visibility barrier (not timed): ensure the caller can route all keys
+    // before the measured BatchGet, otherwise route-miss yields 0 GiB/s.
+    WaitAllVisible(cluster.caller(), *keys);
   };
 
   std::vector<std::string> keys;

--- a/tests/cpp/umbp/distributed/bench_pool_client_batch_get.cpp
+++ b/tests/cpp/umbp/distributed/bench_pool_client_batch_get.cpp
@@ -86,7 +86,8 @@ struct BenchOpts {
 };
 
 void Usage() {
-  std::cerr << "Usage: bench_pool_client_batch_get [--scenario all_zc|mixed|all_stg|multi_peer]\n"
+  std::cerr << "Usage: bench_pool_client_batch_get "
+               "[--scenario all_zc|mixed|mixed_tier|all_stg|multi_peer]\n"
             << "                                   [--batch N] [--page-bytes N]\n"
             << "                                   [--per-item-pages N] [--iters N]\n"
             << "                                   [--peers N]\n"
@@ -305,13 +306,49 @@ void SeedPeer(Cluster& cluster, size_t peer_idx, size_t n, size_t bytes_per_item
   }
 }
 
+// Seed `n` keys onto `client`'s OWN DRAM pool via that client's BatchPut.  With
+// the master running UMBP_ROUTE_PUT_NODE_AFFINITY=local (set in mixed_tier),
+// these Puts self-route, so the client's later BatchGet of them hits the LOCAL
+// DRAM path.  `seed` is a client-owned src buffer (>= n * bytes_per_item).
+void SeedClientLocal(PoolClient* client, std::vector<char>& seed, size_t n, size_t bytes_per_item,
+                     const std::string& key_prefix, std::vector<std::string>* out_keys) {
+  std::vector<const void*> srcs(n);
+  std::vector<size_t> sizes(n);
+  out_keys->clear();
+  out_keys->reserve(n);
+  for (size_t i = 0; i < n; ++i) {
+    char* slot = seed.data() + i * bytes_per_item;
+    std::memset(slot, static_cast<int>(0x40 + (i & 0x3F)), bytes_per_item);
+    srcs[i] = slot;
+    sizes[i] = bytes_per_item;
+    out_keys->push_back(key_prefix + std::to_string(i));
+  }
+  auto r = client->BatchPut(*out_keys, srcs, sizes);
+  for (size_t i = 0; i < n; ++i) {
+    if (!r[i]) {
+      std::cerr << "local seed Put failed for key " << (*out_keys)[i] << "\n";
+      std::exit(2);
+    }
+  }
+}
+
 void RunScenario(const BenchOpts& base, size_t batch_override) {
   BenchOpts o = base;
   o.batch = batch_override > 0 ? batch_override : o.batch;
 
+  const bool mixed_tier = (o.scenario == "mixed_tier");
+  // mixed_tier: half the batch is served from the caller's OWN local DRAM and
+  // half from a remote peer, so the local memcpy overlaps the remote DRAM RDMA
+  // wire under overlap.  Force self-routing of the caller's seed Puts via local
+  // node affinity on the (in-process) master; read once at master construction.
+  if (mixed_tier) {
+    setenv("UMBP_ROUTE_PUT_NODE_AFFINITY", "local", /*overwrite=*/1);
+  }
   size_t num_peers = (o.scenario == "multi_peer") ? std::max<size_t>(o.peers, 2) : 1;
   size_t bytes_per_item = o.per_item_pages * o.page_bytes;
-  size_t per_peer_items = (o.batch + num_peers - 1) / num_peers;
+  const size_t n_local = mixed_tier ? (o.batch / 2) : 0;
+  const size_t n_remote_total = o.batch - n_local;
+  size_t per_peer_items = mixed_tier ? n_remote_total : (o.batch + num_peers - 1) / num_peers;
   // Each iter seeds a fresh, unique key set that stays resident in the peer
   // DRAM pool (no eviction between iters), so the target must hold warmup +
   // all measured iters' keys plus slack — otherwise late-iter seed Puts hit
@@ -320,9 +357,15 @@ void RunScenario(const BenchOpts& base, size_t batch_override) {
                                         per_peer_items * bytes_per_item * (o.iters + 2));
   size_t seed_bytes = per_peer_items * bytes_per_item;
   size_t caller_buf_bytes = o.batch * bytes_per_item;
-  // Caller_local: tiny (forces all routes to remote in master placement
-  // for caller's own self-Puts; not used here but kept for symmetry).
-  size_t caller_local_bytes = (o.scenario == "mixed") ? caller_buf_bytes : o.page_bytes;
+  // Caller_local DRAM pool: tiny by default (forces caller self-Puts to remote);
+  // for mixed_tier it must hold the caller's local half across warmup + iters.
+  size_t caller_local_bytes = mixed_tier
+                                  ? std::max<size_t>(static_cast<size_t>(64) << 20,
+                                                     n_local * bytes_per_item * (o.iters + 2))
+                              : (o.scenario == "mixed") ? caller_buf_bytes
+                                                        : o.page_bytes;
+  // Caller-owned src buffer for the local seed Puts (mixed_tier only).
+  std::vector<char> caller_seed(mixed_tier ? n_local * bytes_per_item : 0, 0);
 
   Cluster cluster(o.page_bytes, target_dram, num_peers, caller_buf_bytes, caller_local_bytes,
                   seed_bytes);
@@ -358,6 +401,16 @@ void RunScenario(const BenchOpts& base, size_t batch_override) {
           keys->push_back(peer_keys[i]);
         }
       }
+    } else if (mixed_tier) {
+      // Half remote (peer 0, REMOTE_ZC) + half local (caller's own DRAM,
+      // LOCAL).  Keys ordered remote-then-local; dsts are caller_buf slots.
+      std::vector<std::string> remote_keys, local_keys;
+      SeedPeer(cluster, 0, n_remote_total, bytes_per_item, "g-" + std::to_string(it) + "-r-",
+               &remote_keys);
+      SeedClientLocal(cluster.caller(), caller_seed, n_local, bytes_per_item,
+                      "g-" + std::to_string(it) + "-l-", &local_keys);
+      for (const auto& k : remote_keys) keys->push_back(k);
+      for (const auto& k : local_keys) keys->push_back(k);
     } else {
       // Single source peer (peer 0).  For mixed, half the items will
       // be served by the caller's own LOCAL DRAM via a separate seed

--- a/tests/cpp/umbp/distributed/test_cross_node_smoke.cpp
+++ b/tests/cpp/umbp/distributed/test_cross_node_smoke.cpp
@@ -557,7 +557,10 @@ class CrossNodeOverlap : public ::testing::Test {
     ASSERT_NE(master_->GetBoundPort(), 0) << "Master failed to start";
   }
 
-  PoolClient* MakeClient(const std::string& node_id, const std::vector<size_t>& buffer_sizes) {
+  // staging_buffer_size==0 keeps the PoolClientConfig default (64 MiB); a small
+  // positive value lets a test force the staging-overflow failure path.
+  PoolClient* MakeClient(const std::string& node_id, const std::vector<size_t>& buffer_sizes,
+                         size_t staging_buffer_size = 0) {
     PoolClientConfig cfg;
     cfg.master_config.node_id = node_id;
     cfg.master_config.node_address = "127.0.0.1";
@@ -566,6 +569,7 @@ class CrossNodeOverlap : public ::testing::Test {
     cfg.io_engine.port = 0;
     cfg.peer_service_port = NextPeerServicePort();
     cfg.dram_page_size = kPageSize;
+    if (staging_buffer_size > 0) cfg.staging_buffer_size = staging_buffer_size;
     uint64_t total = 0;
     for (size_t sz : buffer_sizes) {
       void* p = std::malloc(sz);
@@ -738,6 +742,157 @@ TEST_F(CrossNodeOverlap, MixedLocalAndRemoteZeroCopyByteExact) {
     EXPECT_EQ(std::memcmp(dst.data() + k * kPageSize, expect[k]->data(), kPageSize), 0)
         << "byte mismatch " << keys[k];
   }
+}
+
+// ===========================================================================
+// BatchPut overlap-path coverage (submit/wait split, mirror of the Get tests).
+// Each Put is verified by reading the data back through a (validated) BatchGet:
+// multi-peer ZC (two write in-flights before either waits), mixed local+remote
+// ZC (run_local_put inside the in-flight window), staging multi-peer, and a
+// staging-overflow batch that must fail cleanly and abort its slots.
+// ===========================================================================
+
+// Read every key back into a freshly-registered dst and byte-compare to `srcs`.
+void VerifyReadback(PoolClient* caller, const std::vector<std::string>& keys,
+                    const std::vector<std::vector<char>>& srcs, size_t page_bytes) {
+  const size_t kN = keys.size();
+  std::vector<char> dst(page_bytes * kN, 0);
+  ASSERT_TRUE(caller->RegisterMemory(dst.data(), dst.size()));
+  std::vector<void*> dsts(kN);
+  std::vector<size_t> sizes(kN, page_bytes);
+  for (size_t k = 0; k < kN; ++k) dsts[k] = dst.data() + k * page_bytes;
+  auto res = caller->BatchGet(keys, dsts, sizes);
+  ASSERT_EQ(res.size(), kN);
+  for (size_t k = 0; k < kN; ++k) {
+    EXPECT_TRUE(res[k]) << "readback get failed " << keys[k];
+    EXPECT_EQ(std::memcmp(dst.data() + k * page_bytes, srcs[k].data(), page_bytes), 0)
+        << "readback byte mismatch " << keys[k];
+  }
+  caller->DeregisterMemory(dst.data());
+}
+
+TEST_F(CrossNodeOverlap, PutMultiPeerZeroCopyByteExact) {
+  StartMaster();
+  constexpr size_t kN = 8;
+  // Caller has 1 page (never wins most_available); the two peers hold kN/2 pages
+  // each, so the batch splits across both -> two write in-flights.
+  PoolClient* caller = MakeClient("node-a", {kPageSize});
+  MakeClient("node-b", {kPageSize * (kN / 2)});
+  MakeClient("node-c", {kPageSize * (kN / 2)});
+
+  std::vector<char> src_buf(kPageSize * kN, 0);
+  ASSERT_TRUE(caller->RegisterMemory(src_buf.data(), src_buf.size()));
+  std::vector<std::string> keys;
+  std::vector<std::vector<char>> srcs(kN);
+  std::vector<const void*> psrcs(kN);
+  std::vector<size_t> sizes(kN, kPageSize);
+  for (size_t k = 0; k < kN; ++k) {
+    keys.push_back("pmp-" + std::to_string(k));
+    std::memset(src_buf.data() + k * kPageSize, static_cast<int>(0x51 + k), kPageSize);
+    srcs[k].assign(src_buf.data() + k * kPageSize, src_buf.data() + (k + 1) * kPageSize);
+    psrcs[k] = src_buf.data() + k * kPageSize;
+  }
+
+  auto put = caller->BatchPut(keys, psrcs, sizes);
+  ASSERT_EQ(put.size(), kN);
+  for (size_t k = 0; k < kN; ++k) ASSERT_TRUE(put[k]) << "put failed " << keys[k];
+  for (const auto& key : keys) ASSERT_TRUE(WaitForExists(caller, key));
+
+  caller->DeregisterMemory(src_buf.data());
+  VerifyReadback(caller, keys, srcs, kPageSize);
+}
+
+TEST_F(CrossNodeOverlap, PutMixedLocalAndRemoteZeroCopyByteExact) {
+  // kLocal is per-key local-first with spill once local is full. Caller holds
+  // kHalf pages, so a 2*kHalf batch puts the first kHalf local and spills the
+  // rest to the peer -> one batch with both local_items and remote_groups.
+  StartMaster(ConfigurableRoutePutStrategy::NodeAffinity::kLocal);
+  constexpr size_t kHalf = 3;
+  constexpr size_t kN = kHalf * 2;
+  PoolClient* caller = MakeClient("node-a", {kPageSize * kHalf});
+  MakeClient("node-b", {kPageSize * kN});  // roomy spill target
+
+  std::vector<char> src_buf(kPageSize * kN, 0);
+  ASSERT_TRUE(caller->RegisterMemory(src_buf.data(), src_buf.size()));
+  std::vector<std::string> keys;
+  std::vector<std::vector<char>> srcs(kN);
+  std::vector<const void*> psrcs(kN);
+  std::vector<size_t> sizes(kN, kPageSize);
+  for (size_t k = 0; k < kN; ++k) {
+    keys.push_back("pmix-" + std::to_string(k));
+    std::memset(src_buf.data() + k * kPageSize, static_cast<int>(0x61 + k), kPageSize);
+    srcs[k].assign(src_buf.data() + k * kPageSize, src_buf.data() + (k + 1) * kPageSize);
+    psrcs[k] = src_buf.data() + k * kPageSize;
+  }
+
+  auto put = caller->BatchPut(keys, psrcs, sizes);
+  ASSERT_EQ(put.size(), kN);
+  for (size_t k = 0; k < kN; ++k) ASSERT_TRUE(put[k]) << "put failed " << keys[k];
+  for (const auto& key : keys) ASSERT_TRUE(WaitForExists(caller, key));
+
+  caller->DeregisterMemory(src_buf.data());
+  VerifyReadback(caller, keys, srcs, kPageSize);
+}
+
+TEST_F(CrossNodeOverlap, PutStagingMultiPeerByteExact) {
+  // Un-registered src -> staging path: per-peer serial submit (src->staging
+  // memcpy before BatchWrite) -> wait. Two peers cycle the staging lock.
+  StartMaster();
+  constexpr size_t kN = 8;
+  PoolClient* caller = MakeClient("node-a", {kPageSize});
+  MakeClient("node-b", {kPageSize * (kN / 2)});
+  MakeClient("node-c", {kPageSize * (kN / 2)});
+
+  std::vector<std::string> keys;
+  std::vector<std::vector<char>> srcs(kN);
+  std::vector<const void*> psrcs(kN);
+  std::vector<size_t> sizes(kN, kPageSize);
+  for (size_t k = 0; k < kN; ++k) {
+    keys.push_back("pstg-" + std::to_string(k));
+    srcs[k].assign(kPageSize, static_cast<char>(0x31 + k));  // un-registered src
+    psrcs[k] = srcs[k].data();
+  }
+
+  auto put = caller->BatchPut(keys, psrcs, sizes);
+  ASSERT_EQ(put.size(), kN);
+  for (size_t k = 0; k < kN; ++k) ASSERT_TRUE(put[k]) << "staging put failed " << keys[k];
+  for (const auto& key : keys) ASSERT_TRUE(WaitForExists(caller, key));
+
+  VerifyReadback(caller, keys, srcs, kPageSize);
+}
+
+TEST_F(CrossNodeOverlap, PutStagingOverflowFailsBatchCleanly) {
+  // 1-page staging buffer + un-registered srcs -> BuildRemotePutTransfers
+  // overflow: the whole peer batch fails, every allocated slot is aborted (keys
+  // never visible), and the client stays usable for a later zero-copy Put.
+  StartMaster();
+  constexpr size_t kN = 4;
+  PoolClient* caller = MakeClient("node-a", {kPageSize}, /*staging_buffer_size=*/kPageSize);
+  MakeClient("node-b", {kPageSize * 64});
+
+  std::vector<std::string> keys;
+  std::vector<std::vector<char>> srcs(kN);
+  std::vector<const void*> psrcs(kN);
+  std::vector<size_t> sizes(kN, kPageSize);
+  for (size_t k = 0; k < kN; ++k) {
+    keys.push_back("povf-" + std::to_string(k));
+    srcs[k].assign(kPageSize, static_cast<char>(0x41 + k));  // un-registered -> staging
+    psrcs[k] = srcs[k].data();
+  }
+
+  auto put = caller->BatchPut(keys, psrcs, sizes);
+  ASSERT_EQ(put.size(), kN);
+  for (size_t k = 0; k < kN; ++k) EXPECT_FALSE(put[k]) << "overflow key should fail " << keys[k];
+  // Slots were aborted, never committed -> keys must not be visible.
+  auto present = caller->BatchExists(keys);
+  ASSERT_EQ(present.size(), kN);
+  for (size_t k = 0; k < kN; ++k) EXPECT_FALSE(present[k]) << "aborted key visible " << keys[k];
+
+  // Client is still usable: a registered (zero-copy) single Put succeeds.
+  std::vector<char> ok_src(kPageSize, 0x7E);
+  ASSERT_TRUE(caller->RegisterMemory(ok_src.data(), ok_src.size()));
+  EXPECT_TRUE(caller->Put("povf-ok", ok_src.data(), kPageSize));
+  caller->DeregisterMemory(ok_src.data());
 }
 
 }  // namespace

--- a/tests/cpp/umbp/distributed/test_cross_node_smoke.cpp
+++ b/tests/cpp/umbp/distributed/test_cross_node_smoke.cpp
@@ -341,6 +341,85 @@ TEST_F(CrossNodeMultiPage, CrossBufferScatterPutGet) {
   EXPECT_FALSE(client_a_->Put("xbuf-overflow", src.data(), kPayload));
 }
 
+// Zero-copy BatchGet of several keys whose pages land across MULTIPLE remote
+// buffers.  Exercises per-pair merge with multiple groups (one per distinct
+// remote buffer) and multiple entries contributing to a group, plus the
+// per-key result mapping.  The caller registers a contiguous dst region so
+// every get is zero-copy (not staging).
+TEST_F(CrossNodeMultiPage, BatchGetZeroCopyMultiKeyCrossBuffer) {
+  StartMaster();
+  client_a_ = MakeClient("node-a", NodeSetup{{kPageSize}}, &owned_a_);
+  // Two 2-page buffers: the 4 single-page keys distribute across both, so
+  // their pages span two distinct remote buffer_index values.
+  client_b_ = MakeClient("node-b", NodeSetup{{kPageSize * 2, kPageSize * 2}}, &owned_b_);
+
+  constexpr size_t kN = 4;
+  std::vector<std::string> keys;
+  std::vector<std::vector<char>> srcs(kN);
+  for (size_t k = 0; k < kN; ++k) {
+    keys.push_back("zc-mk-" + std::to_string(k));
+    srcs[k].assign(kPageSize, static_cast<char>(0x41 + k));
+  }
+  for (size_t k = 0; k < kN; ++k) {
+    ASSERT_TRUE(client_a_->Put(keys[k], srcs[k].data(), kPageSize));
+  }
+  for (const auto& key : keys) {
+    EXPECT_TRUE(WaitForExists(client_a_.get(), key));
+    EXPECT_TRUE(WaitForExists(client_b_.get(), key));
+  }
+
+  std::vector<char> dst(kPageSize * kN, 0);
+  client_a_->RegisterMemory(dst.data(), dst.size());
+  std::vector<void*> dsts(kN);
+  std::vector<size_t> sizes(kN, kPageSize);
+  for (size_t k = 0; k < kN; ++k) dsts[k] = dst.data() + k * kPageSize;
+
+  auto res = client_a_->BatchGet(keys, dsts, sizes);
+  ASSERT_EQ(res.size(), kN);
+  for (size_t k = 0; k < kN; ++k) {
+    EXPECT_TRUE(res[k]) << "get failed for " << keys[k];
+    EXPECT_EQ(std::memcmp(dst.data() + k * kPageSize, srcs[k].data(), kPageSize), 0)
+        << "byte mismatch for " << keys[k];
+  }
+}
+
+// Failure isolation: a zero-copy batch where one key is requested with a
+// mismatched size (rejected) must fail ONLY that key; sibling keys still
+// succeed and land byte-exact.  Guards the per-key result mapping that the
+// per-pair merge feeds via entry.failed.
+TEST_F(CrossNodeMultiPage, BatchGetZeroCopyFailureIsolation) {
+  StartMaster();
+  client_a_ = MakeClient("node-a", NodeSetup{{kPageSize}}, &owned_a_);
+  client_b_ = MakeClient("node-b", NodeSetup{{kPageSize * 4}}, &owned_b_);
+
+  std::vector<std::string> keys = {"iso-0", "iso-1", "iso-2"};
+  std::vector<std::vector<char>> srcs(3);
+  for (size_t k = 0; k < 3; ++k) {
+    srcs[k].assign(kPageSize, static_cast<char>(0x11 * (k + 1)));
+    ASSERT_TRUE(client_a_->Put(keys[k], srcs[k].data(), kPageSize));
+  }
+  for (const auto& key : keys) {
+    EXPECT_TRUE(WaitForExists(client_a_.get(), key));
+    EXPECT_TRUE(WaitForExists(client_b_.get(), key));
+  }
+
+  std::vector<char> dst(kPageSize * 3, 0);
+  client_a_->RegisterMemory(dst.data(), dst.size());
+  std::vector<void*> dsts = {dst.data(), dst.data() + kPageSize, dst.data() + 2 * kPageSize};
+  // Middle key requests a size that mismatches the stored size -> rejected;
+  // the half-page stays within its own dst slot so a clean rejection can't
+  // corrupt siblings.
+  std::vector<size_t> sizes = {kPageSize, kPageSize / 2, kPageSize};
+
+  auto res = client_a_->BatchGet(keys, dsts, sizes);
+  ASSERT_EQ(res.size(), 3u);
+  EXPECT_TRUE(res[0]);
+  EXPECT_FALSE(res[1]) << "size-mismatched key must fail";
+  EXPECT_TRUE(res[2]);
+  EXPECT_EQ(std::memcmp(dst.data(), srcs[0].data(), kPageSize), 0);
+  EXPECT_EQ(std::memcmp(dst.data() + 2 * kPageSize, srcs[2].data(), kPageSize), 0);
+}
+
 // ---------------------------------------------------------------------------
 // Partial-tail tests.  Master allocates ceil(size / page_size) pages even
 // when size is not page-aligned; the last page is partially filled.  These

--- a/tests/cpp/umbp/distributed/test_cross_node_smoke.cpp
+++ b/tests/cpp/umbp/distributed/test_cross_node_smoke.cpp
@@ -527,5 +527,218 @@ TEST_F(CrossNodeMultiPage, PartialTailGetSizeMismatchRejected) {
   EXPECT_EQ(std::memcmp(src.data(), dst.data(), kPayload), 0);
 }
 
+// ===========================================================================
+// Overlap-path coverage (step-2 submit/wait split + schedule reorder).
+//   * MultiPeerZeroCopyByteExact: one BatchGet fans out to TWO source peers,
+//     so two remote-DRAM in-flights are posted before either is waited; guards
+//     against cross-talk between concurrent in-flights.
+//   * MixedLocalAndRemoteZeroCopyByteExact: one batch mixes LOCAL DRAM with
+//     REMOTE_ZC, exercising the S2 reorder (local memcpy inside the remote DRAM
+//     in-flight window).
+// Run the whole binary with UMBP_BATCHGET_OVERLAP=0 to confirm overlap-on and
+// overlap-off agree byte-for-byte.
+// ===========================================================================
+class CrossNodeOverlap : public ::testing::Test {
+ protected:
+  static constexpr size_t kPageSize = 4096;
+
+  void StartMaster(ConfigurableRoutePutStrategy::NodeAffinity affinity =
+                       ConfigurableRoutePutStrategy::NodeAffinity::kNone) {
+    MasterServerConfig master_cfg;
+    master_cfg.listen_address = "0.0.0.0:0";
+    master_cfg.registry_config.heartbeat_ttl = std::chrono::seconds{1};
+    master_cfg.put_strategy = std::make_unique<ConfigurableRoutePutStrategy>(
+        ConfigurableRoutePutStrategy::SelectAlgo::kMostAvailable, affinity);
+    master_ = std::make_unique<MasterServer>(std::move(master_cfg));
+    server_thread_ = std::thread([this] { master_->Run(); });
+    for (int i = 0; i < 50 && master_->GetBoundPort() == 0; ++i) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_NE(master_->GetBoundPort(), 0) << "Master failed to start";
+  }
+
+  PoolClient* MakeClient(const std::string& node_id, const std::vector<size_t>& buffer_sizes) {
+    PoolClientConfig cfg;
+    cfg.master_config.node_id = node_id;
+    cfg.master_config.node_address = "127.0.0.1";
+    cfg.master_config.master_address = "localhost:" + std::to_string(master_->GetBoundPort());
+    cfg.io_engine.host = "0.0.0.0";
+    cfg.io_engine.port = 0;
+    cfg.peer_service_port = NextPeerServicePort();
+    cfg.dram_page_size = kPageSize;
+    uint64_t total = 0;
+    for (size_t sz : buffer_sizes) {
+      void* p = std::malloc(sz);
+      EXPECT_NE(p, nullptr);
+      std::memset(p, 0, sz);
+      owned_bufs_.push_back(p);
+      cfg.dram_buffers.push_back({p, sz});
+      total += sz;
+    }
+    cfg.tier_capacities = {{TierType::DRAM, {total, total}}};
+    auto cli = std::make_unique<PoolClient>(std::move(cfg));
+    EXPECT_TRUE(cli->Init());
+    clients_.push_back(std::move(cli));
+    return clients_.back().get();
+  }
+
+  void TearDown() override {
+    for (auto it = clients_.rbegin(); it != clients_.rend(); ++it) {
+      if (*it) (*it)->Shutdown();
+    }
+    clients_.clear();
+    if (master_) master_->Shutdown();
+    if (server_thread_.joinable()) server_thread_.join();
+    master_.reset();
+    for (void* p : owned_bufs_) std::free(p);
+    owned_bufs_.clear();
+  }
+
+  std::unique_ptr<MasterServer> master_;
+  std::thread server_thread_;
+  std::vector<std::unique_ptr<PoolClient>> clients_;
+  std::vector<void*> owned_bufs_;
+};
+
+TEST_F(CrossNodeOverlap, MultiPeerZeroCopyByteExact) {
+  StartMaster();
+  constexpr size_t kN = 8;
+  // caller has a single page so it never wins most_available and routes every
+  // Put out; the two peers each hold exactly kN/2 pages, forcing the batch to
+  // split across both (and never onto the caller).
+  PoolClient* caller = MakeClient("node-a", {kPageSize});
+  MakeClient("node-b", {kPageSize * (kN / 2)});
+  MakeClient("node-c", {kPageSize * (kN / 2)});
+
+  std::vector<std::string> keys;
+  std::vector<std::vector<char>> srcs(kN);
+  std::vector<const void*> psrcs(kN);
+  std::vector<size_t> sizes(kN, kPageSize);
+  for (size_t k = 0; k < kN; ++k) {
+    keys.push_back("mp-" + std::to_string(k));
+    srcs[k].assign(kPageSize, static_cast<char>(0x51 + k));
+    psrcs[k] = srcs[k].data();
+  }
+  auto put = caller->BatchPut(keys, psrcs, sizes);
+  ASSERT_EQ(put.size(), kN);
+  for (size_t k = 0; k < kN; ++k) ASSERT_TRUE(put[k]) << "put failed " << keys[k];
+  for (const auto& key : keys) ASSERT_TRUE(WaitForExists(caller, key));
+
+  std::vector<char> dst(kPageSize * kN, 0);
+  caller->RegisterMemory(dst.data(), dst.size());
+  std::vector<void*> dsts(kN);
+  for (size_t k = 0; k < kN; ++k) dsts[k] = dst.data() + k * kPageSize;
+
+  auto res = caller->BatchGet(keys, dsts, sizes);
+  ASSERT_EQ(res.size(), kN);
+  for (size_t k = 0; k < kN; ++k) {
+    EXPECT_TRUE(res[k]) << "get failed " << keys[k];
+    EXPECT_EQ(std::memcmp(dst.data() + k * kPageSize, srcs[k].data(), kPageSize), 0)
+        << "byte mismatch " << keys[k];
+  }
+}
+
+TEST_F(CrossNodeOverlap, StagingMultiPeerByteExact) {
+  // Caller does NOT register its dst, so remote DRAM reads take the staging
+  // (non-zero-copy) path: per-peer serial submit -> wait -> memcpy out of the
+  // shared staging buffer.  Two source peers exercise the per-peer staging lock
+  // cycling; byte-check guards the staging memcpy + per-key mapping.
+  StartMaster();
+  constexpr size_t kN = 8;
+  PoolClient* caller = MakeClient("node-a", {kPageSize});
+  MakeClient("node-b", {kPageSize * (kN / 2)});
+  MakeClient("node-c", {kPageSize * (kN / 2)});
+
+  std::vector<std::string> keys;
+  std::vector<std::vector<char>> srcs(kN);
+  std::vector<const void*> psrcs(kN);
+  std::vector<size_t> sizes(kN, kPageSize);
+  for (size_t k = 0; k < kN; ++k) {
+    keys.push_back("stg-" + std::to_string(k));
+    srcs[k].assign(kPageSize, static_cast<char>(0x31 + k));
+    psrcs[k] = srcs[k].data();
+  }
+  auto put = caller->BatchPut(keys, psrcs, sizes);
+  ASSERT_EQ(put.size(), kN);
+  for (size_t k = 0; k < kN; ++k) ASSERT_TRUE(put[k]) << "put failed " << keys[k];
+  for (const auto& key : keys) ASSERT_TRUE(WaitForExists(caller, key));
+
+  // Deliberately NOT registered -> staging path.
+  std::vector<char> dst(kPageSize * kN, 0);
+  std::vector<void*> dsts(kN);
+  for (size_t k = 0; k < kN; ++k) dsts[k] = dst.data() + k * kPageSize;
+
+  auto res = caller->BatchGet(keys, dsts, sizes);
+  ASSERT_EQ(res.size(), kN);
+  for (size_t k = 0; k < kN; ++k) {
+    EXPECT_TRUE(res[k]) << "get failed " << keys[k];
+    EXPECT_EQ(std::memcmp(dst.data() + k * kPageSize, srcs[k].data(), kPageSize), 0)
+        << "byte mismatch " << keys[k];
+  }
+}
+
+TEST_F(CrossNodeOverlap, MixedLocalAndRemoteZeroCopyByteExact) {
+  // kLocal affinity keeps each node's own Put local, so the caller can seed half
+  // the keys into its OWN DRAM (LOCAL get) and the peer the other half
+  // (REMOTE_ZC).  The single mixed BatchGet then crosses both tiers.
+  StartMaster(ConfigurableRoutePutStrategy::NodeAffinity::kLocal);
+  constexpr size_t kHalf = 3;
+  PoolClient* caller = MakeClient("node-a", {kPageSize * kHalf});
+  PoolClient* peer = MakeClient("node-b", {kPageSize * kHalf});
+
+  std::vector<std::string> local_keys, remote_keys;
+  std::vector<std::vector<char>> local_src(kHalf), remote_src(kHalf);
+  {
+    std::vector<const void*> s(kHalf);
+    std::vector<size_t> sz(kHalf, kPageSize);
+    for (size_t k = 0; k < kHalf; ++k) {
+      local_keys.push_back("loc-" + std::to_string(k));
+      local_src[k].assign(kPageSize, static_cast<char>(0x61 + k));
+      s[k] = local_src[k].data();
+    }
+    auto r = caller->BatchPut(local_keys, s, sz);
+    for (size_t k = 0; k < kHalf; ++k) ASSERT_TRUE(r[k]) << "local put " << local_keys[k];
+  }
+  {
+    std::vector<const void*> s(kHalf);
+    std::vector<size_t> sz(kHalf, kPageSize);
+    for (size_t k = 0; k < kHalf; ++k) {
+      remote_keys.push_back("rem-" + std::to_string(k));
+      remote_src[k].assign(kPageSize, static_cast<char>(0x71 + k));
+      s[k] = remote_src[k].data();
+    }
+    auto r = peer->BatchPut(remote_keys, s, sz);
+    for (size_t k = 0; k < kHalf; ++k) ASSERT_TRUE(r[k]) << "remote put " << remote_keys[k];
+  }
+  for (const auto& key : local_keys) ASSERT_TRUE(WaitForExists(caller, key));
+  for (const auto& key : remote_keys) ASSERT_TRUE(WaitForExists(caller, key));
+
+  // Remote-first ordering so the overlap probe (first remote-DRAM item) is ZC.
+  std::vector<std::string> keys;
+  std::vector<std::vector<char>*> expect;
+  for (size_t k = 0; k < kHalf; ++k) {
+    keys.push_back(remote_keys[k]);
+    expect.push_back(&remote_src[k]);
+  }
+  for (size_t k = 0; k < kHalf; ++k) {
+    keys.push_back(local_keys[k]);
+    expect.push_back(&local_src[k]);
+  }
+  const size_t kN = keys.size();
+  std::vector<char> dst(kPageSize * kN, 0);
+  caller->RegisterMemory(dst.data(), dst.size());
+  std::vector<void*> dsts(kN);
+  std::vector<size_t> sizes(kN, kPageSize);
+  for (size_t k = 0; k < kN; ++k) dsts[k] = dst.data() + k * kPageSize;
+
+  auto res = caller->BatchGet(keys, dsts, sizes);
+  ASSERT_EQ(res.size(), kN);
+  for (size_t k = 0; k < kN; ++k) {
+    EXPECT_TRUE(res[k]) << "get failed " << keys[k];
+    EXPECT_EQ(std::memcmp(dst.data() + k * kPageSize, expect[k]->data(), kPageSize), 0)
+        << "byte mismatch " << keys[k];
+  }
+}
+
 }  // namespace
 }  // namespace mori::umbp


### PR DESCRIPTION
## Summary
- merge per-pair RDMA transfers in PoolClient batch get/put (one IO transfer + one TransferStatus per (localMR, remoteMR) pair); zero-copy get/put 2-5x.
- overlap BatchGet zero-copy remote DRAM reads: split remote-DRAM get into submit/wait so multi-peer RDMA overlaps, and local DRAM/SSD + remote SSD can run inside the in-flight window (gated by UMBP_BATCHGET_OVERLAP / UMBP_BATCHGET_OVERLAP_MAX_BATCH); unified zero-copy + staging on one Submit/Wait path; BatchGet split into PartitionBatchGetTargets + ExecuteBatchGetPlan.

## Test plan
- [x] test_umbp_cross_node_smoke (incl. new multi-peer / mixed-tier / staging byte-exact cases), overlap on and off
- [x] test_umbp_peer_service, test_umbp_pool_client_batch_put
- [x] ThreadSanitizer: no new races (pre-existing backend/init only)
- [x] bench_pool_client_batch_get (all_zc / multi_peer / mixed_tier sweeps)
