### PR TITLE
feat(ccl): add param-contiguous SDMA allgather

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,12 @@ jobs:
             cd $GITHUB_WORKSPACE && MORI_ENABLE_SDMA=1 timeout 300 pytest tests/python/ops/test_dispatch_combine_async_ll.py -v
           "
 
+      - name: MORI-CCL (param-contiguous allgather SDMA)
+        run: |
+          $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
+            cd $GITHUB_WORKSPACE && MORI_ENABLE_SDMA=1 timeout 300 pytest tests/python/ccl/test_allgather_param_contiguous.py -v
+          "
+
       - name: MORI-EP (async_ll IBGDA)
         run: |
           $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "

--- a/include/mori/collective/allgather/oneshot_allgather_sdma_class.hpp
+++ b/include/mori/collective/allgather/oneshot_allgather_sdma_class.hpp
@@ -238,9 +238,8 @@ class AllgatherSdma {
 
   int64_t prepare_sync(T* input, T* output, size_t total_count, hipStream_t stream);
   int64_t prepare_sync_param_contiguous(T* input, T* output, size_t total_count,
-                                        const size_t* split_sizes,
-                                        const size_t* split_offsets, size_t split_count,
-                                        hipStream_t stream);
+                                        const size_t* split_sizes, const size_t* split_offsets,
+                                        size_t split_count, hipStream_t stream);
   double finish_sync(T* output, size_t total_count, hipStream_t stream);
   int64_t prepare_async_start(T* input, T* output, size_t total_count, hipStream_t stream);
   int64_t prepare_async_start_param_contiguous(T* input, T* output, size_t total_count,

--- a/include/mori/collective/allgather/oneshot_allgather_sdma_class.hpp
+++ b/include/mori/collective/allgather/oneshot_allgather_sdma_class.hpp
@@ -237,8 +237,16 @@ class AllgatherSdma {
   void resetFlags();
 
   int64_t prepare_sync(T* input, T* output, size_t total_count, hipStream_t stream);
+  int64_t prepare_sync_param_contiguous(T* input, T* output, size_t total_count,
+                                        const size_t* split_sizes,
+                                        const size_t* split_offsets, size_t split_count,
+                                        hipStream_t stream);
   double finish_sync(T* output, size_t total_count, hipStream_t stream);
   int64_t prepare_async_start(T* input, T* output, size_t total_count, hipStream_t stream);
+  int64_t prepare_async_start_param_contiguous(T* input, T* output, size_t total_count,
+                                               const size_t* split_sizes,
+                                               const size_t* split_offsets, size_t split_count,
+                                               hipStream_t stream);
   void after_async_start();
   int64_t prepare_async_wait(hipStream_t stream);
   double finish_async_wait(hipStream_t stream);

--- a/include/mori/collective/allgather/oneshot_sdma_async_kernel.hpp
+++ b/include/mori/collective/allgather/oneshot_sdma_async_kernel.hpp
@@ -92,6 +92,58 @@ __global__ void OneShotAllGatherSdmaAsyncPutKernel(int myPe, int npes, T* input,
                                              elementCount, dstBaseOffset);
 }
 
+template <typename T>
+__device__ void OneShotAllGatherSdmaParamContiguousAsyncPutKernel_body(
+    int myPe, int npes, T* input, const application::SymmMemObjPtr srcMemObj,
+    const application::SymmMemObjPtr dstMemObj, const application::SymmMemObjPtr flagsMemObj,
+    size_t elementCount, size_t dstBaseOffset, const size_t* splitSizes,
+    const size_t* splitOffsets, size_t splitCount) {
+  if (elementCount == 0 || npes <= 0 || splitCount == 0) {
+    return;
+  }
+
+  const size_t threadLinearId =
+      static_cast<size_t>(blockIdx.x) * static_cast<size_t>(blockDim.x) + threadIdx.x;
+  int warpId = threadLinearId / warpSize;
+  const int laneId = threadIdx.x % warpSize;
+  const size_t bytesPerElement = sizeof(T);
+
+  if (warpId < npes && laneId == 0) {
+    int remotePe = warpId;
+    application::SymmMemObjPtr dest = dstMemObj;
+    anvil::SdmaQueueDeviceHandle** devicehandles =
+        dest->deviceHandles_d + remotePe * dest->sdmaNumQueue;
+    HSAuint64* signals = dest->signalPtrs + remotePe * dest->sdmaNumQueue;
+    HSAuint64* expectedSignals = dest->expectSignalsPtr + remotePe * dest->sdmaNumQueue;
+
+    for (size_t split = 0; split < splitCount; ++split) {
+      size_t splitElems = splitSizes[split];
+      if (splitElems == 0) {
+        continue;
+      }
+      size_t inputElemOffset = splitOffsets[split];
+      size_t outputElemOffset = splitOffsets[split] * static_cast<size_t>(npes) +
+                                static_cast<size_t>(myPe) * splitElems;
+      uint8_t* srcPtr = reinterpret_cast<uint8_t*>(input) + inputElemOffset * bytesPerElement;
+      uint8_t* dstPtr = reinterpret_cast<uint8_t*>(dest->peerPtrs[remotePe]) + dstBaseOffset +
+                        outputElemOffset * bytesPerElement;
+      core::SdmaPutThread(srcPtr, dstPtr, splitElems * bytesPerElement, devicehandles, signals,
+                          expectedSignals, dest->sdmaNumQueue, 0);
+    }
+  }
+}
+
+template <typename T>
+__global__ void OneShotAllGatherSdmaParamContiguousAsyncPutKernel(
+    int myPe, int npes, T* input, const application::SymmMemObjPtr srcMemObj,
+    const application::SymmMemObjPtr dstMemObj, const application::SymmMemObjPtr flagsMemObj,
+    size_t elementCount, size_t dstBaseOffset = 0, const size_t* splitSizes = nullptr,
+    const size_t* splitOffsets = nullptr, size_t splitCount = 0) {
+  OneShotAllGatherSdmaParamContiguousAsyncPutKernel_body<T>(
+      myPe, npes, input, srcMemObj, dstMemObj, flagsMemObj, elementCount, dstBaseOffset,
+      splitSizes, splitOffsets, splitCount);
+}
+
 __device__ void OneShotAllGatherSdmaAsyncWaitKernel_body(
     int myPe, int npes, const application::SymmMemObjPtr dstMemObj,
     const application::SymmMemObjPtr flagsMemObj, uint64_t flagVal = 1) {

--- a/include/mori/collective/allgather/oneshot_sdma_async_kernel.hpp
+++ b/include/mori/collective/allgather/oneshot_sdma_async_kernel.hpp
@@ -98,7 +98,8 @@ __device__ void OneShotAllGatherSdmaParamContiguousAsyncPutKernel_body(
     const application::SymmMemObjPtr dstMemObj, const application::SymmMemObjPtr flagsMemObj,
     size_t elementCount, size_t dstBaseOffset, const size_t* splitSizes, const size_t* splitOffsets,
     size_t splitCount) {
-  if (elementCount == 0 || npes <= 0 || splitCount == 0) {
+  if (elementCount == 0 || npes <= 0 || splitCount == 0 || splitSizes == nullptr ||
+      splitOffsets == nullptr) {
     return;
   }
 
@@ -122,8 +123,11 @@ __device__ void OneShotAllGatherSdmaParamContiguousAsyncPutKernel_body(
         continue;
       }
       size_t inputElemOffset = splitOffsets[split];
+      if (inputElemOffset > elementCount || splitElems > elementCount - inputElemOffset) {
+        continue;
+      }
       size_t outputElemOffset =
-          splitOffsets[split] * static_cast<size_t>(npes) + static_cast<size_t>(myPe) * splitElems;
+          inputElemOffset * static_cast<size_t>(npes) + static_cast<size_t>(myPe) * splitElems;
       uint8_t* srcPtr = reinterpret_cast<uint8_t*>(input) + inputElemOffset * bytesPerElement;
       uint8_t* dstPtr = reinterpret_cast<uint8_t*>(dest->peerPtrs[remotePe]) + dstBaseOffset +
                         outputElemOffset * bytesPerElement;

--- a/include/mori/collective/allgather/oneshot_sdma_async_kernel.hpp
+++ b/include/mori/collective/allgather/oneshot_sdma_async_kernel.hpp
@@ -96,8 +96,8 @@ template <typename T>
 __device__ void OneShotAllGatherSdmaParamContiguousAsyncPutKernel_body(
     int myPe, int npes, T* input, const application::SymmMemObjPtr srcMemObj,
     const application::SymmMemObjPtr dstMemObj, const application::SymmMemObjPtr flagsMemObj,
-    size_t elementCount, size_t dstBaseOffset, const size_t* splitSizes,
-    const size_t* splitOffsets, size_t splitCount) {
+    size_t elementCount, size_t dstBaseOffset, const size_t* splitSizes, const size_t* splitOffsets,
+    size_t splitCount) {
   if (elementCount == 0 || npes <= 0 || splitCount == 0) {
     return;
   }
@@ -122,8 +122,8 @@ __device__ void OneShotAllGatherSdmaParamContiguousAsyncPutKernel_body(
         continue;
       }
       size_t inputElemOffset = splitOffsets[split];
-      size_t outputElemOffset = splitOffsets[split] * static_cast<size_t>(npes) +
-                                static_cast<size_t>(myPe) * splitElems;
+      size_t outputElemOffset =
+          splitOffsets[split] * static_cast<size_t>(npes) + static_cast<size_t>(myPe) * splitElems;
       uint8_t* srcPtr = reinterpret_cast<uint8_t*>(input) + inputElemOffset * bytesPerElement;
       uint8_t* dstPtr = reinterpret_cast<uint8_t*>(dest->peerPtrs[remotePe]) + dstBaseOffset +
                         outputElemOffset * bytesPerElement;
@@ -140,8 +140,8 @@ __global__ void OneShotAllGatherSdmaParamContiguousAsyncPutKernel(
     size_t elementCount, size_t dstBaseOffset = 0, const size_t* splitSizes = nullptr,
     const size_t* splitOffsets = nullptr, size_t splitCount = 0) {
   OneShotAllGatherSdmaParamContiguousAsyncPutKernel_body<T>(
-      myPe, npes, input, srcMemObj, dstMemObj, flagsMemObj, elementCount, dstBaseOffset,
-      splitSizes, splitOffsets, splitCount);
+      myPe, npes, input, srcMemObj, dstMemObj, flagsMemObj, elementCount, dstBaseOffset, splitSizes,
+      splitOffsets, splitCount);
 }
 
 __device__ void OneShotAllGatherSdmaAsyncWaitKernel_body(

--- a/include/mori/collective/allgather/oneshot_sdma_kernel.hpp
+++ b/include/mori/collective/allgather/oneshot_sdma_kernel.hpp
@@ -128,7 +128,8 @@ __device__ void OneShotAllGatherSdmaParamContiguousKernel_body(
     const application::SymmMemObjPtr dstMemObj, const application::SymmMemObjPtr flagsMemObj,
     size_t elementCount, size_t dstBaseOffset, uint64_t flagVal, const size_t* splitSizes,
     const size_t* splitOffsets, size_t splitCount) {
-  if (elementCount == 0 || npes <= 0 || splitCount == 0) {
+  if (elementCount == 0 || npes <= 0 || splitCount == 0 || splitSizes == nullptr ||
+      splitOffsets == nullptr) {
     return;
   }
 
@@ -152,8 +153,11 @@ __device__ void OneShotAllGatherSdmaParamContiguousKernel_body(
         continue;
       }
       size_t inputElemOffset = splitOffsets[split];
+      if (inputElemOffset > elementCount || splitElems > elementCount - inputElemOffset) {
+        continue;
+      }
       size_t outputElemOffset =
-          splitOffsets[split] * static_cast<size_t>(npes) + static_cast<size_t>(myPe) * splitElems;
+          inputElemOffset * static_cast<size_t>(npes) + static_cast<size_t>(myPe) * splitElems;
       uint8_t* srcPtr = reinterpret_cast<uint8_t*>(input) + inputElemOffset * bytesPerElement;
       uint8_t* dstPtr = reinterpret_cast<uint8_t*>(dest->peerPtrs[remotePe]) + dstBaseOffset +
                         outputElemOffset * bytesPerElement;

--- a/include/mori/collective/allgather/oneshot_sdma_kernel.hpp
+++ b/include/mori/collective/allgather/oneshot_sdma_kernel.hpp
@@ -152,8 +152,8 @@ __device__ void OneShotAllGatherSdmaParamContiguousKernel_body(
         continue;
       }
       size_t inputElemOffset = splitOffsets[split];
-      size_t outputElemOffset = splitOffsets[split] * static_cast<size_t>(npes) +
-                                static_cast<size_t>(myPe) * splitElems;
+      size_t outputElemOffset =
+          splitOffsets[split] * static_cast<size_t>(npes) + static_cast<size_t>(myPe) * splitElems;
       uint8_t* srcPtr = reinterpret_cast<uint8_t*>(input) + inputElemOffset * bytesPerElement;
       uint8_t* dstPtr = reinterpret_cast<uint8_t*>(dest->peerPtrs[remotePe]) + dstBaseOffset +
                         outputElemOffset * bytesPerElement;
@@ -202,9 +202,9 @@ __global__ void OneShotAllGatherSdmaParamContiguousKernel(
     size_t elementCount, size_t dstBaseOffset = 0, uint64_t flagVal = 1,
     const size_t* splitSizes = nullptr, const size_t* splitOffsets = nullptr,
     size_t splitCount = 0) {
-  OneShotAllGatherSdmaParamContiguousKernel_body<T>(
-      myPe, npes, input, srcMemObj, dstMemObj, flagsMemObj, elementCount, dstBaseOffset, flagVal,
-      splitSizes, splitOffsets, splitCount);
+  OneShotAllGatherSdmaParamContiguousKernel_body<T>(myPe, npes, input, srcMemObj, dstMemObj,
+                                                    flagsMemObj, elementCount, dstBaseOffset,
+                                                    flagVal, splitSizes, splitOffsets, splitCount);
 }
 }  // namespace collective
 }  // namespace mori

--- a/include/mori/collective/allgather/oneshot_sdma_kernel.hpp
+++ b/include/mori/collective/allgather/oneshot_sdma_kernel.hpp
@@ -121,5 +121,90 @@ __global__ void OneShotAllGatherSdmaKernel(int myPe, int npes, T* input,
   OneShotAllGatherSdmaKernel_body<T>(myPe, npes, input, srcMemObj, dstMemObj, flagsMemObj,
                                      elementCount, dstBaseOffset, flagVal);
 }
+
+template <typename T>
+__device__ void OneShotAllGatherSdmaParamContiguousKernel_body(
+    int myPe, int npes, T* input, const application::SymmMemObjPtr srcMemObj,
+    const application::SymmMemObjPtr dstMemObj, const application::SymmMemObjPtr flagsMemObj,
+    size_t elementCount, size_t dstBaseOffset, uint64_t flagVal, const size_t* splitSizes,
+    const size_t* splitOffsets, size_t splitCount) {
+  if (elementCount == 0 || npes <= 0 || splitCount == 0) {
+    return;
+  }
+
+  const size_t threadLinearId =
+      static_cast<size_t>(blockIdx.x) * static_cast<size_t>(blockDim.x) + threadIdx.x;
+  int warpId = threadLinearId / warpSize;
+  const int laneId = threadIdx.x % warpSize;
+  const size_t bytesPerElement = sizeof(T);
+
+  if (warpId < npes && laneId == 0) {
+    int remotePe = warpId;
+    application::SymmMemObjPtr dest = dstMemObj;
+    anvil::SdmaQueueDeviceHandle** devicehandles =
+        dest->deviceHandles_d + remotePe * dest->sdmaNumQueue;
+    HSAuint64* signals = dest->signalPtrs + remotePe * dest->sdmaNumQueue;
+    HSAuint64* expectedSignals = dest->expectSignalsPtr + remotePe * dest->sdmaNumQueue;
+
+    for (size_t split = 0; split < splitCount; ++split) {
+      size_t splitElems = splitSizes[split];
+      if (splitElems == 0) {
+        continue;
+      }
+      size_t inputElemOffset = splitOffsets[split];
+      size_t outputElemOffset = splitOffsets[split] * static_cast<size_t>(npes) +
+                                static_cast<size_t>(myPe) * splitElems;
+      uint8_t* srcPtr = reinterpret_cast<uint8_t*>(input) + inputElemOffset * bytesPerElement;
+      uint8_t* dstPtr = reinterpret_cast<uint8_t*>(dest->peerPtrs[remotePe]) + dstBaseOffset +
+                        outputElemOffset * bytesPerElement;
+      core::SdmaPutThread(srcPtr, dstPtr, splitElems * bytesPerElement, devicehandles, signals,
+                          expectedSignals, dest->sdmaNumQueue, 0);
+    }
+  }
+
+  __syncthreads();
+
+  if (warpId < npes && laneId == 0) {
+    int remotePe = warpId;
+    shmem::ShmemQuietThread(remotePe, dstMemObj);
+    shmem::ShmemAtomicSizeNonFetchThreadKernel<application::TransportType::SDMA>(
+        flagsMemObj, static_cast<size_t>(myPe) * sizeof(uint64_t), &flagVal, 8,
+        core::atomicType::AMO_SET, remotePe, 0);
+  }
+  __syncthreads();
+
+  for (int sender = 0; sender < npes; ++sender) {
+    if (sender == myPe) {
+      continue;
+    }
+
+    if (threadLinearId == 0) {
+      int spinCount = 0;
+      bool warned = false;
+      uint64_t* __restrict__ flags = reinterpret_cast<uint64_t*>(flagsMemObj->localPtr);
+      while (core::AtomicLoadRelaxed(flags + sender) < flagVal) {
+        ++spinCount;
+        if (!warned && spinCount > 10000000) {
+          printf("PE %d: Slow wait for param-contiguous data from peer %d (still waiting)\n", myPe,
+                 sender);
+          warned = true;
+        }
+      }
+    }
+    __syncthreads();
+  }
+}
+
+template <typename T>
+__global__ void OneShotAllGatherSdmaParamContiguousKernel(
+    int myPe, int npes, T* input, const application::SymmMemObjPtr srcMemObj,
+    const application::SymmMemObjPtr dstMemObj, const application::SymmMemObjPtr flagsMemObj,
+    size_t elementCount, size_t dstBaseOffset = 0, uint64_t flagVal = 1,
+    const size_t* splitSizes = nullptr, const size_t* splitOffsets = nullptr,
+    size_t splitCount = 0) {
+  OneShotAllGatherSdmaParamContiguousKernel_body<T>(
+      myPe, npes, input, srcMemObj, dstMemObj, flagsMemObj, elementCount, dstBaseOffset, flagVal,
+      splitSizes, splitOffsets, splitCount);
+}
 }  // namespace collective
 }  // namespace mori

--- a/include/mori/collective/ccl_kernel_args.hpp
+++ b/include/mori/collective/ccl_kernel_args.hpp
@@ -53,6 +53,9 @@ struct CclAllgatherArgs {
   size_t elementCount;
   size_t dstBaseOffset;
   uint64_t flagVal;
+  const size_t* splitSizes;
+  const size_t* splitOffsets;
+  size_t splitCount;
 };
 
 template <typename T>

--- a/include/mori/shmem/shmem_api.hpp
+++ b/include/mori/shmem/shmem_api.hpp
@@ -79,6 +79,7 @@ int ShmemSetAttrUniqueIdArgs(int rank, int nranks, mori_shmem_uniqueid_t* uid,
                              mori_shmem_init_attr_t* attr);
 int ShmemInitAttr(unsigned int flags, mori_shmem_init_attr_t* attr);
 
+bool ShmemIsInitialized();
 int ShmemFinalize();
 
 int ShmemModuleInit(void* hipModule);

--- a/python/mori/ccl/collective.py
+++ b/python/mori/ccl/collective.py
@@ -284,6 +284,8 @@ class AllgatherSdma:
         split_offsets,
         stream=None,
     ) -> bool:
+        if split_sizes.numel() != split_offsets.numel():
+            raise ValueError("split_sizes and split_offsets must have the same length")
         byte_count = count * input_data.element_size()
         u32_count = (byte_count + 3) // 4
         s = _stream_to_int(stream)
@@ -299,6 +301,7 @@ class AllgatherSdma:
         _get_ccl_func("OneShotAllGatherSdmaParamContiguousKernel_u32").launch_struct(
             (1,), (512,), 0, s, args
         )
+        self._handle.finish_sync(output_data.data_ptr(), u32_count, s)
         return True
 
     def start_async(self, input_data, output_data, count: int, stream=None) -> bool:
@@ -323,6 +326,8 @@ class AllgatherSdma:
         split_offsets,
         stream=None,
     ) -> bool:
+        if split_sizes.numel() != split_offsets.numel():
+            raise ValueError("split_sizes and split_offsets must have the same length")
         byte_count = count * input_data.element_size()
         u32_count = (byte_count + 3) // 4
         s = _stream_to_int(stream)

--- a/python/mori/ccl/collective.py
+++ b/python/mori/ccl/collective.py
@@ -263,6 +263,38 @@ class AllgatherSdma:
         self._handle.finish_sync(output_data.data_ptr(), u32_count, s)
         return True
 
+    def enqueue(self, input_data, output_data, count: int, stream=None) -> bool:
+        byte_count = count * input_data.element_size()
+        u32_count = (byte_count + 3) // 4
+        s = _stream_to_int(stream)
+        args = self._handle.prepare_sync(
+            input_data.data_ptr(), output_data.data_ptr(), u32_count, s
+        )
+        _get_ccl_func("OneShotAllGatherSdmaKernel_u32").launch_struct(
+            (1,), (512,), 0, s, args
+        )
+        return True
+
+    def enqueue_param_contiguous(
+        self, input_data, output_data, count: int, split_sizes, split_offsets, stream=None
+    ) -> bool:
+        byte_count = count * input_data.element_size()
+        u32_count = (byte_count + 3) // 4
+        s = _stream_to_int(stream)
+        args = self._handle.prepare_sync_param_contiguous(
+            input_data.data_ptr(),
+            output_data.data_ptr(),
+            u32_count,
+            split_sizes.data_ptr(),
+            split_offsets.data_ptr(),
+            split_sizes.numel(),
+            s,
+        )
+        _get_ccl_func("OneShotAllGatherSdmaParamContiguousKernel_u32").launch_struct(
+            (1,), (512,), 0, s, args
+        )
+        return True
+
     def start_async(self, input_data, output_data, count: int, stream=None) -> bool:
         byte_count = count * input_data.element_size()
         u32_count = (byte_count + 3) // 4
@@ -271,6 +303,27 @@ class AllgatherSdma:
             input_data.data_ptr(), output_data.data_ptr(), u32_count, s
         )
         _get_ccl_func("OneShotAllGatherSdmaAsyncPutKernel_u32").launch_struct(
+            (1,), (512,), 0, s, args
+        )
+        self._handle.after_async_start()
+        return True
+
+    def start_async_param_contiguous(
+        self, input_data, output_data, count: int, split_sizes, split_offsets, stream=None
+    ) -> bool:
+        byte_count = count * input_data.element_size()
+        u32_count = (byte_count + 3) // 4
+        s = _stream_to_int(stream)
+        args = self._handle.prepare_async_start_param_contiguous(
+            input_data.data_ptr(),
+            output_data.data_ptr(),
+            u32_count,
+            split_sizes.data_ptr(),
+            split_offsets.data_ptr(),
+            split_sizes.numel(),
+            s,
+        )
+        _get_ccl_func("OneShotAllGatherSdmaParamContiguousAsyncPutKernel_u32").launch_struct(
             (1,), (512,), 0, s, args
         )
         self._handle.after_async_start()

--- a/python/mori/ccl/collective.py
+++ b/python/mori/ccl/collective.py
@@ -276,7 +276,13 @@ class AllgatherSdma:
         return True
 
     def enqueue_param_contiguous(
-        self, input_data, output_data, count: int, split_sizes, split_offsets, stream=None
+        self,
+        input_data,
+        output_data,
+        count: int,
+        split_sizes,
+        split_offsets,
+        stream=None,
     ) -> bool:
         byte_count = count * input_data.element_size()
         u32_count = (byte_count + 3) // 4
@@ -309,7 +315,13 @@ class AllgatherSdma:
         return True
 
     def start_async_param_contiguous(
-        self, input_data, output_data, count: int, split_sizes, split_offsets, stream=None
+        self,
+        input_data,
+        output_data,
+        count: int,
+        split_sizes,
+        split_offsets,
+        stream=None,
     ) -> bool:
         byte_count = count * input_data.element_size()
         u32_count = (byte_count + 3) // 4
@@ -323,9 +335,9 @@ class AllgatherSdma:
             split_sizes.numel(),
             s,
         )
-        _get_ccl_func("OneShotAllGatherSdmaParamContiguousAsyncPutKernel_u32").launch_struct(
-            (1,), (512,), 0, s, args
-        )
+        _get_ccl_func(
+            "OneShotAllGatherSdmaParamContiguousAsyncPutKernel_u32"
+        ).launch_struct((1,), (512,), 0, s, args)
         self._handle.after_async_start()
         return True
 

--- a/python/mori/ccl/collective.py
+++ b/python/mori/ccl/collective.py
@@ -273,6 +273,7 @@ class AllgatherSdma:
         _get_ccl_func("OneShotAllGatherSdmaKernel_u32").launch_struct(
             (1,), (512,), 0, s, args
         )
+        self._handle.finish_sync(output_data.data_ptr(), u32_count, s)
         return True
 
     def enqueue_param_contiguous(

--- a/src/application/memory/symmetric_memory.cpp
+++ b/src/application/memory/symmetric_memory.cpp
@@ -319,8 +319,16 @@ void SymmMemManager::DeregisterSymmMemObj(void* localPtr) {
 
   SymmMemObjPtr memObjPtr = memObjPool.at(localPtr);
   SymmMemObj gpuMemObjHost{};
-  HIP_RUNTIME_CHECK(
-      hipMemcpy(&gpuMemObjHost, memObjPtr.gpu, sizeof(SymmMemObj), hipMemcpyDeviceToHost));
+  bool haveGpuMemObjHost = false;
+  hipError_t copyErr =
+      hipMemcpy(&gpuMemObjHost, memObjPtr.gpu, sizeof(SymmMemObj), hipMemcpyDeviceToHost);
+  if (copyErr == hipSuccess) {
+    haveGpuMemObjHost = true;
+  } else {
+    MORI_APP_WARN("hipMemcpy failed for GPU SymmMemObj during deregistration: {}",
+                  hipGetErrorString(copyErr));
+    (void)hipGetLastError();
+  }
 
   auto freeGpuMetadata = [](void* ptr, const char* name) {
     if (ptr == nullptr) return;
@@ -369,20 +377,24 @@ void SymmMemManager::DeregisterSymmMemObj(void* localPtr) {
     }
     free(memObjPtr.cpu->peerSignalPtrsHost);
   }
-  freeGpuMetadata(gpuMemObjHost.signalPtrs, "signalPtrs");
-  freeGpuMetadata(gpuMemObjHost.expectSignalsPtr, "expectSignalsPtr");
-  freeGpuMetadata(gpuMemObjHost.peerSignalPtrs, "peerSignalPtrs");
-  freeGpuMetadata(gpuMemObjHost.deviceHandles_d, "deviceHandles_d");
+  if (haveGpuMemObjHost) {
+    freeGpuMetadata(gpuMemObjHost.signalPtrs, "signalPtrs");
+    freeGpuMetadata(gpuMemObjHost.expectSignalsPtr, "expectSignalsPtr");
+    freeGpuMetadata(gpuMemObjHost.peerSignalPtrs, "peerSignalPtrs");
+    freeGpuMetadata(gpuMemObjHost.deviceHandles_d, "deviceHandles_d");
+  }
 
   free(memObjPtr.cpu->peerPtrs);
   free(memObjPtr.cpu->p2pPeerPtrs);
   free(memObjPtr.cpu->peerRkeys);
   free(memObjPtr.cpu->ipcMemHandles);
   free(memObjPtr.cpu);
-  HIP_RUNTIME_CHECK(hipFree(gpuMemObjHost.peerPtrs));
-  HIP_RUNTIME_CHECK(hipFree(gpuMemObjHost.p2pPeerPtrs));
-  HIP_RUNTIME_CHECK(hipFree(gpuMemObjHost.peerRkeys));
-  HIP_RUNTIME_CHECK(hipFree(memObjPtr.gpu));
+  if (haveGpuMemObjHost) {
+    freeGpuMetadata(gpuMemObjHost.peerPtrs, "peerPtrs");
+    freeGpuMetadata(gpuMemObjHost.p2pPeerPtrs, "p2pPeerPtrs");
+    freeGpuMetadata(gpuMemObjHost.peerRkeys, "peerRkeys");
+  }
+  freeGpuMetadata(memObjPtr.gpu, "SymmMemObj");
 
   memObjPool.erase(localPtr);
 }

--- a/src/application/memory/symmetric_memory.cpp
+++ b/src/application/memory/symmetric_memory.cpp
@@ -318,6 +318,19 @@ void SymmMemManager::DeregisterSymmMemObj(void* localPtr) {
   if (rdmaDeviceContext) rdmaDeviceContext->DeregisterRdmaMemoryRegion(localPtr);
 
   SymmMemObjPtr memObjPtr = memObjPool.at(localPtr);
+  SymmMemObj gpuMemObjHost{};
+  HIP_RUNTIME_CHECK(
+      hipMemcpy(&gpuMemObjHost, memObjPtr.gpu, sizeof(SymmMemObj), hipMemcpyDeviceToHost));
+
+  auto freeGpuMetadata = [](void* ptr, const char* name) {
+    if (ptr == nullptr) return;
+    hipError_t err = hipFree(ptr);
+    if (err != hipSuccess) {
+      MORI_APP_WARN("hipFree failed for GPU metadata {} ptr {:p}: {}", name, ptr,
+                    hipGetErrorString(err));
+      (void)hipGetLastError();
+    }
+  };
 
   // Close IPC handles for peers that had P2P connection.
   // Skip same-process peers: their p2pPeerPtrs are direct VA pointers, not
@@ -356,19 +369,19 @@ void SymmMemManager::DeregisterSymmMemObj(void* localPtr) {
     }
     free(memObjPtr.cpu->peerSignalPtrsHost);
   }
-  if (memObjPtr.gpu->signalPtrs) HIP_RUNTIME_CHECK(hipFree(memObjPtr.gpu->signalPtrs));
-  if (memObjPtr.gpu->expectSignalsPtr) HIP_RUNTIME_CHECK(hipFree(memObjPtr.gpu->expectSignalsPtr));
-  if (memObjPtr.gpu->peerSignalPtrs) HIP_RUNTIME_CHECK(hipFree(memObjPtr.gpu->peerSignalPtrs));
-  if (memObjPtr.gpu->deviceHandles_d) HIP_RUNTIME_CHECK(hipFree(memObjPtr.gpu->deviceHandles_d));
+  freeGpuMetadata(gpuMemObjHost.signalPtrs, "signalPtrs");
+  freeGpuMetadata(gpuMemObjHost.expectSignalsPtr, "expectSignalsPtr");
+  freeGpuMetadata(gpuMemObjHost.peerSignalPtrs, "peerSignalPtrs");
+  freeGpuMetadata(gpuMemObjHost.deviceHandles_d, "deviceHandles_d");
 
   free(memObjPtr.cpu->peerPtrs);
   free(memObjPtr.cpu->p2pPeerPtrs);
   free(memObjPtr.cpu->peerRkeys);
   free(memObjPtr.cpu->ipcMemHandles);
   free(memObjPtr.cpu);
-  HIP_RUNTIME_CHECK(hipFree(memObjPtr.gpu->peerPtrs));
-  HIP_RUNTIME_CHECK(hipFree(memObjPtr.gpu->p2pPeerPtrs));
-  HIP_RUNTIME_CHECK(hipFree(memObjPtr.gpu->peerRkeys));
+  HIP_RUNTIME_CHECK(hipFree(gpuMemObjHost.peerPtrs));
+  HIP_RUNTIME_CHECK(hipFree(gpuMemObjHost.p2pPeerPtrs));
+  HIP_RUNTIME_CHECK(hipFree(gpuMemObjHost.peerRkeys));
   HIP_RUNTIME_CHECK(hipFree(memObjPtr.gpu));
 
   memObjPool.erase(localPtr);

--- a/src/collective/core/oneshot_allgather_sdma_class.cpp
+++ b/src/collective/core/oneshot_allgather_sdma_class.cpp
@@ -404,9 +404,10 @@ int64_t AllgatherSdma<T>::prepare_sync(T* input, T* output, size_t total_count,
 }
 
 template <typename T>
-int64_t AllgatherSdma<T>::prepare_sync_param_contiguous(
-    T* input, T* output, size_t total_count, const size_t* split_sizes,
-    const size_t* split_offsets, size_t split_count, hipStream_t stream) {
+int64_t AllgatherSdma<T>::prepare_sync_param_contiguous(T* input, T* output, size_t total_count,
+                                                        const size_t* split_sizes,
+                                                        const size_t* split_offsets,
+                                                        size_t split_count, hipStream_t stream) {
   (void)stream;
   uint64_t flag_token = call_seq_.fetch_add(1, std::memory_order_relaxed) + 1;
   auto [regObj, byteOffset] = find_registered(output);
@@ -495,8 +496,8 @@ int64_t AllgatherSdma<T>::prepare_async_start(T* input, T* output, size_t total_
 
 template <typename T>
 int64_t AllgatherSdma<T>::prepare_async_start_param_contiguous(
-    T* input, T* output, size_t total_count, const size_t* split_sizes,
-    const size_t* split_offsets, size_t split_count, hipStream_t stream) {
+    T* input, T* output, size_t total_count, const size_t* split_sizes, const size_t* split_offsets,
+    size_t split_count, hipStream_t stream) {
   bool expected = false;
   if (!async_in_progress_.compare_exchange_strong(expected, true)) {
     throw std::runtime_error("Another async operation is already in progress");

--- a/src/collective/core/oneshot_allgather_sdma_class.cpp
+++ b/src/collective/core/oneshot_allgather_sdma_class.cpp
@@ -26,10 +26,16 @@
 #include <cstring>
 #include <stdexcept>
 
+#include "mori/shmem/internal.hpp"
 #include "mori/shmem/shmem.hpp"
 
 namespace mori {
 namespace collective {
+namespace {
+bool IsShmemInitialized() {
+  return shmem::ShmemStatesSingleton::GetInstance()->status == shmem::ShmemStatesStatus::Initialized;
+}
+}  // namespace
 #if 0
 // Implementation of ShmemDeleter::operator()
 void ShmemDeleter::operator()(void* ptr) const {
@@ -126,6 +132,13 @@ template <typename T>
 AllgatherSdma<T>::~AllgatherSdma() {
   if (async_in_progress_) {
     cancel_async();
+  }
+  if (!IsShmemInitialized()) {
+    registered_output_buffers_.clear();
+    flags_.release();
+    input_transit_buffer_ptr_.release();
+    output_transit_buffer_ptr_.release();
+    return;
   }
   for (auto& [addr, entry] : registered_output_buffers_) {
     shmem::ShmemSymmetricDeregister(reinterpret_cast<void*>(addr), entry.size);
@@ -389,6 +402,34 @@ int64_t AllgatherSdma<T>::prepare_sync(T* input, T* output, size_t total_count,
   jit_args_.elementCount = total_count;
   jit_args_.dstBaseOffset = direct ? byteOffset : 0;
   jit_args_.flagVal = flag_token;
+  jit_args_.splitSizes = nullptr;
+  jit_args_.splitOffsets = nullptr;
+  jit_args_.splitCount = 0;
+
+  return (int64_t)&jit_args_;
+}
+
+template <typename T>
+int64_t AllgatherSdma<T>::prepare_sync_param_contiguous(
+    T* input, T* output, size_t total_count, const size_t* split_sizes,
+    const size_t* split_offsets, size_t split_count, hipStream_t stream) {
+  (void)stream;
+  uint64_t flag_token = call_seq_.fetch_add(1, std::memory_order_relaxed) + 1;
+  auto [regObj, byteOffset] = find_registered(output);
+  bool direct = regObj.IsValid();
+
+  jit_args_.myPe = myPe_;
+  jit_args_.npes = npes_;
+  jit_args_.input = input;
+  jit_args_.srcMemObj = input_transit_buffer_obj_;
+  jit_args_.dstMemObj = direct ? regObj : output_transit_buffer_obj_;
+  jit_args_.flagsMemObj = flagsObj_;
+  jit_args_.elementCount = total_count;
+  jit_args_.dstBaseOffset = direct ? byteOffset : 0;
+  jit_args_.flagVal = flag_token;
+  jit_args_.splitSizes = split_sizes;
+  jit_args_.splitOffsets = split_offsets;
+  jit_args_.splitCount = split_count;
 
   return (int64_t)&jit_args_;
 }
@@ -451,6 +492,46 @@ int64_t AllgatherSdma<T>::prepare_async_start(T* input, T* output, size_t total_
   jit_args_.elementCount = total_count;
   jit_args_.dstBaseOffset = direct ? byteOffset : 0;
   jit_args_.flagVal = async_flag_token_;
+  jit_args_.splitSizes = nullptr;
+  jit_args_.splitOffsets = nullptr;
+  jit_args_.splitCount = 0;
+
+  return (int64_t)&jit_args_;
+}
+
+template <typename T>
+int64_t AllgatherSdma<T>::prepare_async_start_param_contiguous(
+    T* input, T* output, size_t total_count, const size_t* split_sizes,
+    const size_t* split_offsets, size_t split_count, hipStream_t stream) {
+  bool expected = false;
+  if (!async_in_progress_.compare_exchange_strong(expected, true)) {
+    throw std::runtime_error("Another async operation is already in progress");
+  }
+
+  async_input_ = input;
+  async_output_ = output;
+  async_total_count_ = total_count;
+  async_stream_ = stream;
+  async_start_time_ = CollectiveWallTime();
+  async_flag_token_ = call_seq_.fetch_add(1, std::memory_order_relaxed) + 1;
+
+  auto [regObj, byteOffset] = find_registered(output);
+  bool direct = regObj.IsValid();
+  auto& dst_obj = direct ? regObj : output_transit_buffer_obj_;
+  async_dst_obj_ = dst_obj;
+
+  jit_args_.myPe = myPe_;
+  jit_args_.npes = npes_;
+  jit_args_.input = input;
+  jit_args_.srcMemObj = input_transit_buffer_obj_;
+  jit_args_.dstMemObj = dst_obj;
+  jit_args_.flagsMemObj = flagsObj_;
+  jit_args_.elementCount = total_count;
+  jit_args_.dstBaseOffset = direct ? byteOffset : 0;
+  jit_args_.flagVal = async_flag_token_;
+  jit_args_.splitSizes = split_sizes;
+  jit_args_.splitOffsets = split_offsets;
+  jit_args_.splitCount = split_count;
 
   return (int64_t)&jit_args_;
 }
@@ -474,6 +555,9 @@ int64_t AllgatherSdma<T>::prepare_async_wait(hipStream_t stream) {
   jit_args_.elementCount = 0;
   jit_args_.dstBaseOffset = 0;
   jit_args_.flagVal = async_flag_token_;
+  jit_args_.splitSizes = nullptr;
+  jit_args_.splitOffsets = nullptr;
+  jit_args_.splitCount = 0;
 
   return (int64_t)&jit_args_;
 }

--- a/src/collective/core/oneshot_allgather_sdma_class.cpp
+++ b/src/collective/core/oneshot_allgather_sdma_class.cpp
@@ -26,16 +26,10 @@
 #include <cstring>
 #include <stdexcept>
 
-#include "mori/shmem/internal.hpp"
 #include "mori/shmem/shmem.hpp"
 
 namespace mori {
 namespace collective {
-namespace {
-bool IsShmemInitialized() {
-  return shmem::ShmemStatesSingleton::GetInstance()->status == shmem::ShmemStatesStatus::Initialized;
-}
-}  // namespace
 #if 0
 // Implementation of ShmemDeleter::operator()
 void ShmemDeleter::operator()(void* ptr) const {
@@ -133,7 +127,7 @@ AllgatherSdma<T>::~AllgatherSdma() {
   if (async_in_progress_) {
     cancel_async();
   }
-  if (!IsShmemInitialized()) {
+  if (!shmem::ShmemIsInitialized()) {
     registered_output_buffers_.clear();
     flags_.release();
     input_transit_buffer_ptr_.release();

--- a/src/collective/kernels/ccl_kernels.hip
+++ b/src/collective/kernels/ccl_kernels.hip
@@ -75,6 +75,22 @@ using namespace mori::collective;
                      args.dstBaseOffset);                                   \
   }
 
+#define CCL_WRAP_ALLGATHER_PARAM_CONTIGUOUS(kernel, suffix, T)               \
+  extern "C" __global__ void kernel##_##suffix(CclAllgatherArgs<T> args) {  \
+    kernel##_body<T>(args.myPe, args.npes, args.input, args.srcMemObj,      \
+                     args.dstMemObj, args.flagsMemObj, args.elementCount,   \
+                     args.dstBaseOffset, args.flagVal, args.splitSizes,     \
+                     args.splitOffsets, args.splitCount);                   \
+  }
+
+#define CCL_WRAP_ALLGATHER_PARAM_CONTIGUOUS_ASYNC_PUT(kernel, suffix, T)     \
+  extern "C" __global__ void kernel##_##suffix(CclAllgatherArgs<T> args) {  \
+    kernel##_body<T>(args.myPe, args.npes, args.input, args.srcMemObj,      \
+                     args.dstMemObj, args.flagsMemObj, args.elementCount,   \
+                     args.dstBaseOffset, args.splitSizes, args.splitOffsets, \
+                     args.splitCount);                                      \
+  }
+
 // AllReduce reduce-scatter / fused: (myPe, npes, input, dstMemObj,
 //                                    flagsMemObj, barrier, elementCount)
 #define CCL_WRAP_ALLREDUCE_RS(kernel, suffix, T)                              \
@@ -146,6 +162,9 @@ extern "C" __global__ void OneShotAll2allSdmaAsyncWaitKernel_u32(
 
 CCL_WRAP_ALLGATHER(OneShotAllGatherSdmaKernel, u32, uint32_t)
 CCL_WRAP_ALLGATHER_ASYNC_PUT(OneShotAllGatherSdmaAsyncPutKernel, u32, uint32_t)
+CCL_WRAP_ALLGATHER_PARAM_CONTIGUOUS(OneShotAllGatherSdmaParamContiguousKernel, u32, uint32_t)
+CCL_WRAP_ALLGATHER_PARAM_CONTIGUOUS_ASYNC_PUT(OneShotAllGatherSdmaParamContiguousAsyncPutKernel,
+                                              u32, uint32_t)
 
 extern "C" __global__ void OneShotAllGatherSdmaAsyncWaitKernel_u32(
     CclAllgatherArgs<uint32_t> args) {

--- a/src/pybind/pybind_ccl.cpp
+++ b/src/pybind/pybind_ccl.cpp
@@ -219,9 +219,8 @@ void RegisterMoriCcl(pybind11::module_& m) {
                 reinterpret_cast<const size_t*>(split_offsets), split_count,
                 reinterpret_cast<hipStream_t>(stream));
           },
-          py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"),
-          py::arg("split_sizes_ptr"), py::arg("split_offsets_ptr"), py::arg("split_count"),
-          py::arg("stream"))
+          py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"), py::arg("split_sizes_ptr"),
+          py::arg("split_offsets_ptr"), py::arg("split_count"), py::arg("stream"))
       .def(
           "finish_sync",
           [](AllgatherU32& self, uintptr_t output, size_t count, int64_t stream) -> double {
@@ -249,9 +248,8 @@ void RegisterMoriCcl(pybind11::module_& m) {
                 reinterpret_cast<const size_t*>(split_offsets), split_count,
                 reinterpret_cast<hipStream_t>(stream));
           },
-          py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"),
-          py::arg("split_sizes_ptr"), py::arg("split_offsets_ptr"), py::arg("split_count"),
-          py::arg("stream"))
+          py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"), py::arg("split_sizes_ptr"),
+          py::arg("split_offsets_ptr"), py::arg("split_count"), py::arg("stream"))
       .def("after_async_start", &AllgatherU32::after_async_start)
       .def(
           "prepare_async_wait",

--- a/src/pybind/pybind_ccl.cpp
+++ b/src/pybind/pybind_ccl.cpp
@@ -209,6 +209,20 @@ void RegisterMoriCcl(pybind11::module_& m) {
           },
           py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"), py::arg("stream"))
       .def(
+          "prepare_sync_param_contiguous",
+          [](AllgatherU32& self, uintptr_t input, uintptr_t output, size_t count,
+             uintptr_t split_sizes, uintptr_t split_offsets, size_t split_count,
+             int64_t stream) -> int64_t {
+            return self.prepare_sync_param_contiguous(
+                reinterpret_cast<uint32_t*>(input), reinterpret_cast<uint32_t*>(output), count,
+                reinterpret_cast<const size_t*>(split_sizes),
+                reinterpret_cast<const size_t*>(split_offsets), split_count,
+                reinterpret_cast<hipStream_t>(stream));
+          },
+          py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"),
+          py::arg("split_sizes_ptr"), py::arg("split_offsets_ptr"), py::arg("split_count"),
+          py::arg("stream"))
+      .def(
           "finish_sync",
           [](AllgatherU32& self, uintptr_t output, size_t count, int64_t stream) -> double {
             return self.finish_sync(reinterpret_cast<uint32_t*>(output), count,
@@ -224,6 +238,20 @@ void RegisterMoriCcl(pybind11::module_& m) {
                                             reinterpret_cast<hipStream_t>(stream));
           },
           py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"), py::arg("stream"))
+      .def(
+          "prepare_async_start_param_contiguous",
+          [](AllgatherU32& self, uintptr_t input, uintptr_t output, size_t count,
+             uintptr_t split_sizes, uintptr_t split_offsets, size_t split_count,
+             int64_t stream) -> int64_t {
+            return self.prepare_async_start_param_contiguous(
+                reinterpret_cast<uint32_t*>(input), reinterpret_cast<uint32_t*>(output), count,
+                reinterpret_cast<const size_t*>(split_sizes),
+                reinterpret_cast<const size_t*>(split_offsets), split_count,
+                reinterpret_cast<hipStream_t>(stream));
+          },
+          py::arg("input_ptr"), py::arg("output_ptr"), py::arg("count"),
+          py::arg("split_sizes_ptr"), py::arg("split_offsets_ptr"), py::arg("split_count"),
+          py::arg("stream"))
       .def("after_async_start", &AllgatherU32::after_async_start)
       .def(
           "prepare_async_wait",

--- a/src/shmem/init.cpp
+++ b/src/shmem/init.cpp
@@ -680,6 +680,10 @@ int ShmemInit(application::BootstrapNetwork* bootNet) {
   return 0;
 }
 
+bool ShmemIsInitialized() {
+  return ShmemStatesSingleton::GetInstance()->status == ShmemStatesStatus::Initialized;
+}
+
 /* ---------------------------------------------------------------------------------------------- */
 /*                                      Finalization Helpers                                     */
 /* ---------------------------------------------------------------------------------------------- */

--- a/tests/python/ccl/test_allgather_param_contiguous.py
+++ b/tests/python/ccl/test_allgather_param_contiguous.py
@@ -120,7 +120,6 @@ def _worker(rank: int, world_size: int, port: int) -> None:
             npes=world_size,
             input_buffer_size=total_bytes,
             output_buffer_size=total_bytes * world_size,
-            copy_output_to_user=False,
         )
 
         stream = torch.cuda.Stream(device=device)
@@ -137,6 +136,15 @@ def _worker(rank: int, world_size: int, port: int) -> None:
             sync_output = torch.empty(
                 total_count * world_size, dtype=torch.float32, device=device
             )
+            with pytest.raises(ValueError, match="same length"):
+                handle.enqueue_param_contiguous(
+                    sync_input,
+                    sync_output,
+                    total_count,
+                    split_sizes,
+                    split_offsets[:-1],
+                    stream,
+                )
 
             dist.barrier()
             with torch.cuda.stream(stream):
@@ -151,9 +159,7 @@ def _worker(rank: int, world_size: int, port: int) -> None:
             assert ok, "enqueue_param_contiguous returned false"
             stream.synchronize()
 
-            sync_got = handle.get_output_transit_buffer(
-                dtype=torch.float32, device=device
-            )[: total_count * world_size].clone()
+            sync_got = sync_output.clone()
             _assert_matches_param_contiguous(
                 sync_got,
                 world_size,
@@ -174,6 +180,15 @@ def _worker(rank: int, world_size: int, port: int) -> None:
             async_output = torch.empty(
                 total_count * world_size, dtype=torch.float32, device=device
             )
+            with pytest.raises(ValueError, match="same length"):
+                handle.start_async_param_contiguous(
+                    async_input,
+                    async_output,
+                    total_count,
+                    split_sizes,
+                    split_offsets[:-1],
+                    stream,
+                )
 
             dist.barrier()
             with torch.cuda.stream(stream):
@@ -191,9 +206,7 @@ def _worker(rank: int, world_size: int, port: int) -> None:
             assert elapsed >= 0, "wait_async returned a negative duration"
             stream.synchronize()
 
-            async_got = handle.get_output_transit_buffer(
-                dtype=torch.float32, device=device
-            )[: total_count * world_size].clone()
+            async_got = async_output.clone()
             _assert_matches_param_contiguous(
                 async_got,
                 world_size,

--- a/tests/python/ccl/test_allgather_param_contiguous.py
+++ b/tests/python/ccl/test_allgather_param_contiguous.py
@@ -64,9 +64,9 @@ def _expected_param_contiguous(
     device: torch.device,
     base_offset: int,
 ) -> torch.Tensor:
-    expected = torch.empty(total_count * world_size, dtype=torch.uint32, device=device)
+    expected = torch.empty(total_count * world_size, dtype=torch.float32, device=device)
     for src_rank in range(world_size):
-        src = torch.arange(total_count, dtype=torch.uint32, device=device) + (
+        src = torch.arange(total_count, dtype=torch.float32, device=device) + (
             base_offset + src_rank * 1000
         )
         for split_size, split_offset in zip(split_sizes.tolist(), split_offsets.tolist()):
@@ -102,7 +102,7 @@ def _worker(rank: int, world_size: int, port: int) -> None:
     total_count = 10
     split_sizes_host = torch.tensor([3, 5, 2], dtype=torch.uint64)
     split_offsets_host = torch.tensor([0, 3, 8], dtype=torch.uint64)
-    total_bytes = total_count * torch.tensor([], dtype=torch.uint32).element_size()
+    total_bytes = total_count * torch.tensor([], dtype=torch.float32).element_size()
 
     with TorchDistContext(rank=rank, world_size=world_size, master_port=port):
         shmem.shmem_torch_process_group_init("default")
@@ -124,11 +124,11 @@ def _worker(rank: int, world_size: int, port: int) -> None:
         try:
             sync_base = 100
             sync_input = (
-                torch.arange(total_count, dtype=torch.uint32, device=device)
+                torch.arange(total_count, dtype=torch.float32, device=device)
                 + sync_base
                 + rank * 1000
             )
-            sync_output = torch.empty(total_count * world_size, dtype=torch.uint32, device=device)
+            sync_output = torch.empty(total_count * world_size, dtype=torch.float32, device=device)
 
             dist.barrier()
             with torch.cuda.stream(stream):
@@ -143,7 +143,7 @@ def _worker(rank: int, world_size: int, port: int) -> None:
             assert ok, "enqueue_param_contiguous returned false"
             stream.synchronize()
 
-            sync_got = handle.get_output_transit_buffer(dtype=torch.uint32, device=device)[
+            sync_got = handle.get_output_transit_buffer(dtype=torch.float32, device=device)[
                 : total_count * world_size
             ].clone()
             _assert_matches_param_contiguous(
@@ -159,11 +159,11 @@ def _worker(rank: int, world_size: int, port: int) -> None:
 
             async_base = 10000
             async_input = (
-                torch.arange(total_count, dtype=torch.uint32, device=device)
+                torch.arange(total_count, dtype=torch.float32, device=device)
                 + async_base
                 + rank * 1000
             )
-            async_output = torch.empty(total_count * world_size, dtype=torch.uint32, device=device)
+            async_output = torch.empty(total_count * world_size, dtype=torch.float32, device=device)
 
             dist.barrier()
             with torch.cuda.stream(stream):
@@ -181,7 +181,7 @@ def _worker(rank: int, world_size: int, port: int) -> None:
             assert elapsed >= 0, "wait_async returned a negative duration"
             stream.synchronize()
 
-            async_got = handle.get_output_transit_buffer(dtype=torch.uint32, device=device)[
+            async_got = handle.get_output_transit_buffer(dtype=torch.float32, device=device)[
                 : total_count * world_size
             ].clone()
             _assert_matches_param_contiguous(

--- a/tests/python/ccl/test_allgather_param_contiguous.py
+++ b/tests/python/ccl/test_allgather_param_contiguous.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Correctness test for param-contiguous SDMA allgather output.
+
+The param-contiguous layout stores each local input split contiguously across
+all ranks:
+
+  output[split_offset * world_size + rank * split_size : ...]
+
+This is the layout FSDP zero-copy allgather consumes.
+"""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+
+import mori.shmem as shmem
+from mori.ccl import AllgatherSdma
+from tests.python.utils import TorchDistContext, get_free_port
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("MORI_ENABLE_SDMA", "").strip().lower()
+    not in ("1", "true", "yes", "on"),
+    reason="requires MORI_ENABLE_SDMA=1",
+)
+
+
+def _expected_param_contiguous(
+    world_size: int,
+    total_count: int,
+    split_sizes: torch.Tensor,
+    split_offsets: torch.Tensor,
+    device: torch.device,
+    base_offset: int,
+) -> torch.Tensor:
+    expected = torch.empty(total_count * world_size, dtype=torch.uint32, device=device)
+    for src_rank in range(world_size):
+        src = torch.arange(total_count, dtype=torch.uint32, device=device) + (
+            base_offset + src_rank * 1000
+        )
+        for split_size, split_offset in zip(split_sizes.tolist(), split_offsets.tolist()):
+            out_start = split_offset * world_size + src_rank * split_size
+            out_end = out_start + split_size
+            expected[out_start:out_end] = src[split_offset : split_offset + split_size]
+    return expected
+
+
+def _assert_matches_param_contiguous(
+    got: torch.Tensor,
+    world_size: int,
+    total_count: int,
+    split_sizes: torch.Tensor,
+    split_offsets: torch.Tensor,
+    device: torch.device,
+    base_offset: int,
+    label: str,
+) -> None:
+    expected = _expected_param_contiguous(
+        world_size, total_count, split_sizes, split_offsets, device, base_offset
+    )
+    if not torch.equal(got, expected):
+        diff = (got != expected).nonzero(as_tuple=False).flatten()[:8].tolist()
+        raise AssertionError(
+            f"{label} param-contiguous allgather mismatch: "
+            f"first mismatching positions={diff}, "
+            f"got={got[diff].tolist()}, expected={expected[diff].tolist()}"
+        )
+
+
+def _worker(rank: int, world_size: int, port: int) -> None:
+    total_count = 10
+    split_sizes_host = torch.tensor([3, 5, 2], dtype=torch.uint64)
+    split_offsets_host = torch.tensor([0, 3, 8], dtype=torch.uint64)
+    total_bytes = total_count * torch.tensor([], dtype=torch.uint32).element_size()
+
+    with TorchDistContext(rank=rank, world_size=world_size, master_port=port):
+        shmem.shmem_torch_process_group_init("default")
+        device = torch.device(f"cuda:{rank}")
+        torch.cuda.set_device(device)
+
+        handle = AllgatherSdma(
+            my_pe=rank,
+            npes=world_size,
+            input_buffer_size=total_bytes,
+            output_buffer_size=total_bytes * world_size,
+            copy_output_to_user=False,
+        )
+
+        stream = torch.cuda.Stream(device=device)
+        split_sizes = split_sizes_host.to(device=device)
+        split_offsets = split_offsets_host.to(device=device)
+
+        try:
+            sync_base = 100
+            sync_input = (
+                torch.arange(total_count, dtype=torch.uint32, device=device)
+                + sync_base
+                + rank * 1000
+            )
+            sync_output = torch.empty(total_count * world_size, dtype=torch.uint32, device=device)
+
+            dist.barrier()
+            with torch.cuda.stream(stream):
+                ok = handle.enqueue_param_contiguous(
+                    sync_input,
+                    sync_output,
+                    total_count,
+                    split_sizes,
+                    split_offsets,
+                    stream,
+                )
+            assert ok, "enqueue_param_contiguous returned false"
+            stream.synchronize()
+
+            sync_got = handle.get_output_transit_buffer(dtype=torch.uint32, device=device)[
+                : total_count * world_size
+            ].clone()
+            _assert_matches_param_contiguous(
+                sync_got,
+                world_size,
+                total_count,
+                split_sizes_host,
+                split_offsets_host,
+                device,
+                sync_base,
+                "sync",
+            )
+
+            async_base = 10000
+            async_input = (
+                torch.arange(total_count, dtype=torch.uint32, device=device)
+                + async_base
+                + rank * 1000
+            )
+            async_output = torch.empty(total_count * world_size, dtype=torch.uint32, device=device)
+
+            dist.barrier()
+            with torch.cuda.stream(stream):
+                ok = handle.start_async_param_contiguous(
+                    async_input,
+                    async_output,
+                    total_count,
+                    split_sizes,
+                    split_offsets,
+                    stream,
+                )
+            assert ok, "start_async_param_contiguous returned false"
+            with torch.cuda.stream(stream):
+                elapsed = handle.wait_async(stream)
+            assert elapsed >= 0, "wait_async returned a negative duration"
+            stream.synchronize()
+
+            async_got = handle.get_output_transit_buffer(dtype=torch.uint32, device=device)[
+                : total_count * world_size
+            ].clone()
+            _assert_matches_param_contiguous(
+                async_got,
+                world_size,
+                total_count,
+                split_sizes_host,
+                split_offsets_host,
+                device,
+                async_base,
+                "async",
+            )
+
+            torch.cuda.synchronize()
+            dist.barrier()
+        finally:
+            torch.cuda.synchronize()
+            dist.barrier()
+            del handle
+            dist.barrier()
+            shmem.shmem_finalize()
+
+
+def test_allgather_param_contiguous_sdma() -> None:
+    world_size = min(2, torch.cuda.device_count())
+    if world_size < 2:
+        pytest.skip("requires at least 2 GPUs")
+
+    port = get_free_port()
+    torch.multiprocessing.spawn(
+        _worker,
+        args=(world_size, port),
+        nprocs=world_size,
+        join=True,
+    )

--- a/tests/python/ccl/test_allgather_param_contiguous.py
+++ b/tests/python/ccl/test_allgather_param_contiguous.py
@@ -73,7 +73,9 @@ def _expected_param_contiguous(
         src = torch.arange(total_count, dtype=torch.float32, device=device) + (
             base_offset + src_rank * 1000
         )
-        for split_size, split_offset in zip(split_sizes.tolist(), split_offsets.tolist()):
+        for split_size, split_offset in zip(
+            split_sizes.tolist(), split_offsets.tolist()
+        ):
             out_start = split_offset * world_size + src_rank * split_size
             out_end = out_start + split_size
             expected[out_start:out_end] = src[split_offset : split_offset + split_size]
@@ -132,7 +134,9 @@ def _worker(rank: int, world_size: int, port: int) -> None:
                 + sync_base
                 + rank * 1000
             )
-            sync_output = torch.empty(total_count * world_size, dtype=torch.float32, device=device)
+            sync_output = torch.empty(
+                total_count * world_size, dtype=torch.float32, device=device
+            )
 
             dist.barrier()
             with torch.cuda.stream(stream):
@@ -147,9 +151,9 @@ def _worker(rank: int, world_size: int, port: int) -> None:
             assert ok, "enqueue_param_contiguous returned false"
             stream.synchronize()
 
-            sync_got = handle.get_output_transit_buffer(dtype=torch.float32, device=device)[
-                : total_count * world_size
-            ].clone()
+            sync_got = handle.get_output_transit_buffer(
+                dtype=torch.float32, device=device
+            )[: total_count * world_size].clone()
             _assert_matches_param_contiguous(
                 sync_got,
                 world_size,
@@ -167,7 +171,9 @@ def _worker(rank: int, world_size: int, port: int) -> None:
                 + async_base
                 + rank * 1000
             )
-            async_output = torch.empty(total_count * world_size, dtype=torch.float32, device=device)
+            async_output = torch.empty(
+                total_count * world_size, dtype=torch.float32, device=device
+            )
 
             dist.barrier()
             with torch.cuda.stream(stream):
@@ -185,9 +191,9 @@ def _worker(rank: int, world_size: int, port: int) -> None:
             assert elapsed >= 0, "wait_async returned a negative duration"
             stream.synchronize()
 
-            async_got = handle.get_output_transit_buffer(dtype=torch.float32, device=device)[
-                : total_count * world_size
-            ].clone()
+            async_got = handle.get_output_transit_buffer(
+                dtype=torch.float32, device=device
+            )[: total_count * world_size].clone()
             _assert_matches_param_contiguous(
                 async_got,
                 world_size,

--- a/tests/python/ccl/test_allgather_param_contiguous.py
+++ b/tests/python/ccl/test_allgather_param_contiguous.py
@@ -32,6 +32,7 @@ This is the layout FSDP zero-copy allgather consumes.
 
 import os
 import sys
+import importlib
 from pathlib import Path
 
 import pytest
@@ -42,11 +43,14 @@ import mori.shmem as shmem
 from mori.ccl import AllgatherSdma
 
 try:
-    from tests.python.utils import TorchDistContext, get_free_port
+    _test_utils = importlib.import_module("tests.python.utils")
 except ModuleNotFoundError:
     repo_root = Path(__file__).resolve().parents[3]
     sys.path.insert(0, str(repo_root))
-    from tests.python.utils import TorchDistContext, get_free_port
+    _test_utils = importlib.import_module("tests.python.utils")
+
+TorchDistContext = _test_utils.TorchDistContext
+get_free_port = _test_utils.get_free_port
 
 
 pytestmark = pytest.mark.skipif(

--- a/tests/python/ccl/test_allgather_param_contiguous.py
+++ b/tests/python/ccl/test_allgather_param_contiguous.py
@@ -31,6 +31,8 @@ This is the layout FSDP zero-copy allgather consumes.
 """
 
 import os
+import sys
+from pathlib import Path
 
 import pytest
 import torch
@@ -38,7 +40,13 @@ import torch.distributed as dist
 
 import mori.shmem as shmem
 from mori.ccl import AllgatherSdma
-from tests.python.utils import TorchDistContext, get_free_port
+
+try:
+    from tests.python.utils import TorchDistContext, get_free_port
+except ModuleNotFoundError:
+    repo_root = Path(__file__).resolve().parents[3]
+    sys.path.insert(0, str(repo_root))
+    from tests.python.utils import TorchDistContext, get_free_port
 
 
 pytestmark = pytest.mark.skipif(


### PR DESCRIPTION
## Summary

This PR adds a param-contiguous SDMA allgather path for FSDP zero-copy output.

The new path lets MORI write allgather output directly in the layout expected by FSDP flattened parameter views, while preserving the existing rank-major allgather path.

## Changes

- Add param-contiguous sync and async SDMA allgather kernels.
- Extend allgather JIT args and Python/pybind APIs for split sizes and offsets.
- Add Python wrappers for `enqueue_param_contiguous()` and `start_async_param_contiguous()`.
- Harden SDMA symmetric memory teardown after SHMEM finalize.
- Add an SDMA-gated CI correctness test for the param-contiguous allgather layout.

## Test Plan

- `MORI_ENABLE_SDMA=1 pytest tests/python/ccl/test_allgather_param_contiguous.py -v`
- Added CI step: `MORI-CCL (param-contiguous allgather SDMA)`