### PR TITLE
feat(io): Enable worker chunking for GPU single-NIC sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -630,10 +630,42 @@ jobs:
             --num-initiator-dev 8 --num-target-dev 8
           wait
 
-      - name: MORI-IO internode cross-rail write (rail affinity)
+      - name: MORI-IO internode multi-worker executor correctness (chunking on)
         run: |
           SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_io_benchmark.sh"
           PORT=29125
+          # Phase-1 worker+chunking path: GPU memory, single NIC, batch API,
+          # numWorkerThreads>1. Sweep crosses the default 64 KiB chunk size,
+          # covering both unsplit and actually chunk-expanded requests.
+          for OP in write read; do
+            echo "=== MORI-IO internode benchmark: multi-worker executor (chunking on, $OP sweep) port=$PORT ==="
+            NODE2_CMD=(
+              $CT exec $CONTAINER bash $SCRIPT
+              --rank 1 --master-addr $NODE1_HOST --master-port $PORT
+              --ifname $NODE2_IFNAME
+              -- --op-type $OP --transfer-batch-size 64 --all
+              --sweep-start-size 1024 --sweep-max-size 1048576 --iters 4
+              --enable-sess --enable-batch-transfer
+              --num-qp-per-transfer 4 --num-worker-threads 4
+              --num-initiator-dev 8 --num-target-dev 8
+            )
+            ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
+            $CT exec $CONTAINER bash $SCRIPT \
+              --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
+              --ifname $NODE1_IFNAME \
+              -- --op-type $OP --transfer-batch-size 64 --all \
+              --sweep-start-size 1024 --sweep-max-size 1048576 --iters 4 \
+              --enable-sess --enable-batch-transfer \
+              --num-qp-per-transfer 4 --num-worker-threads 4 \
+              --num-initiator-dev 8 --num-target-dev 8
+            wait
+            PORT=$((PORT + 1))
+          done
+
+      - name: MORI-IO internode cross-rail write (rail affinity)
+        run: |
+          SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_io_benchmark.sh"
+          PORT=29127
           # Cross-rail validation: --target-dev-offset 5 makes GPU-0 pair with GPU-5
           # (different NUMA → different NIC preference). With MORI_IO_RAIL_AFFINITY=1
           # the receiver must follow the sender's railId, keeping traffic on-rail.

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -72,8 +72,25 @@ void ValidateRdmaTransferConfig(const RdmaBackendConfig& config) {
   }
 }
 
-bool UsesInlineOnly(const RdmaBackendConfig& config) {
-  return config.enableTransferChunking || config.numNicsPerTransfer > 1;
+bool UsesInlineOnly(const RdmaBackendConfig& config) { return config.numNicsPerTransfer > 1; }
+
+static const char* MemoryLocationTypeName(MemoryLocationType loc) {
+  switch (loc) {
+    case MemoryLocationType::CPU:
+      return "CPU";
+    case MemoryLocationType::GPU:
+      return "GPU";
+    case MemoryLocationType::Unknown:
+    default:
+      return "Unknown";
+  }
+}
+
+static bool EndpointMaxMessageSizesHomogeneous(const EpPairVec& eps) {
+  if (eps.empty()) return false;
+  const uint64_t first = eps.front().local.maxMsgSize;
+  return std::all_of(eps.begin(), eps.end(),
+                     [&](const EpPair& ep) { return ep.local.maxMsgSize == first; });
 }
 
 // Parse MORI_IO_POLL_CQ_MODE: "0"/"polling" or "1"/"event" (case-insensitive).
@@ -1278,12 +1295,14 @@ EpPairVec InterleaveEndpointsByLocalDevice(const EpPairVec& eps,
 RdmaBackendSession::RdmaBackendSession(const RdmaBackendConfig& config,
                                        std::vector<application::RdmaMemoryRegion> localMrPerEp,
                                        std::vector<application::RdmaMemoryRegion> remoteMrPerEp,
-                                       const EpPairVec& e, Executor* exec)
+                                       const EpPairVec& e, Executor* exec,
+                                       MemoryLocationType localLoc)
     : config(config),
       localMrPerEp(std::move(localMrPerEp)),
       remoteMrPerEp(std::move(remoteMrPerEp)),
       eps(e),
-      executor(exec) {}
+      executor(exec),
+      localLoc_(localLoc) {}
 
 void RdmaBackendSession::ReadWrite(size_t localOffset, size_t remoteOffset, size_t size,
                                    TransferStatus* status, TransferUniqueId id, bool isRead) {
@@ -1314,18 +1333,87 @@ void RdmaBackendSession::BatchReadWrite(const SizeVec& localOffsets, const SizeV
                                         TransferUniqueId id, bool isRead) {
   MORI_IO_FUNCTION_TIMER;
   status->SetCode(StatusCode::IN_PROGRESS);
-  auto callbackMeta = std::make_shared<CqCallbackMeta>(status, id, sizes.size());
+
+  const bool chunk = config.enableTransferChunking;
+  const bool canUseWorkerChunking =
+      executor != nullptr && chunk && localLoc_ == MemoryLocationType::GPU;
+  if (executor != nullptr && chunk && !canUseWorkerChunking) {
+    bool expected = false;
+    if (warnedChunkedWorkerFallback_->compare_exchange_strong(expected, true,
+                                                              std::memory_order_relaxed)) {
+      MORI_IO_WARN(
+          "executor skipped for chunked transfer because worker chunking is only enabled for GPU "
+          "local memory in Phase 1 (localLoc={}); falling back to inline posting",
+          MemoryLocationTypeName(localLoc_));
+    }
+  }
+
+  int totalCredit = 0;
+  if (canUseWorkerChunking) {
+    const uint64_t maxMessageSize = eps.front().local.maxMsgSize;
+    uint64_t totalWrCount = 0;
+    for (size_t size : sizes) {
+      if (size > std::numeric_limits<uint32_t>::max()) {
+        status->Update(StatusCode::ERR_INVALID_ARGS,
+                       "single request size exceeds UINT32_MAX; split it before submitting");
+        return;
+      }
+      const uint64_t requestWrCount =
+          CountChunksForSize(size, config.chunkBytes, config.maxChunksPerTransfer, maxMessageSize);
+      if (requestWrCount == 0 ||
+          totalWrCount > static_cast<uint64_t>(std::numeric_limits<int>::max()) - requestWrCount) {
+        status->Update(StatusCode::ERR_INVALID_ARGS, "final WR count exceeds int range");
+        return;
+      }
+      totalWrCount += requestWrCount;
+    }
+    totalCredit = static_cast<int>(totalWrCount);
+  } else {
+    if (sizes.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
+      status->Update(StatusCode::ERR_INVALID_ARGS, "batch size exceeds int range");
+      return;
+    }
+    totalCredit = static_cast<int>(sizes.size());
+  }
+
+  auto callbackMeta = std::make_shared<CqCallbackMeta>(status, id, totalCredit);
   internal::PublishCurrentIoCallDiagnostics(callbackMeta);
   RdmaOpRet ret;
-  if (executor) {
-    ExecutorReq req{eps,   localMrPerEp.front(), localOffsets, remoteMrPerEp.front(), remoteOffsets,
-                    sizes, callbackMeta,         id,           config.postBatchSize,  isRead};
+  if (canUseWorkerChunking) {
+    ExecutorReq req{eps,
+                    localMrPerEp.front(),
+                    localOffsets,
+                    remoteMrPerEp.front(),
+                    remoteOffsets,
+                    sizes,
+                    callbackMeta,
+                    id,
+                    config.postBatchSize,
+                    isRead,
+                    config.chunkBytes,
+                    config.maxChunksPerTransfer};
+    ret = executor->RdmaBatchReadWrite(req);
+  } else if (executor != nullptr && !chunk) {
+    ExecutorReq req{eps,
+                    localMrPerEp.front(),
+                    localOffsets,
+                    remoteMrPerEp.front(),
+                    remoteOffsets,
+                    sizes,
+                    callbackMeta,
+                    id,
+                    config.postBatchSize,
+                    isRead,
+                    0,
+                    1};
     ret = executor->RdmaBatchReadWrite(req);
   } else {
+    RdmaTransferControl control{};
+    control.chunkBytes = chunk ? config.chunkBytes : 0;
+    control.maxChunks = config.maxChunksPerTransfer;
+    control.creditByWrCount = chunk;
     ret = RdmaBatchReadWrite(eps, localMrPerEp, remoteMrPerEp, localOffsets, remoteOffsets, sizes,
-                             callbackMeta, id, isRead, config.postBatchSize,
-                             config.enableTransferChunking ? config.chunkBytes : 0,
-                             config.maxChunksPerTransfer, config.enableTransferChunking);
+                             callbackMeta, id, isRead, config.postBatchSize, control);
   }
   assert(!ret.Init());
   if (ret.Failed() || ret.Succeeded()) {
@@ -1389,8 +1477,8 @@ RdmaBackend::RdmaBackend(EngineKey k, const IOEngineConfig& engConfig,
   bool useInlineOnly = UsesInlineOnly(config);
   if (config.numWorkerThreads > 1 && useInlineOnly) {
     MORI_IO_WARN(
-        "numWorkerThreads={} is ignored because transfer chunking / multi-NIC is enabled; "
-        "using single-thread inline posting",
+        "numWorkerThreads={} is ignored because multi-NIC transfer is enabled; using "
+        "single-thread inline posting",
         config.numWorkerThreads);
   }
   if (config.numWorkerThreads > 1 && !useInlineOnly) {
@@ -1573,8 +1661,15 @@ void RdmaBackend::CreateSession(const MemoryDesc& local, const MemoryDesc& remot
     remoteMrPerEp.push_back(remoteMrByDev.at(ep.rdevId));
   }
 
+#ifndef NDEBUG
+  if (local.loc == MemoryLocationType::GPU && !epSet.empty()) {
+    assert(EndpointMaxMessageSizesHomogeneous(epSet) &&
+           "Phase 1: GPU worker chunking expects all eps to share maxMsgSize");
+  }
+#endif
+
   sess = RdmaBackendSession(config, std::move(localMrPerEp), std::move(remoteMrPerEp), epSet,
-                            executor.get());
+                            executor.get(), local.loc);
 }
 
 bool RdmaBackend::PopInboundTransferStatus(EngineKey remote, TransferUniqueId id,

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -86,13 +86,6 @@ static const char* MemoryLocationTypeName(MemoryLocationType loc) {
   }
 }
 
-static bool EndpointMaxMessageSizesHomogeneous(const EpPairVec& eps) {
-  if (eps.empty()) return false;
-  const uint64_t first = eps.front().local.maxMsgSize;
-  return std::all_of(eps.begin(), eps.end(),
-                     [&](const EpPair& ep) { return ep.local.maxMsgSize == first; });
-}
-
 // Parse MORI_IO_POLL_CQ_MODE: "0"/"polling" or "1"/"event" (case-insensitive).
 // Returns nullopt for anything else so env::Override warns and keeps the
 // config value (no silent fallback).
@@ -1342,8 +1335,8 @@ void RdmaBackendSession::BatchReadWrite(const SizeVec& localOffsets, const SizeV
     if (warnedChunkedWorkerFallback_->compare_exchange_strong(expected, true,
                                                               std::memory_order_relaxed)) {
       MORI_IO_WARN(
-          "executor skipped for chunked transfer because worker chunking is only enabled for GPU "
-          "local memory in Phase 1 (localLoc={}); falling back to inline posting",
+          "executor skipped for chunked transfer: worker chunking requires GPU local memory "
+          "(localLoc={}); falling back to inline posting",
           MemoryLocationTypeName(localLoc_));
     }
   }
@@ -1660,13 +1653,6 @@ void RdmaBackend::CreateSession(const MemoryDesc& local, const MemoryDesc& remot
     localMrPerEp.push_back(localMrByDev.at(ep.ldevId));
     remoteMrPerEp.push_back(remoteMrByDev.at(ep.rdevId));
   }
-
-#ifndef NDEBUG
-  if (local.loc == MemoryLocationType::GPU && !epSet.empty()) {
-    assert(EndpointMaxMessageSizesHomogeneous(epSet) &&
-           "Phase 1: GPU worker chunking expects all eps to share maxMsgSize");
-  }
-#endif
 
   sess = RdmaBackendSession(config, std::move(localMrPerEp), std::move(remoteMrPerEp), epSet,
                             executor.get(), local.loc);

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -588,6 +588,17 @@ application::RdmaDeviceContext* RdmaManager::GetRdmaDeviceContext(int devId) {
   return deviceCtxs[devId];
 }
 
+bool RdmaManager::HasIonicDevice() const {
+  for (const auto& [device, portId] : availDevices) {
+    const ibv_device_attr_ex* attr = device->GetDeviceAttr();
+    if (attr && attr->orig_attr.vendor_id ==
+                    static_cast<uint32_t>(application::RdmaDeviceVendorId::Pensando)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 std::vector<std::shared_ptr<EndpointRuntime>> RdmaManager::SnapshotEndpointRuntimes() {
   std::shared_lock<std::shared_mutex> lock(mu);
   std::vector<std::shared_ptr<EndpointRuntime>> result;
@@ -1466,6 +1477,13 @@ RdmaBackend::RdmaBackend(EngineKey k, const IOEngineConfig& engConfig,
   server.reset(new ControlPlaneServer(myEngKey, engConfig.host, engConfig.port, config, rdma.get(),
                                       notif.get()));
   server->Start();
+
+  if (config.qpPerTransfer == 1 && rdma->HasIonicDevice()) {
+    MORI_IO_WARN(
+        "ionic NIC detected with qpPerTransfer=1: single-QP ionic performance is prone to SQ "
+        "full under load; consider increasing qpPerTransfer (e.g. 4) and setting "
+        "numWorkerThreads to the same value");
+  }
 
   bool useInlineOnly = UsesInlineOnly(config);
   if (config.numWorkerThreads > 1 && useInlineOnly) {

--- a/src/io/rdma/backend_impl.hpp
+++ b/src/io/rdma/backend_impl.hpp
@@ -25,6 +25,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <shared_mutex>
@@ -264,7 +265,7 @@ class RdmaBackendSession : public BackendSession {
   RdmaBackendSession(const RdmaBackendConfig& config,
                      std::vector<application::RdmaMemoryRegion> localMrPerEp,
                      std::vector<application::RdmaMemoryRegion> remoteMrPerEp, const EpPairVec& eps,
-                     Executor* executor);
+                     Executor* executor, MemoryLocationType localLoc = MemoryLocationType::CPU);
   ~RdmaBackendSession() = default;
 
   void ReadWrite(size_t localOffset, size_t remoteOffset, size_t size, TransferStatus* status,
@@ -282,6 +283,9 @@ class RdmaBackendSession : public BackendSession {
   std::vector<application::RdmaMemoryRegion> remoteMrPerEp{};
   EpPairVec eps{};
   Executor* executor{nullptr};
+  MemoryLocationType localLoc_{MemoryLocationType::CPU};
+  std::shared_ptr<std::atomic<bool>> warnedChunkedWorkerFallback_{
+      std::make_shared<std::atomic<bool>>(false)};
 };
 
 /* ---------------------------------------------------------------------------------------------- */

--- a/src/io/rdma/backend_impl.hpp
+++ b/src/io/rdma/backend_impl.hpp
@@ -100,6 +100,7 @@ class RdmaManager {
 
   application::RdmaDeviceContext* GetRdmaDeviceContext(int devId);
   size_t NumAvailDevices() const { return availDevices.size(); }
+  bool HasIonicDevice() const;
 
  private:
   application::RdmaDeviceContext* GetOrCreateDeviceContext(int devId);

--- a/src/io/rdma/common.cpp
+++ b/src/io/rdma/common.cpp
@@ -300,27 +300,52 @@ std::vector<std::pair<uint64_t, uint32_t>> PlanChunks(uint32_t total, size_t chu
   return plan;
 }
 
+static uint64_t CeilDiv(uint64_t value, uint64_t divisor) {
+  return value / divisor + ((value % divisor) != 0);
+}
+
+ChunkGeometry PlanChunkGeometry(uint64_t totalLength, size_t chunkBytes, int maxChunks,
+                                uint64_t maxMessageSize) {
+  if (maxChunks <= 0 || maxMessageSize == 0) return {};
+
+  uint64_t softCount = 1;
+  if (chunkBytes > 0 && totalLength > chunkBytes) {
+    softCount = CeilDiv(totalLength, static_cast<uint64_t>(chunkBytes));
+    softCount = std::min<uint64_t>(softCount, static_cast<uint64_t>(maxChunks));
+  }
+
+  const uint64_t hardMinCount = std::max<uint64_t>(CeilDiv(totalLength, maxMessageSize), 1);
+  const uint64_t finalCount = std::max<uint64_t>(softCount, hardMinCount);
+  const uint64_t targetChunkBytes = std::max<uint64_t>(CeilDiv(totalLength, finalCount), 1);
+  return ChunkGeometry{finalCount, targetChunkBytes};
+}
+
+uint64_t CountChunksForSize(uint64_t totalLength, size_t chunkBytes, int maxChunks,
+                            uint64_t maxMessageSize) {
+  if (maxChunks <= 0 || maxMessageSize == 0) return 0;
+  if (totalLength == 0) return 1;
+
+  const bool splittable =
+      (chunkBytes > 0 && totalLength > chunkBytes) || (totalLength > maxMessageSize);
+  if (!splittable) return 1;
+
+  const ChunkGeometry geometry =
+      PlanChunkGeometry(totalLength, chunkBytes, maxChunks, maxMessageSize);
+  if (geometry.targetChunkBytes == 0) return 0;
+  return CeilDiv(totalLength, geometry.targetChunkBytes);
+}
+
 void PlanSgeStreamChunks(std::vector<ChunkedSgeSegment>& plan, const std::vector<ibv_sge>& sges,
                          uint64_t totalLength, size_t chunkBytes, int maxChunks,
                          uint64_t maxMessageSize) {
   plan.clear();
   if (totalLength == 0 || maxChunks <= 0 || maxMessageSize == 0) return;
 
-  auto ceilDiv = [](uint64_t value, uint64_t divisor) {
-    return value / divisor + ((value % divisor) != 0);
-  };
-
-  uint64_t softCount = 1;
-  if (chunkBytes > 0 && totalLength > chunkBytes) {
-    softCount = ceilDiv(totalLength, static_cast<uint64_t>(chunkBytes));
-    softCount = std::min<uint64_t>(softCount, static_cast<uint64_t>(maxChunks));
-  }
-
-  const uint64_t hardMinCount = std::max<uint64_t>(ceilDiv(totalLength, maxMessageSize), 1);
-  const uint64_t finalCount = std::max<uint64_t>(softCount, hardMinCount);
-  const uint64_t targetChunkBytes = std::max<uint64_t>(ceilDiv(totalLength, finalCount), 1);
+  const ChunkGeometry geometry =
+      PlanChunkGeometry(totalLength, chunkBytes, maxChunks, maxMessageSize);
+  if (geometry.targetChunkBytes == 0) return;
   const uint64_t maxReserve = static_cast<uint64_t>(plan.max_size());
-  uint64_t reserveHint = finalCount;
+  uint64_t reserveHint = geometry.finalCount;
   const uint64_t sgeCount = static_cast<uint64_t>(sges.size());
   if (reserveHint <= maxReserve && sgeCount <= maxReserve - reserveHint) reserveHint += sgeCount;
   if (reserveHint <= maxReserve && plan.capacity() < reserveHint) {
@@ -328,7 +353,7 @@ void PlanSgeStreamChunks(std::vector<ChunkedSgeSegment>& plan, const std::vector
   }
 
   uint64_t remoteStreamOffset = 0;
-  uint64_t targetRemaining = std::min(targetChunkBytes, totalLength);
+  uint64_t targetRemaining = std::min(geometry.targetChunkBytes, totalLength);
   for (const ibv_sge& sge : sges) {
     uint64_t sgeRemaining = sge.length;
     uint64_t sgeOffset = 0;
@@ -346,7 +371,7 @@ void PlanSgeStreamChunks(std::vector<ChunkedSgeSegment>& plan, const std::vector
       targetRemaining -= len64;
       if (targetRemaining == 0 && remoteStreamOffset + sgeOffset < totalLength) {
         const uint64_t streamRemaining = totalLength - (remoteStreamOffset + sgeOffset);
-        targetRemaining = std::min(targetChunkBytes, streamRemaining);
+        targetRemaining = std::min(geometry.targetChunkBytes, streamRemaining);
       }
     }
     remoteStreamOffset += sge.length;
@@ -426,8 +451,8 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
                              const std::vector<application::RdmaMemoryRegion>& remoteMrPerEp,
                              const SizeVec& localOffsets, const SizeVec& remoteOffsets,
                              const SizeVec& sizes, std::shared_ptr<CqCallbackMeta> callbackMeta,
-                             TransferUniqueId id, bool isRead, int postBatchSize, size_t chunkBytes,
-                             int maxChunks, bool creditByWrCount) {
+                             TransferUniqueId id, bool isRead, int postBatchSize,
+                             const RdmaTransferControl& control) {
   MORI_IO_FUNCTION_TIMER;
 
   if ((localOffsets.size() != remoteOffsets.size()) || (sizes.size() != remoteOffsets.size())) {
@@ -448,13 +473,17 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
     return {StatusCode::ERR_INVALID_ARGS, "memory-region vectors must align with endpoints"};
   }
 
-  if (maxChunks <= 0) {
+  if (control.maxChunks <= 0) {
     return {StatusCode::ERR_INVALID_ARGS, "maxChunks must be >= 1"};
   }
 
   const application::RdmaMemoryRegion& baseLocalMr = localMrPerEp.front();
   const application::RdmaMemoryRegion& baseRemoteMr = remoteMrPerEp.front();
   for (size_t i = 0; i < batchSize; i++) {
+    if (sizes[i] > std::numeric_limits<uint32_t>::max()) {
+      return {StatusCode::ERR_INVALID_ARGS, "single request size " + std::to_string(sizes[i]) +
+                                                " exceeds UINT32_MAX; split it before submitting"};
+    }
     if (((localOffsets[i] + sizes[i]) > baseLocalMr.length) ||
         ((remoteOffsets[i] + sizes[i]) > baseRemoteMr.length)) {
       return {StatusCode::ERR_INVALID_ARGS, "length out of range"};
@@ -515,7 +544,7 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
   indices.resize(batchSize);
   std::iota(indices.begin(), indices.end(), 0);
 
-  if (!std::is_sorted(remoteOffsets.begin(), remoteOffsets.end())) {
+  if (!control.disableMerge && !std::is_sorted(remoteOffsets.begin(), remoteOffsets.end())) {
     std::sort(indices.begin(), indices.end(),
               [&](size_t a, size_t b) { return remoteOffsets[a] < remoteOffsets[b]; });
   }
@@ -538,9 +567,9 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
     return static_cast<uint64_t>(wr.totalRemoteLength) > localMaxMessageSize;
   };
   auto hasOversizedSge = [&](const MergedWorkRequest& wr) {
-    if (chunkBytes == 0) return false;
+    if (control.chunkBytes == 0) return false;
     for (const ibv_sge& sge : wr.sges) {
-      if (sge.length > chunkBytes) return true;
+      if (sge.length > control.chunkBytes) return true;
     }
     return false;
   };
@@ -576,7 +605,7 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
     const uint32_t currentSize32 = static_cast<uint32_t>(sizes[idx]);
 
     bool merged = false;
-    if (wrCount > 0) {
+    if (!control.disableMerge && wrCount > 0) {
       MergedWorkRequest& lastWr = mergedPool[wrCount - 1];
       const uint64_t expectedRemoteAddr = lastWr.wr.wr.rdma.remote_addr + lastWr.totalRemoteLength;
       if (expectedRemoteAddr == currentRemoteAddr) {
@@ -610,7 +639,7 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
   // [expand-chunked-precompute] Expand oversized WRs into the pooled `chunkedPool`
   // in place (slot reuse); `chunkPlan` is reused by PlanSgeStreamChunks. Note: small
   // WRs are still copied as-is into chunkedPool when any WR needs splitting.
-  const bool canExpandChunks = creditByWrCount && chunkBytes > 0;
+  const bool canExpandChunks = control.creditByWrCount && control.chunkBytes > 0;
   if (!canExpandChunks) {
     for (size_t k = 0; k < wrCount; ++k) {
       const MergedWorkRequest& wr = mergedPool[k];
@@ -658,7 +687,7 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
       }
       const uint64_t remoteBase = wr.wr.wr.rdma.remote_addr;
       PlanSgeStreamChunks(chunkPlan, wr.sges, static_cast<uint64_t>(wr.totalRemoteLength),
-                          chunkBytes, maxChunks, localMaxMessageSize);
+                          control.chunkBytes, control.maxChunks, localMaxMessageSize);
       if (chunkPlan.empty() && wr.totalRemoteLength != 0) {
         return {StatusCode::ERR_BAD_STATE, "failed to plan RDMA chunks for non-empty SGE stream"};
       }
@@ -671,12 +700,12 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
   std::vector<MergedWorkRequest>& mergedWrs = useChunked ? chunkedPool : mergedPool;
   size_t mergedWrCount = useChunked ? chunkedCount : wrCount;
 
-  if (creditByWrCount) {
+  if (control.creditByWrCount) {
     if (mergedWrCount > static_cast<size_t>(std::numeric_limits<int>::max())) {
       return {StatusCode::ERR_INVALID_ARGS, "final WR count exceeds int range"};
     }
     for (size_t k = 0; k < mergedWrCount; ++k) mergedWrs[k].mergedRequests = 1;
-    callbackMeta->totalBatchSize = static_cast<int>(mergedWrCount);
+    if (control.ownsTotalBatchSize) callbackMeta->totalBatchSize = static_cast<int>(mergedWrCount);
   }
 
   size_t epNum = eps.size();
@@ -843,6 +872,21 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
     MORI_IO_TRACE("ibv_post_send ep index {} batch index range [{}, {})", epId, st, end);
   }
   return {StatusCode::IN_PROGRESS, ""};
+}
+
+RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
+                             const std::vector<application::RdmaMemoryRegion>& localMrPerEp,
+                             const std::vector<application::RdmaMemoryRegion>& remoteMrPerEp,
+                             const SizeVec& localOffsets, const SizeVec& remoteOffsets,
+                             const SizeVec& sizes, std::shared_ptr<CqCallbackMeta> callbackMeta,
+                             TransferUniqueId id, bool isRead, int postBatchSize, size_t chunkBytes,
+                             int maxChunks, bool creditByWrCount) {
+  RdmaTransferControl control{};
+  control.chunkBytes = chunkBytes;
+  control.maxChunks = maxChunks;
+  control.creditByWrCount = creditByWrCount;
+  return RdmaBatchReadWrite(eps, localMrPerEp, remoteMrPerEp, localOffsets, remoteOffsets, sizes,
+                            callbackMeta, id, isRead, postBatchSize, control);
 }
 
 RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps, const application::RdmaMemoryRegion& local,

--- a/src/io/rdma/common.hpp
+++ b/src/io/rdma/common.hpp
@@ -140,6 +140,17 @@ struct ChunkedSgeSegment {
   uint32_t length{0};
 };
 
+struct ChunkGeometry {
+  uint64_t finalCount{0};
+  uint64_t targetChunkBytes{0};
+};
+
+ChunkGeometry PlanChunkGeometry(uint64_t totalLength, size_t chunkBytes, int maxChunks,
+                                uint64_t maxMessageSize);
+
+uint64_t CountChunksForSize(uint64_t totalLength, size_t chunkBytes, int maxChunks,
+                            uint64_t maxMessageSize);
+
 void PlanSgeStreamChunks(std::vector<ChunkedSgeSegment>& plan, const std::vector<ibv_sge>& sges,
                          uint64_t totalLength, size_t chunkBytes, int maxChunks,
                          uint64_t maxMessageSize);
@@ -243,6 +254,22 @@ struct RdmaOpRet {
 };
 
 RdmaOpRet RdmaNotifyTransfer(const EpPairVec& eps, TransferStatus* status, TransferUniqueId id);
+
+struct RdmaTransferControl {
+  size_t chunkBytes{0};
+  int maxChunks{1};
+  bool creditByWrCount{false};
+  bool ownsTotalBatchSize{true};
+  bool disableMerge{false};
+};
+
+RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
+                             const std::vector<application::RdmaMemoryRegion>& localMrPerEp,
+                             const std::vector<application::RdmaMemoryRegion>& remoteMrPerEp,
+                             const SizeVec& localOffsets, const SizeVec& remoteOffsets,
+                             const SizeVec& sizes, std::shared_ptr<CqCallbackMeta> callbackMeta,
+                             TransferUniqueId id, bool isRead, int postBatchSize,
+                             const RdmaTransferControl& control);
 
 RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
                              const std::vector<application::RdmaMemoryRegion>& localMrPerEp,

--- a/src/io/rdma/executor.cpp
+++ b/src/io/rdma/executor.cpp
@@ -130,9 +130,23 @@ void MultithreadExecutor::Worker::MainLoop() {
                            task.req->remoteOffsets.begin() + task.end);
     SizeVec tSizes(task.req->sizes.begin() + task.begin, task.req->sizes.begin() + task.end);
 
+    const bool chunk = task.req->chunkBytes > 0;
+    RdmaTransferControl control{};
+    control.chunkBytes = task.req->chunkBytes;
+    control.maxChunks = task.req->maxChunks;
+    control.creditByWrCount = chunk;
+    control.ownsTotalBatchSize = false;
+    control.disableMerge = chunk;
+
+    thread_local std::vector<application::RdmaMemoryRegion> localMrPerEp(1);
+    thread_local std::vector<application::RdmaMemoryRegion> remoteMrPerEp(1);
+    localMrPerEp[0] = task.req->local;
+    remoteMrPerEp[0] = task.req->remote;
+
     RdmaOpRet ret = mori::io::RdmaBatchReadWrite(
-        {task.req->eps[task.epId]}, task.req->local, tLoclOffsets, task.req->remote, tRemoteOffsets,
-        tSizes, task.req->callbackMeta, task.req->id, task.req->isRead, task.req->postBatchSize);
+        {task.req->eps[task.epId]}, localMrPerEp, remoteMrPerEp, tLoclOffsets, tRemoteOffsets,
+        tSizes, task.req->callbackMeta, task.req->id, task.req->isRead, task.req->postBatchSize,
+        control);
     task.ret.set_value(ret);
     MORI_IO_TRACE("Worker {} execute task {} begin {} end {} ret code {}", workerId, task.req->id,
                   task.begin, task.end, static_cast<uint32_t>(ret.code));

--- a/src/io/rdma/executor.hpp
+++ b/src/io/rdma/executor.hpp
@@ -48,6 +48,8 @@ struct ExecutorReq {
   TransferUniqueId id;
   int postBatchSize;
   bool isRead;
+  size_t chunkBytes{0};
+  int maxChunks{1};
 };
 
 /* ---------------------------------------------------------------------------------------------- */

--- a/tests/cpp/io/test_engine.cpp
+++ b/tests/cpp/io/test_engine.cpp
@@ -35,6 +35,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -345,6 +346,196 @@ void CasePlanChunksBoundaries() {
   }
 }
 
+void CaseChunkGeometrySingleSgeCountMatchesPlanner() {
+  constexpr uint64_t kKiB = 1024ull;
+  constexpr uint64_t kMiB = 1024ull * kKiB;
+  constexpr uint64_t kGiB = 1024ull * kMiB;
+
+  const std::vector<size_t> chunkBytesValues{4 * kKiB, 64 * kKiB, kMiB, 0};
+  const std::vector<int> maxChunksValues{1, 4, 64, 4096};
+  const std::vector<uint64_t> maxMessageValues{8 * kKiB, kMiB, 0x80000000ull};
+  const std::vector<uint64_t> totals{0, 1, 4095, 4096, 4097, 64 * kKiB, kMiB, kGiB};
+
+  for (size_t chunkBytes : chunkBytesValues) {
+    for (int maxChunks : maxChunksValues) {
+      for (uint64_t maxMessageSize : maxMessageValues) {
+        for (uint64_t total : totals) {
+          const uint64_t actual = CountChunksForSize(total, chunkBytes, maxChunks, maxMessageSize);
+
+          uint64_t expected = 1;
+          const bool splittable =
+              total != 0 && ((chunkBytes > 0 && total > chunkBytes) || total > maxMessageSize);
+          if (splittable) {
+            std::vector<ibv_sge> sges{
+                ibv_sge{.addr = 0x1000000000ull, .length = static_cast<uint32_t>(total), .lkey = 1},
+            };
+            std::vector<ChunkedSgeSegment> segments;
+            PlanSgeStreamChunks(segments, sges, total, chunkBytes, maxChunks, maxMessageSize);
+            expected = segments.size();
+          }
+
+          Require(actual == expected,
+                  "CountChunksForSize mismatch for total=" + std::to_string(total) +
+                      " chunkBytes=" + std::to_string(chunkBytes) +
+                      " maxChunks=" + std::to_string(maxChunks) + " maxMessageSize=" +
+                      std::to_string(maxMessageSize) + " expected=" + std::to_string(expected) +
+                      " actual=" + std::to_string(actual));
+        }
+      }
+    }
+  }
+}
+
+void CaseChunkGeometryProperties() {
+  ChunkGeometry geometry = PlanChunkGeometry(6, 1, 4, 2);
+  Require(geometry.finalCount == 4, "geometry repro should cap soft count at 4");
+  Require(geometry.targetChunkBytes == 2, "geometry target should respect max message size");
+  Require(CountChunksForSize(6, 1, 4, 2) == 3,
+          "actual chunk count should be ceil(total/target), not finalCount");
+
+  const std::vector<uint64_t> totals{1, 4096, 4097, 1024 * 1024, 17 * 1024 * 1024};
+  const std::vector<uint64_t> maxMessages{2, 4096, 65536, 1024 * 1024};
+  for (uint64_t total : totals) {
+    for (uint64_t maxMessage : maxMessages) {
+      ChunkGeometry g = PlanChunkGeometry(total, 4096, 64, maxMessage);
+      Require(g.targetChunkBytes <= maxMessage,
+              "target chunk bytes must not exceed max message size");
+      Require(CountChunksForSize(total, 4096, 64, maxMessage) >= 1,
+              "non-empty requests must emit at least one WR");
+    }
+  }
+}
+
+void CaseChunkCountSplitInvariant() {
+  constexpr size_t kKiB = 1024ull;
+  constexpr size_t kMiB = 1024ull * kKiB;
+  const SizeVec sizes{0, 1, 4096, 4097, 64 * kKiB + 1, kMiB, 3 * kMiB + 7};
+  constexpr size_t kChunkBytes = 64 * kKiB;
+  constexpr int kMaxChunks = 64;
+  constexpr uint64_t kMaxMessageSize = kMiB;
+
+  auto countRange = [&](size_t begin, size_t end) {
+    uint64_t sum = 0;
+    for (size_t i = begin; i < end; ++i) {
+      sum += CountChunksForSize(sizes[i], kChunkBytes, kMaxChunks, kMaxMessageSize);
+    }
+    return sum;
+  };
+
+  const uint64_t full = countRange(0, sizes.size());
+  const std::vector<std::vector<size_t>> partitions{
+      {0, sizes.size()},
+      {0, 1, sizes.size()},
+      {0, 2, 5, sizes.size()},
+      {0, 3, 3, sizes.size()},
+  };
+  for (const auto& cuts : partitions) {
+    uint64_t partitioned = 0;
+    for (size_t i = 1; i < cuts.size(); ++i) {
+      partitioned += countRange(cuts[i - 1], cuts[i]);
+    }
+    Require(partitioned == full, "chunk count must be invariant under worker splits");
+  }
+}
+
+EpPair MakeRejectingEp(uint64_t maxMessageSize, uint32_t maxSge = 8) {
+  EpPair ep{};
+  ep.local.handle.maxSge = maxSge;
+  ep.local.maxMsgSize = maxMessageSize;
+  ep.sqDepth = std::make_shared<std::atomic<int>>(0);
+  ep.maxSqDepth = 0;
+  ep.degraded = std::make_shared<std::atomic<bool>>(false);
+  ep.ledger = std::make_shared<SubmissionLedger>(16);
+  return ep;
+}
+
+void CaseRdmaTransferControlDisableMergeAndOwnsTotal() {
+  EpPairVec eps{MakeRejectingEp(1024 * 1024)};
+  mori::application::RdmaMemoryRegion localMr{
+      .addr = 0x1000000000ull,
+      .lkey = 1,
+      .rkey = 0,
+      .length = 4096,
+  };
+  mori::application::RdmaMemoryRegion remoteMr{
+      .addr = 0x2000000000ull,
+      .lkey = 0,
+      .rkey = 2,
+      .length = 4096,
+  };
+  SizeVec offsets{0, 1024, 2048};
+  SizeVec sizes{1024, 1024, 1024};
+
+  RdmaTransferControl control{};
+  control.chunkBytes = 4096;
+  control.maxChunks = 64;
+  control.creditByWrCount = true;
+  control.ownsTotalBatchSize = true;
+  control.disableMerge = true;
+
+  TransferStatus status;
+  auto meta = std::make_shared<CqCallbackMeta>(&status, 91, 99);
+  RdmaOpRet ret = RdmaBatchReadWrite(eps, std::vector<mori::application::RdmaMemoryRegion>{localMr},
+                                     std::vector<mori::application::RdmaMemoryRegion>{remoteMr},
+                                     offsets, offsets, sizes, meta, 91, false, -1, control);
+  Require(ret.Failed(), "rejecting EP should fail before post");
+  Require(meta->totalBatchSize == 3, "disableMerge should keep one WR per request");
+  Require(ret.message.find("requested=3") != std::string::npos,
+          "disableMerge path should reserve three WRs; got: " + ret.message);
+
+  control.disableMerge = false;
+  meta = std::make_shared<CqCallbackMeta>(&status, 92, 99);
+  ret = RdmaBatchReadWrite(eps, std::vector<mori::application::RdmaMemoryRegion>{localMr},
+                           std::vector<mori::application::RdmaMemoryRegion>{remoteMr}, offsets,
+                           offsets, sizes, meta, 92, false, -1, control);
+  Require(ret.Failed(), "rejecting EP should fail before post");
+  Require(meta->totalBatchSize == 1, "merge-enabled path should collapse contiguous requests");
+  Require(ret.message.find("requested=1") != std::string::npos,
+          "merge-enabled path should reserve one WR; got: " + ret.message);
+
+  control.disableMerge = true;
+  control.ownsTotalBatchSize = false;
+  meta = std::make_shared<CqCallbackMeta>(&status, 93, 42);
+  ret = RdmaBatchReadWrite(eps, std::vector<mori::application::RdmaMemoryRegion>{localMr},
+                           std::vector<mori::application::RdmaMemoryRegion>{remoteMr}, offsets,
+                           offsets, sizes, meta, 93, false, -1, control);
+  Require(ret.Failed(), "rejecting EP should fail before post");
+  Require(meta->totalBatchSize == 42,
+          "worker control must not overwrite dispatcher-owned totalBatchSize");
+  Require(ret.message.find("requested=3") != std::string::npos,
+          "worker no-merge path should still post one WR per request; got: " + ret.message);
+}
+
+void CaseRdmaRejectsSingleRequestLargerThanUint32() {
+  EpPairVec eps{MakeRejectingEp(1024 * 1024)};
+  const size_t tooLarge = static_cast<size_t>(std::numeric_limits<uint32_t>::max()) + 1;
+  mori::application::RdmaMemoryRegion localMr{
+      .addr = 0x1000000000ull,
+      .lkey = 1,
+      .rkey = 0,
+      .length = tooLarge,
+  };
+  mori::application::RdmaMemoryRegion remoteMr{
+      .addr = 0x2000000000ull,
+      .lkey = 0,
+      .rkey = 2,
+      .length = tooLarge,
+  };
+
+  TransferStatus status;
+  auto meta = std::make_shared<CqCallbackMeta>(&status, 94, 1);
+  RdmaTransferControl control{};
+  RdmaOpRet ret =
+      RdmaBatchReadWrite(eps, std::vector<mori::application::RdmaMemoryRegion>{localMr},
+                         std::vector<mori::application::RdmaMemoryRegion>{remoteMr}, SizeVec{0},
+                         SizeVec{0}, SizeVec{tooLarge}, meta, 94, false, -1, control);
+
+  Require(ret.Failed(), "single requests larger than uint32 SGE length must be rejected");
+  Require(ret.code == StatusCode::ERR_INVALID_ARGS, "oversized single request status mismatch");
+  Require(ret.message.find("UINT32_MAX") != std::string::npos,
+          "oversized single request error should mention UINT32_MAX");
+}
+
 void CaseChunkingDisabledOversizedWrReturnsError() {
   constexpr size_t kMiB = 1024ull * 1024ull;
 
@@ -595,7 +786,7 @@ void CaseUsesInlineOnly() {
   Require(!UsesInlineOnly(cfg), "default config should keep executor-compatible path");
 
   cfg.enableTransferChunking = true;
-  Require(UsesInlineOnly(cfg), "chunking should force inline-only path");
+  Require(!UsesInlineOnly(cfg), "single-NIC chunking should keep executor-compatible path");
 
   cfg.enableTransferChunking = false;
   cfg.numNicsPerTransfer = 2;
@@ -1455,6 +1646,14 @@ int main(int argc, char* argv[]) {
       {"rdma_backend_config_chunking_fields", CaseRdmaBackendConfigChunkingFields},
       {"resolve_requested_nics", CaseResolveRequestedNics},
       {"plan_chunks_boundaries", CasePlanChunksBoundaries},
+      {"chunk_geometry_single_sge_count_matches_planner",
+       CaseChunkGeometrySingleSgeCountMatchesPlanner},
+      {"chunk_geometry_properties", CaseChunkGeometryProperties},
+      {"chunk_count_split_invariant", CaseChunkCountSplitInvariant},
+      {"rdma_transfer_control_disable_merge_and_owns_total",
+       CaseRdmaTransferControlDisableMergeAndOwnsTotal},
+      {"rdma_rejects_single_request_larger_than_uint32",
+       CaseRdmaRejectsSingleRequestLargerThanUint32},
       {"chunking_disabled_oversized_wr_returns_error", CaseChunkingDisabledOversizedWrReturnsError},
       {"sge_stream_chunking_covers_and_respects_limits",
        CaseSgeStreamChunkingCoversAndRespectsLimits},


### PR DESCRIPTION
## Summary
- enable RDMA batch executor with transfer chunking for GPU single-NIC sessions
- add no-merge worker posting with dispatcher-side WR credit accounting
- add chunk geometry/unit coverage and CI sweep for executor + chunking

## Testing
- ./build/tests/cpp/test_engine