### PR TITLE
Fix RDMA QP load imbalance

### DIFF
--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -403,9 +403,13 @@ application::RdmaEndpointConfig RdmaManager::GetRdmaEndpointConfig(int devId) {
   epConfig.alignment = PAGESIZE;
   epConfig.withCompChannel = (config.pollCqMode == PollCqMode::EVENT);
 
+  bool is_ionic = (deviceAttr->orig_attr.vendor_id ==
+                   static_cast<uint32_t>(application::RdmaDeviceVendorId::Pensando));
+
   uint32_t maxQpWr = static_cast<uint32_t>(deviceAttr->orig_attr.max_qp_wr);
   uint32_t maxCqe = static_cast<uint32_t>(deviceAttr->orig_attr.max_cqe);
   uint32_t maxSge = static_cast<uint32_t>(deviceAttr->orig_attr.max_sge);
+  if (is_ionic) maxSge = std::min(maxSge, 2u);
 
   if (config.enableNotification && maxQpWr < config.notifPerQp) {
     MORI_IO_ERROR(
@@ -449,10 +453,13 @@ application::RdmaEndpointConfig RdmaManager::GetRdmaEndpointConfig(int devId) {
     epConfig.maxCqeNum = newCqeNum;
   }
   if (desiredMsgSge.has_value()) {
-    epConfig.maxMsgSge = std::min(*desiredMsgSge, maxSge);
+    if (*desiredMsgSge > maxSge) {
+      MORI_IO_WARN("maxMsgSge={} is greater than max_sge={}; clamping to max_sge", *desiredMsgSge,
+                   maxSge);
+      *desiredMsgSge = maxSge;
+    }
+    epConfig.maxMsgSge = *desiredMsgSge;
   } else {
-    bool is_ionic = (deviceAttr->orig_attr.vendor_id ==
-                     static_cast<uint32_t>(application::RdmaDeviceVendorId::Pensando));
     epConfig.maxMsgSge = std::min(maxSge, is_ionic ? 2u : 4u);
   }
   return epConfig;

--- a/src/io/rdma/common.cpp
+++ b/src/io/rdma/common.cpp
@@ -696,11 +696,14 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
   epWrsSinceSignal.assign(epNum, 0);
   epMergedSinceSignal.assign(epNum, 0);
 
+  // Rotate the starting EP by transfer id so single-segment (single WR)
+  // transfers spread evenly across all QPs instead of always landing on eps[0].
+  int epStartOffset = static_cast<int>(id % static_cast<uint64_t>(epNum));
   for (int i = 0; i < numPostBatch; i++) {
     int st = i * postBatchSize;
     int end = std::min(static_cast<size_t>(st) + postBatchSize, mergedWrCount);
     if (end - st == 0) break;
-    int epId = i % epNum;
+    int epId = (i + epStartOffset) % static_cast<int>(epNum);
     int batchWrNum = end - st;
 
     std::string reserveErr;

--- a/src/io/rdma/common.cpp
+++ b/src/io/rdma/common.cpp
@@ -52,8 +52,15 @@ enum class PostSendOpKind : uint8_t {
 
 static int GetSqBackoffTimeoutUs() {
   static const int kBackoffTimeoutUs = []() {
-    int v = 5000000;
+    constexpr int kDefaultBackoffTimeoutUs = 5000000;
+    int v = kDefaultBackoffTimeoutUs;
     env::Override("MORI_IO_SQ_BACKOFF_TIMEOUT_US", v, mori::env::detail::ParsePositiveInt);
+    if (v < kDefaultBackoffTimeoutUs) {
+      MORI_IO_WARN(
+          "MORI_IO_SQ_BACKOFF_TIMEOUT_US={} us is below the default {} us; SQ full conditions may "
+          "timeout faster under transient CQ drain delays",
+          v, kDefaultBackoffTimeoutUs);
+    }
     return v;
   }();
   return kBackoffTimeoutUs;

--- a/src/io/rdma/executor.cpp
+++ b/src/io/rdma/executor.cpp
@@ -191,12 +191,18 @@ RdmaOpRet MultithreadExecutor::RdmaBatchReadWrite(const ExecutorReq& req) {
 
   auto splits = SplitWork(req);
   int numSplits = splits.size();
+  int numEps = static_cast<int>(req.eps.size());
+  // Rotate the starting EP by transfer id so single-segment transfers spread
+  // evenly across all QPs instead of always landing on eps[0].
+  int epOffset = static_cast<int>(req.id % static_cast<uint64_t>(numEps));
   std::vector<std::future<RdmaOpRet>> futs;
 
   for (int i = 0; i < numSplits; i++) {
-    Task task{&req, i, splits[i].first, splits[i].second};
+    int epId = (i + epOffset) % numEps;
+    Task task{&req, epId, splits[i].first, splits[i].second};
     futs.push_back(std::move(task.ret.get_future()));
-    pool[i]->Submit(std::move(task));
+    // Keep each QP owned by a stable worker to preserve QP affinity.
+    pool[epId % numWorker]->Submit(std::move(task));
   }
 
   bool hasFail = false;


### PR DESCRIPTION
## Summary
- Rotate RDMA batch starting EP by transfer id to avoid single-WR traffic always using QP0.
- Preserve QP-to-worker affinity in the multithreaded executor.
- Clamp max SGE handling and warn on short SQ backoff timeouts.
