### PR TITLE
fix(cco-bench): align p2p bw scope & sync with shmem for fair comparison

### DIFF
--- a/benchmark/cco/device_utils.hpp
+++ b/benchmark/cco/device_utils.hpp
@@ -44,15 +44,10 @@ __device__ inline void lsa_copy_strided(T* __restrict__ dst, const T* __restrict
   }
 }
 
-// GPU-internal cross-block barrier (single GPU, NOT cross-rank). All nblocks of
-// this kernel launch rendezvous at the end of round i. This matches shmem's
-// bw_cross_block_barrier_round exactly so the LSA bw measurement window includes
-// the same per-round all-block sync — an apples-to-apples comparison against the
-// shmem benchmark. (CCO's ccoLsaBarrierSession is a *cross-GPU* barrier and is
-// not equivalent here: the LSA bw is unidirectional, only PE 0 runs the kernel.)
-//
-// counter_d[0] = arrival counter, counter_d[1] = phase counter. Call from ALL
-// threads of ALL blocks with the same (counter_d, nblocks, i).
+// GPU-internal all-block barrier (single GPU, not cross-rank), matching shmem's
+// bw_cross_block_barrier_round so the LSA bw timed window includes the same
+// per-round sync. counter_d[0]=arrivals, counter_d[1]=phase; call from all
+// threads of all blocks with the same (counter_d, nblocks, i).
 __device__ inline void bw_cross_block_barrier_round(volatile unsigned int* counter_d, int nblocks,
                                                     int i) {
   __syncthreads();

--- a/benchmark/cco/device_utils.hpp
+++ b/benchmark/cco/device_utils.hpp
@@ -44,6 +44,30 @@ __device__ inline void lsa_copy_strided(T* __restrict__ dst, const T* __restrict
   }
 }
 
+// GPU-internal cross-block barrier (single GPU, NOT cross-rank). All nblocks of
+// this kernel launch rendezvous at the end of round i. This matches shmem's
+// bw_cross_block_barrier_round exactly so the LSA bw measurement window includes
+// the same per-round all-block sync — an apples-to-apples comparison against the
+// shmem benchmark. (CCO's ccoLsaBarrierSession is a *cross-GPU* barrier and is
+// not equivalent here: the LSA bw is unidirectional, only PE 0 runs the kernel.)
+//
+// counter_d[0] = arrival counter, counter_d[1] = phase counter. Call from ALL
+// threads of ALL blocks with the same (counter_d, nblocks, i).
+__device__ inline void bw_cross_block_barrier_round(volatile unsigned int* counter_d, int nblocks,
+                                                    int i) {
+  __syncthreads();
+  if (linear_tid() == 0) {
+    __threadfence();
+    unsigned int c = atomicInc((unsigned int*)counter_d, 0xffffffffu);
+    if (c == static_cast<unsigned int>(nblocks * (i + 1) - 1)) {
+      counter_d[1] += 1u;
+    }
+    while (counter_d[1] != static_cast<unsigned int>(i + 1)) {
+    }
+  }
+  __syncthreads();
+}
+
 }  // namespace mori::cco::benchmark
 
 // CCO_GDA_DISPATCH is provided by mori/cco/cco_scale_out.hpp: GDA provider is

--- a/benchmark/cco/p2p_get_bw.cpp
+++ b/benchmark/cco/p2p_get_bw.cpp
@@ -38,11 +38,8 @@
 
 namespace mori::cco::benchmark {
 
-// LSA: each block reads its chunk from the peer's send window into the local
-// recv window. Scope semantics aligned with shmem (see p2p_put_bw): all block
-// threads participate; scope_size only sets the copy cooperation granularity
-// (block=whole block, warp=one wavefront, thread=one thread per contiguous
-// segment).
+// LSA: flat-VA load loop (peer send → local recv). scope_size = copy
+// granularity; all block threads participate (see p2p_put_bw).
 __global__ void lsa_get_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
                            volatile unsigned int* counter_d, size_t len_doubles, int peerLsa,
                            int iter, int scope_size) {
@@ -65,17 +62,13 @@ __global__ void lsa_get_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
 
   for (int i = 0; i < iter; i++) {
     lsa_copy_strided(dst, src, per_unit, lane, scope_size);
-    // System fence + per-round all-block barrier (mirrors shmem) — see
-    // p2p_put_bw for the cache-absorption + fair-comparison rationale.
-    __threadfence_system();
+    __threadfence_system();  // see p2p_put_bw (cache absorption)
     bw_cross_block_barrier_round(counter_d, nblocks, i);
   }
 }
 
-// IBGDA: one QP context per block (ginContext=blockIdx) — each block owns its QP
-// and is independent: pipelines its chunk's reads, then flushes its own QP. No
-// cross-block barrier. block scope = one bulk RDMA read per block; warp/thread
-// scope subdivide. See p2p_put_bw for the flush-vs-quiet note.
+// IBGDA: one QP per block; pipeline reads + flush own QP. block scope = one bulk
+// read; warp/thread subdivide (see p2p_put_bw).
 template <core::ProviderType PrvdType, typename Coop>
 __global__ void ibgda_get_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin, size_t len_doubles,
                              ccoDevComm devComm, int iter) {
@@ -94,15 +87,13 @@ __global__ void ibgda_get_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
   const size_t off_bytes = base * sizeof(double);
   const size_t bytes = per_unit * sizeof(double);
 
-  // AggregateRequests: see p2p_put_bw — defer the doorbell to the end flush so
-  // warp/thread-scope threads sharing the per-block QP don't deadlock in
-  // ringDoorbellOrdered. The end flush rings once and polls the CQ.
+  // AggregateRequests: defer doorbell to end flush (see p2p_put_bw).
   for (int i = 0; i < iter; i++) {
     gda.get(peer, reinterpret_cast<ccoWindow_t>(sendWin), off_bytes,
             reinterpret_cast<ccoWindow_t>(recvWin), off_bytes, bytes, coop,
             ccoGdaOptFlagsAggregateRequests);
   }
-  gda.flush(ccoCoopBlock{});  // rings the aggregated doorbell once + drains this block's QP
+  gda.flush(ccoCoopBlock{});
 }
 
 static void launch_lsa(PutScope scope, dim3 grid, dim3 block, ccoWindow_t sendWin,

--- a/benchmark/cco/p2p_get_bw.cpp
+++ b/benchmark/cco/p2p_get_bw.cpp
@@ -39,26 +39,36 @@
 namespace mori::cco::benchmark {
 
 // LSA: each block reads its chunk from the peer's send window into the local
-// recv window.
-__global__ void lsa_get_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin, size_t len_doubles,
-                           int peerLsa, int iter, int lanes) {
+// recv window. Scope semantics aligned with shmem (see p2p_put_bw): all block
+// threads participate; scope_size only sets the copy cooperation granularity
+// (block=whole block, warp=one wavefront, thread=one thread per contiguous
+// segment).
+__global__ void lsa_get_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
+                           volatile unsigned int* counter_d, size_t len_doubles, int peerLsa,
+                           int iter, int scope_size) {
   const int bid = blockIdx.x;
   const int nblocks = gridDim.x;
   const int tid = linear_tid();
-  if (tid >= lanes) return;
+  const int nthreads = blockDim.x * blockDim.y * blockDim.z;
 
   const size_t chunk = len_doubles / static_cast<size_t>(nblocks);
-  const size_t off_bytes = static_cast<size_t>(bid) * chunk * sizeof(double);
+  const int nunits = nthreads / scope_size;
+  const int unit = tid / scope_size;
+  const int lane = tid % scope_size;
+  const size_t per_unit = chunk / static_cast<size_t>(nunits);
 
+  const size_t off_bytes =
+      (static_cast<size_t>(bid) * chunk + static_cast<size_t>(unit) * per_unit) * sizeof(double);
   const double* src =
       reinterpret_cast<const double*>(ccoGetLsaPeerPtr(sendWin, peerLsa, off_bytes));
   double* dst = reinterpret_cast<double*>(ccoGetLocalPtr(recvWin, off_bytes));
 
   for (int i = 0; i < iter; i++) {
-    lsa_copy_strided(dst, src, chunk, tid, lanes);
-    // Per-iteration system fence — see p2p_put_bw for the cache-absorption
-    // rationale (repeated same-region traffic otherwise measures cache BW).
+    lsa_copy_strided(dst, src, per_unit, lane, scope_size);
+    // System fence + per-round all-block barrier (mirrors shmem) — see
+    // p2p_put_bw for the cache-absorption + fair-comparison rationale.
     __threadfence_system();
+    bw_cross_block_barrier_round(counter_d, nblocks, i);
   }
 }
 
@@ -96,13 +106,13 @@ __global__ void ibgda_get_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
 }
 
 static void launch_lsa(PutScope scope, dim3 grid, dim3 block, ccoWindow_t sendWin,
-                       ccoWindow_t recvWin, size_t len_doubles, int peerLsa, int count,
-                       int warp_size) {
-  int lanes = block.x;
-  if (scope == PutScope::kWarp) lanes = warp_size;
-  if (scope == PutScope::kThread) lanes = 1;
-  hipLaunchKernelGGL(lsa_get_bw, grid, block, 0, 0, sendWin, recvWin, len_doubles, peerLsa, count,
-                     lanes);
+                       ccoWindow_t recvWin, unsigned int* counter_d, size_t len_doubles,
+                       int peerLsa, int count, int warp_size) {
+  int scope_size = block.x;
+  if (scope == PutScope::kWarp) scope_size = warp_size;
+  if (scope == PutScope::kThread) scope_size = 1;
+  hipLaunchKernelGGL(lsa_get_bw, grid, block, 0, 0, sendWin, recvWin, counter_d, len_doubles,
+                     peerLsa, count, scope_size);
 }
 
 template <core::ProviderType PrvdType>
@@ -168,8 +178,8 @@ int main(int argc, char** argv) {
     if (run_kernels) {
       const float ms = RunWarmupAndTimed(res, args.warmup, args.iters, [&](int count) {
         if (args.transport == Transport::kLsa) {
-          launch_lsa(args.put_scope, grid, block, ctx.send_win, ctx.recv_win, len_doubles,
-                     ctx.peer_lsa_rank, count, ctx.device_warp_size);
+          launch_lsa(args.put_scope, grid, block, ctx.send_win, ctx.recv_win, res.counter_d,
+                     len_doubles, ctx.peer_lsa_rank, count, ctx.device_warp_size);
         } else {
           CCO_GDA_DISPATCH(launch_ibgda<P>(args.put_scope, grid, block, ctx.send_win, ctx.recv_win,
                                            len_doubles, ctx.devComm, count));

--- a/benchmark/cco/p2p_put_bw.cpp
+++ b/benchmark/cco/p2p_put_bw.cpp
@@ -40,16 +40,8 @@
 
 namespace mori::cco::benchmark {
 
-// ── LSA: flat-VA store loop, scope semantics aligned with shmem's bw_block /
-// bw_warp / bw_thread. ALL block threads always participate; `scope_size` only
-// changes the cooperation granularity of the copy:
-//   block  scope_size=blockDim → 1 unit, whole block strides the whole chunk
-//   warp   scope_size=warpSize → nwarps units, each warp strides its sub-segment
-//   thread scope_size=1        → blockDim units, each thread copies its own
-//                                contiguous 1/blockDim segment
-// This mirrors ShmemPutMemNbi{Block,Warp,Thread}: same thread count, finer
-// per-unit segments — thread scope is slower because each thread does a small
-// contiguous copy (no wide striding), not because fewer threads participate. ──
+// LSA: flat-VA store loop. scope_size = copy cooperation granularity (block /
+// warp / single thread); all block threads always participate (matches shmem).
 __global__ void lsa_put_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
                            volatile unsigned int* counter_d, size_t len_doubles, int peerLsa,
                            int iter, int scope_size) {
@@ -59,7 +51,6 @@ __global__ void lsa_put_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
   const int nthreads = blockDim.x * blockDim.y * blockDim.z;
 
   const size_t chunk = len_doubles / static_cast<size_t>(nblocks);
-  // Cooperation unit this thread belongs to, and its lane within the unit.
   const int nunits = nthreads / scope_size;
   const int unit = tid / scope_size;
   const int lane = tid % scope_size;
@@ -71,30 +62,18 @@ __global__ void lsa_put_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
   const double* src = reinterpret_cast<const double*>(ccoGetLocalPtr(sendWin, off_bytes));
 
   for (int i = 0; i < iter; i++) {
-    // Unit's threads stride over the unit's segment (thread scope: scope_size==1
-    // so a single thread copies its whole per_unit segment contiguously).
     lsa_copy_strided(dst, src, per_unit, lane, scope_size);
-    // System-scope fence so this round's cross-GPU stores are globally visible
-    // (the barrier's own __threadfence is device scope only). Without it the
-    // repeated same-region traffic is absorbed by L2/Infinity cache and the
-    // timer measures cache bandwidth, not real P2P.
+    // System fence forces each round's cross-GPU stores out — otherwise the
+    // repeated same-region traffic is cache-absorbed and we'd time cache BW.
     __threadfence_system();
-    // Per-round all-block barrier (GPU-internal, mirrors shmem) so the measured
-    // window includes the same cross-block sync as the shmem benchmark.
+    // Per-round all-block barrier mirrors shmem so the timed window matches.
     bw_cross_block_barrier_round(counter_d, nblocks, i);
   }
 }
 
-// ── IBGDA: one QP context per block (ginContext=blockIdx). Each block owns its
-// QP and is fully independent — it pipelines its chunk's `iter` writes back to
-// back, then flushes its own QP. No cross-block barrier needed (blocks don't
-// share a QP). block scope = one bulk RDMA write of the whole chunk (nunits==1),
-// same granularity as shmem's ShmemPutMemNbiBlock; warp/thread scope subdivide.
-//
-// NOTE on flush vs shmem quiet: ccoGda::flush is ring-doorbell + poll-CQ
-// combined; shmem rings inside the put and uses poll-only quiet. Data path /
-// completion semantics are otherwise equivalent (post-fix quietUntil waits for
-// the real CQE).
+// IBGDA: one QP per block (ginContext=blockIdx); each block pipelines its chunk
+// then flushes its own QP. block scope = one bulk write (== shmem
+// ShmemPutMemNbiBlock); warp/thread subdivide.
 template <core::ProviderType PrvdType, typename Coop>
 __global__ void ibgda_put_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin, size_t len_doubles,
                              ccoDevComm devComm, int iter) {
@@ -105,8 +84,6 @@ __global__ void ibgda_put_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
   const int peer = !devComm.rank;
   const size_t chunk = len_doubles / static_cast<size_t>(nblocks);
 
-  // Sub-divide the block's chunk across coop units (block scope: one bulk op;
-  // warp/thread scope: nunits ops).
   const int tid = linear_tid();
   const int unit = tid / coop.size();
   const int nunits = (blockDim.x * blockDim.y * blockDim.z) / coop.size();
@@ -115,18 +92,15 @@ __global__ void ibgda_put_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
   const size_t off_bytes = base * sizeof(double);
   const size_t bytes = per_unit * sizeof(double);
 
-  // AggregateRequests: accumulate WQEs without ringing the doorbell per op. In
-  // warp/thread scope multiple threads of a block post to the SAME per-block QP;
-  // letting each call ringDoorbellOrdered (which spins until dbTouchIdx==its
-  // postIdx) deadlocks under SIMT lock-step. Aggregating defers the ring to the
-  // single end flush, which rings once and polls the CQ. (block scope has one
-  // posting thread per QP, so this is harmless there.)
+  // AggregateRequests defers the doorbell to the end flush: in warp/thread scope
+  // many threads share one QP, and per-op ringDoorbellOrdered deadlocks under
+  // SIMT lock-step. The end flush rings once + polls the CQ.
   for (int i = 0; i < iter; i++) {
     gda.put(peer, reinterpret_cast<ccoWindow_t>(recvWin), off_bytes,
             reinterpret_cast<ccoWindow_t>(sendWin), off_bytes, bytes, ccoGda_NoSignal{}, coop,
             ccoGdaOptFlagsAggregateRequests);
   }
-  gda.flush(ccoCoopBlock{});  // rings the aggregated doorbell once + drains this block's QP
+  gda.flush(ccoCoopBlock{});
 }
 
 static void launch_lsa(PutScope scope, dim3 grid, dim3 block, ccoWindow_t sendWin,

--- a/benchmark/cco/p2p_put_bw.cpp
+++ b/benchmark/cco/p2p_put_bw.cpp
@@ -40,31 +40,48 @@
 
 namespace mori::cco::benchmark {
 
-// ── LSA: flat-VA store loop. Each block copies its chunk into the peer's recv
-// window. `lanes`/`lane0` select how many threads of the block participate
-// (block: all, warp: first warp, thread: thread 0). ──
-__global__ void lsa_put_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin, size_t len_doubles,
-                           int peerLsa, int iter, int lanes) {
+// ── LSA: flat-VA store loop, scope semantics aligned with shmem's bw_block /
+// bw_warp / bw_thread. ALL block threads always participate; `scope_size` only
+// changes the cooperation granularity of the copy:
+//   block  scope_size=blockDim → 1 unit, whole block strides the whole chunk
+//   warp   scope_size=warpSize → nwarps units, each warp strides its sub-segment
+//   thread scope_size=1        → blockDim units, each thread copies its own
+//                                contiguous 1/blockDim segment
+// This mirrors ShmemPutMemNbi{Block,Warp,Thread}: same thread count, finer
+// per-unit segments — thread scope is slower because each thread does a small
+// contiguous copy (no wide striding), not because fewer threads participate. ──
+__global__ void lsa_put_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
+                           volatile unsigned int* counter_d, size_t len_doubles, int peerLsa,
+                           int iter, int scope_size) {
   const int bid = blockIdx.x;
   const int nblocks = gridDim.x;
   const int tid = linear_tid();
-  if (tid >= lanes) return;
+  const int nthreads = blockDim.x * blockDim.y * blockDim.z;
 
   const size_t chunk = len_doubles / static_cast<size_t>(nblocks);
-  const size_t off_bytes = static_cast<size_t>(bid) * chunk * sizeof(double);
+  // Cooperation unit this thread belongs to, and its lane within the unit.
+  const int nunits = nthreads / scope_size;
+  const int unit = tid / scope_size;
+  const int lane = tid % scope_size;
+  const size_t per_unit = chunk / static_cast<size_t>(nunits);
 
+  const size_t off_bytes =
+      (static_cast<size_t>(bid) * chunk + static_cast<size_t>(unit) * per_unit) * sizeof(double);
   double* dst = reinterpret_cast<double*>(ccoGetLsaPeerPtr(recvWin, peerLsa, off_bytes));
   const double* src = reinterpret_cast<const double*>(ccoGetLocalPtr(sendWin, off_bytes));
 
   for (int i = 0; i < iter; i++) {
-    lsa_copy_strided(dst, src, chunk, tid, lanes);
-    // Per-iteration system fence: every iteration writes the SAME src->dst, so
-    // without forcing each round's stores out to the peer they get absorbed by
-    // L2/Infinity cache and the timer measures cache bandwidth, not real P2P
-    // (symptom: mid-size BW spikes far above the NIC/xGMI limit, then drops to
-    // the true rate once the buffer exceeds cache). The fence makes each round's
-    // writes visible to the peer before the next round reuses the same region.
+    // Unit's threads stride over the unit's segment (thread scope: scope_size==1
+    // so a single thread copies its whole per_unit segment contiguously).
+    lsa_copy_strided(dst, src, per_unit, lane, scope_size);
+    // System-scope fence so this round's cross-GPU stores are globally visible
+    // (the barrier's own __threadfence is device scope only). Without it the
+    // repeated same-region traffic is absorbed by L2/Infinity cache and the
+    // timer measures cache bandwidth, not real P2P.
     __threadfence_system();
+    // Per-round all-block barrier (GPU-internal, mirrors shmem) so the measured
+    // window includes the same cross-block sync as the shmem benchmark.
+    bw_cross_block_barrier_round(counter_d, nblocks, i);
   }
 }
 
@@ -113,13 +130,15 @@ __global__ void ibgda_put_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
 }
 
 static void launch_lsa(PutScope scope, dim3 grid, dim3 block, ccoWindow_t sendWin,
-                       ccoWindow_t recvWin, size_t len_doubles, int peerLsa, int count,
-                       int warp_size) {
-  int lanes = block.x;
-  if (scope == PutScope::kWarp) lanes = warp_size;
-  if (scope == PutScope::kThread) lanes = 1;
-  hipLaunchKernelGGL(lsa_put_bw, grid, block, 0, 0, sendWin, recvWin, len_doubles, peerLsa, count,
-                     lanes);
+                       ccoWindow_t recvWin, unsigned int* counter_d, size_t len_doubles,
+                       int peerLsa, int count, int warp_size) {
+  // scope_size = cooperation granularity of the copy (block: whole block,
+  // warp: one wavefront, thread: a single thread). All threads always run.
+  int scope_size = block.x;
+  if (scope == PutScope::kWarp) scope_size = warp_size;
+  if (scope == PutScope::kThread) scope_size = 1;
+  hipLaunchKernelGGL(lsa_put_bw, grid, block, 0, 0, sendWin, recvWin, counter_d, len_doubles,
+                     peerLsa, count, scope_size);
 }
 
 template <core::ProviderType PrvdType>
@@ -185,8 +204,8 @@ int main(int argc, char** argv) {
     if (run_kernels) {
       const float ms = RunWarmupAndTimed(res, args.warmup, args.iters, [&](int count) {
         if (args.transport == Transport::kLsa) {
-          launch_lsa(args.put_scope, grid, block, ctx.send_win, ctx.recv_win, len_doubles,
-                     ctx.peer_lsa_rank, count, ctx.device_warp_size);
+          launch_lsa(args.put_scope, grid, block, ctx.send_win, ctx.recv_win, res.counter_d,
+                     len_doubles, ctx.peer_lsa_rank, count, ctx.device_warp_size);
         } else {
           CCO_GDA_DISPATCH(launch_ibgda<P>(args.put_scope, grid, block, ctx.send_win, ctx.recv_win,
                                            len_doubles, ctx.devComm, count));

--- a/benchmark/cco/util.cpp
+++ b/benchmark/cco/util.cpp
@@ -371,18 +371,22 @@ void PerfFinalize(PerfContext* ctx) {
 void PerfResAlloc(PerfRes* res) {
   HIP_RUNTIME_CHECK(hipEventCreate(&res->start));
   HIP_RUNTIME_CHECK(hipEventCreate(&res->stop));
+  HIP_RUNTIME_CHECK(hipMalloc(&res->counter_d, 2 * sizeof(unsigned int)));
 }
 
 void PerfResFree(PerfRes* res) {
   HIP_RUNTIME_CHECK(hipEventDestroy(res->start));
   HIP_RUNTIME_CHECK(hipEventDestroy(res->stop));
+  if (res->counter_d) HIP_RUNTIME_CHECK(hipFree(res->counter_d));
 }
 
 float RunWarmupAndTimed(PerfRes& res, std::size_t warmup, std::size_t iters, LaunchFn launch) {
+  if (res.counter_d) HIP_RUNTIME_CHECK(hipMemset(res.counter_d, 0, 2 * sizeof(unsigned int)));
   launch(static_cast<int>(warmup));
   HIP_RUNTIME_CHECK(hipGetLastError());
   HIP_RUNTIME_CHECK(hipDeviceSynchronize());
 
+  if (res.counter_d) HIP_RUNTIME_CHECK(hipMemset(res.counter_d, 0, 2 * sizeof(unsigned int)));
   HIP_RUNTIME_CHECK(hipEventRecord(res.start, nullptr));
   launch(static_cast<int>(iters));
   HIP_RUNTIME_CHECK(hipGetLastError());

--- a/benchmark/cco/util.hpp
+++ b/benchmark/cco/util.hpp
@@ -116,6 +116,9 @@ using LaunchFn = std::function<void(int /*count*/)>;
 struct PerfRes {
   hipEvent_t start{};
   hipEvent_t stop{};
+  // [0]=arrival counter, [1]=phase counter for the LSA bw cross-block barrier
+  // (apples-to-apples with shmem). Zeroed before each warmup/timed launch.
+  unsigned int* counter_d = nullptr;
 };
 
 void PerfResAlloc(PerfRes* res);


### PR DESCRIPTION
LSA scope & sync aligned with shmem:
all block threads now always participate — scope_size only sets copy granularity (block strides the whole chunk, warp per-wavefront, thread copies its own contiguous segment), instead of the old behavior that wrongly cut the thread count for thread/warp scope. Added a per-round cross-block barrier (mirrors shmem's bw_cross_block_barrier_round) so the timed window includes the same synchronization, removing the artificial mid-size speedup.