### PR TITLE
fix(shmem): public RDMA quiet returned before the caller's WQEs completed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,7 @@ jobs:
       - name: MORI-CPP shmem (P2P)
         run: |
           $CT exec $CONTAINER bash -c "
+            set -e
             cd $GITHUB_WORKSPACE
             timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/concurrent_put_thread
             timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/concurrent_get_thread
@@ -243,6 +244,7 @@ jobs:
       - name: MORI-CPP shmem (IBGDA)
         run: |
           $CT exec $CONTAINER bash -c "
+            set -e
             cd $GITHUB_WORKSPACE
             MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/concurrent_put_thread
             MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/concurrent_get_thread

--- a/examples/shmem/concurrent_get_thread.cpp
+++ b/examples/shmem/concurrent_get_thread.cpp
@@ -43,6 +43,9 @@ using namespace mori::application;
 // Test 3: Large multi-chunk GET (>200MB spanning multiple 64MB chunks)
 // ============================================================================
 
+// Counts failed verifications (on PE 0) so main() can return non-zero and fail CI.
+static int gFailures = 0;
+
 // ============================================================================
 // GPU Kernels
 // ============================================================================
@@ -220,6 +223,7 @@ void Test1_LegacyAPI(int myPe) {
       printf("✓ Legacy API GET test PASSED! All %d elements verified.\n", numEle);
     } else {
       printf("✗ Legacy API GET test FAILED!\n");
+      gFailures++;
     }
   }
 
@@ -278,6 +282,7 @@ void Test1_LegacyAPI_Block(int myPe) {
       printf("✓ Legacy API GET block test PASSED! All %d elements verified.\n", numEle);
     } else {
       printf("✗ Legacy API GET block test FAILED!\n");
+      gFailures++;
     }
   }
 
@@ -345,6 +350,7 @@ void Test2_PureAddressAPI(int myPe) {
       printf("✓ Pure address API GET test PASSED! All %d elements verified.\n", numEle);
     } else {
       printf("✗ Pure address API GET test FAILED!\n");
+      gFailures++;
     }
   }
 
@@ -410,6 +416,7 @@ void Test2_PureAddressAPI_Block(int myPe) {
       printf("✓ Pure address API GET block test PASSED! All %d elements verified.\n", numEle);
     } else {
       printf("✗ Pure address API GET block test FAILED!\n");
+      gFailures++;
     }
   }
 
@@ -484,6 +491,7 @@ void Test3_LargeMultiChunk(int myPe) {
       printf("✓ Large multi-chunk GET test PASSED! Verified %zu elements.\n", testElements);
     } else {
       printf("✗ Large multi-chunk GET test FAILED!\n");
+      gFailures++;
     }
   }
 
@@ -542,6 +550,7 @@ void Test4_BlockingLegacyAPI(int myPe) {
       printf("✓ Blocking GET legacy API test PASSED! All %d elements verified.\n", numEle);
     } else {
       printf("✗ Blocking GET legacy API test FAILED!\n");
+      gFailures++;
     }
   }
 
@@ -607,6 +616,7 @@ void Test5_BlockingPureAddressAPI(int myPe) {
       printf("✓ Blocking GET pure address API test PASSED! All %d elements verified.\n", numEle);
     } else {
       printf("✗ Blocking GET pure address API test FAILED!\n");
+      gFailures++;
     }
   }
 
@@ -676,5 +686,6 @@ void ConcurrentGetThread() {
 
 int main(int argc, char* argv[]) {
   ConcurrentGetThread();
-  return 0;
+  // Non-zero exit on any failed verification so mpirun/CI catches regressions.
+  return gFailures > 0 ? 1 : 0;
 }

--- a/examples/shmem/concurrent_put_imm_thread.cpp
+++ b/examples/shmem/concurrent_put_imm_thread.cpp
@@ -32,6 +32,9 @@ using namespace mori::core;
 using namespace mori::shmem;
 using namespace mori::application;
 
+// Counts failed verifications (on PE 1) so main() can return non-zero and fail CI.
+static int gFailures = 0;
+
 // Legacy API: Using SymmMemObjPtr + offset
 __global__ void ConcurrentPutImmThreadKernel(int myPe, const SymmMemObjPtr memObj) {
   constexpr int sendPe = 0;
@@ -144,6 +147,7 @@ void ConcurrentPutImmThread() {
   std::vector<uint32_t> hostBuff1(numEle);
   HIP_RUNTIME_CHECK(hipMemcpy(hostBuff1.data(), buff1, buffSize, hipMemcpyDeviceToHost));
 
+  // Data lands on PE 1 (the put-imm receiver), so PE 1 verifies and gates.
   if (myPe == 1) {
     bool success = true;
     for (int i = 0; i < numEle; i++) {
@@ -153,13 +157,12 @@ void ConcurrentPutImmThread() {
         break;
       }
     }
-    if (success && myPe == 0) {
+    if (success) {
       printf("✓ Legacy API test PASSED! All %d elements verified.\n", numEle);
-    } else if (!success && myPe == 0) {
+    } else {
       printf("✗ Legacy API test FAILED!\n");
+      gFailures++;
     }
-  } else if (myPe == 0) {
-    printf("✓ Legacy API test PASSED! All %d elements verified.\n", numEle);
   }
 
   // ===== Test 2: Pure Address API =====
@@ -197,14 +200,17 @@ void ConcurrentPutImmThread() {
       bool success = true;
       for (int i = 0; i < numEle; i++) {
         if (hostBuff2[i] != 42) {
+          printf("Error at index %d: expected 42, got %u\n", i, hostBuff2[i]);
           success = false;
           break;
         }
       }
-    }
-
-    if (myPe == 0) {
-      printf("✓ Pure address API test PASSED!\n");
+      if (success) {
+        printf("✓ Pure address API test PASSED!\n");
+      } else {
+        printf("✗ Pure address API test FAILED!\n");
+        gFailures++;
+      }
     }
 
     ShmemFree(buff2);
@@ -224,5 +230,6 @@ void ConcurrentPutImmThread() {
 
 int main(int argc, char* argv[]) {
   ConcurrentPutImmThread();
-  return 0;
+  // Non-zero exit on any failed verification so mpirun/CI catches regressions.
+  return gFailures > 0 ? 1 : 0;
 }

--- a/examples/shmem/concurrent_put_signal_thread.cpp
+++ b/examples/shmem/concurrent_put_signal_thread.cpp
@@ -32,6 +32,9 @@ using namespace mori::core;
 using namespace mori::shmem;
 using namespace mori::application;
 
+// Counts failed verifications (on PE 1) so main() can return non-zero and fail CI.
+static int gFailures = 0;
+
 // Legacy API: Using SymmMemObjPtr + offset
 __global__ void ConcurrentPutSignalThreadKernelAdd(int myPe, const SymmMemObjPtr dataObj,
                                                    const SymmMemObjPtr signalObj) {
@@ -628,6 +631,7 @@ void ConcurrentPutSignalThread() {
         (threadNum * blockNum + warpSize - 1) / warpSize;  // One signal per warp
     printf("✓ Legacy API AMO_ADD test PASSED! Signal counter: %lu (expected: %lu), Data: %s\n",
            signalValue, expectedSignals, success ? "OK" : "FAILED");
+    if (!success || signalValue != expectedSignals) gFailures++;
   }
 
   // Cleanup Test 1
@@ -682,6 +686,7 @@ void ConcurrentPutSignalThread() {
       printf(
           "✓ Pure Address API AMO_ADD test PASSED! Signal counter: %lu (expected: %lu), Data: %s\n",
           signalValue, expectedSignals, success ? "OK" : "FAILED");
+      if (!success || signalValue != expectedSignals) gFailures++;
     }
 
     // Cleanup Test 2
@@ -736,6 +741,7 @@ void ConcurrentPutSignalThread() {
     uint64_t expectedSignals = blockNum;  // One signal per block
     printf("✓ Legacy Block AMO_ADD test PASSED! Signal counter: %lu (expected: %lu), Data: %s\n",
            signalValue, expectedSignals, success ? "OK" : "FAILED");
+    if (!success || signalValue != expectedSignals) gFailures++;
   }
 
   ShmemFree(dataBuff2b);
@@ -790,6 +796,7 @@ void ConcurrentPutSignalThread() {
           "✓ Pure Address Block AMO_ADD test PASSED! Signal counter: %lu (expected: %lu), Data: "
           "%s\n",
           signalValue, expectedSignals, success ? "OK" : "FAILED");
+      if (!success || signalValue != expectedSignals) gFailures++;
     }
 
     ShmemFree(dataBuff2c);
@@ -855,6 +862,7 @@ void ConcurrentPutSignalThread() {
     }
     printf("✓ Legacy API AMO_SET test PASSED! Data: %s, Valid signals: %d/%d\n",
            dataSuccess ? "OK" : "FAILED", validSignals, totalWarps);
+    if (!dataSuccess || validSignals != totalWarps) gFailures++;
   }
 
   // Cleanup Test 3
@@ -916,6 +924,7 @@ void ConcurrentPutSignalThread() {
     }
     printf("✓ Legacy Block AMO_SET test PASSED! Data: %s, Valid signals: %d/%d\n",
            dataSuccess ? "OK" : "FAILED", validSignals, blockNum);
+    if (!dataSuccess || validSignals != blockNum) gFailures++;
   }
 
   ShmemFree(dataBuff3b);
@@ -979,6 +988,7 @@ void ConcurrentPutSignalThread() {
       }
       printf("✓ Pure Address API AMO_SET test PASSED! Data: %s, Valid signals: %d/%d\n",
              dataSuccess ? "OK" : "FAILED", validSignals, totalWarps);
+      if (!dataSuccess || validSignals != totalWarps) gFailures++;
     }
 
     // Finalize
@@ -1041,6 +1051,7 @@ void ConcurrentPutSignalThread() {
       }
       printf("✓ Pure Address Block AMO_SET test PASSED! Data: %s, Valid signals: %d/%d\n",
              dataSuccess ? "OK" : "FAILED", validSignals, blockNum);
+      if (!dataSuccess || validSignals != blockNum) gFailures++;
     }
 
     ShmemFree(dataBuff4b);
@@ -1118,6 +1129,7 @@ void ConcurrentPutSignalThread() {
            expectedSignals);
     printf("  Data verification: First 1KB: %s, Last 1KB: %s\n", firstOk ? "OK" : "FAILED",
            lastOk ? "OK" : "FAILED");
+    if (!firstOk || !lastOk || signalValue != expectedSignals) gFailures++;
   }
 
   // Cleanup Test 5
@@ -1225,6 +1237,7 @@ void ConcurrentPutSignalThread() {
           totalSizeLarge / (1024.0 * 1024.0 * 1024.0), signalValue, expectedSignals);
       printf("  Data verification: First 1KB: %s, Middle 1KB: %s, Last 1KB: %s\n",
              firstOk ? "OK" : "FAILED", midOk ? "OK" : "FAILED", lastOk ? "OK" : "FAILED");
+      if (!firstOk || !midOk || !lastOk || signalValue != expectedSignals) gFailures++;
     }
 
     // Cleanup Test 6
@@ -1327,6 +1340,7 @@ void ConcurrentPutSignalThread() {
           totalSizeLarge / (1024.0 * 1024.0 * 1024.0), signalValue, expectedSignals);
       printf("  Data verification: First 1KB: %s, Middle 1KB: %s, Last 1KB: %s\n",
              firstOk ? "OK" : "FAILED", midOk ? "OK" : "FAILED", lastOk ? "OK" : "FAILED");
+      if (!firstOk || !midOk || !lastOk || signalValue != expectedSignals) gFailures++;
     }
 
     // Cleanup Test 7
@@ -1345,5 +1359,6 @@ void ConcurrentPutSignalThread() {
 
 int main(int argc, char* argv[]) {
   ConcurrentPutSignalThread();
-  return 0;
+  // Non-zero exit on any failed verification so mpirun/CI catches regressions.
+  return gFailures > 0 ? 1 : 0;
 }

--- a/examples/shmem/concurrent_put_thread.cpp
+++ b/examples/shmem/concurrent_put_thread.cpp
@@ -32,6 +32,11 @@ using namespace mori::core;
 using namespace mori::shmem;
 using namespace mori::application;
 
+// Counts failed verifications so main() can return non-zero and fail CI. Only the
+// RDMA put-correctness tests feed this; the P2P-only direct-access test is left
+// out since it is expected to differ under MORI_DISABLE_P2P (IBGDA).
+static int gFailures = 0;
+
 // ============================================================================
 // Test Suite Overview
 // ============================================================================
@@ -340,6 +345,7 @@ void Test1_LegacyAPI(int myPe) {
     }
     if (!success) {
       printf("✗ Legacy API test FAILED!\n");
+      gFailures++;
     }
   }
 
@@ -390,6 +396,7 @@ void Test1_LegacyAPI_Block(int myPe) {
     }
     if (!success) {
       printf("✗ Legacy block API test FAILED!\n");
+      gFailures++;
     }
   }
 
@@ -450,6 +457,7 @@ void Test2_PureAddressAPI(int myPe) {
     }
     if (!success) {
       printf("✗ Pure address API test FAILED!\n");
+      gFailures++;
     }
   }
 
@@ -510,6 +518,7 @@ void Test2_PureAddressAPI_Block(int myPe) {
     }
     if (!success) {
       printf("✗ Pure address block API test FAILED!\n");
+      gFailures++;
     }
   }
 
@@ -579,6 +588,7 @@ void Test3_LargeMultiChunk(int myPe) {
     }
     if (!success) {
       printf("✗ Large multi-chunk allocation test FAILED!\n");
+      gFailures++;
     }
   }
 
@@ -636,6 +646,7 @@ void Test4_MixedMallocFree(int myPe) {
   if (testValB != 0xBBBB0000 + myPe) {
     printf("PE %d: ✗ Buffer B corrupted after freeing A! Got 0x%x, expected 0x%x\n", myPe, testValB,
            0xBBBB0000 + myPe);
+    gFailures++;
   } else {
     if (myPe == 0) {
       printf("✓ Buffer B still valid after freeing A (reference counting works!)\n");
@@ -828,5 +839,6 @@ void ConcurrentPutThread() {
 
 int main(int argc, char* argv[]) {
   ConcurrentPutThread();
-  return 0;
+  // Non-zero exit on any failed verification so mpirun/CI catches regressions.
+  return gFailures > 0 ? 1 : 0;
 }

--- a/include/mori/shmem/shmem_ibgda_kernels.hpp
+++ b/include/mori/shmem/shmem_ibgda_kernels.hpp
@@ -413,7 +413,14 @@ inline __device__ void ShmemQuietThreadKernel<application::TransportType::RDMA>(
   for (int peId = 0; peId < worldSize; peId++) {
     if (peId != rank && globalGpuStates->transportTypes[peId] == application::TransportType::RDMA) {
       for (int qpId = 0; qpId < globalGpuStates->numQpPerPe; qpId++) {
-        DISPATCH_PROVIDER_TYPE_COMPILE_TIME(ShmemQuietThreadKernelImpl, peId, qpId);
+        // Real completion wait (DrainToLive=true), like the per-PE / per-QP overloads.
+        if constexpr (DISPATCH_BNXT == 1) {
+          ShmemQuietThreadKernelImpl<core::ProviderType::BNXT, true>(peId, qpId);
+        } else if constexpr (DISPATCH_PSD == 1) {
+          ShmemQuietThreadKernelImpl<core::ProviderType::PSD, true>(peId, qpId);
+        } else {
+          ShmemQuietThreadKernelImpl<core::ProviderType::MLX5, true>(peId, qpId);
+        }
       }
     }
   }
@@ -447,7 +454,16 @@ inline __device__ void ShmemQuietThreadKernel<application::TransportType::RDMA>(
   int rank = globalGpuStates->rank;
   if (pe == rank) return;
   if (globalGpuStates->transportTypes[pe] != application::TransportType::RDMA) return;
-  DISPATCH_PROVIDER_TYPE_COMPILE_TIME(ShmemQuietThreadKernelImpl, pe, qpId);
+  // Real completion wait (DrainToLive=true): the caller's own WQEs must be done on
+  // return (e.g. a GET reads its local dest right after). Snapshot drain is only
+  // for the recycle gate, which calls ShmemQuietThreadKernelImpl directly.
+  if constexpr (DISPATCH_BNXT == 1) {
+    ShmemQuietThreadKernelImpl<core::ProviderType::BNXT, true>(pe, qpId);
+  } else if constexpr (DISPATCH_PSD == 1) {
+    ShmemQuietThreadKernelImpl<core::ProviderType::PSD, true>(pe, qpId);
+  } else {
+    ShmemQuietThreadKernelImpl<core::ProviderType::MLX5, true>(pe, qpId);
+  }
 }
 
 /* ---------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
## What

The public `ShmemQuietThread()` and `ShmemQuietThread(pe, qpId)` overloads used the snapshot drain (`DrainToLive=false`), so under multi-warp contention on a shared QP a warp could return from quiet before its own posted WQEs completed. A GET reads its local destination right after quiet, so this yields stale data (`0xDEAD`); `concurrent_get_thread` thread-scope GET failed intermittently on bnxt.

## Fix

Make both public quiet overloads real completion waits (`DrainToLive=true`), matching the per-PE overload. The recycle gate is unaffected — it calls `ShmemQuietThreadKernelImpl` directly and must stay snapshot.

## Test hardening

The failure was invisible to CI because the shmem examples always returned `0` and the CI steps had no `set -e`. Made the CPP shmem examples return non-zero on verification failure and added `set -e` to the shmem CI steps.

## Verification

On bnxt (P2P and IBGDA): all shmem examples pass; built against the old code, `concurrent_get_thread` now exits non-zero.
