### PR TITLE
refactor(cco): drop application bootstrap overload from host API

### DIFF
--- a/benchmark/cco/util.cpp
+++ b/benchmark/cco/util.cpp
@@ -26,7 +26,8 @@
 #include <string>
 
 #include "hip/hip_runtime.h"
-#include "mori/application/bootstrap/mpi_bootstrap.hpp"
+#include <mpi.h>
+
 #include "mori/application/utils/check.hpp"
 #include "mori/utils/env_utils.hpp"
 
@@ -240,17 +241,27 @@ int PerfInit(int argc, char** argv, PerfContext* ctx) {
     if (can_access) (void)hipDeviceEnablePeerAccess(i, 0);
   }
 
-  // CCO comm. bootNet ownership transfers to comm (freed in ccoCommDestroy).
-  auto* bootNet = new application::MpiBootstrapNetwork(MPI_COMM_WORLD);
+  // CCO comm via the cco-native uniqueId API: rank 0 mints the id (its socket
+  // rendezvous), MPI broadcasts the POD, all ranks create the comm.
+  int world_size = 0;
+  MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+  ccoUniqueId uid;
+  if (ctx->world_rank == 0) {
+    if (ccoGetUniqueId(&uid) != 0) {
+      std::fprintf(stderr, "ccoGetUniqueId failed (set MORI_SOCKET_IFNAME=<iface>)\n");
+      MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+  }
+  MPI_Bcast(&uid, sizeof(uid), MPI_BYTE, 0, MPI_COMM_WORLD);
   const std::size_t per_rank_vmm = 2 * args.max_size + kVmmSlack;
-  if (ccoCommCreate(bootNet, per_rank_vmm, &ctx->comm) != 0) {
+  if (ccoCommCreate(uid, world_size, ctx->world_rank, per_rank_vmm, &ctx->comm) != 0) {
     if (ctx->world_rank == 0) std::fprintf(stderr, "ccoCommCreate failed\n");
     PerfFinalize(ctx);
     return 1;
   }
 
-  ctx->my_pe = ctx->comm->rank;
-  ctx->npes = ctx->comm->worldSize;
+  ctx->my_pe = ctx->world_rank;
+  ctx->npes = world_size;
   if (ctx->npes != 2) {
     if (ctx->my_pe == 0) {
       std::fprintf(stderr, "CCO p2p benchmark requires exactly 2 PEs (npes=%d)\n", ctx->npes);
@@ -338,9 +349,6 @@ int PerfInit(int argc, char** argv, PerfContext* ctx) {
 }
 
 void PerfFinalize(PerfContext* ctx) {
-  // Free our local communicator first: ccoCommDestroy below calls
-  // bootNet->Finalize(), which invokes MPI_Finalize — any MPI_Comm_free after
-  // that is illegal and aborts the job.
   if (ctx->local_comm != MPI_COMM_NULL) {
     MPI_Comm_free(&ctx->local_comm);
     ctx->local_comm = MPI_COMM_NULL;
@@ -356,16 +364,13 @@ void PerfFinalize(PerfContext* ctx) {
     if (ctx->send_win) ccoWindowDeregister(ctx->comm, ctx->send_win);
     if (ctx->recv_buf) ccoMemFree(ctx->comm, ctx->recv_buf);
     if (ctx->send_buf) ccoMemFree(ctx->comm, ctx->send_buf);
-    // ccoCommDestroy finalizes MPI via bootNet->Finalize().
-    ccoCommDestroy(ctx->comm);
+    ccoCommDestroy(ctx->comm);  // cco's socket bootstrap — does NOT finalize MPI
     ctx->comm = nullptr;
-  } else {
-    int finalized = 0;
-    MPI_Finalized(&finalized);
-    if (!finalized) {
-      MPI_Finalize();
-    }
   }
+  // We own MPI now (uniqueId bootstrap); finalize it ourselves.
+  int finalized = 0;
+  MPI_Finalized(&finalized);
+  if (!finalized) MPI_Finalize();
 }
 
 void PerfResAlloc(PerfRes* res) {

--- a/include/mori/cco/cco.hpp
+++ b/include/mori/cco/cco.hpp
@@ -886,21 +886,15 @@ struct ccoComm;  // device/kernel TUs: opaque handle only
 
 // ── Phase 1: Communicator ──
 //
-// Two ways to bootstrap:
+// Self-contained bootstrap (needs only this header). Rank 0 calls
+// ccoGetUniqueId, broadcasts the 128-byte POD id to all ranks out-of-band
+// (MPI_Bcast, a file, your launcher, ...), then every rank calls ccoCommCreate.
+// cco builds its built-in socket bootstrap internally.
 //
-//  A) Self-contained (needs only this header). Rank 0 calls
-//     ccoGetUniqueId, broadcasts the 128-byte POD id to all ranks out-of-band
-//     (MPI_Bcast, a file, your launcher, ...), then every rank calls the
-//     ccoUniqueId overload. cco builds its built-in socket bootstrap internally.
-//
-//       ccoUniqueId id;
-//       if (rank == 0) ccoGetUniqueId(&id);
-//       /* broadcast id to all ranks */
-//       ccoCommCreate(id, nRanks, rank, vmm, &comm);
-//
-//  B) Pluggable transport: construct a concrete bootstrap yourself (include the
-//     matching mori/application/bootstrap/{socket,mpi,torch}_bootstrap.hpp) and
-//     pass it in. cco takes ownership and destroys it in ccoCommDestroy.
+//   ccoUniqueId id;
+//   if (rank == 0) ccoGetUniqueId(&id);
+//   /* broadcast id to all ranks */
+//   ccoCommCreate(id, nRanks, rank, vmm, &comm);
 //
 // ccoUniqueId encodes rank 0's socket rendezvous address; the interface is
 // picked from MORI_SOCKET_IFNAME (see socket bootstrap docs).
@@ -911,9 +905,6 @@ struct ccoUniqueId {
 int ccoGetUniqueId(ccoUniqueId* uniqueId);
 int ccoCommCreate(const ccoUniqueId& uniqueId, int nRanks, int rank, size_t perRankVmmSize,
                   ccoComm** comm);
-
-// Overload B: caller-provided bootstrap (ownership transferred to the comm).
-int ccoCommCreate(application::BootstrapNetwork* bootNet, size_t perRankVmmSize, ccoComm** comm);
 int ccoCommDestroy(ccoComm* comm);
 
 // ── Phase 1.5 (optional): VMM allocation + P2P flat-space mapping ──

--- a/src/cco/cco_init.cpp
+++ b/src/cco/cco_init.cpp
@@ -130,20 +130,27 @@ int ccoGetUniqueId(ccoUniqueId* uniqueId) {
   return -1;
 }
 
+// Internal bootstrap helper: caller-provided transport (ownership transferred to
+// the comm; Finalize()d + deleted in ccoCommDestroy). Not part of the public API
+// — the ccoUniqueId overload below builds the built-in socket bootstrap and
+// delegates here.
+static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perRankVmmSize,
+                             ccoComm** outComm);
+
 // Self-contained overload: build cco's built-in socket bootstrap from the id and
-// delegate to the BootstrapNetwork* overload, which takes ownership (the socket
-// bootstrap is Finalize()d + deleted in ccoCommDestroy).
+// delegate to the internal helper, which takes ownership (the socket bootstrap is
+// Finalize()d + deleted in ccoCommDestroy).
 int ccoCommCreate(const ccoUniqueId& uniqueId, int nRanks, int rank, size_t perRankVmmSize,
                   ccoComm** outComm) {
   if (!outComm || nRanks <= 0 || rank < 0 || rank >= nRanks) return -1;
   application::UniqueId appUid;
   std::memcpy(&appUid, &uniqueId, sizeof(appUid));
   auto* boot = new application::SocketBootstrapNetwork(appUid, rank, nRanks);
-  return ccoCommCreate(boot, perRankVmmSize, outComm);
+  return ccoCommCreateImpl(boot, perRankVmmSize, outComm);
 }
 
-int ccoCommCreate(application::BootstrapNetwork* bootNet, size_t perRankVmmSize,
-                  ccoComm** outComm) {
+static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perRankVmmSize,
+                             ccoComm** outComm) {
   auto* comm = new ccoComm();
   *outComm = comm;
 

--- a/tests/cpp/cco/cco_test_harness.hpp
+++ b/tests/cpp/cco/cco_test_harness.hpp
@@ -20,21 +20,22 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// Shared launch harness for multi-rank CCO GDA tests.
+// Shared launch harness for multi-rank CCO tests.
 //
 // Each test provides only:
 //   - its __global__ kernel(s)
-//   - int run_test(int rank, int nranks, mori::application::BootstrapNetwork*)
+//   - int run_test(int rank, int nranks, const mori::cco::ccoUniqueId& uid)
 //   - a one-line main() that calls ccoTestMain(...)
-// This header owns the rest: HIP_CHECK, the fork / single-rank / gen-uid launch
-// modes, and the MPI/fork dispatch. See test_cco_gda_put.cpp for usage.
+// This header owns the rest: HIP_CHECK and the fork / single-rank / gen-uid /
+// MPI launch modes. It obtains a ccoUniqueId (rank 0 / parent), distributes it
+// over the launch channel (MPI_Bcast or a file), and hands it to run_test, which
+// creates the comm via the cco-native ccoCommCreate(uid, nRanks, rank, ...) API —
+// no application:: bootstrap types are used.
 
 #pragma once
 
 #ifdef MORI_WITH_MPI
 #include <mpi.h>
-
-#include "mori/application/bootstrap/mpi_bootstrap.hpp"
 #endif
 
 #include <sys/wait.h>
@@ -46,7 +47,7 @@
 #include <vector>
 
 #include "hip/hip_runtime.h"
-#include "mori/application/bootstrap/socket_bootstrap.hpp"
+#include "mori/cco/cco.hpp"
 
 // Current rank, set at the top of each run_test; used by HIP_CHECK diagnostics.
 inline int g_rank = 0;
@@ -65,10 +66,11 @@ inline int g_rank = 0;
 // now — it is compile-time (per-NIC build), so GDA tests include that header and
 // call CCO_GDA_DISPATCH(Kernel<P, ...><<<...>>>(...)) with no runtime provider.
 
-// Each test implements this; the harness invokes it for every rank.
-int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet);
+// Each test implements this; the harness invokes it for every rank with the
+// shared cco unique id (rank 0's socket rendezvous, distributed out-of-band).
+int run_test(int rank, int nranks, const mori::cco::ccoUniqueId& uid);
 
-// ── small file helpers (UID exchange for socket bootstrap) ───────────────────
+// ── small file helpers (UID exchange for fork / cross-host launches) ──────────
 
 static inline void ccoTestWriteFile(const char* path, const void* data, size_t len) {
   FILE* f = fopen(path, "wb");
@@ -86,26 +88,30 @@ static inline bool ccoTestReadFile(const char* path, void* data, size_t len) {
 
 // ── fork mode: spawn nranks children, each binds one GPU ─────────────────────
 
-static inline int ccoTestForkMode(int nranks, const char* name, const char* uidPrefix, int port) {
+static inline int ccoTestForkMode(int nranks, const char* name, const char* uidPrefix,
+                                  int /*port*/) {
   char uidPath[256];
   snprintf(uidPath, sizeof(uidPath), "%s_%d", uidPrefix, getpid());
 
   printf("=== %s Test (fork, %d ranks) ===\n", name, nranks);
   fflush(stdout);
 
-  auto uid = mori::application::SocketBootstrapNetwork::GenerateUniqueIdWithInterface("lo", port);
+  mori::cco::ccoUniqueId uid;
+  if (mori::cco::ccoGetUniqueId(&uid) != 0) {
+    fprintf(stderr, "ccoGetUniqueId failed (set MORI_SOCKET_IFNAME=<iface>)\n");
+    return 1;
+  }
   ccoTestWriteFile(uidPath, &uid, sizeof(uid));
 
   std::vector<pid_t> children;
   for (int r = 0; r < nranks; r++) {
     pid_t pid = fork();
     if (pid == 0) {
-      mori::application::UniqueId childUid;
+      mori::cco::ccoUniqueId childUid;
       while (!ccoTestReadFile(uidPath, &childUid, sizeof(childUid))) {
         usleep(10000);
       }
-      auto* boot = new mori::application::SocketBootstrapNetwork(childUid, r, nranks);
-      _exit(run_test(r, nranks, boot));
+      _exit(run_test(r, nranks, childUid));
     }
     children.push_back(pid);
   }
@@ -142,24 +148,23 @@ static inline int ccoTestSingleRankMode(int argc, char** argv) {
   }
   if (rank < 0 || worldSize <= 0 || !uidPath) return -1;
 
-  mori::application::UniqueId uid;
+  mori::cco::ccoUniqueId uid;
+  bool got = false;
   for (int tries = 0; tries < 600; tries++) {
-    FILE* f = fopen(uidPath, "rb");
-    if (f) {
-      size_t n = fread(&uid, 1, sizeof(uid), f);
-      fclose(f);
-      if (n == sizeof(uid)) break;
+    if (ccoTestReadFile(uidPath, &uid, sizeof(uid))) {
+      got = true;
+      break;
     }
     usleep(100000);
   }
+  if (!got) return -1;
 
   if (gpuOffset >= 0) HIP_CHECK(hipSetDevice(rank - gpuOffset));
 
-  auto* boot = new mori::application::SocketBootstrapNetwork(uid, rank, worldSize);
-  return run_test(rank, worldSize, boot);
+  return run_test(rank, worldSize, uid);
 }
 
-// ── gen-uid mode: emit a UID file for cross-host single-rank launches ────────
+// ── gen-uid mode: emit a UID file for cross-host single-rank launches ─────────
 
 static inline int ccoTestGenUidMode(int argc, char** argv) {
   if (argc < 5) {
@@ -167,9 +172,15 @@ static inline int ccoTestGenUidMode(int argc, char** argv) {
     return 1;
   }
   const char* iface = argv[2];
-  int port = atoi(argv[3]);
   const char* outPath = argv[4];
-  auto uid = mori::application::SocketBootstrapNetwork::GenerateUniqueIdWithInterface(iface, port);
+  // ccoGetUniqueId reads the interface from MORI_SOCKET_IFNAME and picks a free
+  // port itself; honour the iface arg by exporting it. (PORT is ignored.)
+  setenv("MORI_SOCKET_IFNAME", iface, /*overwrite=*/1);
+  mori::cco::ccoUniqueId uid;
+  if (mori::cco::ccoGetUniqueId(&uid) != 0) {
+    fprintf(stderr, "ccoGetUniqueId failed for iface=%s\n", iface);
+    return 1;
+  }
   FILE* f = fopen(outPath, "wb");
   if (!f) {
     fprintf(stderr, "fopen(%s) failed\n", outPath);
@@ -177,7 +188,7 @@ static inline int ccoTestGenUidMode(int argc, char** argv) {
   }
   fwrite(&uid, 1, sizeof(uid), f);
   fclose(f);
-  printf("Wrote UID (%zu bytes) for iface=%s port=%d to %s\n", sizeof(uid), iface, port, outPath);
+  printf("Wrote UID (%zu bytes) for iface=%s to %s\n", sizeof(uid), iface, outPath);
   return 0;
 }
 
@@ -185,7 +196,7 @@ static inline int ccoTestGenUidMode(int argc, char** argv) {
 //
 // name      — human label printed in headers (e.g. "CCO GDA flushAsync")
 // uidPrefix — fork-mode UID file prefix    (e.g. "/tmp/cco_gda_flush_async_uid")
-// port      — socket bootstrap port for GenerateUniqueIdWithInterface
+// port      — unused (ccoGetUniqueId picks its own free port); kept for API compat
 static inline int ccoTestMain(int argc, char** argv, const char* name, const char* uidPrefix,
                               int port) {
   if (argc >= 2 && !strcmp(argv[1], "--gen-uid")) return ccoTestGenUidMode(argc, argv);
@@ -206,8 +217,17 @@ static inline int ccoTestMain(int argc, char** argv, const char* name, const cha
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &nranks);
     if (rank == 0) printf("=== %s Test (MPI, %d ranks) ===\n", name, nranks);
-    auto* boot = new mori::application::MpiBootstrapNetwork(MPI_COMM_WORLD);
-    return run_test(rank, nranks, boot);
+    // Rank 0 mints the cco unique id (its socket rendezvous) and broadcasts the
+    // POD to every rank; all ranks then create the comm via the uniqueId API.
+    mori::cco::ccoUniqueId uid;
+    if (rank == 0) {
+      if (mori::cco::ccoGetUniqueId(&uid) != 0) {
+        fprintf(stderr, "ccoGetUniqueId failed (set MORI_SOCKET_IFNAME=<iface>)\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+      }
+    }
+    MPI_Bcast(&uid, sizeof(uid), MPI_BYTE, 0, MPI_COMM_WORLD);
+    return run_test(rank, nranks, uid);
   }
 #endif
 

--- a/tests/cpp/cco/test_gda_barrier.cpp
+++ b/tests/cpp/cco/test_gda_barrier.cpp
@@ -179,7 +179,7 @@ static int run_all_tests(UtCtx& ctx) {
 
 // ── host driver ──────────────────────────────────────────────────────────────
 
-int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet) {
+int run_test(int rank, int nranks, const mori::cco::ccoUniqueId& uid) {
   g_rank = rank;
 
   int numDevices = 0;
@@ -196,7 +196,7 @@ int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet)
   printf("[rank %d/%d] pid=%d GPU=%d\n", rank, nranks, getpid(), dev);
 
   mori::cco::ccoComm* comm = nullptr;
-  if (mori::cco::ccoCommCreate(bootNet, PER_RANK_VMM_SIZE, &comm) != 0) {
+  if (mori::cco::ccoCommCreate(uid, nranks, rank, PER_RANK_VMM_SIZE, &comm) != 0) {
     fprintf(stderr, "[rank %d] CommCreate failed\n", rank);
     return 1;
   }

--- a/tests/cpp/cco/test_gda_counter.cpp
+++ b/tests/cpp/cco/test_gda_counter.cpp
@@ -234,7 +234,7 @@ static int run_all_tests(UtCtx& ctx) {
 
 // ── host driver ──────────────────────────────────────────────────────────────
 
-int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet) {
+int run_test(int rank, int nranks, const mori::cco::ccoUniqueId& uid) {
   g_rank = rank;
 
   int numDevices = 0;
@@ -251,7 +251,7 @@ int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet)
   printf("[rank %d/%d] pid=%d GPU=%d\n", rank, nranks, getpid(), dev);
 
   mori::cco::ccoComm* comm = nullptr;
-  if (mori::cco::ccoCommCreate(bootNet, PER_RANK_VMM_SIZE, &comm) != 0) {
+  if (mori::cco::ccoCommCreate(uid, nranks, rank, PER_RANK_VMM_SIZE, &comm) != 0) {
     fprintf(stderr, "[rank %d] CommCreate failed\n", rank);
     return 1;
   }

--- a/tests/cpp/cco/test_gda_flush_async.cpp
+++ b/tests/cpp/cco/test_gda_flush_async.cpp
@@ -93,7 +93,7 @@ __global__ void GdaAlltoAllFlushAsyncKernel(mori::cco::ccoWindowDevice* sendWin,
   }
 }
 
-int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet) {
+int run_test(int rank, int nranks, const mori::cco::ccoUniqueId& uid) {
   g_rank = rank;
 
   int numDevices = 0;
@@ -112,7 +112,7 @@ int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet)
 
   // setup: comm, send/recv buffers, windows
   mori::cco::ccoComm* comm = nullptr;
-  if (mori::cco::ccoCommCreate(bootNet, PER_RANK_VMM_SIZE, &comm) != 0) {
+  if (mori::cco::ccoCommCreate(uid, nranks, rank, PER_RANK_VMM_SIZE, &comm) != 0) {
     fprintf(stderr, "[rank %d] CommCreate failed\n", rank);
     return 1;
   }

--- a/tests/cpp/cco/test_gda_get.cpp
+++ b/tests/cpp/cco/test_gda_get.cpp
@@ -70,7 +70,7 @@ __global__ void GdaAlltoAllGetKernel(mori::cco::ccoWindowDevice* sendWin,
   gda.flush(mori::cco::ccoCoopBlock{});
 }
 
-int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet) {
+int run_test(int rank, int nranks, const mori::cco::ccoUniqueId& uid) {
   g_rank = rank;
 
   int numDevices = 0;
@@ -89,7 +89,7 @@ int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet)
 
   // setup: comm, send/recv buffers, windows
   mori::cco::ccoComm* comm = nullptr;
-  if (mori::cco::ccoCommCreate(bootNet, PER_RANK_VMM_SIZE, &comm) != 0) {
+  if (mori::cco::ccoCommCreate(uid, nranks, rank, PER_RANK_VMM_SIZE, &comm) != 0) {
     fprintf(stderr, "[rank %d] CommCreate failed\n", rank);
     return 1;
   }

--- a/tests/cpp/cco/test_gda_modes.cpp
+++ b/tests/cpp/cco/test_gda_modes.cpp
@@ -39,9 +39,8 @@
 #include <vector>
 
 #include "hip/hip_runtime.h"
-#include "mori/application/application_device_types.hpp"  // white-box: RdmaEndpointDevice (count QPs)
-#include "mori/application/bootstrap/socket_bootstrap.hpp"
 #include "mori/cco/cco.hpp"
+#include "mori/core/transport/rdma/core_device_types.hpp"  // core::RdmaEndpointDevice (endpoint readback)
 #include "mori/utils/mori_log.hpp"
 
 #define HIP_CHECK(cmd)                                                            \
@@ -176,7 +175,7 @@ static bool exercise_window_register(mori::cco::ccoComm* comm, mori::cco::ccoWin
   return true;
 }
 
-static void run_rank(int rank, int nranks, const mori::application::UniqueId& uid, Result* r) {
+static void run_rank(int rank, int nranks, const mori::cco::ccoUniqueId& uid, Result* r) {
   r->rank = rank;
   r->passed = false;
 
@@ -193,11 +192,9 @@ static void run_rank(int rank, int nranks, const mori::application::UniqueId& ui
     if (canAccess) (void)hipDeviceEnablePeerAccess(i, 0);
   }
 
-  auto* bootNet = new mori::application::SocketBootstrapNetwork(uid, rank, nranks);
-
-  // Phase 1: ccoCommCreate
+  // Phase 1: ccoCommCreate (cco builds its own socket bootstrap from the uid)
   mori::cco::ccoComm* comm = nullptr;
-  if (mori::cco::ccoCommCreate(bootNet, PER_RANK_VMM_SIZE, &comm) != 0) {
+  if (mori::cco::ccoCommCreate(uid, nranks, rank, PER_RANK_VMM_SIZE, &comm) != 0) {
     snprintf(r->detail, sizeof(r->detail), "CommCreate failed");
     return;
   }
@@ -328,7 +325,11 @@ int main(int argc, char** argv) {
 
   printf("=== CCO GDA Connection Modes Test (%d ranks) ===\n\n", nranks);
 
-  auto uid = mori::application::SocketBootstrapNetwork::GenerateUniqueIdWithInterface("lo", 18458);
+  mori::cco::ccoUniqueId uid;
+  if (mori::cco::ccoGetUniqueId(&uid) != 0) {
+    printf("ccoGetUniqueId failed (set MORI_SOCKET_IFNAME=<iface>)\n");
+    return 1;
+  }
 
   std::vector<Result> results(nranks);
   std::vector<std::thread> threads;

--- a/tests/cpp/cco/test_gda_multi_context.cpp
+++ b/tests/cpp/cco/test_gda_multi_context.cpp
@@ -97,7 +97,7 @@ __global__ void GdaMultiCtxAlltoAllKernel(mori::cco::ccoWindowDevice* sendWin,
   }
 }
 
-int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet) {
+int run_test(int rank, int nranks, const mori::cco::ccoUniqueId& uid) {
   g_rank = rank;
 
   int numDevices = 0;
@@ -115,7 +115,7 @@ int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet)
   printf("[rank %d/%d] pid=%d GPU=%d\n", rank, nranks, getpid(), dev);
 
   mori::cco::ccoComm* comm = nullptr;
-  if (mori::cco::ccoCommCreate(bootNet, PER_RANK_VMM_SIZE, &comm) != 0) {
+  if (mori::cco::ccoCommCreate(uid, nranks, rank, PER_RANK_VMM_SIZE, &comm) != 0) {
     fprintf(stderr, "[rank %d] CommCreate failed\n", rank);
     return 1;
   }

--- a/tests/cpp/cco/test_gda_put.cpp
+++ b/tests/cpp/cco/test_gda_put.cpp
@@ -68,7 +68,7 @@ __global__ void GdaAlltoAllKernel(mori::cco::ccoWindowDevice* sendWin,
   }
 }
 
-int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet) {
+int run_test(int rank, int nranks, const mori::cco::ccoUniqueId& uid) {
   g_rank = rank;
 
   int numDevices = 0;
@@ -87,7 +87,7 @@ int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet)
 
   // setup: comm, send/recv buffers, windows
   mori::cco::ccoComm* comm = nullptr;
-  if (mori::cco::ccoCommCreate(bootNet, PER_RANK_VMM_SIZE, &comm) != 0) {
+  if (mori::cco::ccoCommCreate(uid, nranks, rank, PER_RANK_VMM_SIZE, &comm) != 0) {
     fprintf(stderr, "[rank %d] CommCreate failed\n", rank);
     return 1;
   }

--- a/tests/cpp/cco/test_gda_signal_ut.cpp
+++ b/tests/cpp/cco/test_gda_signal_ut.cpp
@@ -392,7 +392,7 @@ static int run_all_tests(UtCtx& ctx) {
 
 // ── host driver: setup → run_all_tests → teardown ────────────────────────────
 
-int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet) {
+int run_test(int rank, int nranks, const mori::cco::ccoUniqueId& uid) {
   g_rank = rank;
 
   int numDevices = 0;
@@ -410,7 +410,7 @@ int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet)
   printf("[rank %d/%d] pid=%d GPU=%d\n", rank, nranks, getpid(), dev);
 
   mori::cco::ccoComm* comm = nullptr;
-  if (mori::cco::ccoCommCreate(bootNet, PER_RANK_VMM_SIZE, &comm) != 0) {
+  if (mori::cco::ccoCommCreate(uid, nranks, rank, PER_RANK_VMM_SIZE, &comm) != 0) {
     fprintf(stderr, "[rank %d] CommCreate failed\n", rank);
     return 1;
   }

--- a/tests/cpp/cco/test_host.cpp
+++ b/tests/cpp/cco/test_host.cpp
@@ -29,7 +29,6 @@
 #include <vector>
 
 #include "hip/hip_runtime.h"
-#include "mori/application/bootstrap/socket_bootstrap.hpp"
 #include "mori/cco/cco.hpp"
 #include "mori/utils/mori_log.hpp"
 
@@ -52,7 +51,7 @@ struct ThreadResult {
   char detail[512];
 };
 
-static void run_rank(int rank, int nranks, const mori::application::UniqueId& uid,
+static void run_rank(int rank, int nranks, const mori::cco::ccoUniqueId& uid,
                      ThreadResult* result) {
   result->rank = rank;
   result->passed = false;
@@ -74,11 +73,9 @@ static void run_rank(int rank, int nranks, const mori::application::UniqueId& ui
 
   printf("[rank %d] GPU %d\n", rank, dev);
 
-  auto* bootNet = new mori::application::SocketBootstrapNetwork(uid, rank, nranks);
-
-  // Phase 1: CommCreate
+  // Phase 1: CommCreate (cco builds its own socket bootstrap from the uid)
   mori::cco::ccoComm* comm = nullptr;
-  int ret = mori::cco::ccoCommCreate(bootNet, PER_RANK_VMM_SIZE, &comm);
+  int ret = mori::cco::ccoCommCreate(uid, nranks, rank, PER_RANK_VMM_SIZE, &comm);
   if (ret != 0) {
     snprintf(result->detail, sizeof(result->detail), "CommCreate failed: %d", ret);
     return;
@@ -268,7 +265,11 @@ int main(int argc, char** argv) {
 
   printf("=== CCO Host API Test (%d ranks on %d GPUs) ===\n\n", nranks, numDevices);
 
-  auto uid = mori::application::SocketBootstrapNetwork::GenerateUniqueIdWithInterface("lo", 18456);
+  mori::cco::ccoUniqueId uid;
+  if (mori::cco::ccoGetUniqueId(&uid) != 0) {
+    printf("ccoGetUniqueId failed (set MORI_SOCKET_IFNAME=<iface>)\n");
+    return 1;
+  }
 
   std::vector<ThreadResult> results(nranks);
   std::vector<std::thread> threads;

--- a/tests/cpp/cco/test_lsa_allreduce.cpp
+++ b/tests/cpp/cco/test_lsa_allreduce.cpp
@@ -133,7 +133,7 @@ __global__ void lsa_allreduce_kernel(ccoDevComm devComm, ccoWindow_t sendWin, si
 // ===========================================================================
 // Host driver
 // ===========================================================================
-int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet) {
+int run_test(int rank, int nranks, const mori::cco::ccoUniqueId& uid) {
   g_rank = rank;
 
   // Bind each rank to its own GPU BEFORE ccoCommCreate (which calls
@@ -143,7 +143,7 @@ int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet)
   CCO_MUST(hipSetDevice(rank % hipDevCount) == hipSuccess);
 
   ccoComm* comm = nullptr;
-  if (ccoCommCreate(bootNet, /*perRankVmmSize=*/0, &comm) != 0) {
+  if (ccoCommCreate(uid, nranks, rank, /*perRankVmmSize=*/0, &comm) != 0) {
     std::fprintf(stderr, "[rank %d] CommCreate failed\n", rank);
     return 1;
   }

--- a/tests/cpp/cco/test_lsa_barrier.cpp
+++ b/tests/cpp/cco/test_lsa_barrier.cpp
@@ -610,7 +610,7 @@ static int run_all_tests(UtCtx& ctx) {
 // Host driver — setup, single call to run_all_tests, teardown.
 // ============================================================================
 
-int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet) {
+int run_test(int rank, int nranks, const mori::cco::ccoUniqueId& uid) {
   g_rank = rank;
 
   // Bind each rank to its own GPU BEFORE ccoCommCreate (which pins
@@ -621,7 +621,7 @@ int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet)
 
   // ── Phase 1: communicator ──
   ccoComm* comm = nullptr;
-  if (ccoCommCreate(bootNet, PER_RANK_VMM_SIZE, &comm) != 0) {
+  if (ccoCommCreate(uid, nranks, rank, PER_RANK_VMM_SIZE, &comm) != 0) {
     std::fprintf(stderr, "[rank %d] CommCreate failed\n", rank);
     return 1;
   }

--- a/tests/cpp/cco/test_lsa_memcheck.cpp
+++ b/tests/cpp/cco/test_lsa_memcheck.cpp
@@ -80,7 +80,7 @@ __global__ void lsa_barrier_kernel(ccoDevComm devComm) {
 }
 
 // ── main ───────────────────────────────────────────────────────────────────
-int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet) {
+int run_test(int rank, int nranks, const mori::cco::ccoUniqueId& uid) {
   g_rank = rank;
 
   int window_iters = 100;
@@ -100,7 +100,7 @@ int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet)
   CCO_MUST(hipSetDevice(rank % hipDevCount) == hipSuccess);
 
   mori::cco::ccoComm* comm = nullptr;
-  if (ccoCommCreate(bootNet, /*perRankVmmSize=*/0, &comm) != 0) {
+  if (ccoCommCreate(uid, nranks, rank, /*perRankVmmSize=*/0, &comm) != 0) {
     fprintf(stderr, "[rank %d] CommCreate failed\n", rank);
     return 1;
   }

--- a/tests/cpp/cco/test_multiprocess.cpp
+++ b/tests/cpp/cco/test_multiprocess.cpp
@@ -28,7 +28,6 @@
 #ifdef MORI_WITH_MPI
 #include <mpi.h>
 
-#include "mori/application/bootstrap/mpi_bootstrap.hpp"
 #endif
 
 #include <sys/wait.h>
@@ -39,9 +38,8 @@
 #include <vector>
 
 #include "hip/hip_runtime.h"
-#include "mori/application/application_device_types.hpp"  // white-box: RdmaEndpointDevice (count QPs)
-#include "mori/application/bootstrap/socket_bootstrap.hpp"
 #include "mori/cco/cco.hpp"
+#include "mori/core/transport/rdma/core_device_types.hpp"  // core::RdmaEndpointDevice (endpoint readback)
 
 static int g_rank = 0;
 
@@ -58,7 +56,7 @@ static int g_rank = 0;
 static const size_t PER_RANK_VMM_SIZE = 256ULL * 1024 * 1024;
 static const size_t WINDOW_SIZE = 4096 * 1024;
 
-static int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet) {
+static int run_test(int rank, int nranks, const mori::cco::ccoUniqueId& uid) {
   g_rank = rank;
 
   int numDevices = 0;
@@ -76,7 +74,7 @@ static int run_test(int rank, int nranks, mori::application::BootstrapNetwork* b
   printf("[rank %d/%d] pid=%d GPU=%d\n", rank, nranks, getpid(), dev);
 
   mori::cco::ccoComm* comm = nullptr;
-  if (mori::cco::ccoCommCreate(bootNet, PER_RANK_VMM_SIZE, &comm) != 0) {
+  if (mori::cco::ccoCommCreate(uid, nranks, rank, PER_RANK_VMM_SIZE, &comm) != 0) {
     fprintf(stderr, "[rank %d] CommCreate failed\n", rank);
     return 1;
   }
@@ -253,20 +251,23 @@ static int run_fork_mode(int nranks) {
   printf("=== CCO Multi-Process Test (fork, %d ranks) ===\n", nranks);
   fflush(stdout);
 
-  auto uid = mori::application::SocketBootstrapNetwork::GenerateUniqueIdWithInterface("lo", 19876);
+  mori::cco::ccoUniqueId uid;
+  if (mori::cco::ccoGetUniqueId(&uid) != 0) {
+    fprintf(stderr, "ccoGetUniqueId failed (set MORI_SOCKET_IFNAME=<iface>)\n");
+    return 1;
+  }
   write_file(uidPath, &uid, sizeof(uid));
 
   std::vector<pid_t> children;
   for (int r = 0; r < nranks; r++) {
     pid_t pid = fork();
     if (pid == 0) {
-      // Child: read uid, run test
-      mori::application::UniqueId childUid;
+      // Child: read uid, run test (cco builds its own socket bootstrap from it)
+      mori::cco::ccoUniqueId childUid;
       while (!read_file(uidPath, &childUid, sizeof(childUid))) {
         usleep(10000);
       }
-      auto* boot = new mori::application::SocketBootstrapNetwork(childUid, r, nranks);
-      _exit(run_test(r, nranks, boot));
+      _exit(run_test(r, nranks, childUid));
     }
     children.push_back(pid);
   }
@@ -304,7 +305,7 @@ static int run_single_rank_mode(int argc, char** argv) {
   }
   if (rank < 0 || worldSize <= 0 || !uidPath) return -1;
 
-  mori::application::UniqueId uid;
+  mori::cco::ccoUniqueId uid;
   for (int tries = 0; tries < 600; tries++) {
     FILE* f = fopen(uidPath, "rb");
     if (f) {
@@ -320,8 +321,7 @@ static int run_single_rank_mode(int argc, char** argv) {
   // 8..15 -> GPU 0..7 on node B). Otherwise fall back to rank % numDevices.
   if (gpuOffset >= 0) HIP_CHECK(hipSetDevice(rank - gpuOffset));
 
-  auto* boot = new mori::application::SocketBootstrapNetwork(uid, rank, worldSize);
-  return run_test(rank, worldSize, boot);
+  return run_test(rank, worldSize, uid);
 }
 
 // ── --gen-uid IFACE PORT OUTFILE ──
@@ -334,9 +334,15 @@ static int run_gen_uid_mode(int argc, char** argv) {
     return 1;
   }
   const char* iface = argv[2];
-  int port = atoi(argv[3]);
   const char* outPath = argv[4];
-  auto uid = mori::application::SocketBootstrapNetwork::GenerateUniqueIdWithInterface(iface, port);
+  // ccoGetUniqueId reads the interface from MORI_SOCKET_IFNAME and picks a free
+  // port itself; honour the iface arg by exporting it. (PORT arg is ignored.)
+  setenv("MORI_SOCKET_IFNAME", iface, /*overwrite=*/1);
+  mori::cco::ccoUniqueId uid;
+  if (mori::cco::ccoGetUniqueId(&uid) != 0) {
+    fprintf(stderr, "ccoGetUniqueId failed for iface=%s\n", iface);
+    return 1;
+  }
   FILE* f = fopen(outPath, "wb");
   if (!f) {
     fprintf(stderr, "fopen(%s) failed\n", outPath);
@@ -344,7 +350,7 @@ static int run_gen_uid_mode(int argc, char** argv) {
   }
   fwrite(&uid, 1, sizeof(uid), f);
   fclose(f);
-  printf("Wrote UID (%zu bytes) for iface=%s port=%d to %s\n", sizeof(uid), iface, port, outPath);
+  printf("Wrote UID (%zu bytes) for iface=%s to %s\n", sizeof(uid), iface, outPath);
   return 0;
 }
 
@@ -372,9 +378,18 @@ int main(int argc, char** argv) {
     MPI_Comm_size(MPI_COMM_WORLD, &nranks);
     if (rank == 0) printf("=== CCO Multi-Process Test (MPI, %d ranks) ===\n", nranks);
 
-    auto* boot = new mori::application::MpiBootstrapNetwork(MPI_COMM_WORLD);
-    int ret = run_test(rank, nranks, boot);
-    // MPI_Finalize is called by MpiBootstrapNetwork::Finalize() inside CommDestroy
+    // Rank 0 mints the cco unique id and broadcasts the POD to every rank; all
+    // ranks create the comm via the uniqueId API (cco's own socket bootstrap).
+    mori::cco::ccoUniqueId uid;
+    if (rank == 0) {
+      if (mori::cco::ccoGetUniqueId(&uid) != 0) {
+        fprintf(stderr, "ccoGetUniqueId failed (set MORI_SOCKET_IFNAME=<iface>)\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+      }
+    }
+    MPI_Bcast(&uid, sizeof(uid), MPI_BYTE, 0, MPI_COMM_WORLD);
+    int ret = run_test(rank, nranks, uid);
+    MPI_Finalize();
     return ret;
   }
 #endif


### PR DESCRIPTION
ccoCommCreate's public API is now ccoUniqueId-only; the application::BootstrapNetwork* overload is removed from cco.hpp and folded into an internal static ccoCommCreateImpl in cco_init.cpp, so the host API surface carries no application types.

Migrate the whole cco test suite + harness + benchmark off the bootstrap overload to the ccoUniqueId path (rank 0 ccoGetUniqueId + out-of-band broadcast). The harness obtains/distributes the id across all launch modes (fork / single-rank / gen-uid / MPI); the benchmark uses MPI_Bcast. The two host-only DevComm tests include core_device_types.hpp directly for core::RdmaEndpointDevice endpoint readback.
