### PR TITLE
perf(mori-io): eliminate SQ full spin with futex admission

### DIFF
--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -567,7 +567,8 @@ EndpointId RdmaManager::ConnectEndpoint(EngineKey remoteKey, int devId,
             std::make_shared<std::atomic<int>>(0),
             static_cast<int>(epConfig.maxMsgsNum),
             std::make_shared<std::atomic<bool>>(false),
-            std::make_shared<SubmissionLedger>(config.notifPerQp)};
+            std::make_shared<SubmissionLedger>(config.notifPerQp),
+            std::make_shared<SqAdmissionEvent>()};
   meta.rTable[topoKey].push_back(ep);
 
   EndpointId id = nextEndpointId_.fetch_add(1);
@@ -747,15 +748,19 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
             statusPtr->Update(StatusCode::ERR_RDMA_OP, failureAdvice.ComposeStatusMessage());
             meta->status = nullptr;
           }
-          if (ep.degraded && ep.degraded->load(std::memory_order_relaxed) && ep.ledger) {
+          if (ep.degraded && ep.degraded->load(kSqAdmissionOrder) && ep.ledger) {
             const int orphanedReleased = ep.ledger->ReleaseOrphanedByRecovery(ep.sqDepth.get());
-            ep.degraded->store(false, std::memory_order_relaxed);
+            ep.degraded->store(false, kSqAdmissionOrder);
             MORI_IO_WARN(
                 "ProcessOneCqe: recovered degraded EP eid={} qpn={} by releasing {} orphaned WRs",
                 rt->id, ep.local.handle.qpn, orphanedReleased);
           }
+          NotifySqStateChanged(ep);
         } else if (IsNotifSendWrId(wc[i].wr_id)) {
-          if (ep.sqDepth) ep.sqDepth->fetch_sub(1, std::memory_order_relaxed);
+          if (ep.sqDepth) {
+            ep.sqDepth->fetch_sub(1, kSqAdmissionOrder);
+            NotifySqStateChanged(ep);
+          }
           if (!isFlush) {
             MORI_IO_WARN(
                 "ProcessOneCqe: failed notification SEND CQE, transfer_id={}, released 1 sqDepth",
@@ -821,7 +826,10 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
               "releasing 1 sqDepth under current SEND invariant",
               wc[i].wr_id);
         }
-        if (ep.sqDepth) ep.sqDepth->fetch_sub(1, std::memory_order_relaxed);
+        if (ep.sqDepth) {
+          ep.sqDepth->fetch_sub(1, kSqAdmissionOrder);
+          NotifySqStateChanged(ep);
+        }
       } else {
         // Batch path: wr_id carries a recordId from the SubmissionLedger.
         uint64_t recordId = wc[i].wr_id;
@@ -830,6 +838,7 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
                         ? ep.ledger->ReleaseByCqe(recordId, ep.sqDepth.get(), &mergedBatchSize)
                         : nullptr;
         if (meta) {
+          NotifySqStateChanged(ep);
           uint32_t finishedBefore = meta->finishedBatchSize.fetch_add(mergedBatchSize);
           TransferStatus* statusPtr = meta->status;
           if (statusPtr != nullptr && (finishedBefore + mergedBatchSize) == meta->totalBatchSize) {

--- a/src/io/rdma/common.cpp
+++ b/src/io/rdma/common.cpp
@@ -22,11 +22,16 @@
 #include "src/io/rdma/common.hpp"
 
 #include <infiniband/verbs.h>  // dereferences ibvHandle.qp (forward-declared in core)
+#include <linux/futex.h>
+#include <sys/syscall.h>
+#include <unistd.h>
 
 #include <algorithm>
 #include <cerrno>
 #include <chrono>
+#include <climits>
 #include <cstdlib>
+#include <ctime>
 #include <limits>
 #include <numeric>
 #include <thread>
@@ -191,12 +196,131 @@ uint64_t MakeNotifSendWrId(TransferUniqueId id) {
   return kNotifSendWrIdTag | id;
 }
 
-// SQ depth is an admission counter only. It does not publish data dependencies
-// across threads, so relaxed atomics are sufficient for correctness.
+namespace {
+
+int* FutexAddr(std::atomic<uint32_t>* word) {
+  static_assert(sizeof(std::atomic<uint32_t>) == sizeof(uint32_t));
+  static_assert(alignof(std::atomic<uint32_t>) >= alignof(uint32_t));
+  static_assert(std::atomic<uint32_t>::is_always_lock_free);
+  // Linux futex ABI requires an int* uaddr. Keep this cast local and pass the
+  // returned pointer only to the syscall; do not dereference it in C++.
+  return reinterpret_cast<int*>(word);
+}
+
+timespec ToTimespec(std::chrono::steady_clock::duration d) {
+  using namespace std::chrono;
+  if (d <= steady_clock::duration::zero()) return timespec{0, 0};
+  const auto ns = duration_cast<nanoseconds>(d);
+  timespec ts{};
+  ts.tv_sec = static_cast<time_t>(ns.count() / 1000000000LL);
+  ts.tv_nsec = static_cast<long>(ns.count() % 1000000000LL);
+  return ts;
+}
+
+enum class FutexWaitResult {
+  WokenOrChanged,
+  TimedOut,
+  Unavailable,
+};
+
+FutexWaitResult FutexWaitUntil(std::atomic<uint32_t>* word, uint32_t expected,
+                               std::chrono::steady_clock::time_point deadline) {
+  const auto now = std::chrono::steady_clock::now();
+  if (now >= deadline) return FutexWaitResult::TimedOut;
+
+  timespec timeout = ToTimespec(deadline - now);
+  const int rc = static_cast<int>(syscall(SYS_futex, FutexAddr(word), FUTEX_WAIT_PRIVATE,
+                                          static_cast<int>(expected), &timeout, nullptr, 0));
+  if (rc == 0) return FutexWaitResult::WokenOrChanged;
+
+  const int e = errno;
+  if (e == ETIMEDOUT) return FutexWaitResult::TimedOut;
+  if (e == EAGAIN || e == EINTR) return FutexWaitResult::WokenOrChanged;
+
+  static std::atomic<bool> loggedUnexpectedFutexWait{false};
+  if (!loggedUnexpectedFutexWait.exchange(true, std::memory_order_relaxed)) {
+    MORI_IO_WARN("FUTEX_WAIT_PRIVATE failed: errno={}", e);
+  }
+  return FutexWaitResult::Unavailable;
+}
+
+void FutexWakeAll(std::atomic<uint32_t>* word) {
+  const int rc = static_cast<int>(
+      syscall(SYS_futex, FutexAddr(word), FUTEX_WAKE_PRIVATE, INT_MAX, nullptr, nullptr, 0));
+  if (rc < 0) {
+    MORI_IO_WARN("FUTEX_WAKE_PRIVATE failed: errno={}", errno);
+  }
+}
+
+}  // namespace
+
+void NotifySqStateChanged(const EpPair& ep) {
+  auto* event = ep.sqAdmission.get();
+  if (!event) return;
+
+  event->epoch.fetch_add(1, kSqAdmissionOrder);
+  if (event->waiters.load(kSqAdmissionOrder) == 0) return;
+
+  FutexWakeAll(&event->epoch);
+}
+
+static bool TryReserveSqDepthOnce(const EpPair& ep, int wrCount) {
+  int observed = ep.sqDepth->load(kSqAdmissionOrder);
+  while (true) {
+    const int base = std::max(observed, 0);
+    if (base > ep.maxSqDepth - wrCount) return false;
+
+    const int desired = base + wrCount;
+    if (ep.sqDepth->compare_exchange_weak(observed, desired, kSqAdmissionOrder,
+                                          kSqAdmissionOrder)) {
+      return true;
+    }
+  }
+}
+
+static bool TryReserveSqDepthSpin(const EpPair& ep, int wrCount, int epId, const char* opTag,
+                                  std::string* errMsg,
+                                  SqReserveFailureKind* failureKind = nullptr) {
+  const int kBackoffTimeoutUs = GetSqBackoffTimeoutUs();
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::microseconds(kBackoffTimeoutUs);
+  int backoff = 0;
+  while (true) {
+    if (ep.degraded && ep.degraded->load(kSqAdmissionOrder)) {
+      SetSqReserveFailureKind(failureKind, SqReserveFailureKind::Degraded);
+      if (errMsg) *errMsg = "EP is degraded, rejecting new submissions";
+      return false;
+    }
+
+    if (TryReserveSqDepthOnce(ep, wrCount)) return true;
+
+    if (std::chrono::steady_clock::now() >= deadline) {
+      SetSqReserveFailureKind(failureKind, SqReserveFailureKind::Timeout);
+      const int cur = ep.sqDepth->load(kSqAdmissionOrder);
+      MORI_IO_WARN(
+          "SQ full timeout ({}): ep={} depth={} requested={} max={} after {} us (backoff={})",
+          opTag, epId, cur, wrCount, ep.maxSqDepth, kBackoffTimeoutUs, backoff);
+      if (errMsg) {
+        *errMsg = "SQ full (" + std::string(opTag) + "): ep=" + std::to_string(epId) +
+                  " depth=" + std::to_string(cur) + " requested=" + std::to_string(wrCount) +
+                  " max=" + std::to_string(ep.maxSqDepth);
+      }
+      return false;
+    }
+
+    if (backoff < 16) {
+      std::this_thread::yield();
+    } else {
+      std::this_thread::sleep_for(std::chrono::microseconds(2));
+    }
+    backoff++;
+  }
+}
+
 static bool TryReserveSqDepth(const EpPair& ep, int wrCount, int epId, const char* opTag,
                               std::string* errMsg, SqReserveFailureKind* failureKind = nullptr) {
   if (wrCount <= 0 || !ep.sqDepth) return true;
-  if (ep.degraded && ep.degraded->load(std::memory_order_relaxed)) {
+  if (ep.degraded && ep.degraded->load(kSqAdmissionOrder)) {
     SetSqReserveFailureKind(failureKind, SqReserveFailureKind::Degraded);
     if (errMsg) *errMsg = "EP is degraded, rejecting new submissions";
     return false;
@@ -212,58 +336,83 @@ static bool TryReserveSqDepth(const EpPair& ep, int wrCount, int epId, const cha
     }
     return false;
   }
-  const int kBackoffTimeoutUs = GetSqBackoffTimeoutUs();
-  const auto deadline =
-      std::chrono::steady_clock::now() + std::chrono::microseconds(kBackoffTimeoutUs);
-  int backoff = 0;
-  int cur = ep.sqDepth->load(std::memory_order_relaxed);
-  if (cur < 0) cur = 0;  // defensive: clamp stale negative depth
+
+  if (TryReserveSqDepthOnce(ep, wrCount)) return true;
+
+  auto* event = ep.sqAdmission.get();
+  if (!event) {
+    return TryReserveSqDepthSpin(ep, wrCount, epId, opTag, errMsg, failureKind);
+  }
+
+  const int timeoutUs = GetSqBackoffTimeoutUs();
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::microseconds(timeoutUs);
+  bool useFutex = true;
+  int futexFallbackBackoff = 0;
+
+  struct WaiterGuard {
+    explicit WaiterGuard(SqAdmissionEvent& ev_) : ev(ev_) {
+      ev.waiters.fetch_add(1, kSqAdmissionOrder);
+    }
+    ~WaiterGuard() { ev.waiters.fetch_sub(1, kSqAdmissionOrder); }
+    SqAdmissionEvent& ev;
+  } guard(*event);
+
   while (true) {
-    // Re-check degraded state while waiting to avoid accepting new submissions
-    // after another thread has marked this EP as degraded.
-    if (ep.degraded && ep.degraded->load(std::memory_order_relaxed)) {
+    const uint32_t observedEpoch = event->epoch.load(kSqAdmissionOrder);
+
+    if (ep.degraded && ep.degraded->load(kSqAdmissionOrder)) {
       SetSqReserveFailureKind(failureKind, SqReserveFailureKind::Degraded);
       if (errMsg) *errMsg = "EP is degraded, rejecting new submissions";
       return false;
     }
-    if (cur + wrCount > ep.maxSqDepth) {
-      if (std::chrono::steady_clock::now() >= deadline) {
-        SetSqReserveFailureKind(failureKind, SqReserveFailureKind::Timeout);
-        MORI_IO_WARN(
-            "SQ full timeout ({}): ep={} depth={} requested={} max={} after {} us (backoff={})",
-            opTag, epId, cur, wrCount, ep.maxSqDepth, kBackoffTimeoutUs, backoff);
-        if (errMsg) {
-          *errMsg = "SQ full (" + std::string(opTag) + "): ep=" + std::to_string(epId) +
-                    " depth=" + std::to_string(cur) + " requested=" + std::to_string(wrCount) +
-                    " max=" + std::to_string(ep.maxSqDepth);
-        }
-        return false;
+
+    if (TryReserveSqDepthOnce(ep, wrCount)) return true;
+
+    const auto now = std::chrono::steady_clock::now();
+    if (now >= deadline) {
+      SetSqReserveFailureKind(failureKind, SqReserveFailureKind::Timeout);
+      const int cur = ep.sqDepth->load(kSqAdmissionOrder);
+      MORI_IO_WARN("SQ full timeout ({}): ep={} depth={} requested={} max={} after {} us", opTag,
+                   epId, cur, wrCount, ep.maxSqDepth, timeoutUs);
+      if (errMsg) {
+        *errMsg = "SQ full (" + std::string(opTag) + "): ep=" + std::to_string(epId) +
+                  " depth=" + std::to_string(cur) + " requested=" + std::to_string(wrCount) +
+                  " max=" + std::to_string(ep.maxSqDepth);
       }
-      // Phased backoff: short polite yields, then tiny sleeps to reduce CPU burn.
-      if (backoff < 16) {
-        std::this_thread::yield();
-      } else {
-        std::this_thread::sleep_for(std::chrono::microseconds(2));
-      }
-      backoff++;
-      cur = ep.sqDepth->load(std::memory_order_relaxed);
-      continue;
+      return false;
     }
-    if (ep.sqDepth->compare_exchange_weak(cur, cur + wrCount, std::memory_order_relaxed))
-      return true;
-    if (backoff < 16) {
+
+    if (useFutex) {
+      const FutexWaitResult waitResult = FutexWaitUntil(&event->epoch, observedEpoch, deadline);
+      if (waitResult != FutexWaitResult::Unavailable) {
+        continue;
+      }
+      useFutex = false;
+    }
+
+    if (futexFallbackBackoff < 16) {
       std::this_thread::yield();
     } else {
       std::this_thread::sleep_for(std::chrono::microseconds(2));
     }
-    backoff++;
+    futexFallbackBackoff++;
   }
 }
 
 static void ReleaseSqDepth(const EpPair& ep, int wrCount) {
   if (wrCount <= 0 || !ep.sqDepth) return;
-  ep.sqDepth->fetch_sub(wrCount, std::memory_order_relaxed);
+  ep.sqDepth->fetch_sub(wrCount, kSqAdmissionOrder);
+  NotifySqStateChanged(ep);
 }
+
+namespace detail {
+
+bool TryReserveSqDepthForTesting(const EpPair& ep, int wrCount, std::string* errMsg) {
+  SqReserveFailureKind failureKind = SqReserveFailureKind::None;
+  return TryReserveSqDepth(ep, wrCount, 0, "test", errMsg, &failureKind);
+}
+
+}  // namespace detail
 
 // Fill `plan` with (offset, len) chunks for a transfer of `total` bytes. Clears
 // `plan` first but keeps its capacity so callers can reuse a pooled buffer.
@@ -827,13 +976,14 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
             "ibv_post_send partially posted {} / {} WRs without a posted signaled tail; "
             "marking EP {} as degraded until recovery",
             postedCount, batchWrNum, epId);
-        if (eps[epId].degraded) {
-          eps[epId].degraded->store(true, std::memory_order_relaxed);
-        }
         if (eps[epId].ledger) {
           eps[epId].ledger->InsertOrphaned(epWrsSinceSignal[epId], callbackMeta,
                                            static_cast<int>(epMergedSinceSignal[epId]));
         }
+        if (eps[epId].degraded) {
+          eps[epId].degraded->store(true, kSqAdmissionOrder);
+        }
+        NotifySqStateChanged(eps[epId]);
       }
 
       for (size_t otherEpId = 0; otherEpId < epNum; ++otherEpId) {
@@ -843,9 +993,6 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
             "ibv_post_send failed on ep {}: moving pending unsignaled WRs on ep {} "
             "(wrCount={}, mergedReq={}) to orphaned and marking degraded",
             epId, otherEpId, epWrsSinceSignal[otherEpId], epMergedSinceSignal[otherEpId]);
-        if (eps[otherEpId].degraded) {
-          eps[otherEpId].degraded->store(true, std::memory_order_relaxed);
-        }
         if (eps[otherEpId].ledger) {
           eps[otherEpId].ledger->InsertOrphaned(epWrsSinceSignal[otherEpId], callbackMeta,
                                                 static_cast<int>(epMergedSinceSignal[otherEpId]));
@@ -855,6 +1002,10 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
               "sqDepth may remain stale until endpoint restart",
               otherEpId);
         }
+        if (eps[otherEpId].degraded) {
+          eps[otherEpId].degraded->store(true, kSqAdmissionOrder);
+        }
+        NotifySqStateChanged(eps[otherEpId]);
       }
 
       std::string message = "ibv_post_send failed with " + std::to_string(ret) + ": " +

--- a/src/io/rdma/common.cpp
+++ b/src/io/rdma/common.cpp
@@ -258,9 +258,12 @@ void NotifySqStateChanged(const EpPair& ep) {
   auto* event = ep.sqAdmission.get();
   if (!event) return;
 
-  event->epoch.fetch_add(1, kSqAdmissionOrder);
+  // Avoid an atomic RMW on the CQ hot path when no thread is waiting. A waiter
+  // that this load misses registers after the predicate update and re-checks
+  // sqDepth/degraded before sleeping, so it will not block on stale state.
   if (event->waiters.load(kSqAdmissionOrder) == 0) return;
 
+  event->epoch.fetch_add(1, kSqAdmissionOrder);
   FutexWakeAll(&event->epoch);
 }
 

--- a/src/io/rdma/common.hpp
+++ b/src/io/rdma/common.hpp
@@ -208,6 +208,13 @@ class SubmissionLedger {
   std::unordered_map<uint64_t, SubmissionRecord> records_;
 };
 
+inline constexpr std::memory_order kSqAdmissionOrder = std::memory_order_seq_cst;
+
+struct SqAdmissionEvent {
+  alignas(4) std::atomic<uint32_t> epoch{0};
+  std::atomic<uint32_t> waiters{0};
+};
+
 struct EpPair {
   int weight;
   int ldevId;
@@ -221,6 +228,8 @@ struct EpPair {
   // Degraded flag — set on partial post without signaled tail.
   std::shared_ptr<std::atomic<bool>> degraded;
   std::shared_ptr<SubmissionLedger> ledger;
+  // Shared across EpPair copies that refer to the same QP.
+  std::shared_ptr<SqAdmissionEvent> sqAdmission;
 };
 
 using EndpointId = uint64_t;
@@ -253,7 +262,16 @@ struct RdmaOpRet {
   bool Failed() { return code > StatusCode::ERR_BEGIN; }
 };
 
+void NotifySqStateChanged(const EpPair& ep);
+
 RdmaOpRet RdmaNotifyTransfer(const EpPairVec& eps, TransferStatus* status, TransferUniqueId id);
+
+namespace detail {
+
+// Test hook for SQ admission without proceeding to ibv_post_send on a fake QP.
+bool TryReserveSqDepthForTesting(const EpPair& ep, int wrCount, std::string* errMsg = nullptr);
+
+}  // namespace detail
 
 struct RdmaTransferControl {
   size_t chunkBytes{0};

--- a/src/io/rdma/ledger.cpp
+++ b/src/io/rdma/ledger.cpp
@@ -48,7 +48,7 @@ std::shared_ptr<CqCallbackMeta> SubmissionLedger::ReleaseByCqe(uint64_t recordId
   auto it = records_.find(recordId);
   if (it == records_.end()) return nullptr;
   SubmissionRecord& rec = it->second;
-  if (sqDepth && rec.postedWr > 0) sqDepth->fetch_sub(rec.postedWr, std::memory_order_relaxed);
+  if (sqDepth && rec.postedWr > 0) sqDepth->fetch_sub(rec.postedWr, kSqAdmissionOrder);
   if (outBatchSize) *outBatchSize = rec.batchSize;
   auto meta = std::move(rec.meta);
   records_.erase(it);
@@ -70,7 +70,7 @@ int SubmissionLedger::ReleaseOrphanedByRecovery(std::atomic<int>* sqDepth) {
       ++it;
     }
   }
-  if (sqDepth && total > 0) sqDepth->fetch_sub(total, std::memory_order_relaxed);
+  if (sqDepth && total > 0) sqDepth->fetch_sub(total, kSqAdmissionOrder);
   return total;
 }
 

--- a/tests/cpp/io/test_engine.cpp
+++ b/tests/cpp/io/test_engine.cpp
@@ -247,6 +247,92 @@ void CaseSubmissionLedgerBasic() {
   Require(sqDepth2.load(std::memory_order_relaxed) == 5, "sq depth after posted CQE release");
 }
 
+EpPair MakeSqAdmissionEp(int maxSqDepth, int currentDepth, bool withAdmission = true) {
+  EpPair ep{};
+  ep.sqDepth = std::make_shared<std::atomic<int>>(currentDepth);
+  ep.maxSqDepth = maxSqDepth;
+  ep.degraded = std::make_shared<std::atomic<bool>>(false);
+  if (withAdmission) ep.sqAdmission = std::make_shared<SqAdmissionEvent>();
+  return ep;
+}
+
+bool WaitForSqAdmissionWaiter(const EpPair& ep) {
+  Require(ep.sqAdmission != nullptr, "test EP must have sq admission state");
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (ep.sqAdmission->waiters.load(kSqAdmissionOrder) > 0) return true;
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  return false;
+}
+
+void CaseSqAdmissionReleaseWakesWaiter() {
+  EpPair ep = MakeSqAdmissionEp(1, 1);
+  bool reserveOk = false;
+  std::string err;
+
+  std::thread worker([&]() { reserveOk = detail::TryReserveSqDepthForTesting(ep, 1, &err); });
+
+  const bool sawWaiter = WaitForSqAdmissionWaiter(ep);
+  const auto releaseAt = std::chrono::steady_clock::now();
+  ep.sqDepth->fetch_sub(1, kSqAdmissionOrder);
+  NotifySqStateChanged(ep);
+  worker.join();
+
+  Require(sawWaiter, "timed out waiting for SQ admission waiter in release wake");
+  const auto wakeMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                          std::chrono::steady_clock::now() - releaseAt)
+                          .count();
+  Require(reserveOk, "reserve should succeed after SQ depth release: " + err);
+  Require(wakeMs < 1000, "reserve should wake promptly after SQ depth release");
+  Require(ep.sqDepth->load(kSqAdmissionOrder) == 1, "release wake should reserve returned credit");
+  Require(ep.sqAdmission->waiters.load(kSqAdmissionOrder) == 0,
+          "waiter count should be cleared after release wake");
+}
+
+void CaseSqAdmissionDegradedWakesWaiter() {
+  EpPair ep = MakeSqAdmissionEp(1, 1);
+  bool reserveOk = true;
+  std::string err;
+
+  std::thread worker([&]() { reserveOk = detail::TryReserveSqDepthForTesting(ep, 1, &err); });
+
+  const bool sawWaiter = WaitForSqAdmissionWaiter(ep);
+  const auto notifyAt = std::chrono::steady_clock::now();
+  ep.degraded->store(true, kSqAdmissionOrder);
+  NotifySqStateChanged(ep);
+  worker.join();
+
+  Require(sawWaiter, "timed out waiting for SQ admission waiter in degraded wake");
+  const auto wakeMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                          std::chrono::steady_clock::now() - notifyAt)
+                          .count();
+  Require(!reserveOk, "reserve should fail after degraded notification");
+  Require(err.find("degraded") != std::string::npos,
+          "degraded wake should report degraded failure, got: " + err);
+  Require(wakeMs < 1000, "reserve should wake promptly after degraded notification");
+  Require(ep.sqAdmission->waiters.load(kSqAdmissionOrder) == 0,
+          "waiter count should be cleared after degraded wake");
+}
+
+void CaseSqAdmissionNegativeDepthReserveRepairsCounter() {
+  EpPair ep = MakeSqAdmissionEp(2, -1);
+  std::string err;
+  Require(detail::TryReserveSqDepthForTesting(ep, 1, &err),
+          "reserve from negative sqDepth should succeed: " + err);
+  Require(ep.sqDepth->load(kSqAdmissionOrder) == 1,
+          "reserve from negative sqDepth should repair counter to requested credit");
+}
+
+void CaseSqAdmissionMissingEventFallsBack() {
+  EpPair ep = MakeSqAdmissionEp(1, 0, false);
+  std::string err;
+  Require(detail::TryReserveSqDepthForTesting(ep, 1, &err),
+          "reserve should work when sqAdmission is absent: " + err);
+  Require(ep.sqDepth->load(kSqAdmissionOrder) == 1,
+          "reserve without sqAdmission should still update sqDepth");
+}
+
 void CaseWrIdNamespaceHelpers() {
   const uint64_t taggedZero = MakeNotifSendWrId(0);
   Require(taggedZero == kNotifSendWrIdTag, "tagged zero should only set the reserved high bit");
@@ -1642,6 +1728,11 @@ int main(int argc, char* argv[]) {
   SetLogLevel("info");
   std::vector<TestCase> cases = {
       {"submission_ledger_basic", CaseSubmissionLedgerBasic},
+      {"sq_admission_release_wakes_waiter", CaseSqAdmissionReleaseWakesWaiter},
+      {"sq_admission_degraded_wakes_waiter", CaseSqAdmissionDegradedWakesWaiter},
+      {"sq_admission_negative_depth_reserve_repairs_counter",
+       CaseSqAdmissionNegativeDepthReserveRepairsCounter},
+      {"sq_admission_missing_event_falls_back", CaseSqAdmissionMissingEventFallsBack},
       {"wr_id_namespace_helpers", CaseWrIdNamespaceHelpers},
       {"rdma_backend_config_chunking_fields", CaseRdmaBackendConfigChunkingFields},
       {"resolve_requested_nics", CaseResolveRequestedNics},


### PR DESCRIPTION
## Summary
- add per-QP SQ admission eventcount backed by Linux futex waits
- wake SQ waiters on CQE release, notification SEND release, and degraded state changes
- preserve existing timeout/degraded/capacity behavior and fallback for manually constructed EpPair values
- add focused admission tests for release wake, degraded wake, negative depth repair, and missing admission fallback

## Testing
- ./build/tests/cpp/test_engine