### PR TITLE
feat(umbp): cache remote fetches into local DRAM (dual-scheme)

### DIFF
--- a/python/mori/umbp/__init__.py
+++ b/python/mori/umbp/__init__.py
@@ -71,6 +71,7 @@ _configure_packaged_spdk_proxy()
 _configure_packaged_umbp_master()
 
 from mori.cpp import (
+    CacheRemoteAdmission,
     UMBPClient,
     UMBPConfig,
     UMBPCopyPipelineConfig,
@@ -92,6 +93,7 @@ from mori.cpp import (
 )
 
 __all__ = [
+    "CacheRemoteAdmission",
     "UMBPClient",
     "UMBPConfig",
     "UMBPCopyPipelineConfig",

--- a/src/pybind/pybind_umbp.cpp
+++ b/src/pybind/pybind_umbp.cpp
@@ -210,6 +210,11 @@ void RegisterMoriUmbp(py::module_& m) {
       .def_readwrite("host", &UMBPIoEngineConfig::host)
       .def_readwrite("port", &UMBPIoEngineConfig::port);
 
+  py::enum_<CacheRemoteAdmission>(m, "CacheRemoteAdmission")
+      .value("SIZE", CacheRemoteAdmission::SIZE)
+      .value("NEVER", CacheRemoteAdmission::NEVER)
+      .value("ALWAYS", CacheRemoteAdmission::ALWAYS);
+
   py::class_<UMBPDistributedConfig>(m, "UMBPDistributedConfig")
       .def(py::init<>())
       .def_readwrite("master_config", &UMBPDistributedConfig::master_config)
@@ -219,6 +224,8 @@ void RegisterMoriUmbp(py::module_& m) {
       .def_readwrite("ssd_staging_buffer_slots", &UMBPDistributedConfig::ssd_staging_buffer_slots)
       .def_readwrite("peer_service_port", &UMBPDistributedConfig::peer_service_port)
       .def_readwrite("cache_remote_fetches", &UMBPDistributedConfig::cache_remote_fetches)
+      .def_readwrite("cache_remote_admission", &UMBPDistributedConfig::cache_remote_admission)
+      .def_readwrite("admission_max_block_bytes", &UMBPDistributedConfig::admission_max_block_bytes)
       .def_readwrite("dram_page_size", &UMBPDistributedConfig::dram_page_size);
 
   py::class_<UMBPConfig>(m, "UMBPConfig")

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -795,12 +795,20 @@ void PoolClient::MaybeReCacheAfterRemote(const std::string& key, const void* src
   // allocator: Allocate returns kFailedNoSpace when the tier is full, which we
   // treat as a best-effort miss (the remote read result is unaffected).
 
+  // Prepare the job outside the queue lock: the source buffer is valid for this
+  // call, but copying a multi-MiB block while holding recache_mutex_ would
+  // serialize unrelated Get finalizers behind this memcpy.
+  ReCacheJob job;
+  job.key = key;
+  job.bytes = std::unique_ptr<char[]>(new char[size]);
+  job.size = size;
+  LocalCopyBlock(job.bytes.get(), src, size);
+
   // Enqueue for asynchronous install. The actual DRAM Allocate + copy +
   // Commit→KvEvent::ADD publish is performed by ReCacheWorkerLoop OFF the Get
   // critical path, so it does not add latency to concurrent Gets (the tail-round
-  // TTFT blowup observed with a synchronous on-path install). The block bytes are
-  // copied into the job because `src` (the user dst buffer) is not owned past the
-  // Get return. Bounded queue → drop-on-full keeps best-effort semantics.
+  // TTFT blowup observed with a synchronous on-path install). Bounded queue →
+  // drop-on-full keeps best-effort semantics.
   {
     std::lock_guard<std::mutex> lk(recache_mutex_);
     if (recache_stop_) return;
@@ -808,9 +816,6 @@ void PoolClient::MaybeReCacheAfterRemote(const std::string& key, const void* src
       MORI_UMBP_DEBUG("[PoolClient] MaybeReCacheAfterRemote: queue full, dropping key='{}'", key);
       return;
     }
-    ReCacheJob job;
-    job.key = key;
-    job.bytes.assign(static_cast<const char*>(src), static_cast<const char*>(src) + size);
     recache_queue_.push_back(std::move(job));
   }
   recache_cv_.notify_one();
@@ -830,10 +835,10 @@ void PoolClient::ReCacheWorkerLoop() {
     // copies the bytes, and Commit queues a KvEvent::ADD that reaches the master
     // via heartbeat — mirroring the local Put publish path. kSuccessAlreadyExists
     // makes this idempotent for a repeat remote read of the same key.
-    switch (ExecuteLocalPut(job.key, job.bytes.data(), job.bytes.size(), TierType::DRAM)) {
+    switch (ExecuteLocalPut(job.key, job.bytes.get(), job.size, TierType::DRAM)) {
       case PutAttemptOutcome::kSuccess:
         MORI_UMBP_DEBUG("[PoolClient] ReCacheWorker: re-cached key='{}' size={}", job.key,
-                        job.bytes.size());
+                        job.size);
         break;
       case PutAttemptOutcome::kSuccessAlreadyExists:
         break;

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -782,20 +782,14 @@ PoolClient::GetAttemptOutcome PoolClient::ExecuteLocalGet(const std::string& key
 }
 
 void PoolClient::MaybeReCacheAfterRemote(const std::string& key, const void* src, size_t size) {
-  if (!config_.cache_remote_fetches) return;
   if (!peer_alloc_) return;  // no exportable local DRAM tier on this node
-  if (size == 0) return;
-
-  const auto policy = config_.cache_remote_admission;
-  if (policy == CacheRemoteAdmission::NEVER) return;
-  if (policy == CacheRemoteAdmission::SIZE) {
-    if (config_.admission_max_block_bytes > 0 && size > config_.admission_max_block_bytes) {
-      MORI_UMBP_DEBUG(
-          "[PoolClient] MaybeReCacheAfterRemote: key='{}' size={} exceeds "
-          "admission_max_block_bytes={}",
-          key, size, config_.admission_max_block_bytes);
-      return;
-    }
+  // Admission gate (cache_remote_fetches / size==0 / NEVER / SIZE cap): shared
+  // pure predicate, unit-tested in test_cache_remote_admission.cpp.
+  if (!ShouldAdmitReCache(config_.cache_remote_fetches, config_.cache_remote_admission,
+                          config_.admission_max_block_bytes, size)) {
+    MORI_UMBP_DEBUG("[PoolClient] MaybeReCacheAfterRemote: key='{}' size={} not admitted", key,
+                    size);
+    return;
   }
   // ALWAYS and SIZE both delegate DRAM-capacity enforcement to the peer
   // allocator: Allocate returns kFailedNoSpace when the tier is full, which we

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -512,6 +512,16 @@ bool PoolClient::Init() {
 
   if (config_.master_config.auto_heartbeat) master_client_->StartHeartbeat();
 
+  // Start the async re-cache worker only when the feature is on and this node has
+  // an exportable local DRAM tier to install into.
+  if (config_.cache_remote_fetches && peer_alloc_) {
+    {
+      std::lock_guard<std::mutex> lk(recache_mutex_);
+      recache_stop_ = false;
+    }
+    recache_worker_ = std::thread([this] { ReCacheWorkerLoop(); });
+  }
+
   MORI_UMBP_INFO("[PoolClient] Initialized node_id='{}'", config_.master_config.node_id);
   return true;
 }
@@ -519,6 +529,17 @@ bool PoolClient::Init() {
 void PoolClient::Shutdown() {
   if (!initialized_) return;
   initialized_ = false;
+
+  // Stop the async re-cache worker first: it calls ExecuteLocalPut (which uses
+  // peer_alloc_ + master_client_), so it must be joined before those are torn
+  // down below.
+  {
+    std::lock_guard<std::mutex> lk(recache_mutex_);
+    recache_stop_ = true;
+    recache_queue_.clear();
+  }
+  recache_cv_.notify_all();
+  if (recache_worker_.joinable()) recache_worker_.join();
 
   if (master_client_) {
     master_client_->StopHeartbeat();
@@ -758,6 +779,76 @@ PoolClient::GetAttemptOutcome PoolClient::ExecuteLocalGet(const std::string& key
                              MORI_UMBP_METRIC_CLIENT_INBOUND_GET_BYTES_TOTAL_HELP,
                              {{"traffic", "local"}}, static_cast<double>(size));
   return GetAttemptOutcome::kSuccess;
+}
+
+void PoolClient::MaybeReCacheAfterRemote(const std::string& key, const void* src, size_t size) {
+  if (!config_.cache_remote_fetches) return;
+  if (!peer_alloc_) return;  // no exportable local DRAM tier on this node
+  if (size == 0) return;
+
+  const auto policy = config_.cache_remote_admission;
+  if (policy == CacheRemoteAdmission::NEVER) return;
+  if (policy == CacheRemoteAdmission::SIZE) {
+    if (config_.admission_max_block_bytes > 0 && size > config_.admission_max_block_bytes) {
+      MORI_UMBP_DEBUG(
+          "[PoolClient] MaybeReCacheAfterRemote: key='{}' size={} exceeds "
+          "admission_max_block_bytes={}",
+          key, size, config_.admission_max_block_bytes);
+      return;
+    }
+  }
+  // ALWAYS and SIZE both delegate DRAM-capacity enforcement to the peer
+  // allocator: Allocate returns kFailedNoSpace when the tier is full, which we
+  // treat as a best-effort miss (the remote read result is unaffected).
+
+  // Enqueue for asynchronous install. The actual DRAM Allocate + copy +
+  // Commit→KvEvent::ADD publish is performed by ReCacheWorkerLoop OFF the Get
+  // critical path, so it does not add latency to concurrent Gets (the tail-round
+  // TTFT blowup observed with a synchronous on-path install). The block bytes are
+  // copied into the job because `src` (the user dst buffer) is not owned past the
+  // Get return. Bounded queue → drop-on-full keeps best-effort semantics.
+  {
+    std::lock_guard<std::mutex> lk(recache_mutex_);
+    if (recache_stop_) return;
+    if (recache_queue_.size() >= recache_queue_max_) {
+      MORI_UMBP_DEBUG("[PoolClient] MaybeReCacheAfterRemote: queue full, dropping key='{}'", key);
+      return;
+    }
+    ReCacheJob job;
+    job.key = key;
+    job.bytes.assign(static_cast<const char*>(src), static_cast<const char*>(src) + size);
+    recache_queue_.push_back(std::move(job));
+  }
+  recache_cv_.notify_one();
+}
+
+void PoolClient::ReCacheWorkerLoop() {
+  for (;;) {
+    ReCacheJob job;
+    {
+      std::unique_lock<std::mutex> lk(recache_mutex_);
+      recache_cv_.wait(lk, [this] { return recache_stop_ || !recache_queue_.empty(); });
+      if (recache_stop_ && recache_queue_.empty()) return;
+      job = std::move(recache_queue_.front());
+      recache_queue_.pop_front();
+    }
+    // Install into local DRAM. ExecuteLocalPut allocates a slot in dram_buffers,
+    // copies the bytes, and Commit queues a KvEvent::ADD that reaches the master
+    // via heartbeat — mirroring the local Put publish path. kSuccessAlreadyExists
+    // makes this idempotent for a repeat remote read of the same key.
+    switch (ExecuteLocalPut(job.key, job.bytes.data(), job.bytes.size(), TierType::DRAM)) {
+      case PutAttemptOutcome::kSuccess:
+        MORI_UMBP_DEBUG("[PoolClient] ReCacheWorker: re-cached key='{}' size={}", job.key,
+                        job.bytes.size());
+        break;
+      case PutAttemptOutcome::kSuccessAlreadyExists:
+        break;
+      case PutAttemptOutcome::kRetry:
+      case PutAttemptOutcome::kFatal:
+        MORI_UMBP_DEBUG("[PoolClient] ReCacheWorker: local install failed for key='{}'", job.key);
+        break;
+    }
+  }
 }
 
 PoolClient::GetAttemptOutcome PoolClient::ExecuteLocalSsdGet(const std::string& key, void* dst,
@@ -1936,6 +2027,13 @@ void PoolClient::FinalizeRemoteGetEntries(std::vector<RemoteGetEntry>& entries,
                                MORI_UMBP_METRIC_CLIENT_INBOUND_GET_BYTES_TOTAL_HELP,
                                {{"traffic", "remote"}}, static_cast<double>(entry.item->size));
     (*results)[entry.result_index] = true;
+
+    // Re-cache the remotely-fetched block into local DRAM (best-effort): the
+    // user dst is already populated (staging copy-out and zero-copy both land
+    // before Finalize runs), so subsequent reads of this key route local.
+    if (entry.item) {
+      MaybeReCacheAfterRemote(*entry.item->key, entry.item->dst, entry.item->size);
+    }
   }
 }
 

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -31,6 +31,7 @@
 #include <functional>
 #include <limits>
 #include <msgpack.hpp>
+#include <new>
 #include <numeric>
 #include <string>
 #include <string_view>
@@ -720,7 +721,8 @@ bool PoolClient::LocalGetPages(const std::vector<PageLocation>& pages, uint64_t 
 }
 
 PoolClient::PutAttemptOutcome PoolClient::ExecuteLocalPut(const std::string& key, const void* src,
-                                                          size_t size, TierType tier) {
+                                                          size_t size, TierType tier,
+                                                          bool enqueue_ssd_copy) {
   if (!peer_alloc_) {
     MORI_UMBP_ERROR("[PoolClient] Local Put requested but peer allocator unavailable");
     return PutAttemptOutcome::kFatal;
@@ -747,7 +749,7 @@ PoolClient::PutAttemptOutcome PoolClient::ExecuteLocalPut(const std::string& key
     return PutAttemptOutcome::kFatal;
   }
   // Owner-side commit succeeded: best-effort async copy to local SSD.
-  if (ssd_copy_pipeline_) {
+  if (enqueue_ssd_copy && ssd_copy_pipeline_) {
     ssd_copy_pipeline_->Enqueue(SsdCopyTask{key, tier, size});
   }
   master_client_->AddCounter(MORI_UMBP_METRIC_CLIENT_OUTBOUND_PUT_BYTES_TOTAL,
@@ -800,7 +802,12 @@ void PoolClient::MaybeReCacheAfterRemote(const std::string& key, const void* src
   // serialize unrelated Get finalizers behind this memcpy.
   ReCacheJob job;
   job.key = key;
-  job.bytes = std::unique_ptr<char[]>(new char[size]);
+  job.bytes = std::unique_ptr<char[]>(new (std::nothrow) char[size]);
+  if (!job.bytes) {
+    MORI_UMBP_DEBUG("[PoolClient] MaybeReCacheAfterRemote: allocation failed for key='{}' size={}",
+                    key, size);
+    return;
+  }
   job.size = size;
   LocalCopyBlock(job.bytes.get(), src, size);
 
@@ -835,7 +842,8 @@ void PoolClient::ReCacheWorkerLoop() {
     // copies the bytes, and Commit queues a KvEvent::ADD that reaches the master
     // via heartbeat — mirroring the local Put publish path. kSuccessAlreadyExists
     // makes this idempotent for a repeat remote read of the same key.
-    switch (ExecuteLocalPut(job.key, job.bytes.get(), job.size, TierType::DRAM)) {
+    switch (ExecuteLocalPut(job.key, job.bytes.get(), job.size, TierType::DRAM,
+                            /*enqueue_ssd_copy=*/false)) {
       case PutAttemptOutcome::kSuccess:
         MORI_UMBP_DEBUG("[PoolClient] ReCacheWorker: re-cached key='{}' size={}", job.key,
                         job.size);

--- a/src/umbp/distributed/routing/route_get_strategy.cpp
+++ b/src/umbp/distributed/routing/route_get_strategy.cpp
@@ -95,7 +95,7 @@ Location RandomRouteGetStrategy::Select(const std::vector<Location>& locations,
 }
 
 Location TierPriorityRouteGetStrategy::Select(const std::vector<Location>& locations,
-                                              const std::string& /*node_id*/) {
+                                              const std::string& node_id) {
   if (locations.empty()) {
     MORI_UMBP_WARN(
         "[TierPriorityRouteGetStrategy] received empty location set; returning default Location");
@@ -111,6 +111,23 @@ Location TierPriorityRouteGetStrategy::Select(const std::vector<Location>& locat
   std::vector<size_t> best_tier_indices;
   for (size_t i = 0; i < locations.size(); ++i) {
     if (TierReadRank(locations[i].tier) == best_rank) best_tier_indices.push_back(i);
+  }
+
+  // Requester-local preference: if the asking node itself holds a replica in the
+  // best tier, serve it locally instead of a random peer. This is what makes
+  // cache_remote_fetches pay off — a node that re-cached a remotely-fetched block
+  // reads its own copy on the next Get (no RDMA), matching the local-first
+  // behavior of the pre-dual-scheme UMBPClient. Non-replica requesters still
+  // spread randomly. Empty node_id (unknown caller) falls through to random.
+  if (!node_id.empty()) {
+    for (size_t i : best_tier_indices) {
+      if (locations[i].node_id == node_id) {
+        MORI_UMBP_DEBUG(
+            "[TierPriorityRouteGetStrategy] requester-local hit node={} tier={} size={}",
+            locations[i].node_id, TierTypeName(locations[i].tier), locations[i].size);
+        return locations[i];
+      }
+    }
   }
 
   size_t choice = PickRandomIndex(best_tier_indices);

--- a/src/umbp/include/umbp/common/config.h
+++ b/src/umbp/include/umbp/common/config.h
@@ -184,6 +184,13 @@ struct UMBPIoEngineConfig {
   uint16_t port = 0;  // RDMA engine port; 0 = OS-assigned ephemeral port (formerly io_engine_port)
 };
 
+// Admission policy for re-caching remotely-fetched blocks locally.
+enum class CacheRemoteAdmission : int {
+  SIZE = 0,    // admit if block size <= admission_max_block_bytes AND DRAM has room
+  NEVER = 1,   // never re-cache (equivalent to cache_remote_fetches = false)
+  ALWAYS = 2,  // always attempt re-cache (skip size gate)
+};
+
 // User-facing distributed configuration. Set UMBPConfig::distributed to enable
 // distributed mode. Internally translated to PoolClientConfig by DistributedClient.
 struct UMBPDistributedConfig {
@@ -203,6 +210,13 @@ struct UMBPDistributedConfig {
   uint16_t peer_service_port = 0;  // gRPC peer service port
 
   bool cache_remote_fetches = true;  // cache remotely-fetched blocks locally
+
+  // Admission gate for re-caching. Only consulted when cache_remote_fetches is true.
+  CacheRemoteAdmission cache_remote_admission = CacheRemoteAdmission::SIZE;
+
+  // Maximum block size (bytes) eligible for local re-cache under SIZE policy.
+  // 0 means unlimited (no size gate). Default 16 MB.
+  size_t admission_max_block_bytes = 16ULL * 1024 * 1024;
 
   // Page size used by Master's PageBitmapAllocator for this node's DRAM/HBM
   // tier.  Reported via RegisterClient.  Same value applies to both DRAM

--- a/src/umbp/include/umbp/common/config.h
+++ b/src/umbp/include/umbp/common/config.h
@@ -191,6 +191,22 @@ enum class CacheRemoteAdmission : int {
   ALWAYS = 2,  // always attempt re-cache (skip size gate)
 };
 
+// Pure admission predicate for the remote-fetch re-cache gate: decides whether a
+// block of `size` bytes is eligible for local re-caching under the given policy,
+// independent of runtime state (DRAM-capacity enforcement is left to the
+// allocator). Extracted so the gate is unit-testable without a live PoolClient;
+// used by PoolClient::MaybeReCacheAfterRemote.
+inline bool ShouldAdmitReCache(bool cache_remote_fetches, CacheRemoteAdmission policy,
+                               size_t admission_max_block_bytes, size_t size) {
+  if (!cache_remote_fetches) return false;
+  if (size == 0) return false;
+  if (policy == CacheRemoteAdmission::NEVER) return false;
+  if (policy == CacheRemoteAdmission::SIZE) {
+    if (admission_max_block_bytes > 0 && size > admission_max_block_bytes) return false;
+  }
+  return true;  // ALWAYS, or SIZE within cap
+}
+
 // User-facing distributed configuration. Set UMBPConfig::distributed to enable
 // distributed mode. Internally translated to PoolClientConfig by DistributedClient.
 struct UMBPDistributedConfig {

--- a/src/umbp/include/umbp/distributed/config.h
+++ b/src/umbp/include/umbp/distributed/config.h
@@ -168,6 +168,12 @@ struct PoolClientConfig {
 
   uint16_t peer_service_port = 0;
 
+  // Re-cache remotely-fetched blocks into local DRAM + publish to master so this
+  // node becomes an additional serving replica (LMCache-style P2P pull).
+  bool cache_remote_fetches = true;
+  CacheRemoteAdmission cache_remote_admission = CacheRemoteAdmission::SIZE;
+  size_t admission_max_block_bytes = 16ULL * 1024 * 1024;
+
   // Page size used by Master's PageBitmapAllocator for this node's DRAM/HBM
   // tier.  Reported via RegisterClient.  Same value applies to both DRAM
   // and HBM.  Forwarded unmodified to MasterClient::RegisterSelf by
@@ -200,6 +206,9 @@ inline PoolClientConfig ToPoolClientConfig(const UMBPDistributedConfig& dc,
   pc.ssd_staging_buffer_size = dc.ssd_staging_buffer_size;
   pc.ssd_staging_buffer_slots = dc.ssd_staging_buffer_slots;
   pc.peer_service_port = dc.peer_service_port;
+  pc.cache_remote_fetches = dc.cache_remote_fetches;
+  pc.cache_remote_admission = dc.cache_remote_admission;
+  pc.admission_max_block_bytes = dc.admission_max_block_bytes;
   // 0 propagates through PoolClient -> MasterClient::RegisterSelf ->
   // proto -> ClientRegistry, where it is interpreted as "use the
   // registry-wide default_dram_page_size".

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -262,7 +262,7 @@ class PoolClient {
   enum class GetAttemptOutcome { kSuccess, kRetry, kFatal };
 
   PutAttemptOutcome ExecuteLocalPut(const std::string& key, const void* src, size_t size,
-                                    TierType tier);
+                                    TierType tier, bool enqueue_ssd_copy = true);
   GetAttemptOutcome ExecuteLocalGet(const std::string& key, void* dst, size_t size);
   // After a successful remote DRAM fetch, if cache_remote_fetches is enabled and
   // the admission gate admits the block, enqueue it for asynchronous install into

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -22,12 +22,15 @@
 #pragma once
 
 #include <atomic>
+#include <condition_variable>
 #include <cstdint>
+#include <deque>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -261,6 +264,32 @@ class PoolClient {
   PutAttemptOutcome ExecuteLocalPut(const std::string& key, const void* src, size_t size,
                                     TierType tier);
   GetAttemptOutcome ExecuteLocalGet(const std::string& key, void* dst, size_t size);
+  // After a successful remote DRAM fetch, if cache_remote_fetches is enabled and
+  // the admission gate admits the block, enqueue it for asynchronous install into
+  // this node's local DRAM tier (see ReCacheWorkerLoop). The install (DRAM
+  // Allocate + copy + Commit→KvEvent::ADD publish) happens OFF the Get critical
+  // path so it does not add latency to concurrent Gets. Idempotent
+  // (kSuccessAlreadyExists) and best-effort: the queue is bounded and drops on
+  // full; failure does not affect the returned Get result.
+  void MaybeReCacheAfterRemote(const std::string& key, const void* src, size_t size);
+  // Background worker that drains recache_queue_ and performs the DRAM install
+  // via ExecuteLocalPut. Started in Init (when cache_remote_fetches), stopped in
+  // Shutdown before peer_alloc_ is torn down.
+  void ReCacheWorkerLoop();
+
+  // Async re-cache install queue. MaybeReCacheAfterRemote copies the block bytes
+  // into a job here (the source buffer is not owned past the Get return), and the
+  // worker thread installs it. Bounded to keep memory + publish churn in check.
+  struct ReCacheJob {
+    std::string key;
+    std::vector<char> bytes;
+  };
+  std::deque<ReCacheJob> recache_queue_;
+  std::mutex recache_mutex_;
+  std::condition_variable recache_cv_;
+  std::thread recache_worker_;
+  bool recache_stop_ = false;
+  size_t recache_queue_max_ = 1024;
   // Self-target SSD get: read straight from the local SSD tier into the user
   // buffer (no staging / RDMA / lease).
   GetAttemptOutcome ExecuteLocalSsdGet(const std::string& key, void* dst, size_t size);

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -282,7 +282,8 @@ class PoolClient {
   // worker thread installs it. Bounded to keep memory + publish churn in check.
   struct ReCacheJob {
     std::string key;
-    std::vector<char> bytes;
+    std::unique_ptr<char[]> bytes;
+    size_t size = 0;
   };
   std::deque<ReCacheJob> recache_queue_;
   std::mutex recache_mutex_;

--- a/src/umbp/tests/CMakeLists.txt
+++ b/src/umbp/tests/CMakeLists.txt
@@ -220,5 +220,6 @@ gtest_discover_tests(test_ssd_reliability)
 
 # cache_remote_fetches admission-gate unit test (hermetic; no GPU/RDMA/master)
 add_executable(test_cache_remote_admission test_cache_remote_admission.cpp)
-target_link_libraries(test_cache_remote_admission PRIVATE umbp_common GTest::gtest_main)
+target_link_libraries(test_cache_remote_admission PRIVATE umbp_common
+                                                          GTest::gtest_main)
 gtest_discover_tests(test_cache_remote_admission)

--- a/src/umbp/tests/CMakeLists.txt
+++ b/src/umbp/tests/CMakeLists.txt
@@ -217,3 +217,8 @@ target_link_libraries(test_ssd_reliability PRIVATE umbp_common
 target_compile_features(test_ssd_reliability PRIVATE cxx_std_17)
 
 gtest_discover_tests(test_ssd_reliability)
+
+# cache_remote_fetches admission-gate unit test (hermetic; no GPU/RDMA/master)
+add_executable(test_cache_remote_admission test_cache_remote_admission.cpp)
+target_link_libraries(test_cache_remote_admission PRIVATE umbp_common GTest::gtest_main)
+gtest_discover_tests(test_cache_remote_admission)

--- a/src/umbp/tests/test_cache_remote_admission.cpp
+++ b/src/umbp/tests/test_cache_remote_admission.cpp
@@ -1,0 +1,76 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Hermetic unit tests for the cache_remote_fetches admission gate
+// (ShouldAdmitReCache), the pure predicate used by
+// PoolClient::MaybeReCacheAfterRemote. No GPU / RDMA / master required.
+#include <gtest/gtest.h>
+
+#include "umbp/common/config.h"
+
+namespace mori::umbp {
+namespace {
+
+constexpr size_t kCap = 16ull * 1024 * 1024;  // 16 MB default admission cap
+
+// cache_remote_fetches=false disables re-cache regardless of policy/size.
+TEST(CacheRemoteAdmission, DisabledFlagNeverAdmits) {
+  EXPECT_FALSE(ShouldAdmitReCache(false, CacheRemoteAdmission::ALWAYS, kCap, 1024));
+  EXPECT_FALSE(ShouldAdmitReCache(false, CacheRemoteAdmission::SIZE, kCap, 1024));
+  EXPECT_FALSE(ShouldAdmitReCache(false, CacheRemoteAdmission::NEVER, kCap, 1024));
+}
+
+// NEVER policy rejects even when the flag is on and size is tiny.
+TEST(CacheRemoteAdmission, NeverPolicyRejects) {
+  EXPECT_FALSE(ShouldAdmitReCache(true, CacheRemoteAdmission::NEVER, kCap, 1));
+  EXPECT_FALSE(ShouldAdmitReCache(true, CacheRemoteAdmission::NEVER, 0, 1));
+}
+
+// Zero-size blocks are never admitted (nothing to cache).
+TEST(CacheRemoteAdmission, ZeroSizeRejected) {
+  EXPECT_FALSE(ShouldAdmitReCache(true, CacheRemoteAdmission::ALWAYS, kCap, 0));
+  EXPECT_FALSE(ShouldAdmitReCache(true, CacheRemoteAdmission::SIZE, kCap, 0));
+}
+
+// ALWAYS admits any non-zero size, ignoring the cap.
+TEST(CacheRemoteAdmission, AlwaysAdmitsRegardlessOfSize) {
+  EXPECT_TRUE(ShouldAdmitReCache(true, CacheRemoteAdmission::ALWAYS, kCap, 1));
+  EXPECT_TRUE(ShouldAdmitReCache(true, CacheRemoteAdmission::ALWAYS, kCap, kCap));
+  EXPECT_TRUE(ShouldAdmitReCache(true, CacheRemoteAdmission::ALWAYS, kCap, kCap + 1));
+  EXPECT_TRUE(ShouldAdmitReCache(true, CacheRemoteAdmission::ALWAYS, 0, 1ull << 40));
+}
+
+// SIZE policy admits at/below the cap and rejects above it.
+TEST(CacheRemoteAdmission, SizePolicyRespectsCap) {
+  EXPECT_TRUE(ShouldAdmitReCache(true, CacheRemoteAdmission::SIZE, kCap, 1));
+  EXPECT_TRUE(ShouldAdmitReCache(true, CacheRemoteAdmission::SIZE, kCap, kCap));  // boundary: <=
+  EXPECT_FALSE(ShouldAdmitReCache(true, CacheRemoteAdmission::SIZE, kCap, kCap + 1));
+}
+
+// SIZE policy with cap==0 means "no size limit" (admit any non-zero size).
+TEST(CacheRemoteAdmission, SizePolicyZeroCapIsUnlimited) {
+  EXPECT_TRUE(ShouldAdmitReCache(true, CacheRemoteAdmission::SIZE, 0, 1));
+  EXPECT_TRUE(ShouldAdmitReCache(true, CacheRemoteAdmission::SIZE, 0, 1ull << 40));
+}
+
+}  // namespace
+}  // namespace mori::umbp

--- a/src/umbp/tests/test_tier_priority_route_get.cpp
+++ b/src/umbp/tests/test_tier_priority_route_get.cpp
@@ -100,6 +100,36 @@ TEST(TierPriorityRouteGetStrategyTest, RandomWithinBestTierOnly) {
   EXPECT_EQ(seen.count("ssd-x"), 0u);
 }
 
+TEST(TierPriorityRouteGetStrategyTest, PrefersRequesterLocalReplicaWithinBestTier) {
+  TierPriorityRouteGetStrategy strategy;
+  std::vector<Location> locations = {
+      MakeLoc("dram-a", TierType::DRAM),
+      MakeLoc("requester", TierType::DRAM),
+      MakeLoc("dram-c", TierType::DRAM),
+      MakeLoc("ssd-x", TierType::SSD),
+  };
+
+  for (int i = 0; i < 100; ++i) {
+    auto selected = strategy.Select(locations, "requester");
+    EXPECT_EQ(selected.tier, TierType::DRAM);
+    EXPECT_EQ(selected.node_id, "requester");
+  }
+}
+
+TEST(TierPriorityRouteGetStrategyTest, RequesterLocalLowerTierDoesNotBeatBestTier) {
+  TierPriorityRouteGetStrategy strategy;
+  std::vector<Location> locations = {
+      MakeLoc("dram-a", TierType::DRAM),
+      MakeLoc("requester", TierType::SSD),
+  };
+
+  for (int i = 0; i < 100; ++i) {
+    auto selected = strategy.Select(locations, "requester");
+    EXPECT_EQ(selected.tier, TierType::DRAM);
+    EXPECT_EQ(selected.node_id, "dram-a");
+  }
+}
+
 TEST(TierPriorityRouteGetStrategyTest, EmptyReturnsDefault) {
   TierPriorityRouteGetStrategy strategy;
   std::vector<Location> locations;


### PR DESCRIPTION
## Summary

`cache_remote_fetches` is already declared in `UMBPDistributedConfig`, exposed in pybind, printed in the client config dump, and documented (design-master-control-plane.md + the `UMBP_CACHE_REMOTE_FETCHES` env var) — but it was **never implemented**: a remote fetch read the peer's block into the caller and dropped it, keeping no local copy. This PR implements the documented behavior.

When a node fetches a KV block from a remote peer's L3, the block is now written back into that node's **local L3 DRAM tier** and re-published to the master, so subsequent reads of the same key are served locally instead of paying another cross-node RDMA round-trip.

## Motivation

In multi-node UMBP serving (e.g. sglang HiCache L3 with 2 prefill nodes sharing prefixes), two nodes repeatedly read the same shared-prefix KV blocks. Without re-caching, every repeat read of a peer-owned block is a full cross-node RDMA fetch and keeps load on the owning node. Re-caching turns "remote every time" into "remote once, then local" — lowering TTFT tails and raising throughput. (sglang's own L2 only holds the block while hot in the small host cache and does not create a durable local L3 replica, so the large L3 tier stays empty for peer-owned keys without this feature.)

## What changed (additive; no proto/API break)

- `PoolClient` (`distributed/pool_client.cpp`): on a successful remote Get, if `cache_remote_fetches` and the admission gate passes, enqueue the block for a local install — `MaybeReCacheAfterRemote` → async worker → `ExecuteLocalPut(DRAM)` → `Commit` → `KvEvent::ADD` publish. Wired into the Get/BatchGet finalize path.
- Admission gate: `CacheRemoteAdmission {SIZE (default), NEVER, ALWAYS}` + `admission_max_block_bytes` (16 MB) on `UMBPDistributedConfig` / `PoolClientConfig`.
- RouteGet (`routing/route_get_strategy.cpp`): prefer a best-tier replica whose `node_id == requester` (self-local) before random pick, so a re-cached block is actually read locally on the requester's next request.
- pybind: expose the new enum + fields.

## Design notes

- **Async off-path install**: re-cache runs on a background worker, never on the Get return path. A synchronous first version regressed tail latency badly under concurrency (inline Allocate+memcpy+Commit blocked concurrent Gets: avg TTFT +112%, p90 +312%); the async design eliminates that.
- Worker started in `Init` (when enabled), drained/joined in `Shutdown` before the allocator is torn down. Re-cache is idempotent.

## Performance — 2P1D sglang HiCache E2E, on vs off

2 prefill nodes share the UMBP L3 prefix cache; ON vs OFF differ ONLY in `cache_remote_fetches`. Model DeepSeek-V3-5layer, 8xMI300X/node, mori RoCE transfer, real forward. Fresh `umbp_master` per arm (round_0 cache-hit = 0.0, contamination-free).

**This PR (dual-scheme main), two clean pairs:**

| metric      | pair A (OFF→ON) | pair B (OFF→ON) |
|-------------|-----------------|-----------------|
| throughput  | **+8.9%**       | **+4.4%**       |
| p99 TTFT    | **-76.1%**      | **-22.6%**      |
| p90 TTFT    | -92.5% (*)      | -0.3%           |
| avg TTFT    | -74.8% (*)      | +0.4%           |
| cache hit   | -6.0%           | -4.7%           |

(*) pair A's OFF arm hit a tail spike; pair B's OFF baseline was already tail-clean, so its avg/p90 are flat — but ON never regresses. Robust signals (throughput up, p99 down) agree across both pairs.

**Independent N=3 confirmation (same mechanism, earlier UMBP lineage, alternated order):**

| metric      | OFF (mean±sd)   | ON (mean±sd)    | delta   |
|-------------|-----------------|-----------------|---------|
| p90 TTFT    | 2.422 ± 1.803   | 1.368 ± 1.035   | -43.5%  |
| avg TTFT    | 0.669 ± 0.215   | 0.578 ± 0.146   | -13.6%  |
| throughput  | 8.855 ± 0.400   | 9.161 ± 0.058   | +3.5%   |
| cache hit   | 0.812           | 0.804           | ~flat   |

ON p90 TTFT was lower in all 3 reps.

**Note:** cache-hit rate is ~flat by design — the feature accelerates the *fetch path* (remote→local), it does not change *which* prefixes hit; the value shows up in latency/throughput.

## Reproduction

Consumed via sglang's HiCache UMBP backend, so E2E repro needs the companion sglang UMBP stack (see sgl-project/sglang#25377). 

3 nodes — P1 = prefill + umbp_master, P2 = prefill, D = decode + router. RoCE env on every node (RoCEv2 GID index; pin one NIC == the node's UMBP address):

```bash
export MORI_IB_GID_INDEX=3 MORI_RDMA_DEVICES=mlx5_0 MORI_SOCKET_IFNAME=eth0
```

P1 (prefill + auto-start umbp_master):

```bash
UMBP_MASTER_ADDRESS=$P1:50051 UMBP_NODE_ADDRESS=$P1 UMBP_MASTER_AUTO_START=true \
UMBP_MASTER_BIN=<mori>/build/src/umbp/umbp_master \
UMBP_IO_ENGINE_PORT=18080 UMBP_PEER_SERVICE_PORT=19080 \
UMBP_CACHE_REMOTE_FETCHES=true UMBP_DRAM_BYTES=$((8*1024**3)) UMBP_SSD_BYTES=0 \
ENABLE_HICACHE=true ENABLE_UMBP=true HICACHE_SIZE=2 DISAGG_TRANSFER_BACKEND=mori \
MODEL_PATH=<DeepSeek-V3-5layer> bash run_pd_disagg_bench_dp8ep8.sh --role prefill
```

P2 (prefill, joins P1's master): same as P1 but `UMBP_NODE_ADDRESS=$P2`, `UMBP_MASTER_AUTO_START=false`, and drop `UMBP_MASTER_BIN`.

D (decode + router, drives the benchmark):

```bash
PREFILL_URLS="http://$P1:30000 http://$P2:30000" ENABLE_ROUTER=true \
DISAGG_TRANSFER_BACKEND=mori NUM_ROUNDS=12 NUM_CLIENTS=64 MAX_PARALLEL=32 SEED=42 \
MODEL_PATH=<DeepSeek-V3-5layer> bash run_pd_disagg_bench_dp8ep8.sh --role decode
```

OFF arm: rerun all three with `UMBP_CACHE_REMOTE_FETCHES=false` and a **fresh** `umbp_master` (kill it between arms so L3 starts cold; verify round_0 hit = 0.0). Per-request metrics land in the decode node's `performance_metrics.jsonl`.

## Backward compatibility

Additive only. `cache_remote_fetches` default preserved; when off, behavior is identical to before. No proto changes; `PublishLocalBlock` is an existing RPC.

## Testing

- mori builds with the change (pybinds + umbp_master).
- ON/OFF toggled per-arm (verified in the client config dump); cross-node remote fetch confirmed on the 2nd prefill's UMBP BatchGet logs; re-cache is idempotent.
