### PR TITLE
ci(cco): enable cco python test

### DIFF
--- a/.github/workflows/ci_cco.yml
+++ b/.github/workflows/ci_cco.yml
@@ -65,6 +65,19 @@ jobs:
         run: |
           $CT exec $CONTAINER bash $GITHUB_WORKSPACE/tools/run_cco_tests.sh $GITHUB_WORKSPACE/build 4 2>&1
 
+      - name: Run CCO C++ examples (2 ranks)
+        run: |
+          $CT exec $CONTAINER bash -c "\
+            mpirun --allow-run-as-root -np 2 $GITHUB_WORKSPACE/build/examples/cco_lsa_put && \
+            mpirun --allow-run-as-root -np 2 $GITHUB_WORKSPACE/build/examples/cco_gda_put"
+
+      - name: Run CCO Python examples (2 ranks)
+        run: |
+          $CT exec $CONTAINER bash -c "pip install mpi4py && \
+            cd $GITHUB_WORKSPACE/examples/cco/python && \
+            mpirun --allow-run-as-root -np 2 python 01_barrier/main.py && \
+            mpirun --allow-run-as-root -np 2 python 02_lsa_put/main.py"
+
       - name: Cleanup
         if: always()
         run: |

--- a/.github/workflows/ci_cco.yml
+++ b/.github/workflows/ci_cco.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Build mori with tests
         run: |
           $CT exec $CONTAINER bash -c \
-            "cd $GITHUB_WORKSPACE && BUILD_TESTS=ON MORI_WITH_MPI=ON pip install ."
+            "cd $GITHUB_WORKSPACE && BUILD_TESTS=ON BUILD_EXAMPLES=ON MORI_WITH_MPI=ON pip install ."
 
       - name: Run CCO unit tests (fork mode, 4 ranks)
         run: |

--- a/examples/cco/python/03_flydsl_put/main.py
+++ b/examples/cco/python/03_flydsl_put/main.py
@@ -174,8 +174,10 @@ def main() -> int:
 
     errors = 0
     with Communicator.init(nranks, rank, uid, per_rank_vmm=PER_RANK_VMM) as comm:
-        send_win = comm.alloc_window(NBYTES)
-        recv_win = comm.alloc_window(NBYTES)
+        send_mem = comm.alloc_mem(NBYTES)
+        send_win = comm.register_window(send_mem.ptr, send_mem.size)
+        recv_mem = comm.alloc_mem(NBYTES)
+        recv_win = comm.register_window(recv_mem.ptr, recv_mem.size)
 
         zero(recv_win.local_ptr, NBYTES)
         if rank == 0:

--- a/examples/cco/python/04_flydsl_lsa_put/main.py
+++ b/examples/cco/python/04_flydsl_lsa_put/main.py
@@ -101,7 +101,8 @@ def main() -> int:
 
     errors = 0
     with Communicator.init(nranks, rank, uid, per_rank_vmm=PER_RANK_VMM) as comm:
-        win = comm.alloc_window(NBYTES)
+        mem = comm.alloc_mem(NBYTES)
+        win = comm.register_window(mem.ptr, mem.size)
         zero(win.local_ptr, NBYTES)
         if rank == 0:
             fill(win.local_ptr, range(1, NUM_ELEMS + 1))

--- a/examples/cco/python/05_flydsl_lsa_allreduce/main.py
+++ b/examples/cco/python/05_flydsl_lsa_allreduce/main.py
@@ -171,7 +171,8 @@ def main() -> int:
 
     errors = 0
     with Communicator.init(nranks, rank, uid, per_rank_vmm=256 * 1024 * 1024) as comm:
-        win = comm.alloc_window(WIN_BYTES)
+        mem = comm.alloc_mem(WIN_BYTES)
+        win = comm.register_window(mem.ptr, mem.size)
 
         # Zero the whole window (incl. signal slots), then fill my input region:
         #   input[i] = (rank + 1) * (i + 1)  ->  allreduce sum = S * (i+1),

--- a/examples/cco/python/06_flydsl_gda_modes/main.py
+++ b/examples/cco/python/06_flydsl_gda_modes/main.py
@@ -173,8 +173,10 @@ def main() -> int:
     failures = 0
 
     with Communicator.init(nranks, rank, uid, per_rank_vmm=PER_RANK_VMM) as comm:
-        send_win = comm.alloc_window(NBYTES)
-        recv_win = comm.alloc_window(NBYTES)
+        send_mem = comm.alloc_mem(NBYTES)
+        send_win = comm.register_window(send_mem.ptr, send_mem.size)
+        recv_mem = comm.alloc_mem(NBYTES)
+        recv_win = comm.register_window(recv_mem.ptr, recv_mem.size)
         reqs = CCODevCommRequirements()
         reqs.gda_connection_type = GDA_CONNECTION_FULL
         reqs.gda_signal_count = 16


### PR DESCRIPTION
 ## Summary

  - Add CCO example tests (C++ and Python) to the CI workflow, running after unit tests
  - Enable `BUILD_EXAMPLES=ON` in the CI build step so C++ example binaries are compiled
  - Fix FlyDSL Python examples that used the removed `alloc_window` API — replaced with `alloc_mem` + `register_window`

  ## Changes

  ### CI (`ci_cco.yml`)

  - Added `BUILD_EXAMPLES=ON` to the `pip install` build step
  - New step **"Run CCO C++ examples (2 ranks)"**: runs `cco_lsa_put` and `cco_gda_put` via `mpirun -np 2`
  - New step **"Run CCO Python examples (2 ranks)"**: installs `mpi4py` and runs `01_barrier` and `02_lsa_put` via `mpirun -np 2`

  ### FlyDSL example fixes (`examples/cco/python/`)

  - Updated 4 examples (`03_flydsl_put`, `04_flydsl_lsa_put`, `05_flydsl_lsa_allreduce`, `06_flydsl_gda_modes`) to replace the removed `comm.alloc_window(size)` with the current two-step API:
   ```python
  mem = comm.alloc_mem(size)
  win = comm.register_window(mem.ptr, mem.size)