### PR TITLE
perf(rdma): default to ibv_reg_mr, opt into dmabuf via MORI_ENABLE_DMABUF_REG

### DIFF
--- a/include/mori/application/transport/rdma/rdma.hpp
+++ b/include/mori/application/transport/rdma/rdma.hpp
@@ -216,7 +216,8 @@ class RdmaDeviceContext {
   // dmabuf registration with iova=0 (CCO symmetric flat-VA path; BNXT GDA).
   virtual RdmaMemoryRegion RegisterRdmaMemoryRegionDmabufIova0(
       void* ptr, size_t size, int dmabuf_fd, int accessFlag = MR_DEFAULT_ACCESS_FLAG);
-  // dmabuf-first registration; falls back to ibv_reg_mr. Disable via MORI_DISABLE_DMABUF_REG.
+  // ibv_reg_mr-first registration; falls back to dmabuf. Set MORI_ENABLE_DMABUF_REG to try
+  // dmabuf first instead (falling back to ibv_reg_mr).
   virtual RdmaMemoryRegion RegisterRdmaMemoryRegionAuto(void* ptr, size_t size,
                                                         int accessFlag = MR_DEFAULT_ACCESS_FLAG);
   virtual void DeregisterRdmaMemoryRegion(void* ptr);
@@ -257,7 +258,7 @@ class RdmaDeviceContext {
  private:
   RdmaDevice* device;
   std::unordered_map<void*, ibv_mr*> mrPool;
-  bool dmabufRegDisabled{false};
+  bool preferDmabufReg{false};
 };
 
 /* -------------------------------------------------------------------------- */

--- a/src/application/transport/rdma/rdma.cpp
+++ b/src/application/transport/rdma/rdma.cpp
@@ -349,7 +349,7 @@ int MaybeAddRelaxedOrderingFlag(int accessFlag) {
 /* ---------------------------------------------------------------------------------------------- */
 RdmaDeviceContext::RdmaDeviceContext(RdmaDevice* device, ibv_pd* inPd) : device(device), pd(inPd) {
   InitializeUdpSportConfiguration();
-  dmabufRegDisabled = env::IsEnvVarEnabled("MORI_DISABLE_DMABUF_REG");
+  preferDmabufReg = env::IsEnvVarEnabled("MORI_ENABLE_DMABUF_REG");
 }
 
 RdmaDeviceContext::~RdmaDeviceContext() {
@@ -452,31 +452,49 @@ static int TryExportDmabufFd(void* ptr, size_t size) {
 application::RdmaMemoryRegion RdmaDeviceContext::RegisterRdmaMemoryRegionAuto(void* ptr,
                                                                               size_t size,
                                                                               int accessFlag) {
-  if (!dmabufRegDisabled) {
+  int effectiveAccessFlag = MaybeAddRelaxedOrderingFlag(accessFlag);
+
+  auto makeHandle = [&](ibv_mr* mr) {
+    mrPool.insert({ptr, mr});
+    application::RdmaMemoryRegion handle;
+    handle.addr = reinterpret_cast<uintptr_t>(ptr);
+    handle.lkey = mr->lkey;
+    handle.rkey = mr->rkey;
+    handle.length = mr->length;
+    return handle;
+  };
+  auto tryPlain = [&]() -> ibv_mr* { return ibv_reg_mr(pd, ptr, size, effectiveAccessFlag); };
+  auto tryDmabuf = [&]() -> ibv_mr* {
     int dmabufFd = TryExportDmabufFd(ptr, size);
-    if (dmabufFd >= 0) {
-      int effectiveAccessFlag = MaybeAddRelaxedOrderingFlag(accessFlag);
-      ibv_mr* mr = ibv_reg_dmabuf_mr(pd, 0, size, reinterpret_cast<uint64_t>(ptr), dmabufFd,
-                                     effectiveAccessFlag);
-      close(dmabufFd);
-      if (mr) {
-        MORI_APP_TRACE("RegisterRdmaMemoryRegionAuto[dmabuf], addr:{}, size:{}, lkey:{}, rkey:{}",
-                       ptr, size, mr->lkey, mr->rkey);
-        mrPool.insert({ptr, mr});
-        application::RdmaMemoryRegion handle;
-        handle.addr = reinterpret_cast<uintptr_t>(ptr);
-        handle.lkey = mr->lkey;
-        handle.rkey = mr->rkey;
-        handle.length = mr->length;
-        return handle;
-      }
-      MORI_APP_WARN(
-          "ibv_reg_dmabuf_mr failed (addr:{}, size:{}, errno:{} ({})), falling back to "
-          "ibv_reg_mr",
-          ptr, size, errno, strerror(errno));
+    if (dmabufFd < 0) return nullptr;
+    ibv_mr* mr = ibv_reg_dmabuf_mr(pd, 0, size, reinterpret_cast<uint64_t>(ptr), dmabufFd,
+                                   effectiveAccessFlag);
+    close(dmabufFd);
+    return mr;
+  };
+
+  // Default: ibv_reg_mr first, dmabuf fallback (fast on bnxt). Set
+  // MORI_ENABLE_DMABUF_REG to prefer dmabuf first, falling back to ibv_reg_mr.
+  for (int attempt = 0; attempt < 2; ++attempt) {
+    bool useDmabuf = (attempt == 0) ? preferDmabufReg : !preferDmabufReg;
+    const char* name = useDmabuf ? "dmabuf" : "ibv_reg_mr";
+    ibv_mr* mr = useDmabuf ? tryDmabuf() : tryPlain();
+    if (mr) {
+      MORI_APP_TRACE("RegisterRdmaMemoryRegionAuto[{}], addr:{}, size:{}, lkey:{}, rkey:{}", name,
+                     ptr, size, mr->lkey, mr->rkey);
+      return makeHandle(mr);
     }
+    MORI_APP_WARN(
+        "RegisterRdmaMemoryRegionAuto {} registration failed (addr:{}, size:{}, "
+        "errno:{} ({}))",
+        name, ptr, size, errno, strerror(errno));
   }
-  return RegisterRdmaMemoryRegion(ptr, size, accessFlag);
+
+  MORI_APP_ERROR(
+      "RegisterRdmaMemoryRegionAuto failed: ibv_reg_mr and dmabuf registration both failed "
+      "(addr:{}, size:{}, accessFlag:{}, errno:{} ({}))",
+      ptr, size, effectiveAccessFlag, errno, strerror(errno));
+  std::abort();
 }
 
 void RdmaDeviceContext::DeregisterRdmaMemoryRegion(void* ptr) {


### PR DESCRIPTION
## Summary

- The dmabuf-first MR registration added in #355 (commit `6e58fe8`) regressed bnxt throughput.
- `RegisterRdmaMemoryRegionAuto` now tries plain `ibv_reg_mr` **first** (fast path on bnxt) and falls back to dmabuf registration only when it fails.
- New env flag **`MORI_ENABLE_DMABUF_REG`**: set it to prefer dmabuf first (falling back to `ibv_reg_mr`). This replaces the old `MORI_DISABLE_DMABUF_REG` (which fit the previous dmabuf-first default).
- If both registrations fail, it aborts with a combined error (the existing `RegisterRdmaMemoryRegion` `std::abort()`s on failure, so it can't be reused as the first soft attempt).

## Test plan

- [x] clang-format clean; builds in the `Dockerfile.cco` container
- [x] bnxt: confirm MORI-IO / RDMA throughput recovers vs current main
- [x] `MORI_ENABLE_DMABUF_REG=1`: confirm dmabuf-first path still works (dmabuf-only setups)