### PR TITLE
(bugfix)Fix MLX5 collapsed-CQ bandwidth spikes

### DIFF
--- a/benchmark/shmem/util.hpp
+++ b/benchmark/shmem/util.hpp
@@ -42,7 +42,7 @@ enum class PutScope { kThread, kWarp, kBlock };
 inline constexpr std::size_t kDefaultMinSize = 4;
 inline constexpr std::size_t kDefaultMaxSize = 64ULL * 1024ULL * 1024ULL;
 inline constexpr std::size_t kDefaultStepFactor = 2;
-inline constexpr std::size_t kDefaultIters = 10;
+inline constexpr std::size_t kDefaultIters = 100;
 inline constexpr std::size_t kDefaultWarmup = 5;
 inline constexpr int kDefaultNumBlocks = 32;
 inline constexpr int kDefaultThreadsPerBlock = 256;

--- a/benchmark/shmem/util.hpp
+++ b/benchmark/shmem/util.hpp
@@ -42,7 +42,7 @@ enum class PutScope { kThread, kWarp, kBlock };
 inline constexpr std::size_t kDefaultMinSize = 4;
 inline constexpr std::size_t kDefaultMaxSize = 64ULL * 1024ULL * 1024ULL;
 inline constexpr std::size_t kDefaultStepFactor = 2;
-inline constexpr std::size_t kDefaultIters = 100;
+inline constexpr std::size_t kDefaultIters = 10;
 inline constexpr std::size_t kDefaultWarmup = 5;
 inline constexpr int kDefaultNumBlocks = 32;
 inline constexpr int kDefaultThreadsPerBlock = 256;

--- a/include/mori/shmem/shmem_ibgda_kernels.hpp
+++ b/include/mori/shmem/shmem_ibgda_kernels.hpp
@@ -366,9 +366,16 @@ inline __device__ void Mlx5CollapsedCqDrain(core::WorkQueueHandle& wq,
       return;
     }
 
+    // Rebuild the 32-bit completion from the 16-bit wqe_counter via the forward
+    // delta, bounded by outstanding (<65536) to drop stale CQEs sitting behind cons.
     uint16_t comp16 = static_cast<uint16_t>(wqeCounter + 1);
-    uint32_t completed = (cons & ~0xffffu) | comp16;
-    if (completed < cons) completed += 0x10000u;  // low-bit wrap into next 64K block
+    uint16_t delta = static_cast<uint16_t>(comp16 - static_cast<uint16_t>(cons));
+    uint32_t live = __hip_atomic_load(&wq.postIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    uint32_t window = live - cons;
+    uint32_t completed = cons;
+    if (delta != 0 && delta <= window) {
+      completed = cons + delta;
+    }
 
     __hip_atomic_fetch_max(&wq.doneIdx, completed, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
     cons = __hip_atomic_load(&wq.doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);

--- a/setup.py
+++ b/setup.py
@@ -382,12 +382,6 @@ class CMakeBuild(build_ext):
         build_umbp = "ON" if build_umbp_enabled else "OFF"
         build_umbp_spdk = "ON" if build_umbp_spdk_enabled else "OFF"
         build_xla_ffi_ops = os.environ.get("BUILD_XLA_FFI_OPS", "OFF")
-        # Benchmarks and examples both require MPI (they bootstrap via
-        # ShmemMpiInit and run under mpirun); the benchmark targets are wrapped
-        # in `if(WITH_MPI)` in benchmark/CMakeLists.txt, so leaving WITH_MPI=OFF
-        # while BUILD_BENCHMARK=ON silently drops every benchmark target and
-        # produces a libmori_shmem.so without ShmemMpiInit. Keep WITH_MPI in
-        # lockstep with anything that needs it.
         with_mpi = (
             "ON"
             if (

--- a/setup.py
+++ b/setup.py
@@ -339,6 +339,7 @@ class CMakeBuild(build_ext):
             ) from exn
         mpi_enabled = (
             os.environ.get("BUILD_EXAMPLES", "OFF").upper() == "ON"
+            or os.environ.get("BUILD_BENCHMARK", "OFF").upper() == "ON"
             or os.environ.get("MORI_WITH_MPI", "OFF").upper() == "ON"
         )
         if mpi_enabled:
@@ -381,10 +382,17 @@ class CMakeBuild(build_ext):
         build_umbp = "ON" if build_umbp_enabled else "OFF"
         build_umbp_spdk = "ON" if build_umbp_spdk_enabled else "OFF"
         build_xla_ffi_ops = os.environ.get("BUILD_XLA_FFI_OPS", "OFF")
+        # Benchmarks and examples both require MPI (they bootstrap via
+        # ShmemMpiInit and run under mpirun); the benchmark targets are wrapped
+        # in `if(WITH_MPI)` in benchmark/CMakeLists.txt, so leaving WITH_MPI=OFF
+        # while BUILD_BENCHMARK=ON silently drops every benchmark target and
+        # produces a libmori_shmem.so without ShmemMpiInit. Keep WITH_MPI in
+        # lockstep with anything that needs it.
         with_mpi = (
             "ON"
             if (
                 build_examples.upper() == "ON"
+                or build_benchmark.upper() == "ON"
                 or os.environ.get("MORI_WITH_MPI", "OFF").upper() == "ON"
             )
             else "OFF"


### PR DESCRIPTION
The old reconstruction misread a stale 16-bit CQE behind cons as a 64K wrap, pushing doneIdx ~64K past postIdx, so quiet returned early and inflated bandwidth (8MB ~120 GB/s). Now we rebuild via the forward 16-bit delta, bounded by the in-flight window (postIdx - cons, <65536), dropping stale reads. Verified: 0 spikes over 100+ runs.