### PR TITLE
fix(io): set QP max_inline_data for notification SENDs

### DIFF
--- a/include/mori/application/transport/rdma/rdma.hpp
+++ b/include/mori/application/transport/rdma/rdma.hpp
@@ -88,6 +88,8 @@ struct RdmaEndpointConfig {
                           // be large, e.g. notification)
   uint32_t maxCqeNum{128};
   uint32_t maxMsgSge{1};
+  uint32_t maxInlineData{0};  // SEND inline capacity; required by providers (e.g. bnxt_re)
+                              // for IBV_SEND_INLINE
   uint32_t alignment{PAGESIZE};
   bool onGpu{false};
   bool withCompChannel{false};

--- a/src/application/transport/rdma/providers/ibverbs/ibverbs.cpp
+++ b/src/application/transport/rdma/providers/ibverbs/ibverbs.cpp
@@ -105,6 +105,7 @@ RdmaEndpoint IBVerbsDeviceContext::CreateRdmaEndpoint(const RdmaEndpointConfig& 
                                      .max_recv_wr = maxRecvWr,
                                      .max_send_sge = config.maxMsgSge,
                                      .max_recv_sge = config.maxMsgSge,
+                                     .max_inline_data = config.maxInlineData,
                                  },
                              .qp_type = IBV_QPT_RC};
   endpoint.ibvHandle.qp = ibv_create_qp(pd, &qpAttr);

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -462,6 +462,14 @@ application::RdmaEndpointConfig RdmaManager::GetRdmaEndpointConfig(int devId) {
   } else {
     epConfig.maxMsgSge = std::min(maxSge, is_ionic ? 2u : 4u);
   }
+
+  // Inline capacity for the small notification SEND (NotifMessage). Providers such as
+  // bnxt_re reject IBV_SEND_INLINE with ENOMEM unless the QP was created with enough
+  // max_inline_data, so request a small but sufficient amount here.
+  uint32_t desiredInline = config.enableNotification ? 64u : 0u;
+  env::Override("MORI_IO_QP_MAX_INLINE_DATA", desiredInline, mori::env::detail::ParsePositiveU32);
+  epConfig.maxInlineData = desiredInline;
+
   return epConfig;
 }
 


### PR DESCRIPTION
# fix(io): set QP max_inline_data for notification SENDs
## Problem
MORI-IO's notification path posts a 16-byte `NotifMessage` as an inline SEND
(`IBV_SEND_INLINE`) from an unregistered stack buffer (`lkey=0`), so inline
posting is mandatory. The generic IBVerbs provider creates the QP without
requesting any inline capacity (`max_inline_data` defaults to 0).
Providers that strictly enforce inline capacity (e.g. Broadcom `bnxt_re`/Thor2)
reject this with **ENOMEM**, so every notification-enabled transfer fails:
```
ibv_post_send (notify) failed with 12: Cannot allocate memory
```

## Fix
- Add `maxInlineData` to `RdmaEndpointConfig`.
- Pass it through to `ibv_create_qp` in the IBVerbs provider.
- Request 64 B from the IO RDMA backend, overridable via `MORI_IO_QP_MAX_INLINE_DATA`.
The request is harmless on providers that don't require it and has no measurable
bandwidth impact. The bnxt DirectVerbs/IBGDA path is unaffected (it sets its own
inline capacity).
