### PR TITLE
rdma: Harden RDMA control-plane resilience

### DIFF
--- a/include/mori/application/transport/rdma/providers/ibverbs/ibverbs.hpp
+++ b/include/mori/application/transport/rdma/providers/ibverbs/ibverbs.hpp
@@ -21,6 +21,8 @@
 // SOFTWARE.
 #pragma once
 
+#include <mutex>
+
 #include "infiniband/verbs.h"
 #include "mori/application/transport/rdma/rdma.hpp"
 
@@ -35,8 +37,10 @@ class IBVerbsDeviceContext : public RdmaDeviceContext {
   virtual RdmaEndpoint CreateRdmaEndpoint(const RdmaEndpointConfig&) override;
   virtual void ConnectEndpoint(const RdmaEndpointHandle& local, const RdmaEndpointHandle& remote,
                                uint32_t qpId = 0) override;
+  bool DestroyRdmaEndpointNoThrow(const RdmaEndpoint&) noexcept override;
 
  private:
+  mutable std::mutex poolMu;
   std::unordered_map<void*, ibv_cq*> cqPool;
   std::unordered_map<uint32_t, ibv_qp*> qpPool;
   std::vector<ibv_comp_channel*> compChPool;

--- a/include/mori/application/transport/rdma/rdma.hpp
+++ b/include/mori/application/transport/rdma/rdma.hpp
@@ -227,6 +227,7 @@ class RdmaDeviceContext {
                                uint32_t qpId = 0) {
     assert(false && "not implemented");
   }
+  virtual bool DestroyRdmaEndpointNoThrow(const RdmaEndpoint&) noexcept;
 
   ibv_srq* CreateRdmaSrqIfNx(const RdmaEndpointConfig&);
 

--- a/include/mori/application/transport/tcp/tcp.hpp
+++ b/include/mori/application/transport/tcp/tcp.hpp
@@ -24,6 +24,7 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -35,8 +36,8 @@ namespace application {
 /*                                           TCPEndpoint                                          */
 /* ---------------------------------------------------------------------------------------------- */
 struct TCPEndpointHandle {
-  int fd;
-  sockaddr_in peer;
+  int fd{-1};
+  sockaddr_in peer{};
 };
 
 using TCPEndpointHandleVec = std::vector<TCPEndpointHandle>;
@@ -47,7 +48,7 @@ class TCPEndpoint {
   ~TCPEndpoint() = default;
 
   int Send(const void* buf, size_t len);
-  int Recv(void* buf, size_t len);
+  int Recv(void* buf, size_t len, size_t* consumed = nullptr);
 
  public:
   TCPEndpointHandle handle;
@@ -81,12 +82,15 @@ class TCPContext {
   TCPEndpointHandle Connect(std::string remote, uint16_t port);
   TCPEndpointHandleVec Accept();
   void CloseEndpoint(TCPEndpointHandle);
+  bool CloseEndpointNoThrow(TCPEndpointHandle) noexcept;
+  bool CloseEndpointNoThrow(int fd) noexcept;
 
  public:
   TCPContextHandle handle;
 
  private:
   int listenFd{-1};
+  mutable std::mutex endpointsMu;
   std::unordered_map<int, TCPEndpointHandle> endpoints;
 };
 

--- a/include/mori/application/utils/check.hpp
+++ b/include/mori/application/utils/check.hpp
@@ -58,6 +58,8 @@ namespace application {
     }                                                                      \
   } while (0)
 
+// Bootstrap-only helper: this macro terminates the process and should not be
+// used in per-connection or per-transfer runtime paths.
 #define SYSCALL_RETURN_ZERO(stmt)                                                               \
   do {                                                                                          \
     auto _ret = (stmt);                                                                         \

--- a/src/application/transport/rdma/providers/ibverbs/ibverbs.cpp
+++ b/src/application/transport/rdma/providers/ibverbs/ibverbs.cpp
@@ -23,14 +23,102 @@
 
 #include <infiniband/verbs.h>  // dereferences ibvHandle.qp/cq/srq (forward-declared in core)
 
+#include <algorithm>
 #include <cerrno>
 #include <cstring>
+#include <iomanip>
+#include <sstream>
 #include <stdexcept>
+#include <string>
+#include <utility>
 
 #include "mori/application/utils/check.hpp"
 #include "mori/utils/mori_log.hpp"
 namespace mori {
 namespace application {
+
+namespace {
+
+class RdmaError : public std::runtime_error {
+ public:
+  RdmaError(int errnoValue, std::string what)
+      : std::runtime_error(std::move(what)), errno_(errnoValue) {}
+
+  int Errno() const noexcept { return errno_; }
+
+ private:
+  int errno_{0};
+};
+
+bool HasAnyNonZeroByte(const uint8_t* bytes, size_t len) {
+  return std::any_of(bytes, bytes + len, [](uint8_t byte) { return byte != 0; });
+}
+
+std::string BytesToHex(const uint8_t* bytes, size_t len) {
+  std::ostringstream os;
+  os << std::hex << std::setfill('0');
+  for (size_t i = 0; i < len; ++i) {
+    if (i != 0) os << ':';
+    os << std::setw(2) << static_cast<unsigned>(bytes[i]);
+  }
+  return os.str();
+}
+
+const char* LinkLayerName(uint8_t linkLayer) {
+  switch (linkLayer) {
+    case IBV_LINK_LAYER_UNSPECIFIED:
+      return "unspecified";
+    case IBV_LINK_LAYER_INFINIBAND:
+      return "infiniband";
+    case IBV_LINK_LAYER_ETHERNET:
+      return "ethernet";
+    default:
+      return "unknown";
+  }
+}
+
+std::string DescribeQpTransition(const char* transition, const ibv_qp_attr& attr, int flags,
+                                 const ibv_device_attr_ex& devAttr, const ibv_port_attr& portAttr,
+                                 const RdmaEndpointHandle& local, const char* devName) {
+  std::ostringstream os;
+  os << "transition=" << (transition != nullptr ? transition : "unknown")
+     << " dev=" << (devName != nullptr ? devName : "unknown") << " flags=0x" << std::hex << flags
+     << std::dec << " qp_state=" << static_cast<int>(attr.qp_state)
+     << " port_num=" << static_cast<int>(attr.port_num)
+     << " path_mtu=" << static_cast<int>(attr.path_mtu) << " dest_qp_num=" << attr.dest_qp_num
+     << " rq_psn=" << attr.rq_psn << " sq_psn=" << attr.sq_psn
+     << " max_dest_rd_atomic=" << static_cast<int>(attr.max_dest_rd_atomic)
+     << " max_rd_atomic=" << static_cast<int>(attr.max_rd_atomic)
+     << " min_rnr_timer=" << static_cast<int>(attr.min_rnr_timer)
+     << " timeout=" << static_cast<int>(attr.timeout)
+     << " retry_cnt=" << static_cast<int>(attr.retry_cnt)
+     << " rnr_retry=" << static_cast<int>(attr.rnr_retry)
+     << " ah_attr.is_global=" << static_cast<int>(attr.ah_attr.is_global)
+     << " ah_attr.sl=" << static_cast<int>(attr.ah_attr.sl) << " ah_attr.dlid=" << attr.ah_attr.dlid
+     << " ah_attr.port_num=" << static_cast<int>(attr.ah_attr.port_num)
+     << " grh.sgid_index=" << static_cast<int>(attr.ah_attr.grh.sgid_index)
+     << " grh.hop_limit=" << static_cast<int>(attr.ah_attr.grh.hop_limit)
+     << " grh.traffic_class=" << static_cast<int>(attr.ah_attr.grh.traffic_class)
+     << " local.qpn=" << local.qpn << " local.psn=" << local.psn << " local.portId=" << local.portId
+     << " local.gidIdx=" << local.eth.gidIdx
+     << " local.gid=" << BytesToHex(local.eth.gid, sizeof(local.eth.gid));
+
+  if (HasAnyNonZeroByte(local.eth.mac, sizeof(local.eth.mac))) {
+    os << " local.mac=" << BytesToHex(local.eth.mac, sizeof(local.eth.mac));
+  }
+
+  os << " caps.max_qp_rd_atom=" << devAttr.orig_attr.max_qp_rd_atom
+     << " caps.max_qp_init_rd_atom=" << devAttr.orig_attr.max_qp_init_rd_atom
+     << " caps.max_qp_wr=" << devAttr.orig_attr.max_qp_wr
+     << " caps.max_sge=" << devAttr.orig_attr.max_sge
+     << " port.active_mtu=" << static_cast<int>(portAttr.active_mtu)
+     << " port.gid_tbl_len=" << static_cast<int>(portAttr.gid_tbl_len)
+     << " port.link_layer=" << LinkLayerName(portAttr.link_layer) << '('
+     << static_cast<int>(portAttr.link_layer) << ')';
+  return os.str();
+}
+
+}  // namespace
 
 /* ---------------------------------------------------------------------------------------------- */
 /*                                      IBVerbsDeviceContext                                      */
@@ -39,6 +127,7 @@ IBVerbsDeviceContext::IBVerbsDeviceContext(RdmaDevice* rdma_device, ibv_pd* inPd
     : RdmaDeviceContext(rdma_device, inPd) {}
 
 IBVerbsDeviceContext::~IBVerbsDeviceContext() {
+  std::lock_guard<std::mutex> lock(poolMu);
   for (auto& it : qpPool) ibv_destroy_qp(it.second);
   for (auto& it : cqPool) ibv_destroy_cq(it.second);
   for (auto* compCh : compChPool) {
@@ -67,23 +156,38 @@ RdmaEndpoint IBVerbsDeviceContext::CreateRdmaEndpoint(const RdmaEndpointConfig& 
   } else if (portAttr->link_layer == IBV_LINK_LAYER_ETHERNET) {
     GidSelectionResult gidSelection =
         AutoSelectGidIndex(context, config.portId, portAttr, config.gidIdx);
-    assert(gidSelection.gidIdx >= 0 && gidSelection.valid);
+    if (gidSelection.gidIdx < 0 || !gidSelection.valid) {
+      throw std::runtime_error("failed to select a valid RDMA GID index");
+    }
 
     memcpy(endpoint.handle.eth.gid, gidSelection.gid.raw, 16);
     endpoint.handle.eth.gidIdx = gidSelection.gidIdx;
   } else {
-    assert(false && "unsupported link layer");
+    throw std::runtime_error("unsupported RDMA link layer " +
+                             std::to_string(static_cast<int>(portAttr->link_layer)));
   }
 
   // TODO: we need to add more options in config, include min cqe num for ib_create_cq
   endpoint.ibvHandle.compCh = config.withCompChannel ? ibv_create_comp_channel(context) : nullptr;
+  if (config.withCompChannel && !endpoint.ibvHandle.compCh) {
+    MORI_APP_ERROR("ibv_create_comp_channel failed: errno={} ({}); dev={}", errno, strerror(errno),
+                   GetRdmaDevice()->Name());
+    throw std::runtime_error("ibv_create_comp_channel failed: " + std::string(strerror(errno)));
+  }
+
   endpoint.ibvHandle.cq =
       ibv_create_cq(context, config.maxCqeNum, NULL, endpoint.ibvHandle.compCh, 0);
   if (!endpoint.ibvHandle.cq) {
+    size_t cqPoolSize = 0;
+    {
+      std::lock_guard<std::mutex> lock(poolMu);
+      cqPoolSize = cqPool.size();
+    }
     MORI_APP_ERROR(
         "ibv_create_cq failed: errno={} ({}); dev={} max_cqe={} dev_max_cqe={} cqs_in_pool={}",
         errno, strerror(errno), GetRdmaDevice()->Name(), config.maxCqeNum,
-        deviceAttr->orig_attr.max_cqe, cqPool.size());
+        deviceAttr->orig_attr.max_cqe, cqPoolSize);
+    if (endpoint.ibvHandle.compCh) ibv_destroy_comp_channel(endpoint.ibvHandle.compCh);
     throw std::runtime_error("ibv_create_cq failed: " + std::string(strerror(errno)));
   }
 
@@ -92,7 +196,9 @@ RdmaEndpoint IBVerbsDeviceContext::CreateRdmaEndpoint(const RdmaEndpointConfig& 
     assert(endpoint.ibvHandle.compCh &&
            (endpoint.ibvHandle.cq->channel == endpoint.ibvHandle.compCh));
 
-  assert(config.maxMsgSge <= GetRdmaDevice()->GetDeviceAttr()->orig_attr.max_sge);
+  if (config.maxMsgSge > GetRdmaDevice()->GetDeviceAttr()->orig_attr.max_sge) {
+    throw std::runtime_error("requested RDMA maxMsgSge exceeds device max_sge");
+  }
   endpoint.ibvHandle.srq = config.enableSrq ? CreateRdmaSrqIfNx(config) : nullptr;
 
   uint32_t maxRecvWr = config.maxRecvWr != 0 ? config.maxRecvWr : config.maxMsgsNum;
@@ -110,13 +216,20 @@ RdmaEndpoint IBVerbsDeviceContext::CreateRdmaEndpoint(const RdmaEndpointConfig& 
                              .qp_type = IBV_QPT_RC};
   endpoint.ibvHandle.qp = ibv_create_qp(pd, &qpAttr);
   if (!endpoint.ibvHandle.qp) {
+    size_t qpPoolSize = 0;
+    {
+      std::lock_guard<std::mutex> lock(poolMu);
+      qpPoolSize = qpPool.size();
+    }
     MORI_APP_ERROR(
         "ibv_create_qp failed: errno={} ({}); dev={} port={} max_send_wr={} max_recv_wr={} "
         "max_send_sge={} max_cqe={} dev_caps(max_qp_wr={} max_qp={} max_cqe={}) qps_in_pool={}",
         errno, strerror(errno), GetRdmaDevice()->Name(), config.portId, qpAttr.cap.max_send_wr,
         qpAttr.cap.max_recv_wr, qpAttr.cap.max_send_sge, config.maxCqeNum,
         deviceAttr->orig_attr.max_qp_wr, deviceAttr->orig_attr.max_qp,
-        deviceAttr->orig_attr.max_cqe, qpPool.size());
+        deviceAttr->orig_attr.max_cqe, qpPoolSize);
+    ibv_destroy_cq(endpoint.ibvHandle.cq);
+    if (endpoint.ibvHandle.compCh) ibv_destroy_comp_channel(endpoint.ibvHandle.compCh);
     throw std::runtime_error("ibv_create_qp failed: " + std::string(strerror(errno)));
   }
   endpoint.handle.qpn = endpoint.ibvHandle.qp->qp_num;
@@ -124,34 +237,64 @@ RdmaEndpoint IBVerbsDeviceContext::CreateRdmaEndpoint(const RdmaEndpointConfig& 
   if (config.enableSrq)
     assert(endpoint.ibvHandle.srq && (endpoint.ibvHandle.qp->srq == endpoint.ibvHandle.srq));
 
-  cqPool.insert({endpoint.ibvHandle.cq, endpoint.ibvHandle.cq});
-  qpPool.insert({endpoint.ibvHandle.qp->qp_num, endpoint.ibvHandle.qp});
-  if (endpoint.ibvHandle.compCh) {
-    compChPool.push_back(endpoint.ibvHandle.compCh);
+  {
+    std::lock_guard<std::mutex> lock(poolMu);
+    cqPool.insert({endpoint.ibvHandle.cq, endpoint.ibvHandle.cq});
+    qpPool.insert({endpoint.ibvHandle.qp->qp_num, endpoint.ibvHandle.qp});
+    if (endpoint.ibvHandle.compCh) {
+      compChPool.push_back(endpoint.ibvHandle.compCh);
+    }
   }
   return endpoint;
 }
 
 void IBVerbsDeviceContext::ConnectEndpoint(const RdmaEndpointHandle& local,
                                            const RdmaEndpointHandle& remote, uint32_t qpId) {
-  ibv_qp_attr attr;
+  (void)qpId;
+  ibv_qp_attr attr{};
   int flags;
 
   const ibv_device_attr_ex* devAttr = GetRdmaDevice()->GetDeviceAttr();
-  ibv_qp* qp = qpPool.find(local.qpn)->second;
+  const ibv_port_attr* portAttr = GetRdmaDevice()->GetPortAttr(local.portId);
+  if (devAttr == nullptr || portAttr == nullptr) {
+    throw RdmaError(EINVAL, "RDMA device or port attributes are unavailable");
+  }
+
+  ibv_qp* qp = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(poolMu);
+    auto qpIt = qpPool.find(local.qpn);
+    if (qpIt != qpPool.end()) qp = qpIt->second;
+  }
+  if (qp == nullptr) {
+    throw RdmaError(ENOENT, "local RDMA QP is not in the ibverbs pool");
+  }
+
+  auto ModifyOrThrow = [&](const char* transition, ibv_qp_attr& qpAttr, int modifyFlags) {
+    int ret = ibv_modify_qp(qp, &qpAttr, modifyFlags);
+    if (ret == 0) return;
+
+    int err = ret > 0 ? ret : errno;
+    if (err == 0) err = EIO;
+    std::string detail = DescribeQpTransition(transition, qpAttr, modifyFlags, *devAttr, *portAttr,
+                                              local, GetRdmaDevice()->Name().c_str());
+    MORI_APP_ERROR("ibv_modify_qp({}) failed: err={} ({}); {}", transition, err, strerror(err),
+                   detail);
+    throw RdmaError(err, "ibv_modify_qp(" + std::string(transition) +
+                             ") failed: " + std::string(strerror(err)));
+  };
 
   // INIT
-  memset(&attr, 0, sizeof(attr));
+  attr = {};
   attr.qp_state = IBV_QPS_INIT;
   attr.port_num = local.portId;
   attr.pkey_index = 0;
   attr.qp_access_flags = MR_DEFAULT_ACCESS_FLAG;
   flags = IBV_QP_STATE | IBV_QP_PORT | IBV_QP_PKEY_INDEX | IBV_QP_ACCESS_FLAGS;
-  SYSCALL_RETURN_ZERO(ibv_modify_qp(qp, &attr, flags));
+  ModifyOrThrow("INIT", attr, flags);
 
-  const ibv_port_attr* portAttr = GetRdmaDevice()->GetPortAttr(local.portId);
-  assert(portAttr);
   // RTR
+  attr = {};
   attr.qp_state = IBV_QPS_RTR;
   {
     ibv_mtu path_mtu = portAttr->active_mtu;
@@ -212,9 +355,10 @@ void IBVerbsDeviceContext::ConnectEndpoint(const RdmaEndpointHandle& local,
   }
   flags = IBV_QP_STATE | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN | IBV_QP_RQ_PSN |
           IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER | IBV_QP_AV;
-  SYSCALL_RETURN_ZERO(ibv_modify_qp(qp, &attr, flags));
+  ModifyOrThrow("RTR", attr, flags);
 
   // RTS
+  attr = {};
   attr.qp_state = IBV_QPS_RTS;
   attr.sq_psn = 0;
   attr.timeout = 14;
@@ -223,7 +367,68 @@ void IBVerbsDeviceContext::ConnectEndpoint(const RdmaEndpointHandle& local,
   attr.max_rd_atomic = devAttr->orig_attr.max_qp_init_rd_atom;
   flags = IBV_QP_STATE | IBV_QP_SQ_PSN | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY |
           IBV_QP_MAX_QP_RD_ATOMIC;
-  SYSCALL_RETURN_ZERO(ibv_modify_qp(qp, &attr, flags));
+  ModifyOrThrow("RTS", attr, flags);
+}
+
+bool IBVerbsDeviceContext::DestroyRdmaEndpointNoThrow(const RdmaEndpoint& ep) noexcept {
+  bool ok = true;
+  try {
+    std::lock_guard<std::mutex> lock(poolMu);
+
+    auto qpIt = qpPool.find(ep.handle.qpn);
+    if (qpIt != qpPool.end() && qpIt->second != nullptr) {
+      int ret = ibv_destroy_qp(qpIt->second);
+      if (ret == 0) {
+        qpPool.erase(qpIt);
+      } else {
+        int err = ret > 0 ? ret : errno;
+        if (err == 0) err = EIO;
+        MORI_APP_ERROR("ibv_destroy_qp failed during endpoint rollback: qpn={} err={} ({})",
+                       ep.handle.qpn, err, strerror(err));
+        ok = false;
+      }
+    }
+
+    if (ep.ibvHandle.cq != nullptr) {
+      auto cqIt = cqPool.find(ep.ibvHandle.cq);
+      if (cqIt != cqPool.end()) {
+        int ret = ibv_destroy_cq(cqIt->second);
+        if (ret == 0) {
+          cqPool.erase(cqIt);
+        } else {
+          int err = ret > 0 ? ret : errno;
+          if (err == 0) err = EIO;
+          MORI_APP_ERROR("ibv_destroy_cq failed during endpoint rollback: cq={} err={} ({})",
+                         static_cast<void*>(ep.ibvHandle.cq), err, strerror(err));
+          ok = false;
+        }
+      }
+    }
+
+    if (ep.ibvHandle.compCh != nullptr) {
+      auto compIt = std::find(compChPool.begin(), compChPool.end(), ep.ibvHandle.compCh);
+      if (compIt != compChPool.end()) {
+        int ret = ibv_destroy_comp_channel(ep.ibvHandle.compCh);
+        if (ret == 0) {
+          compChPool.erase(compIt);
+        } else {
+          int err = ret > 0 ? ret : errno;
+          if (err == 0) err = EIO;
+          MORI_APP_ERROR(
+              "ibv_destroy_comp_channel failed during endpoint rollback: comp_ch={} err={} ({})",
+              static_cast<void*>(ep.ibvHandle.compCh), err, strerror(err));
+          ok = false;
+        }
+      }
+    }
+  } catch (const std::exception& e) {
+    MORI_APP_ERROR("DestroyRdmaEndpointNoThrow caught exception during rollback: {}", e.what());
+    return false;
+  } catch (...) {
+    MORI_APP_ERROR("DestroyRdmaEndpointNoThrow caught unknown exception during rollback");
+    return false;
+  }
+  return ok;
 }
 
 /* ---------------------------------------------------------------------------------------------- */

--- a/src/application/transport/rdma/rdma.cpp
+++ b/src/application/transport/rdma/rdma.cpp
@@ -417,6 +417,17 @@ void RdmaDeviceContext::DeregisterRdmaMemoryRegion(void* ptr) {
   mrPool.erase(ptr);
 }
 
+bool RdmaDeviceContext::DestroyRdmaEndpointNoThrow(const RdmaEndpoint& ep) noexcept {
+  try {
+    MORI_APP_WARN(
+        "DestroyRdmaEndpointNoThrow is unsupported for provider vendorId={} qpn={} cq={}; "
+        "leaving endpoint for normal context teardown",
+        static_cast<uint32_t>(ep.vendorId), ep.handle.qpn, static_cast<void*>(ep.ibvHandle.cq));
+  } catch (...) {
+  }
+  return false;
+}
+
 ibv_srq* RdmaDeviceContext::CreateRdmaSrqIfNx(const RdmaEndpointConfig& config) {
   assert(config.maxMsgSge <= GetRdmaDevice()->GetDeviceAttr()->orig_attr.max_sge);
   if (srq == nullptr) {

--- a/src/application/transport/tcp/tcp.cpp
+++ b/src/application/transport/tcp/tcp.cpp
@@ -23,15 +23,79 @@
 #include "mori/application/transport/tcp/tcp.hpp"
 
 #include <string.h>
+#include <sys/socket.h>
 
 #include <cassert>
+#include <cerrno>
+#include <cstdlib>
+#include <system_error>
 
 #include "mori/application/utils/check.hpp"
+#include "mori/utils/mori_log.hpp"
 
 namespace mori {
 namespace application {
 
 #define DEFAULT_LISTEN_BACKLOG 128
+
+namespace {
+
+int ReadControlPlaneTimeoutMs() {
+  static const int timeoutMs = [] {
+    const char* raw = std::getenv("MORI_IO_CP_TIMEOUT_MS");
+    if (raw == nullptr || raw[0] == '\0') return 5000;
+
+    errno = 0;
+    char* end = nullptr;
+    long parsed = std::strtol(raw, &end, 10);
+    if (errno != 0 || end == raw || *end != '\0' || parsed < 0 ||
+        parsed > 24L * 60L * 60L * 1000L) {
+      MORI_APP_WARN("Ignoring invalid MORI_IO_CP_TIMEOUT_MS={} (expected [0, 86400000])", raw);
+      return 5000;
+    }
+    return static_cast<int>(parsed);
+  }();
+  return timeoutMs;
+}
+
+void SetControlPlaneSocketTimeoutNoThrow(int fd) noexcept {
+  int timeoutMs = ReadControlPlaneTimeoutMs();
+  if (fd < 0 || timeoutMs == 0) return;
+
+  timeval tv{};
+  tv.tv_sec = timeoutMs / 1000;
+  tv.tv_usec = (timeoutMs % 1000) * 1000;
+
+  if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) != 0) {
+    MORI_APP_WARN("Failed to set SO_RCVTIMEO on control-plane fd {}: errno={} ({})", fd, errno,
+                  strerror(errno));
+  }
+  if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv)) != 0) {
+    MORI_APP_WARN("Failed to set SO_SNDTIMEO on control-plane fd {}: errno={} ({})", fd, errno,
+                  strerror(errno));
+  }
+}
+
+bool ShutdownCloseNoThrow(int fd) noexcept {
+  bool ok = true;
+  if (shutdown(fd, SHUT_WR) != 0) {
+    int err = errno;
+    if (err != ENOTCONN && err != EINVAL) {
+      MORI_APP_WARN("shutdown(fd={}) failed during endpoint close: errno={} ({})", fd, err,
+                    strerror(err));
+      ok = false;
+    }
+  }
+  if (close(fd) != 0) {
+    int err = errno;
+    MORI_APP_WARN("close(fd={}) failed during endpoint close: errno={} ({})", fd, err,
+                  strerror(err));
+    ok = false;
+  }
+  return ok;
+}
+
+}  // namespace
 
 /* ---------------------------------------------------------------------------------------------- */
 /*                                           TCPEndpoint                                          */
@@ -40,22 +104,40 @@ namespace application {
 int TCPEndpoint::Send(const void* buf, size_t len) {
   const char* p = static_cast<const char*>(buf);
   while (len > 0) {
-    size_t n = send(handle.fd, p, len, 0);
-    if (n < 0) return n;
+    ssize_t n = send(handle.fd, p, len, MSG_NOSIGNAL);
+    if (n < 0) {
+      if (errno == EINTR) continue;
+      return -1;
+    }
+    if (n == 0) {
+      errno = EPIPE;
+      return -1;
+    }
     p += n;
     len -= n;
   }
   return 0;
 }
 
-int TCPEndpoint::Recv(void* buf, size_t len) {
+int TCPEndpoint::Recv(void* buf, size_t len, size_t* consumed) {
   char* p = static_cast<char*>(buf);
+  size_t got = 0;
   while (len > 0) {
-    size_t n = ::recv(handle.fd, p, len, 0);
-    if (n <= 0) return n;
+    ssize_t n = ::recv(handle.fd, p, len, 0);
+    if (n == 0) {
+      if (consumed) *consumed = got;
+      return 1;
+    }
+    if (n < 0) {
+      if (errno == EINTR) continue;
+      if (consumed) *consumed = got;
+      return -1;
+    }
     p += n;
     len -= n;
+    got += static_cast<size_t>(n);
   }
+  if (consumed) *consumed = got;
   return 0;
 }
 
@@ -92,28 +174,47 @@ void TCPContext::Listen() {
 
 void TCPContext::Close() {
   if (listenFd >= 0) {
-    SYSCALL_RETURN_ZERO(close(listenFd));
+    if (close(listenFd) != 0) {
+      MORI_APP_WARN("close(listenFd={}) failed: errno={} ({})", listenFd, errno, strerror(errno));
+    }
     listenFd = -1;
   }
-  while (!endpoints.empty()) {
-    auto it = endpoints.begin();
-    CloseEndpoint(it->second);
+
+  while (true) {
+    TCPEndpointHandle ep;
+    {
+      std::lock_guard<std::mutex> lock(endpointsMu);
+      if (endpoints.empty()) break;
+      ep = endpoints.begin()->second;
+    }
+    CloseEndpointNoThrow(ep);
   }
 }
 
 TCPEndpointHandle TCPContext::Connect(std::string remote, uint16_t port) {
   int sock = socket(AF_INET, SOCK_STREAM, 0);
-  assert(sock >= 0);
+  if (sock < 0) {
+    throw std::system_error(errno, std::generic_category(), "socket(AF_INET, SOCK_STREAM)");
+  }
+  SetControlPlaneSocketTimeoutNoThrow(sock);
 
   sockaddr_in peer{};
   peer.sin_family = AF_INET;
   peer.sin_port = htons(port);
   peer.sin_addr.s_addr = inet_addr(remote.c_str());
 
-  SYSCALL_RETURN_ZERO(connect(sock, reinterpret_cast<sockaddr*>(&peer), sizeof(peer)));
+  if (connect(sock, reinterpret_cast<sockaddr*>(&peer), sizeof(peer)) != 0) {
+    int err = errno;
+    close(sock);
+    throw std::system_error(err, std::generic_category(),
+                            "connect(" + remote + ":" + std::to_string(port) + ")");
+  }
 
   TCPEndpointHandle ep{sock, peer};
-  endpoints.insert({sock, ep});
+  {
+    std::lock_guard<std::mutex> lock(endpointsMu);
+    endpoints.insert({sock, ep});
+  }
   return ep;
 }
 
@@ -124,13 +225,24 @@ TCPEndpointHandleVec TCPContext::Accept() {
   TCPEndpointHandleVec newEps;
 
   while (true) {
+    len = sizeof(peer);
     int sock = accept(listenFd, reinterpret_cast<sockaddr*>(&peer), &len);
     if (sock >= 0) {
+      SetControlPlaneSocketTimeoutNoThrow(sock);
       TCPEndpointHandle ep{sock, peer};
+      {
+        std::lock_guard<std::mutex> lock(endpointsMu);
+        endpoints.insert({sock, ep});
+      }
       newEps.push_back(ep);
-      endpoints.insert({sock, ep});
+      continue;
     }
+    if ((sock == -1) && errno == EINTR) continue;
     if ((sock == -1) && ((errno == EAGAIN) || (errno == EWOULDBLOCK))) {
+      break;
+    }
+    if (sock == -1) {
+      MORI_APP_WARN("accept(listenFd={}) failed: errno={} ({})", listenFd, errno, strerror(errno));
       break;
     }
   }
@@ -138,11 +250,30 @@ TCPEndpointHandleVec TCPContext::Accept() {
   return newEps;
 }
 
-void TCPContext::CloseEndpoint(TCPEndpointHandle ep) {
-  if (endpoints.find(ep.fd) == endpoints.end()) return;
-  SYSCALL_RETURN_ZERO_IGNORE_ERROR(shutdown(ep.fd, SHUT_WR), ENOTCONN);
-  SYSCALL_RETURN_ZERO(close(ep.fd));
-  endpoints.erase(ep.fd);
+void TCPContext::CloseEndpoint(TCPEndpointHandle ep) { CloseEndpointNoThrow(ep); }
+
+bool TCPContext::CloseEndpointNoThrow(int fd) noexcept {
+  if (fd < 0) return true;
+
+  {
+    std::lock_guard<std::mutex> lock(endpointsMu);
+    auto it = endpoints.find(fd);
+    if (it == endpoints.end()) return true;
+    endpoints.erase(it);
+  }
+  return ShutdownCloseNoThrow(fd);
+}
+
+bool TCPContext::CloseEndpointNoThrow(TCPEndpointHandle ep) noexcept {
+  if (ep.fd < 0) return true;
+
+  {
+    std::lock_guard<std::mutex> lock(endpointsMu);
+    auto it = endpoints.find(ep.fd);
+    if (it == endpoints.end()) return true;
+    endpoints.erase(it);
+  }
+  return ShutdownCloseNoThrow(ep.fd);
 }
 
 }  // namespace application

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -25,6 +25,7 @@
 #include <sys/epoll.h>
 
 #include <algorithm>
+#include <cerrno>
 #include <cstdlib>
 #include <cstring>
 #include <limits>
@@ -124,6 +125,43 @@ struct CqeFailureAdvice {
     message += hint;
     return message;
   }
+};
+
+class TcpEndpointGuard {
+ public:
+  TcpEndpointGuard(application::TCPContext* ctx, application::TCPEndpointHandle ep)
+      : ctx_(ctx), ep_(ep), armed_(true) {}
+  ~TcpEndpointGuard() {
+    if (armed_ && ctx_ != nullptr) ctx_->CloseEndpointNoThrow(ep_);
+  }
+
+  TcpEndpointGuard(const TcpEndpointGuard&) = delete;
+  TcpEndpointGuard& operator=(const TcpEndpointGuard&) = delete;
+
+ private:
+  application::TCPContext* ctx_{nullptr};
+  application::TCPEndpointHandle ep_{};
+  bool armed_{false};
+};
+
+class PendingEndpointGuard {
+ public:
+  PendingEndpointGuard(RdmaManager* rdma, int devId, application::RdmaEndpoint ep)
+      : rdma_(rdma), devId_(devId), ep_(ep), armed_(true) {}
+  ~PendingEndpointGuard() {
+    if (armed_ && rdma_ != nullptr) rdma_->DestroyEndpointNoThrow(devId_, ep_);
+  }
+
+  PendingEndpointGuard(const PendingEndpointGuard&) = delete;
+  PendingEndpointGuard& operator=(const PendingEndpointGuard&) = delete;
+
+  void Commit() noexcept { armed_ = false; }
+
+ private:
+  RdmaManager* rdma_{nullptr};
+  int devId_{-1};
+  application::RdmaEndpoint ep_{};
+  bool armed_{false};
 };
 
 static void LogAsyncTransferFailureIfNeeded(internal::IoCallDiagnostics* diagnostics, uint32_t code,
@@ -482,6 +520,24 @@ application::RdmaEndpoint RdmaManager::CreateEndpoint(int devId) {
   if (config.pollCqMode == PollCqMode::EVENT)
     SYSCALL_RETURN_ZERO(ibv_req_notify_cq(rdmaEp.ibvHandle.cq, 0));
   return rdmaEp;
+}
+
+bool RdmaManager::DestroyEndpointNoThrow(int devId, const application::RdmaEndpoint& ep) noexcept {
+  try {
+    std::unique_lock<std::shared_mutex> lock(mu);
+    if (devId < 0 || devId >= static_cast<int>(deviceCtxs.size()) || deviceCtxs[devId] == nullptr) {
+      MORI_IO_WARN("DestroyEndpointNoThrow: invalid devId={} for qpn={}", devId, ep.handle.qpn);
+      return false;
+    }
+    return deviceCtxs[devId]->DestroyRdmaEndpointNoThrow(ep);
+  } catch (const std::exception& e) {
+    MORI_IO_ERROR("DestroyEndpointNoThrow caught exception for devId={} qpn={}: {}", devId,
+                  ep.handle.qpn, e.what());
+  } catch (...) {
+    MORI_IO_ERROR("DestroyEndpointNoThrow caught unknown exception for devId={} qpn={}", devId,
+                  ep.handle.qpn);
+  }
+  return false;
 }
 
 EndpointId RdmaManager::ConnectEndpoint(EngineKey remoteKey, int devId,
@@ -930,31 +986,38 @@ void ControlPlaneServer::BuildRdmaConn(EngineKey ekey, TopoKeyPair topo, int nic
   application::TCPEndpointHandle tcph;
   {
     std::lock_guard<std::mutex> lock(mu);
-    assert((engines.find(ekey) != engines.end()) && "register engine first");
-    EngineDesc& rdesc = engines[ekey];
+    auto engineIt = engines.find(ekey);
+    if (engineIt == engines.end()) {
+      throw std::runtime_error("BuildRdmaConn: remote engine " + ekey + " is not registered");
+    }
+    EngineDesc& rdesc = engineIt->second;
     tcph = ctx->Connect(rdesc.host, rdesc.port);
   }
+  TcpEndpointGuard tcpGuard(ctx.get(), tcph);
 
   int requestedNics = ResolveRequestedNics(config, topo.local, topo.remote);
   auto candidates = rdma->Search(topo.local, requestedNics);
-  assert(!candidates.empty());
+  if (candidates.empty()) {
+    throw std::runtime_error("BuildRdmaConn: no matching local RDMA NIC candidate");
+  }
   int rank = std::min<int>(nicRank, static_cast<int>(candidates.size()) - 1);
   auto [devId, weight] = candidates[rank];
 
   application::RdmaEndpoint lep = rdma->CreateEndpoint(devId);
+  PendingEndpointGuard pendingEndpoint(rdma, devId, lep);
 
   Protocol p(tcph);
   p.WriteMessageRegEndpoint({myEngKey, topo, devId, lep.handle, rank, devId});
   MessageHeader hdr = p.ReadMessageHeader();
-  assert(hdr.type == MessageType::RegEndpoint);
+  ExpectMessage(hdr, MessageType::RegEndpoint, "BuildRdmaConn reply from " + ekey);
   MessageRegEndpoint msg = p.ReadMessageRegEndpoint(hdr.len);
 
   EndpointId eid = rdma->ConnectEndpoint(ekey, devId, lep, msg.devId, msg.eph, topo, weight);
+  pendingEndpoint.Commit();
   auto ert = rdma->GetEndpointRuntime(eid);
   notif->RegisterEndpoint(ert);
   MORI_IO_INFO("Built RdmaConn for engine {} with topo local({},{}) remote({},{})", ekey,
                topo.local.deviceId, topo.local.loc, topo.remote.deviceId, topo.remote.loc);
-  ctx->CloseEndpoint(tcph);
 }
 
 void ControlPlaneServer::RegisterMemory(MemoryDesc& desc) {
@@ -972,15 +1035,20 @@ application::RdmaMemoryRegion ControlPlaneServer::AskRemoteMemoryRegion(EngineKe
   application::TCPEndpointHandle tcph;
   {
     std::lock_guard<std::mutex> lock(mu);
-    assert((engines.find(ekey) != engines.end()) && "register engine first");
-    EngineDesc& rdesc = engines[ekey];
+    auto engineIt = engines.find(ekey);
+    if (engineIt == engines.end()) {
+      throw std::runtime_error("AskRemoteMemoryRegion: remote engine " + ekey +
+                               " is not registered");
+    }
+    EngineDesc& rdesc = engineIt->second;
     tcph = ctx->Connect(rdesc.host, rdesc.port);
   }
+  TcpEndpointGuard tcpGuard(ctx.get(), tcph);
 
   Protocol p(tcph);
   p.WriteMessageAskMemoryRegion({ekey, rdevId, id, {}});
   MessageHeader hdr = p.ReadMessageHeader();
-  assert(hdr.type == MessageType::AskMemoryRegion);
+  ExpectMessage(hdr, MessageType::AskMemoryRegion, "AskRemoteMemoryRegion reply from " + ekey);
   MessageAskMemoryRegion msg = p.ReadMessageAskMemoryRegion(hdr.len);
 
   return msg.mr;
@@ -992,27 +1060,22 @@ void ControlPlaneServer::AcceptRemoteEngineConn() {
     epoll_event ev{};
     ev.events = EPOLLIN | EPOLLET;
     ev.data.fd = ep.fd;
-    SYSCALL_RETURN_ZERO(epoll_ctl(epfd, EPOLL_CTL_ADD, ep.fd, &ev));
+    if (epoll_ctl(epfd, EPOLL_CTL_ADD, ep.fd, &ev) != 0) {
+      MORI_IO_ERROR("ControlPlaneServer: epoll_ctl ADD failed for fd {}: errno={} ({})", ep.fd,
+                    errno, strerror(errno));
+      ctx->CloseEndpointNoThrow(ep);
+      continue;
+    }
     eps.insert({ep.fd, ep});
   }
 }
 
 void ControlPlaneServer::HandleControlPlaneProtocol(int fd) {
-  assert(eps.find(fd) != eps.end());
-  application::TCPEndpointHandle tcph = eps[fd];
-
-  // Detect remote close: Recv returns 0 for both success and EOF, so
-  // SYSCALL_RETURN_ZERO can't distinguish them — peek before reading to avoid
-  // processing an uninitialized header when the peer disconnects.
-  {
-    char probe;
-    if (::recv(fd, &probe, 1, MSG_PEEK) == 0) {
-      MORI_IO_DEBUG("ControlPlaneServer: peer closed connection on fd {}", fd);
-      ctx->CloseEndpoint(tcph);
-      eps.erase(fd);
-      return;
-    }
+  auto epIt = eps.find(fd);
+  if (epIt == eps.end()) {
+    throw ProtocolError("ControlPlaneServer: no TCP endpoint for fd " + std::to_string(fd));
   }
+  application::TCPEndpointHandle tcph = epIt->second;
 
   Protocol p(tcph);
   MessageHeader hdr = p.ReadMessageHeader();
@@ -1041,19 +1104,22 @@ void ControlPlaneServer::HandleControlPlaneProtocol(int fd) {
         // Fallback: original behavior (topo search + nicRank)
         int requestedNics = ResolveRequestedNics(config, msg.topo.remote, msg.topo.local);
         auto candidates = rdma->Search(msg.topo.remote, requestedNics);
-        assert(!candidates.empty());
+        if (candidates.empty()) {
+          throw ProtocolError("RegEndpoint: no matching local RDMA NIC candidate");
+        }
         int rank = std::min<int>(msg.nicRank, static_cast<int>(candidates.size()) - 1);
         std::tie(devId, weight) = candidates[rank];
       }
 
       application::RdmaEndpoint lep = rdma->CreateEndpoint(devId);
+      PendingEndpointGuard pendingEndpoint(rdma, devId, lep);
       EndpointId eid =
           rdma->ConnectEndpoint(msg.ekey, devId, lep, rdevId, msg.eph, msg.topo, weight);
+      pendingEndpoint.Commit();
       auto ert = rdma->GetEndpointRuntime(eid);
       notif->RegisterEndpoint(ert);
       p.WriteMessageRegEndpoint(
           MessageRegEndpoint{myEngKey, msg.topo, devId, lep.handle, 0, devId});
-      SYSCALL_RETURN_ZERO(epoll_ctl(epfd, EPOLL_CTL_DEL, fd, NULL));
       break;
     }
     case MessageType::AskMemoryRegion: {
@@ -1073,11 +1139,24 @@ void ControlPlaneServer::HandleControlPlaneProtocol(int fd) {
       break;
     }
     default:
-      assert(false && "not implemented");
+      throw ProtocolError("unsupported control-plane message type " +
+                          std::to_string(static_cast<int>(hdr.type)));
   }
 
-  ctx->CloseEndpoint(tcph);
+  DropConnection(fd);
+}
+
+void ControlPlaneServer::DropConnection(int fd) noexcept {
+  if (fd < 0) return;
+  if (epfd >= 0 && epoll_ctl(epfd, EPOLL_CTL_DEL, fd, NULL) != 0) {
+    int err = errno;
+    if (err != ENOENT && err != EBADF) {
+      MORI_IO_DEBUG("ControlPlaneServer: epoll_ctl DEL failed for fd {}: errno={} ({})", fd, err,
+                    strerror(err));
+    }
+  }
   eps.erase(fd);
+  if (ctx) ctx->CloseEndpointNoThrow(fd);
 }
 
 void ControlPlaneServer::MainLoop() {
@@ -1096,7 +1175,19 @@ void ControlPlaneServer::MainLoop() {
         continue;
       }
 
-      HandleControlPlaneProtocol(fd);
+      try {
+        HandleControlPlaneProtocol(fd);
+      } catch (const std::exception& e) {
+        MORI_IO_ERROR("control-plane handler for fd {} failed: {}; dropping connection", fd,
+                      e.what());
+        DropConnection(fd);
+      } catch (...) {
+        MORI_IO_ERROR(
+            "control-plane handler for fd {} failed with unknown exception; dropping "
+            "connection",
+            fd);
+        DropConnection(fd);
+      }
     }
   }
 }
@@ -1463,9 +1554,17 @@ void RdmaBackend::CreateSession(const MemoryDesc& local, const MemoryDesc& remot
     if (remoteMrByDev.find(ep.rdevId) == remoteMrByDev.end()) {
       auto remoteMr = rdma->GetRemoteMemory(ekey, ep.rdevId, remote.id);
       if (!remoteMr.has_value()) {
-        remoteMr = server->AskRemoteMemoryRegion(ekey, ep.rdevId, remote.id);
-        assert(remoteMr->length == remote.size);
-        rdma->RegisterRemoteMemory(ekey, ep.rdevId, remote.id, remoteMr.value());
+        application::RdmaMemoryRegion fetchedMr =
+            server->AskRemoteMemoryRegion(ekey, ep.rdevId, remote.id);
+        if (fetchedMr.length != remote.size) {
+          std::stringstream ss;
+          ss << "RdmaBackend::CreateSession: remote MR size mismatch for engine " << ekey
+             << " rdevId=" << ep.rdevId << " memId=" << remote.id << " expected=" << remote.size
+             << " got=" << fetchedMr.length;
+          throw std::runtime_error(ss.str());
+        }
+        remoteMr = fetchedMr;
+        rdma->RegisterRemoteMemory(ekey, ep.rdevId, remote.id, *remoteMr);
       }
       remoteMrByDev[ep.rdevId] = *remoteMr;
     }

--- a/src/io/rdma/backend_impl.hpp
+++ b/src/io/rdma/backend_impl.hpp
@@ -90,6 +90,7 @@ class RdmaManager {
   int CountEndpoint(EngineKey, TopoKeyPair);
   EpPairVec GetAllEndpoint(EngineKey, TopoKeyPair);
   application::RdmaEndpoint CreateEndpoint(int devId);
+  bool DestroyEndpointNoThrow(int devId, const application::RdmaEndpoint& ep) noexcept;
   EndpointId ConnectEndpoint(EngineKey remoteKey, int ldevId, application::RdmaEndpoint local,
                              int rdevId, application::RdmaEndpointHandle remote, TopoKeyPair key,
                              int weight);
@@ -234,6 +235,7 @@ class ControlPlaneServer {
  private:
   void AcceptRemoteEngineConn();
   void HandleControlPlaneProtocol(int fd);
+  void DropConnection(int fd) noexcept;
 
  private:
   EngineKey myEngKey;

--- a/src/io/rdma/protocol.cpp
+++ b/src/io/rdma/protocol.cpp
@@ -21,36 +21,105 @@
 // SOFTWARE.
 #include "src/io/rdma/protocol.hpp"
 
+#include <cerrno>
+#include <cstring>
 #include <msgpack.hpp>
-
-#include "mori/application/utils/check.hpp"
+#include <sstream>
 
 namespace mori {
 namespace io {
+namespace {
+
+void ThrowRecvError(const char* op, size_t expected, size_t received, int rc, int err) {
+  std::ostringstream os;
+  os << op << " failed: expected " << expected << " byte(s), received " << received;
+  if (rc > 0) {
+    os << " before EOF";
+  } else {
+    os << ", errno=" << err << " (" << strerror(err) << ")";
+  }
+  throw ProtocolError(os.str());
+}
+
+void ReadExact(application::TCPEndpoint* ep, void* buf, size_t len, const char* op) {
+  size_t consumed = 0;
+  int rc = ep->Recv(buf, len, &consumed);
+  int err = errno;
+  if (rc != 0) ThrowRecvError(op, len, consumed, rc, err);
+}
+
+void WriteExact(application::TCPEndpoint* ep, const void* buf, size_t len, const char* op) {
+  if (ep->Send(buf, len) != 0) {
+    int err = errno;
+    std::ostringstream os;
+    os << op << " failed while writing " << len << " byte(s): errno=" << err << " ("
+       << strerror(err) << ")";
+    throw ProtocolError(os.str());
+  }
+}
+
+void ValidateControlMessageLength(size_t len, const char* messageName) {
+  if (len > kMaxControlMessageBytes) {
+    std::ostringstream os;
+    os << messageName << " length " << len << " exceeds control-plane limit "
+       << kMaxControlMessageBytes;
+    throw ProtocolError(os.str());
+  }
+}
+
+}  // namespace
+
+const char* MessageTypeName(MessageType type) {
+  switch (type) {
+    case MessageType::RegEndpoint:
+      return "RegEndpoint";
+    case MessageType::AskMemoryRegion:
+      return "AskMemoryRegion";
+    default:
+      return "Unknown";
+  }
+}
+
+void ExpectMessage(const MessageHeader& hdr, MessageType expected, const std::string& context) {
+  if (hdr.type == expected) return;
+
+  std::ostringstream os;
+  os << "unexpected control-plane message";
+  if (!context.empty()) os << " (" << context << ")";
+  os << ": expected " << MessageTypeName(expected) << '(' << static_cast<int>(expected) << ')'
+     << ", observed " << MessageTypeName(hdr.type) << '(' << static_cast<int>(hdr.type) << ')'
+     << ", len=" << hdr.len;
+  throw ProtocolError(os.str());
+}
 
 Protocol::Protocol(application::TCPEndpointHandle eph) : ep(eph) {}
 
 Protocol::~Protocol() {}
 
 MessageHeader Protocol::ReadMessageHeader() {
-  MessageHeader hdr;
-  SYSCALL_RETURN_ZERO(ep.Recv(&hdr.type, sizeof(hdr.type)));
-  SYSCALL_RETURN_ZERO(ep.Recv(&hdr.len, sizeof(hdr.len)));
+  MessageHeader hdr{};
+  ReadExact(&ep, &hdr.type, sizeof(hdr.type), "ReadMessageHeader(type)");
+  ReadExact(&ep, &hdr.len, sizeof(hdr.len), "ReadMessageHeader(len)");
   hdr.len = ntohl(hdr.len);
   return hdr;
 }
 
 void Protocol::WriteMessageHeader(const MessageHeader& hdr) {
-  SYSCALL_RETURN_ZERO(ep.Send(&hdr.type, sizeof(hdr.type)));
+  WriteExact(&ep, &hdr.type, sizeof(hdr.type), "WriteMessageHeader(type)");
   uint32_t len = htonl(hdr.len);
-  SYSCALL_RETURN_ZERO(ep.Send(&len, sizeof(len)));
+  WriteExact(&ep, &len, sizeof(len), "WriteMessageHeader(len)");
 }
 
 MessageRegEndpoint Protocol::ReadMessageRegEndpoint(size_t len) {
+  ValidateControlMessageLength(len, "MessageRegEndpoint");
   std::vector<char> buf(len);
-  SYSCALL_RETURN_ZERO(ep.Recv(buf.data(), len));
-  auto out = msgpack::unpack(buf.data(), len);
-  return out.get().as<MessageRegEndpoint>();
+  ReadExact(&ep, buf.data(), len, "ReadMessageRegEndpoint(body)");
+  try {
+    auto out = msgpack::unpack(buf.data(), len);
+    return out.get().as<MessageRegEndpoint>();
+  } catch (const std::exception& e) {
+    throw ProtocolError(std::string("failed to decode MessageRegEndpoint: ") + e.what());
+  }
 }
 
 void Protocol::WriteMessageRegEndpoint(const MessageRegEndpoint& msg) {
@@ -58,14 +127,19 @@ void Protocol::WriteMessageRegEndpoint(const MessageRegEndpoint& msg) {
   msgpack::pack(buf, msg);
   uint32_t len = static_cast<uint32_t>(buf.size());
   WriteMessageHeader({MessageType::RegEndpoint, len});
-  SYSCALL_RETURN_ZERO(ep.Send(buf.data(), buf.size()));
+  WriteExact(&ep, buf.data(), buf.size(), "WriteMessageRegEndpoint(body)");
 }
 
 MessageAskMemoryRegion Protocol::ReadMessageAskMemoryRegion(size_t len) {
+  ValidateControlMessageLength(len, "MessageAskMemoryRegion");
   std::vector<char> buf(len);
-  SYSCALL_RETURN_ZERO(ep.Recv(buf.data(), len));
-  auto out = msgpack::unpack(buf.data(), len);
-  return out.get().as<MessageAskMemoryRegion>();
+  ReadExact(&ep, buf.data(), len, "ReadMessageAskMemoryRegion(body)");
+  try {
+    auto out = msgpack::unpack(buf.data(), len);
+    return out.get().as<MessageAskMemoryRegion>();
+  } catch (const std::exception& e) {
+    throw ProtocolError(std::string("failed to decode MessageAskMemoryRegion: ") + e.what());
+  }
 }
 
 void Protocol::WriteMessageAskMemoryRegion(const MessageAskMemoryRegion& msg) {
@@ -73,7 +147,7 @@ void Protocol::WriteMessageAskMemoryRegion(const MessageAskMemoryRegion& msg) {
   msgpack::pack(buf, msg);
   uint32_t len = static_cast<uint32_t>(buf.size());
   WriteMessageHeader({MessageType::AskMemoryRegion, len});
-  SYSCALL_RETURN_ZERO(ep.Send(buf.data(), buf.size()));
+  WriteExact(&ep, buf.data(), buf.size(), "WriteMessageAskMemoryRegion(body)");
 }
 
 }  // namespace io

--- a/src/io/rdma/protocol.hpp
+++ b/src/io/rdma/protocol.hpp
@@ -21,7 +21,10 @@
 // SOFTWARE.
 #pragma once
 
+#include <cstddef>
 #include <msgpack.hpp>
+#include <stdexcept>
+#include <string>
 
 #include "mori/io/common.hpp"
 #include "mori/io/msgpack_adaptor.hpp"
@@ -64,6 +67,16 @@ struct MessageBuildConn {
   EngineKey key;
   MSGPACK_DEFINE(key);
 };
+
+inline constexpr size_t kMaxControlMessageBytes = 1 << 20;
+
+class ProtocolError : public std::runtime_error {
+ public:
+  using std::runtime_error::runtime_error;
+};
+
+const char* MessageTypeName(MessageType type);
+void ExpectMessage(const MessageHeader& hdr, MessageType expected, const std::string& context = {});
 
 /* ---------------------------------------------------------------------------------------------- */
 /*                                            Protocol                                            */

--- a/tests/cpp/application/test_transport_tcp.cpp
+++ b/tests/cpp/application/test_transport_tcp.cpp
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 #include <cassert>
+#include <system_error>
 #include <vector>
 
 #include "mori/application/transport/tcp/tcp.hpp"
@@ -49,10 +50,55 @@ void TestTcpContext() {
 
   assert(ep1.Send(sendBuf.c_str(), sendBuf.size()) == 0);
   assert(ep2.Recv(recvBuf.data(), sendBuf.size()) == 0);
-  assert(std::string(recvBuf.data()) == sendBuf);
+  assert(std::string(recvBuf.begin(), recvBuf.end()) == sendBuf);
 
   context1.Close();
   context2.Close();
 }
 
-int main() { TestTcpContext(); }
+void TestTcpRecvReportsEof() {
+  std::string host = "127.0.0.1";
+
+  TCPContext context1(host, 0);
+  TCPContext context2(host, 0);
+
+  context1.Listen();
+  context2.Listen();
+
+  TCPEndpointHandle eph1 = context1.Connect(host, context2.GetPort());
+  TCPEndpointHandle eph2 = context2.Accept()[0];
+  context1.CloseEndpoint(eph1);
+
+  TCPEndpoint ep2(eph2);
+  char buf[8]{};
+  size_t consumed = 99;
+  assert(ep2.Recv(buf, sizeof(buf), &consumed) == 1);
+  assert(consumed == 0);
+
+  context2.Close();
+}
+
+void TestTcpConnectFailureThrows() {
+  std::string host = "127.0.0.1";
+
+  TCPContext listener(host, 0);
+  listener.Listen();
+  uint16_t closedPort = listener.GetPort();
+  listener.Close();
+
+  TCPContext client(host, 0);
+  bool threw = false;
+  try {
+    (void)client.Connect(host, closedPort);
+  } catch (const std::system_error& e) {
+    threw = true;
+    assert(e.code().value() != 0);
+  }
+  assert(threw);
+}
+
+int main() {
+  TestTcpContext();
+  TestTcpRecvReportsEof();
+  TestTcpConnectFailureThrows();
+}

--- a/tests/cpp/io/test_protocol.cpp
+++ b/tests/cpp/io/test_protocol.cpp
@@ -23,6 +23,7 @@
 #include <cstdio>
 #include <cstring>
 #include <msgpack.hpp>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -243,6 +244,73 @@ void TestRailAffinityDecisionLogic() {
   printf("  PASS: TestRailAffinityDecisionLogic\n");
 }
 
+void TestReadMessageHeaderThrowsOnEof() {
+  auto tcpPair = PrepareTCPEndpoints();
+  tcpPair.first.first->CloseEndpoint(tcpPair.first.second);
+
+  Protocol receiver(tcpPair.second.second);
+  bool threw = false;
+  try {
+    (void)receiver.ReadMessageHeader();
+  } catch (const ProtocolError& e) {
+    threw = true;
+    assert(std::string(e.what()).find("EOF") != std::string::npos);
+  }
+  assert(threw);
+
+  tcpPair.first.first->Close();
+  tcpPair.second.first->Close();
+  delete tcpPair.first.first;
+  delete tcpPair.second.first;
+  printf("  PASS: TestReadMessageHeaderThrowsOnEof\n");
+}
+
+void TestExpectMessageThrowsOnMismatch() {
+  auto tcpPair = PrepareTCPEndpoints();
+  Protocol sender(tcpPair.first.second);
+  Protocol receiver(tcpPair.second.second);
+
+  sender.WriteMessageAskMemoryRegion({});
+  MessageHeader hdr = receiver.ReadMessageHeader();
+
+  bool threw = false;
+  try {
+    ExpectMessage(hdr, MessageType::RegEndpoint, "unit-test");
+  } catch (const ProtocolError& e) {
+    threw = true;
+    std::string what = e.what();
+    assert(what.find("expected RegEndpoint") != std::string::npos);
+    assert(what.find("observed AskMemoryRegion") != std::string::npos);
+  }
+  assert(threw);
+
+  tcpPair.first.first->Close();
+  tcpPair.second.first->Close();
+  delete tcpPair.first.first;
+  delete tcpPair.second.first;
+  printf("  PASS: TestExpectMessageThrowsOnMismatch\n");
+}
+
+void TestOversizedControlMessageRejectedBeforeRead() {
+  auto tcpPair = PrepareTCPEndpoints();
+  Protocol receiver(tcpPair.second.second);
+
+  bool threw = false;
+  try {
+    (void)receiver.ReadMessageRegEndpoint(kMaxControlMessageBytes + 1);
+  } catch (const ProtocolError& e) {
+    threw = true;
+    assert(std::string(e.what()).find("exceeds control-plane limit") != std::string::npos);
+  }
+  assert(threw);
+
+  tcpPair.first.first->Close();
+  tcpPair.second.first->Close();
+  delete tcpPair.first.first;
+  delete tcpPair.second.first;
+  printf("  PASS: TestOversizedControlMessageRejectedBeforeRead\n");
+}
+
 /* -------------------------------------------------------------------------- */
 /*                                    main                                    */
 /* -------------------------------------------------------------------------- */
@@ -253,6 +321,9 @@ int main() {
   TestMessageRegEndpointBackwardCompat();
   TestMessageRegEndpointMsgpackRoundTrip();
   TestRailAffinityDecisionLogic();
+  TestReadMessageHeaderThrowsOnEof();
+  TestExpectMessageThrowsOnMismatch();
+  TestOversizedControlMessageRejectedBeforeRead();
   printf("All protocol tests passed.\n");
   return 0;
 }


### PR DESCRIPTION
## Summary
- Replace per-connection RDMA/TCP abort paths with catchable errors and cleanup guards
- Add ibverbs QP transition diagnostics and max_rd_atomic clamping
- Harden control-plane protocol reads, message validation, and TCP EOF/timeout handling