### PR TITLE
(bugfix) fix tool bug when tested in ROCm 714 docker

### DIFF
--- a/.claude/skills/deploy-mori/SKILL.md
+++ b/.claude/skills/deploy-mori/SKILL.md
@@ -96,7 +96,7 @@ All subsequent steps run **inside** `$CONTAINER_NAME` via `docker exec`.
 
 ```bash
 sudo docker exec $CONTAINER_NAME bash -c "apt-get update && apt-get install -y --no-install-recommends \
-    git libpci-dev libdw1 libibverbs-dev ibverbs-utils \
+    git libpci-dev pciutils sudo libdw1 libibverbs-dev ibverbs-utils \
     locales iputils-ping iproute2 ethtool jq perftest \
     wget unzip ca-certificates curl \
     libgrpc++-dev protobuf-compiler-grpc libprotobuf-dev protobuf-compiler \
@@ -105,6 +105,11 @@ sudo docker exec $CONTAINER_NAME bash -c "apt-get update && apt-get install -y -
 
 Package roles:
 - `jq` — required by `mori check`.
+- `pciutils` — provides `lspci`, which `nicctl` shells out to in order to enumerate
+  the NIC cards. Without it `nicctl` fails with `Invalid card handle` and the ionic
+  firmware / QoS / DCQCN checks in `mori check` / `mori setup` break.
+- `sudo` — the ionic and bnxt paths of `mori check` / `mori setup` invoke `nicctl`,
+  `dcb`, `ethtool`, and sysfs writes via `sudo`.
 - `perftest` — provides `ib_write_bw` / `ib_write_lat` for intra/inter-node bandwidth + latency checks.
 - `iproute2` — provides `dcb`, required by `mori setup` on bnxt NICs.
 - `wget unzip ca-certificates curl` — used by the NIC userspace install steps (Step 3a/3b).

--- a/tools/env_check.sh
+++ b/tools/env_check.sh
@@ -865,23 +865,45 @@ check_inter_node_lat() {
 LOCAL_DEVS=()
 
 # detect NIC vendor and run the matching checks
+# Detect NICs by PCI vendor id, not by IB device name: ionic cards may show up as
+# ionic_*, roceensp*, etc., so name matching is not reliable. The vendor id under
+# /sys/class/infiniband/<dev>/device/vendor is stable.
+_ib_has_vendor() {
+    local vid="$1" d
+    [[ -d /sys/class/infiniband ]] || return 1
+    for d in /sys/class/infiniband/*; do
+        [[ -e "$d/device/vendor" ]] || continue
+        [[ "$(cat "$d/device/vendor" 2>/dev/null)" == "$vid" ]] && return 0
+    done
+    return 1
+}
+
 _have_ionic=false
-if command -v nicctl >/dev/null 2>&1; then
-    _nicctl_out=$(nicctl show version firmware 2>&1 || true)
-    echo "$_nicctl_out" | grep -qi "No AMD NICs" || _have_ionic=true
+_ib_has_vendor 0x1dd8 && _have_ionic=true   # AMD/Pensando (ionic)
+
+# The ionic firmware/QoS/DCQCN checks all shell out to `sudo nicctl`. Probe that
+# nicctl is installed AND can actually enumerate the cards; otherwise skip those
+# checks gracefully instead of spewing "Invalid card handle" errors.
+_nicctl_ok=false
+if [[ "$_have_ionic" == "true" ]] && command -v nicctl >/dev/null 2>&1; then
+    _nicctl_out=$(sudo nicctl show version firmware 2>&1 || true)
+    if ! echo "$_nicctl_out" | grep -qiE 'No AMD NICs|Invalid card handle|Failed to get NIC'; then
+        _nicctl_ok=true
+    fi
     unset _nicctl_out
 fi
 
 _have_bnxt=false
-if [[ -d /sys/class/infiniband ]] && \
-   find /sys/class/infiniband -maxdepth 1 -name 'bnxt_re*' 2>/dev/null | grep -q .; then
-    _have_bnxt=true
-fi
+_ib_has_vendor 0x14e4 && _have_bnxt=true     # Broadcom (bnxt_re)
 
 if [[ "$_have_ionic" == "true" ]]; then
-    check_versions
-    check_qos
-    check_dcqcn
+    if [[ "$_nicctl_ok" == "true" ]]; then
+        check_versions
+        check_qos
+        check_dcqcn
+    else
+        log_warn "ionic NICs present but nicctl is unavailable or cannot access them — skipping nicctl-based checks (firmware / QoS / DCQCN)"
+    fi
 elif [[ "$_have_bnxt" == "true" ]]; then
     check_bnxt_versions
     check_bnxt_qos


### PR DESCRIPTION
# Make `mori check` robust to NIC naming and missing tooling

Detect RDMA NICs by PCI vendor id (`0x1dd8` ionic, `0x14e4` bnxt) instead of IB device names, which are unreliable — ionic cards may appear as `ionic_*`, `roceensp*`, etc. Added a `nicctl` availability probe: when `nicctl` is absent or cannot enumerate the cards, the ionic firmware/QoS/DCQCN checks are skipped gracefully with a warning instead of spewing `Invalid card handle` errors, while the bandwidth checks still run. Also added `pciutils` (provides `lspci`, required by `nicctl`) and `sudo` to the `deploy-mori` skill's base package install, since their absence was the root cause of the failures.