### PR TITLE
fix(cco): fix hip vmm memory leak and crash issues

### DIFF
--- a/docker/Dockerfile.cco
+++ b/docker/Dockerfile.cco
@@ -75,4 +75,38 @@ RUN set -ex && \
         cd / && rm -rf /tmp/clr /tmp/hip; \
     fi
 
+# ── Build ROCR runtime (libhsa-runtime64.so) from release tag ──
+#
+# Build rocr-runtime from the matching rocm-X.Y.Z release tag.
+# The release tag already includes the MappedHandle DRM FD fix
+# (ROCm/rocm-systems#4363), so no extra patch is needed.
+#
+# Only applies to ROCm >= 7.0 (matching the CLR patch above).
+RUN set -ex && \
+    ROCM_VER=$(cat /opt/rocm/.info/version 2>/dev/null | head -c 5) && \
+    test -n "${ROCM_VER}" || { echo "ERROR: cannot read /opt/rocm/.info/version"; exit 1; } && \
+    ROCM_MAJOR=$(echo "${ROCM_VER}" | cut -d. -f1) && \
+    if [ "${ROCM_MAJOR}" -lt 7 ]; then \
+        echo "Skipping libhsa-runtime64 patch: ROCm ${ROCM_VER} (< 7.0)"; \
+    else \
+        apt-get update && \
+        apt-get install -y --no-install-recommends \
+            libelf-dev xxd pkg-config rocm-llvm-dev && \
+        rm -rf /var/lib/apt/lists/* && \
+        LIBHSA_TARGET=$(basename $(readlink -f /opt/rocm/lib/libhsa-runtime64.so.1)) && \
+        echo "Building libhsa-runtime64.so from rocm-${ROCM_VER} tag, target=${LIBHSA_TARGET}" && \
+        git clone --depth 1 --branch rocm-${ROCM_VER} --quiet \
+            https://github.com/ROCm/rocm-systems.git /tmp/rocm-systems && \
+        mkdir /tmp/rocm-systems/projects/rocr-runtime/build && \
+        cd /tmp/rocm-systems/projects/rocr-runtime/build && \
+        cmake -DCMAKE_PREFIX_PATH=/opt/rocm \
+              -DCMAKE_INSTALL_PREFIX=/opt/rocm \
+              -DBUILD_SHARED_LIBS=ON .. && \
+        make -j$(nproc) hsa-runtime64 && \
+        BUILT_LIB=$(find . -name 'libhsa-runtime64.so.1.*' -type f | head -1) && \
+        test -f "${BUILT_LIB}" || { echo "ERROR: built libhsa-runtime64 not found"; exit 1; } && \
+        cp "${BUILT_LIB}" /opt/rocm/lib/${LIBHSA_TARGET} && \
+        cd / && rm -rf /tmp/rocm-systems; \
+    fi
+
 RUN pip install --no-cache-dir flydsl

--- a/docker/Dockerfile.cco
+++ b/docker/Dockerfile.cco
@@ -75,13 +75,18 @@ RUN set -ex && \
         cd / && rm -rf /tmp/clr /tmp/hip; \
     fi
 
-# ── Build ROCR runtime (libhsa-runtime64.so) from release tag ──
+# ── Patch ROCR runtime (libhsa-runtime64.so) for MappedHandle DRM FD leak ──
 #
-# Build rocr-runtime from the matching rocm-X.Y.Z release tag.
-# The release tag already includes the MappedHandle DRM FD fix
-# (ROCm/rocm-systems#4363), so no extra patch is needed.
+# Bug: MappedHandleAllowedAgent destructor leaks DRM FDs, causing
+# hipMemMap failures after ~500 mappings (EMFILE).
+#
+# Fix: apply rocr-mapped-handle-fix.patch (from ROCm/rocm-systems#4363,
+# commit e27ce55c5) onto the matching rocm-X.Y.Z release tag.
 #
 # Only applies to ROCm >= 7.0 (matching the CLR patch above).
+#
+# Remove this block once the base image ships a rocr-runtime with the fix.
+COPY docker/rocr-mapped-handle-fix.patch /tmp/rocr-mapped-handle-fix.patch
 RUN set -ex && \
     ROCM_VER=$(cat /opt/rocm/.info/version 2>/dev/null | head -c 5) && \
     test -n "${ROCM_VER}" || { echo "ERROR: cannot read /opt/rocm/.info/version"; exit 1; } && \
@@ -94,11 +99,13 @@ RUN set -ex && \
             libelf-dev xxd pkg-config rocm-llvm-dev && \
         rm -rf /var/lib/apt/lists/* && \
         LIBHSA_TARGET=$(basename $(readlink -f /opt/rocm/lib/libhsa-runtime64.so.1)) && \
-        echo "Building libhsa-runtime64.so from rocm-${ROCM_VER} tag, target=${LIBHSA_TARGET}" && \
+        echo "Patching libhsa-runtime64.so on ROCm ${ROCM_VER}, target=${LIBHSA_TARGET}" && \
         git clone --depth 1 --branch rocm-${ROCM_VER} --quiet \
             https://github.com/ROCm/rocm-systems.git /tmp/rocm-systems && \
-        mkdir /tmp/rocm-systems/projects/rocr-runtime/build && \
-        cd /tmp/rocm-systems/projects/rocr-runtime/build && \
+        cd /tmp/rocm-systems && \
+        git apply /tmp/rocr-mapped-handle-fix.patch && \
+        mkdir projects/rocr-runtime/build && \
+        cd projects/rocr-runtime/build && \
         cmake -DCMAKE_PREFIX_PATH=/opt/rocm \
               -DCMAKE_INSTALL_PREFIX=/opt/rocm \
               -DBUILD_SHARED_LIBS=ON .. && \

--- a/docker/Dockerfile.cco
+++ b/docker/Dockerfile.cco
@@ -18,7 +18,7 @@ RUN apt-get update && \
     cmake && \
     rm -rf /var/lib/apt/lists/*
 
-# ── Patch ROCm CLR for SWDEV-568260 (hipMemSetAccess sub-buffer validation bug) ──
+# ── Install patched ROCm CLR + ROCR via amdrocm7.13 package ──
 #
 # Bug: `hipMemSetAccess` validates sub-buffer coverage by iterating from
 # parent's sub-buffer 0, ignoring the ptr argument. Returns InvalidValue

--- a/docker/rocr-mapped-handle-fix.patch
+++ b/docker/rocr-mapped-handle-fix.patch
@@ -1,0 +1,28 @@
+diff --git a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+index 41b6f758da..e4572bcfae 100644
+--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
++++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+@@ -3787,11 +3787,18 @@ Runtime::MappedHandleAllowedAgent::MappedHandleAllowedAgent(
+ }
+
+ Runtime::MappedHandleAllowedAgent::~MappedHandleAllowedAgent() {
+-  if (targetAgent->device_type() == core::Agent::DeviceType::kAmdCpuDevice) return;
+-
+-  hsa_status_t status =
+-      targetAgent->driver().ReleaseShareableHandle(shareable_handle);
+-  assert(status == HSA_STATUS_SUCCESS);
++  if (targetAgent->device_type() == core::Agent::DeviceType::kAmdCpuDevice) {
++#if defined(__linux__)
++    if (core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()) assert(!"Unimplemented");
++#endif
++    /* Remap the CPU mapping back to anonymous, freeing the DRM FD while retaining VA reservation */
++    bool result = rocr::os::UncommitMemory(va, size);
++    assert(result && "Failed to remap VA to anonymous");
++  }
++  else {
++    hsa_status_t status = targetAgent->driver().ReleaseShareableHandle(shareable_handle);
++    assert(status == HSA_STATUS_SUCCESS);
++  }
+ }
+
+ hsa_status_t Runtime::MappedHandleAllowedAgent::EnableAccess(hsa_access_permission_t perms) {

--- a/src/cco/cco_init.cpp
+++ b/src/cco/cco_init.cpp
@@ -46,6 +46,19 @@
 namespace mori {
 namespace cco {
 
+namespace {
+// Serialize HIP VMM calls across threads in one process. ROCm ROCR can race on
+// concurrent hsa_amd_vmem_map / hipMemSetAccess from SPMT callers.
+std::recursive_mutex& vmmProcessMutex() {
+  static std::recursive_mutex mutex;
+  return mutex;
+}
+
+struct vmmProcessLock {
+  std::lock_guard<std::recursive_mutex> guard{vmmProcessMutex()};
+};
+}  // namespace
+
 // ccoProviderType is cco's self-contained copy of core::ProviderType; the cast
 // below relies on a 1:1 mapping, so guard it (this TU sees both enums).
 static_assert(static_cast<int>(CCO_PROVIDER_UNKNOWN) ==
@@ -256,17 +269,17 @@ static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perR
   allocProp.location.type = hipMemLocationTypeDevice;
   allocProp.location.id = comm->hipDev;
 
-  // RECOMMENDED granularity: fewer page-table entries, matching CCO's
-  // few-large-buffers usage pattern.
   size_t granularity = 0;
-  HIP_RUNTIME_CHECK(hipMemGetAllocationGranularity(&granularity, &allocProp,
-                                                   hipMemAllocationGranularityRecommended));
-  comm->vmmGranularity = granularity;
-
   // Flat VA covers the LSA team only. Cross-node peers don't use VA — RDMA
   // goes through iova=0 + offset.
   size_t totalVaSize = static_cast<size_t>(comm->lsaSize) * perRankVmmSize;
-  HIP_RUNTIME_CHECK(hipMemAddressReserve(&comm->flatBase, totalVaSize, granularity, nullptr, 0));
+  {
+    vmmProcessLock vmmLock;
+    HIP_RUNTIME_CHECK(hipMemGetAllocationGranularity(&granularity, &allocProp,
+                                                     hipMemAllocationGranularityRecommended));
+    comm->vmmGranularity = granularity;
+    HIP_RUNTIME_CHECK(hipMemAddressReserve(&comm->flatBase, totalVaSize, granularity, nullptr, 0));
+  }
   MORI_SHMEM_TRACE(
       "ccoCommCreate: flatBase={} totalVA={} (lsaSize={} x perRankSize={}) granularity={}",
       comm->flatBase, totalVaSize, comm->lsaSize, perRankVmmSize, granularity);
@@ -360,6 +373,7 @@ int ccoCommDestroy(ccoComm* comm) {
   // unmap + release each straggler (same as ccoMemFree) so no mappings remain
   // in the flat VA. hipMemAddressFree fails if any sub-range is still mapped.
   for (auto& [ptr, meta] : comm->allocTable) {
+    vmmProcessLock vmmLock;
     (void)hipMemUnmap(ptr, meta.size);
     (void)hipMemRelease(meta.physHandle);
     if (meta.shareFd >= 0) close(meta.shareFd);
@@ -371,6 +385,7 @@ int ccoCommDestroy(ccoComm* comm) {
   // Release flat VA — sized to match the reservation in ccoCommCreate.
   if (comm->flatBase) {
     size_t totalVaSize = static_cast<size_t>(comm->lsaSize) * comm->perRankSize;
+    vmmProcessLock vmmLock;
     HIP_RUNTIME_CHECK(hipMemAddressFree(comm->flatBase, totalVaSize));
   }
 
@@ -427,54 +442,66 @@ int ccoMemAlloc(ccoComm* comm, size_t size, void** outPtr) {
   allocProp.location.id = comm->hipDev;
 
   hipMemGenericAllocationHandle_t physHandle = 0;
-  hipError_t err = hipMemCreate(&physHandle, alignedSize, &allocProp, 0);
-  if (err != hipSuccess) {
-    MORI_SHMEM_ERROR("ccoMemAlloc: hipMemCreate failed: {} ({})", static_cast<int>(err),
-                     hipGetErrorString(err));
-    rollbackSlot();
-    return -1;
-  }
-
-  // Map only the local slot. Peer slots are mapped lazily in WindowRegister.
-  // slotAddr already equals flatBase + lsaRank*perRankSize + slotOffset because
-  // vaManager's baseAddr was set to LocalSlotBase(comm).
+  hipError_t err = hipSuccess;
+  int shareFd = -1;
   void* localVa = reinterpret_cast<void*>(slotAddr);
-  err = hipMemMap(localVa, alignedSize, 0, physHandle, 0);
-  if (err != hipSuccess) {
-    MORI_SHMEM_ERROR("ccoMemAlloc: hipMemMap failed: {} ({})", static_cast<int>(err),
-                     hipGetErrorString(err));
-    (void)hipMemRelease(physHandle);
-    rollbackSlot();
-    return -1;
+  {
+    vmmProcessLock vmmLock;
+    err = hipMemCreate(&physHandle, alignedSize, &allocProp, 0);
+    if (err != hipSuccess) {
+      MORI_SHMEM_ERROR("ccoMemAlloc: hipMemCreate failed: {} ({})", static_cast<int>(err),
+                       hipGetErrorString(err));
+      rollbackSlot();
+      return -1;
+    }
+
+    err = hipMemMap(localVa, alignedSize, 0, physHandle, 0);
+    if (err != hipSuccess) {
+      MORI_SHMEM_ERROR("ccoMemAlloc: hipMemMap failed: {} ({})", static_cast<int>(err),
+                       hipGetErrorString(err));
+      (void)hipMemRelease(physHandle);
+      rollbackSlot();
+      return -1;
+    }
   }
 
   hipMemAccessDesc accessDesc = {};
   accessDesc.location.type = hipMemLocationTypeDevice;
   accessDesc.location.id = comm->hipDev;
   accessDesc.flags = hipMemAccessFlagsProtReadWrite;
-  err = hipMemSetAccess(localVa, alignedSize, &accessDesc, 1);
+  for (int retry = 0; retry < 5; retry++) {
+    {
+      vmmProcessLock vmmLock;
+      err = hipMemSetAccess(localVa, alignedSize, &accessDesc, 1);
+    }
+    if (err == hipSuccess) break;
+    usleep(1000 * (1 << retry));
+  }
   if (err != hipSuccess) {
-    MORI_SHMEM_ERROR("ccoMemAlloc: hipMemSetAccess failed: {} ({})", static_cast<int>(err),
-                     hipGetErrorString(err));
-    (void)hipMemUnmap(localVa, alignedSize);
-    (void)hipMemRelease(physHandle);
+    MORI_SHMEM_ERROR("ccoMemAlloc: hipMemSetAccess failed after retries: {} ({})",
+                     static_cast<int>(err), hipGetErrorString(err));
+    {
+      vmmProcessLock vmmLock;
+      (void)hipMemUnmap(localVa, alignedSize);
+      (void)hipMemRelease(physHandle);
+    }
     rollbackSlot();
     return -1;
   }
 
-  // dma-buf FD is stashed for WindowRegister to share (P2P FD exchange + RDMA MR).
-  int shareFd = -1;
   err = hipMemExportToShareableHandle(reinterpret_cast<void*>(&shareFd), physHandle,
                                       hipMemHandleTypePosixFileDescriptor, 0);
   if (err != hipSuccess) {
     MORI_SHMEM_ERROR("ccoMemAlloc: hipMemExportToShareableHandle failed: {} ({})",
                      static_cast<int>(err), hipGetErrorString(err));
-    (void)hipMemUnmap(localVa, alignedSize);
-    (void)hipMemRelease(physHandle);
+    {
+      vmmProcessLock vmmLock;
+      (void)hipMemUnmap(localVa, alignedSize);
+      (void)hipMemRelease(physHandle);
+    }
     rollbackSlot();
     return -1;
   }
-
   {
     std::lock_guard<std::mutex> lock(comm->allocMutex);
     ccoComm::AllocMeta meta;
@@ -518,15 +545,18 @@ int ccoMemFree(ccoComm* comm, void* ptr) {
 
   MORI_SHMEM_TRACE("ccoMemFree: rank={} ptr={} size={}", comm->rank, ptr, alignedSize);
 
-  hipError_t err = hipMemUnmap(ptr, alignedSize);
-  if (err != hipSuccess) {
-    MORI_SHMEM_WARN("ccoMemFree: local hipMemUnmap failed: {} ({})", static_cast<int>(err),
-                    hipGetErrorString(err));
-  }
-  err = hipMemRelease(meta.physHandle);
-  if (err != hipSuccess) {
-    MORI_SHMEM_WARN("ccoMemFree: hipMemRelease failed: {} ({})", static_cast<int>(err),
-                    hipGetErrorString(err));
+  {
+    vmmProcessLock vmmLock;
+    hipError_t err = hipMemUnmap(ptr, alignedSize);
+    if (err != hipSuccess) {
+      MORI_SHMEM_WARN("ccoMemFree: local hipMemUnmap failed: {} ({})", static_cast<int>(err),
+                      hipGetErrorString(err));
+    }
+    err = hipMemRelease(meta.physHandle);
+    if (err != hipSuccess) {
+      MORI_SHMEM_WARN("ccoMemFree: hipMemRelease failed: {} ({})", static_cast<int>(err),
+                      hipGetErrorString(err));
+    }
   }
 
   if (meta.shareFd >= 0) close(meta.shareFd);
@@ -653,6 +683,7 @@ int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin
     mappedPeers.reserve(p2pPeers.size());
 
     auto rollbackMappedPeers = [&]() {
+      vmmProcessLock vmmLock;
       for (auto& mp : mappedPeers) {
         (void)hipMemUnmap(mp.peerVa, alignedSize);
         (void)hipMemRelease(mp.handle);
@@ -681,39 +712,47 @@ int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin
       }
 
       hipMemGenericAllocationHandle_t importedHandle;
-      hipError_t err = hipMemImportFromShareableHandleCompat(&importedHandle, peerFd,
-                                                             hipMemHandleTypePosixFileDescriptor);
-      if (err != hipSuccess) {
-        MORI_SHMEM_ERROR("ccoWindowRegister: import from PE {} failed: {}", pe,
-                         static_cast<int>(err));
-        bail();
-        return -1;
-      }
-
       int peerLsaRank = pe - comm->myNodeStart;
       void* peerVa = static_cast<char*>(comm->flatBase) +
                      static_cast<size_t>(peerLsaRank) * comm->perRankSize + slotOffset;
-      hipError_t mapErr = hipMemMap(peerVa, alignedSize, 0, importedHandle, 0);
-      if (mapErr != hipSuccess) {
-        MORI_SHMEM_ERROR("ccoWindowRegister: hipMemMap PE {} failed: {}", pe,
-                         static_cast<int>(mapErr));
-        (void)hipMemRelease(importedHandle);
-        bail();
-        return -1;
+      {
+        vmmProcessLock vmmLock;
+        hipError_t err = hipMemImportFromShareableHandleCompat(&importedHandle, peerFd,
+                                                               hipMemHandleTypePosixFileDescriptor);
+        if (err != hipSuccess) {
+          MORI_SHMEM_ERROR("ccoWindowRegister: import from PE {} failed: {}", pe,
+                           static_cast<int>(err));
+          bail();
+          return -1;
+        }
+
+        hipError_t mapErr = hipMemMap(peerVa, alignedSize, 0, importedHandle, 0);
+        if (mapErr != hipSuccess) {
+          MORI_SHMEM_ERROR("ccoWindowRegister: hipMemMap PE {} failed: {}", pe,
+                           static_cast<int>(mapErr));
+          (void)hipMemRelease(importedHandle);
+          bail();
+          return -1;
+        }
       }
 
-      // hipMemSetAccess can transiently fail under concurrent VMM operations.
       hipError_t setErr = hipSuccess;
       for (int retry = 0; retry < 5; retry++) {
-        setErr = hipMemSetAccess(peerVa, alignedSize, &accessDesc, 1);
+        {
+          vmmProcessLock vmmLock;
+          setErr = hipMemSetAccess(peerVa, alignedSize, &accessDesc, 1);
+        }
         if (setErr == hipSuccess) break;
         usleep(1000 * (1 << retry));
       }
       if (setErr != hipSuccess) {
         MORI_SHMEM_ERROR("ccoWindowRegister: hipMemSetAccess PE {} failed after retries: {}", pe,
                          static_cast<int>(setErr));
-        (void)hipMemUnmap(peerVa, alignedSize);
-        (void)hipMemRelease(importedHandle);
+        {
+          vmmProcessLock vmmLock;
+          (void)hipMemUnmap(peerVa, alignedSize);
+          (void)hipMemRelease(importedHandle);
+        }
         bail();
         return -1;
       }
@@ -850,6 +889,7 @@ int ccoWindowDeregister(ccoComm* comm, ccoWindow_t win) {
   if (allocIt != comm->allocTable.end()) {
     size_t slotOff = allocIt->second.slotOffset;
     size_t allocSize = allocIt->second.size;
+    vmmProcessLock vmmLock;
     for (int lsa = 0; lsa < comm->lsaSize; lsa++) {
       if (lsa == comm->lsaRank) continue;
       int pe = comm->myNodeStart + lsa;
@@ -862,8 +902,11 @@ int ccoWindowDeregister(ccoComm* comm, ccoWindow_t win) {
 
   // Drop refcount on each peer's imported handle. hipMemUnmap above
   // detaches VA mappings but doesn't release the handle itself.
-  for (auto handle : wh->peerImportedHandles) {
-    (void)hipMemRelease(handle);
+  {
+    vmmProcessLock vmmLock;
+    for (auto handle : wh->peerImportedHandles) {
+      (void)hipMemRelease(handle);
+    }
   }
   wh->peerImportedHandles.clear();
 


### PR DESCRIPTION
## Summary

  Fix two CCO stability issues: ROCR DRM file descriptor leak causing `hipMemMap` EMFILE after ~500 mappings, and missing thread safety for HIP VMM APIs.

## Changes

  **ROCR DRM FD leak** (`docker/rocr-mapped-handle-fix.patch`, `Dockerfile.cco`)
  - `MappedHandleAllowedAgent::~MappedHandleAllowedAgent()` early-returned for CPU agents without releasing the DRM FD, leaking one per `hipMemUnmap`.
  Backport fix from ROCm/rocm-systems#4363 (commit e27ce55c5).
  - Switch ROCR build from `develop` branch to `rocm-${ROCM_VER}` release tag, removing gfx1200/gfx1250 sed workarounds.

  **HIP VMM thread safety** (`src/cco/cco_init.cpp`)
  - Add process-wide `recursive_mutex` serializing all VMM calls (`hipMemCreate/Map/Unmap/Release/SetAccess/AddressReserve/Free`). ROCR races on concurrent
  `hsa_amd_vmem_map` / `hipMemSetAccess` from SPMT callers which leads to crash.