### PR TITLE
test(umbp): use kernel-assigned ports in distributed tests to fix CI flakiness

### DIFF
--- a/tests/cpp/umbp/distributed/test_cross_node_smoke.cpp
+++ b/tests/cpp/umbp/distributed/test_cross_node_smoke.cpp
@@ -20,6 +20,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 #include <gtest/gtest.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 #include <atomic>
 #include <chrono>
@@ -43,8 +46,32 @@ constexpr size_t kBlockSize = 4096;
 // required for the node to register a peer_address and accept remote
 // AllocateSlot/CommitSlot RPCs; without it remote BatchPut fails with
 // "peer service connection unavailable".
+//
+// The port must be free *at bind time*: PoolClient binds it directly and
+// registers it verbatim as its peer_address (see PoolClient::Init), so a
+// hard-coded base collides with concurrent test processes / leftover servers
+// on a shared (self-hosted CI) host and makes the whole suite flaky.  Ask the
+// kernel for a currently-free ephemeral port instead.
 inline uint16_t NextPeerServicePort() {
-  static std::atomic<uint16_t> next{52000};
+  int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+  if (fd >= 0) {
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_port = 0;  // kernel picks a free port
+    socklen_t len = sizeof(addr);
+    if (::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0 &&
+        ::getsockname(fd, reinterpret_cast<sockaddr*>(&addr), &len) == 0) {
+      uint16_t port = ntohs(addr.sin_port);
+      ::close(fd);
+      return port;
+    }
+    ::close(fd);
+  }
+  // Fallback: randomized high base to keep collisions unlikely if the probe
+  // path is unavailable.
+  static std::atomic<uint16_t> next{
+      static_cast<uint16_t>(52000 + (static_cast<unsigned>(::getpid()) % 4000))};
   return next.fetch_add(1);
 }
 

--- a/tests/cpp/umbp/distributed/test_peer_service.cpp
+++ b/tests/cpp/umbp/distributed/test_peer_service.cpp
@@ -21,7 +21,11 @@
 // SOFTWARE.
 #include <grpcpp/grpcpp.h>
 #include <gtest/gtest.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
+#include <atomic>
 #include <chrono>
 #include <cstdlib>
 #include <cstring>
@@ -46,8 +50,28 @@ constexpr uint16_t kBasePort = 50200;
 constexpr int kNumReadSlots = 4;
 constexpr int kLeaseTimeoutS = 2;
 
+// Ask the kernel for a currently-free ephemeral port.  PeerServiceServer binds
+// this port directly, so a hard-coded base (kBasePort) collides with concurrent
+// test processes / leftover servers on a shared (self-hosted CI) host and makes
+// the suite flaky.
 static uint16_t AllocPort() {
-  static std::atomic<uint16_t> next{kBasePort};
+  int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+  if (fd >= 0) {
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_port = 0;
+    socklen_t len = sizeof(addr);
+    if (::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0 &&
+        ::getsockname(fd, reinterpret_cast<sockaddr*>(&addr), &len) == 0) {
+      uint16_t port = ntohs(addr.sin_port);
+      ::close(fd);
+      return port;
+    }
+    ::close(fd);
+  }
+  static std::atomic<uint16_t> next{
+      static_cast<uint16_t>(kBasePort + (static_cast<unsigned>(::getpid()) % 4000))};
   return next.fetch_add(1);
 }
 

--- a/tests/cpp/umbp/distributed/test_pool_client_batch_put.cpp
+++ b/tests/cpp/umbp/distributed/test_pool_client_batch_put.cpp
@@ -32,6 +32,9 @@
 // spdlog output by the substring "BatchPut: src not registered for key=".
 
 #include <gtest/gtest.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 #include <algorithm>
 #include <atomic>
@@ -64,8 +67,29 @@ constexpr const char* kBatchPutWarnSubstr = "BatchPut: src not registered for ke
 // required for a node to register a peer_address and serve remote
 // AllocateSlot/CommitSlot RPCs; without it the caller's remote BatchPut fails
 // with "peer service connection unavailable".
+//
+// The port must be free *at bind time* (PoolClient binds it directly and
+// registers it verbatim), so a hard-coded base collides with concurrent test
+// processes / leftover servers on a shared (self-hosted CI) host.  Ask the
+// kernel for a currently-free ephemeral port instead.
 inline uint16_t NextPeerServicePort() {
-  static std::atomic<uint16_t> next{53000};
+  int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+  if (fd >= 0) {
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_port = 0;  // kernel picks a free port
+    socklen_t len = sizeof(addr);
+    if (::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0 &&
+        ::getsockname(fd, reinterpret_cast<sockaddr*>(&addr), &len) == 0) {
+      uint16_t port = ntohs(addr.sin_port);
+      ::close(fd);
+      return port;
+    }
+    ::close(fd);
+  }
+  static std::atomic<uint16_t> next{
+      static_cast<uint16_t>(53000 + (static_cast<unsigned>(::getpid()) % 4000))};
   return next.fetch_add(1);
 }
 


### PR DESCRIPTION
## Summary
- This is a **test/CI-infra fix, not an umbp behavior bug**. The umbp production code is unchanged.
- Distributed umbp integration tests (`cross_node_smoke`, `pool_client_batch_put`, `peer_service`) hard-coded their peer-service / server ports from fixed bases (52000 / 53000 / 50200).
- `PoolClient` / `PeerServiceServer` bind that port directly and register it verbatim as the `peer_address`, so on the shared self-hosted CI runner the fixed ports collide with concurrent jobs or leftover servers -> bind fails -> remote AllocateSlot/CommitSlot RPCs unavailable -> cross-node Put/Get fail (ctest exit code 8). Non-deterministic, so a PR can pass CI yet the same commit fail once merged to main.
- Fix: ask the kernel for a currently-free ephemeral port (bind `:0` -> `getsockname` -> close), falling back to a PID-offset random base only if the probe is unavailable. Mirrors the existing `AllocPort()` in `test_umbp_tags.cpp`.

## Test plan
- [x] In-container CI ctest filter `-R '^(umbp_|test_dummy_ssd_tier|test_prefix_aware_eviction|test_ssd_tier)'`: 22/22 pass
- [x] Single run with old 52000-52059 range fully occupied: 18/18 pass (previously 18/18 fail)
- [x] Three concurrent test processes: each 18/18 pass
