### PR TITLE
feat(cco): BNXT GDA per-packet PSN + per-peer doorbell grouping

### DIFF
--- a/benchmark/cco/p2p_get_bw.cpp
+++ b/benchmark/cco/p2p_get_bw.cpp
@@ -87,11 +87,11 @@ __global__ void ibgda_get_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
   const size_t off_bytes = base * sizeof(double);
   const size_t bytes = per_unit * sizeof(double);
 
-  // AggregateRequests: defer doorbell to end flush (see p2p_put_bw).
+  // Per-op doorbell: per-op flow control drains completions as the SQ fills
+  // (see p2p_put_bw). The trailing flush waits for the last ops before timing.
   for (int i = 0; i < iter; i++) {
     gda.get(peer, reinterpret_cast<ccoWindow_t>(sendWin), off_bytes,
-            reinterpret_cast<ccoWindow_t>(recvWin), off_bytes, bytes, coop,
-            ccoGdaOptFlagsAggregateRequests);
+            reinterpret_cast<ccoWindow_t>(recvWin), off_bytes, bytes, coop);
   }
   gda.flush(ccoCoopBlock{});
 }

--- a/benchmark/cco/p2p_get_bw.cpp
+++ b/benchmark/cco/p2p_get_bw.cpp
@@ -69,7 +69,7 @@ __global__ void lsa_get_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
 
 // IBGDA: one QP per block; pipeline reads + flush own QP. block scope = one bulk
 // read; warp/thread subdivide (see p2p_put_bw).
-template <core::ProviderType PrvdType, typename Coop, ccoGdaWarpMode WarpMode = ccoGdaWarpDefault>
+template <core::ProviderType PrvdType, typename Coop, ccoGdaThreadMode ThreadMode = ccoGdaThreadIndependent>
 __global__ void ibgda_get_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin, size_t len_doubles,
                              ccoDevComm devComm, int iter) {
   Coop coop;
@@ -90,7 +90,7 @@ __global__ void ibgda_get_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
   // Per-op doorbell: per-op flow control drains completions as the SQ fills
   // (see p2p_put_bw). The trailing flush waits for the last ops before timing.
   for (int i = 0; i < iter; i++) {
-    gda.template get<CCO_TEAM_WORLD, WarpMode>(peer, reinterpret_cast<ccoWindow_t>(sendWin),
+    gda.template get<CCO_TEAM_WORLD, ThreadMode>(peer, reinterpret_cast<ccoWindow_t>(sendWin),
                                                off_bytes, reinterpret_cast<ccoWindow_t>(recvWin),
                                                off_bytes, bytes, coop);
   }
@@ -124,7 +124,7 @@ static void launch_ibgda(PutScope scope, dim3 grid, dim3 block, ccoWindow_t send
                          recvWin, len_doubles, devComm, count);
       break;
     case PutScope::kThreadAgg:
-      hipLaunchKernelGGL((ibgda_get_bw<PrvdType, ccoCoopThread, ccoGdaWarpAggregate>), grid, block,
+      hipLaunchKernelGGL((ibgda_get_bw<PrvdType, ccoCoopThread, ccoGdaThreadAggregate>), grid, block,
                          0, 0, sendWin, recvWin, len_doubles, devComm, count);
       break;
   }

--- a/benchmark/cco/p2p_get_bw.cpp
+++ b/benchmark/cco/p2p_get_bw.cpp
@@ -69,7 +69,7 @@ __global__ void lsa_get_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
 
 // IBGDA: one QP per block; pipeline reads + flush own QP. block scope = one bulk
 // read; warp/thread subdivide (see p2p_put_bw).
-template <core::ProviderType PrvdType, typename Coop>
+template <core::ProviderType PrvdType, typename Coop, ccoGdaWarpMode WarpMode = ccoGdaWarpDefault>
 __global__ void ibgda_get_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin, size_t len_doubles,
                              ccoDevComm devComm, int iter) {
   Coop coop;
@@ -90,8 +90,9 @@ __global__ void ibgda_get_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
   // Per-op doorbell: per-op flow control drains completions as the SQ fills
   // (see p2p_put_bw). The trailing flush waits for the last ops before timing.
   for (int i = 0; i < iter; i++) {
-    gda.get(peer, reinterpret_cast<ccoWindow_t>(sendWin), off_bytes,
-            reinterpret_cast<ccoWindow_t>(recvWin), off_bytes, bytes, coop);
+    gda.template get<CCO_TEAM_WORLD, WarpMode>(peer, reinterpret_cast<ccoWindow_t>(sendWin),
+                                               off_bytes, reinterpret_cast<ccoWindow_t>(recvWin),
+                                               off_bytes, bytes, coop);
   }
   gda.flush(ccoCoopBlock{});
 }
@@ -101,7 +102,7 @@ static void launch_lsa(PutScope scope, dim3 grid, dim3 block, ccoWindow_t sendWi
                        int peerLsa, int count, int warp_size) {
   int scope_size = block.x;
   if (scope == PutScope::kWarp) scope_size = warp_size;
-  if (scope == PutScope::kThread) scope_size = 1;
+  if (scope == PutScope::kThread || scope == PutScope::kThreadAgg) scope_size = 1;
   hipLaunchKernelGGL(lsa_get_bw, grid, block, 0, 0, sendWin, recvWin, counter_d, len_doubles,
                      peerLsa, count, scope_size);
 }
@@ -121,6 +122,10 @@ static void launch_ibgda(PutScope scope, dim3 grid, dim3 block, ccoWindow_t send
     case PutScope::kThread:
       hipLaunchKernelGGL((ibgda_get_bw<PrvdType, ccoCoopThread>), grid, block, 0, 0, sendWin,
                          recvWin, len_doubles, devComm, count);
+      break;
+    case PutScope::kThreadAgg:
+      hipLaunchKernelGGL((ibgda_get_bw<PrvdType, ccoCoopThread, ccoGdaWarpAggregate>), grid, block,
+                         0, 0, sendWin, recvWin, len_doubles, devComm, count);
       break;
   }
 }

--- a/benchmark/cco/p2p_put_bw.cpp
+++ b/benchmark/cco/p2p_put_bw.cpp
@@ -74,7 +74,7 @@ __global__ void lsa_put_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
 // IBGDA: one QP per block (ginContext=blockIdx); each block pipelines its chunk
 // then flushes its own QP. block scope = one bulk write (== shmem
 // ShmemPutMemNbiBlock); warp/thread subdivide.
-template <core::ProviderType PrvdType, typename Coop>
+template <core::ProviderType PrvdType, typename Coop, ccoGdaWarpMode WarpMode = ccoGdaWarpDefault>
 __global__ void ibgda_put_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin, size_t len_doubles,
                              ccoDevComm devComm, int iter) {
   Coop coop;
@@ -96,8 +96,9 @@ __global__ void ibgda_put_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
   // SQ-space flow control inside put drains completions (quietUntil) as the queue
   // fills. The trailing flush waits for the last ops to complete before timing.
   for (int i = 0; i < iter; i++) {
-    gda.put(peer, reinterpret_cast<ccoWindow_t>(recvWin), off_bytes,
-            reinterpret_cast<ccoWindow_t>(sendWin), off_bytes, bytes, ccoGda_NoSignal{}, coop);
+    gda.template put<CCO_TEAM_WORLD, WarpMode>(peer, reinterpret_cast<ccoWindow_t>(recvWin),
+                                               off_bytes, reinterpret_cast<ccoWindow_t>(sendWin),
+                                               off_bytes, bytes, ccoGda_NoSignal{}, coop);
   }
   gda.flush(ccoCoopBlock{});
 }
@@ -109,7 +110,7 @@ static void launch_lsa(PutScope scope, dim3 grid, dim3 block, ccoWindow_t sendWi
   // warp: one wavefront, thread: a single thread). All threads always run.
   int scope_size = block.x;
   if (scope == PutScope::kWarp) scope_size = warp_size;
-  if (scope == PutScope::kThread) scope_size = 1;
+  if (scope == PutScope::kThread || scope == PutScope::kThreadAgg) scope_size = 1;
   hipLaunchKernelGGL(lsa_put_bw, grid, block, 0, 0, sendWin, recvWin, counter_d, len_doubles,
                      peerLsa, count, scope_size);
 }
@@ -129,6 +130,10 @@ static void launch_ibgda(PutScope scope, dim3 grid, dim3 block, ccoWindow_t send
     case PutScope::kThread:
       hipLaunchKernelGGL((ibgda_put_bw<PrvdType, ccoCoopThread>), grid, block, 0, 0, sendWin,
                          recvWin, len_doubles, devComm, count);
+      break;
+    case PutScope::kThreadAgg:
+      hipLaunchKernelGGL((ibgda_put_bw<PrvdType, ccoCoopThread, ccoGdaWarpAggregate>), grid, block,
+                         0, 0, sendWin, recvWin, len_doubles, devComm, count);
       break;
   }
 }

--- a/benchmark/cco/p2p_put_bw.cpp
+++ b/benchmark/cco/p2p_put_bw.cpp
@@ -74,7 +74,7 @@ __global__ void lsa_put_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
 // IBGDA: one QP per block (ginContext=blockIdx); each block pipelines its chunk
 // then flushes its own QP. block scope = one bulk write (== shmem
 // ShmemPutMemNbiBlock); warp/thread subdivide.
-template <core::ProviderType PrvdType, typename Coop, ccoGdaWarpMode WarpMode = ccoGdaWarpDefault>
+template <core::ProviderType PrvdType, typename Coop, ccoGdaThreadMode ThreadMode = ccoGdaThreadIndependent>
 __global__ void ibgda_put_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin, size_t len_doubles,
                              ccoDevComm devComm, int iter) {
   Coop coop;
@@ -96,7 +96,7 @@ __global__ void ibgda_put_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
   // SQ-space flow control inside put drains completions (quietUntil) as the queue
   // fills. The trailing flush waits for the last ops to complete before timing.
   for (int i = 0; i < iter; i++) {
-    gda.template put<CCO_TEAM_WORLD, WarpMode>(peer, reinterpret_cast<ccoWindow_t>(recvWin),
+    gda.template put<CCO_TEAM_WORLD, ThreadMode>(peer, reinterpret_cast<ccoWindow_t>(recvWin),
                                                off_bytes, reinterpret_cast<ccoWindow_t>(sendWin),
                                                off_bytes, bytes, ccoGda_NoSignal{}, coop);
   }
@@ -132,7 +132,7 @@ static void launch_ibgda(PutScope scope, dim3 grid, dim3 block, ccoWindow_t send
                          recvWin, len_doubles, devComm, count);
       break;
     case PutScope::kThreadAgg:
-      hipLaunchKernelGGL((ibgda_put_bw<PrvdType, ccoCoopThread, ccoGdaWarpAggregate>), grid, block,
+      hipLaunchKernelGGL((ibgda_put_bw<PrvdType, ccoCoopThread, ccoGdaThreadAggregate>), grid, block,
                          0, 0, sendWin, recvWin, len_doubles, devComm, count);
       break;
   }

--- a/benchmark/cco/p2p_put_bw.cpp
+++ b/benchmark/cco/p2p_put_bw.cpp
@@ -92,13 +92,12 @@ __global__ void ibgda_put_bw(ccoWindowDevice* sendWin, ccoWindowDevice* recvWin,
   const size_t off_bytes = base * sizeof(double);
   const size_t bytes = per_unit * sizeof(double);
 
-  // AggregateRequests defers the doorbell to the end flush: in warp/thread scope
-  // many threads share one QP, and per-op ringDoorbellOrdered deadlocks under
-  // SIMT lock-step. The end flush rings once + polls the CQ.
+  // Per-op doorbell: each put rings its own (grouped-per-peer) doorbell, so the
+  // SQ-space flow control inside put drains completions (quietUntil) as the queue
+  // fills. The trailing flush waits for the last ops to complete before timing.
   for (int i = 0; i < iter; i++) {
     gda.put(peer, reinterpret_cast<ccoWindow_t>(recvWin), off_bytes,
-            reinterpret_cast<ccoWindow_t>(sendWin), off_bytes, bytes, ccoGda_NoSignal{}, coop,
-            ccoGdaOptFlagsAggregateRequests);
+            reinterpret_cast<ccoWindow_t>(sendWin), off_bytes, bytes, ccoGda_NoSignal{}, coop);
   }
   gda.flush(ccoCoopBlock{});
 }

--- a/benchmark/cco/util.cpp
+++ b/benchmark/cco/util.cpp
@@ -46,7 +46,8 @@ void PrintUsage(const char* program) {
                "  -w warmup      warmup iterations\n"
                "  -c grid_x      HIP grid x (blocks)\n"
                "  -t threads     threads per block\n"
-               "  -s scope       thread | warp | block (default block)\n"
+               "  -s scope       thread | warp | block | thread_agg (default block)\n"
+               "                 thread_agg = thread scope + WarpAggregate (bw only)\n"
                "  -h             this help\n",
                program != nullptr ? program : "program");
 }
@@ -110,6 +111,8 @@ int ParseArgs(int argc, char** argv, PerfArgs* out_args) {
           out_args->put_scope = PutScope::kWarp;
         } else if (std::strcmp(optarg, "block") == 0) {
           out_args->put_scope = PutScope::kBlock;
+        } else if (std::strcmp(optarg, "thread_agg") == 0) {
+          out_args->put_scope = PutScope::kThreadAgg;
         } else {
           return 1;
         }
@@ -156,7 +159,8 @@ void PrintPerfTable(const char* test_name, const char* transport_name, const cha
   int units = grid_x;
   if (scope_name != nullptr && std::strcmp(scope_name, "warp") == 0) {
     units = grid_x * (warp_size > 0 ? block_threads / warp_size : 1);
-  } else if (scope_name != nullptr && std::strcmp(scope_name, "thread") == 0) {
+  } else if (scope_name != nullptr && (std::strcmp(scope_name, "thread") == 0 ||
+                                       std::strcmp(scope_name, "thread_agg") == 0)) {
     units = grid_x * block_threads;
   }
   if (units < 1) units = 1;

--- a/benchmark/cco/util.cpp
+++ b/benchmark/cco/util.cpp
@@ -150,10 +150,23 @@ void PrintPerfTable(const char* test_name, const char* transport_name, const cha
   const char* scope_col = (scope_name != nullptr && scope_name[0] != '\0') ? scope_name : "none";
   const char* tag = (test_name != nullptr && test_name[0] != '\0') ? test_name : "p2p";
 
-  std::printf("# %s transport=%s scope=%s grid=%d block=%d warpSize=%d iters=%zu warmup=%zu\n", tag,
-              transport_name, scope_col, grid_x, block_threads, warp_size, iters, warmup);
+  // Number of cooperative units the total size is split across (one WQE / message
+  // per unit): block scope = one unit per block, warp = one per wavefront, thread
+  // = one per thread. So each message is size / units bytes.
+  int units = grid_x;
+  if (scope_name != nullptr && std::strcmp(scope_name, "warp") == 0) {
+    units = grid_x * (warp_size > 0 ? block_threads / warp_size : 1);
+  } else if (scope_name != nullptr && std::strcmp(scope_name, "thread") == 0) {
+    units = grid_x * block_threads;
+  }
+  if (units < 1) units = 1;
+
+  std::printf(
+      "# %s transport=%s scope=%s grid=%d block=%d warpSize=%d units=%d iters=%zu warmup=%zu\n", tag,
+      transport_name, scope_col, grid_x, block_threads, warp_size, units, iters, warmup);
 
   constexpr int kWSize = 10;
+  constexpr int kWMsg = 10;
   constexpr int kWScope = 8;
   constexpr int kWNum = 12;
 
@@ -161,15 +174,20 @@ void PrintPerfTable(const char* test_name, const char* transport_name, const cha
   const char* num_header = is_bw ? "Bandwidth" : "Latency";
   const char* unit_str = is_bw ? "GB/s" : "us";
 
-  std::printf("%-*s %-*s %*s %s\n", kWSize, "size", kWScope, "scope", kWNum, num_header, unit_str);
+  // "msg" = per-unit message size (size / units): the actual bytes carried by one
+  // WQE in this scope.
+  std::printf("%-*s %-*s %-*s %*s %s\n", kWSize, "size", kWMsg, "msg", kWScope, "scope", kWNum,
+              num_header, unit_str);
 
   for (const PerfTableRow& r : rows) {
     std::string sz = fmt_size(r.size_bytes);
+    std::string msg = fmt_size(r.size_bytes / static_cast<std::size_t>(units));
     if (r.skipped) {
-      std::printf("%-*s %-*s %*s\n", kWSize, sz.c_str(), kWScope, scope_col, kWNum, "skip");
+      std::printf("%-*s %-*s %-*s %*s\n", kWSize, sz.c_str(), kWMsg, msg.c_str(), kWScope, scope_col,
+                  kWNum, "skip");
     } else {
-      std::printf("%-*s %-*s %*.3f %s\n", kWSize, sz.c_str(), kWScope, scope_col, kWNum, r.value,
-                  unit_str);
+      std::printf("%-*s %-*s %-*s %*.3f %s\n", kWSize, sz.c_str(), kWMsg, msg.c_str(), kWScope,
+                  scope_col, kWNum, r.value, unit_str);
     }
   }
   std::fflush(stdout);

--- a/benchmark/cco/util.cpp
+++ b/benchmark/cco/util.cpp
@@ -47,7 +47,7 @@ void PrintUsage(const char* program) {
                "  -c grid_x      HIP grid x (blocks)\n"
                "  -t threads     threads per block\n"
                "  -s scope       thread | warp | block | thread_agg (default block)\n"
-               "                 thread_agg = thread scope + WarpAggregate (bw only)\n"
+               "                 thread_agg = thread scope + ThreadAggregate (bw only)\n"
                "  -h             this help\n",
                program != nullptr ? program : "program");
 }
@@ -153,9 +153,8 @@ void PrintPerfTable(const char* test_name, const char* transport_name, const cha
   const char* scope_col = (scope_name != nullptr && scope_name[0] != '\0') ? scope_name : "none";
   const char* tag = (test_name != nullptr && test_name[0] != '\0') ? test_name : "p2p";
 
-  // Number of cooperative units the total size is split across (one WQE / message
-  // per unit): block scope = one unit per block, warp = one per wavefront, thread
-  // = one per thread. So each message is size / units bytes.
+  // Units the total size is split across (one WQE/message each): block=one per
+  // block, warp=one per wavefront, thread=one per thread. Each message is size/units.
   int units = grid_x;
   if (scope_name != nullptr && std::strcmp(scope_name, "warp") == 0) {
     units = grid_x * (warp_size > 0 ? block_threads / warp_size : 1);
@@ -179,10 +178,8 @@ void PrintPerfTable(const char* test_name, const char* transport_name, const cha
   const char* num_header = is_bw ? "Bandwidth" : "Latency";
   const char* unit_str = is_bw ? "GB/s" : "us";
 
-  // "msg" = per-unit message size (size / units): the actual bytes carried by one
-  // WQE in this scope. For bandwidth, "Mpps" = WQEs/messages issued per second
-  // (= GB/s * 1e3 * units / size); it exposes the per-WQE issue-rate ceiling that
-  // dominates small messages.
+  // "msg" = per-unit message size (size/units). "Mpps" = messages/s issued
+  // (GB/s * 1e3 * units / size), exposing the per-WQE issue-rate ceiling.
   if (is_bw) {
     std::printf("%-*s %-*s %-*s %*s %-5s %*s\n", kWSize, "size", kWMsg, "msg", kWScope, "scope",
                 kWNum, num_header, unit_str, kWMpps, "Mpps");

--- a/benchmark/cco/util.cpp
+++ b/benchmark/cco/util.cpp
@@ -173,15 +173,23 @@ void PrintPerfTable(const char* test_name, const char* transport_name, const cha
   constexpr int kWMsg = 10;
   constexpr int kWScope = 8;
   constexpr int kWNum = 12;
+  constexpr int kWMpps = 10;
 
   const bool is_bw = (metric == PerfTableMetric::kBandwidthGbps);
   const char* num_header = is_bw ? "Bandwidth" : "Latency";
   const char* unit_str = is_bw ? "GB/s" : "us";
 
   // "msg" = per-unit message size (size / units): the actual bytes carried by one
-  // WQE in this scope.
-  std::printf("%-*s %-*s %-*s %*s %s\n", kWSize, "size", kWMsg, "msg", kWScope, "scope", kWNum,
-              num_header, unit_str);
+  // WQE in this scope. For bandwidth, "Mpps" = WQEs/messages issued per second
+  // (= GB/s * 1e3 * units / size); it exposes the per-WQE issue-rate ceiling that
+  // dominates small messages.
+  if (is_bw) {
+    std::printf("%-*s %-*s %-*s %*s %-5s %*s\n", kWSize, "size", kWMsg, "msg", kWScope, "scope",
+                kWNum, num_header, unit_str, kWMpps, "Mpps");
+  } else {
+    std::printf("%-*s %-*s %-*s %*s %s\n", kWSize, "size", kWMsg, "msg", kWScope, "scope", kWNum,
+                num_header, unit_str);
+  }
 
   for (const PerfTableRow& r : rows) {
     std::string sz = fmt_size(r.size_bytes);
@@ -189,6 +197,13 @@ void PrintPerfTable(const char* test_name, const char* transport_name, const cha
     if (r.skipped) {
       std::printf("%-*s %-*s %-*s %*s\n", kWSize, sz.c_str(), kWMsg, msg.c_str(), kWScope, scope_col,
                   kWNum, "skip");
+    } else if (is_bw) {
+      const double mpps = (r.size_bytes > 0)
+                              ? r.value * 1.0e3 * static_cast<double>(units) /
+                                    static_cast<double>(r.size_bytes)
+                              : 0.0;
+      std::printf("%-*s %-*s %-*s %*.3f %-5s %*.3f\n", kWSize, sz.c_str(), kWMsg, msg.c_str(),
+                  kWScope, scope_col, kWNum, r.value, unit_str, kWMpps, mpps);
     } else {
       std::printf("%-*s %-*s %-*s %*.3f %s\n", kWSize, sz.c_str(), kWMsg, msg.c_str(), kWScope,
                   scope_col, kWNum, r.value, unit_str);

--- a/benchmark/cco/util.hpp
+++ b/benchmark/cco/util.hpp
@@ -41,7 +41,11 @@
 namespace mori::cco::benchmark {
 
 // Cooperation granularity of the kernel transfer loop / RDMA op.
-enum class PutScope { kThread, kWarp, kBlock };
+// kThreadAgg: thread scope (one WQE per thread) but with ccoGdaWarpAggregate —
+// the warp's same-peer lanes post as one aggregated batch (one reservation +
+// leader doorbell) instead of the default per-peer __ballot grouping. Bandwidth
+// kernels only; latency falls back to thread behavior.
+enum class PutScope { kThread, kWarp, kBlock, kThreadAgg };
 
 // Which CCO p2p transport to exercise. Selected by the MORI_DISABLE_P2P env
 // var (consistent with the rest of mori): unset or enabled → kIbgda (P2P
@@ -149,6 +153,8 @@ inline const char* ScopeToChar(PutScope scope) {
       return "warp";
     case PutScope::kBlock:
       return "block";
+    case PutScope::kThreadAgg:
+      return "thread_agg";
   }
   return "none";
 }
@@ -176,7 +182,7 @@ inline bool size_ok(PutScope scope, std::size_t size_bytes, int nblocks, int thr
     return false;
   }
   const std::size_t per_block = len / static_cast<std::size_t>(nblocks);
-  if (scope == PutScope::kThread) {
+  if (scope == PutScope::kThread || scope == PutScope::kThreadAgg) {
     return per_block % static_cast<std::size_t>(threads_per_block) == 0;
   }
   if (scope == PutScope::kWarp) {

--- a/benchmark/cco/util.hpp
+++ b/benchmark/cco/util.hpp
@@ -41,10 +41,8 @@
 namespace mori::cco::benchmark {
 
 // Cooperation granularity of the kernel transfer loop / RDMA op.
-// kThreadAgg: thread scope (one WQE per thread) but with ccoGdaWarpAggregate —
-// the warp's same-peer lanes post as one aggregated batch (one reservation +
-// leader doorbell) instead of the default per-peer __ballot grouping. Bandwidth
-// kernels only; latency falls back to thread behavior.
+// kThreadAgg: thread scope with ccoGdaThreadAggregate (same-peer lanes post as one
+// batch instead of per-peer grouping). Bandwidth kernels only; latency uses thread.
 enum class PutScope { kThread, kWarp, kBlock, kThreadAgg };
 
 // Which CCO p2p transport to exercise. Selected by the MORI_DISABLE_P2P env

--- a/include/mori/cco/cco_scale_out.hpp
+++ b/include/mori/cco/cco_scale_out.hpp
@@ -86,9 +86,9 @@ typedef struct {
 typedef uint32_t ccoGdaSignal_t;
 typedef uint32_t ccoGdaCounter_t;
 
-enum ccoGdaWarpMode : uint32_t {
-  ccoGdaWarpDefault = 0,
-  ccoGdaWarpAggregate = 1,
+enum ccoGdaThreadMode : uint32_t {
+  ccoGdaThreadIndependent = 0,
+  ccoGdaThreadAggregate = 1,
 };
 
 enum ccoGdaOptFlags {
@@ -142,7 +142,7 @@ struct ccoGda {
   __device__ inline int resolveWorldPeer(int peer) const;
 
   // put: rdma write with optional remote signal.
-  template <ccoTeamMode TeamMode = CCO_TEAM_WORLD, ccoGdaWarpMode WarpMode = ccoGdaWarpDefault,
+  template <ccoTeamMode TeamMode = CCO_TEAM_WORLD, ccoGdaThreadMode ThreadMode = ccoGdaThreadIndependent,
             typename RemoteAction = ccoGda_NoSignal, typename Coop = ccoCoopThread>
   __device__ inline void put(int peer, ccoWindow_t dstWin, size_t dstOffset, ccoWindow_t srcWin,
                              size_t srcOffset, size_t bytes,
@@ -150,7 +150,7 @@ struct ccoGda {
                              uint32_t optFlags = ccoGdaOptFlagsDefault);
 
   // putValue: write an immediate value (≤8 bytes) with optional remote signal.
-  template <ccoTeamMode TeamMode = CCO_TEAM_WORLD, ccoGdaWarpMode WarpMode = ccoGdaWarpDefault,
+  template <ccoTeamMode TeamMode = CCO_TEAM_WORLD, ccoGdaThreadMode ThreadMode = ccoGdaThreadIndependent,
             typename T, typename RemoteAction = ccoGda_NoSignal,
             typename Coop = ccoCoopThread>
   __device__ inline void putValue(int peer, ccoWindow_t dstWin, size_t dstOffset, T value,
@@ -158,7 +158,7 @@ struct ccoGda {
                                   uint32_t optFlags = ccoGdaOptFlagsDefault);
 
   // get: rdma read — pull peer's window content into our local window.
-  template <ccoTeamMode TeamMode = CCO_TEAM_WORLD, ccoGdaWarpMode WarpMode = ccoGdaWarpDefault,
+  template <ccoTeamMode TeamMode = CCO_TEAM_WORLD, ccoGdaThreadMode ThreadMode = ccoGdaThreadIndependent,
             typename Coop = ccoCoopThread>
   __device__ inline void get(int peer, ccoWindow_t remoteWin, size_t remoteOffset,
                              ccoWindow_t localWin, size_t localOffset, size_t bytes,
@@ -399,9 +399,8 @@ __device__ inline static void quietUntil(core::RdmaEndpointDevice* ep, uint32_t 
   }
 }
 
-// BNXT only: exclusive prefix-sum of psnCnt over the warp's active lanes (by
-// physical lane id). Returns this lane's prefix; *outTotal = warp total. Mirrors
-// shmem. All active lanes must call together.
+// BNXT: exclusive prefix-sum of psnCnt over active lanes. Returns this lane's
+// prefix; *outTotal = warp total. All active lanes must call together.
 __device__ inline static uint32_t warpActivePsnPrefix(uint32_t psnCnt, uint64_t activemask,
                                                       uint32_t* outTotal) {
   const uint32_t myPhys = static_cast<uint32_t>(__lane_id());
@@ -418,11 +417,10 @@ __device__ inline static uint32_t warpActivePsnPrefix(uint32_t psnCnt, uint64_t 
   return excl;
 }
 
-// BNXT warp-aggregate PSN: each active lane contributes dataPsnCnt data packets;
-// the warp leader optionally adds one trailing signal packet. The leader advances
-// wq->msnPack once by the warp totals; returns this lane's data-PSN base and (via
-// outSignalPsn) the PSN for the warp's single signal. BNXT PSN must advance by
-// PACKET count, not WQE count (post-#395 per-lane fix; mirrors shmem).
+// BNXT warp-aggregate PSN: each active lane contributes dataPsnCnt data packets,
+// the leader optionally one signal packet. The leader advances wq->msnPack once by
+// the warp totals; returns this lane's data-PSN base and the signal PSN (outSignalPsn).
+// BNXT PSN advances by PACKET count, not WQE count.
 __device__ inline static uint32_t warpAggregateBnxtPsn(core::WorkQueueHandle* wq,
                                                        uint32_t dataPsnCnt, bool hasSignalPacket,
                                                        uint32_t totalWqes, uint64_t activemask,
@@ -442,11 +440,9 @@ __device__ inline static uint32_t warpAggregateBnxtPsn(core::WorkQueueHandle* wq
   return warpPsnBase + myExcl;
 }
 
-// Reserve numWqesNeeded SQ slots (per-lane) and wait for SQ space. For BNXT, also
-// reserve lanePsnCnt packet-sequence numbers on wq->msnPack and return the PSN
-// base via outPsnBase (BNXT PSN advances by PACKET count, not WQE count).
-// lanePsnCnt/outPsnBase are ignored for MLX5/PSD. Warp-aggregate callers reserve
-// the whole warp themselves; this is the per-lane path.
+// Reserve numWqesNeeded SQ slots (per-lane) and wait for SQ space. BNXT also
+// reserves lanePsnCnt packet PSNs on wq->msnPack and returns the base via
+// outPsnBase (advances by PACKET count); lanePsnCnt/outPsnBase ignored elsewhere.
 template <core::ProviderType PrvdType>
 __device__ inline static uint32_t reserveWqeSlots(core::RdmaEndpointDevice* ep,
                                                   uint32_t numWqesNeeded, uint32_t lanePsnCnt = 0,
@@ -472,9 +468,8 @@ __device__ inline static uint32_t reserveWqeSlots(core::RdmaEndpointDevice* ep,
       break;
     }
     if constexpr (PrvdType == core::ProviderType::BNXT) {
-      // BNXT: drain to the doorbelled snapshot (reachable), not our own
-      // un-doorbelled reservation — else we'd wait on WQEs that may never be
-      // doorbelled and self-deadlock. Mirrors shmem's snapshot drain.
+      // BNXT: drain to the doorbelled snapshot, not our un-doorbelled
+      // reservation — else we'd wait on WQEs that may never ring (self-deadlock).
       quietUntil<PrvdType>(ep, static_cast<uint32_t>(dbTouched));
     } else {
       quietUntil<PrvdType>(ep, curPostIdx);
@@ -483,10 +478,9 @@ __device__ inline static uint32_t reserveWqeSlots(core::RdmaEndpointDevice* ep,
   return curPostIdx;
 }
 
-// Warp-aggregate flow control: wait until the SQ has room for the whole batch
-// [base, base+totalWqes). BNXT drains to the doorbelled snapshot (not the warp's
-// own un-doorbelled reservation) to avoid self-deadlock (mirrors shmem); other
-// providers keep the original drain-to-reservation behavior.
+// Warp-aggregate flow control: wait until the SQ has room for [base, base+totalWqes).
+// BNXT drains to the doorbelled snapshot (avoids self-deadlock); others drain to
+// the reservation.
 template <core::ProviderType PrvdType>
 __device__ inline static void waitSqSpace(core::RdmaEndpointDevice* ep, uint32_t base,
                                           uint32_t totalWqes) {
@@ -507,19 +501,12 @@ __device__ inline static void waitSqSpace(core::RdmaEndpointDevice* ep, uint32_t
   }
 }
 
-// PSD/BNXT only: walk the warp's active lane mask and let one lane at a time
-// issue the doorbell MMIO store. These providers can share one dbrAddr across
-// QPs — Ionic shares it across every QP of an ibv_context; BNXT dedups the UAR
-// page across endpoints (BnxtCqContainer / TryRegisterUar). When lanes targeting
-// distinct QPs that share a dbrAddr store in one SIMT instruction, the stores
-// coalesce into a single transaction and only one lane's dbrVal survives — the
-// dropped doorbells' WQEs are never fetched and quiet hangs. Serializing one lane
-// per iteration avoids that. MLX5 has a per-QP dbrAddr and never needs this.
-//
-// No __syncwarp between iterations: AMD wavefronts are lock-step, so the per-lane
-// predication already serializes the stores in program order; a __syncwarp would
-// also deadlock on divergent entry (a lane that already rang must not wait on
-// lanes still spinning for their turn).
+// PSD/BNXT: walk the active lane mask, ringing one lane at a time. These providers
+// share one dbrAddr across QPs (Ionic per ibv_context; BNXT per UAR page), so lanes
+// ringing distinct QPs in one SIMT store would coalesce — only one doorbell survives
+// and the rest hang. Serializing per lane avoids that; MLX5 has per-QP dbrAddr.
+// No __syncwarp: wavefronts are lock-step (predication already orders the stores)
+// and a __syncwarp would deadlock on divergent entry.
 template <core::ProviderType PrvdType>
 __device__ inline static void ringDoorbellWalk(core::WorkQueueHandle* wq, uint32_t dbrRecVal,
                                                uint64_t dbrVal) {
@@ -537,16 +524,10 @@ __device__ inline static void ringDoorbellWalk(core::WorkQueueHandle* wq, uint32
   }
 }
 
-// Wait for this QP's doorbell turn (preserve per-QP ordering across warps/groups),
-// then ring. Both modes keep the wait-for-turn; LeaderOnly selects the ring step:
-//   LeaderOnly=true  — the caller guarantees exactly one active lane rings (the
-//     per-peer group leader, e.g. grouped put/get/putValue). One store suffices,
-//     no SIMT coalescing possible → single RingDoorbell (shmem-style).
-//   LeaderOnly=false — multiple active lanes may ring distinct QPs that share a
-//     UAR (BNXT) / dbrAddr (Ionic) in one SIMT step; same-address store coalescing
-//     would drop all but one doorbell. Serialize the stores per active lane (no
-//     __syncwarp: lock-step wavefront + predication already order them, and a
-//     __syncwarp would deadlock on divergent entry).
+// Wait for this QP's doorbell turn (preserve per-QP ordering), then ring.
+// LeaderOnly=true: caller guarantees one active lane rings (per-peer group leader)
+// → single store. LeaderOnly=false: multiple lanes may ring shared-dbrAddr QPs →
+// serialize via ringDoorbellWalk to avoid coalescing.
 template <core::ProviderType PrvdType, bool LeaderOnly = false>
 __device__ inline static void ringDoorbellOrdered(core::RdmaEndpointDevice* ep, uint32_t myPostIdx,
                                                   uint32_t numWqes, uint64_t dbrVal) {
@@ -626,10 +607,9 @@ __device__ inline static uint64_t buildFlushDbrVal(core::WorkQueueHandle* wq, ui
   }
 }
 
-// putImpl - post ONE warp-aggregated put for the currently-active lanes, which
-// must all target this ep/qpn (the facade groups lanes by peer before calling).
-// Each active lane posts its data WQE into a contiguous reservation; the leader
-// posts one shared signal WQE and rings one doorbell for the whole group.
+// putImpl - post one warp-aggregated put for the active lanes (all targeting this
+// ep/qpn; the facade groups by peer). Each lane posts its data WQE into a contiguous
+// reservation; the leader posts the shared signal WQE and rings one doorbell.
 template <core::ProviderType PrvdType>
 __device__ inline static void putImpl(
     // Hardware resources (already selected endpoint)
@@ -666,8 +646,8 @@ __device__ inline static void putImpl(
   uint32_t atomicLkey = ep->atomicIbuf.lkey;
 
   if constexpr (PrvdType == core::ProviderType::BNXT) {
-    // Reserve per-packet PSNs first (before the SQ-space wait, so PSN order
-    // matches slot order across concurrent warps), then post with packet PSN.
+    // Reserve per-packet PSNs before the SQ-space wait so PSN order matches slot
+    // order across concurrent warps, then post with packet PSN.
     uint32_t dataPsnCnt = (bytes == 0) ? 1 : (bytes + wq->mtuSize - 1) / wq->mtuSize;
     uint32_t sigPsn = 0;
     uint32_t dataPsn = warpAggregateBnxtPsn(wq, dataPsnCnt, hasSignal, totalWqes, activemask,
@@ -1058,18 +1038,18 @@ __device__ inline ccoGda<PrvdType>::ccoGda(ccoDevComm const& comm_, int contextI
 
 // put: RDMA write with optional signal
 template <core::ProviderType PrvdType>
-template <ccoTeamMode TeamMode, ccoGdaWarpMode WarpMode, typename RemoteAction, typename Coop>
+template <ccoTeamMode TeamMode, ccoGdaThreadMode ThreadMode, typename RemoteAction, typename Coop>
 __device__ inline void ccoGda<PrvdType>::put(int peer, ccoWindow_t dstWin, size_t dstOffset,
                                              ccoWindow_t srcWin, size_t srcOffset, size_t bytes,
                                              RemoteAction remoteAction, Coop coop,
                                              uint32_t optFlags) {
-  if constexpr (WarpMode == ccoGdaWarpAggregate) {
+  if constexpr (ThreadMode == ccoGdaThreadAggregate) {
     static_assert(std::is_same_v<Coop, ccoCoopThread>,
-                  "ccoGdaWarpAggregate requires ccoCoopThread — all warp lanes must enter putImpl.");
+                  "ccoGdaThreadAggregate requires ccoCoopThread — all warp lanes must enter putImpl.");
   }
   coop.sync();
   if (coop.thread_rank() == 0) {
-    // Each active lane resolves its own peer endpoint/keys (pure per-lane work).
+    // Each active lane resolves its own peer endpoint/keys.
     int worldPeer = resolveWorldPeer<TeamMode>(peer);
 
     ccoWindowDevice* dstWinDev = reinterpret_cast<ccoWindowDevice*>(dstWin);
@@ -1104,10 +1084,9 @@ __device__ inline void ccoGda<PrvdType>::put(int peer, ccoWindow_t dstWin, size_
       signalOpArg = remoteAction.value;
     }
 
-    // Only mixed-peer thread scope needs per-peer grouping (lanes may target
-    // different QPs). Every other case is a single group: WarpAggregate (whole
-    // warp same peer) or CoopWarp/CoopBlock (one active lane).
-    if constexpr (WarpMode == ccoGdaWarpDefault && std::is_same_v<Coop, ccoCoopThread>) {
+    // Only mixed-peer thread scope needs per-peer grouping; ThreadAggregate and
+    // CoopWarp/CoopBlock are a single group.
+    if constexpr (ThreadMode == ccoGdaThreadIndependent && std::is_same_v<Coop, ccoCoopThread>) {
       // Group active lanes by peer: each peer reserves contiguously + one doorbell.
       bool needTurn = true;
       for (uint64_t turns = __ballot(needTurn); turns != 0; turns = __ballot(needTurn)) {
@@ -1127,15 +1106,15 @@ __device__ inline void ccoGda<PrvdType>::put(int peer, ccoWindow_t dstWin, size_
 
 // putValue: write immediate value (≤8 bytes)
 template <core::ProviderType PrvdType>
-template <ccoTeamMode TeamMode, ccoGdaWarpMode WarpMode, typename T, typename RemoteAction,
+template <ccoTeamMode TeamMode, ccoGdaThreadMode ThreadMode, typename T, typename RemoteAction,
           typename Coop>
 __device__ inline void ccoGda<PrvdType>::putValue(int peer, ccoWindow_t dstWin, size_t dstOffset,
                                                   T value, RemoteAction remoteAction, Coop coop,
                                                   uint32_t optFlags) {
   static_assert(sizeof(T) <= 8, "putValue only supports types <= 8 bytes");
-  if constexpr (WarpMode == ccoGdaWarpAggregate) {
+  if constexpr (ThreadMode == ccoGdaThreadAggregate) {
     static_assert(std::is_same_v<Coop, ccoCoopThread>,
-                  "ccoGdaWarpAggregate requires ccoCoopThread — all warp lanes must enter putValueImpl.");
+                  "ccoGdaThreadAggregate requires ccoCoopThread — all warp lanes must enter putValueImpl.");
   }
 
   coop.sync();
@@ -1170,7 +1149,7 @@ __device__ inline void ccoGda<PrvdType>::putValue(int peer, ccoWindow_t dstWin, 
     }
 
     // Only mixed-peer thread scope needs per-peer grouping; else a single group.
-    if constexpr (WarpMode == ccoGdaWarpDefault && std::is_same_v<Coop, ccoCoopThread>) {
+    if constexpr (ThreadMode == ccoGdaThreadIndependent && std::is_same_v<Coop, ccoCoopThread>) {
       bool needTurn = true;
       for (uint64_t turns = __ballot(needTurn); turns != 0; turns = __ballot(needTurn)) {
         int lead = __ffsll(static_cast<unsigned long long>(turns)) - 1;
@@ -1189,13 +1168,13 @@ __device__ inline void ccoGda<PrvdType>::putValue(int peer, ccoWindow_t dstWin, 
 
 // get: RDMA read
 template <core::ProviderType PrvdType>
-template <ccoTeamMode TeamMode, ccoGdaWarpMode WarpMode, typename Coop>
+template <ccoTeamMode TeamMode, ccoGdaThreadMode ThreadMode, typename Coop>
 __device__ inline void ccoGda<PrvdType>::get(int peer, ccoWindow_t remoteWin, size_t remoteOffset,
                                              ccoWindow_t localWin, size_t localOffset, size_t bytes,
                                              Coop coop, uint32_t optFlags) {
-  if constexpr (WarpMode == ccoGdaWarpAggregate) {
+  if constexpr (ThreadMode == ccoGdaThreadAggregate) {
     static_assert(std::is_same_v<Coop, ccoCoopThread>,
-                  "ccoGdaWarpAggregate requires ccoCoopThread — all warp lanes must enter getImpl.");
+                  "ccoGdaThreadAggregate requires ccoCoopThread — all warp lanes must enter getImpl.");
   }
   coop.sync();
   if (coop.thread_rank() == 0) {
@@ -1216,7 +1195,7 @@ __device__ inline void ccoGda<PrvdType>::get(int peer, ccoWindow_t remoteWin, si
     uint32_t qpn = ep->qpn;
 
     // Only mixed-peer thread scope needs per-peer grouping; else a single group.
-    if constexpr (WarpMode == ccoGdaWarpDefault && std::is_same_v<Coop, ccoCoopThread>) {
+    if constexpr (ThreadMode == ccoGdaThreadIndependent && std::is_same_v<Coop, ccoCoopThread>) {
       bool needTurn = true;
       for (uint64_t turns = __ballot(needTurn); turns != 0; turns = __ballot(needTurn)) {
         int lead = __ffsll(static_cast<unsigned long long>(turns)) - 1;

--- a/include/mori/cco/cco_scale_out.hpp
+++ b/include/mori/cco/cco_scale_out.hpp
@@ -381,6 +381,11 @@ __device__ inline static void quietUntil(core::RdmaEndpointDevice* ep, uint32_t 
         int opcode = core::PollCqOnce<core::ProviderType::BNXT>(cq->cqAddr, cq->cqeNum,
                                                                 consIdxIgnored, &wqeCounter);
         if (opcode < 0) continue;  // no new completion yet
+        if (opcode != BNXT_RE_REQ_ST_OK) {
+          MORI_PRINTF("quietUntil[BNXT]: CQE error opcode=%d\n", opcode);
+          assert(false);
+          break;
+        }
         // Largest V <= dbTouchIdx with V % sqWqeNum == con_indx % sqWqeNum.
         uint32_t dbTouch =
             __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
@@ -394,15 +399,68 @@ __device__ inline static void quietUntil(core::RdmaEndpointDevice* ep, uint32_t 
   }
 }
 
-// Reserve WQE slots and wait for SQ space (per-lane).
-// For warp-aggregate mode the caller has the leader lane call this once
-// with the warp total, then broadcasts the returned base via __shfl.
+// BNXT only: exclusive prefix-sum of psnCnt over the warp's active lanes (by
+// physical lane id). Returns this lane's prefix; *outTotal = warp total. Mirrors
+// shmem. All active lanes must call together.
+__device__ inline static uint32_t warpActivePsnPrefix(uint32_t psnCnt, uint64_t activemask,
+                                                      uint32_t* outTotal) {
+  const uint32_t myPhys = static_cast<uint32_t>(__lane_id());
+  uint32_t excl = 0, total = 0;
+  uint64_t m = activemask;
+  while (m) {
+    int l = __ffsll(static_cast<unsigned long long>(m)) - 1;
+    uint32_t v = __shfl(psnCnt, l);
+    total += v;
+    if (static_cast<uint32_t>(l) < myPhys) excl += v;
+    m &= m - 1;
+  }
+  *outTotal = total;
+  return excl;
+}
+
+// BNXT warp-aggregate PSN: each active lane contributes dataPsnCnt data packets;
+// the warp leader optionally adds one trailing signal packet. The leader advances
+// wq->msnPack once by the warp totals; returns this lane's data-PSN base and (via
+// outSignalPsn) the PSN for the warp's single signal. BNXT PSN must advance by
+// PACKET count, not WQE count (post-#395 per-lane fix; mirrors shmem).
+__device__ inline static uint32_t warpAggregateBnxtPsn(core::WorkQueueHandle* wq,
+                                                       uint32_t dataPsnCnt, bool hasSignalPacket,
+                                                       uint32_t totalWqes, uint64_t activemask,
+                                                       int leaderLane, bool isLeader,
+                                                       uint32_t* outSignalPsn) {
+  uint32_t warpDataPsnTotal = 0;
+  uint32_t myExcl = warpActivePsnPrefix(dataPsnCnt, activemask, &warpDataPsnTotal);
+  uint32_t warpTotalPsn = warpDataPsnTotal + (hasSignalPacket ? 1u : 0u);
+  uint32_t warpPsnBase = 0;
+  if (isLeader) {
+    uint32_t slotIgnored = 0;
+    core::atomic_add_packed_msn_and_psn(&wq->msnPack, totalWqes, warpTotalPsn, &slotIgnored,
+                                        &warpPsnBase);
+  }
+  warpPsnBase = __shfl(warpPsnBase, leaderLane);
+  if (outSignalPsn) *outSignalPsn = warpPsnBase + warpDataPsnTotal;
+  return warpPsnBase + myExcl;
+}
+
+// Reserve numWqesNeeded SQ slots (per-lane) and wait for SQ space. For BNXT, also
+// reserve lanePsnCnt packet-sequence numbers on wq->msnPack and return the PSN
+// base via outPsnBase (BNXT PSN advances by PACKET count, not WQE count).
+// lanePsnCnt/outPsnBase are ignored for MLX5/PSD. Warp-aggregate callers reserve
+// the whole warp themselves; this is the per-lane path.
 template <core::ProviderType PrvdType>
 __device__ inline static uint32_t reserveWqeSlots(core::RdmaEndpointDevice* ep,
-                                                  uint32_t numWqesNeeded) {
+                                                  uint32_t numWqesNeeded, uint32_t lanePsnCnt = 0,
+                                                  uint32_t* outPsnBase = nullptr) {
   core::WorkQueueHandle* wq = &ep->wqHandle;
 
   uint32_t curPostIdx = atomicAdd(&wq->postIdx, numWqesNeeded);
+  if constexpr (PrvdType == core::ProviderType::BNXT) {
+    uint32_t slotIgnored = 0;
+    uint32_t psnBase = 0;
+    core::atomic_add_packed_msn_and_psn(&wq->msnPack, numWqesNeeded, lanePsnCnt, &slotIgnored,
+                                        &psnBase);
+    if (outPsnBase) *outPsnBase = psnBase;
+  }
   while (true) {
     uint64_t dbTouched =
         __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
@@ -413,9 +471,40 @@ __device__ inline static uint32_t reserveWqeSlots(core::RdmaEndpointDevice* ep,
     if (numFreeEntries > entriesUntilMine) {
       break;
     }
-    quietUntil<PrvdType>(ep, curPostIdx);
+    if constexpr (PrvdType == core::ProviderType::BNXT) {
+      // BNXT: drain to the doorbelled snapshot (reachable), not our own
+      // un-doorbelled reservation — else we'd wait on WQEs that may never be
+      // doorbelled and self-deadlock. Mirrors shmem's snapshot drain.
+      quietUntil<PrvdType>(ep, static_cast<uint32_t>(dbTouched));
+    } else {
+      quietUntil<PrvdType>(ep, curPostIdx);
+    }
   }
   return curPostIdx;
+}
+
+// Warp-aggregate flow control: wait until the SQ has room for the whole batch
+// [base, base+totalWqes). BNXT drains to the doorbelled snapshot (not the warp's
+// own un-doorbelled reservation) to avoid self-deadlock (mirrors shmem); other
+// providers keep the original drain-to-reservation behavior.
+template <core::ProviderType PrvdType>
+__device__ inline static void waitSqSpace(core::RdmaEndpointDevice* ep, uint32_t base,
+                                          uint32_t totalWqes) {
+  core::WorkQueueHandle* wq = &ep->wqHandle;
+  while (true) {
+    uint64_t dbTouched =
+        __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    uint64_t dbDone = __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    uint64_t numActiveSqEntries = dbTouched - dbDone;
+    uint64_t numFreeEntries = wq->sqWqeNum - numActiveSqEntries;
+    uint64_t entriesUntilBatchLast = base + totalWqes - dbTouched;
+    if (numFreeEntries > entriesUntilBatchLast) break;
+    if constexpr (PrvdType == core::ProviderType::BNXT) {
+      quietUntil<PrvdType>(ep, static_cast<uint32_t>(dbTouched));
+    } else {
+      quietUntil<PrvdType>(ep, base);
+    }
+  }
 }
 
 // PSD/Ionic only: walk the warp's active lane mask and let one lane at a
@@ -566,43 +655,50 @@ __device__ inline static void putImpl(
     uint32_t totalWqes = numActiveLanes + signalWqes;
 
     uint32_t base = 0;
-    if (isLeader) {
-      base = atomicAdd(&wq->postIdx, totalWqes);
-    }
+    if (isLeader) base = atomicAdd(&wq->postIdx, totalWqes);
     base = __shfl(base, leaderLane);
-
-    while (true) {
-      uint64_t dbTouched =
-          __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint64_t dbDone =
-          __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint64_t numActiveSqEntries = dbTouched - dbDone;
-      uint64_t numFreeEntries = wq->sqWqeNum - numActiveSqEntries;
-      uint64_t entriesUntilBatchLast = base + totalWqes - dbTouched;
-      if (numFreeEntries > entriesUntilBatchLast) break;
-      quietUntil<PrvdType>(ep, base);
-    }
-
     uint32_t mySlot = base + myLogicalLaneId;
-    uint64_t dbrVal =
-        core::PostWrite<PrvdType>(*wq, mySlot, mySlot, mySlot, true /*cqeSignal*/, qpn, localAddr,
-                                  localKey, remoteAddr, remoteKey, bytes);
+    uint32_t signalSlot = base + numActiveLanes;
+    uintptr_t atomicLaddr = reinterpret_cast<uintptr_t>(ep->atomicIbuf.addr);
+    uint32_t atomicLkey = ep->atomicIbuf.lkey;
 
-    __threadfence();
-
-    if (isLeader) {
-      if (hasSignal) {
-        uintptr_t atomicLaddr = reinterpret_cast<uintptr_t>(ep->atomicIbuf.addr);
-        uint32_t atomicLkey = ep->atomicIbuf.lkey;
-        uint32_t signalSlot = base + numActiveLanes;
-        dbrVal = core::PostAtomic<PrvdType, uint64_t>(
-            *wq, signalSlot, signalSlot, signalSlot, true /*cqeSignal*/, qpn, atomicLaddr,
-            atomicLkey, signalRemoteAddr, signalRemoteKey, signalOpArg, 0 /*compare*/,
-            core::AMO_FETCH_ADD);
+    if constexpr (PrvdType == core::ProviderType::BNXT) {
+      // Reserve per-packet PSNs first (before the SQ-space wait, so PSN order
+      // matches slot order across concurrent warps), then post with packet PSN.
+      uint32_t dataPsnCnt = (bytes == 0) ? 1 : (bytes + wq->mtuSize - 1) / wq->mtuSize;
+      uint32_t sigPsn = 0;
+      uint32_t dataPsn = warpAggregateBnxtPsn(wq, dataPsnCnt, hasSignal, totalWqes, activemask,
+                                              leaderLane, isLeader, &sigPsn);
+      waitSqSpace<PrvdType>(ep, base, totalWqes);
+      uint64_t dbrVal = core::PostWrite<PrvdType>(*wq, mySlot, mySlot, dataPsn, true /*cqeSignal*/,
+                                                  qpn, localAddr, localKey, remoteAddr, remoteKey,
+                                                  bytes);
+      __threadfence();
+      if (isLeader) {
+        if (hasSignal) {
+          dbrVal = core::PostAtomic<PrvdType, uint64_t>(
+              *wq, signalSlot, signalSlot, sigPsn, true /*cqeSignal*/, qpn, atomicLaddr, atomicLkey,
+              signalRemoteAddr, signalRemoteKey, signalOpArg, 0 /*compare*/, core::AMO_FETCH_ADD);
+        }
+        if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
+          ringDoorbellOrdered<PrvdType>(ep, base, totalWqes, dbrVal);
       }
-
-      if (!(optFlags & ccoGdaOptFlagsAggregateRequests)) {
-        ringDoorbellOrdered<PrvdType>(ep, base, totalWqes, dbrVal);
+    } else {
+      // MLX5/PSD: the WQE slot index doubles as the PSN.
+      waitSqSpace<PrvdType>(ep, base, totalWqes);
+      uint64_t dbrVal = core::PostWrite<PrvdType>(*wq, mySlot, mySlot, mySlot, true /*cqeSignal*/,
+                                                  qpn, localAddr, localKey, remoteAddr, remoteKey,
+                                                  bytes);
+      __threadfence();
+      if (isLeader) {
+        if (hasSignal) {
+          dbrVal = core::PostAtomic<PrvdType, uint64_t>(
+              *wq, signalSlot, signalSlot, signalSlot, true /*cqeSignal*/, qpn, atomicLaddr,
+              atomicLkey, signalRemoteAddr, signalRemoteKey, signalOpArg, 0 /*compare*/,
+              core::AMO_FETCH_ADD);
+        }
+        if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
+          ringDoorbellOrdered<PrvdType>(ep, base, totalWqes, dbrVal);
       }
     }
     return;
@@ -610,24 +706,40 @@ __device__ inline static void putImpl(
 
   // Per-lane path
   uint32_t numWqesNeeded = 1 + signalWqes;
-  uint32_t curPostIdx = reserveWqeSlots<PrvdType>(ep, numWqesNeeded);
+  uintptr_t atomicLaddr = reinterpret_cast<uintptr_t>(ep->atomicIbuf.addr);
+  uint32_t atomicLkey = ep->atomicIbuf.lkey;
 
-  uint32_t wqeIdx = curPostIdx;
-  uint64_t dbrVal = core::PostWrite<PrvdType>(*wq, wqeIdx, wqeIdx, wqeIdx, true /*cqeSignal*/, qpn,
-                                              localAddr, localKey, remoteAddr, remoteKey, bytes);
-  wqeIdx++;
-
-  if (hasSignal) {
-    uintptr_t atomicLaddr = reinterpret_cast<uintptr_t>(ep->atomicIbuf.addr);
-    uint32_t atomicLkey = ep->atomicIbuf.lkey;
-
-    dbrVal = core::PostAtomic<PrvdType, uint64_t>(
-        *wq, wqeIdx, wqeIdx, wqeIdx, true /*cqeSignal*/, qpn, atomicLaddr, atomicLkey,
-        signalRemoteAddr, signalRemoteKey, signalOpArg, 0 /*compare*/, core::AMO_FETCH_ADD);
-  }
-
-  if (!(optFlags & ccoGdaOptFlagsAggregateRequests)) {
-    ringDoorbellOrdered<PrvdType>(ep, curPostIdx, numWqesNeeded, dbrVal);
+  if constexpr (PrvdType == core::ProviderType::BNXT) {
+    uint32_t dataPsnCnt = (bytes == 0) ? 1 : (bytes + wq->mtuSize - 1) / wq->mtuSize;
+    uint32_t psnBase = 0;
+    uint32_t curPostIdx =
+        reserveWqeSlots<PrvdType>(ep, numWqesNeeded, dataPsnCnt + (hasSignal ? 1u : 0u), &psnBase);
+    uint32_t wqeIdx = curPostIdx;
+    uint64_t dbrVal = core::PostWrite<PrvdType>(*wq, wqeIdx, wqeIdx, psnBase, true /*cqeSignal*/,
+                                                qpn, localAddr, localKey, remoteAddr, remoteKey,
+                                                bytes);
+    wqeIdx++;
+    if (hasSignal) {
+      dbrVal = core::PostAtomic<PrvdType, uint64_t>(
+          *wq, wqeIdx, wqeIdx, psnBase + dataPsnCnt, true /*cqeSignal*/, qpn, atomicLaddr,
+          atomicLkey, signalRemoteAddr, signalRemoteKey, signalOpArg, 0 /*compare*/,
+          core::AMO_FETCH_ADD);
+    }
+    if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
+      ringDoorbellOrdered<PrvdType>(ep, curPostIdx, numWqesNeeded, dbrVal);
+  } else {
+    uint32_t curPostIdx = reserveWqeSlots<PrvdType>(ep, numWqesNeeded);
+    uint32_t wqeIdx = curPostIdx;
+    uint64_t dbrVal = core::PostWrite<PrvdType>(*wq, wqeIdx, wqeIdx, wqeIdx, true /*cqeSignal*/, qpn,
+                                                localAddr, localKey, remoteAddr, remoteKey, bytes);
+    wqeIdx++;
+    if (hasSignal) {
+      dbrVal = core::PostAtomic<PrvdType, uint64_t>(
+          *wq, wqeIdx, wqeIdx, wqeIdx, true /*cqeSignal*/, qpn, atomicLaddr, atomicLkey,
+          signalRemoteAddr, signalRemoteKey, signalOpArg, 0 /*compare*/, core::AMO_FETCH_ADD);
+    }
+    if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
+      ringDoorbellOrdered<PrvdType>(ep, curPostIdx, numWqesNeeded, dbrVal);
   }
 }
 
@@ -655,42 +767,47 @@ __device__ inline static void putValueImpl(core::RdmaEndpointDevice* ep, uint32_
     uint32_t totalWqes = numActiveLanes + signalWqes;
 
     uint32_t base = 0;
-    if (isLeader) {
-      base = atomicAdd(&wq->postIdx, totalWqes);
-    }
+    if (isLeader) base = atomicAdd(&wq->postIdx, totalWqes);
     base = __shfl(base, leaderLane);
-
-    while (true) {
-      uint64_t dbTouched =
-          __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint64_t dbDone =
-          __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint64_t numActiveSqEntries = dbTouched - dbDone;
-      uint64_t numFreeEntries = wq->sqWqeNum - numActiveSqEntries;
-      uint64_t entriesUntilBatchLast = base + totalWqes - dbTouched;
-      if (numFreeEntries > entriesUntilBatchLast) break;
-      quietUntil<PrvdType>(ep, base);
-    }
-
     uint32_t mySlot = base + myLogicalLaneId;
-    uint64_t dbrVal =
-        core::PostWriteInline<PrvdType>(*wq, mySlot, mySlot, mySlot, true /*cqeSignal*/, qpn,
-                                        &value, remoteAddr, remoteKey, sizeof(T));
+    uint32_t signalSlot = base + numActiveLanes;
+    uintptr_t atomicLaddr = reinterpret_cast<uintptr_t>(ep->atomicIbuf.addr);
+    uint32_t atomicLkey = ep->atomicIbuf.lkey;
 
-    __threadfence();
-
-    if (isLeader) {
-      if (hasSignal) {
-        uintptr_t atomicLaddr = reinterpret_cast<uintptr_t>(ep->atomicIbuf.addr);
-        uint32_t atomicLkey = ep->atomicIbuf.lkey;
-        uint32_t signalSlot = base + numActiveLanes;
-        dbrVal = core::PostAtomic<PrvdType, uint64_t>(
-            *wq, signalSlot, signalSlot, signalSlot, true /*cqeSignal*/, qpn, atomicLaddr,
-            atomicLkey, signalRemoteAddr, signalRemoteKey, signalOpArg, 0, core::AMO_FETCH_ADD);
+    if constexpr (PrvdType == core::ProviderType::BNXT) {
+      // Reserve per-packet PSNs first (inline write is 1 packet), then post.
+      uint32_t sigPsn = 0;
+      uint32_t dataPsn = warpAggregateBnxtPsn(wq, /*dataPsnCnt=*/1, hasSignal, totalWqes, activemask,
+                                              leaderLane, isLeader, &sigPsn);
+      waitSqSpace<PrvdType>(ep, base, totalWqes);
+      uint64_t dbrVal = core::PostWriteInline<PrvdType>(*wq, mySlot, mySlot, dataPsn,
+                                                        true /*cqeSignal*/, qpn, &value, remoteAddr,
+                                                        remoteKey, sizeof(T));
+      __threadfence();
+      if (isLeader) {
+        if (hasSignal) {
+          dbrVal = core::PostAtomic<PrvdType, uint64_t>(
+              *wq, signalSlot, signalSlot, sigPsn, true /*cqeSignal*/, qpn, atomicLaddr, atomicLkey,
+              signalRemoteAddr, signalRemoteKey, signalOpArg, 0, core::AMO_FETCH_ADD);
+        }
+        if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
+          ringDoorbellOrdered<PrvdType>(ep, base, totalWqes, dbrVal);
       }
-
-      if (!(optFlags & ccoGdaOptFlagsAggregateRequests)) {
-        ringDoorbellOrdered<PrvdType>(ep, base, totalWqes, dbrVal);
+    } else {
+      // MLX5/PSD: the WQE slot index doubles as the PSN.
+      waitSqSpace<PrvdType>(ep, base, totalWqes);
+      uint64_t dbrVal = core::PostWriteInline<PrvdType>(*wq, mySlot, mySlot, mySlot,
+                                                        true /*cqeSignal*/, qpn, &value, remoteAddr,
+                                                        remoteKey, sizeof(T));
+      __threadfence();
+      if (isLeader) {
+        if (hasSignal) {
+          dbrVal = core::PostAtomic<PrvdType, uint64_t>(
+              *wq, signalSlot, signalSlot, signalSlot, true /*cqeSignal*/, qpn, atomicLaddr,
+              atomicLkey, signalRemoteAddr, signalRemoteKey, signalOpArg, 0, core::AMO_FETCH_ADD);
+        }
+        if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
+          ringDoorbellOrdered<PrvdType>(ep, base, totalWqes, dbrVal);
       }
     }
     return;
@@ -698,24 +815,38 @@ __device__ inline static void putValueImpl(core::RdmaEndpointDevice* ep, uint32_
 
   // Per-lane path
   uint32_t numWqesNeeded = 1 + signalWqes;
-  uint32_t curPostIdx = reserveWqeSlots<PrvdType>(ep, numWqesNeeded);
+  uintptr_t atomicLaddr = reinterpret_cast<uintptr_t>(ep->atomicIbuf.addr);
+  uint32_t atomicLkey = ep->atomicIbuf.lkey;
 
-  uint32_t wqeIdx = curPostIdx;
-  uint64_t dbrVal = core::PostWriteInline<PrvdType>(*wq, wqeIdx, wqeIdx, wqeIdx, true /*cqeSignal*/,
-                                                    qpn, &value, remoteAddr, remoteKey, sizeof(T));
-  wqeIdx++;
-
-  if (hasSignal) {
-    uintptr_t atomicLaddr = reinterpret_cast<uintptr_t>(ep->atomicIbuf.addr);
-    uint32_t atomicLkey = ep->atomicIbuf.lkey;
-
-    dbrVal = core::PostAtomic<PrvdType, uint64_t>(
-        *wq, wqeIdx, wqeIdx, wqeIdx, true /*cqeSignal*/, qpn, atomicLaddr, atomicLkey,
-        signalRemoteAddr, signalRemoteKey, signalOpArg, 0, core::AMO_FETCH_ADD);
-  }
-
-  if (!(optFlags & ccoGdaOptFlagsAggregateRequests)) {
-    ringDoorbellOrdered<PrvdType>(ep, curPostIdx, numWqesNeeded, dbrVal);
+  if constexpr (PrvdType == core::ProviderType::BNXT) {
+    uint32_t psnBase = 0;
+    uint32_t curPostIdx =
+        reserveWqeSlots<PrvdType>(ep, numWqesNeeded, 1u + (hasSignal ? 1u : 0u), &psnBase);
+    uint32_t wqeIdx = curPostIdx;
+    uint64_t dbrVal = core::PostWriteInline<PrvdType>(*wq, wqeIdx, wqeIdx, psnBase,
+                                                      true /*cqeSignal*/, qpn, &value, remoteAddr,
+                                                      remoteKey, sizeof(T));
+    wqeIdx++;
+    if (hasSignal) {
+      dbrVal = core::PostAtomic<PrvdType, uint64_t>(
+          *wq, wqeIdx, wqeIdx, psnBase + 1u, true /*cqeSignal*/, qpn, atomicLaddr, atomicLkey,
+          signalRemoteAddr, signalRemoteKey, signalOpArg, 0, core::AMO_FETCH_ADD);
+    }
+    if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
+      ringDoorbellOrdered<PrvdType>(ep, curPostIdx, numWqesNeeded, dbrVal);
+  } else {
+    uint32_t curPostIdx = reserveWqeSlots<PrvdType>(ep, numWqesNeeded);
+    uint32_t wqeIdx = curPostIdx;
+    uint64_t dbrVal = core::PostWriteInline<PrvdType>(*wq, wqeIdx, wqeIdx, wqeIdx, true /*cqeSignal*/,
+                                                      qpn, &value, remoteAddr, remoteKey, sizeof(T));
+    wqeIdx++;
+    if (hasSignal) {
+      dbrVal = core::PostAtomic<PrvdType, uint64_t>(
+          *wq, wqeIdx, wqeIdx, wqeIdx, true /*cqeSignal*/, qpn, atomicLaddr, atomicLkey,
+          signalRemoteAddr, signalRemoteKey, signalOpArg, 0, core::AMO_FETCH_ADD);
+    }
+    if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
+      ringDoorbellOrdered<PrvdType>(ep, curPostIdx, numWqesNeeded, dbrVal);
   }
 }
 
@@ -736,47 +867,53 @@ __device__ inline static void getImpl(core::RdmaEndpointDevice* ep, uint32_t qpn
     uint32_t totalWqes = numActiveLanes;
 
     uint32_t base = 0;
-    if (isLeader) {
-      base = atomicAdd(&wq->postIdx, totalWqes);
-    }
+    if (isLeader) base = atomicAdd(&wq->postIdx, totalWqes);
     base = __shfl(base, leaderLane);
-
-    while (true) {
-      uint64_t dbTouched =
-          __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint64_t dbDone =
-          __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint64_t numActiveSqEntries = dbTouched - dbDone;
-      uint64_t numFreeEntries = wq->sqWqeNum - numActiveSqEntries;
-      uint64_t entriesUntilBatchLast = base + totalWqes - dbTouched;
-      if (numFreeEntries > entriesUntilBatchLast) break;
-      quietUntil<PrvdType>(ep, base);
-    }
-
     uint32_t mySlot = base + myLogicalLaneId;
-    uint64_t dbrVal =
-        core::PostRead<PrvdType>(*wq, mySlot, mySlot, mySlot, true /*cqeSignal*/, qpn, localAddr,
-                                 localKey, remoteAddr, remoteKey, bytes);
 
-    __threadfence();
-
-    if (isLeader) {
-      if (!(optFlags & ccoGdaOptFlagsAggregateRequests)) {
+    if constexpr (PrvdType == core::ProviderType::BNXT) {
+      // Reserve per-packet PSNs first (read consumes response-packet PSNs), then post.
+      uint32_t dataPsnCnt = (bytes == 0) ? 1 : (bytes + wq->mtuSize - 1) / wq->mtuSize;
+      uint32_t dataPsn = warpAggregateBnxtPsn(wq, dataPsnCnt, /*hasSignalPacket=*/false, totalWqes,
+                                              activemask, leaderLane, isLeader,
+                                              /*outSignalPsn=*/nullptr);
+      waitSqSpace<PrvdType>(ep, base, totalWqes);
+      uint64_t dbrVal = core::PostRead<PrvdType>(*wq, mySlot, mySlot, dataPsn, true /*cqeSignal*/,
+                                                 qpn, localAddr, localKey, remoteAddr, remoteKey,
+                                                 bytes);
+      __threadfence();
+      if (isLeader && !(optFlags & ccoGdaOptFlagsAggregateRequests))
         ringDoorbellOrdered<PrvdType>(ep, base, totalWqes, dbrVal);
-      }
+    } else {
+      // MLX5/PSD: the WQE slot index doubles as the PSN.
+      waitSqSpace<PrvdType>(ep, base, totalWqes);
+      uint64_t dbrVal = core::PostRead<PrvdType>(*wq, mySlot, mySlot, mySlot, true /*cqeSignal*/,
+                                                 qpn, localAddr, localKey, remoteAddr, remoteKey,
+                                                 bytes);
+      __threadfence();
+      if (isLeader && !(optFlags & ccoGdaOptFlagsAggregateRequests))
+        ringDoorbellOrdered<PrvdType>(ep, base, totalWqes, dbrVal);
     }
     return;
   }
 
   // Per-lane path
-  uint32_t curPostIdx = reserveWqeSlots<PrvdType>(ep, 1);
-
-  uint64_t dbrVal =
-      core::PostRead<PrvdType>(*wq, curPostIdx, curPostIdx, curPostIdx, true /*cqeSignal*/, qpn,
-                               localAddr, localKey, remoteAddr, remoteKey, bytes);
-
-  if (!(optFlags & ccoGdaOptFlagsAggregateRequests)) {
-    ringDoorbellOrdered<PrvdType>(ep, curPostIdx, 1, dbrVal);
+  if constexpr (PrvdType == core::ProviderType::BNXT) {
+    uint32_t dataPsnCnt = (bytes == 0) ? 1 : (bytes + wq->mtuSize - 1) / wq->mtuSize;
+    uint32_t psnBase = 0;
+    uint32_t curPostIdx = reserveWqeSlots<PrvdType>(ep, 1, dataPsnCnt, &psnBase);
+    uint64_t dbrVal = core::PostRead<PrvdType>(*wq, curPostIdx, curPostIdx, psnBase,
+                                               true /*cqeSignal*/, qpn, localAddr, localKey,
+                                               remoteAddr, remoteKey, bytes);
+    if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
+      ringDoorbellOrdered<PrvdType>(ep, curPostIdx, 1, dbrVal);
+  } else {
+    uint32_t curPostIdx = reserveWqeSlots<PrvdType>(ep, 1);
+    uint64_t dbrVal = core::PostRead<PrvdType>(*wq, curPostIdx, curPostIdx, curPostIdx,
+                                               true /*cqeSignal*/, qpn, localAddr, localKey,
+                                               remoteAddr, remoteKey, bytes);
+    if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
+      ringDoorbellOrdered<PrvdType>(ep, curPostIdx, 1, dbrVal);
   }
 }
 
@@ -829,24 +966,28 @@ __device__ inline static void signalImpl(core::RdmaEndpointDevice* ep, uint32_t 
                                          ccoGdaSignalOp_t signalOp, uint64_t signalOpArg,
                                          uint32_t optFlags = ccoGdaOptFlagsDefault) {
   core::WorkQueueHandle* wq = &ep->wqHandle;
-
-  // Reserve WQE slot
-  uint32_t curPostIdx = reserveWqeSlots<PrvdType>(ep, 1);
-
-  // Post RDMA atomic operation
-
-  // RDMA atomic requires local buffer for FetchAdd result (even if unused)
+  // RDMA atomic requires a local buffer for the FetchAdd result (even if unused).
   uintptr_t atomicLaddr = reinterpret_cast<uintptr_t>(ep->atomicIbuf.addr);
   uint32_t atomicLkey = ep->atomicIbuf.lkey;
-
   uint64_t addValue = (signalOp == ccoGdaSignalInc) ? 1 : signalOpArg;
-  uint64_t dbrVal = core::PostAtomic<PrvdType, uint64_t>(
-      *wq, curPostIdx, curPostIdx, curPostIdx, true /*cqeSignal*/, qpn, atomicLaddr, atomicLkey,
-      signalRemoteAddr, signalRemoteKey, addValue, 0 /*compare*/, core::AMO_FETCH_ADD);
 
-  // Ring doorbell unless AggregateRequests is set
-  if (!(optFlags & ccoGdaOptFlagsAggregateRequests)) {
-    ringDoorbellOrdered<PrvdType>(ep, curPostIdx, 1, dbrVal);
+  if constexpr (PrvdType == core::ProviderType::BNXT) {
+    // Reserve a WQE slot + 1 packet PSN; post the atomic with the packet PSN.
+    uint32_t psnBase = 0;
+    uint32_t curPostIdx = reserveWqeSlots<PrvdType>(ep, 1, /*lanePsnCnt=*/1, &psnBase);
+    uint64_t dbrVal = core::PostAtomic<PrvdType, uint64_t>(
+        *wq, curPostIdx, curPostIdx, psnBase, true /*cqeSignal*/, qpn, atomicLaddr, atomicLkey,
+        signalRemoteAddr, signalRemoteKey, addValue, 0 /*compare*/, core::AMO_FETCH_ADD);
+    if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
+      ringDoorbellOrdered<PrvdType>(ep, curPostIdx, 1, dbrVal);
+  } else {
+    // MLX5/PSD: the WQE slot index doubles as the PSN.
+    uint32_t curPostIdx = reserveWqeSlots<PrvdType>(ep, 1);
+    uint64_t dbrVal = core::PostAtomic<PrvdType, uint64_t>(
+        *wq, curPostIdx, curPostIdx, curPostIdx, true /*cqeSignal*/, qpn, atomicLaddr, atomicLkey,
+        signalRemoteAddr, signalRemoteKey, addValue, 0 /*compare*/, core::AMO_FETCH_ADD);
+    if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
+      ringDoorbellOrdered<PrvdType>(ep, curPostIdx, 1, dbrVal);
   }
 }
 

--- a/include/mori/cco/cco_scale_out.hpp
+++ b/include/mori/cco/cco_scale_out.hpp
@@ -507,27 +507,47 @@ __device__ inline static void waitSqSpace(core::RdmaEndpointDevice* ep, uint32_t
   }
 }
 
-// PSD/Ionic only: walk the warp's active lane mask and let one lane at a
-// time issue the doorbell MMIO store. Ionic's dbrAddr is shared across every
-// QP of the same ibv_context; multiple lanes of one warp storing to that
-// shared address in one SIMT instruction get coalesced into a single
-// transaction and only one lane's dbrVal survives. Atomic-store ordering
-// does not protect against this. MLX5/BNXT each have a per-QP dbrAddr so
-// multi-lane stores hit distinct addresses and stay on the fast path.
-__device__ inline static void ringDoorbellWarpPsd(void* dbrAddr, uint64_t dbrVal) {
+// PSD/BNXT only: walk the warp's active lane mask and let one lane at a time
+// issue the doorbell MMIO store. These providers can share one dbrAddr across
+// QPs — Ionic shares it across every QP of an ibv_context; BNXT dedups the UAR
+// page across endpoints (BnxtCqContainer / TryRegisterUar). When lanes targeting
+// distinct QPs that share a dbrAddr store in one SIMT instruction, the stores
+// coalesce into a single transaction and only one lane's dbrVal survives — the
+// dropped doorbells' WQEs are never fetched and quiet hangs. Serializing one lane
+// per iteration avoids that. MLX5 has a per-QP dbrAddr and never needs this.
+//
+// No __syncwarp between iterations: AMD wavefronts are lock-step, so the per-lane
+// predication already serializes the stores in program order; a __syncwarp would
+// also deadlock on divergent entry (a lane that already rang must not wait on
+// lanes still spinning for their turn).
+template <core::ProviderType PrvdType>
+__device__ inline static void ringDoorbellWalk(core::WorkQueueHandle* wq, uint32_t dbrRecVal,
+                                               uint64_t dbrVal) {
+  if constexpr (PrvdType == core::ProviderType::BNXT) {
+    core::UpdateSendDbrRecord<PrvdType>(wq->dbrRecAddr, dbrRecVal);
+    __threadfence_system();
+  }
   uint64_t mask = core::GetActiveLaneMask();
   while (mask) {
     int lane = __ffsll(static_cast<unsigned long long>(mask)) - 1;
     if (__lane_id() == lane) {
-      core::RingDoorbell<core::ProviderType::PSD>(dbrAddr, dbrVal);
+      core::RingDoorbell<PrvdType>(wq->dbrAddr, dbrVal);
     }
-    __syncwarp();
     mask &= ~(1ull << lane);
   }
 }
 
-// Wait for doorbell ordering and ring doorbell
-template <core::ProviderType PrvdType>
+// Wait for this QP's doorbell turn (preserve per-QP ordering across warps/groups),
+// then ring. Both modes keep the wait-for-turn; LeaderOnly selects the ring step:
+//   LeaderOnly=true  — the caller guarantees exactly one active lane rings (the
+//     per-peer group leader, e.g. grouped put/get/putValue). One store suffices,
+//     no SIMT coalescing possible → single RingDoorbell (shmem-style).
+//   LeaderOnly=false — multiple active lanes may ring distinct QPs that share a
+//     UAR (BNXT) / dbrAddr (Ionic) in one SIMT step; same-address store coalescing
+//     would drop all but one doorbell. Serialize the stores per active lane (no
+//     __syncwarp: lock-step wavefront + predication already order them, and a
+//     __syncwarp would deadlock on divergent entry).
+template <core::ProviderType PrvdType, bool LeaderOnly = false>
 __device__ inline static void ringDoorbellOrdered(core::RdmaEndpointDevice* ep, uint32_t myPostIdx,
                                                   uint32_t numWqes, uint64_t dbrVal) {
   core::WorkQueueHandle* wq = &ep->wqHandle;
@@ -545,34 +565,21 @@ __device__ inline static void ringDoorbellOrdered(core::RdmaEndpointDevice* ep, 
   // Ring doorbell - provider-specific sequence
   __threadfence_system();
 
-  if constexpr (PrvdType == core::ProviderType::PSD) {
-    // PSD/Ionic: shared dbrAddr, lane-serialize to avoid SIMT same-address
-    // store coalescing dropping doorbells.
-    ringDoorbellWarpPsd(wq->dbrAddr, dbrVal);
+  if constexpr (LeaderOnly) {
+    // Single active lane: MLX5/BNXT update the DBR record first, then one store.
+    if constexpr (PrvdType != core::ProviderType::PSD) {
+      core::UpdateSendDbrRecord<PrvdType>(wq->dbrRecAddr, myPostIdx + numWqes);
+      __threadfence_system();
+    }
+    core::RingDoorbell<PrvdType>(wq->dbrAddr, dbrVal);
   } else if constexpr (PrvdType == core::ProviderType::MLX5) {
-    // MLX5: must update DBR record before ringing doorbell
+    // MLX5: per-QP dbrAddr (no coalescing across lanes); update DBR record + ring.
     core::UpdateSendDbrRecord<PrvdType>(wq->dbrRecAddr, myPostIdx + numWqes);
     __threadfence_system();
     core::RingDoorbell<PrvdType>(wq->dbrAddr, dbrVal);
-  } else if constexpr (PrvdType == core::ProviderType::BNXT) {
-    // BNXT: update DBR record, then ring doorbell. BNXT dedups the UAR page
-    // across endpoints (see BnxtCqContainer / TryRegisterUar), so distinct QPs
-    // in one warp can share the same dbrAddr. A per-thread GDA put has each
-    // active lane targeting a *different* peer's QP in the same SIMT step; if
-    // those QPs share a UAR, same-address store coalescing drops all but one
-    // lane's doorbell — the dropped WQE is never fetched and quiet hangs. Walk
-    // the warp's active lanes one at a time so every doorbell store survives.
-    core::UpdateSendDbrRecord<PrvdType>(wq->dbrRecAddr, myPostIdx + numWqes);
-    __threadfence_system();
-    uint64_t mask = core::GetActiveLaneMask();
-    while (mask) {
-      int lane = __ffsll(static_cast<unsigned long long>(mask)) - 1;
-      if (__lane_id() == lane) {
-        core::RingDoorbell<PrvdType>(wq->dbrAddr, dbrVal);
-      }
-      __syncwarp();
-      mask &= ~(1ull << lane);
-    }
+  } else {
+    // PSD/BNXT: lanes may share a dbrAddr → serialize per lane.
+    ringDoorbellWalk<PrvdType>(wq, myPostIdx + numWqes, dbrVal);
   }
 
   __threadfence_system();
@@ -619,13 +626,11 @@ __device__ inline static uint64_t buildFlushDbrVal(core::WorkQueueHandle* wq, ui
   }
 }
 
-// putImpl - Pure hardware operation layer
-//
-// ccoGdaWarpAggregate: all active warp lanes must target the same QP.
-// Leader reserves slots for (N data WQEs + 1 signal WQE), each lane posts
-// its data WQE, and the leader posts one shared signal WQE + rings one
-// doorbell for the entire batch.
-template <core::ProviderType PrvdType, ccoGdaWarpMode WarpMode = ccoGdaWarpDefault>
+// putImpl - post ONE warp-aggregated put for the currently-active lanes, which
+// must all target this ep/qpn (the facade groups lanes by peer before calling).
+// Each active lane posts its data WQE into a contiguous reservation; the leader
+// posts one shared signal WQE and rings one doorbell for the whole group.
+template <core::ProviderType PrvdType>
 __device__ inline static void putImpl(
     // Hardware resources (already selected endpoint)
     core::RdmaEndpointDevice* ep, uint32_t qpn,
@@ -642,109 +647,67 @@ __device__ inline static void putImpl(
     // Optimization flags
     uint32_t optFlags = ccoGdaOptFlagsDefault) {
   core::WorkQueueHandle* wq = &ep->wqHandle;
-
   uint32_t signalWqes =
       hasSignal ? getAtomicWqeCount<PrvdType>(core::AMO_FETCH_ADD, sizeof(uint64_t)) : 0;
 
-  if constexpr (WarpMode == ccoGdaWarpAggregate) {
-    uint64_t activemask = core::GetActiveLaneMask();
-    int leaderLane = core::GetLastActiveLaneID(activemask);
-    uint32_t numActiveLanes = core::GetActiveLaneCount(activemask);
-    uint32_t myLogicalLaneId = core::GetActiveLaneNum(activemask);
-    bool isLeader = (myLogicalLaneId == numActiveLanes - 1);
-    uint32_t totalWqes = numActiveLanes + signalWqes;
+  uint64_t activemask = core::GetActiveLaneMask();
+  int leaderLane = core::GetLastActiveLaneID(activemask);
+  uint32_t numActiveLanes = core::GetActiveLaneCount(activemask);
+  uint32_t myLogicalLaneId = core::GetActiveLaneNum(activemask);
+  bool isLeader = (myLogicalLaneId == numActiveLanes - 1);
+  uint32_t totalWqes = numActiveLanes + signalWqes;
 
-    uint32_t base = 0;
-    if (isLeader) base = atomicAdd(&wq->postIdx, totalWqes);
-    base = __shfl(base, leaderLane);
-    uint32_t mySlot = base + myLogicalLaneId;
-    uint32_t signalSlot = base + numActiveLanes;
-    uintptr_t atomicLaddr = reinterpret_cast<uintptr_t>(ep->atomicIbuf.addr);
-    uint32_t atomicLkey = ep->atomicIbuf.lkey;
-
-    if constexpr (PrvdType == core::ProviderType::BNXT) {
-      // Reserve per-packet PSNs first (before the SQ-space wait, so PSN order
-      // matches slot order across concurrent warps), then post with packet PSN.
-      uint32_t dataPsnCnt = (bytes == 0) ? 1 : (bytes + wq->mtuSize - 1) / wq->mtuSize;
-      uint32_t sigPsn = 0;
-      uint32_t dataPsn = warpAggregateBnxtPsn(wq, dataPsnCnt, hasSignal, totalWqes, activemask,
-                                              leaderLane, isLeader, &sigPsn);
-      waitSqSpace<PrvdType>(ep, base, totalWqes);
-      uint64_t dbrVal = core::PostWrite<PrvdType>(*wq, mySlot, mySlot, dataPsn, true /*cqeSignal*/,
-                                                  qpn, localAddr, localKey, remoteAddr, remoteKey,
-                                                  bytes);
-      __threadfence();
-      if (isLeader) {
-        if (hasSignal) {
-          dbrVal = core::PostAtomic<PrvdType, uint64_t>(
-              *wq, signalSlot, signalSlot, sigPsn, true /*cqeSignal*/, qpn, atomicLaddr, atomicLkey,
-              signalRemoteAddr, signalRemoteKey, signalOpArg, 0 /*compare*/, core::AMO_FETCH_ADD);
-        }
-        if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
-          ringDoorbellOrdered<PrvdType>(ep, base, totalWqes, dbrVal);
-      }
-    } else {
-      // MLX5/PSD: the WQE slot index doubles as the PSN.
-      waitSqSpace<PrvdType>(ep, base, totalWqes);
-      uint64_t dbrVal = core::PostWrite<PrvdType>(*wq, mySlot, mySlot, mySlot, true /*cqeSignal*/,
-                                                  qpn, localAddr, localKey, remoteAddr, remoteKey,
-                                                  bytes);
-      __threadfence();
-      if (isLeader) {
-        if (hasSignal) {
-          dbrVal = core::PostAtomic<PrvdType, uint64_t>(
-              *wq, signalSlot, signalSlot, signalSlot, true /*cqeSignal*/, qpn, atomicLaddr,
-              atomicLkey, signalRemoteAddr, signalRemoteKey, signalOpArg, 0 /*compare*/,
-              core::AMO_FETCH_ADD);
-        }
-        if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
-          ringDoorbellOrdered<PrvdType>(ep, base, totalWqes, dbrVal);
-      }
-    }
-    return;
-  }
-
-  // Per-lane path
-  uint32_t numWqesNeeded = 1 + signalWqes;
+  uint32_t base = 0;
+  if (isLeader) base = atomicAdd(&wq->postIdx, totalWqes);
+  base = __shfl(base, leaderLane);
+  uint32_t mySlot = base + myLogicalLaneId;
+  uint32_t signalSlot = base + numActiveLanes;
   uintptr_t atomicLaddr = reinterpret_cast<uintptr_t>(ep->atomicIbuf.addr);
   uint32_t atomicLkey = ep->atomicIbuf.lkey;
 
   if constexpr (PrvdType == core::ProviderType::BNXT) {
+    // Reserve per-packet PSNs first (before the SQ-space wait, so PSN order
+    // matches slot order across concurrent warps), then post with packet PSN.
     uint32_t dataPsnCnt = (bytes == 0) ? 1 : (bytes + wq->mtuSize - 1) / wq->mtuSize;
-    uint32_t psnBase = 0;
-    uint32_t curPostIdx =
-        reserveWqeSlots<PrvdType>(ep, numWqesNeeded, dataPsnCnt + (hasSignal ? 1u : 0u), &psnBase);
-    uint32_t wqeIdx = curPostIdx;
-    uint64_t dbrVal = core::PostWrite<PrvdType>(*wq, wqeIdx, wqeIdx, psnBase, true /*cqeSignal*/,
+    uint32_t sigPsn = 0;
+    uint32_t dataPsn = warpAggregateBnxtPsn(wq, dataPsnCnt, hasSignal, totalWqes, activemask,
+                                            leaderLane, isLeader, &sigPsn);
+    waitSqSpace<PrvdType>(ep, base, totalWqes);
+    uint64_t dbrVal = core::PostWrite<PrvdType>(*wq, mySlot, mySlot, dataPsn, true /*cqeSignal*/,
                                                 qpn, localAddr, localKey, remoteAddr, remoteKey,
                                                 bytes);
-    wqeIdx++;
-    if (hasSignal) {
-      dbrVal = core::PostAtomic<PrvdType, uint64_t>(
-          *wq, wqeIdx, wqeIdx, psnBase + dataPsnCnt, true /*cqeSignal*/, qpn, atomicLaddr,
-          atomicLkey, signalRemoteAddr, signalRemoteKey, signalOpArg, 0 /*compare*/,
-          core::AMO_FETCH_ADD);
+    __threadfence();
+    if (isLeader) {
+      if (hasSignal) {
+        dbrVal = core::PostAtomic<PrvdType, uint64_t>(
+            *wq, signalSlot, signalSlot, sigPsn, true /*cqeSignal*/, qpn, atomicLaddr, atomicLkey,
+            signalRemoteAddr, signalRemoteKey, signalOpArg, 0 /*compare*/, core::AMO_FETCH_ADD);
+      }
+      if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
+        ringDoorbellOrdered<PrvdType, /*LeaderOnly=*/true>(ep, base, totalWqes, dbrVal);
     }
-    if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
-      ringDoorbellOrdered<PrvdType>(ep, curPostIdx, numWqesNeeded, dbrVal);
   } else {
-    uint32_t curPostIdx = reserveWqeSlots<PrvdType>(ep, numWqesNeeded);
-    uint32_t wqeIdx = curPostIdx;
-    uint64_t dbrVal = core::PostWrite<PrvdType>(*wq, wqeIdx, wqeIdx, wqeIdx, true /*cqeSignal*/, qpn,
+    // MLX5/PSD: the WQE slot index doubles as the PSN.
+    waitSqSpace<PrvdType>(ep, base, totalWqes);
+    uint64_t dbrVal = core::PostWrite<PrvdType>(*wq, mySlot, mySlot, mySlot, true /*cqeSignal*/, qpn,
                                                 localAddr, localKey, remoteAddr, remoteKey, bytes);
-    wqeIdx++;
-    if (hasSignal) {
-      dbrVal = core::PostAtomic<PrvdType, uint64_t>(
-          *wq, wqeIdx, wqeIdx, wqeIdx, true /*cqeSignal*/, qpn, atomicLaddr, atomicLkey,
-          signalRemoteAddr, signalRemoteKey, signalOpArg, 0 /*compare*/, core::AMO_FETCH_ADD);
+    __threadfence();
+    if (isLeader) {
+      if (hasSignal) {
+        dbrVal = core::PostAtomic<PrvdType, uint64_t>(
+            *wq, signalSlot, signalSlot, signalSlot, true /*cqeSignal*/, qpn, atomicLaddr,
+            atomicLkey, signalRemoteAddr, signalRemoteKey, signalOpArg, 0 /*compare*/,
+            core::AMO_FETCH_ADD);
+      }
+      if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
+        ringDoorbellOrdered<PrvdType, /*LeaderOnly=*/true>(ep, base, totalWqes, dbrVal);
     }
-    if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
-      ringDoorbellOrdered<PrvdType>(ep, curPostIdx, numWqesNeeded, dbrVal);
   }
 }
 
-// putValueImpl - Inline write for small values
-template <core::ProviderType PrvdType, typename T, ccoGdaWarpMode WarpMode = ccoGdaWarpDefault>
+// putValueImpl - Inline write for small values. One group per call (the facade
+// groups lanes by peer); same warp-aggregate posting as putImpl.
+template <core::ProviderType PrvdType, typename T>
 __device__ inline static void putValueImpl(core::RdmaEndpointDevice* ep, uint32_t qpn,
                                            uintptr_t remoteAddr, uint32_t remoteKey, T value,
                                            bool hasSignal, uintptr_t signalRemoteAddr,
@@ -754,166 +717,102 @@ __device__ inline static void putValueImpl(core::RdmaEndpointDevice* ep, uint32_
   static_assert(sizeof(T) <= 8, "putValue only supports types <= 8 bytes");
 
   core::WorkQueueHandle* wq = &ep->wqHandle;
-
   uint32_t signalWqes =
       hasSignal ? getAtomicWqeCount<PrvdType>(core::AMO_FETCH_ADD, sizeof(uint64_t)) : 0;
 
-  if constexpr (WarpMode == ccoGdaWarpAggregate) {
-    uint64_t activemask = core::GetActiveLaneMask();
-    int leaderLane = core::GetLastActiveLaneID(activemask);
-    uint32_t numActiveLanes = core::GetActiveLaneCount(activemask);
-    uint32_t myLogicalLaneId = core::GetActiveLaneNum(activemask);
-    bool isLeader = (myLogicalLaneId == numActiveLanes - 1);
-    uint32_t totalWqes = numActiveLanes + signalWqes;
+  uint64_t activemask = core::GetActiveLaneMask();
+  int leaderLane = core::GetLastActiveLaneID(activemask);
+  uint32_t numActiveLanes = core::GetActiveLaneCount(activemask);
+  uint32_t myLogicalLaneId = core::GetActiveLaneNum(activemask);
+  bool isLeader = (myLogicalLaneId == numActiveLanes - 1);
+  uint32_t totalWqes = numActiveLanes + signalWqes;
 
-    uint32_t base = 0;
-    if (isLeader) base = atomicAdd(&wq->postIdx, totalWqes);
-    base = __shfl(base, leaderLane);
-    uint32_t mySlot = base + myLogicalLaneId;
-    uint32_t signalSlot = base + numActiveLanes;
-    uintptr_t atomicLaddr = reinterpret_cast<uintptr_t>(ep->atomicIbuf.addr);
-    uint32_t atomicLkey = ep->atomicIbuf.lkey;
-
-    if constexpr (PrvdType == core::ProviderType::BNXT) {
-      // Reserve per-packet PSNs first (inline write is 1 packet), then post.
-      uint32_t sigPsn = 0;
-      uint32_t dataPsn = warpAggregateBnxtPsn(wq, /*dataPsnCnt=*/1, hasSignal, totalWqes, activemask,
-                                              leaderLane, isLeader, &sigPsn);
-      waitSqSpace<PrvdType>(ep, base, totalWqes);
-      uint64_t dbrVal = core::PostWriteInline<PrvdType>(*wq, mySlot, mySlot, dataPsn,
-                                                        true /*cqeSignal*/, qpn, &value, remoteAddr,
-                                                        remoteKey, sizeof(T));
-      __threadfence();
-      if (isLeader) {
-        if (hasSignal) {
-          dbrVal = core::PostAtomic<PrvdType, uint64_t>(
-              *wq, signalSlot, signalSlot, sigPsn, true /*cqeSignal*/, qpn, atomicLaddr, atomicLkey,
-              signalRemoteAddr, signalRemoteKey, signalOpArg, 0, core::AMO_FETCH_ADD);
-        }
-        if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
-          ringDoorbellOrdered<PrvdType>(ep, base, totalWqes, dbrVal);
-      }
-    } else {
-      // MLX5/PSD: the WQE slot index doubles as the PSN.
-      waitSqSpace<PrvdType>(ep, base, totalWqes);
-      uint64_t dbrVal = core::PostWriteInline<PrvdType>(*wq, mySlot, mySlot, mySlot,
-                                                        true /*cqeSignal*/, qpn, &value, remoteAddr,
-                                                        remoteKey, sizeof(T));
-      __threadfence();
-      if (isLeader) {
-        if (hasSignal) {
-          dbrVal = core::PostAtomic<PrvdType, uint64_t>(
-              *wq, signalSlot, signalSlot, signalSlot, true /*cqeSignal*/, qpn, atomicLaddr,
-              atomicLkey, signalRemoteAddr, signalRemoteKey, signalOpArg, 0, core::AMO_FETCH_ADD);
-        }
-        if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
-          ringDoorbellOrdered<PrvdType>(ep, base, totalWqes, dbrVal);
-      }
-    }
-    return;
-  }
-
-  // Per-lane path
-  uint32_t numWqesNeeded = 1 + signalWqes;
+  uint32_t base = 0;
+  if (isLeader) base = atomicAdd(&wq->postIdx, totalWqes);
+  base = __shfl(base, leaderLane);
+  uint32_t mySlot = base + myLogicalLaneId;
+  uint32_t signalSlot = base + numActiveLanes;
   uintptr_t atomicLaddr = reinterpret_cast<uintptr_t>(ep->atomicIbuf.addr);
   uint32_t atomicLkey = ep->atomicIbuf.lkey;
 
   if constexpr (PrvdType == core::ProviderType::BNXT) {
-    uint32_t psnBase = 0;
-    uint32_t curPostIdx =
-        reserveWqeSlots<PrvdType>(ep, numWqesNeeded, 1u + (hasSignal ? 1u : 0u), &psnBase);
-    uint32_t wqeIdx = curPostIdx;
-    uint64_t dbrVal = core::PostWriteInline<PrvdType>(*wq, wqeIdx, wqeIdx, psnBase,
+    // Reserve per-packet PSNs first (inline write is 1 packet), then post.
+    uint32_t sigPsn = 0;
+    uint32_t dataPsn = warpAggregateBnxtPsn(wq, /*dataPsnCnt=*/1, hasSignal, totalWqes, activemask,
+                                            leaderLane, isLeader, &sigPsn);
+    waitSqSpace<PrvdType>(ep, base, totalWqes);
+    uint64_t dbrVal = core::PostWriteInline<PrvdType>(*wq, mySlot, mySlot, dataPsn,
                                                       true /*cqeSignal*/, qpn, &value, remoteAddr,
                                                       remoteKey, sizeof(T));
-    wqeIdx++;
-    if (hasSignal) {
-      dbrVal = core::PostAtomic<PrvdType, uint64_t>(
-          *wq, wqeIdx, wqeIdx, psnBase + 1u, true /*cqeSignal*/, qpn, atomicLaddr, atomicLkey,
-          signalRemoteAddr, signalRemoteKey, signalOpArg, 0, core::AMO_FETCH_ADD);
+    __threadfence();
+    if (isLeader) {
+      if (hasSignal) {
+        dbrVal = core::PostAtomic<PrvdType, uint64_t>(
+            *wq, signalSlot, signalSlot, sigPsn, true /*cqeSignal*/, qpn, atomicLaddr, atomicLkey,
+            signalRemoteAddr, signalRemoteKey, signalOpArg, 0, core::AMO_FETCH_ADD);
+      }
+      if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
+        ringDoorbellOrdered<PrvdType, /*LeaderOnly=*/true>(ep, base, totalWqes, dbrVal);
     }
-    if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
-      ringDoorbellOrdered<PrvdType>(ep, curPostIdx, numWqesNeeded, dbrVal);
   } else {
-    uint32_t curPostIdx = reserveWqeSlots<PrvdType>(ep, numWqesNeeded);
-    uint32_t wqeIdx = curPostIdx;
-    uint64_t dbrVal = core::PostWriteInline<PrvdType>(*wq, wqeIdx, wqeIdx, wqeIdx, true /*cqeSignal*/,
+    // MLX5/PSD: the WQE slot index doubles as the PSN.
+    waitSqSpace<PrvdType>(ep, base, totalWqes);
+    uint64_t dbrVal = core::PostWriteInline<PrvdType>(*wq, mySlot, mySlot, mySlot, true /*cqeSignal*/,
                                                       qpn, &value, remoteAddr, remoteKey, sizeof(T));
-    wqeIdx++;
-    if (hasSignal) {
-      dbrVal = core::PostAtomic<PrvdType, uint64_t>(
-          *wq, wqeIdx, wqeIdx, wqeIdx, true /*cqeSignal*/, qpn, atomicLaddr, atomicLkey,
-          signalRemoteAddr, signalRemoteKey, signalOpArg, 0, core::AMO_FETCH_ADD);
+    __threadfence();
+    if (isLeader) {
+      if (hasSignal) {
+        dbrVal = core::PostAtomic<PrvdType, uint64_t>(
+            *wq, signalSlot, signalSlot, signalSlot, true /*cqeSignal*/, qpn, atomicLaddr,
+            atomicLkey, signalRemoteAddr, signalRemoteKey, signalOpArg, 0, core::AMO_FETCH_ADD);
+      }
+      if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
+        ringDoorbellOrdered<PrvdType, /*LeaderOnly=*/true>(ep, base, totalWqes, dbrVal);
     }
-    if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
-      ringDoorbellOrdered<PrvdType>(ep, curPostIdx, numWqesNeeded, dbrVal);
   }
 }
 
-// getImpl - RDMA read
-template <core::ProviderType PrvdType, ccoGdaWarpMode WarpMode = ccoGdaWarpDefault>
+// getImpl - RDMA read. One group per call (the facade groups lanes by peer):
+// each active lane posts its read WQE into a contiguous reservation, the leader
+// rings one doorbell.
+template <core::ProviderType PrvdType>
 __device__ inline static void getImpl(core::RdmaEndpointDevice* ep, uint32_t qpn,
                                       uintptr_t localAddr, uint32_t localKey, uintptr_t remoteAddr,
                                       uint32_t remoteKey, size_t bytes,
                                       uint32_t optFlags = ccoGdaOptFlagsDefault) {
   core::WorkQueueHandle* wq = &ep->wqHandle;
+  uint64_t activemask = core::GetActiveLaneMask();
+  int leaderLane = core::GetLastActiveLaneID(activemask);
+  uint32_t numActiveLanes = core::GetActiveLaneCount(activemask);
+  uint32_t myLogicalLaneId = core::GetActiveLaneNum(activemask);
+  bool isLeader = (myLogicalLaneId == numActiveLanes - 1);
+  uint32_t totalWqes = numActiveLanes;
 
-  if constexpr (WarpMode == ccoGdaWarpAggregate) {
-    uint64_t activemask = core::GetActiveLaneMask();
-    int leaderLane = core::GetLastActiveLaneID(activemask);
-    uint32_t numActiveLanes = core::GetActiveLaneCount(activemask);
-    uint32_t myLogicalLaneId = core::GetActiveLaneNum(activemask);
-    bool isLeader = (myLogicalLaneId == numActiveLanes - 1);
-    uint32_t totalWqes = numActiveLanes;
+  uint32_t base = 0;
+  if (isLeader) base = atomicAdd(&wq->postIdx, totalWqes);
+  base = __shfl(base, leaderLane);
+  uint32_t mySlot = base + myLogicalLaneId;
 
-    uint32_t base = 0;
-    if (isLeader) base = atomicAdd(&wq->postIdx, totalWqes);
-    base = __shfl(base, leaderLane);
-    uint32_t mySlot = base + myLogicalLaneId;
-
-    if constexpr (PrvdType == core::ProviderType::BNXT) {
-      // Reserve per-packet PSNs first (read consumes response-packet PSNs), then post.
-      uint32_t dataPsnCnt = (bytes == 0) ? 1 : (bytes + wq->mtuSize - 1) / wq->mtuSize;
-      uint32_t dataPsn = warpAggregateBnxtPsn(wq, dataPsnCnt, /*hasSignalPacket=*/false, totalWqes,
-                                              activemask, leaderLane, isLeader,
-                                              /*outSignalPsn=*/nullptr);
-      waitSqSpace<PrvdType>(ep, base, totalWqes);
-      uint64_t dbrVal = core::PostRead<PrvdType>(*wq, mySlot, mySlot, dataPsn, true /*cqeSignal*/,
-                                                 qpn, localAddr, localKey, remoteAddr, remoteKey,
-                                                 bytes);
-      __threadfence();
-      if (isLeader && !(optFlags & ccoGdaOptFlagsAggregateRequests))
-        ringDoorbellOrdered<PrvdType>(ep, base, totalWqes, dbrVal);
-    } else {
-      // MLX5/PSD: the WQE slot index doubles as the PSN.
-      waitSqSpace<PrvdType>(ep, base, totalWqes);
-      uint64_t dbrVal = core::PostRead<PrvdType>(*wq, mySlot, mySlot, mySlot, true /*cqeSignal*/,
-                                                 qpn, localAddr, localKey, remoteAddr, remoteKey,
-                                                 bytes);
-      __threadfence();
-      if (isLeader && !(optFlags & ccoGdaOptFlagsAggregateRequests))
-        ringDoorbellOrdered<PrvdType>(ep, base, totalWqes, dbrVal);
-    }
-    return;
-  }
-
-  // Per-lane path
   if constexpr (PrvdType == core::ProviderType::BNXT) {
+    // Reserve per-packet PSNs first (read consumes response-packet PSNs), then post.
     uint32_t dataPsnCnt = (bytes == 0) ? 1 : (bytes + wq->mtuSize - 1) / wq->mtuSize;
-    uint32_t psnBase = 0;
-    uint32_t curPostIdx = reserveWqeSlots<PrvdType>(ep, 1, dataPsnCnt, &psnBase);
-    uint64_t dbrVal = core::PostRead<PrvdType>(*wq, curPostIdx, curPostIdx, psnBase,
-                                               true /*cqeSignal*/, qpn, localAddr, localKey,
-                                               remoteAddr, remoteKey, bytes);
-    if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
-      ringDoorbellOrdered<PrvdType>(ep, curPostIdx, 1, dbrVal);
+    uint32_t dataPsn = warpAggregateBnxtPsn(wq, dataPsnCnt, /*hasSignalPacket=*/false, totalWqes,
+                                            activemask, leaderLane, isLeader,
+                                            /*outSignalPsn=*/nullptr);
+    waitSqSpace<PrvdType>(ep, base, totalWqes);
+    uint64_t dbrVal = core::PostRead<PrvdType>(*wq, mySlot, mySlot, dataPsn, true /*cqeSignal*/, qpn,
+                                               localAddr, localKey, remoteAddr, remoteKey, bytes);
+    __threadfence();
+    if (isLeader && !(optFlags & ccoGdaOptFlagsAggregateRequests))
+      ringDoorbellOrdered<PrvdType, /*LeaderOnly=*/true>(ep, base, totalWqes, dbrVal);
   } else {
-    uint32_t curPostIdx = reserveWqeSlots<PrvdType>(ep, 1);
-    uint64_t dbrVal = core::PostRead<PrvdType>(*wq, curPostIdx, curPostIdx, curPostIdx,
-                                               true /*cqeSignal*/, qpn, localAddr, localKey,
-                                               remoteAddr, remoteKey, bytes);
-    if (!(optFlags & ccoGdaOptFlagsAggregateRequests))
-      ringDoorbellOrdered<PrvdType>(ep, curPostIdx, 1, dbrVal);
+    // MLX5/PSD: the WQE slot index doubles as the PSN.
+    waitSqSpace<PrvdType>(ep, base, totalWqes);
+    uint64_t dbrVal = core::PostRead<PrvdType>(*wq, mySlot, mySlot, mySlot, true /*cqeSignal*/, qpn,
+                                               localAddr, localKey, remoteAddr, remoteKey, bytes);
+    __threadfence();
+    if (isLeader && !(optFlags & ccoGdaOptFlagsAggregateRequests))
+      ringDoorbellOrdered<PrvdType, /*LeaderOnly=*/true>(ep, base, totalWqes, dbrVal);
   }
 }
 
@@ -937,12 +836,15 @@ __device__ inline static void flushAsyncImpl(core::RdmaEndpointDevice* ep, uint3
 
   __threadfence_system();
 
-  if constexpr (PrvdType == core::ProviderType::PSD) {
-    ringDoorbellWarpPsd(wq->dbrAddr, dbrVal);
-  } else {
+  // flush() is multi-lane (each lane flushes a different peer/QP), so PSD/BNXT
+  // must serialize doorbells per lane (shared dbrAddr/UAR); MLX5 has a per-QP
+  // dbrAddr and rings directly.
+  if constexpr (PrvdType == core::ProviderType::MLX5) {
     core::UpdateSendDbrRecord<PrvdType>(wq->dbrRecAddr, curPostIdx);
     __threadfence_system();
     core::RingDoorbell<PrvdType>(wq->dbrAddr, dbrVal);
+  } else {
+    ringDoorbellWalk<PrvdType>(wq, curPostIdx, dbrVal);
   }
 
   __threadfence_system();
@@ -1167,6 +1069,7 @@ __device__ inline void ccoGda<PrvdType>::put(int peer, ccoWindow_t dstWin, size_
   }
   coop.sync();
   if (coop.thread_rank() == 0) {
+    // Each active lane resolves its own peer endpoint/keys (pure per-lane work).
     int worldPeer = resolveWorldPeer<TeamMode>(peer);
 
     ccoWindowDevice* dstWinDev = reinterpret_cast<ccoWindowDevice*>(dstWin);
@@ -1201,9 +1104,23 @@ __device__ inline void ccoGda<PrvdType>::put(int peer, ccoWindow_t dstWin, size_
       signalOpArg = remoteAction.value;
     }
 
-    impl::putImpl<PrvdType, WarpMode>(ep, qpn, localAddr, srcLkey, remoteAddr, dstRkey, bytes,
-                                           hasSignal, signalRaddr, signalRkey, signalOp, signalOpArg,
-                                           optFlags);
+    // Only mixed-peer thread scope needs per-peer grouping (lanes may target
+    // different QPs). Every other case is a single group: WarpAggregate (whole
+    // warp same peer) or CoopWarp/CoopBlock (one active lane).
+    if constexpr (WarpMode == ccoGdaWarpDefault && std::is_same_v<Coop, ccoCoopThread>) {
+      // Group active lanes by peer: each peer reserves contiguously + one doorbell.
+      bool needTurn = true;
+      for (uint64_t turns = __ballot(needTurn); turns != 0; turns = __ballot(needTurn)) {
+        int lead = __ffsll(static_cast<unsigned long long>(turns)) - 1;
+        if (peer != __shfl(peer, lead)) continue;
+        needTurn = false;
+        impl::putImpl<PrvdType>(ep, qpn, localAddr, srcLkey, remoteAddr, dstRkey, bytes, hasSignal,
+                                signalRaddr, signalRkey, signalOp, signalOpArg, optFlags);
+      }
+    } else {
+      impl::putImpl<PrvdType>(ep, qpn, localAddr, srcLkey, remoteAddr, dstRkey, bytes, hasSignal,
+                              signalRaddr, signalRkey, signalOp, signalOpArg, optFlags);
+    }
   }
   coop.sync();
 }
@@ -1252,9 +1169,20 @@ __device__ inline void ccoGda<PrvdType>::putValue(int peer, ccoWindow_t dstWin, 
       signalOpArg = remoteAction.value;
     }
 
-    impl::putValueImpl<PrvdType, T, WarpMode>(ep, qpn, remoteAddr, dstRkey, value, hasSignal,
-                                                   signalRaddr, signalRkey, signalOp, signalOpArg,
-                                                   optFlags);
+    // Only mixed-peer thread scope needs per-peer grouping; else a single group.
+    if constexpr (WarpMode == ccoGdaWarpDefault && std::is_same_v<Coop, ccoCoopThread>) {
+      bool needTurn = true;
+      for (uint64_t turns = __ballot(needTurn); turns != 0; turns = __ballot(needTurn)) {
+        int lead = __ffsll(static_cast<unsigned long long>(turns)) - 1;
+        if (peer != __shfl(peer, lead)) continue;
+        needTurn = false;
+        impl::putValueImpl<PrvdType, T>(ep, qpn, remoteAddr, dstRkey, value, hasSignal, signalRaddr,
+                                        signalRkey, signalOp, signalOpArg, optFlags);
+      }
+    } else {
+      impl::putValueImpl<PrvdType, T>(ep, qpn, remoteAddr, dstRkey, value, hasSignal, signalRaddr,
+                                      signalRkey, signalOp, signalOpArg, optFlags);
+    }
   }
   coop.sync();
 }
@@ -1287,8 +1215,20 @@ __device__ inline void ccoGda<PrvdType>::get(int peer, ccoWindow_t remoteWin, si
     core::RdmaEndpointDevice* ep = &ibgda->endpoints[qpIdx];
     uint32_t qpn = ep->qpn;
 
-    impl::getImpl<PrvdType, WarpMode>(ep, qpn, localAddr, localLkey, remoteAddr, remoteRkey,
-                                           bytes, optFlags);
+    // Only mixed-peer thread scope needs per-peer grouping; else a single group.
+    if constexpr (WarpMode == ccoGdaWarpDefault && std::is_same_v<Coop, ccoCoopThread>) {
+      bool needTurn = true;
+      for (uint64_t turns = __ballot(needTurn); turns != 0; turns = __ballot(needTurn)) {
+        int lead = __ffsll(static_cast<unsigned long long>(turns)) - 1;
+        if (peer != __shfl(peer, lead)) continue;
+        needTurn = false;
+        impl::getImpl<PrvdType>(ep, qpn, localAddr, localLkey, remoteAddr, remoteRkey, bytes,
+                                optFlags);
+      }
+    } else {
+      impl::getImpl<PrvdType>(ep, qpn, localAddr, localLkey, remoteAddr, remoteRkey, bytes,
+                              optFlags);
+    }
   }
   coop.sync();
 }

--- a/tests/cpp/cco/test_gda_thread_aggregate.cpp
+++ b/tests/cpp/cco/test_gda_thread_aggregate.cpp
@@ -20,10 +20,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// test: cco gda WarpAggregate mode.
+// test: cco gda ThreadAggregate mode.
 //
-// Verifies the WarpAggregate template parameter on put / putValue / get.
-// With WarpAggregate=true all warp lanes target the same peer; the leader
+// Verifies the ccoGdaThreadAggregate template parameter on put / putValue / get.
+// With ThreadAggregate all warp lanes target the same peer; the leader
 // posts one shared signal WQE and rings one doorbell for the batch, instead
 // of each lane posting its own.
 //
@@ -42,14 +42,14 @@ static constexpr mori::core::ProviderType kPrvdType = CCO_GDA_BUILD_PROVIDER;
 
 // ── Kernels ─────────────────────────────────────────────────────────────────
 
-__global__ void WarpPutKernel(mori::cco::ccoWindowDevice* sendWin,
+__global__ void ThreadAggPutKernel(mori::cco::ccoWindowDevice* sendWin,
                               mori::cco::ccoWindowDevice* recvWin, size_t chunkBytes,
                               mori::cco::ccoDevComm devComm, int peer) {
   using namespace mori::cco;
   ccoGda<kPrvdType> gda{devComm, 0};
   int tid = threadIdx.x;
 
-  gda.put<CCO_TEAM_WORLD, ccoGdaWarpAggregate, ccoGda_SignalInc, ccoCoopThread>(
+  gda.put<CCO_TEAM_WORLD, ccoGdaThreadAggregate, ccoGda_SignalInc, ccoCoopThread>(
       peer, reinterpret_cast<ccoWindow_t>(recvWin), tid * chunkBytes,
       reinterpret_cast<ccoWindow_t>(sendWin), tid * chunkBytes, chunkBytes,
       ccoGda_SignalInc{0});
@@ -57,28 +57,28 @@ __global__ void WarpPutKernel(mori::cco::ccoWindowDevice* sendWin,
   gda.flush(ccoCoopWarp{});
 }
 
-__global__ void WarpPutValueKernel(mori::cco::ccoWindowDevice* recvWin,
+__global__ void ThreadAggPutValueKernel(mori::cco::ccoWindowDevice* recvWin,
                                    mori::cco::ccoDevComm devComm, int peer, uint64_t baseVal) {
   using namespace mori::cco;
   ccoGda<kPrvdType> gda{devComm, 0};
   int tid = threadIdx.x;
 
   uint64_t val = baseVal + static_cast<uint64_t>(tid);
-  gda.putValue<CCO_TEAM_WORLD, ccoGdaWarpAggregate, uint64_t, ccoGda_SignalInc, ccoCoopThread>(
+  gda.putValue<CCO_TEAM_WORLD, ccoGdaThreadAggregate, uint64_t, ccoGda_SignalInc, ccoCoopThread>(
       peer, reinterpret_cast<ccoWindow_t>(recvWin), tid * sizeof(uint64_t), val,
       ccoGda_SignalInc{1});
 
   gda.flush(ccoCoopWarp{});
 }
 
-__global__ void WarpGetKernel(mori::cco::ccoWindowDevice* remoteWin,
+__global__ void ThreadAggGetKernel(mori::cco::ccoWindowDevice* remoteWin,
                               mori::cco::ccoWindowDevice* localWin, size_t chunkBytes,
                               mori::cco::ccoDevComm devComm, int peer) {
   using namespace mori::cco;
   ccoGda<kPrvdType> gda{devComm, 0};
   int tid = threadIdx.x;
 
-  gda.get<CCO_TEAM_WORLD, ccoGdaWarpAggregate, ccoCoopThread>(
+  gda.get<CCO_TEAM_WORLD, ccoGdaThreadAggregate, ccoCoopThread>(
       peer, reinterpret_cast<ccoWindow_t>(remoteWin), tid * chunkBytes,
       reinterpret_cast<ccoWindow_t>(localWin), tid * chunkBytes, chunkBytes);
 
@@ -150,7 +150,7 @@ struct UtCtx {
 // ── Test cases ──────────────────────────────────────────────────────────────
 
 // 64 threads put different chunks to same peer, verify data + signal == 1
-static int ut_warp_put(UtCtx& c) {
+static int ut_thread_agg_put(UtCtx& c) {
   c.resetSignals();
 
   size_t totalElems = WARP_SIZE * CHUNK_ELEMS;
@@ -166,11 +166,11 @@ static int ut_warp_put(UtCtx& c) {
   mori::cco::ccoBarrierAll(c.comm);
 
   c.step([&] {
-    WarpPutKernel
+    ThreadAggPutKernel
         <<<1, WARP_SIZE, 0, c.stream>>>(c.sendWin, c.recvWin, chunkBytes, c.dc, c.nextPeer);
   });
 
-  // WarpAggregate → leader posts 1 signal, not 64
+  // ThreadAggregate → leader posts 1 signal, not 64
   c.step([&] {
     CheckSignalKernel<<<1, 1, 0, c.stream>>>(c.dc, 0, 1, 0, c.dErr);
   });
@@ -195,7 +195,7 @@ static int ut_warp_put(UtCtx& c) {
 }
 
 // 64 threads putValue different uint64_t, verify data + signal == 1
-static int ut_warp_putvalue(UtCtx& c) {
+static int ut_thread_agg_putvalue(UtCtx& c) {
   c.resetSignals();
   HIP_CHECK(hipMemset(c.recvBuf, 0xff, c.bufSize));
   mori::cco::ccoBarrierAll(c.comm);
@@ -203,7 +203,7 @@ static int ut_warp_putvalue(UtCtx& c) {
   uint64_t baseVal = static_cast<uint64_t>(c.rank) * 10000;
 
   c.step([&] {
-    WarpPutValueKernel
+    ThreadAggPutValueKernel
         <<<1, WARP_SIZE, 0, c.stream>>>(c.recvWin, c.dc, c.nextPeer, baseVal);
   });
 
@@ -229,7 +229,7 @@ static int ut_warp_putvalue(UtCtx& c) {
 }
 
 // 64 threads get different chunks from same peer, verify data
-static int ut_warp_get(UtCtx& c) {
+static int ut_thread_agg_get(UtCtx& c) {
   size_t totalElems = WARP_SIZE * CHUNK_ELEMS;
   size_t chunkBytes = CHUNK_ELEMS * sizeof(float);
 
@@ -243,7 +243,7 @@ static int ut_warp_get(UtCtx& c) {
   mori::cco::ccoBarrierAll(c.comm);
 
   c.step([&] {
-    WarpGetKernel
+    ThreadAggGetKernel
         <<<1, WARP_SIZE, 0, c.stream>>>(c.sendWin, c.recvWin, chunkBytes, c.dc, c.nextPeer);
   });
 
@@ -273,9 +273,9 @@ static int run_all_tests(UtCtx& ctx) {
     const char* name;
     UtFn fn;
   } kCases[] = {
-      {"put", ut_warp_put},
-      // {"putvalue", ut_warp_putvalue},
-      // {"get", ut_warp_get},
+      {"put", ut_thread_agg_put},
+      // {"putvalue", ut_thread_agg_putvalue},
+      // {"get", ut_thread_agg_get},
   };
   int fails = 0;
   for (const auto& c : kCases) fails += c.fn(ctx);
@@ -368,5 +368,5 @@ int run_test(int rank, int nranks, const mori::cco::ccoUniqueId& uid) {
 }
 
 int main(int argc, char** argv) {
-  return ccoTestMain(argc, argv, "CCO GDA warp aggregate", "/tmp/cco_gda_warp_agg_uid", 19883);
+  return ccoTestMain(argc, argv, "CCO GDA thread aggregate", "/tmp/cco_gda_thread_agg_uid", 19883);
 }

--- a/tests/cpp/cco/test_gda_warp_aggregate.cpp
+++ b/tests/cpp/cco/test_gda_warp_aggregate.cpp
@@ -286,7 +286,7 @@ static int run_all_tests(UtCtx& ctx) {
 
 // ── Host driver ─────────────────────────────────────────────────────────────
 
-int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet) {
+int run_test(int rank, int nranks, const mori::cco::ccoUniqueId& uid) {
   g_rank = rank;
 
   int numDevices = 0;
@@ -303,7 +303,7 @@ int run_test(int rank, int nranks, mori::application::BootstrapNetwork* bootNet)
   printf("[rank %d/%d] pid=%d GPU=%d\n", rank, nranks, getpid(), dev);
 
   mori::cco::ccoComm* comm = nullptr;
-  if (mori::cco::ccoCommCreate(bootNet, PER_RANK_VMM_SIZE, &comm) != 0) {
+  if (mori::cco::ccoCommCreate(uid, nranks, rank, PER_RANK_VMM_SIZE, &comm) != 0) {
     fprintf(stderr, "[rank %d] CommCreate failed\n", rank);
     return 1;
   }


### PR DESCRIPTION
## Summary

Targets cco's GDA (cross-node IBGDA) device path. Fixes BNXT correctness, regroups doorbells per peer (unblocking thread/warp-scope bandwidth), and adds benchmark instrumentation. All changes are BNXT-only on the device side; MLX5/IONIC behavior is preserved.

Verified on BNXT (rocm/mori:ci): all cco GDA tests pass single-node (fork) and cross-node (2-node a07u19↔a07u25, 16 ranks); p2p bandwidth saturates ~49 GB/s (≈98% of 400G line rate) across block/warp/thread scopes.

## Commits

### `fix(cco)`: BNXT GDA per-packet PSN + reserve-gate drain
Ports the BNXT GDA correctness fixes onto #411's warp-aggregate architecture (all BNXT-only):
- **Per-packet PSN**: BNXT PSN must advance by packet count (`ceil(bytes/mtu)`), not WQE-slot index. Reserved via `wq->msnPack` — per lane in `reserveWqeSlots`, and per warp via `warpAggregateBnxtPsn` (leader advances once, lanes take a prefix-ordered base). Applied to put / putValue / get / signal.
- **Reserve-gate drain**: BNXT drains to the doorbelled snapshot (`dbTouchIdx`), not the un-doorbelled reservation, avoiding self-deadlock when WQEs are posted without an immediate doorbell. MLX5/IONIC keep their original drain target.
- **Error CQE**: `quietUntil` traps on a non-OK BNXT completion instead of treating the error as progress.

### `perf(cco)`: group GDA doorbells per peer; unblock thread/warp-scope bw
- `put/get/putValue` group active lanes by peer via a `__ballot` turn loop (only in the `WarpDefault + CoopThread` path); each peer reserves contiguously and the group leader rings one doorbell (new `LeaderOnly` template path). `WarpAggregate` / `CoopWarp` / `CoopBlock` are a single group and skip the loop.
- Unified the BNXT/PSD anti-coalescing lane-walk into `ringDoorbellWalk<PrvdType>`, used by both `ringDoorbellOrdered` and `flushAsyncImpl` — fixing a missing walk on BNXT `flush` (a multi-peer flush could drop coalesced doorbells and hang).
- Dropped `__syncwarp` from the lane-walk: AMD wavefronts are lock-step, so per-lane predication already orders the stores; `__syncwarp` was also a deadlock on divergent entry.
- benchmark p2p bw drops `ccoGdaOptFlagsAggregateRequests`: per-op doorbell is now safe in thread/warp scope and `waitSqSpace` drains the CQ as the SQ fills, so the deferred-doorbell SQ overflow that hung those scopes is gone.

### `feat(cco-bench)`: perf-table instrumentation
- **`msg` + `units` columns**: show how the total size is split (one WQE/message per cooperative unit) and the per-WQE size (`size/units`).
- **`-s thread_agg`**: thread scope + `ccoGdaWarpAggregate`, to benchmark the aggregate path. On BNXT p2p it matches plain `thread` within noise (the per-peer grouping already aggregates same-peer warp lanes).
- **`Mpps` column**: WQE/packet issue rate (`GB/s * 1e3 * units / size`). Exposes the issue-rate ceiling — ~115 Mpps flat for small messages (rate-bound) vs line-rate / low Mpps for large messages (bandwidth-bound).

