### PR TITLE
Feature: add umbp benchmark / distributed mode flush API / hot-path optimization

### DIFF
--- a/src/umbp/distributed/distributed_client.cpp
+++ b/src/umbp/distributed/distributed_client.cpp
@@ -256,7 +256,7 @@ bool DistributedClient::Clear() {
 }
 
 bool DistributedClient::Flush() {
-  MORI_UMBP_DEBUG("[DistributedClient] Flush() — no-op");
+  if (pool_client_) pool_client_->Master().FlushHeartbeat();
   return true;
 }
 

--- a/src/umbp/distributed/distributed_client.cpp
+++ b/src/umbp/distributed/distributed_client.cpp
@@ -256,7 +256,10 @@ bool DistributedClient::Clear() {
 }
 
 bool DistributedClient::Flush() {
-  if (pool_client_) pool_client_->Master().FlushHeartbeat();
+  if (closing_) return true;
+  std::shared_lock lk(op_mutex_);
+  if (closed_ || !pool_client_) return true;
+  pool_client_->Master().FlushHeartbeat();
   return true;
 }
 

--- a/src/umbp/distributed/master/global_block_index.cpp
+++ b/src/umbp/distributed/master/global_block_index.cpp
@@ -238,17 +238,31 @@ std::vector<std::vector<Location>> GlobalBlockIndex::BatchLookupForRouteGet(
   std::vector<std::vector<Location>> out(keys.size());
   if (keys.empty()) return out;
   std::shared_lock lock(mutex_);
+  const bool has_exclude = !exclude_nodes.empty();
+  // Read the clock once for the whole batch: the per-hit access/lease bump
+  // would otherwise call steady_clock::now() twice per key. All keys in a
+  // batch are stamped within the same ~ms, which is well within lease/LRU
+  // granularity.
+  const auto now = std::chrono::steady_clock::now();
   for (size_t i = 0; i < keys.size(); ++i) {
     auto it = entries_.find(keys[i]);
     if (it == entries_.end()) continue;
+    const auto& src = it->second.locations;
     auto& locs = out[i];
-    for (const auto& loc : it->second.locations) {
-      if (!exclude_nodes.empty() && exclude_nodes.count(loc.node_id)) continue;
-      locs.push_back(loc);
+    if (!has_exclude) {
+      // Common case: copy the whole location vector in one allocation
+      // (no per-element vector growth).
+      locs = src;
+    } else {
+      locs.reserve(src.size());
+      for (const auto& loc : src) {
+        if (exclude_nodes.count(loc.node_id)) continue;
+        locs.push_back(loc);
+      }
     }
     if (locs.empty()) continue;
-    it->second.RecordAccessAtomic();
-    it->second.GrantLease(lease_duration);
+    it->second.RecordAccessAtomic(now);
+    it->second.GrantLease(now, lease_duration);
   }
   return out;
 }

--- a/src/umbp/distributed/master/master_client.cpp
+++ b/src/umbp/distributed/master/master_client.cpp
@@ -447,14 +447,21 @@ void MasterClient::StopHeartbeat() {
   MORI_UMBP_INFO("[Client] Heartbeat thread stopped");
 }
 
+void MasterClient::FlushHeartbeat() {
+  if (!heartbeat_running_) return;
+  flush_requested_ = true;
+  hb_cv_.notify_one();
+}
+
 void MasterClient::HeartbeatLoop() {
   while (heartbeat_running_) {
     {
       std::unique_lock lock(hb_cv_mutex_);
       hb_cv_.wait_for(lock, std::chrono::milliseconds(heartbeat_interval_ms_),
-                      [this] { return !heartbeat_running_.load(); });
+                      [this] { return !heartbeat_running_.load() || flush_requested_.load(); });
     }
     if (!heartbeat_running_) break;
+    flush_requested_ = false;
     SendHeartbeatOnce();
   }
 }

--- a/src/umbp/distributed/master/master_client.cpp
+++ b/src/umbp/distributed/master/master_client.cpp
@@ -331,15 +331,18 @@ grpc::Status MasterClient::BatchRouteGet(const std::vector<std::string>& keys,
   _rpc_timer.SetStatus(status);
   if (!status.ok()) return status;
 
-  out->resize(static_cast<size_t>(resp.entries_size()));
-  for (int i = 0; i < resp.entries_size(); ++i) {
-    const auto& e = resp.entries(i);
-    if (!e.found()) continue;
+  // Columnar response: node_ref[i] is a 1-based index into resp.nodes()
+  // (0 = not found); tier[i] / size[i] are parallel per-key arrays.
+  out->resize(static_cast<size_t>(resp.node_ref_size()));
+  for (int i = 0; i < resp.node_ref_size(); ++i) {
+    const uint32_t node_ref = resp.node_ref(i);
+    if (node_ref == 0) continue;  // not found
+    const auto& node = resp.nodes(static_cast<int>(node_ref) - 1);
     RouteGetResult r;
-    r.node_id = e.node_id();
-    r.tier = FromProtoTier(e.tier());
-    r.size = e.size();
-    r.peer_address = e.peer_address();
+    r.node_id = node.node_id();
+    r.tier = FromProtoTier(resp.tier(i));
+    r.size = resp.size(i);
+    r.peer_address = node.peer_address();
     (*out)[i] = std::move(r);
   }
   return grpc::Status::OK;

--- a/src/umbp/distributed/master/master_client.cpp
+++ b/src/umbp/distributed/master/master_client.cpp
@@ -333,10 +333,18 @@ grpc::Status MasterClient::BatchRouteGet(const std::vector<std::string>& keys,
 
   // Columnar response: node_ref[i] is a 1-based index into resp.nodes()
   // (0 = not found); tier[i] / size[i] are parallel per-key arrays.
-  out->resize(static_cast<size_t>(resp.node_ref_size()));
-  for (int i = 0; i < resp.node_ref_size(); ++i) {
+  const int n = resp.node_ref_size();
+  if (resp.tier_size() != n || resp.size_size() != n) {
+    return grpc::Status(grpc::StatusCode::INTERNAL,
+                        "BatchRouteGet: malformed columnar response (array length mismatch)");
+  }
+  out->resize(static_cast<size_t>(n));
+  for (int i = 0; i < n; ++i) {
     const uint32_t node_ref = resp.node_ref(i);
     if (node_ref == 0) continue;  // not found
+    if (node_ref > static_cast<uint32_t>(resp.nodes_size())) {
+      return grpc::Status(grpc::StatusCode::INTERNAL, "BatchRouteGet: node_ref index out of range");
+    }
     const auto& node = resp.nodes(static_cast<int>(node_ref) - 1);
     RouteGetResult r;
     r.node_id = node.node_id();
@@ -444,7 +452,10 @@ void MasterClient::StartHeartbeat() {
 
 void MasterClient::StopHeartbeat() {
   if (!heartbeat_running_) return;
-  heartbeat_running_ = false;
+  {
+    std::lock_guard lock(hb_cv_mutex_);
+    heartbeat_running_ = false;
+  }
   hb_cv_.notify_one();
   if (heartbeat_thread_.joinable()) heartbeat_thread_.join();
   MORI_UMBP_INFO("[Client] Heartbeat thread stopped");
@@ -452,7 +463,10 @@ void MasterClient::StopHeartbeat() {
 
 void MasterClient::FlushHeartbeat() {
   if (!heartbeat_running_) return;
-  flush_requested_ = true;
+  {
+    std::lock_guard lock(hb_cv_mutex_);
+    flush_requested_ = true;
+  }
   hb_cv_.notify_one();
 }
 
@@ -462,9 +476,9 @@ void MasterClient::HeartbeatLoop() {
       std::unique_lock lock(hb_cv_mutex_);
       hb_cv_.wait_for(lock, std::chrono::milliseconds(heartbeat_interval_ms_),
                       [this] { return !heartbeat_running_.load() || flush_requested_.load(); });
+      flush_requested_ = false;
     }
     if (!heartbeat_running_) break;
-    flush_requested_ = false;
     SendHeartbeatOnce();
   }
 }

--- a/src/umbp/distributed/master/master_server.cpp
+++ b/src/umbp/distributed/master/master_server.cpp
@@ -427,17 +427,35 @@ class MasterServer::UMBPMasterServiceImpl final : public ::umbp::UMBPMaster::Ser
     std::unordered_set<std::string> excludes(request->exclude_nodes().begin(),
                                              request->exclude_nodes().end());
     auto results = router_.BatchRouteGet(keys, request->node_id(), excludes);
+    // Columnar response: distinct (node_id, peer_address) pairs are emitted
+    // once into `nodes`; each key carries a 1-based node_ref index (0 = not
+    // found). node_ref/tier/size are parallel arrays aligned with the request
+    // keys, so the per-key fields default to 0 for unresolved keys.
+    response->mutable_node_ref()->Reserve(static_cast<int>(results.size()));
+    response->mutable_tier()->Reserve(static_cast<int>(results.size()));
+    response->mutable_size()->Reserve(static_cast<int>(results.size()));
+    // Maps "node_id\0peer_address" -> 1-based index into response->nodes().
+    std::unordered_map<std::string, uint32_t> node_index;
     for (auto& opt : results) {
-      auto* entry = response->add_entries();
       if (!opt.has_value()) {
-        entry->set_found(false);
+        response->add_node_ref(0);
+        response->add_tier(::umbp::TIER_UNKNOWN);
+        response->add_size(0);
         continue;
       }
-      entry->set_found(true);
-      entry->set_node_id(opt->location.node_id);
-      entry->set_tier(static_cast<::umbp::TierType>(opt->location.tier));
-      entry->set_size(opt->location.size);
-      entry->set_peer_address(opt->peer_address);
+      std::string node_key = opt->location.node_id;
+      node_key.push_back('\0');
+      node_key.append(opt->peer_address);
+      auto [it, inserted] = node_index.try_emplace(node_key, 0);
+      if (inserted) {
+        auto* node = response->add_nodes();
+        node->set_node_id(opt->location.node_id);
+        node->set_peer_address(opt->peer_address);
+        it->second = static_cast<uint32_t>(response->nodes_size());  // 1-based
+      }
+      response->add_node_ref(it->second);
+      response->add_tier(static_cast<::umbp::TierType>(opt->location.tier));
+      response->add_size(opt->location.size);
       if (metrics_) {
         metrics_->addCounter(MORI_UMBP_METRIC_CLIENT_BATCH_ROUTE_GET,
                              MORI_UMBP_METRIC_CLIENT_BATCH_ROUTE_GET_HELP,

--- a/src/umbp/distributed/peer/peer_dram_allocator.cpp
+++ b/src/umbp/distributed/peer/peer_dram_allocator.cpp
@@ -263,7 +263,7 @@ PeerDramAllocator::ResolveResult PeerDramAllocator::Resolve(const std::string& k
 }
 
 std::vector<PeerDramAllocator::ResolvedEntry> PeerDramAllocator::BatchResolve(
-    const std::vector<std::string>& keys) {
+    const std::vector<std::string>& keys, bool include_descs) {
   std::vector<ResolvedEntry> out(keys.size());
   if (keys.empty()) return out;
   std::lock_guard<std::mutex> lock(mutex_);
@@ -276,7 +276,9 @@ std::vector<PeerDramAllocator::ResolvedEntry> PeerDramAllocator::BatchResolve(
     entry.tier = it->second.tier;
     entry.pages = it->second.pages;
     entry.size = it->second.size;
-    entry.descs = BuildBufferDescsLocked(it->second.tier, it->second.pages);
+    if (include_descs) {
+      entry.descs = BuildBufferDescsLocked(it->second.tier, it->second.pages);
+    }
     // Per-key now(): matches single-key Resolve() so the last key in
     // a large batch isn't shortchanged by earlier keys' work.
     read_lease_until_[key] = std::chrono::steady_clock::now() + read_lease_ttl_;

--- a/src/umbp/distributed/peer/peer_service.cpp
+++ b/src/umbp/distributed/peer/peer_service.cpp
@@ -500,8 +500,8 @@ class PeerServiceServer::UMBPPeerServiceImpl final : public ::umbp::UMBPPeer::Se
                                 const ::umbp::BatchResolveKeysRequest* request,
                                 ::umbp::BatchResolveKeysResponse* response) override {
     if (dram_alloc_ == nullptr) {
-      // SoA layout: one found=false slot per key, no pages, no descs.
-      for (int i = 0; i < request->keys_size(); ++i) response->add_found(false);
+      std::vector<ResolvedKeyEntry> misses(request->keys_size());
+      EncodeBatchResolveResponse(misses, /*page_size=*/0, /*descs=*/{}, response);
       return grpc::Status::OK;
     }
     // The client can suppress descs entirely via omit_descs when it already

--- a/src/umbp/distributed/peer/peer_service.cpp
+++ b/src/umbp/distributed/peer/peer_service.cpp
@@ -32,6 +32,7 @@
 #include "umbp/common/env_time.h"
 #include "umbp/distributed/master/master_client.h"
 #include "umbp/distributed/master/master_metrics.h"
+#include "umbp/distributed/peer/batch_resolve_codec.h"
 #include "umbp/distributed/peer/peer_dram_allocator.h"
 #include "umbp/distributed/peer/peer_ssd_manager.h"
 #include "umbp/distributed/peer/ssd_copy_pipeline.h"
@@ -499,22 +500,45 @@ class PeerServiceServer::UMBPPeerServiceImpl final : public ::umbp::UMBPPeer::Se
                                 const ::umbp::BatchResolveKeysRequest* request,
                                 ::umbp::BatchResolveKeysResponse* response) override {
     if (dram_alloc_ == nullptr) {
-      for (int i = 0; i < request->keys_size(); ++i) {
-        response->add_entries()->set_found(false);
-      }
+      // SoA layout: one found=false slot per key, no pages, no descs.
+      for (int i = 0; i < request->keys_size(); ++i) response->add_found(false);
       return grpc::Status::OK;
     }
+    // The client can suppress descs entirely via omit_descs when it already
+    // hydrated them from GetPeerInfo — skip BuildBufferDescsLocked for the
+    // whole batch in that case rather than computing and discarding it.
+    const bool omit_descs = request->omit_descs();
     std::vector<std::string> keys(request->keys().begin(), request->keys().end());
-    auto resolved = dram_alloc_->BatchResolve(keys);
+    auto resolved = dram_alloc_->BatchResolve(keys, /*include_descs=*/!omit_descs);
+
+    // Project to the encoder's host shape and deduplicate the buffer
+    // descriptors once for the whole batch (their bytes are identical across
+    // keys for a given buffer_index).
+    std::vector<ResolvedKeyEntry> entries;
+    entries.reserve(resolved.size());
+    std::vector<BufferMemoryDescBytes> batch_descs;
+    std::vector<bool> desc_seen;  // indexed by buffer_index
     uint64_t total_bytes = 0;
-    for (const auto& r : resolved) {
-      auto* out = response->add_entries();
-      out->set_found(r.found);
-      if (!r.found) continue;
-      FillPagesAndDescs(out, r.pages, dram_alloc_->PageSize(), r.descs);
-      out->set_size(r.size);
-      total_bytes += r.size;
+    for (auto& r : resolved) {
+      ResolvedKeyEntry e;
+      e.found = r.found;
+      if (r.found) {
+        e.tier = r.tier;
+        e.size = r.size;
+        e.pages = std::move(r.pages);
+        total_bytes += r.size;
+        if (!omit_descs) {
+          for (const auto& d : r.descs) {
+            if (d.buffer_index >= desc_seen.size()) desc_seen.resize(d.buffer_index + 1, false);
+            if (desc_seen[d.buffer_index]) continue;
+            desc_seen[d.buffer_index] = true;
+            batch_descs.push_back(d);
+          }
+        }
+      }
+      entries.push_back(std::move(e));
     }
+    EncodeBatchResolveResponse(entries, dram_alloc_->PageSize(), batch_descs, response);
     RecordInboundGet(total_bytes, "remote");
     return grpc::Status::OK;
   }

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -44,6 +44,7 @@
 #include "mori/utils/mori_log.hpp"
 #include "umbp/common/env_time.h"
 #include "umbp/distributed/master/master_metrics.h"
+#include "umbp/distributed/peer/batch_resolve_codec.h"
 #include "umbp/distributed/peer/peer_dram_allocator.h"
 #include "umbp/distributed/peer/peer_service.h"
 #include "umbp/distributed/peer/peer_ssd_manager.h"
@@ -351,21 +352,6 @@ PeerDramAllocator::TierConfig BuildDramTierConfig(const std::vector<ExportableDr
 PoolClient::SlotPlan FromAllocateSlotResponse(const ::umbp::AllocateSlotResponse& resp) {
   PoolClient::SlotPlan p;
   p.slot_id = resp.slot_id();
-  p.page_size = resp.page_size();
-  p.pages.reserve(resp.pages_size());
-  for (const auto& pp : resp.pages()) p.pages.push_back({pp.buffer_index(), pp.page_index()});
-  p.descs.reserve(resp.descs_size());
-  for (const auto& d : resp.descs()) {
-    BufferMemoryDescBytes b;
-    b.buffer_index = d.buffer_index();
-    b.desc_bytes.assign(d.desc().begin(), d.desc().end());
-    p.descs.push_back(std::move(b));
-  }
-  return p;
-}
-
-PoolClient::SlotPlan FromResolveKeyResponse(const ::umbp::ResolveKeyResponse& resp) {
-  PoolClient::SlotPlan p;
   p.page_size = resp.page_size();
   p.pages.reserve(resp.pages_size());
   for (const auto& pp : resp.pages()) p.pages.push_back({pp.buffer_index(), pp.page_index()});
@@ -1644,7 +1630,7 @@ std::unique_ptr<PoolClient::RemoteDramGetInFlight> PoolClient::SubmitRemoteBatch
   inflight->peer = &peer;
 
   // resolve RPC + per-key validation; failed keys already written to *results.
-  if (!PrepareRemoteGetEntries(items, stub, &inflight->entries, results)) {
+  if (!PrepareRemoteGetEntries(items, peer, stub, &inflight->entries, results)) {
     return nullptr;
   }
 
@@ -1769,17 +1755,30 @@ void PoolClient::WaitRemoteBatchGet(RemoteDramGetInFlight& f, std::vector<bool>*
 }
 
 bool PoolClient::PrepareRemoteGetEntries(const std::vector<BatchGetItem>& items,
-                                         ::umbp::UMBPPeer::Stub* stub,
+                                         PeerConnection& peer, ::umbp::UMBPPeer::Stub* stub,
                                          std::vector<RemoteGetEntry>* entries,
                                          std::vector<bool>* results) {
   entries->clear();
+
+  // Ask the peer to omit the buffer descriptors once we have already hydrated
+  // them (from the GetPeerInfo handshake, or a prior resolve).  A wrong guess
+  // is safe: a missing descriptor is caught by the transfer-build guard and the
+  // entry degrades to a miss, never a corrupt read.
+  bool have_descs = false;
+  {
+    std::lock_guard<std::mutex> lock(peers_mutex_);
+    have_descs = !peer.dram_memories.empty();
+  }
+
   ::umbp::BatchResolveKeysRequest resolve_req;
   for (const auto& item : items) resolve_req.add_keys(*item.key);
+  resolve_req.set_omit_descs(have_descs);
 
   ::umbp::BatchResolveKeysResponse resolve_resp;
   grpc::ClientContext resolve_ctx;
   auto resolve_status = stub->BatchResolveKeys(&resolve_ctx, resolve_req, &resolve_resp);
-  if (!resolve_status.ok() || resolve_resp.entries_size() != static_cast<int>(items.size())) {
+  if (!resolve_status.ok() ||
+      BatchResolveKeyCount(resolve_resp) != static_cast<int>(items.size())) {
     MORI_UMBP_WARN("[PoolClient] BatchResolveKeys failed on {}: {}", items.front().route.node_id,
                    resolve_status.error_message());
     for (const auto& item : items) {
@@ -1788,22 +1787,36 @@ bool PoolClient::PrepareRemoteGetEntries(const std::vector<BatchGetItem>& items,
     return false;
   }
 
+  DecodedBatchResolve decoded = DecodeBatchResolveResponse(resolve_resp);
+  if (decoded.keys.size() != items.size()) {
+    // Malformed (mismatched parallel arrays); fail the whole batch rather than
+    // partially-read it.
+    MORI_UMBP_WARN("[PoolClient] BatchResolveKeys malformed response on {}: {} keys for {} items",
+                   items.front().route.node_id, decoded.keys.size(), items.size());
+    for (const auto& item : items) {
+      (*results)[item.index] = false;
+    }
+    return false;
+  }
+  // Hydrate the batch-level descriptors once (skipped when the peer honored
+  // omit_descs and sent none).
+  if (!decoded.descs.empty()) EnsureBufferDescsCached(peer, decoded.descs);
+
   entries->reserve(items.size());
   for (size_t i = 0; i < items.size(); ++i) {
     const auto& item = items[i];
-    const auto& resp_entry = resolve_resp.entries(static_cast<int>(i));
-    if (!resp_entry.found()) {
+    const auto& key = decoded.keys[i];
+    if (!key.found) {
       (*results)[item.index] = false;
       continue;
     }
-    if (resp_entry.size() != item.size) {
+    if (key.size != item.size) {
       MORI_UMBP_WARN("[PoolClient] BatchGet: size mismatch for key='{}' (wanted {}, got {})",
-                     *item.key, item.size, resp_entry.size());
+                     *item.key, item.size, key.size);
       (*results)[item.index] = false;
       continue;
     }
-    PoolClient::SlotPlan plan = FromResolveKeyResponse(resp_entry);
-    if (!SizeMatchesAllocation(item.size, plan.pages.size(), plan.page_size)) {
+    if (!SizeMatchesAllocation(item.size, key.pages.size(), decoded.page_size)) {
       MORI_UMBP_ERROR("[PoolClient] BatchGet: malformed slot for key='{}'", *item.key);
       (*results)[item.index] = false;
       continue;
@@ -1812,7 +1825,11 @@ bool PoolClient::PrepareRemoteGetEntries(const std::vector<BatchGetItem>& items,
     RemoteGetEntry entry;
     entry.result_index = item.index;
     entry.item = &item;
-    entry.plan = std::move(plan);
+    entry.plan.page_size = decoded.page_size;
+    entry.plan.pages = std::move(decoded.keys[i].pages);
+    // Descriptors were hydrated batch-level above; the per-entry plan carries
+    // none (BuildRemoteGetTransfers' EnsureBufferDescsCached call is a no-op on
+    // an empty list and the read path resolves descriptors by buffer_index).
     entries->push_back(std::move(entry));
   }
 

--- a/src/umbp/distributed/proto/umbp.proto
+++ b/src/umbp/distributed/proto/umbp.proto
@@ -178,15 +178,25 @@ message BatchRouteGetRequest {
   repeated string keys = 2;
   repeated string exclude_nodes = 3;
 }
-message BatchRouteGetEntry {
-  bool     found        = 1;
-  string   node_id      = 2;
-  TierType tier         = 3;
-  uint64   size         = 4;
-  string   peer_address = 5;
+// Distinct routing target.  Sent once in BatchRouteGetResponse.nodes and
+// referenced per key by a 1-based index, so the (node_id, peer_address)
+// strings are not repeated for every one of the (potentially thousands of)
+// keys that resolve to the same node.
+message NodeInfo {
+  string node_id      = 1;
+  string peer_address = 2;
 }
+// Columnar response: instead of one BatchRouteGetEntry message per key
+// (which repeated the node strings and paid per-entry/per-field tag bytes),
+// the per-key fields are parallel packed arrays aligned with the request's
+// keys.  node_ref folds away the old `found` bool: 0 = not found, otherwise
+// a 1-based index into `nodes`.  tier[i] / size[i] are only meaningful when
+// node_ref[i] != 0.
 message BatchRouteGetResponse {
-  repeated BatchRouteGetEntry entries = 1;
+  repeated NodeInfo nodes    = 1;  // distinct nodes, sent once
+  repeated uint32   node_ref = 2;  // per key; 1-based index into nodes, 0 = not found  [packed]
+  repeated TierType tier     = 3;  // per key  [packed]
+  repeated uint64   size     = 4;  // per key  [packed]
 }
 
 // Read-only batched existence probe.  Unlike BatchRouteGet, this does

--- a/src/umbp/distributed/proto/umbp_peer.proto
+++ b/src/umbp/distributed/proto/umbp_peer.proto
@@ -197,7 +197,35 @@ message BatchAbortSlotsResponse {
 
 message BatchResolveKeysRequest {
   repeated string keys = 1;
+  // When set, the peer omits the per-buffer descriptors from the response: the
+  // client has already hydrated buffer_index -> MemoryDesc from GetPeerInfo
+  // (dram_memory_descs) and the read path looks descriptors up in that cache.
+  // A wrongly-omitted descriptor degrades to a cache miss on the client (the
+  // transfer-build guard rejects the entry), never to a corrupt read.
+  bool omit_descs = 2;
 }
+// Struct-of-arrays layout.  The previous shape repeated a full ResolveKeyResponse
+// per key, each carrying its own copy of the peer's buffer descriptors and
+// page_size — the descriptors and page_size are batch-invariant, so that
+// duplicated O(keys * buffers) payload per BatchGet.  Here the descriptors are
+// deduplicated once per batch (by buffer_index), page_size is hoisted to a
+// single field, the per-key fixed fields live in parallel arrays (index i ==
+// request.keys[i]), and every key's page locations are flattened into
+// buffer_index/page_index with page_count[i] delimiting key i's slice.  This
+// removes the per-key sub-message framing and the descriptor duplication.
 message BatchResolveKeysResponse {
-  repeated ResolveKeyResponse entries = 1;
+  // Deduplicated buffer descriptors, once per batch (empty when the request set
+  // omit_descs, or when no resolved key was found).
+  repeated BufferMemoryDesc descs = 1;
+  // Peer-global page size.
+  uint64 page_size = 2;
+  // Per-key fixed fields, parallel to request.keys.
+  repeated bool     found      = 3;
+  repeated TierType tier       = 4;
+  repeated uint64   size       = 5;
+  repeated uint32   page_count = 6;
+  // Flattened page locations across all keys: key i owns the next page_count[i]
+  // (buffer_index, page_index) pairs, walking keys in order.
+  repeated uint32 buffer_index = 7;
+  repeated uint32 page_index   = 8;
 }

--- a/src/umbp/include/umbp/distributed/master/global_block_index.h
+++ b/src/umbp/include/umbp/distributed/master/global_block_index.h
@@ -45,7 +45,14 @@ struct BlockEntry {
   std::atomic<uint64_t> atomic_access_count{0};
 
   void GrantLease(std::chrono::steady_clock::duration duration) {
-    auto expiry = std::chrono::steady_clock::now() + duration;
+    GrantLease(std::chrono::steady_clock::now(), duration);
+  }
+
+  // Overload taking a caller-supplied "now": lets a batch capture the clock
+  // once and reuse it across many keys instead of re-reading it per key.
+  void GrantLease(std::chrono::steady_clock::time_point now,
+                  std::chrono::steady_clock::duration duration) {
+    auto expiry = now + duration;
     lease_expiry_rep.store(expiry.time_since_epoch().count(), std::memory_order_release);
   }
 
@@ -54,9 +61,11 @@ struct BlockEntry {
     return lease_expiry_rep.load(std::memory_order_acquire) > now_rep;
   }
 
-  void RecordAccessAtomic() {
-    last_accessed_rep.store(std::chrono::steady_clock::now().time_since_epoch().count(),
-                            std::memory_order_release);
+  void RecordAccessAtomic() { RecordAccessAtomic(std::chrono::steady_clock::now()); }
+
+  // Overload taking a caller-supplied "now"; see GrantLease above.
+  void RecordAccessAtomic(std::chrono::steady_clock::time_point now) {
+    last_accessed_rep.store(now.time_since_epoch().count(), std::memory_order_release);
     atomic_access_count.fetch_add(1, std::memory_order_relaxed);
   }
 

--- a/src/umbp/include/umbp/distributed/master/master_client.h
+++ b/src/umbp/include/umbp/distributed/master/master_client.h
@@ -143,6 +143,8 @@ class MasterClient {
 
   void StartHeartbeat();
   void StopHeartbeat();
+  // Wake the heartbeat thread immediately to drain pending KV events.
+  void FlushHeartbeat();
 
   // Synchronously clear this node's UMBP-owned and external HiCache
   // placement from master. When peer_alloc_ is bound, caller MUST have
@@ -217,6 +219,7 @@ class MasterClient {
 
   std::thread heartbeat_thread_;
   std::atomic<bool> heartbeat_running_{false};
+  std::atomic<bool> flush_requested_{false};
   std::atomic<bool> registered_{false};
   uint64_t heartbeat_interval_ms_ = 5000;
 

--- a/src/umbp/include/umbp/distributed/peer/batch_resolve_codec.h
+++ b/src/umbp/include/umbp/distributed/peer/batch_resolve_codec.h
@@ -1,0 +1,189 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+// Wire codec for the struct-of-arrays BatchResolveKeysResponse.  Shared by the
+// peer service (producer) and the pool client (consumer) so the flattened
+// layout is defined in exactly one place and the two sides cannot drift.  It is
+// header-only and depends only on the generated proto plus the host-side POD
+// types, so it is unit-testable without gRPC / RDMA.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "umbp/distributed/types.h"
+#include "umbp_peer.pb.h"
+
+namespace mori::umbp {
+
+// Host-side view of one resolved key, independent of the generated proto.
+// Used as the encoder input on the peer side.
+struct ResolvedKeyEntry {
+  bool found = false;
+  TierType tier = TierType::UNKNOWN;
+  uint64_t size = 0;
+  std::vector<PageLocation> pages;
+};
+
+// One key decoded out of the SoA response (page_size and descs are batch-level
+// and live on DecodedBatchResolve, not here).
+struct DecodedResolveKey {
+  bool found = false;
+  TierType tier = TierType::UNKNOWN;
+  uint64_t size = 0;
+  std::vector<PageLocation> pages;
+};
+
+// Whole-batch decode result.
+struct DecodedBatchResolve {
+  uint64_t page_size = 0;
+  std::vector<BufferMemoryDescBytes> descs;  // batch-level; empty when omitted
+  std::vector<DecodedResolveKey> keys;       // parallel to request.keys
+};
+
+// proto <-> host tier.  Header-local (inline) to avoid a second definition of
+// the anonymous-namespace helpers already living in the .cpp files.
+inline TierType BatchResolveTierFromProto(::umbp::TierType t) {
+  switch (t) {
+    case ::umbp::TIER_HBM:
+      return TierType::HBM;
+    case ::umbp::TIER_DRAM:
+      return TierType::DRAM;
+    case ::umbp::TIER_SSD:
+      return TierType::SSD;
+    default:
+      return TierType::UNKNOWN;
+  }
+}
+inline ::umbp::TierType BatchResolveTierToProto(TierType t) {
+  switch (t) {
+    case TierType::HBM:
+      return ::umbp::TIER_HBM;
+    case TierType::DRAM:
+      return ::umbp::TIER_DRAM;
+    case TierType::SSD:
+      return ::umbp::TIER_SSD;
+    default:
+      return ::umbp::TIER_UNKNOWN;
+  }
+}
+
+// Encode resolved keys into the SoA response.  `descs` are the batch-level
+// deduplicated buffer descriptors (by buffer_index); pass an empty vector to
+// omit them (honoring BatchResolveKeysRequest.omit_descs).  Clears `resp`
+// first.  Not-found keys contribute a found=false slot and no pages.
+inline void EncodeBatchResolveResponse(const std::vector<ResolvedKeyEntry>& keys,
+                                       uint64_t page_size,
+                                       const std::vector<BufferMemoryDescBytes>& descs,
+                                       ::umbp::BatchResolveKeysResponse* resp) {
+  resp->Clear();
+  resp->set_page_size(page_size);
+
+  for (const auto& d : descs) {
+    auto* desc = resp->add_descs();
+    desc->set_buffer_index(d.buffer_index);
+    desc->set_desc(std::string(d.desc_bytes.begin(), d.desc_bytes.end()));
+  }
+
+  size_t total_pages = 0;
+  for (const auto& k : keys) total_pages += k.pages.size();
+  resp->mutable_found()->Reserve(static_cast<int>(keys.size()));
+  resp->mutable_tier()->Reserve(static_cast<int>(keys.size()));
+  resp->mutable_size()->Reserve(static_cast<int>(keys.size()));
+  resp->mutable_page_count()->Reserve(static_cast<int>(keys.size()));
+  resp->mutable_buffer_index()->Reserve(static_cast<int>(total_pages));
+  resp->mutable_page_index()->Reserve(static_cast<int>(total_pages));
+
+  for (const auto& k : keys) {
+    resp->add_found(k.found);
+    resp->add_tier(BatchResolveTierToProto(k.tier));
+    resp->add_size(k.size);
+    resp->add_page_count(static_cast<uint32_t>(k.pages.size()));
+    for (const auto& p : k.pages) {
+      resp->add_buffer_index(p.buffer_index);
+      resp->add_page_index(p.page_index);
+    }
+  }
+}
+
+// Number of keys carried by the response (== request.keys.size() for a
+// well-formed response).
+inline int BatchResolveKeyCount(const ::umbp::BatchResolveKeysResponse& resp) {
+  return resp.found_size();
+}
+
+// Decode the whole response.  Page offsets into the flattened arrays are
+// resolved internally.  A malformed response (parallel arrays of unequal
+// length, or fewer flattened pages than page_count sums to) yields an empty
+// `keys` vector so the caller treats the whole batch as failed rather than
+// reading past the arrays.
+inline DecodedBatchResolve DecodeBatchResolveResponse(
+    const ::umbp::BatchResolveKeysResponse& resp) {
+  DecodedBatchResolve out;
+  out.page_size = resp.page_size();
+
+  out.descs.reserve(resp.descs_size());
+  for (const auto& d : resp.descs()) {
+    BufferMemoryDescBytes b;
+    b.buffer_index = d.buffer_index();
+    b.desc_bytes.assign(d.desc().begin(), d.desc().end());
+    out.descs.push_back(std::move(b));
+  }
+
+  const int n = resp.found_size();
+  // All per-key arrays must agree in length, and the flattened page arrays must
+  // hold at least the summed page_count.  Anything else is a malformed peer
+  // response; refuse to decode it.
+  if (resp.tier_size() != n || resp.size_size() != n || resp.page_count_size() != n ||
+      resp.buffer_index_size() != resp.page_index_size()) {
+    return out;
+  }
+
+  size_t total_pages = 0;
+  for (int i = 0; i < n; ++i) total_pages += resp.page_count(i);
+  if (total_pages > static_cast<size_t>(resp.buffer_index_size())) {
+    return out;
+  }
+
+  out.keys.reserve(n);
+  size_t cursor = 0;
+  for (int i = 0; i < n; ++i) {
+    DecodedResolveKey k;
+    k.found = resp.found(i);
+    k.tier = BatchResolveTierFromProto(resp.tier(i));
+    k.size = resp.size(i);
+    const uint32_t pc = resp.page_count(i);
+    k.pages.reserve(pc);
+    for (uint32_t p = 0; p < pc; ++p) {
+      PageLocation pl;
+      pl.buffer_index = resp.buffer_index(static_cast<int>(cursor));
+      pl.page_index = resp.page_index(static_cast<int>(cursor));
+      k.pages.push_back(pl);
+      ++cursor;
+    }
+    out.keys.push_back(std::move(k));
+  }
+  return out;
+}
+
+}  // namespace mori::umbp

--- a/src/umbp/include/umbp/distributed/peer/peer_dram_allocator.h
+++ b/src/umbp/include/umbp/distributed/peer/peer_dram_allocator.h
@@ -197,7 +197,11 @@ class PeerDramAllocator : public OwnedLocationSource {
 
   // Batched Resolve + BufferDescsForPages under a single mutex_ hold.
   // Per-key behavior byte-identical to Resolve() + BufferDescsForPages().
-  std::vector<ResolvedEntry> BatchResolve(const std::vector<std::string>& keys);
+  // `include_descs=false` skips BuildBufferDescsLocked entirely (leaving
+  // descs empty) — for callers that already have the buffer descs cached
+  // (e.g. from GetPeerInfo) and would otherwise discard the result.
+  std::vector<ResolvedEntry> BatchResolve(const std::vector<std::string>& keys,
+                                          bool include_descs = true);
 
   // Master-driven eviction.  Idempotent: keys that are unknown or
   // already gone produce zero-bytes entries; keys with active read

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -413,8 +413,9 @@ class PoolClient {
                                 std::vector<PutEntryOutcome>* results,
                                 ::umbp::UMBPPeer::Stub* stub);
 
-  bool PrepareRemoteGetEntries(const std::vector<BatchGetItem>& items, ::umbp::UMBPPeer::Stub* stub,
-                               std::vector<RemoteGetEntry>* entries, std::vector<bool>* results);
+  bool PrepareRemoteGetEntries(const std::vector<BatchGetItem>& items, PeerConnection& peer,
+                               ::umbp::UMBPPeer::Stub* stub, std::vector<RemoteGetEntry>* entries,
+                               std::vector<bool>* results);
   bool BuildRemoteGetTransfers(std::vector<RemoteGetEntry>& entries, PeerConnection& peer,
                                std::vector<TransferInstruction>* transfers,
                                uint64_t* staging_bytes);

--- a/src/umbp/tests/CMakeLists.txt
+++ b/src/umbp/tests/CMakeLists.txt
@@ -174,6 +174,24 @@ target_compile_features(test_peer_ssd_read_rpc PRIVATE cxx_std_17)
 gtest_discover_tests(test_peer_ssd_read_rpc)
 
 # ---------------------------------------------------------------------------
+# test_batch_resolve_codec — struct-of-arrays BatchResolveKeysResponse wire
+# codec (batch_resolve_codec.h): encode/decode round-trip, page flattening, desc
+# dedup / omit_descs, malformed-response rejection, and the payload-size win.
+# Needs the generated proto (carried by umbp_common) + protobuf.
+# ---------------------------------------------------------------------------
+add_executable(test_batch_resolve_codec test_batch_resolve_codec.cpp)
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  target_link_options(test_batch_resolve_codec PRIVATE -Wl,--no-as-needed)
+endif()
+
+target_link_libraries(test_batch_resolve_codec
+                      PRIVATE umbp_common ${_PROTOBUF_LIB} GTest::gtest_main)
+
+target_compile_features(test_batch_resolve_codec PRIVATE cxx_std_17)
+
+gtest_discover_tests(test_batch_resolve_codec)
+
+# ---------------------------------------------------------------------------
 # test_ssd_read_lease_gating — pure reader-side lease gating decision logic
 # (ssd_read_lease.h).  Header-only under test (no gRPC / RDMA deps).
 # ---------------------------------------------------------------------------

--- a/src/umbp/tests/test_batch_resolve_codec.cpp
+++ b/src/umbp/tests/test_batch_resolve_codec.cpp
@@ -1,0 +1,249 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Unit tests for the struct-of-arrays BatchResolveKeysResponse codec
+// (batch_resolve_codec.h).  This is the wire format shared by the peer service
+// (encoder) and the pool client (decoder) after the resolve-keys payload
+// optimization: per-key fields hoisted into parallel arrays, page locations
+// flattened, buffer descriptors deduplicated once per batch, and page_size
+// hoisted to a single field.  The tests assert the encode->decode round-trip is
+// lossless (correctness of the optimization), that the optimization actually
+// shrinks the wire payload, that the omit_descs path is honored, and that a
+// malformed response is rejected rather than over-read.
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "umbp/distributed/peer/batch_resolve_codec.h"
+#include "umbp/distributed/types.h"
+#include "umbp_peer.pb.h"
+
+namespace mori::umbp {
+namespace {
+
+BufferMemoryDescBytes MakeDesc(uint32_t buffer_index, const std::string& bytes) {
+  BufferMemoryDescBytes d;
+  d.buffer_index = buffer_index;
+  d.desc_bytes.assign(bytes.begin(), bytes.end());
+  return d;
+}
+
+// A representative batch: 4 keys mixing found / not-found, varying page counts
+// (including a found-but-zero-page key), and several tiers.
+std::vector<ResolvedKeyEntry> SampleEntries() {
+  std::vector<ResolvedKeyEntry> entries(4);
+
+  entries[0].found = true;
+  entries[0].tier = TierType::HBM;
+  entries[0].size = 3 * 4096;
+  entries[0].pages = {{0, 10}, {1, 11}, {0, 12}};
+
+  entries[1].found = false;  // miss: no tier / size / pages
+
+  entries[2].found = true;
+  entries[2].tier = TierType::DRAM;
+  entries[2].size = 4096;
+  entries[2].pages = {{2, 7}};
+
+  entries[3].found = true;
+  entries[3].tier = TierType::SSD;
+  entries[3].size = 0;  // found but zero pages (degenerate but legal)
+  entries[3].pages = {};
+
+  return entries;
+}
+
+void ExpectKeyMatches(const ResolvedKeyEntry& src, const DecodedResolveKey& dec) {
+  EXPECT_EQ(src.found, dec.found);
+  if (!src.found) return;
+  EXPECT_EQ(src.tier, dec.tier);
+  EXPECT_EQ(src.size, dec.size);
+  ASSERT_EQ(src.pages.size(), dec.pages.size());
+  for (size_t p = 0; p < src.pages.size(); ++p) {
+    EXPECT_EQ(src.pages[p].buffer_index, dec.pages[p].buffer_index);
+    EXPECT_EQ(src.pages[p].page_index, dec.pages[p].page_index);
+  }
+}
+
+TEST(BatchResolveCodec, RoundTripPreservesEveryField) {
+  const auto entries = SampleEntries();
+  const uint64_t page_size = 4096;
+  const std::vector<BufferMemoryDescBytes> descs = {
+      MakeDesc(0, "desc-zero"), MakeDesc(1, "desc-one"), MakeDesc(2, "desc-two")};
+
+  ::umbp::BatchResolveKeysResponse resp;
+  EncodeBatchResolveResponse(entries, page_size, descs, &resp);
+
+  // Survives a real serialize/parse cycle, not just in-memory copy.
+  std::string wire;
+  ASSERT_TRUE(resp.SerializeToString(&wire));
+  ::umbp::BatchResolveKeysResponse parsed;
+  ASSERT_TRUE(parsed.ParseFromString(wire));
+
+  EXPECT_EQ(BatchResolveKeyCount(parsed), static_cast<int>(entries.size()));
+
+  DecodedBatchResolve decoded = DecodeBatchResolveResponse(parsed);
+  EXPECT_EQ(decoded.page_size, page_size);
+  ASSERT_EQ(decoded.keys.size(), entries.size());
+  for (size_t i = 0; i < entries.size(); ++i) ExpectKeyMatches(entries[i], decoded.keys[i]);
+
+  ASSERT_EQ(decoded.descs.size(), descs.size());
+  for (size_t i = 0; i < descs.size(); ++i) {
+    EXPECT_EQ(decoded.descs[i].buffer_index, descs[i].buffer_index);
+    EXPECT_EQ(decoded.descs[i].desc_bytes, descs[i].desc_bytes);
+  }
+}
+
+TEST(BatchResolveCodec, FlattenedPagesSliceByKey) {
+  // Two found keys with different page counts must not bleed into each other.
+  std::vector<ResolvedKeyEntry> entries(2);
+  entries[0].found = true;
+  entries[0].size = 2 * 4096;
+  entries[0].pages = {{5, 100}, {6, 101}};
+  entries[1].found = true;
+  entries[1].size = 4096;
+  entries[1].pages = {{7, 200}};
+
+  ::umbp::BatchResolveKeysResponse resp;
+  EncodeBatchResolveResponse(entries, 4096, {}, &resp);
+
+  // Flattened arrays hold exactly the concatenation, in order.
+  ASSERT_EQ(resp.buffer_index_size(), 3);
+  EXPECT_EQ(resp.buffer_index(0), 5u);
+  EXPECT_EQ(resp.buffer_index(1), 6u);
+  EXPECT_EQ(resp.buffer_index(2), 7u);
+  EXPECT_EQ(resp.page_count(0), 2u);
+  EXPECT_EQ(resp.page_count(1), 1u);
+
+  DecodedBatchResolve decoded = DecodeBatchResolveResponse(resp);
+  ASSERT_EQ(decoded.keys.size(), 2u);
+  ASSERT_EQ(decoded.keys[0].pages.size(), 2u);
+  ASSERT_EQ(decoded.keys[1].pages.size(), 1u);
+  EXPECT_EQ(decoded.keys[1].pages[0].buffer_index, 7u);
+  EXPECT_EQ(decoded.keys[1].pages[0].page_index, 200u);
+}
+
+TEST(BatchResolveCodec, OmitDescsRoundTrips) {
+  const auto entries = SampleEntries();
+
+  ::umbp::BatchResolveKeysResponse resp;
+  EncodeBatchResolveResponse(entries, 4096, /*descs=*/{}, &resp);
+  EXPECT_EQ(resp.descs_size(), 0);
+
+  DecodedBatchResolve decoded = DecodeBatchResolveResponse(resp);
+  EXPECT_TRUE(decoded.descs.empty());
+  ASSERT_EQ(decoded.keys.size(), entries.size());
+  for (size_t i = 0; i < entries.size(); ++i) ExpectKeyMatches(entries[i], decoded.keys[i]);
+}
+
+TEST(BatchResolveCodec, AllNotFound) {
+  std::vector<ResolvedKeyEntry> entries(3);  // all default => found=false
+  ::umbp::BatchResolveKeysResponse resp;
+  EncodeBatchResolveResponse(entries, 4096, {}, &resp);
+
+  EXPECT_EQ(BatchResolveKeyCount(resp), 3);
+  EXPECT_EQ(resp.buffer_index_size(), 0);
+
+  DecodedBatchResolve decoded = DecodeBatchResolveResponse(resp);
+  ASSERT_EQ(decoded.keys.size(), 3u);
+  for (const auto& k : decoded.keys) EXPECT_FALSE(k.found);
+}
+
+TEST(BatchResolveCodec, EmptyBatch) {
+  ::umbp::BatchResolveKeysResponse resp;
+  EncodeBatchResolveResponse({}, 4096, {}, &resp);
+  EXPECT_EQ(BatchResolveKeyCount(resp), 0);
+  DecodedBatchResolve decoded = DecodeBatchResolveResponse(resp);
+  EXPECT_TRUE(decoded.keys.empty());
+  EXPECT_EQ(decoded.page_size, 4096u);
+}
+
+TEST(BatchResolveCodec, MalformedMismatchedArraysRejected) {
+  // found has 2 entries but the per-key arrays disagree -> decoder must refuse.
+  ::umbp::BatchResolveKeysResponse resp;
+  resp.set_page_size(4096);
+  resp.add_found(true);
+  resp.add_found(true);
+  resp.add_size(4096);  // only one size for two found
+  resp.add_page_count(0);
+  resp.add_page_count(0);
+  // tier intentionally left empty (size 0 != 2)
+
+  EXPECT_EQ(BatchResolveKeyCount(resp), 2);
+  DecodedBatchResolve decoded = DecodeBatchResolveResponse(resp);
+  EXPECT_TRUE(decoded.keys.empty());  // rejected, not partially decoded
+}
+
+TEST(BatchResolveCodec, MalformedTruncatedPagesRejected) {
+  // page_count sums to 3 but only 1 flattened page is present.
+  ::umbp::BatchResolveKeysResponse resp;
+  resp.set_page_size(4096);
+  resp.add_found(true);
+  resp.add_tier(::umbp::TIER_HBM);
+  resp.add_size(3 * 4096);
+  resp.add_page_count(3);
+  resp.add_buffer_index(0);
+  resp.add_page_index(0);
+
+  DecodedBatchResolve decoded = DecodeBatchResolveResponse(resp);
+  EXPECT_TRUE(decoded.keys.empty());
+}
+
+// The whole point of the optimization: with descriptors shared across many
+// keys, the SoA layout that dedupes them once per batch is dramatically smaller
+// than repeating a full descriptor set under every key.
+TEST(BatchResolveCodec, OptimizedWireIsSmallerThanPerKeyDescs) {
+  const int kKeys = 1000;
+  const int kPagesPerKey = 8;
+  const int kBuffers = 4;
+  std::vector<BufferMemoryDescBytes> descs;
+  for (int b = 0; b < kBuffers; ++b) descs.push_back(MakeDesc(b, std::string(64, 'x')));
+
+  std::vector<ResolvedKeyEntry> entries(kKeys);
+  for (int i = 0; i < kKeys; ++i) {
+    entries[i].found = true;
+    entries[i].tier = TierType::HBM;
+    entries[i].size = kPagesPerKey * 4096;
+    for (int p = 0; p < kPagesPerKey; ++p) {
+      entries[i].pages.push_back({static_cast<uint32_t>(p % kBuffers), static_cast<uint32_t>(p)});
+    }
+  }
+
+  ::umbp::BatchResolveKeysResponse opt;
+  EncodeBatchResolveResponse(entries, 4096, descs, &opt);
+  std::string opt_wire;
+  ASSERT_TRUE(opt.SerializeToString(&opt_wire));
+
+  // Naive baseline: the descriptor bytes repeated once per key (what the old
+  // per-entry ResolveKeyResponse layout carried).
+  const size_t per_key_desc_bytes = descs.size() * (64 + 4);
+  const size_t naive_desc_total = per_key_desc_bytes * kKeys;
+  const size_t opt_desc_total = per_key_desc_bytes;  // once per batch
+
+  EXPECT_LT(opt_wire.size(), naive_desc_total);
+  EXPECT_GT(naive_desc_total - opt_desc_total, 0u);
+}
+
+}  // namespace
+}  // namespace mori::umbp

--- a/src/umbp/tests/test_peer_dram_allocator.cpp
+++ b/src/umbp/tests/test_peer_dram_allocator.cpp
@@ -517,6 +517,30 @@ TEST(PeerDramAllocator, BatchResolveMixedHitsAndMisses) {
   EXPECT_FALSE(results[3].found);
 }
 
+TEST(PeerDramAllocator, BatchResolveIncludeDescsFalseSkipsDescs) {
+  auto a = MakeAllocator();
+  auto p_hit = AllocateOk(*a, "hit", kPageSize * 5, TierType::DRAM);
+  ASSERT_TRUE(p_hit.has_value());
+  uint64_t committed_bytes = 0;
+  ASSERT_TRUE(a->Commit(p_hit->slot_id, "hit", committed_bytes));
+  a->DrainPendingEvents();
+
+  auto ref_hit = a->Resolve("hit");
+  ASSERT_TRUE(ref_hit.found);
+
+  auto results = a->BatchResolve({"hit", "ghost"}, /*include_descs=*/false);
+  ASSERT_EQ(results.size(), 2u);
+
+  EXPECT_TRUE(results[0].found);
+  EXPECT_EQ(results[0].tier, ref_hit.tier);
+  EXPECT_EQ(results[0].pages, ref_hit.pages);
+  EXPECT_EQ(results[0].size, ref_hit.size);
+  EXPECT_TRUE(results[0].descs.empty());
+
+  EXPECT_FALSE(results[1].found);
+  EXPECT_TRUE(results[1].descs.empty());
+}
+
 TEST(PeerDramAllocator, BatchResolveExtendsLeaseForHitsOnly) {
   auto a = std::make_unique<PeerDramAllocator>(kPageSize, MakeDramCfg(), EmptyCfg(),
                                                /*pending_ttl=*/std::chrono::milliseconds{5000},

--- a/tests/cpp/umbp/distributed/CMakeLists.txt
+++ b/tests/cpp/umbp/distributed/CMakeLists.txt
@@ -22,6 +22,21 @@ else()
   find_library(_TEST_GRPCPP_LIB NAMES grpc++ REQUIRED)
 endif()
 
+# MasterClient::FlushHeartbeat: immediate wakeup, no-op before start,
+# flush-while-in-flight.
+add_executable(test_umbp_master_client_flush_heartbeat
+               test_master_client_flush_heartbeat.cpp)
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  target_link_options(test_umbp_master_client_flush_heartbeat PRIVATE
+                      -Wl,--no-as-needed)
+endif()
+target_link_libraries(
+  test_umbp_master_client_flush_heartbeat
+  PRIVATE umbp_core umbp_common ${_TEST_PROTOBUF_LIB} ${_TEST_GRPCPP_LIB}
+          gtest_main)
+add_test(NAME umbp_master_client_flush_heartbeat
+         COMMAND test_umbp_master_client_flush_heartbeat)
+
 # MasterClient lifecycle: destructor budget, heartbeat thread shutdown, etc.
 add_executable(test_umbp_master_client_lifecycle
                test_master_client_lifecycle.cpp)

--- a/tests/cpp/umbp/distributed/CMakeLists.txt
+++ b/tests/cpp/umbp/distributed/CMakeLists.txt
@@ -76,6 +76,22 @@ target_link_libraries(
 add_test(NAME umbp_master_client_rpc_latency
          COMMAND test_umbp_master_client_rpc_latency)
 
+# BatchRouteGet columnar response wire-format round-trip (node-table dedup,
+# 1-based node_ref, node_ref==0 -> not found, parallel tier/size columns). gRPC
+# mock master + real MasterClient; no RDMA.
+add_executable(test_umbp_batch_route_get_columnar
+               test_batch_route_get_columnar.cpp)
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  target_link_options(test_umbp_batch_route_get_columnar PRIVATE
+                      -Wl,--no-as-needed)
+endif()
+target_link_libraries(
+  test_umbp_batch_route_get_columnar
+  PRIVATE umbp_core umbp_common ${_TEST_PROTOBUF_LIB} ${_TEST_GRPCPP_LIB}
+          gtest_main)
+add_test(NAME umbp_batch_route_get_columnar
+         COMMAND test_umbp_batch_route_get_columnar)
+
 # Client-tag registration + metrics label injection.
 add_executable(test_umbp_tags test_umbp_tags.cpp)
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")

--- a/tests/cpp/umbp/distributed/CMakeLists.txt
+++ b/tests/cpp/umbp/distributed/CMakeLists.txt
@@ -209,3 +209,13 @@ target_link_libraries(
   bench_umbp_route_put_strategy
   PRIVATE umbp_core umbp_common ${_TEST_PROTOBUF_LIB} ${_TEST_GRPCPP_LIB}
           gtest_main)
+
+# GlobalBlockIndex::BatchLookupForRouteGet micro-bench (pure logic; no gRPC /
+# RDMA, so umbp_common only).  Drives the master-side BatchRouteGet hot path
+# directly: hash lookup + exclude filter + access bump + lease grant under a
+# single shared_lock.  Reports us/call, Mlookups/s, and concurrent read scaling
+# via --threads.
+add_executable(bench_umbp_global_block_index_route_get
+               bench_global_block_index_route_get.cpp)
+target_link_libraries(bench_umbp_global_block_index_route_get
+                      PRIVATE umbp_common gtest_main)

--- a/tests/cpp/umbp/distributed/bench_global_block_index_route_get.cpp
+++ b/tests/cpp/umbp/distributed/bench_global_block_index_route_get.cpp
@@ -1,0 +1,275 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// GlobalBlockIndex::BatchLookupForRouteGet micro-bench (pure logic; no gRPC /
+// RDMA).  This is the hot master-side path that BatchRouteGet drives: for a
+// batch of keys it does, under a single shared_lock, a hash lookup +
+// exclude-node filter + (on a non-empty result) an atomic access-count bump and
+// lease grant.  Because the lock is shared, multiple caller threads can run the
+// path concurrently; --threads measures that read-scaling.
+//
+// The index is pre-populated via ApplyEvents (the only real mutator) with
+// `index-keys` keys, each replicated across `locs-per-key` of `nodes` peers, so
+// the per-key location vector and the exclude filter have realistic length.
+//
+// Usage:
+//   bench_umbp_global_block_index_route_get
+//       [--index-keys N] [--batch N] [--nodes N] [--locs-per-key N]
+//       [--exclude N] [--hit-pct P] [--threads N] [--iters N] [--lease-ms N]
+//       [--sweep batch=1,8,64,512]
+//
+// CSV (stdout):
+//   index_keys,batch,nodes,locs_per_key,exclude,hit_pct,threads,iters,
+//   wall_us_per_call,Mlookups_s,locs_per_call
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <random>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
+#include "umbp/distributed/master/global_block_index.h"
+#include "umbp/distributed/types.h"
+
+using mori::umbp::GlobalBlockIndex;
+using mori::umbp::KvEvent;
+using mori::umbp::Location;
+using mori::umbp::TierType;
+
+namespace {
+
+struct BenchOpts {
+  size_t index_keys = 100000;  // keys resident in the index
+  size_t batch = 64;           // keys per BatchLookupForRouteGet call
+  size_t nodes = 8;            // distinct peer node_ids holding locations
+  size_t locs_per_key = 2;     // replicas (distinct nodes) per key
+  size_t exclude = 0;          // node_ids in the exclude set
+  size_t hit_pct = 100;        // % of looked-up keys that exist in the index
+  size_t threads = 1;          // concurrent caller threads (shared_lock read scaling)
+  size_t iters = 2000;         // measured calls per thread
+  size_t lease_ms = 10;        // lease_duration handed to the method
+  std::vector<size_t> sweep;   // batch sweep
+};
+
+void Usage() {
+  std::cerr << "Usage: bench_umbp_global_block_index_route_get\n"
+            << "    [--index-keys N] [--batch N] [--nodes N] [--locs-per-key N]\n"
+            << "    [--exclude N] [--hit-pct P] [--threads N] [--iters N] [--lease-ms N]\n"
+            << "    [--sweep batch=1,8,64,512]\n";
+}
+
+bool ParseArgs(int argc, char** argv, BenchOpts* o) {
+  for (int i = 1; i < argc; ++i) {
+    std::string a = argv[i];
+    auto next = [&](const char* what) -> const char* {
+      if (i + 1 >= argc) {
+        std::cerr << "Missing value for " << what << "\n";
+        std::exit(2);
+      }
+      return argv[++i];
+    };
+    auto u64 = [&](const char* what) { return std::strtoull(next(what), nullptr, 10); };
+    if (a == "--index-keys") {
+      o->index_keys = u64("--index-keys");
+    } else if (a == "--batch") {
+      o->batch = u64("--batch");
+    } else if (a == "--nodes") {
+      o->nodes = u64("--nodes");
+    } else if (a == "--locs-per-key") {
+      o->locs_per_key = u64("--locs-per-key");
+    } else if (a == "--exclude") {
+      o->exclude = u64("--exclude");
+    } else if (a == "--hit-pct") {
+      o->hit_pct = u64("--hit-pct");
+    } else if (a == "--threads") {
+      o->threads = u64("--threads");
+    } else if (a == "--iters") {
+      o->iters = u64("--iters");
+    } else if (a == "--lease-ms") {
+      o->lease_ms = u64("--lease-ms");
+    } else if (a == "--sweep") {
+      std::string s = next("--sweep");
+      auto eq = s.find('=');
+      if (eq == std::string::npos) {
+        std::cerr << "--sweep expects 'batch=N1,N2,...'\n";
+        return false;
+      }
+      std::stringstream ss(s.substr(eq + 1));
+      std::string tok;
+      while (std::getline(ss, tok, ',')) {
+        if (!tok.empty()) o->sweep.push_back(std::strtoull(tok.c_str(), nullptr, 10));
+      }
+    } else if (a == "-h" || a == "--help") {
+      Usage();
+      std::exit(0);
+    } else {
+      std::cerr << "Unknown arg: " << a << "\n";
+      Usage();
+      return false;
+    }
+  }
+  if (o->locs_per_key < 1) o->locs_per_key = 1;
+  if (o->nodes < o->locs_per_key) o->nodes = o->locs_per_key;
+  if (o->threads < 1) o->threads = 1;
+  if (o->hit_pct > 100) o->hit_pct = 100;
+  return true;
+}
+
+std::string KeyName(size_t i) { return "k" + std::to_string(i); }
+std::string NodeName(size_t n) { return "node-" + std::to_string(n); }
+
+// Populate the index with `index_keys` keys.  Key i is owned by nodes
+// (i + 0 .. i + locs_per_key-1) mod nodes, so replicas are spread evenly and
+// every node carries a comparable share.  We batch all ADDs for a given node
+// into one ApplyEvents call (ApplyEvents groups by node_id).
+void Populate(GlobalBlockIndex* idx, const BenchOpts& o) {
+  std::vector<std::vector<KvEvent>> per_node(o.nodes);
+  for (size_t i = 0; i < o.index_keys; ++i) {
+    for (size_t r = 0; r < o.locs_per_key; ++r) {
+      size_t node = (i + r) % o.nodes;
+      KvEvent ev;
+      ev.kind = KvEvent::Kind::ADD;
+      ev.key = KeyName(i);
+      ev.tier = TierType::DRAM;
+      ev.size = 4096;
+      per_node[node].push_back(std::move(ev));
+    }
+  }
+  for (size_t n = 0; n < o.nodes; ++n) {
+    idx->ApplyEvents(NodeName(n), per_node[n]);
+  }
+}
+
+// Pre-build the per-iteration key batches so the measured loop touches only the
+// method under test (no string formatting or RNG in the hot path).  `hit_pct`
+// of the keys index into the populated range; the rest are guaranteed misses.
+std::vector<std::vector<std::string>> BuildBatches(const BenchOpts& o, uint64_t seed) {
+  std::mt19937_64 rng(seed);
+  std::uniform_int_distribution<size_t> hit_dist(0, o.index_keys ? o.index_keys - 1 : 0);
+  std::uniform_int_distribution<size_t> pct(1, 100);
+  std::vector<std::vector<std::string>> batches(o.iters);
+  for (size_t it = 0; it < o.iters; ++it) {
+    auto& b = batches[it];
+    b.reserve(o.batch);
+    for (size_t j = 0; j < o.batch; ++j) {
+      if (pct(rng) <= o.hit_pct && o.index_keys > 0) {
+        b.push_back(KeyName(hit_dist(rng)));
+      } else {
+        b.push_back("miss-" + std::to_string(it) + "-" + std::to_string(j));
+      }
+    }
+  }
+  return batches;
+}
+
+std::unordered_set<std::string> BuildExclude(const BenchOpts& o) {
+  std::unordered_set<std::string> ex;
+  for (size_t n = 0; n < o.exclude && n < o.nodes; ++n) ex.insert(NodeName(n));
+  return ex;
+}
+
+void RunScenario(const BenchOpts& base, size_t batch_override) {
+  BenchOpts o = base;
+  o.batch = batch_override > 0 ? batch_override : o.batch;
+
+  GlobalBlockIndex idx;
+  Populate(&idx, o);
+  const auto exclude = BuildExclude(o);
+  const auto lease = std::chrono::milliseconds(o.lease_ms);
+
+  // Per-thread inputs (distinct seeds so threads don't all hammer one bucket).
+  std::vector<std::vector<std::vector<std::string>>> thread_batches(o.threads);
+  for (size_t t = 0; t < o.threads; ++t) {
+    thread_batches[t] = BuildBatches(o, 0x9E3779B97F4A7C15ULL ^ (t + 1));
+  }
+
+  // Warm-up (not measured): one pass per thread's first batch, single-threaded.
+  for (size_t t = 0; t < o.threads; ++t) {
+    (void)idx.BatchLookupForRouteGet(thread_batches[t][0], exclude, lease);
+  }
+
+  std::atomic<uint64_t> total_locs{0};
+  std::atomic<double> max_wall_ms{0.0};
+
+  auto worker = [&](size_t t) {
+    const auto& batches = thread_batches[t];
+    uint64_t locs = 0;
+    auto t0 = std::chrono::steady_clock::now();
+    for (size_t it = 0; it < o.iters; ++it) {
+      auto out = idx.BatchLookupForRouteGet(batches[it], exclude, lease);
+      for (const auto& v : out) locs += v.size();
+    }
+    auto t1 = std::chrono::steady_clock::now();
+    total_locs.fetch_add(locs, std::memory_order_relaxed);
+    const double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    // Wall clock is the slowest thread (calls run concurrently under shared_lock).
+    double prev = max_wall_ms.load(std::memory_order_relaxed);
+    while (ms > prev && !max_wall_ms.compare_exchange_weak(prev, ms)) {
+    }
+  };
+
+  std::vector<std::thread> pool;
+  pool.reserve(o.threads);
+  auto wall0 = std::chrono::steady_clock::now();
+  for (size_t t = 0; t < o.threads; ++t) pool.emplace_back(worker, t);
+  for (auto& th : pool) th.join();
+  auto wall1 = std::chrono::steady_clock::now();
+
+  const double wall_ms = std::chrono::duration<double, std::milli>(wall1 - wall0).count();
+  const uint64_t total_calls = static_cast<uint64_t>(o.iters) * o.threads;
+  const uint64_t total_keys = total_calls * o.batch;
+  const double us_per_call = total_calls > 0 ? (wall_ms * 1000.0) / total_calls : 0.0;
+  const double mlookups_s = wall_ms > 0 ? (total_keys / 1e6) / (wall_ms / 1000.0) : 0.0;
+  const double locs_per_call =
+      total_calls > 0 ? static_cast<double>(total_locs.load()) / total_calls : 0.0;
+
+  std::printf("%zu,%zu,%zu,%zu,%zu,%zu,%zu,%zu,%.4f,%.2f,%.2f\n", o.index_keys, o.batch, o.nodes,
+              o.locs_per_key, o.exclude, o.hit_pct, o.threads, o.iters, us_per_call, mlookups_s,
+              locs_per_call);
+  std::fflush(stdout);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  BenchOpts opts;
+  if (!ParseArgs(argc, argv, &opts)) return 2;
+
+  std::printf(
+      "index_keys,batch,nodes,locs_per_key,exclude,hit_pct,threads,iters,"
+      "wall_us_per_call,Mlookups_s,locs_per_call\n");
+  std::fflush(stdout);
+
+  if (!opts.sweep.empty()) {
+    for (size_t b : opts.sweep) RunScenario(opts, b);
+  } else {
+    RunScenario(opts, 0);
+  }
+  return 0;
+}

--- a/tests/cpp/umbp/distributed/test_batch_route_get_columnar.cpp
+++ b/tests/cpp/umbp/distributed/test_batch_route_get_columnar.cpp
@@ -1,0 +1,234 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// BatchRouteGet columnar wire-format round-trip.
+//
+// The BatchRouteGetResponse was reshaped from a repeated array-of-structs
+// (one BatchRouteGetEntry per key, repeating node_id/peer_address strings) to
+// a columnar form: a deduplicated `nodes` table plus parallel packed `node_ref`
+// / `tier` / `size` arrays, where node_ref == 0 means "not found" (folding away
+// the old `found` bool).
+//
+// This test stands up a mock UMBPMaster service whose BatchRouteGet emits a
+// response using the SAME node-table-dedup algorithm as the real
+// master_server.cpp producer, then asserts that the real
+// MasterClient::BatchRouteGet consumer decodes it correctly.  It therefore
+// locks both halves of the contract: that distinct nodes are sent once and
+// referenced by a 1-based index, that repeated references to one node resolve
+// transparently, that node_ref == 0 maps to a "not found" optional, and that
+// the per-key tier/size columns stay aligned with the request keys.
+//
+// gRPC only, no RDMA — runs unconditionally (not under the "integration" label).
+
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/server_builder.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdint>
+#include <ctime>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "umbp.grpc.pb.h"
+#include "umbp/distributed/config.h"
+#include "umbp/distributed/master/master_client.h"
+#include "umbp/distributed/types.h"
+
+namespace mori::umbp {
+namespace {
+
+static uint16_t AllocPort() {
+  static std::atomic<uint16_t> next{0};
+  if (next.load() == 0) {
+    std::srand(static_cast<unsigned>(std::time(nullptr)));
+    next.store(static_cast<uint16_t>(52000 + (std::rand() % 1500)));
+  }
+  return next.fetch_add(7);
+}
+
+// Canned per-key routing answer the mock server hands back.  A nullopt entry
+// (or a key absent from the table) is "not found".
+struct Route {
+  std::string node_id;
+  std::string peer_address;
+  ::umbp::TierType tier;
+  uint64_t size;
+};
+
+// Mock master.  BatchRouteGet builds the columnar response exactly the way the
+// real producer (master_server.cpp) does: distinct (node_id, peer_address)
+// pairs go into `nodes` once, each key gets a 1-based node_ref (0 = not found),
+// and tier/size are parallel per-key columns.
+class MockMasterService final : public ::umbp::UMBPMaster::Service {
+ public:
+  void SetRoute(const std::string& key, Route r) { table_[key] = std::move(r); }
+
+  // Distinct node count emitted by the most recent BatchRouteGet — lets the
+  // test assert the response actually deduplicated rather than just that the
+  // decoded strings happen to match.
+  int LastNodeTableSize() const { return last_nodes_size_.load(); }
+
+  grpc::Status RegisterClient(grpc::ServerContext*, const ::umbp::RegisterClientRequest*,
+                              ::umbp::RegisterClientResponse* resp) override {
+    resp->set_heartbeat_interval_ms(100000);  // effectively never; no heartbeat in this test
+    return grpc::Status::OK;
+  }
+
+  grpc::Status BatchRouteGet(grpc::ServerContext*, const ::umbp::BatchRouteGetRequest* req,
+                             ::umbp::BatchRouteGetResponse* resp) override {
+    std::unordered_map<std::string, uint32_t> node_index;  // "id\0addr" -> 1-based
+    for (const auto& key : req->keys()) {
+      auto it = table_.find(key);
+      if (it == table_.end()) {
+        resp->add_node_ref(0);
+        resp->add_tier(::umbp::TIER_UNKNOWN);
+        resp->add_size(0);
+        continue;
+      }
+      const Route& r = it->second;
+      std::string nk = r.node_id;
+      nk.push_back('\0');
+      nk.append(r.peer_address);
+      auto [slot, inserted] = node_index.try_emplace(nk, 0);
+      if (inserted) {
+        auto* node = resp->add_nodes();
+        node->set_node_id(r.node_id);
+        node->set_peer_address(r.peer_address);
+        slot->second = static_cast<uint32_t>(resp->nodes_size());  // 1-based
+      }
+      resp->add_node_ref(slot->second);
+      resp->add_tier(r.tier);
+      resp->add_size(r.size);
+    }
+    last_nodes_size_.store(resp->nodes_size());
+    return grpc::Status::OK;
+  }
+
+ private:
+  std::unordered_map<std::string, Route> table_;
+  std::atomic<int> last_nodes_size_{0};
+};
+
+class BatchRouteGetColumnarTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    address_ = "127.0.0.1:" + std::to_string(AllocPort());
+    service_ = std::make_unique<MockMasterService>();
+    grpc::ServerBuilder builder;
+    builder.AddListeningPort(address_, grpc::InsecureServerCredentials());
+    builder.RegisterService(service_.get());
+    server_ = builder.BuildAndStart();
+    ASSERT_NE(server_, nullptr);
+
+    UMBPMasterClientConfig cfg;
+    cfg.node_id = "caller";
+    cfg.node_address = "127.0.0.1";
+    cfg.master_address = address_;
+    client_ = std::make_unique<MasterClient>(cfg);
+  }
+
+  void TearDown() override {
+    client_.reset();
+    if (server_) {
+      server_->Shutdown(std::chrono::system_clock::now() + std::chrono::milliseconds(200));
+      server_->Wait();
+    }
+  }
+
+  std::string address_;
+  std::unique_ptr<MockMasterService> service_;
+  std::unique_ptr<grpc::Server> server_;
+  std::unique_ptr<MasterClient> client_;
+};
+
+// Two distinct nodes, one node referenced by two keys (dedup), and one
+// not-found key — the headline case for the columnar reshape.
+TEST_F(BatchRouteGetColumnarTest, DedupDistinctNodesAndNotFound) {
+  service_->SetRoute("kA1", {"node-a", "10.0.0.1:47071", ::umbp::TIER_DRAM, 100});
+  service_->SetRoute("kB", {"node-b", "10.0.0.2:47072", ::umbp::TIER_HBM, 200});
+  service_->SetRoute("kA2", {"node-a", "10.0.0.1:47071", ::umbp::TIER_SSD, 300});
+  // "kMiss" intentionally has no route -> not found.
+
+  const std::vector<std::string> keys = {"kA1", "kB", "kA2", "kMiss"};
+  std::vector<std::optional<RouteGetResult>> out;
+  auto status = client_->BatchRouteGet(keys, /*exclude_nodes=*/{}, &out);
+  ASSERT_TRUE(status.ok()) << status.error_message();
+
+  // One decoded slot per request key, in request order.
+  ASSERT_EQ(out.size(), keys.size());
+
+  // kA1 -> node-a / DRAM / 100
+  ASSERT_TRUE(out[0].has_value());
+  EXPECT_EQ(out[0]->node_id, "node-a");
+  EXPECT_EQ(out[0]->peer_address, "10.0.0.1:47071");
+  EXPECT_EQ(out[0]->tier, TierType::DRAM);
+  EXPECT_EQ(out[0]->size, 100u);
+
+  // kB -> node-b / HBM / 200
+  ASSERT_TRUE(out[1].has_value());
+  EXPECT_EQ(out[1]->node_id, "node-b");
+  EXPECT_EQ(out[1]->peer_address, "10.0.0.2:47072");
+  EXPECT_EQ(out[1]->tier, TierType::HBM);
+  EXPECT_EQ(out[1]->size, 200u);
+
+  // kA2 -> node-a again (same strings as out[0]) but its own tier/size column.
+  ASSERT_TRUE(out[2].has_value());
+  EXPECT_EQ(out[2]->node_id, "node-a");
+  EXPECT_EQ(out[2]->peer_address, "10.0.0.1:47071");
+  EXPECT_EQ(out[2]->tier, TierType::SSD);
+  EXPECT_EQ(out[2]->size, 300u);
+
+  // kMiss -> node_ref 0 -> not found.
+  EXPECT_FALSE(out[3].has_value());
+
+  // The two node-a keys must have shared a single node-table entry, so the
+  // table holds exactly the 2 distinct nodes, not 3.
+  EXPECT_EQ(service_->LastNodeTableSize(), 2);
+}
+
+// Every key unresolved: all slots present (parallel to keys) and all empty.
+TEST_F(BatchRouteGetColumnarTest, AllNotFound) {
+  const std::vector<std::string> keys = {"x", "y", "z"};
+  std::vector<std::optional<RouteGetResult>> out;
+  auto status = client_->BatchRouteGet(keys, {}, &out);
+  ASSERT_TRUE(status.ok()) << status.error_message();
+
+  ASSERT_EQ(out.size(), keys.size());
+  for (const auto& o : out) EXPECT_FALSE(o.has_value());
+  EXPECT_EQ(service_->LastNodeTableSize(), 0);  // empty node table when nothing resolves
+}
+
+// Empty request -> empty result, no error.
+TEST_F(BatchRouteGetColumnarTest, EmptyKeys) {
+  std::vector<std::optional<RouteGetResult>> out;
+  auto status = client_->BatchRouteGet({}, {}, &out);
+  ASSERT_TRUE(status.ok()) << status.error_message();
+  EXPECT_TRUE(out.empty());
+}
+
+}  // namespace
+}  // namespace mori::umbp

--- a/tests/cpp/umbp/distributed/test_master_client_flush_heartbeat.cpp
+++ b/tests/cpp/umbp/distributed/test_master_client_flush_heartbeat.cpp
@@ -1,0 +1,286 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Tests for MasterClient::FlushHeartbeat():
+//
+//  1. FlushHeartbeat() wakes the sleeping heartbeat thread and fires a
+//     heartbeat immediately, well before the configured interval elapses.
+//
+//  2. FlushHeartbeat() called before StartHeartbeat() is a safe no-op —
+//     no crash, no heartbeat sent.
+//
+//  3. FlushHeartbeat() called while a heartbeat RPC is in-flight sets
+//     flush_requested_, so the next loop iteration fires immediately once
+//     the in-flight RPC completes (rather than sleeping the full interval).
+
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/server_builder.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
+#include <ctime>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include "umbp.grpc.pb.h"
+#include "umbp/distributed/master/master_client.h"
+
+namespace mori::umbp {
+namespace {
+
+static uint16_t AllocPort() {
+  static std::atomic<uint16_t> next{0};
+  if (next.load() == 0) {
+    std::srand(static_cast<unsigned>(std::time(nullptr)));
+    next.store(static_cast<uint16_t>(55500 + (std::rand() % 1500)));
+  }
+  return next.fetch_add(7);
+}
+
+// --------------------------------------------------------------------------
+// Fake master: records heartbeat arrival times; optionally blocks each
+// Heartbeat RPC until ReleaseAll() is called.
+// --------------------------------------------------------------------------
+class RecordingMasterService final : public ::umbp::UMBPMaster::Service {
+ public:
+  explicit RecordingMasterService(int interval_ms, bool block_heartbeats = false)
+      : interval_ms_(interval_ms), block_heartbeats_(block_heartbeats) {}
+
+  grpc::Status RegisterClient(grpc::ServerContext*, const ::umbp::RegisterClientRequest*,
+                              ::umbp::RegisterClientResponse* resp) override {
+    resp->set_heartbeat_interval_ms(interval_ms_);
+    return grpc::Status::OK;
+  }
+
+  grpc::Status Heartbeat(grpc::ServerContext* ctx, const ::umbp::HeartbeatRequest*,
+                         ::umbp::HeartbeatResponse* resp) override {
+    {
+      std::lock_guard<std::mutex> lock(mu_);
+      ++count_;
+      last_time_ = std::chrono::steady_clock::now();
+      entered_cv_.notify_all();
+    }
+    if (block_heartbeats_) {
+      std::unique_lock<std::mutex> lock(mu_);
+      // Poll cancel flag at 25 ms so server shutdown isn't stuck.
+      release_cv_.wait_for(lock, std::chrono::milliseconds(25),
+                           [&] { return released_ || ctx->IsCancelled(); });
+      while (!released_ && !ctx->IsCancelled()) {
+        release_cv_.wait_for(lock, std::chrono::milliseconds(25),
+                             [&] { return released_ || ctx->IsCancelled(); });
+      }
+    }
+    resp->set_acked_seq(0);
+    return grpc::Status::OK;
+  }
+
+  grpc::Status UnregisterClient(grpc::ServerContext*, const ::umbp::UnregisterClientRequest*,
+                                ::umbp::UnregisterClientResponse*) override {
+    return grpc::Status::OK;
+  }
+
+  void ReleaseAll() {
+    std::lock_guard<std::mutex> lock(mu_);
+    released_ = true;
+    release_cv_.notify_all();
+  }
+
+  // Block until at least `target` heartbeats have been received, or `timeout` elapses.
+  bool WaitForCount(int target, std::chrono::milliseconds timeout) {
+    std::unique_lock<std::mutex> lock(mu_);
+    return entered_cv_.wait_for(lock, timeout, [&] { return count_ >= target; });
+  }
+
+  // Block until a heartbeat that arrived strictly after `since` is recorded.
+  bool WaitForHeartbeatAfter(std::chrono::steady_clock::time_point since,
+                             std::chrono::milliseconds timeout) {
+    std::unique_lock<std::mutex> lock(mu_);
+    return entered_cv_.wait_for(lock, timeout, [&] { return count_ > 0 && last_time_ > since; });
+  }
+
+  int Count() {
+    std::lock_guard<std::mutex> lock(mu_);
+    return count_;
+  }
+
+  std::chrono::steady_clock::time_point LastTime() {
+    std::lock_guard<std::mutex> lock(mu_);
+    return last_time_;
+  }
+
+ private:
+  const int interval_ms_;
+  const bool block_heartbeats_;
+
+  std::mutex mu_;
+  std::condition_variable entered_cv_;
+  std::condition_variable release_cv_;
+  int count_ = 0;
+  std::chrono::steady_clock::time_point last_time_;
+  bool released_ = false;
+};
+
+// --------------------------------------------------------------------------
+// Test fixture
+// --------------------------------------------------------------------------
+class FlushHeartbeatTest : public ::testing::Test {
+ protected:
+  void BuildServer(int interval_ms, bool block = false) {
+    service_ = std::make_unique<RecordingMasterService>(interval_ms, block);
+    uint16_t port = AllocPort();
+    address_ = "127.0.0.1:" + std::to_string(port);
+
+    grpc::ServerBuilder builder;
+    builder.AddListeningPort(address_, grpc::InsecureServerCredentials());
+    builder.RegisterService(service_.get());
+    server_ = builder.BuildAndStart();
+    ASSERT_NE(server_, nullptr);
+  }
+
+  std::unique_ptr<MasterClient> MakeRegisteredClient() {
+    UMBPMasterClientConfig cfg;
+    cfg.node_id = "flush-hb-test-node";
+    cfg.node_address = "127.0.0.1";
+    cfg.master_address = address_;
+    auto client = std::make_unique<MasterClient>(cfg);
+    std::map<TierType, TierCapacity> caps;
+    caps[TierType::DRAM] = {1u << 20, 1u << 20};
+    auto status = client->RegisterSelf(caps);
+    EXPECT_TRUE(status.ok()) << "RegisterSelf failed: " << status.error_message();
+    return client;
+  }
+
+  void TearDown() override {
+    if (service_) service_->ReleaseAll();
+    if (server_) {
+      server_->Shutdown(std::chrono::system_clock::now() + std::chrono::milliseconds(500));
+      server_->Wait();
+    }
+  }
+
+  std::string address_;
+  std::unique_ptr<RecordingMasterService> service_;
+  std::unique_ptr<grpc::Server> server_;
+};
+
+// --------------------------------------------------------------------------
+// Test 1: FlushHeartbeat wakes the sleeping heartbeat thread immediately.
+//
+// With a 10-second interval the first heartbeat would not arrive for ~10s.
+// FlushHeartbeat() must deliver it within 500 ms.
+// --------------------------------------------------------------------------
+TEST_F(FlushHeartbeatTest, WakesHeartbeatThreadImmediately) {
+  constexpr int kLongIntervalMs = 10'000;
+  constexpr int kFlushDeadlineMs = 500;
+
+  ASSERT_NO_FATAL_FAILURE(BuildServer(kLongIntervalMs));
+  auto client = MakeRegisteredClient();
+
+  client->StartHeartbeat();
+  ASSERT_EQ(service_->Count(), 0) << "Unexpected heartbeat before FlushHeartbeat()";
+
+  auto t0 = std::chrono::steady_clock::now();
+  client->FlushHeartbeat();
+
+  bool fired = service_->WaitForHeartbeatAfter(t0, std::chrono::milliseconds(kFlushDeadlineMs));
+  ASSERT_TRUE(fired) << "Heartbeat did not arrive within " << kFlushDeadlineMs
+                     << " ms after FlushHeartbeat()";
+
+  auto elapsed_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(service_->LastTime() - t0).count();
+  EXPECT_LT(elapsed_ms, kFlushDeadlineMs)
+      << "Heartbeat arrived after " << elapsed_ms << " ms (budget " << kFlushDeadlineMs << " ms)";
+}
+
+// --------------------------------------------------------------------------
+// Test 2: FlushHeartbeat() before StartHeartbeat() is a safe no-op.
+// --------------------------------------------------------------------------
+TEST_F(FlushHeartbeatTest, NoOpBeforeStart) {
+  ASSERT_NO_FATAL_FAILURE(BuildServer(5000));
+
+  // Case A: before RegisterSelf and StartHeartbeat.
+  {
+    UMBPMasterClientConfig cfg;
+    cfg.node_id = "flush-noop-node";
+    cfg.node_address = "127.0.0.1";
+    cfg.master_address = address_;
+    MasterClient client(cfg);
+    EXPECT_NO_FATAL_FAILURE(client.FlushHeartbeat());
+  }
+
+  // Case B: after RegisterSelf but before StartHeartbeat.
+  {
+    auto client = MakeRegisteredClient();
+    EXPECT_NO_FATAL_FAILURE(client->FlushHeartbeat());
+    // Destructor runs without starting the heartbeat thread — should be clean.
+  }
+
+  EXPECT_EQ(service_->Count(), 0) << "No heartbeat should have been sent";
+}
+
+// --------------------------------------------------------------------------
+// Test 3: FlushHeartbeat() called while a heartbeat RPC is in-flight.
+//
+// flush_requested_ persists past the in-flight send; the next wait_for
+// iteration sees it as true and fires immediately — gap from RPC release
+// to second heartbeat must be well under the 10-second interval.
+// --------------------------------------------------------------------------
+TEST_F(FlushHeartbeatTest, FlushWhileRPCInFlightFiresNextTickImmediately) {
+  constexpr int kLongIntervalMs = 10'000;
+  constexpr int kDeadlineMs = 1000;
+
+  ASSERT_NO_FATAL_FAILURE(BuildServer(kLongIntervalMs, /*block=*/true));
+  auto client = MakeRegisteredClient();
+  client->StartHeartbeat();
+
+  // Kick the first heartbeat and wait for it to enter (and block in) the RPC.
+  client->FlushHeartbeat();
+  ASSERT_TRUE(service_->WaitForCount(1, std::chrono::milliseconds(500)))
+      << "First heartbeat never reached the server";
+
+  // While the RPC is still blocked, request a second flush.
+  client->FlushHeartbeat();
+
+  // Release the blocked RPC and measure how quickly the second heartbeat arrives.
+  auto t_release = std::chrono::steady_clock::now();
+  service_->ReleaseAll();
+
+  bool got_second = service_->WaitForCount(2, std::chrono::milliseconds(kDeadlineMs));
+  ASSERT_TRUE(got_second) << "Second heartbeat did not arrive within " << kDeadlineMs
+                          << " ms after releasing the blocked RPC";
+
+  auto gap_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(service_->LastTime() - t_release)
+          .count();
+  EXPECT_LT(gap_ms, kDeadlineMs)
+      << "Second heartbeat arrived " << gap_ms << " ms after release (budget " << kDeadlineMs
+      << " ms); flush_requested_ may not have been preserved across the in-flight RPC";
+}
+
+}  // namespace
+}  // namespace mori::umbp

--- a/tests/cpp/umbp/distributed/test_master_client_rpc_latency.cpp
+++ b/tests/cpp/umbp/distributed/test_master_client_rpc_latency.cpp
@@ -114,7 +114,8 @@ class RecordingMasterService final : public ::umbp::UMBPMaster::Service {
       std::lock_guard<std::mutex> lock(mu_);
       ++batch_route_get_calls_;
     }
-    for (int i = 0; i < req->keys_size(); ++i) resp->add_entries()->set_found(false);
+    // node_ref == 0 means "not found" in the columnar response; emit one per key.
+    for (int i = 0; i < req->keys_size(); ++i) resp->add_node_ref(0);
     return grpc::Status::OK;
   }
   int BatchLookupCalls() {

--- a/tests/python/io/benchmark.py
+++ b/tests/python/io/benchmark.py
@@ -19,7 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from tests.python.utils import get_free_port, TorchDistContext
+from tests.python.utils import TorchDistContext
 import torch
 import torch.distributed as dist
 from mori.io import (
@@ -1020,7 +1020,7 @@ def benchmark_engine(local_rank, node_rank, args):
         sweep_max_size=args.sweep_max_size,
         backend_type="rdma",
         host=args.host,
-        port=get_free_port(),
+        port=0,
         node_rank=node_rank,
         rank_in_node=local_rank,
         num_initiator_dev=args.num_initiator_dev,

--- a/tests/python/io/stress_test.py
+++ b/tests/python/io/stress_test.py
@@ -33,7 +33,7 @@ from typing import List, Tuple
 import torch
 import torch.distributed as dist
 
-from tests.python.utils import get_free_port, TorchDistContext
+from tests.python.utils import TorchDistContext
 from mori.io import (
     IOEngineConfig,
     BackendType,
@@ -745,7 +745,7 @@ def parse_args():
 
 
 def launch_stress(local_rank: int, node_rank: int, args):
-    port = get_free_port()
+    port = 0
     stress = MoriIoStress(
         host=args.host,
         port=port,

--- a/tests/python/io/test_engine.py
+++ b/tests/python/io/test_engine.py
@@ -23,7 +23,6 @@ import pytest
 import os
 import time
 from contextlib import contextmanager
-from tests.python.utils import get_free_port
 import torch
 from mori.io import (
     IOEngineConfig,
@@ -48,10 +47,9 @@ def create_connected_engine_pair(
 ):
     config = IOEngineConfig(
         host="127.0.0.1",
-        port=get_free_port(),
+        port=0,
     )
     initiator = IOEngine(key=f"{name_prefix}_initiator", config=config)
-    config.port = get_free_port()
     target = IOEngine(key=f"{name_prefix}_target", config=config)
 
     config = RdmaBackendConfig(
@@ -116,7 +114,7 @@ def pre_connected_engine_pair():
 def test_engine_desc():
     config = IOEngineConfig(
         host="127.0.0.1",
-        port=get_free_port(),
+        port=0,
     )
     engine = IOEngine(key="engine", config=config)
     engine.create_backend(BackendType.RDMA)
@@ -152,7 +150,7 @@ def test_engine_desc_node_id_env_override(monkeypatch):
     monkeypatch.setenv("MORI_NODE_ID", "node-id-test")
     config = IOEngineConfig(
         host="127.0.0.1",
-        port=get_free_port(),
+        port=0,
     )
     engine = IOEngine(key="engine_node_id", config=config)
     desc = engine.get_engine_desc()
@@ -191,7 +189,7 @@ def test_rdmabackend_auto_creates_xgmi_backend_for_gpu_mem(monkeypatch):
     monkeypatch.setenv("MORI_DISABLE_AUTO_XGMI", "0")
     config = IOEngineConfig(
         host="127.0.0.1",
-        port=get_free_port(),
+        port=0,
     )
     engine = IOEngine(key="auto_xgmi_engine", config=config)
     engine.create_backend(BackendType.RDMA)
@@ -208,7 +206,7 @@ def test_rdmabackend_auto_xgmi_can_be_disabled(monkeypatch):
     monkeypatch.setenv("MORI_DISABLE_AUTO_XGMI", "1")
     config = IOEngineConfig(
         host="127.0.0.1",
-        port=get_free_port(),
+        port=0,
     )
     engine = IOEngine(key="auto_xgmi_disabled_engine", config=config)
     engine.create_backend(BackendType.RDMA)
@@ -225,7 +223,7 @@ def test_intra_node_prefers_xgmi_after_rdma_creation(monkeypatch):
     monkeypatch.setenv("MORI_DISABLE_AUTO_XGMI", "0")
     config = IOEngineConfig(
         host="127.0.0.1",
-        port=get_free_port(),
+        port=0,
     )
     engine = IOEngine(key="auto_xgmi_route_engine", config=config)
     engine.create_backend(BackendType.RDMA)
@@ -248,7 +246,7 @@ def test_intra_node_prefers_xgmi_after_rdma_creation(monkeypatch):
 def test_mem_desc():
     config = IOEngineConfig(
         host="127.0.0.1",
-        port=get_free_port(),
+        port=0,
     )
     engine = IOEngine(key="engine", config=config)
     engine.create_backend(BackendType.RDMA)
@@ -626,10 +624,9 @@ def test_successful_writes_always_have_inbound_notification_under_pressure():
 def test_no_backend():
     config = IOEngineConfig(
         host="127.0.0.1",
-        port=get_free_port(),
+        port=0,
     )
     initiator = IOEngine(key="no_be_initiator", config=config)
-    config.port = get_free_port()
     target = IOEngine(key="no_be_target", config=config)
 
     initiator_desc = initiator.get_engine_desc()

--- a/tests/python/io/test_engine_multi_session_batch.py
+++ b/tests/python/io/test_engine_multi_session_batch.py
@@ -40,7 +40,6 @@ import os
 import torch
 from contextlib import contextmanager
 
-from tests.python.utils import get_free_port
 from mori.io import (
     IOEngineConfig,
     BackendType,
@@ -62,9 +61,8 @@ def create_connected_engine_pair(
 
     Returns (initiator, target).
     """
-    config = IOEngineConfig(host="127.0.0.1", port=get_free_port())
+    config = IOEngineConfig(host="127.0.0.1", port=0)
     initiator = IOEngine(key=f"{name_prefix}_initiator", config=config)
-    config.port = get_free_port()
     target = IOEngine(key=f"{name_prefix}_target", config=config)
 
     be_cfg = RdmaBackendConfig(

--- a/tests/python/umbp/umbp_bench.py
+++ b/tests/python/umbp/umbp_bench.py
@@ -1,0 +1,822 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import argparse
+import atexit
+import ctypes
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from abc import ABC, abstractmethod
+
+_DEFAULT_NR_OBJECTS = 2048
+_DEFAULT_VALUE_SIZE = 2097152
+_DEFAULT_SYNC_PORT = 18515
+
+
+# --- optional in-process server startup (--start-server) ---
+
+
+def _port_in_use(port) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(0.5)
+        return s.connect_ex(("127.0.0.1", int(port))) == 0
+
+
+def _wait_for_port(port, timeout: float = 15.0) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if _port_in_use(port):
+            return True
+        time.sleep(0.2)
+    return False
+
+
+_PR_SET_PDEATHSIG = 1
+
+
+def _die_with_parent():
+    # Linux only: ask the kernel to SIGKILL this child when the bench process
+    # dies -- including when the bench is itself killed with SIGKILL, which
+    # can't be caught so atexit never runs. Also start a new session so the
+    # child becomes a process-group leader; this lets us SIGKILL the whole
+    # group (including grandchildren that PDEATHSIG doesn't reach) on cleanup.
+    os.setsid()
+    ctypes.CDLL("libc.so.6", use_errno=True).prctl(_PR_SET_PDEATHSIG, signal.SIGKILL)
+
+
+def _kill_group(proc):
+    # Kill the spawned process and any descendants it left behind (e.g.
+    # mooncake_master's metrics/admin server). PDEATHSIG only covers direct
+    # children and doesn't propagate to grandchildren, so reap the whole group.
+    if proc.poll() is not None:
+        return
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    except OSError:
+        proc.kill()
+
+
+def _spawn(argv, log_path, env=None) -> subprocess.Popen:
+    log = open(log_path, "w")
+    proc = subprocess.Popen(
+        argv, stdout=log, stderr=subprocess.STDOUT, env=env, preexec_fn=_die_with_parent
+    )
+    atexit.register(lambda: _kill_group(proc))
+    return proc
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="umbp_bench.py")
+    cmd_sub = parser.add_subparsers(dest="command", required=True, metavar="COMMAND")
+
+    def _add_backend_sub(cmd_parser, *, batch_perf: bool = False):
+        be_sub = cmd_parser.add_subparsers(
+            dest="backend", required=True, metavar="BACKEND"
+        )
+        for be_name in ("umbp", "mooncake"):
+            be_p = be_sub.add_parser(be_name)
+            if be_name == "umbp":
+                be_p.add_argument("master_address", help="e.g. ip:port")
+            else:
+                be_p.add_argument(
+                    "metadata_server", help="e.g. http://ip:8080/metadata"
+                )
+                be_p.add_argument("master_server", help="e.g. ip:50051")
+            be_p.add_argument("--nr-objects", type=int, default=_DEFAULT_NR_OBJECTS)
+            be_p.add_argument("--value-size", type=int, default=_DEFAULT_VALUE_SIZE)
+            be_p.add_argument(
+                "--role",
+                choices=["both", "writer", "reader"],
+                default="both",
+                help="Process role for split-node runs. 'both' (default) writes "
+                "then reads in a single process (original behavior). 'writer' "
+                "writes the dataset and stays alive holding it in DRAM until "
+                "the reader is done. 'reader' connects to the writer's "
+                "already-running master and reads. Run writer and reader on "
+                "different nodes, passing the reader the writer's master "
+                "address, and the same --key-prefix and --sync-port to both.",
+            )
+            be_p.add_argument(
+                "--key-prefix",
+                default=None,
+                help="Shared key namespace (first 4 chars used). REQUIRED to match "
+                "between writer and reader in split runs so they compute the "
+                "same keys; defaults to a per-pid value when unset (fine for "
+                "role=both, broken for split).",
+            )
+            be_p.add_argument(
+                "--sync-port",
+                type=int,
+                default=_DEFAULT_SYNC_PORT,
+                help="TCP port on the writer node used as a write-done/read-done "
+                "rendezvous between a split writer and reader (default: "
+                f"{_DEFAULT_SYNC_PORT}). Ignored for role=both.",
+            )
+            be_p.add_argument(
+                "--numa-node",
+                type=int,
+                default=-1,
+                help="Pin this process to a NUMA node (default: -1 = no binding): "
+                "binds CPU affinity to the node's cpulist, allocates the bench "
+                "DMA buffers on it, and (UMBP) places the DRAM tier there. The "
+                "IO engine then auto-selects NUMA-local NICs. In a same-node "
+                "split, give the writer and reader different --numa-node values "
+                "to exercise a cross-NUMA transfer. Overridable per-allocation "
+                "via UMBP_DRAM_NUMA_NODE.",
+            )
+            be_p.add_argument(
+                "--start-server",
+                action=argparse.BooleanOptionalAction,
+                default=True,
+                help="Launch the backend metadata/master server(s) for this run "
+                "and tear them down on exit (default: on; use --no-start-server "
+                "to reuse an already-running server).",
+            )
+            if batch_perf:
+                be_p.add_argument("--passes", type=int, default=10)
+                be_p.add_argument("--batch-sizes", type=int, nargs="+", metavar="N")
+                be_p.add_argument(
+                    "--dest-layout",
+                    choices=["contiguous", "shuffled"],
+                    default="shuffled",
+                    help="Destination buffer layout for reads (default: shuffled). "
+                    "'shuffled' maps keys to a random permutation of slots in the "
+                    "same buffer so consecutive keys are non-adjacent in memory "
+                    "(non-consecutive transfer). 'contiguous' packs objects "
+                    "back-to-back (coalesceable), but a full-dataset batch then "
+                    "coalesces into a single multi-GB SGE that the ionic provider "
+                    "rejects (ibv_post_send EINVAL), so large batches all-miss.",
+                )
+                be_p.add_argument(
+                    "--shuffle-seed",
+                    type=int,
+                    default=0,
+                    help="Seed for --dest-layout shuffled (default: 0).",
+                )
+
+    _add_backend_sub(cmd_sub.add_parser("correctness"))
+    _add_backend_sub(cmd_sub.add_parser("batch_perf"), batch_perf=True)
+    return parser
+
+
+args = _build_parser().parse_args()
+command = args.command
+backend_name = args.backend
+nr_objects = args.nr_objects
+value_size = args.value_size
+role = args.role
+numa_node = args.numa_node
+
+if role != "both" and not args.key_prefix:
+    print(
+        "ERROR: split runs (--role writer/reader) require a shared --key-prefix on "
+        "both writer and reader so they compute the same keys",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+if backend_name == "umbp":
+    from mori.umbp import UMBPClient, UMBPConfig, UMBPDistributedConfig
+
+    master_address = args.master_address
+    _resolve_host = master_address.split(":")[0]
+else:
+    from mooncake.store import MooncakeDistributedStore, ReplicateConfig
+
+    metadata_server = args.metadata_server
+    master_server = args.master_server
+    _resolve_host = master_server.split(":")[0]
+
+key_prefix = args.key_prefix if args.key_prefix else f"{os.getpid() % 10000:04d}"
+key_size = 20
+pattern = b"\xab"
+
+with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as _s:
+    _s.connect((_resolve_host, 1))
+    node_address = _s.getsockname()[0]
+
+
+def make_key(object_id: int) -> str:
+    suffix = f"{object_id:016d}"
+    prefix_part = key_prefix[: key_size - len(suffix)].ljust(
+        key_size - len(suffix), "_"
+    )
+    return f"{prefix_part}{suffix}"
+
+
+def expected_payload(size: int) -> bytes:
+    reps = (size // len(pattern)) + 1
+    return (pattern * reps)[:size]
+
+
+# --- backend abstraction ---
+
+
+class Backend(ABC):
+    """Uniform KV-store interface; subclass per backend."""
+
+    @classmethod
+    @abstractmethod
+    def start_server(cls, args):
+        """Launch this backend's metadata/master server(s) for the run; tear down on exit."""
+
+    @abstractmethod
+    def put(self, key: str, payload: bytes, ptr: int, size: int) -> bool:
+        """Write value. ptr is a pre-registered DMA buffer (may be ignored by some backends)."""
+
+    @abstractmethod
+    def flush(self): ...
+
+    @abstractmethod
+    def register_memory(self, ptr: int, size: int):
+        """Register a memory region for RDMA (no-op for backends that don't need it)."""
+
+    @abstractmethod
+    def get_into_ptr(self, key: str, ptr: int, size: int) -> bool:
+        """Read value into ptr. Returns True on hit."""
+
+    @abstractmethod
+    def batch_get_into_ptr(self, keys: list, ptrs: list, sizes: list) -> list:
+        """Batch read into ptrs. Returns bytes_read per key (0 = miss)."""
+
+    @abstractmethod
+    def make_reader(self) -> "Backend":
+        """Return a backend instance for reading (may be self)."""
+
+
+class UMBPBackend(Backend):
+    @classmethod
+    def start_server(cls, args):
+        # In a split run the reader connects using the exact master port it was
+        # given on the CLI, so the writer must bind that port instead of an
+        # auto-picked one. role=both keeps auto-picking to avoid collisions on
+        # repeated single-node runs.
+        parts = args.master_address.split(":")
+        desired_port = int(parts[1]) if len(parts) > 1 and parts[1] else 0
+        port = (
+            desired_port if (args.role == "writer" and desired_port) else _free_port()
+        )
+        mori_root = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "..", "..")
+        )
+        fqdn = subprocess.run(
+            ["hostname", "-f"], capture_output=True, text=True
+        ).stdout.strip()
+        binary = os.path.join(mori_root, f"build_{fqdn}", "src", "umbp", "umbp_master")
+        if not os.path.exists(binary):
+            print(
+                f"umbp_master binary not found: {binary} (run ./build.sh first)",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        env = dict(os.environ)
+        env.setdefault("MORI_UMBP_LOG_LEVEL", "DEBUG")
+        proc = _spawn([binary, f"0.0.0.0:{port}", "0"], "/tmp/umbp_master.log", env)
+        if not _wait_for_port(port):
+            print(
+                "umbp_master failed to start; see /tmp/umbp_master.log", file=sys.stderr
+            )
+            sys.exit(1)
+        print(f"started umbp_master pid={proc.pid} on 0.0.0.0:{port}", flush=True)
+        # Return the address the client should connect to (port may have been
+        # auto-picked, so it can differ from what was passed on the CLI).
+        return f"{args.master_address.split(':')[0]}:{port}"
+
+    def __init__(
+        self,
+        node_id: str,
+        port: int,
+        reader_node_id: str = None,
+        reader_port: int = None,
+    ):
+        cfg = UMBPConfig()
+        cfg.dram.capacity_bytes = int(
+            os.environ.get("UMBP_DRAM_CAPACITY_BYTES", 8 * 1024 * 1024 * 1024)
+        )
+        cfg.dram.use_hugepages = os.environ.get("UMBP_DRAM_USE_HUGEPAGES", "1") not in (
+            "0",
+            "",
+        )
+        cfg.dram.hugepage_size = int(
+            os.environ.get("UMBP_DRAM_HUGEPAGE_SIZE", 2 * 1024 * 1024)
+        )
+        cfg.dram.numa_node = int(os.environ.get("UMBP_DRAM_NUMA_NODE", numa_node))
+        dist = UMBPDistributedConfig()
+        dist.master_config.master_address = master_address
+        dist.master_config.node_id = node_id
+        dist.master_config.node_address = node_address
+        dist.peer_service_port = port
+        dist.io_engine.host = node_address
+        cfg.distributed = dist
+        self._client = UMBPClient(cfg)
+        self._reader_node_id = reader_node_id
+        self._reader_port = reader_port
+
+    def put(self, key: str, payload: bytes, ptr: int, size: int) -> bool:
+        ctypes.memmove(ptr, payload, size)
+        return self._client.put_from_ptr(key, ptr, size)
+
+    def flush(self):
+        self._client.flush()
+
+    def register_memory(self, ptr: int, size: int):
+        self._client.register_memory(ptr, size)
+
+    def get_into_ptr(self, key: str, ptr: int, size: int) -> bool:
+        return self._client.get_into_ptr(key, ptr, size)
+
+    def batch_get_into_ptr(self, keys: list, ptrs: list, sizes: list) -> list:
+        raw = self._client.batch_get_into_ptr(keys, ptrs, sizes)
+        return [sz if hit else 0 for hit, sz in zip(raw, sizes)]
+
+    def make_reader(self) -> "UMBPBackend":
+        return UMBPBackend(self._reader_node_id, self._reader_port)
+
+
+class MooncakeBackend(Backend):
+    @classmethod
+    def start_server(cls, args):
+        scheme, _, rest = args.metadata_server.partition("://")
+        meta_hostport, _, meta_path = rest.partition("/")
+        meta_host = meta_hostport.partition(":")[0]
+        master_host = args.master_server.partition(":")[0]
+        # For a split run honor the CLI-provided meta/master ports (role=writer)
+        # so the reader on another node can connect using the same addresses.
+        cli_meta_port = int(meta_hostport.partition(":")[2] or 0)
+        cli_master_port = int(args.master_server.partition(":")[2] or 0)
+        meta_port = (
+            cli_meta_port if (args.role == "writer" and cli_meta_port) else _free_port()
+        )
+        master_port = (
+            cli_master_port
+            if (args.role == "writer" and cli_master_port)
+            else _free_port()
+        )
+        # mooncake_master also binds a metrics/admin HTTP server, hardcoded to
+        # 9003 by default. --enable_metric_reporting=false only disables
+        # reporting, not the bind, so a leaked master from a prior run holds
+        # 9003 and the next master collides. Give it a free port too.
+        metrics_port = _free_port()
+        meta = _spawn(
+            [
+                "mooncake_http_metadata_server",
+                "--port",
+                str(meta_port),
+                "--host",
+                "0.0.0.0",
+            ],
+            "/tmp/mc_http_metadata.log",
+        )
+        master = _spawn(
+            [
+                "mooncake_master",
+                "--rpc_port",
+                str(master_port),
+                "--metrics_port",
+                str(metrics_port),
+                "--enable_metric_reporting=false",
+            ],
+            "/tmp/mc_master.log",
+        )
+        if not _wait_for_port(meta_port) or not _wait_for_port(master_port):
+            print(
+                "mooncake servers failed to start; see /tmp/mc_*.log", file=sys.stderr
+            )
+            sys.exit(1)
+        print(
+            f"started mooncake servers meta pid={meta.pid} port={meta_port} "
+            f"master pid={master.pid} port={master_port}",
+            flush=True,
+        )
+        # Return the addresses the client should use (ports may have been auto-picked).
+        return (
+            f"{scheme}://{meta_host}:{meta_port}/{meta_path}",
+            f"{master_host}:{master_port}",
+        )
+
+    def __init__(self):
+        # Enable hugepages (2MB) by default, matching the UMBP backend. These are
+        # read by the C++ client at store construction / setup() time. Presence of
+        # MC_STORE_USE_HUGEPAGE (any value) enables it; MC_STORE_HUGEPAGE_SIZE
+        # accepts "2MB" or "1GB". Both stay overridable via the environment.
+        os.environ.setdefault("MC_STORE_USE_HUGEPAGE", "1")
+        os.environ.setdefault("MC_STORE_HUGEPAGE_SIZE", "2MB")
+        segment_size = max(1 << 24, nr_objects * value_size * 2)
+        # local_buffer_size is the client-side RDMA staging pool. It is
+        # registered on EVERY NIC at setup, so on multi-NIC ionic an 8 GB pool
+        # blows up the device/IOMMU page-table footprint (8 GB x N NICs) and
+        # ibv_reg_mr returns ENOMEM at >=6 NICs. The zero-copy batch_get_into
+        # path never touches it; only sequential put()/single get() stage
+        # through it, one 2 MB object at a time, so a small pool is plenty.
+        # Override via MC_LOCAL_BUFFER_SIZE (bytes) if a workload needs more.
+        local_buffer_size = int(
+            os.environ.get("MC_LOCAL_BUFFER_SIZE", 256 * 1024 * 1024)
+        )
+        self._store = MooncakeDistributedStore()
+        # rdma_devices is a comma-separated HCA list. Empty string => Mooncake
+        # auto-discovers all RDMA NICs (no longer pinned to a single device).
+        rdma_devices = os.environ.get("MC_RDMA_DEVICES", "")
+        # Pass the sizes by keyword: setup()'s positional order is
+        # (..., global_segment_size, local_buffer_size, ...) -- the reverse of
+        # how it reads -- so a positional swap silently mis-sizes the segment
+        # (segment too small => puts fail "insufficient space").
+        ret = self._store.setup(
+            node_address,
+            metadata_server,
+            global_segment_size=segment_size,
+            local_buffer_size=local_buffer_size,
+            protocol="rdma",
+            rdma_devices=rdma_devices,
+            master_server_addr=master_server,
+        )
+        if ret != 0:
+            print(f"mooncake setup failed: {ret}", file=sys.stderr)
+            sys.exit(1)
+        self._config = ReplicateConfig()
+        self._config.replica_num = 1
+
+    def put(self, key: str, payload: bytes, ptr: int, size: int) -> bool:
+        return self._store.put(key, payload, self._config) == 0
+
+    def flush(self):
+        pass
+
+    def register_memory(self, ptr: int, size: int):
+        self._store.register_buffer(ptr, size)
+
+    def get_into_ptr(self, key: str, ptr: int, size: int) -> bool:
+        data = self._store.get(key)
+        if data in (None, b""):
+            return False
+        ctypes.memmove(ptr, bytes(data), min(len(data), size))
+        return True
+
+    def batch_get_into_ptr(self, keys: list, ptrs: list, sizes: list) -> list:
+        return self._store.batch_get_into(keys, ptrs, sizes)
+
+    def make_reader(self) -> "MooncakeBackend":
+        return self
+
+
+# --- backend init ---
+
+_BACKENDS = {"umbp": UMBPBackend, "mooncake": MooncakeBackend}
+
+
+def _free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as _s:
+        _s.bind(("", 0))
+        return _s.getsockname()[1]
+
+
+# --- split writer/reader rendezvous (TCP, hosted on the writer node) ---
+
+
+def _sync_recv_until(conn, token: bytes, timeout: float = 600.0):
+    conn.settimeout(timeout)
+    buf = b""
+    while token not in buf:
+        chunk = conn.recv(64)
+        if not chunk:
+            raise ConnectionError(f"sync peer closed before sending {token!r}")
+        buf += chunk
+
+
+def _sync_listen(port: int):
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("0.0.0.0", port))
+    srv.listen(1)
+    return srv
+
+
+def _sync_connect(host: str, port: int, timeout: float = 300.0):
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        try:
+            return socket.create_connection((host, port), timeout=5)
+        except OSError as e:
+            last = e
+            time.sleep(0.5)
+    raise TimeoutError(f"could not reach writer sync {host}:{port}: {last}")
+
+
+def _bind_numa_cpus(node: int):
+    # Pin CPU affinity to the given NUMA node's cpulist. Memory placement is
+    # handled separately (UMBP DRAM tier + bench buffers take an explicit
+    # numa_node), but binding CPUs first means any first-touch allocation and
+    # the IO engine's worker threads also land on this node. Call before
+    # constructing any client or allocating buffers so threads inherit it.
+    if node < 0:
+        return
+    try:
+        with open(f"/sys/devices/system/node/node{node}/cpulist") as f:
+            spec = f.read().strip()
+    except OSError as e:
+        print(
+            f"WARNING: NUMA node {node} has no cpulist ({e}); not binding CPUs",
+            file=sys.stderr,
+        )
+        return
+    cpus = set()
+    for part in spec.split(","):
+        if not part:
+            continue
+        if "-" in part:
+            lo, hi = part.split("-")
+            cpus.update(range(int(lo), int(hi) + 1))
+        else:
+            cpus.add(int(part))
+    if not cpus:
+        return
+    os.sched_setaffinity(0, cpus)
+    print(f"bound to NUMA node {node}: {len(cpus)} cpus ({spec})", flush=True)
+
+
+# Only the writer (or a combined both) owns the master/metadata server(s); the
+# reader connects to the writer's already-running master, so it never starts one.
+if args.start_server and role != "reader":
+    _resolved = _BACKENDS[backend_name].start_server(args)
+    # The server may have been moved to an auto-picked free port; point the
+    # client at the address(es) it actually bound.
+    if backend_name == "umbp":
+        master_address = _resolved
+    else:
+        metadata_server, master_server = _resolved
+
+# Pin to the requested NUMA node before any client/thread/buffer is created so
+# affinity and first-touch placement are inherited. In a same-node split the
+# writer and reader pass different --numa-node values (cross-NUMA transfer).
+_bind_numa_cpus(numa_node)
+
+# Build the writer only for role in {both, writer}; build a standalone reader
+# backend lazily (role=reader uses _build_reader; role=both uses
+# writer.make_reader() so the two clients still share one process).
+writer = None
+if backend_name == "umbp":
+
+    def _build_reader():
+        rid = f"reader_{os.getpid()}_{int(time.time())}"
+        return UMBPBackend(rid, _free_port())
+
+    if role in ("both", "writer"):
+        ts = int(time.time())
+        node_id = f"{command}_{os.getpid()}_{ts}"
+        reader_node_id = f"reader_{os.getpid()}_{ts}"
+        peer_service_port = _free_port()
+        reader_peer_port = _free_port()
+        writer = UMBPBackend(
+            node_id, peer_service_port, reader_node_id, reader_peer_port
+        )
+        print(
+            f"backend=umbp role={role} writer_node_id={node_id} reader_node_id={reader_node_id} "
+            f"node_address={node_address} writer_port={peer_service_port} reader_port={reader_peer_port}",
+            flush=True,
+        )
+elif backend_name == "mooncake":
+
+    def _build_reader():
+        return MooncakeBackend()
+
+    if role in ("both", "writer"):
+        print(
+            f"backend=mooncake role={role} node_address={node_address} metadata={metadata_server} master={master_server}",
+            flush=True,
+        )
+        writer = MooncakeBackend()
+
+# --- host buffer allocation (hugepage-backed via mori's UMBP allocator) ---
+
+
+class HostBuffer:
+    """Host DMA buffer allocated through mori's UMBPHostMemAllocator so the bench
+    buffers are hugepage-backed (matching the DRAM tier) instead of the 4 KiB-paged
+    ctypes arrays used previously. Keeps the handle alive for the object's lifetime
+    and exposes a raw integer `ptr`. Honors the same UMBP_DRAM_USE_HUGEPAGES /
+    UMBP_DRAM_HUGEPAGE_SIZE env knobs (default: on, 2MB)."""
+
+    _allocator = None
+
+    def __init__(self, size: int):
+        from mori.umbp import UMBPHostBufferBacking, UMBPHostMemAllocator
+
+        if HostBuffer._allocator is None:
+            HostBuffer._allocator = UMBPHostMemAllocator()
+        use_hp = os.environ.get("UMBP_DRAM_USE_HUGEPAGES", "1") not in ("0", "")
+        hp_size = int(os.environ.get("UMBP_DRAM_HUGEPAGE_SIZE", 2 * 1024 * 1024))
+        backing = (
+            UMBPHostBufferBacking.AnonymousHugetlb
+            if use_hp
+            else UMBPHostBufferBacking.Anonymous
+        )
+        numa = int(os.environ.get("UMBP_DRAM_NUMA_NODE", numa_node))
+        self._handle = HostBuffer._allocator.alloc(size, backing, hp_size, numa, True)
+        if not self._handle:
+            raise RuntimeError(f"UMBPHostMemAllocator.alloc({size}) failed")
+        if use_hp and self._handle.actual_backing == UMBPHostBufferBacking.Anonymous:
+            print(
+                "WARNING: requested hugepages but kernel demoted to 4 KiB pages; "
+                "check vm.nr_hugepages and HugePages_Free in /proc/meminfo",
+                file=sys.stderr,
+            )
+        self.ptr = int(self._handle.ptr)
+        self.size = size
+
+    def __del__(self):
+        handle = getattr(self, "_handle", None)
+        if handle is not None and HostBuffer._allocator is not None:
+            try:
+                HostBuffer._allocator.free(handle)
+            except Exception:
+                pass
+            self._handle = None
+
+
+if role in ("both", "writer"):
+    buf = HostBuffer(value_size)
+    ptr = buf.ptr
+    writer.register_memory(ptr, value_size)
+
+
+# --- shared write helper ---
+
+
+def write_all() -> bool:
+    payload = expected_payload(value_size)
+    ok = fail = 0
+    for i in range(nr_objects):
+        if writer.put(make_key(i), payload, ptr, value_size):
+            ok += 1
+        else:
+            fail += 1
+    print(f"WRITE_DONE ok={ok} fail={fail} total={nr_objects}", flush=True)
+    writer.flush()
+    return fail == 0
+
+
+# --- write + reader setup (role-aware) ---
+#
+# role=writer : write the dataset, then host a TCP rendezvous on this node:
+#   signal READY (data flushed) -> wait for the reader's DONE -> release & exit.
+#   The writer must outlive the reads because UMBP serves them via RDMA out of
+#   this process's DRAM.
+# role=reader : connect to the writer's rendezvous, wait for READY, read, then
+#   signal DONE.
+# role=both   : original single-process behavior, no rendezvous.
+
+if role == "writer":
+    srv = _sync_listen(args.sync_port)
+    write_all()
+    print(
+        f"WRITER_READY holding dataset; waiting for reader on :{args.sync_port}",
+        flush=True,
+    )
+    conn, peer = srv.accept()
+    conn.sendall(b"READY\n")
+    print(f"reader connected from {peer[0]}:{peer[1]}; signalled READY", flush=True)
+    _sync_recv_until(conn, b"DONE")
+    print("READER_DONE; writer releasing dataset and exiting", flush=True)
+    conn.close()
+    srv.close()
+    sys.exit(0)
+
+sync_conn = None
+if role == "reader":
+    sync_conn = _sync_connect(_resolve_host, args.sync_port)
+    print(
+        f"connected to writer sync {_resolve_host}:{args.sync_port}; waiting for READY",
+        flush=True,
+    )
+    _sync_recv_until(sync_conn, b"READY")
+    print("writer signalled READY; starting reads", flush=True)
+    reader = _build_reader()
+else:  # both
+    write_all()
+    reader = writer.make_reader()
+
+# --- commands (reader side) ---
+
+exit_code = 0
+
+if command == "correctness":
+    read_buf = HostBuffer(value_size)
+    read_ptr = read_buf.ptr
+    reader.register_memory(read_ptr, value_size)
+    hits = misses = mismatches = 0
+    expected = expected_payload(value_size)
+    for i in range(nr_objects):
+        ctypes.memset(read_ptr, 0, value_size)
+        if not reader.get_into_ptr(make_key(i), read_ptr, value_size):
+            misses += 1
+            continue
+        hits += 1
+        if ctypes.string_at(read_ptr, value_size) != expected:
+            mismatches += 1
+    print(
+        f"CORRECTNESS hits={hits} misses={misses} mismatches={mismatches} total={nr_objects}",
+        flush=True,
+    )
+    if hits == nr_objects and mismatches == 0:
+        print("CORRECTNESS_OK", flush=True)
+    else:
+        print("CORRECTNESS_FAILED", flush=True)
+        exit_code = 1
+
+elif command == "batch_perf":
+    passes = args.passes
+    batch_sizes = args.batch_sizes if args.batch_sizes else [1, 32, 128, nr_objects]
+
+    keys = [make_key(i) for i in range(nr_objects)]
+    buf_total = value_size * nr_objects
+    whole = HostBuffer(buf_total)
+    base = whole.ptr
+    # Destination slot for each key. 'contiguous' packs them back-to-back so the
+    # IO engine can coalesce adjacent SGEs; 'shuffled' assigns each key a random
+    # slot in the same buffer so consecutive keys land at non-adjacent addresses
+    # (simulates a non-consecutive transfer; defeats adjacency coalescing).
+    if args.dest_layout == "shuffled":
+        import random
+
+        slots = list(range(nr_objects))
+        random.Random(args.shuffle_seed).shuffle(slots)
+        print(f"dest_layout=shuffled seed={args.shuffle_seed}", flush=True)
+    else:
+        slots = range(nr_objects)
+    ptrs = [base + slot * value_size for slot in slots]
+    sizes = [value_size] * nr_objects
+
+    reader.register_memory(base, buf_total)
+
+    for batch_size in batch_sizes:
+        batches = [keys[i : i + batch_size] for i in range(0, nr_objects, batch_size)]
+        ptr_batches = [
+            ptrs[i : i + batch_size] for i in range(0, nr_objects, batch_size)
+        ]
+        size_batches = [
+            sizes[i : i + batch_size] for i in range(0, nr_objects, batch_size)
+        ]
+
+        # warmup
+        for kb, pb, sb in zip(batches, ptr_batches, size_batches):
+            reader.batch_get_into_ptr(kb, pb, sb)
+
+        hits = misses = 0
+        total_bytes = 0
+        start = time.perf_counter()
+        for _ in range(passes):
+            for kb, pb, sb in zip(batches, ptr_batches, size_batches):
+                results = reader.batch_get_into_ptr(kb, pb, sb)
+                for r in results:
+                    if r > 0:
+                        hits += 1
+                        total_bytes += r
+                    else:
+                        misses += 1
+        elapsed = time.perf_counter() - start
+        total_reqs = nr_objects * passes
+        total_batches = len(batches) * passes
+        print(
+            f"RESULT batch_size={batch_size} hits={hits} misses={misses} requests={total_reqs} "
+            f"batches={total_batches} duration={elapsed:.3f}s "
+            f"req_per_s={total_reqs / elapsed:.2f} batch_per_s={total_batches / elapsed:.2f} "
+            f"MiB_per_s={(total_bytes / 1024 / 1024) / elapsed:.2f} "
+            f"avg_latency_ms={(elapsed / total_reqs) * 1000:.3f}",
+            flush=True,
+        )
+
+# In a split run, tell the writer we're finished so it can release the dataset
+# and exit; the writer is blocked in _sync_recv_until(b"DONE") until this lands.
+if sync_conn is not None:
+    try:
+        sync_conn.sendall(b"DONE\n")
+        sync_conn.close()
+    except OSError:
+        pass
+
+if exit_code:
+    sys.exit(exit_code)

--- a/tests/python/umbp/umbp_bench.py
+++ b/tests/python/umbp/umbp_bench.py
@@ -82,9 +82,16 @@ def _kill_group(proc):
 
 def _spawn(argv, log_path, env=None) -> subprocess.Popen:
     log = open(log_path, "w")
-    proc = subprocess.Popen(
-        argv, stdout=log, stderr=subprocess.STDOUT, env=env, preexec_fn=_die_with_parent
-    )
+    try:
+        proc = subprocess.Popen(
+            argv,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            env=env,
+            preexec_fn=_die_with_parent,
+        )
+    finally:
+        log.close()
     atexit.register(lambda: _kill_group(proc))
     return proc
 


### PR DESCRIPTION
 perf(umbp): BatchRouteGet/BatchResolveKeys optimization + Flush fix

  Summary
  
  - Fix Flush(): was a no-op; KV placement events now drain immediately via heartbeat condvar wakeup instead of waiting for the next interval tick.
  - Hot-path optimization (BatchLookupForRouteGet): single steady_clock read per batch threaded through per-key lease/LRU bumps; fast-path whole-vector copy for the common no-exclude case.
  - Columnar wire format: BatchRouteGetResponse deduplicates repeated (node_id, peer_address) targets into a nodes array referenced by 1-based node_ref;
  - BatchResolveKeysResponse hoists batch-invariant buffer descriptors and page_size out of per-key entries, with omit_descs to suppress after first hydration. Encode/decode in batch_resolve_codec.h.
  
  Tests

  - test_batch_resolve_codec — codec round-trip correctness
  - test_batch_route_get_columnar — end-to-end columnar encoding
  - test_master_client_flush_heartbeat — immediate wakeup, no-op pre-start, flush-while-in-flight
  - bench_global_block_index_route_get — index-only microbench (µs/call, Mlookups/s, thread scaling)
  - umbp_bench.py — correctness + BatchGet perf sweep vs. Mooncake
  - cross_node_smoke now uses OS-assigned port to avoid VS Code server collisions

Perf

Perf comparison with mooncake, 2nodes, 4NICs per node. This is a very naive UT that is only used for testing pure RDMA transfer perf.
<img width="425" height="171" alt="image" src="https://github.com/user-attachments/assets/fd075eee-665f-421a-8bb2-4831d352b8e7" />