### PR TITLE
ci: recover podman state before internode build on MI355X_AINIC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,6 +475,10 @@ jobs:
         with:
           submodules: true
 
+      - name: Recover podman if needed
+        if: ${{ matrix.ct == 'podman' }}
+        run: podman system migrate || true
+
       - name: Build CI image
         run: $CT build --network=host --build-arg BASE_IMAGE=$BASE_IMAGE -t $IMAGE -f docker/Dockerfile.dev .
 


### PR DESCRIPTION
The MI355X_AINIC internode job uses podman and occasionally hits "invalid internal status" at `podman build`, caused by stale pause-process state from a previous run. 
FIX: add a `podman system migrate || true` step before Build CI image to self-heal without manual intervention.
