### PR TITLE
feat(sdma): use KFD recommended engine mask for SDMA engine selection

### DIFF
--- a/include/mori/application/transport/sdma/anvil.hpp
+++ b/include/mori/application/transport/sdma/anvil.hpp
@@ -102,15 +102,25 @@ class AnvilLib {
 
   int getSdmaEngineId(int srcDeviceId, int dstDeviceId);
 
+  // KFD topology node id for a HIP device id.
+  uint32_t getNodeId(int deviceId);
+
+  // Bitmask of SDMA engine ids KFD recommends for the src->dst xGMI link to
+  // reach maximum bandwidth (sysfs recommended_sdma_engine_id_mask). Returns 0
+  // if the link or property is unavailable, in which case callers fall back to
+  // the static OAM map.
+  uint32_t getRecommendedEngineMask(int srcDeviceId, int dstDeviceId);
+
   struct PairHash {
     std::size_t operator()(const std::pair<int, int>& p) const {
       return std::hash<int>()(p.first) ^ (std::hash<int>()(p.second) << 16);
     }
   };
+  using SdmaQueueVector = std::vector<std::unique_ptr<SdmaQueue>>;
 
   std::once_flag init_flag;
   std::mutex channels_mutex_;
-  std::unordered_map<std::pair<int, int>, std::vector<std::unique_ptr<SdmaQueue>>, PairHash>
+  std::unordered_map<std::pair<int, int>, SdmaQueueVector, PairHash>
       sdma_channels_;
 };
 

--- a/include/mori/application/transport/sdma/anvil.hpp
+++ b/include/mori/application/transport/sdma/anvil.hpp
@@ -120,8 +120,7 @@ class AnvilLib {
 
   std::once_flag init_flag;
   std::mutex channels_mutex_;
-  std::unordered_map<std::pair<int, int>, SdmaQueueVector, PairHash>
-      sdma_channels_;
+  std::unordered_map<std::pair<int, int>, SdmaQueueVector, PairHash> sdma_channels_;
 };
 
 extern AnvilLib& anvil;

--- a/src/application/transport/sdma/anvil.cpp
+++ b/src/application/transport/sdma/anvil.cpp
@@ -29,11 +29,10 @@
 
 #include "mori/application/transport/sdma/anvil.hpp"
 
-#include <algorithm>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <iostream>
-#include <set>
 #include <stdexcept>
 namespace anvil {
 

--- a/src/application/transport/sdma/anvil.cpp
+++ b/src/application/transport/sdma/anvil.cpp
@@ -214,16 +214,13 @@ SdmaQueue::SdmaQueue(int localDeviceId, int remoteDeviceId, hsa_agent_t& localAg
       hipMemcpy(committedWptr_, &committedWptr, sizeof(uint64_t), hipMemcpyHostToDevice));
 }
 
-SdmaQueue::~SdmaQueue() try {
+SdmaQueue::~SdmaQueue() {
   CHECK_HSAKMT_SUCCESS(hsaKmtDestroyQueue(queue_.QueueId), "Failed to destroy queue.");
   CHECK_HIP_ERROR(hipFree(deviceHandle_));
   CHECK_HIP_ERROR(hipFree(cachedWptr_));
   CHECK_HIP_ERROR(hipFree(committedWptr_));
   CHECK_HSAKMT_SUCCESS(hsaKmtUnmapMemoryToGPU(queueBuffer_), "Failed");
   CHECK_HSAKMT_SUCCESS(hsaKmtFreeMemory(queueBuffer_, SDMA_QUEUE_SIZE), "Failed");
-} catch (...) {
-  std::cerr << "Exception in ~SdmaQueue()" << std::endl;
-  std::exit(EXIT_FAILURE);
 }
 
 SdmaQueueDeviceHandle* SdmaQueue::deviceHandle() const { return deviceHandle_; }

--- a/src/application/transport/sdma/anvil.cpp
+++ b/src/application/transport/sdma/anvil.cpp
@@ -221,11 +221,8 @@ SdmaQueue::~SdmaQueue() try {
   CHECK_HIP_ERROR(hipFree(committedWptr_));
   CHECK_HSAKMT_SUCCESS(hsaKmtUnmapMemoryToGPU(queueBuffer_), "Failed");
   CHECK_HSAKMT_SUCCESS(hsaKmtFreeMemory(queueBuffer_, SDMA_QUEUE_SIZE), "Failed");
-} catch (const std::exception& e) {
-  std::cerr << "Exception in ~SdmaQueue(): " << e.what() << std::endl;
-  std::exit(EXIT_FAILURE);
 } catch (...) {
-  std::cerr << "Unknown exception in ~SdmaQueue()" << std::endl;
+  std::cerr << "Exception in ~SdmaQueue()" << std::endl;
   std::exit(EXIT_FAILURE);
 }
 

--- a/src/application/transport/sdma/anvil.cpp
+++ b/src/application/transport/sdma/anvil.cpp
@@ -29,9 +29,12 @@
 
 #include "mori/application/transport/sdma/anvil.hpp"
 
+#include <algorithm>
 #include <cstring>
 #include <fstream>
 #include <iostream>
+#include <set>
+#include <stdexcept>
 namespace anvil {
 
 auto checkHsaError = [](hsa_status_t s, const char* msg, const char* file, int line) {
@@ -160,13 +163,6 @@ SdmaQueue::SdmaQueue(int localDeviceId, int remoteDeviceId, hsa_agent_t& localAg
     // return status;
   }
 
-  // std::cout << "Allocating queue for engine " << engineId << " on device " << localDeviceId << "
-  // to device "
-  //           << remoteDeviceId << std::endl;
-  // std::cout << "original device id: " << originalDeviceId << " local " << localDeviceId << "
-  // remote " << remoteDeviceId
-  //           << " local node " << localNodeId << std::endl;
-
   // Allocate SDMA queue buffer on device side, requires ExecuteAccess
   HsaMemFlags memFlags = {};
   memFlags.ui32.NonPaged = 1;
@@ -188,7 +184,7 @@ SdmaQueue::SdmaQueue(int localDeviceId, int remoteDeviceId, hsa_agent_t& localAg
   memset(&queue_, 0, sizeof(HsaQueueResource));
 
   CHECK_HSAKMT_SUCCESS(hsaKmtCreateQueueExt(localNodeId, HSA_QUEUE_SDMA_BY_ENG_ID,
-                                            DEFAULT_QUEUE_PERCENTAGE, DEFAULT_PRIORITY, engineId,
+                                            100, HSA_QUEUE_PRIORITY_MAXIMUM, engineId,
                                             queueBuffer_, SDMA_QUEUE_SIZE, nullptr, &queue_),
                        "Failed");
 
@@ -219,14 +215,16 @@ SdmaQueue::SdmaQueue(int localDeviceId, int remoteDeviceId, hsa_agent_t& localAg
       hipMemcpy(committedWptr_, &committedWptr, sizeof(uint64_t), hipMemcpyHostToDevice));
 }
 
-SdmaQueue::~SdmaQueue() {
-  // TODO catch exception?
+SdmaQueue::~SdmaQueue() try {
   CHECK_HSAKMT_SUCCESS(hsaKmtDestroyQueue(queue_.QueueId), "Failed to destroy queue.");
   CHECK_HIP_ERROR(hipFree(deviceHandle_));
   CHECK_HIP_ERROR(hipFree(cachedWptr_));
   CHECK_HIP_ERROR(hipFree(committedWptr_));
   CHECK_HSAKMT_SUCCESS(hsaKmtUnmapMemoryToGPU(queueBuffer_), "Failed");
   CHECK_HSAKMT_SUCCESS(hsaKmtFreeMemory(queueBuffer_, SDMA_QUEUE_SIZE), "Failed");
+} catch (const std::exception&e) {
+  std::cerr << "Exception in ~SdmaQueue(): " << e.what() << std::endl;
+  std::exit(EXIT_FAILURE);
 }
 
 SdmaQueueDeviceHandle* SdmaQueue::deviceHandle() const { return deviceHandle_; }
@@ -265,14 +263,65 @@ void AnvilLib::init() {
 }
 
 bool AnvilLib::connect(int srcDeviceId, int dstDeviceId, int numChannels) {
-  uint32_t engineId = getSdmaEngineId(srcDeviceId, dstDeviceId);
+
   std::lock_guard<std::mutex> lock(channels_mutex_);
+  // Spread the channels across the engines recommended for this peer link. On
+  // MI350 the mask typically reports 2 engines per peer; on platforms with a
+  // single recommended engine all channels share it.
+  std::vector<uint32_t> engines;
+  if (srcDeviceId == dstDeviceId) {
+    // A loopback copy never traverses xGMI and has no self io_link, so KFD
+    // reports no recommended engine. Use a general (non-xGMI) SDMA engine.
+    engines.push_back(0);
+  } else {
+    uint32_t mask = getRecommendedEngineMask(srcDeviceId, dstDeviceId);
+    for (uint32_t b = 0; b < 32; ++b) {
+      if (mask & (1u << b)) engines.push_back(b);
+    }
+    // Fall back to the static OAM table if KFD did not report a mask.
+    if (engines.empty()) {
+      int e = getSdmaEngineId(srcDeviceId, dstDeviceId);
+      engines.push_back(e);
+    }
+  }
+  int numEngines = static_cast<int>(engines.size());
+
   auto key = std::make_pair(srcDeviceId, dstDeviceId);
   for (int c = 0; c < numChannels; ++c) {
-    sdma_channels_[key].emplace_back(
-        std::make_unique<SdmaQueue>(srcDeviceId, dstDeviceId, gpuAgents_[srcDeviceId], engineId));
+    uint32_t engineId = engines[c % numEngines];
+    sdma_channels_[key].emplace_back(std::make_unique<SdmaQueue>(
+                 srcDeviceId, dstDeviceId, gpuAgents_[srcDeviceId], engineId));
   }
   return true;
+}
+
+uint32_t AnvilLib::getNodeId(int deviceId) {
+  uint32_t nodeId = 0;
+  CHECK_HSA_ERROR(hsa_agent_get_info(gpuAgents_[deviceId], HSA_AGENT_INFO_NODE, &nodeId));
+  return nodeId;
+}
+
+uint32_t AnvilLib::getRecommendedEngineMask(int srcDeviceId, int dstDeviceId) {
+  uint32_t srcNode = getNodeId(srcDeviceId),
+           dstNode = getNodeId(dstDeviceId);
+
+  HsaNodeProperties props{};
+  if (hsaKmtGetNodeProperties(srcNode, &props) != HSAKMT_STATUS_SUCCESS || 
+                              props.NumIOLinks == 0) {
+    return 0;
+  }
+
+  std::vector<HsaIoLinkProperties> links(props.NumIOLinks);
+  if (hsaKmtGetNodeIoLinkProperties(srcNode, props.NumIOLinks, links.data()) !=
+      HSAKMT_STATUS_SUCCESS) {
+    return 0;
+  }
+  for (const auto& link : links) {
+    if (link.NodeTo == dstNode) {
+      return link.RecSdmaEngIdMask;
+    }
+  }
+  return 0;
 }
 
 SdmaQueue* AnvilLib::getSdmaQueue(int srcDeviceId, int dstDeviceId, int channel_idx) {

--- a/src/application/transport/sdma/anvil.cpp
+++ b/src/application/transport/sdma/anvil.cpp
@@ -182,10 +182,10 @@ SdmaQueue::SdmaQueue(int localDeviceId, int remoteDeviceId, hsa_agent_t& localAg
   // TODO needed here?
   memset(&queue_, 0, sizeof(HsaQueueResource));
 
-  CHECK_HSAKMT_SUCCESS(hsaKmtCreateQueueExt(localNodeId, HSA_QUEUE_SDMA_BY_ENG_ID,
-                                            100, HSA_QUEUE_PRIORITY_MAXIMUM, engineId,
-                                            queueBuffer_, SDMA_QUEUE_SIZE, nullptr, &queue_),
-                       "Failed");
+  CHECK_HSAKMT_SUCCESS(
+      hsaKmtCreateQueueExt(localNodeId, HSA_QUEUE_SDMA_BY_ENG_ID, 100, HSA_QUEUE_PRIORITY_MAXIMUM,
+                           engineId, queueBuffer_, SDMA_QUEUE_SIZE, nullptr, &queue_),
+      "Failed");
 
   // Populate Device Handle
   // TODO uncached
@@ -262,7 +262,6 @@ void AnvilLib::init() {
 }
 
 bool AnvilLib::connect(int srcDeviceId, int dstDeviceId, int numChannels) {
-
   std::lock_guard<std::mutex> lock(channels_mutex_);
   // Spread the channels across the engines recommended for this peer link. On
   // MI350 the mask typically reports 2 engines per peer; on platforms with a
@@ -288,8 +287,8 @@ bool AnvilLib::connect(int srcDeviceId, int dstDeviceId, int numChannels) {
   auto key = std::make_pair(srcDeviceId, dstDeviceId);
   for (int c = 0; c < numChannels; ++c) {
     uint32_t engineId = engines[c % numEngines];
-    sdma_channels_[key].emplace_back(std::make_unique<SdmaQueue>(
-                 srcDeviceId, dstDeviceId, gpuAgents_[srcDeviceId], engineId));
+    sdma_channels_[key].emplace_back(
+        std::make_unique<SdmaQueue>(srcDeviceId, dstDeviceId, gpuAgents_[srcDeviceId], engineId));
   }
   return true;
 }
@@ -301,12 +300,10 @@ uint32_t AnvilLib::getNodeId(int deviceId) {
 }
 
 uint32_t AnvilLib::getRecommendedEngineMask(int srcDeviceId, int dstDeviceId) {
-  uint32_t srcNode = getNodeId(srcDeviceId),
-           dstNode = getNodeId(dstDeviceId);
+  uint32_t srcNode = getNodeId(srcDeviceId), dstNode = getNodeId(dstDeviceId);
 
   HsaNodeProperties props{};
-  if (hsaKmtGetNodeProperties(srcNode, &props) != HSAKMT_STATUS_SUCCESS || 
-                              props.NumIOLinks == 0) {
+  if (hsaKmtGetNodeProperties(srcNode, &props) != HSAKMT_STATUS_SUCCESS || props.NumIOLinks == 0) {
     return 0;
   }
 

--- a/src/application/transport/sdma/anvil.cpp
+++ b/src/application/transport/sdma/anvil.cpp
@@ -222,8 +222,11 @@ SdmaQueue::~SdmaQueue() try {
   CHECK_HIP_ERROR(hipFree(committedWptr_));
   CHECK_HSAKMT_SUCCESS(hsaKmtUnmapMemoryToGPU(queueBuffer_), "Failed");
   CHECK_HSAKMT_SUCCESS(hsaKmtFreeMemory(queueBuffer_, SDMA_QUEUE_SIZE), "Failed");
-} catch (const std::exception&e) {
+} catch (const std::exception& e) {
   std::cerr << "Exception in ~SdmaQueue(): " << e.what() << std::endl;
+  std::exit(EXIT_FAILURE);
+} catch (...) {
+  std::cerr << "Unknown exception in ~SdmaQueue()" << std::endl;
   std::exit(EXIT_FAILURE);
 }
 


### PR DESCRIPTION
## Summary

Replaces the hard-coded static SDMA-engine assignment in the Anvil SDMA
transport with the engine recommendation that KFD already exposes via topology,
and uses it to spread connection channels across the recommended engine(s).
The previous static `mi300xOamMap` lookup is kept as a fallback for platforms or
kernels that don't report a recommendation.

## Motivation

For a peer (xGMI) link, KFD publishes a per-link
`recommended_sdma_engine_id_mask` (sysfs), computed by
`kfd_set_recommended_sdma_engines()` in the kernel. It is a load-balancing
assignment that gives each ordered GPU pair a dedicated xGMI SDMA engine so that
concurrent peer pairs land on different engines.

Until now Anvil duplicated this mapping by hand (`mi300xOamMap`, with engine id
= `map[src][dst] * 2`). Reading the mask directly from KFD:

- removes a hand-maintained table that can silently drift from the kernel,
- automatically adapts to topology/kernel differences (e.g. the `reshift` case,
  non-8-GPU systems, partitioned/APU configs, future parts),
- lets the transport spread channels across multiple engines on platforms that
  recommend more than one per link (e.g. MI350), while still collapsing to a
  single engine where only one is recommended (e.g. 8x MI300X).

The decoded engine id from the mask is bit-for-bit equivalent to the old
`mi300xOamMap[src][dst] * 2` on MI300X, so behavior is unchanged on that
platform while becoming correct-by-construction elsewhere.

## Changes

- **KFD-driven engine selection** (`getRecommendedEngineMask`): queries
  `hsaKmtGetNodeProperties` / `hsaKmtGetNodeIoLinkProperties` for the src node,
  finds the io_link to the dst node, and returns its `RecSdmaEngIdMask`. Returns
  0 when no link/recommendation is available.
- **`connect()` spreads channels across engines**: decodes the mask into a list
  of engine ids and round-robins the requested channels over them
  (`engines[c % numEngines]`).
- **Self-copy short-circuit**: `src == dst` has no xGMI io_link (so KFD reports
  nothing); it now directly uses a general (non-xGMI) SDMA engine instead of
  going through the lookup/fallback.
- **Static-map fallback retained**: if KFD reports no mask for a peer pair, fall
  back to `getSdmaEngineId()` (the existing `mi300xOamMap`).
- **Queue creation parameters**: SDMA queues are now created with
  `QueuePercentage = 100` and `HSA_QUEUE_PRIORITY_MAXIMUM`, matching ROCr's own
  `amd_blit_sdma` SDMA copy queues.
- **Destructor hardening**: `SdmaQueue::~SdmaQueue()` is now a function-try-block
  that logs and exits on teardown failure instead of letting an exception escape
  a destructor.
- Minor cleanups: `getNodeId()` helper, `SdmaQueueVector` type alias, removed
  stale commented-out debug prints.