### PR TITLE
(bugfix) mori bug on RoCM714

### DIFF
--- a/src/application/CMakeLists.txt
+++ b/src/application/CMakeLists.txt
@@ -9,6 +9,29 @@ if(WITH_MPI)
   endif()
 endif()
 find_package(hsa-runtime64 REQUIRED)
+
+# ROCm 7.14's hsakmt cmake config declares a link dependency on the imported
+# target `numa::numa` but never provides it (no FindNUMA / find_package(NUMA)).
+# Without it, find_package(hsakmt) fails at generate time: "The link interface
+# of target hsakmt::hsakmt contains: numa::numa but the target was not found."
+# Define it ourselves from the system libnuma before pulling in hsakmt.
+if(NOT TARGET numa::numa)
+  find_library(NUMA_LIBRARY NAMES numa)
+  find_path(NUMA_INCLUDE_DIR NAMES numa.h)
+  if(NUMA_LIBRARY)
+    add_library(numa::numa UNKNOWN IMPORTED)
+    set_target_properties(numa::numa PROPERTIES IMPORTED_LOCATION
+                                                "${NUMA_LIBRARY}")
+    if(NUMA_INCLUDE_DIR)
+      set_target_properties(numa::numa PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                                  "${NUMA_INCLUDE_DIR}")
+    endif()
+  else()
+    message(FATAL_ERROR "libnuma not found but required by hsakmt::hsakmt. "
+                        "Install it (e.g. 'apt install libnuma-dev').")
+  endif()
+endif()
+
 find_package(hsakmt REQUIRED)
 # find_library(IONIC_LIBRARY NAMES ionic HINTS /lib/x86_64-linux-gnu REQUIRED )
 

--- a/src/application/CMakeLists.txt
+++ b/src/application/CMakeLists.txt
@@ -83,17 +83,9 @@ add_library(mori_application SHARED ${MORI_APP_SOURCES})
 
 target_include_directories(mori_application PUBLIC ${CMAKE_SOURCE_DIR}/include)
 target_include_directories(mori_application PUBLIC ${CMAKE_SOURCE_DIR})
-find_library(ROCM_SMI_LIB rocm_smi64 HINTS /opt/rocm/lib REQUIRED)
 find_library(HSA_RUNTIME_LIB hsa-runtime64 HINTS /opt/rocm/lib REQUIRED)
-target_link_libraries(
-  mori_application
-  PUBLIC hip::host
-         dl
-         ${ROCM_SMI_LIB}
-         pci
-         mori_logging
-         ${HSA_RUNTIME_LIB}
-         hsakmt::hsakmt)
+target_link_libraries(mori_application PUBLIC hip::host dl pci mori_logging
+                                              ${HSA_RUNTIME_LIB} hsakmt::hsakmt)
 # Embed the libibverbs dlopen shim (object library, hidden visibility).
 target_link_libraries(mori_application PRIVATE mori_ibv_shim)
 

--- a/src/application/topology/gpu.cpp
+++ b/src/application/topology/gpu.cpp
@@ -117,6 +117,7 @@ void TopoSystemGpu::Load() {
     uint64_t rsmiBusId = 0;
     ROCM_SMI_CHECK(rsmi_dev_pci_id_get(i, &rsmiBusId));
     gpu->busId = RsmiBusId2PciBusId(rsmiBusId);
+    // ROCM_SMI_CHECK(rsmi_topo_numa_affinity_get(reinterpret_cast<uint32_t>(i), &gpu->numaNode));
   }
 
   for (uint32_t i = 0; i < numGpus; ++i) {

--- a/src/application/topology/gpu.cpp
+++ b/src/application/topology/gpu.cpp
@@ -21,14 +21,60 @@
 // SOFTWARE.
 #include "mori/application/topology/gpu.hpp"
 
+#include <dlfcn.h>
+
 #include <cstdio>
-#include <cstring>
-#include <string>
+#include <cstdlib>
 
 #include "mori/application/utils/check.hpp"
 
 namespace mori {
 namespace application {
+
+// rocm-smi is loaded via a private dlopen(RTLD_LOCAL) instead of being linked.
+//
+// On the ROCm 7.14 docker we observed that the rsmi_* symbols resolve to two
+// different shared objects in the same process: some calls (e.g. rsmi_init,
+// rsmi_is_P2P_accessible) bind to libamd_smi.so (amdsmi), while the rest bind to
+// librocm_smi64. The two libraries keep separate singletons, so init lands on
+// one and num_monitor_devices on the other -> RSMI_STATUS_INIT_ERROR. This does
+// not happen on ROCm 7.2, so we pin the so ourselves: load librocm_smi64 with
+// RTLD_LOCAL and resolve every rsmi_* symbol from that one handle. Keeping it out
+// of the global scope means all calls hit the same instance.
+//
+// Doing it lazily (after torch has initialized HIP) also lets its NEEDED
+// libamdhip64 resolve to the already-loaded copy instead of pulling in a second
+// HIP runtime, which an LD_PRELOAD of librocm_smi64 would do (causing
+// hipErrorInvalidImage).
+namespace {
+
+void* OpenRocmSmi() {
+  const char* candidates[] = {std::getenv("MORI_ROCM_SMI_PATH"), "librocm_smi64.so.1",
+                              "librocm_smi64.so", "/opt/rocm/lib/librocm_smi64.so.1"};
+  for (const char* path : candidates) {
+    if (path && path[0]) {
+      if (void* h = dlopen(path, RTLD_NOW | RTLD_LOCAL)) return h;
+    }
+  }
+  fprintf(stderr, "[ROCm-SMI] dlopen(librocm_smi64) failed: %s\n", dlerror());
+  exit(-1);
+}
+
+template <typename Fn>
+Fn Sym(void* handle, const char* name) {
+  void* sym = dlsym(handle, name);
+  if (!sym) {
+    fprintf(stderr, "[ROCm-SMI] missing symbol %s\n", name);
+    exit(-1);
+  }
+  return reinterpret_cast<Fn>(sym);
+}
+
+// Declare a local function pointer `name` resolved from `lib`, reusing the exact
+// signature declared in rocm_smi.h so callers below read like normal rsmi calls.
+#define RSMI_FN(lib, name) auto name = Sym<decltype(&::name)>(lib, #name)
+
+}  // namespace
 
 /* ---------------------------------------------------------------------------------------------- */
 /*                                          TopoSystemGpu                                         */
@@ -37,25 +83,72 @@ TopoSystemGpu::TopoSystemGpu() { Load(); }
 
 TopoSystemGpu::~TopoSystemGpu() {}
 
+PciBusId RsmiBusId2PciBusId(uint64_t rsmiBusId) {
+  uint16_t domain = (rsmiBusId >> 32);
+  uint8_t bus = (rsmiBusId >> 8);
+  uint8_t dev = (rsmiBusId >> 3) & 0x1f;
+  uint8_t func = rsmiBusId & 0x7;
+  return PciBusId(domain, bus, dev, func);
+}
+
 void TopoSystemGpu::Load() {
-  // GPU topology is sourced purely from the HIP runtime (hipDeviceGetPCIBusId).
-  //
-  // We intentionally do NOT use rocm-smi (rsmi_*) here: its rsmi_init() races
-  // across processes (multiple ranks contending on the per-device shared-memory
-  // mutexes under /dev/shm/rocm_smi_*), which returned RSMI_STATUS_INIT_ERROR
-  // and killed ranks. The only extra information rocm-smi provided over HIP was
-  // the GPU<->GPU P2P link graph (type/hops/weight), which is currently unused
-  // anywhere in the codebase. HIP gives us each GPU's PCI bus id, which is all
-  // the NIC-matching logic (TopoSystem::CollectAndSortCandidates) needs.
-  int hipDevCount = 0;
-  HIP_RUNTIME_CHECK(hipGetDeviceCount(&hipDevCount));
-  for (int i = 0; i < hipDevCount; ++i) {
-    char buf[16] = {};
-    HIP_RUNTIME_CHECK(hipDeviceGetPCIBusId(buf, sizeof(buf), i));
+  void* lib = OpenRocmSmi();
+  RSMI_FN(lib, rsmi_init);
+  RSMI_FN(lib, rsmi_num_monitor_devices);
+  RSMI_FN(lib, rsmi_dev_pci_id_get);
+  RSMI_FN(lib, rsmi_is_P2P_accessible);
+  RSMI_FN(lib, rsmi_topo_get_link_type);
+  RSMI_FN(lib, rsmi_topo_get_link_weight);
+  RSMI_FN(lib, rsmi_shut_down);
+  RSMI_FN(lib, rsmi_status_string);
+
+#define RSMI_CHECK(stmt)                                                       \
+  do {                                                                         \
+    rsmi_status_t _r = (stmt);                                                 \
+    if (_r != RSMI_STATUS_SUCCESS) {                                           \
+      const char* _msg = nullptr;                                              \
+      rsmi_status_string(_r, &_msg);                                           \
+      fprintf(stderr, "[ROCm-SMI] %s failed: %s\n", #stmt, _msg ? _msg : "?"); \
+      exit(-1);                                                                \
+    }                                                                          \
+  } while (0)
+
+  uint32_t numGpus = 0;
+  RSMI_CHECK(rsmi_init(0));
+  RSMI_CHECK(rsmi_num_monitor_devices(&numGpus));
+
+  assert(numGpus > 0);
+
+  for (uint32_t i = 0; i < numGpus; ++i) {
     TopoNodeGpu* gpu = new TopoNodeGpu();
-    gpu->busId = PciBusId(std::string(buf));
     gpus.emplace_back(gpu);
+    uint64_t rsmiBusId = 0;
+    RSMI_CHECK(rsmi_dev_pci_id_get(i, &rsmiBusId));
+    gpu->busId = RsmiBusId2PciBusId(rsmiBusId);
   }
+
+  for (uint32_t i = 0; i < numGpus; ++i) {
+    for (uint32_t j = i; j < numGpus; ++j) {
+      if (i == j) continue;
+      bool accessible = false;
+      RSMI_CHECK(rsmi_is_P2P_accessible(i, j, &accessible));
+      if (!accessible) continue;
+
+      TopoNodeGpuP2pLink* p2p = new TopoNodeGpuP2pLink();
+      RSMI_CHECK(rsmi_topo_get_link_type(i, j, &p2p->hops, &p2p->type));
+      RSMI_CHECK(rsmi_topo_get_link_weight(i, j, &p2p->weight));
+      p2p->gpu1 = gpus[i].get();
+      p2p->gpu2 = gpus[j].get();
+      p2ps.emplace_back(p2p);
+
+      gpus[i]->p2ps.push_back(p2p);
+      gpus[j]->p2ps.push_back(p2p);
+    }
+  }
+
+  RSMI_CHECK(rsmi_shut_down());
+#undef RSMI_CHECK
+  dlclose(lib);
 }
 
 std::vector<TopoNodeGpu*> TopoSystemGpu::GetGpus() const {

--- a/src/application/topology/gpu.cpp
+++ b/src/application/topology/gpu.cpp
@@ -22,6 +22,8 @@
 #include "mori/application/topology/gpu.hpp"
 
 #include <cstdio>
+#include <cstring>
+#include <string>
 
 #include "mori/application/utils/check.hpp"
 
@@ -35,49 +37,25 @@ TopoSystemGpu::TopoSystemGpu() { Load(); }
 
 TopoSystemGpu::~TopoSystemGpu() {}
 
-PciBusId RsmiBusId2PciBusId(uint64_t rsmiBusId) {
-  uint16_t domain = (rsmiBusId >> 32);
-  uint8_t bus = (rsmiBusId >> 8);
-  uint8_t dev = (rsmiBusId >> 3) & 0x1f;
-  uint8_t func = rsmiBusId & 0x7;
-  return PciBusId(domain, bus, dev, func);
-}
-
 void TopoSystemGpu::Load() {
-  uint32_t numGpus;
-
-  ROCM_SMI_CHECK(rsmi_init(0));
-  ROCM_SMI_CHECK(rsmi_num_monitor_devices(&numGpus));
-
-  for (uint32_t i = 0; i < numGpus; ++i) {
+  // GPU topology is sourced purely from the HIP runtime (hipDeviceGetPCIBusId).
+  //
+  // We intentionally do NOT use rocm-smi (rsmi_*) here: its rsmi_init() races
+  // across processes (multiple ranks contending on the per-device shared-memory
+  // mutexes under /dev/shm/rocm_smi_*), which returned RSMI_STATUS_INIT_ERROR
+  // and killed ranks. The only extra information rocm-smi provided over HIP was
+  // the GPU<->GPU P2P link graph (type/hops/weight), which is currently unused
+  // anywhere in the codebase. HIP gives us each GPU's PCI bus id, which is all
+  // the NIC-matching logic (TopoSystem::CollectAndSortCandidates) needs.
+  int hipDevCount = 0;
+  HIP_RUNTIME_CHECK(hipGetDeviceCount(&hipDevCount));
+  for (int i = 0; i < hipDevCount; ++i) {
+    char buf[16] = {};
+    HIP_RUNTIME_CHECK(hipDeviceGetPCIBusId(buf, sizeof(buf), i));
     TopoNodeGpu* gpu = new TopoNodeGpu();
+    gpu->busId = PciBusId(std::string(buf));
     gpus.emplace_back(gpu);
-    uint64_t rsmiBusId = 0;
-    ROCM_SMI_CHECK(rsmi_dev_pci_id_get(i, &rsmiBusId));
-    gpu->busId = RsmiBusId2PciBusId(rsmiBusId);
-    // ROCM_SMI_CHECK(rsmi_topo_numa_affinity_get(reinterpret_cast<uint32_t>(i), &gpu->numaNode));
   }
-
-  for (uint32_t i = 0; i < numGpus; ++i) {
-    for (uint32_t j = i; j < numGpus; ++j) {
-      if (i == j) continue;
-      bool accessible = false;
-      ROCM_SMI_CHECK(rsmi_is_P2P_accessible(i, j, &accessible));
-      if (!accessible) continue;
-
-      TopoNodeGpuP2pLink* p2p = new TopoNodeGpuP2pLink();
-      ROCM_SMI_CHECK(rsmi_topo_get_link_type(i, j, &p2p->hops, &p2p->type));
-      ROCM_SMI_CHECK(rsmi_topo_get_link_weight(i, j, &p2p->weight));
-      p2p->gpu1 = gpus[i].get();
-      p2p->gpu2 = gpus[j].get();
-      p2ps.emplace_back(p2p);
-
-      gpus[i]->p2ps.push_back(p2p);
-      gpus[j]->p2ps.push_back(p2p);
-    }
-  }
-
-  ROCM_SMI_CHECK(rsmi_shut_down());
 }
 
 std::vector<TopoNodeGpu*> TopoSystemGpu::GetGpus() const {
@@ -87,10 +65,9 @@ std::vector<TopoNodeGpu*> TopoSystemGpu::GetGpus() const {
 }
 
 TopoNodeGpu* TopoSystemGpu::GetGpuByLogicalId(int id) const {
-  std::string str;
-  str.resize(13);
-  HIP_RUNTIME_CHECK(hipDeviceGetPCIBusId(str.data(), str.size(), id));
-  PciBusId target{str};
+  char buf[16] = {};
+  HIP_RUNTIME_CHECK(hipDeviceGetPCIBusId(buf, sizeof(buf), id));
+  PciBusId target{std::string(buf)};
   for (auto& gpuPtr : gpus) {
     TopoNodeGpu* gpu = gpuPtr.get();
     if (gpu->busId == target) return gpu;

--- a/src/application/topology/gpu.cpp
+++ b/src/application/topology/gpu.cpp
@@ -102,20 +102,9 @@ void TopoSystemGpu::Load() {
   RSMI_FN(lib, rsmi_shut_down);
   RSMI_FN(lib, rsmi_status_string);
 
-#define RSMI_CHECK(stmt)                                                       \
-  do {                                                                         \
-    rsmi_status_t _r = (stmt);                                                 \
-    if (_r != RSMI_STATUS_SUCCESS) {                                           \
-      const char* _msg = nullptr;                                              \
-      rsmi_status_string(_r, &_msg);                                           \
-      fprintf(stderr, "[ROCm-SMI] %s failed: %s\n", #stmt, _msg ? _msg : "?"); \
-      exit(-1);                                                                \
-    }                                                                          \
-  } while (0)
-
   uint32_t numGpus = 0;
-  RSMI_CHECK(rsmi_init(0));
-  RSMI_CHECK(rsmi_num_monitor_devices(&numGpus));
+  ROCM_SMI_CHECK(rsmi_init(0));
+  ROCM_SMI_CHECK(rsmi_num_monitor_devices(&numGpus));
 
   if (numGpus == 0) {
     fprintf(stderr, "[ROCm-SMI] rsmi_num_monitor_devices reported 0 GPUs\n");
@@ -126,7 +115,7 @@ void TopoSystemGpu::Load() {
     TopoNodeGpu* gpu = new TopoNodeGpu();
     gpus.emplace_back(gpu);
     uint64_t rsmiBusId = 0;
-    RSMI_CHECK(rsmi_dev_pci_id_get(i, &rsmiBusId));
+    ROCM_SMI_CHECK(rsmi_dev_pci_id_get(i, &rsmiBusId));
     gpu->busId = RsmiBusId2PciBusId(rsmiBusId);
   }
 
@@ -134,12 +123,12 @@ void TopoSystemGpu::Load() {
     for (uint32_t j = i; j < numGpus; ++j) {
       if (i == j) continue;
       bool accessible = false;
-      RSMI_CHECK(rsmi_is_P2P_accessible(i, j, &accessible));
+      ROCM_SMI_CHECK(rsmi_is_P2P_accessible(i, j, &accessible));
       if (!accessible) continue;
 
       TopoNodeGpuP2pLink* p2p = new TopoNodeGpuP2pLink();
-      RSMI_CHECK(rsmi_topo_get_link_type(i, j, &p2p->hops, &p2p->type));
-      RSMI_CHECK(rsmi_topo_get_link_weight(i, j, &p2p->weight));
+      ROCM_SMI_CHECK(rsmi_topo_get_link_type(i, j, &p2p->hops, &p2p->type));
+      ROCM_SMI_CHECK(rsmi_topo_get_link_weight(i, j, &p2p->weight));
       p2p->gpu1 = gpus[i].get();
       p2p->gpu2 = gpus[j].get();
       p2ps.emplace_back(p2p);
@@ -149,8 +138,7 @@ void TopoSystemGpu::Load() {
     }
   }
 
-  RSMI_CHECK(rsmi_shut_down());
-#undef RSMI_CHECK
+  ROCM_SMI_CHECK(rsmi_shut_down());
   dlclose(lib);
 }
 

--- a/src/application/topology/gpu.cpp
+++ b/src/application/topology/gpu.cpp
@@ -149,9 +149,10 @@ std::vector<TopoNodeGpu*> TopoSystemGpu::GetGpus() const {
 }
 
 TopoNodeGpu* TopoSystemGpu::GetGpuByLogicalId(int id) const {
-  char buf[16] = {};
-  HIP_RUNTIME_CHECK(hipDeviceGetPCIBusId(buf, sizeof(buf), id));
-  PciBusId target{std::string(buf)};
+  std::string str;
+  str.resize(13);
+  HIP_RUNTIME_CHECK(hipDeviceGetPCIBusId(str.data(), str.size(), id));
+  PciBusId target{str};
   for (auto& gpuPtr : gpus) {
     TopoNodeGpu* gpu = gpuPtr.get();
     if (gpu->busId == target) return gpu;

--- a/src/application/topology/gpu.cpp
+++ b/src/application/topology/gpu.cpp
@@ -117,7 +117,10 @@ void TopoSystemGpu::Load() {
   RSMI_CHECK(rsmi_init(0));
   RSMI_CHECK(rsmi_num_monitor_devices(&numGpus));
 
-  assert(numGpus > 0);
+  if (numGpus == 0) {
+    fprintf(stderr, "[ROCm-SMI] rsmi_num_monitor_devices reported 0 GPUs\n");
+    exit(-1);
+  }
 
   for (uint32_t i = 0; i < numGpus; ++i) {
     TopoNodeGpu* gpu = new TopoNodeGpu();


### PR DESCRIPTION
# Fix MORI build + multi-process topology crash on ROCm 7.14

## Summary
Two fixes that let MORI build and run on ROCm 7.14 (no regression on 7.2).

## 1. CMake: missing `numa::numa` target
ROCm 7.14's `hsakmt-config.cmake` declares that `hsakmt::hsakmt` links `numa::numa`, but ships no `find_package`/finder to define it, so configuration aborts:

> The link interface of target "hsakmt::hsakmt" contains: numa::numa but the target was not found.

**Fix:** define a `numa::numa` IMPORTED target from the system `libnuma` before `find_package(hsakmt)`.

## 2. Runtime: `rsmi_init()` crash under multi-process (rsmi symbol split-brain)
On the **ROCm 7.14** docker, the `rsmi_*` symbols resolve to **two different shared objects in the same process**: some calls (e.g. `rsmi_init`, `rsmi_is_P2P_accessible`) bind to `libamd_smi.so` (amdsmi), while the rest (`rsmi_num_monitor_devices`, `rsmi_dev_pci_id_get`, …) bind to `librocm_smi64`. amdsmi sits in the global symbol scope and interposes the subset of the rsmi ABI it re-exports.

The two libraries keep **separate global singletons**, so `rsmi_init()` initializes one while `rsmi_num_monitor_devices()` queries the other (uninitialized) → `RSMI_STATUS_INIT_ERROR`, and the check's `exit(-1)` kills every rank. This does **not** happen on ROCm 7.2, where all symbols resolve to a single library.

**Fix:** pin the library ourselves. `TopoSystemGpu::Load()` now `dlopen`s `librocm_smi64` with `RTLD_NOW | RTLD_LOCAL` and resolves **every** `rsmi_*` symbol from that one handle, so all calls hit the same instance and amdsmi can no longer interpose. The link-time dependency on `librocm_smi64` is removed from CMake, which also means the library is loaded **lazily, after torch has initialized HIP** — its `NEEDED libamdhip64` then resolves to the already-loaded copy by SONAME instead of pulling in a second HIP runtime.

An optional `MORI_ROCM_SMI_PATH` env var overrides the library path.

## Test plan
- `pip install . --no-build-isolation` builds on ROCm 7.14.
- 8-rank `test_dispatch_combine_internode.py --cmd stress` completes 5000/5000 dispatch + combine with no `RSMI_STATUS_INIT_ERROR` (no `LD_PRELOAD` needed).
- No regression on ROCm 7.2.