### PR TITLE
test(ep): add configurable CLI knobs to dispatch/combine benchmark

### DIFF
--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -52,8 +52,10 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
         force_scale_active=False,
         report_scale_stats=False,
         combine_scale_dim=None,
+        routing="random",
     ):
         super().__init__(config)
+        self.routing = routing
         self.combine_data_type = (
             combine_data_type if combine_data_type is not None else config.data_type
         )
@@ -83,6 +85,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
         self.config.hidden_dim = self.dispatch_hidden_dim
         result = super().gen_test_data(
             use_max_token_num=True,
+            routing=self.routing,
             input_dist=self.input_dist,
             input_scale=self.input_scale,
             input_shift=self.input_shift,
@@ -908,6 +911,7 @@ def _bench_dispatch_combine(
     warmup=None,
     iters=None,
     verify=True,
+    routing="random",
 ):
     if combine_data_type is None:
         combine_data_type = data_type
@@ -973,6 +977,7 @@ def _bench_dispatch_combine(
             force_scale_active=force_scale_active,
             report_scale_stats=report_scale_stats,
             combine_scale_dim=bench_combine_scale_dim,
+            routing=routing,
         )
 
         (
@@ -1252,6 +1257,7 @@ def bench_dispatch_combine(
     warmup=None,
     iters=None,
     verify=True,
+    routing="random",
 ):
     if combine_data_type is None:
         combine_data_type = dtype
@@ -1287,6 +1293,7 @@ def bench_dispatch_combine(
             warmup,
             iters,
             verify,
+            routing,
         ),
         nprocs=world_size,
         join=True,
@@ -1506,6 +1513,22 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument(
+        "--routing",
+        type=str,
+        default="random",
+        choices=[
+            "random",
+            "round_robin",
+            "remote_round_robin",
+            "spread",
+            "all_to_one",
+        ],
+        help=(
+            "Token-to-expert routing pattern used to generate test data "
+            "(default: random)"
+        ),
+    )
+    parser.add_argument(
         "--verify",
         type=int,
         default=1,
@@ -1587,4 +1610,5 @@ if __name__ == "__main__":
         warmup=args.warmup,
         iters=args.iters,
         verify=bool(args.verify),
+        routing=args.routing,
     )

--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -851,6 +851,24 @@ def _optional_kwargs(**kwargs):
     return {k: v for k, v in kwargs.items() if v is not None}
 
 
+KERNEL_TYPE_CHOICES = {
+    "IntraNode": mori.ops.EpDispatchCombineKernelType.IntraNode,
+    "IntraNodeLL": mori.ops.EpDispatchCombineKernelType.IntraNodeLL,
+    "InterNode": mori.ops.EpDispatchCombineKernelType.InterNode,
+    "InterNodeV1": mori.ops.EpDispatchCombineKernelType.InterNodeV1,
+    "InterNodeV1LL": mori.ops.EpDispatchCombineKernelType.InterNodeV1LL,
+    "AsyncLL": mori.ops.EpDispatchCombineKernelType.AsyncLL,
+}
+
+
+def _resolve_bench_kernel_type(name):
+    if name not in KERNEL_TYPE_CHOICES:
+        raise ValueError(
+            f"Unknown kernel_type={name!r}; choose from {sorted(KERNEL_TYPE_CHOICES)}"
+        )
+    return KERNEL_TYPE_CHOICES[name]
+
+
 def _get_default_launch_config(
     world_size,
     max_num_inp_token_per_rank,
@@ -912,6 +930,7 @@ def _bench_dispatch_combine(
     iters=None,
     verify=True,
     routing="random",
+    kernel_type="IntraNode",
 ):
     if combine_data_type is None:
         combine_data_type = data_type
@@ -954,6 +973,7 @@ def _bench_dispatch_combine(
         use_external_inp_buf=not zero_copy,  # zero-copy mode requires use_external_inp_buf=False
         gpu_per_node=world_size,
         quant_type=quant_type,
+        kernel_type=_resolve_bench_kernel_type(kernel_type),
     )
     with TorchDistContext(rank=rank, world_size=world_size, master_port=port):
         mori.shmem.shmem_torch_process_group_init("default")
@@ -1258,6 +1278,7 @@ def bench_dispatch_combine(
     iters=None,
     verify=True,
     routing="random",
+    kernel_type="IntraNode",
 ):
     if combine_data_type is None:
         combine_data_type = dtype
@@ -1294,6 +1315,7 @@ def bench_dispatch_combine(
             iters,
             verify,
             routing,
+            kernel_type,
         ),
         nprocs=world_size,
         join=True,
@@ -1538,6 +1560,13 @@ if __name__ == "__main__":
             "warmup. --cmd bench only"
         ),
     )
+    parser.add_argument(
+        "--kernel-type",
+        type=str,
+        default="IntraNode",
+        choices=sorted(KERNEL_TYPE_CHOICES),
+        help="Dispatch/combine kernel implementation to benchmark (default: IntraNode)",
+    )
     args = parser.parse_args()
 
     if args.num_experts_per_rank is None:
@@ -1580,7 +1609,8 @@ if __name__ == "__main__":
         f"dispatch_block_num: {args.dispatch_block_num}, "
         f"dispatch_warp_per_block: {args.dispatch_warp_per_block}, "
         f"combine_block_num: {args.combine_block_num}, "
-        f"combine_warp_per_block: {args.combine_warp_per_block}"
+        f"combine_warp_per_block: {args.combine_warp_per_block}, "
+        f"kernel_type: {args.kernel_type}"
     )
     print("-" * 60)
     bench_dispatch_combine(
@@ -1611,4 +1641,5 @@ if __name__ == "__main__":
         iters=args.iters,
         verify=bool(args.verify),
         routing=args.routing,
+        kernel_type=args.kernel_type,
     )

--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -481,6 +481,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
         graph_replay_iters=10,
         skip_e2e=False,
         call_local_expert_count=False,
+        verify=True,
     ):
         test_data = self.gen_test_data()
         for _ in range(warmup):
@@ -491,6 +492,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
                 dispatch_warp_per_block,
                 combine_block_num,
                 combine_warp_per_block,
+                check=verify,
                 call_local_expert_count=call_local_expert_count,
             )
 
@@ -905,6 +907,7 @@ def _bench_dispatch_combine(
     report_scale_stats=False,
     warmup=None,
     iters=None,
+    verify=True,
 ):
     if combine_data_type is None:
         combine_data_type = data_type
@@ -1007,6 +1010,7 @@ def _bench_dispatch_combine(
                 combine_block_num=combine_block_num,
                 combine_warp_per_block=combine_warp_per_block,
                 call_local_expert_count=call_local_expert_count,
+                verify=verify,
                 **_optional_kwargs(warmup=warmup, iters=iters),
             )
 
@@ -1247,6 +1251,7 @@ def bench_dispatch_combine(
     report_scale_stats=False,
     warmup=None,
     iters=None,
+    verify=True,
 ):
     if combine_data_type is None:
         combine_data_type = dtype
@@ -1281,6 +1286,7 @@ def bench_dispatch_combine(
             report_scale_stats,
             warmup,
             iters,
+            verify,
         ),
         nprocs=world_size,
         join=True,
@@ -1499,6 +1505,16 @@ if __name__ == "__main__":
             "(default: 10) and --cmd profile (default: 3) "
         ),
     )
+    parser.add_argument(
+        "--verify",
+        type=int,
+        default=1,
+        choices=[0, 1],
+        help=(
+            "When 1 (default), verify dispatch/combine correctness during "
+            "warmup. --cmd bench only"
+        ),
+    )
     args = parser.parse_args()
 
     if args.num_experts_per_rank is None:
@@ -1570,4 +1586,5 @@ if __name__ == "__main__":
         report_scale_stats=bool(args.report_scale_stats),
         warmup=args.warmup,
         iters=args.iters,
+        verify=bool(args.verify),
     )

--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -931,6 +931,7 @@ def _bench_dispatch_combine(
     verify=True,
     routing="random",
     kernel_type="IntraNode",
+    graph_replay_iters=None,
 ):
     if combine_data_type is None:
         combine_data_type = data_type
@@ -1036,7 +1037,9 @@ def _bench_dispatch_combine(
                 combine_warp_per_block=combine_warp_per_block,
                 call_local_expert_count=call_local_expert_count,
                 verify=verify,
-                **_optional_kwargs(warmup=warmup, iters=iters),
+                **_optional_kwargs(
+                    warmup=warmup, iters=iters, graph_replay_iters=graph_replay_iters
+                ),
             )
 
         elif cmd == "stress":
@@ -1279,6 +1282,7 @@ def bench_dispatch_combine(
     verify=True,
     routing="random",
     kernel_type="IntraNode",
+    graph_replay_iters=None,
 ):
     if combine_data_type is None:
         combine_data_type = dtype
@@ -1316,6 +1320,7 @@ def bench_dispatch_combine(
             verify,
             routing,
             kernel_type,
+            graph_replay_iters,
         ),
         nprocs=world_size,
         join=True,
@@ -1535,6 +1540,15 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument(
+        "--graph-replay-iters",
+        type=int,
+        default=None,
+        help=(
+            "Number of times each captured CUDA graph is replayed per "
+            "timed --iters sample (default: 10). --cmd bench only"
+        ),
+    )
+    parser.add_argument(
         "--routing",
         type=str,
         default="random",
@@ -1610,7 +1624,8 @@ if __name__ == "__main__":
         f"dispatch_warp_per_block: {args.dispatch_warp_per_block}, "
         f"combine_block_num: {args.combine_block_num}, "
         f"combine_warp_per_block: {args.combine_warp_per_block}, "
-        f"kernel_type: {args.kernel_type}"
+        f"kernel_type: {args.kernel_type}, "
+        f"graph_replay_iters: {args.graph_replay_iters}"
     )
     print("-" * 60)
     bench_dispatch_combine(
@@ -1642,4 +1657,5 @@ if __name__ == "__main__":
         verify=bool(args.verify),
         routing=args.routing,
         kernel_type=args.kernel_type,
+        graph_replay_iters=args.graph_replay_iters,
     )

--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -841,6 +841,11 @@ LaunchConfig = namedtuple(
 )
 
 
+def _optional_kwargs(**kwargs):
+    """Drop keys whose value is None, so the callee's own default applies."""
+    return {k: v for k, v in kwargs.items() if v is not None}
+
+
 def _get_default_launch_config(
     world_size,
     max_num_inp_token_per_rank,
@@ -898,6 +903,8 @@ def _bench_dispatch_combine(
     input_shift=0.0,
     force_scale_active=False,
     report_scale_stats=False,
+    warmup=None,
+    iters=None,
 ):
     if combine_data_type is None:
         combine_data_type = data_type
@@ -1000,6 +1007,7 @@ def _bench_dispatch_combine(
                 combine_block_num=combine_block_num,
                 combine_warp_per_block=combine_warp_per_block,
                 call_local_expert_count=call_local_expert_count,
+                **_optional_kwargs(warmup=warmup, iters=iters),
             )
 
         elif cmd == "stress":
@@ -1033,6 +1041,7 @@ def _bench_dispatch_combine(
                 combine_block_num=combine_block_num,
                 combine_warp_per_block=combine_warp_per_block,
                 call_local_expert_count=call_local_expert_count,
+                **_optional_kwargs(warmup=warmup, capture_iters=iters),
             )
 
         elif cmd == "tuning":
@@ -1236,6 +1245,8 @@ def bench_dispatch_combine(
     input_shift=0.0,
     force_scale_active=False,
     report_scale_stats=False,
+    warmup=None,
+    iters=None,
 ):
     if combine_data_type is None:
         combine_data_type = dtype
@@ -1268,6 +1279,8 @@ def bench_dispatch_combine(
             input_shift,
             force_scale_active,
             report_scale_stats,
+            warmup,
+            iters,
         ),
         nprocs=world_size,
         join=True,
@@ -1468,6 +1481,24 @@ if __name__ == "__main__":
             "p50/p90/p99/max) for the generated input."
         ),
     )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=None,
+        help=(
+            "Number of warmup iterations before timing. Applies to --cmd bench "
+            "(default: 1) and --cmd profile (default: 5);"
+        ),
+    )
+    parser.add_argument(
+        "--iters",
+        type=int,
+        default=None,
+        help=(
+            "Number of timed/captured iterations. Applies to --cmd bench "
+            "(default: 10) and --cmd profile (default: 3) "
+        ),
+    )
     args = parser.parse_args()
 
     if args.num_experts_per_rank is None:
@@ -1537,4 +1568,6 @@ if __name__ == "__main__":
         input_shift=args.input_shift,
         force_scale_active=bool(args.force_scale_active),
         report_scale_stats=bool(args.report_scale_stats),
+        warmup=args.warmup,
+        iters=args.iters,
     )

--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -481,6 +481,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
         graph_replay_iters=10,
         skip_e2e=False,
         call_local_expert_count=False,
+        verify=True,
     ):
         test_data = self.gen_test_data()
         for _ in range(warmup):
@@ -491,6 +492,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
                 dispatch_warp_per_block,
                 combine_block_num,
                 combine_warp_per_block,
+                check=verify,
                 call_local_expert_count=call_local_expert_count,
             )
 
@@ -907,6 +909,7 @@ def _bench_dispatch_combine(
     kernel_type_str="IntraNode",
     warmup=None,
     iters=None,
+    verify=True,
 ):
     if combine_data_type is None:
         combine_data_type = data_type
@@ -1016,6 +1019,7 @@ def _bench_dispatch_combine(
                 combine_block_num=combine_block_num,
                 combine_warp_per_block=combine_warp_per_block,
                 call_local_expert_count=call_local_expert_count,
+                verify=verify,
                 **_optional_kwargs(warmup=warmup, iters=iters),
             )
 
@@ -1258,6 +1262,7 @@ def bench_dispatch_combine(
     kernel_type_str="IntraNode",
     warmup=None,
     iters=None,
+    verify=True,
 ):
     if combine_data_type is None:
         combine_data_type = dtype
@@ -1293,6 +1298,7 @@ def bench_dispatch_combine(
             kernel_type_str,
             warmup,
             iters,
+            verify,
         ),
         nprocs=world_size,
         join=True,
@@ -1518,6 +1524,16 @@ if __name__ == "__main__":
             "(default: 10) and --cmd profile (default: 3) "
         ),
     )
+    parser.add_argument(
+        "--verify",
+        type=int,
+        default=1,
+        choices=[0, 1],
+        help=(
+            "When 1 (default), verify dispatch/combine correctness during "
+            "warmup. --cmd bench only"
+        ),
+    )
     args = parser.parse_args()
 
     if args.num_experts_per_rank is None:
@@ -1590,4 +1606,5 @@ if __name__ == "__main__":
         kernel_type_str=args.kernel_type,
         warmup=args.warmup,
         iters=args.iters,
+        verify=bool(args.verify),
     )

--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -842,6 +842,11 @@ LaunchConfig = namedtuple(
 )
 
 
+def _optional_kwargs(**kwargs):
+    """Drop keys whose value is None, so the callee's own default applies."""
+    return {k: v for k, v in kwargs.items() if v is not None}
+
+
 def _get_default_launch_config(
     world_size,
     max_num_inp_token_per_rank,
@@ -900,6 +905,8 @@ def _bench_dispatch_combine(
     force_scale_active=False,
     report_scale_stats=False,
     kernel_type_str="IntraNode",
+    warmup=None,
+    iters=None,
 ):
     if combine_data_type is None:
         combine_data_type = data_type
@@ -1009,6 +1016,7 @@ def _bench_dispatch_combine(
                 combine_block_num=combine_block_num,
                 combine_warp_per_block=combine_warp_per_block,
                 call_local_expert_count=call_local_expert_count,
+                **_optional_kwargs(warmup=warmup, iters=iters),
             )
 
         elif cmd == "stress":
@@ -1042,6 +1050,7 @@ def _bench_dispatch_combine(
                 combine_block_num=combine_block_num,
                 combine_warp_per_block=combine_warp_per_block,
                 call_local_expert_count=call_local_expert_count,
+                **_optional_kwargs(warmup=warmup, capture_iters=iters),
             )
 
         elif cmd == "tuning":
@@ -1247,6 +1256,8 @@ def bench_dispatch_combine(
     force_scale_active=False,
     report_scale_stats=False,
     kernel_type_str="IntraNode",
+    warmup=None,
+    iters=None,
 ):
     if combine_data_type is None:
         combine_data_type = dtype
@@ -1280,6 +1291,8 @@ def bench_dispatch_combine(
             force_scale_active,
             report_scale_stats,
             kernel_type_str,
+            warmup,
+            iters,
         ),
         nprocs=world_size,
         join=True,
@@ -1487,6 +1500,24 @@ if __name__ == "__main__":
             "p50/p90/p99/max) for the generated input."
         ),
     )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=None,
+        help=(
+            "Number of warmup iterations before timing. Applies to --cmd bench "
+            "(default: 1) and --cmd profile (default: 5);"
+        ),
+    )
+    parser.add_argument(
+        "--iters",
+        type=int,
+        default=None,
+        help=(
+            "Number of timed/captured iterations. Applies to --cmd bench "
+            "(default: 10) and --cmd profile (default: 3) "
+        ),
+    )
     args = parser.parse_args()
 
     if args.num_experts_per_rank is None:
@@ -1557,4 +1588,6 @@ if __name__ == "__main__":
         force_scale_active=bool(args.force_scale_active),
         report_scale_stats=bool(args.report_scale_stats),
         kernel_type_str=args.kernel_type,
+        warmup=args.warmup,
+        iters=args.iters,
     )

--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -52,8 +52,10 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
         force_scale_active=False,
         report_scale_stats=False,
         combine_scale_dim=None,
+        routing="random",
     ):
         super().__init__(config)
+        self.routing = routing
         self.combine_data_type = (
             combine_data_type if combine_data_type is not None else config.data_type
         )
@@ -83,6 +85,7 @@ class EpDispatchCombineBenchmark(EpDispatchCombineTestCase):
         self.config.hidden_dim = self.dispatch_hidden_dim
         result = super().gen_test_data(
             use_max_token_num=True,
+            routing=self.routing,
             input_dist=self.input_dist,
             input_scale=self.input_scale,
             input_shift=self.input_shift,
@@ -910,6 +913,7 @@ def _bench_dispatch_combine(
     warmup=None,
     iters=None,
     verify=True,
+    routing="random",
 ):
     if combine_data_type is None:
         combine_data_type = data_type
@@ -982,6 +986,7 @@ def _bench_dispatch_combine(
             force_scale_active=force_scale_active,
             report_scale_stats=report_scale_stats,
             combine_scale_dim=bench_combine_scale_dim,
+            routing=routing,
         )
 
         (
@@ -1263,6 +1268,7 @@ def bench_dispatch_combine(
     warmup=None,
     iters=None,
     verify=True,
+    routing="random",
 ):
     if combine_data_type is None:
         combine_data_type = dtype
@@ -1299,6 +1305,7 @@ def bench_dispatch_combine(
             warmup,
             iters,
             verify,
+            routing,
         ),
         nprocs=world_size,
         join=True,
@@ -1525,6 +1532,22 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument(
+        "--routing",
+        type=str,
+        default="random",
+        choices=[
+            "random",
+            "round_robin",
+            "remote_round_robin",
+            "spread",
+            "all_to_one",
+        ],
+        help=(
+            "Token-to-expert routing pattern used to generate test data "
+            "(default: random)"
+        ),
+    )
+    parser.add_argument(
         "--verify",
         type=int,
         default=1,
@@ -1607,4 +1630,5 @@ if __name__ == "__main__":
         warmup=args.warmup,
         iters=args.iters,
         verify=bool(args.verify),
+        routing=args.routing,
     )

--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -914,6 +914,7 @@ def _bench_dispatch_combine(
     iters=None,
     verify=True,
     routing="random",
+    graph_replay_iters=None,
 ):
     if combine_data_type is None:
         combine_data_type = data_type
@@ -1025,7 +1026,9 @@ def _bench_dispatch_combine(
                 combine_warp_per_block=combine_warp_per_block,
                 call_local_expert_count=call_local_expert_count,
                 verify=verify,
-                **_optional_kwargs(warmup=warmup, iters=iters),
+                **_optional_kwargs(
+                    warmup=warmup, iters=iters, graph_replay_iters=graph_replay_iters
+                ),
             )
 
         elif cmd == "stress":
@@ -1269,6 +1272,7 @@ def bench_dispatch_combine(
     iters=None,
     verify=True,
     routing="random",
+    graph_replay_iters=None,
 ):
     if combine_data_type is None:
         combine_data_type = dtype
@@ -1306,6 +1310,7 @@ def bench_dispatch_combine(
             iters,
             verify,
             routing,
+            graph_replay_iters,
         ),
         nprocs=world_size,
         join=True,
@@ -1532,6 +1537,15 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument(
+        "--graph-replay-iters",
+        type=int,
+        default=None,
+        help=(
+            "Number of times each captured CUDA graph is replayed per "
+            "timed --iters sample (default: 10). --cmd bench only"
+        ),
+    )
+    parser.add_argument(
         "--routing",
         type=str,
         default="random",
@@ -1599,7 +1613,8 @@ if __name__ == "__main__":
         f"dispatch_block_num: {args.dispatch_block_num}, "
         f"dispatch_warp_per_block: {args.dispatch_warp_per_block}, "
         f"combine_block_num: {args.combine_block_num}, "
-        f"combine_warp_per_block: {args.combine_warp_per_block}"
+        f"combine_warp_per_block: {args.combine_warp_per_block}, "
+        f"graph_replay_iters: {args.graph_replay_iters}"
     )
     print("-" * 60)
     bench_dispatch_combine(
@@ -1631,4 +1646,5 @@ if __name__ == "__main__":
         iters=args.iters,
         verify=bool(args.verify),
         routing=args.routing,
+        graph_replay_iters=args.graph_replay_iters,
     )

--- a/tests/python/ops/dispatch_combine_test_utils.py
+++ b/tests/python/ops/dispatch_combine_test_utils.py
@@ -411,6 +411,24 @@ class EpDispatchCombineTestCase:
                     ) * self.config.num_experts_per_token
                     for j in range(self.config.num_experts_per_token):
                         indices[i, j] = (base + j) % total_experts
+            elif routing == "remote_round_robin":
+                # Balanced, no-skew round-robin over every destination rank
+                # except the local one, then round-robins over that rank's
+                # own experts to pick which one receives the token.
+                assert (
+                    self.config.world_size > 1
+                ), "remote_round_robin routing requires world_size > 1"
+                indices = torch.empty(
+                    n, self.config.num_experts_per_token, dtype=torch.int64
+                )
+                ws = self.config.world_size
+                nepr = self.config.num_experts_per_rank
+                for i in range(n):
+                    for j in range(self.config.num_experts_per_token):
+                        rec = i * self.config.num_experts_per_token + j
+                        dst = (r + 1 + (rec % (ws - 1))) % ws
+                        local_e = (rec // (ws - 1)) % nepr
+                        indices[i, j] = dst * nepr + local_e
             elif routing == "spread":
                 # Sends exactly one expert to every rank (requires num_experts_per_token ==
                 # world_size). After per-rank deduplication each rank receives every source


### PR DESCRIPTION
## Motivation

The dispatch/combine benchmark script only supported a fixed set of scenarios. This makes it hard to explore different kernel implementations, routing patterns, or tune benchmark timing without editing the script. This PR adds CLI flags to cover these cases.

## Technical Details

Adds the following flags to `--cmd bench` (all optional, defaulting to prior behavior):
- `--warmup` / `--iters` – number of warmup and timing iteration.
- `--routing` – select the token-to-expert routing pattern; adds a new `remote_round_robin` pattern that always routes to a remote rank.
- `--verify` – skip the host-side correctness check during warmup.
- `--graph-replay-iters` – control how many times each captured CUDA graph is replayed per timed sample.

## Test Plan

Run bench_dispatch_combine.py with new command line options

## Test Result

bench_dispatch_combine.py works, default values were not changed, new command line arguments work as expected

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
