### PR TITLE
feat(EPv2): gfx1250 + cross-node fabric support

### DIFF
--- a/.github/workflows/ci_cco.yml
+++ b/.github/workflows/ci_cco.yml
@@ -58,8 +58,9 @@ jobs:
 
       - name: Build mori with tests
         run: |
+          # BUILD_UMBP=OFF: not needed for CCO, and its gtest discovery breaks under cmake 4.4.
           $CT exec $CONTAINER bash -c \
-            "cd $GITHUB_WORKSPACE && BUILD_TESTS=ON BUILD_EXAMPLES=ON MORI_WITH_MPI=ON pip install ."
+            "cd $GITHUB_WORKSPACE && BUILD_TESTS=ON BUILD_EXAMPLES=ON MORI_WITH_MPI=ON BUILD_UMBP=OFF pip install ."
 
       - name: Run CCO unit tests (fork mode, 4 ranks)
         run: |

--- a/examples/cco/cpp/01_lsa_put.cpp
+++ b/examples/cco/cpp/01_lsa_put.cpp
@@ -23,7 +23,7 @@
 //
 // MIT License
 
-// CCO C++ example 01 — LSA put (intra-node, direct peer pointer)
+// CCO C++ example 01 — LSA put (direct peer pointer via flat VA)
 //
 // LSA model: cco hands the kernel the peer's load/store-accessible VA via
 // ccoGetLsaPeerPtr(); the kernel writes it *directly* — cco does NOT move the
@@ -31,8 +31,8 @@
 // the symmetric flat VA, and the window device handle already carries
 // winBase / stride4G / lsaRank.
 //
-// Rank 0 copies its send window into rank 1's recv window slot. Single node,
-// 2 ranks. Only cco.hpp is included.
+// Rank 0 copies its send window into rank 1's recv window slot (2 ranks).
+// With fabric cross-node LSA enabled, ranks may span multiple nodes.
 //
 //   mpirun -n 2 ./cco_lsa_put        (set MORI_SOCKET_IFNAME=<iface>)
 
@@ -83,7 +83,7 @@ int main(int argc, char** argv) {
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &nranks);
   if (nranks != 2) {
-    if (rank == 0) fprintf(stderr, "This example needs exactly 2 ranks on one node.\n");
+    if (rank == 0) fprintf(stderr, "This example needs exactly 2 ranks.\n");
     MPI_Finalize();
     return 1;
   }
@@ -116,7 +116,7 @@ int main(int argc, char** argv) {
 
   CCO_CHECK(ccoBarrierAll(comm));
 
-  // Rank 0 writes into rank 1's window slot (peer lsaRank = 1 on a single node).
+  // Rank 0 writes into rank 1's window slot (peer lsaRank = 1).
   if (rank == 0) {
     LsaPutKernel<<<1, 256>>>(sendWin, recvWin, /*peerLsaRank=*/1, COUNT);
     HIP_CHECK(hipDeviceSynchronize());

--- a/include/mori/cco/cco.hpp
+++ b/include/mori/cco/cco.hpp
@@ -787,6 +787,11 @@ struct ccoComm {
   // Stored as int to avoid pulling hip_runtime_api.h into this header.
   int handleType{0x1};  // hipMemHandleTypePosixFileDescriptor
 
+  // Hardcoded cross-node LSA: when fabric probe succeeds on a multi-node
+  // comm, expand lsaSize to worldSize so all peers are flat-VA reachable.
+  bool fabricCrossNodeLsa{false};
+  std::vector<int> peerHipDevs;
+
   // GDA backend provider of this comm's NICs; resolved at the first
   // ccoDevCommCreate (CCO_PROVIDER_UNKNOWN until then / when GDA is off).
   // Informational host-side parameter — GDA dispatch is compile-time per-NIC.

--- a/include/mori/cco/cco.hpp
+++ b/include/mori/cco/cco.hpp
@@ -787,8 +787,10 @@ struct ccoComm {
   // Stored as int to avoid pulling hip_runtime_api.h into this header.
   int handleType{0x1};  // hipMemHandleTypePosixFileDescriptor
 
-  // Hardcoded cross-node LSA: when fabric probe succeeds on a multi-node
-  // comm, expand lsaSize to worldSize so all peers are flat-VA reachable.
+  // Cross-node LSA: set when the LSA team (vPOD) spans hosts, so peer windows
+  // are mapped via fabric handles into the flat VA (no intra-node peer-access).
+  // lsaSize/myNodeStart still describe the contiguous team; this only selects
+  // the cross-node mapping path in ccoWindowRegister.
   bool fabricCrossNodeLsa{false};
   std::vector<int> peerHipDevs;
 

--- a/include/mori/cco/cco.hpp
+++ b/include/mori/cco/cco.hpp
@@ -80,6 +80,13 @@ struct SdmaQueueDeviceHandle;  // ccoSdmaContext / ccoComm (pointer)
 // Opaque HIP typedef, replicated so ccoComm can name it without the ROCm header.
 struct ihipMemGenericAllocationHandle;
 typedef struct ihipMemGenericAllocationHandle* hipMemGenericAllocationHandle_t;
+// Fabric handle — 64-byte opaque token for cross-process sharing.
+// Intentionally a separate type from hipMemFabricHandle_compat_t (hip_compat.hpp)
+// so this header stays self-contained; the two are layout-compatible and
+// cco_init.cpp reinterpret_casts between them.
+struct ccoFabricHandle_t {
+  unsigned char data[64];
+};
 
 namespace mori {
 namespace cco {
@@ -775,6 +782,11 @@ struct ccoComm {
   int defaultNumQpPerPe{4};
   bool iovaZeroMode{true};
 
+  // Handle type for VMM allocations. Fabric (0x8) when the runtime supports it
+  // (probed at CommCreate); falls back to PosixFileDescriptor (0x1).
+  // Stored as int to avoid pulling hip_runtime_api.h into this header.
+  int handleType{0x1};  // hipMemHandleTypePosixFileDescriptor
+
   // GDA backend provider of this comm's NICs; resolved at the first
   // ccoDevCommCreate (CCO_PROVIDER_UNKNOWN until then / when GDA is off).
   // Informational host-side parameter — GDA dispatch is compile-time per-NIC.
@@ -786,7 +798,11 @@ struct ccoComm {
 
   struct AllocMeta {
     hipMemGenericAllocationHandle_t physHandle;
-    int shareFd{-1};
+    union {
+      int shareFd;
+      ccoFabricHandle_t fabricHandle;
+    };
+    bool isFabric{false};
     size_t slotOffset{0};
     size_t size{0};
   };

--- a/include/mori/utils/hip_compat.hpp
+++ b/include/mori/utils/hip_compat.hpp
@@ -63,3 +63,25 @@ inline hipError_t hipMemImportFromShareableHandleCompat(hipMemGenericAllocationH
   return hipMemImportFromShareableHandle(handle, (void*)&fd, handleType);
 #endif
 }
+
+// Fabric handle compat — mirrors RCCL's mem_manager.h shim.
+// When HIP exposes hipMemFabricHandle_t natively, use it; otherwise define a
+// 64-byte opaque struct and the handle-type sentinel (0x8).
+#ifdef HIP_FABRIC_API
+typedef hipMemFabricHandle_t hipMemFabricHandle_compat_t;
+#define MORI_MEM_HANDLE_TYPE_FABRIC hipMemHandleTypeFabric
+#else
+#ifndef MORI_FABRIC_HANDLE_DEFINED
+#define MORI_FABRIC_HANDLE_DEFINED
+typedef struct {
+  unsigned char data[64];
+} hipMemFabricHandle_compat_t;
+#endif
+#define MORI_MEM_HANDLE_TYPE_FABRIC ((hipMemAllocationHandleType)0x8)
+#endif
+
+inline hipMemAllocationHandleType hipMemHandleTypeFabricCompat_value() {
+  return MORI_MEM_HANDLE_TYPE_FABRIC;
+}
+static const hipMemAllocationHandleType hipMemHandleTypeFabricCompat =
+    MORI_MEM_HANDLE_TYPE_FABRIC;

--- a/include/mori/utils/hip_compat.hpp
+++ b/include/mori/utils/hip_compat.hpp
@@ -83,5 +83,4 @@ typedef struct {
 inline hipMemAllocationHandleType hipMemHandleTypeFabricCompat_value() {
   return MORI_MEM_HANDLE_TYPE_FABRIC;
 }
-static const hipMemAllocationHandleType hipMemHandleTypeFabricCompat =
-    MORI_MEM_HANDLE_TYPE_FABRIC;
+static const hipMemAllocationHandleType hipMemHandleTypeFabricCompat = MORI_MEM_HANDLE_TYPE_FABRIC;

--- a/python/mori/jit/config.py
+++ b/python/mori/jit/config.py
@@ -28,7 +28,7 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
-_SUPPORTED_ARCHS = ["gfx942", "gfx950"]
+_SUPPORTED_ARCHS = ["gfx942", "gfx950", "gfx1250"]
 
 
 @dataclass(frozen=True)

--- a/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
+++ b/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
@@ -108,7 +108,12 @@ class EpDispatchCombineConfig:
     max_num_inp_token_per_rank: int
     num_experts_per_rank: int
     num_experts_per_token: int
+    # Base token dtype; dispatch_data_type / combine_data_type override it per-op
+    # (None => data_type). Asymmetric (fp8 dispatch -> bf16 combine) fits an expert
+    # op that converts dtype between the two. gather mode only.
     data_type: torch.dtype = torch.bfloat16
+    dispatch_data_type: torch.dtype = None
+    combine_data_type: torch.dtype = None
     # Per-token quant scales forwarded verbatim to dest out_scales (0 disables).
     scale_dim: int = 0
     scale_type_size: int = 0
@@ -130,6 +135,15 @@ class EpDispatchCombineConfig:
     max_total_recv_tokens: int = 0  # mori maxTotalRecvTokens; 0 = worst-case ws*M
 
     def __post_init__(self):
+        # all-or-none: setting only one silently defaults the other to data_type.
+        if (self.dispatch_data_type is None) != (self.combine_data_type is None):
+            raise ValueError(
+                "dispatch_data_type / combine_data_type must be set together "
+                "(all-or-none): got dispatch_data_type="
+                f"{self.dispatch_data_type}, combine_data_type={self.combine_data_type}. "
+                "Set data_type alone for a symmetric op, or set both explicitly for "
+                "asymmetric dispatch/combine dtypes."
+            )
         if self.quant_type not in _QUANT_TYPES:
             raise ValueError(
                 f"quant_type must be one of {_QUANT_TYPES}, got {self.quant_type!r}"
@@ -153,9 +167,24 @@ class EpDispatchCombineConfig:
         if self.token_nbytes % 16 != 0:
             raise ValueError(
                 f"per-token transport bytes must be 16 B aligned (vec4 copy); "
-                f"hidden_dim={self.hidden_dim}, data_type={self.data_type} -> "
+                f"hidden_dim={self.hidden_dim}, dispatch_dtype={self.dispatch_dtype} -> "
                 f"token_nbytes={self.token_nbytes}"
             )
+        if self.is_asymmetric_dtype:
+            # out_tok holds dispatch output then (post-expert) combine input; the
+            # two dtype layouts never coexist. gather/non-quant/non-StdMoE only.
+            if self.combine_mode != "gather" or self.quant_type != "none" or self.enable_std_moe:
+                raise ValueError(
+                    "combine_data_type (asymmetric dtype) requires combine_mode=gather, "
+                    "quant_type=none, enable_std_moe=False"
+                )
+            if torch.float4_e2m1fn_x2 in (self.dispatch_dtype, self.combine_dtype):
+                raise ValueError("asymmetric dispatch/combine dtype does not support fp4")
+            if self.combine_token_nbytes % 16 != 0:
+                raise ValueError(
+                    f"combine per-token bytes must be 16 B aligned; combine_data_type="
+                    f"{self.combine_data_type} -> {self.combine_token_nbytes}"
+                )
 
     @property
     def is_scatter(self):
@@ -206,23 +235,51 @@ class EpDispatchCombineConfig:
         return cls(**kwargs)
 
     @property
+    def dispatch_dtype(self):
+        """Dispatch transport dtype (== data_type unless dispatch_data_type set)."""
+        return self.dispatch_data_type if self.dispatch_data_type is not None else self.data_type
+
+    @property
     def is_fp4(self):
-        return self.data_type == torch.float4_e2m1fn_x2
+        return self.dispatch_dtype == torch.float4_e2m1fn_x2
 
     @property
     def is_fp8(self):
-        return self.data_type in _FP8_DTYPES
+        return self.dispatch_dtype in _FP8_DTYPES
 
     @property
     def elem_size(self):
         # fp4 is 0.5 B/elem; return a nominal 1 (kernels use the fp4 flag +
         # token_nbytes for actual sizing, never elem_size for fp4 token buffers).
-        return 1 if self.is_fp4 else _DT[self.data_type]
+        return 1 if self.is_fp4 else _DT[self.dispatch_dtype]
 
     @property
     def token_nbytes(self):
         """Per-token transport bytes (fp4 packs 2 e2m1/byte -> hidden/2)."""
         return self.hidden_dim // 2 if self.is_fp4 else self.hidden_dim * self.elem_size
+
+    @property
+    def combine_dtype(self):
+        """Combine transport dtype (== data_type unless combine_data_type set)."""
+        return self.combine_data_type if self.combine_data_type is not None else self.data_type
+
+    @property
+    def combine_elem_size(self):
+        cdt = self.combine_dtype
+        return 1 if cdt == torch.float4_e2m1fn_x2 else _DT[cdt]
+
+    @property
+    def combine_token_nbytes(self):
+        cdt = self.combine_dtype
+        return (
+            self.hidden_dim // 2
+            if cdt == torch.float4_e2m1fn_x2
+            else self.hidden_dim * self.combine_elem_size
+        )
+
+    @property
+    def is_asymmetric_dtype(self):
+        return self.dispatch_dtype != self.combine_dtype
 
     @property
     def dtype_str(self):
@@ -343,7 +400,8 @@ class EpDispatchCombineOp:
             ("recv_to_src_token", recv_cap * 4),
             ("out_idx", recv_cap * topk * 4),
             ("out_wts", recv_cap * topk * 4),
-            ("out_tok", recv_cap * token_nbytes),
+            # out_tok holds dispatch output then combine input — size to the larger.
+            ("out_tok", recv_cap * max(token_nbytes, cfg.combine_token_nbytes)),
             ("cross_device_barrier", cfg.world_size * 8),
         ]
         if self._enable_scales:
@@ -381,18 +439,20 @@ class EpDispatchCombineOp:
         self.total_recv = torch.zeros(1, dtype=torch.int32, device=device)
         self.combine_barrier = torch.zeros(1, dtype=torch.int32, device=device)
         self.cross_device_flag = torch.ones(1, dtype=torch.int64, device=device)
-        if is_fp4:  # fp4 combine outputs fp4 (hidden/2 bytes/token)
+        c_dt = cfg.combine_dtype  # combine output dtype
+        c_elem = cfg.combine_elem_size
+        if c_dt == torch.float4_e2m1fn_x2:  # fp4 combine outputs fp4 (hidden/2 B/token)
             self.combine_out = torch.zeros(
                 max_tok_per_rank * (hidden_dim // 2), dtype=torch.int8, device=device
             )
-        elif is_fp8:  # fp8 combine outputs fp8 (1 byte/elem)
+        elif c_dt in _FP8_DTYPES:  # fp8 combine outputs fp8 (1 byte/elem)
             self.combine_out = torch.zeros(
                 max_tok_per_rank * hidden_dim, dtype=torch.int8, device=device
             )
         else:
             self.combine_out = torch.zeros(
                 max_tok_per_rank * hidden_dim,
-                dtype=torch.int16 if elem_size == 2 else torch.int32,
+                dtype=torch.int16 if c_elem == 2 else torch.int32,
                 device=device,
             )
         self.combine_out_weights = torch.zeros(
@@ -478,7 +538,7 @@ class EpDispatchCombineOp:
                     npes=cfg.world_size,
                     experts_per_token=topk,
                     hidden_dim=hidden_dim,
-                    hidden_elem_size=elem_size,
+                    hidden_elem_size=cfg.combine_elem_size,
                     max_tok_per_rank=max_tok_per_rank,
                     max_recv=recv_cap,
                     block_num=b,
@@ -487,7 +547,7 @@ class EpDispatchCombineOp:
                     off_xdb_mem=arena.offset("cross_device_barrier"),
                     off_out_wts=arena.offset("out_wts"),
                     reset_total_recv=True,
-                    fp4=is_fp4,
+                    fp4=(cfg.combine_dtype == torch.float4_e2m1fn_x2),
                 )
                 for (b, w) in combine_specs
             }
@@ -548,8 +608,14 @@ class EpDispatchCombineOp:
         fp4 packs 2 e2m1 per float4_e2m1fn_x2 element -> last dim is hidden/2."""
         cols = self.cfg.hidden_dim // 2 if self.cfg.is_fp4 else self.cfg.hidden_dim
         return from_gpu_ptr(
-            self.arena.local_ptr("out_tok"), (self._recv_cap, cols), self.cfg.data_type
+            self.arena.local_ptr("out_tok"), (self._recv_cap, cols), self.cfg.dispatch_dtype
         )
+
+    def combine_in_view(self):
+        """out_tok as combine dtype [max_recv, hidden] — combine()'s copy target."""
+        cdt = self.cfg.combine_dtype
+        cols = self.cfg.hidden_dim // 2 if cdt == torch.float4_e2m1fn_x2 else self.cfg.hidden_dim
+        return from_gpu_ptr(self.arena.local_ptr("out_tok"), (self._recv_cap, cols), cdt)
 
     def convert_dispatch_output(self):
         """mori ConvertDispatchOutput: repack recv tokens into per-local-expert
@@ -577,7 +643,7 @@ class EpDispatchCombineOp:
         packed_x_view = from_gpu_ptr(
             self.packed_x.data_ptr(),
             (experts_per_rank, max_tok_per_expert, hidden_dim),
-            self.cfg.data_type,
+            self.cfg.dispatch_dtype,
         )
         return packed_x_view, self.packed_count, self.packed_src
 
@@ -743,7 +809,8 @@ class EpDispatchCombineOp:
         """
         out_tok_ptr = self.arena.local_ptr("out_tok")
         if input.data_ptr() != out_tok_ptr:
-            dst = self.recv_tokens().view(-1)[: input.numel()]
+            # copy in the combine-dtype layout (not recv_tokens()'s dispatch view)
+            dst = self.combine_in_view().view(-1)[: input.numel()]
             dst.copy_(input.reshape(-1))
         self.combine_out.zero_()
         stream = fx.Stream(torch.cuda.current_stream())
@@ -763,12 +830,11 @@ class EpDispatchCombineOp:
         count = routing.cur_rank_num_token
         hidden_dim = self.cfg.hidden_dim
         topk = self.cfg.num_experts_per_token
+        cdt = self.cfg.combine_dtype
         cols = (
-            hidden_dim // 2 if self.cfg.is_fp4 else hidden_dim
+            hidden_dim // 2 if cdt == torch.float4_e2m1fn_x2 else hidden_dim
         )  # fp4 out is hidden/2 float4 elems
-        out = (
-            self.combine_out[: count * cols].view(self.cfg.data_type).view(count, cols)
-        )
+        out = self.combine_out[: count * cols].view(cdt).view(count, cols)
         return out, self.combine_out_weights[: count * topk].view(count, topk)
 
     def local_expert_count(self):

--- a/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
+++ b/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
@@ -174,13 +174,19 @@ class EpDispatchCombineConfig:
             # dispatch output (disp_out, dispatch dtype) and combine staging
             # (out_tok, combine dtype) are separate buffers. gather/non-quant/
             # non-StdMoE only (the asymmetric path is implemented for gather).
-            if self.combine_mode != "gather" or self.quant_type != "none" or self.enable_std_moe:
+            if (
+                self.combine_mode != "gather"
+                or self.quant_type != "none"
+                or self.enable_std_moe
+            ):
                 raise ValueError(
                     "combine_data_type (asymmetric dtype) requires combine_mode=gather, "
                     "quant_type=none, enable_std_moe=False"
                 )
             if torch.float4_e2m1fn_x2 in (self.dispatch_dtype, self.combine_dtype):
-                raise ValueError("asymmetric dispatch/combine dtype does not support fp4")
+                raise ValueError(
+                    "asymmetric dispatch/combine dtype does not support fp4"
+                )
             if self.combine_token_nbytes % 16 != 0:
                 raise ValueError(
                     f"combine per-token bytes must be 16 B aligned; combine_data_type="
@@ -238,7 +244,11 @@ class EpDispatchCombineConfig:
     @property
     def dispatch_dtype(self):
         """Dispatch transport dtype (== data_type unless dispatch_data_type set)."""
-        return self.dispatch_data_type if self.dispatch_data_type is not None else self.data_type
+        return (
+            self.dispatch_data_type
+            if self.dispatch_data_type is not None
+            else self.data_type
+        )
 
     @property
     def is_fp4(self):
@@ -262,7 +272,11 @@ class EpDispatchCombineConfig:
     @property
     def combine_dtype(self):
         """Combine transport dtype (== data_type unless combine_data_type set)."""
-        return self.combine_data_type if self.combine_data_type is not None else self.data_type
+        return (
+            self.combine_data_type
+            if self.combine_data_type is not None
+            else self.data_type
+        )
 
     @property
     def combine_elem_size(self):
@@ -615,14 +629,22 @@ class EpDispatchCombineOp:
         fp4 packs 2 e2m1 per float4_e2m1fn_x2 element -> last dim is hidden/2."""
         cols = self.cfg.hidden_dim // 2 if self.cfg.is_fp4 else self.cfg.hidden_dim
         return from_gpu_ptr(
-            self.arena.local_ptr("disp_out"), (self._recv_cap, cols), self.cfg.dispatch_dtype
+            self.arena.local_ptr("disp_out"),
+            (self._recv_cap, cols),
+            self.cfg.dispatch_dtype,
         )
 
     def combine_in_view(self):
         """out_tok as combine dtype [max_recv, hidden] — combine()'s copy target."""
         cdt = self.cfg.combine_dtype
-        cols = self.cfg.hidden_dim // 2 if cdt == torch.float4_e2m1fn_x2 else self.cfg.hidden_dim
-        return from_gpu_ptr(self.arena.local_ptr("out_tok"), (self._recv_cap, cols), cdt)
+        cols = (
+            self.cfg.hidden_dim // 2
+            if cdt == torch.float4_e2m1fn_x2
+            else self.cfg.hidden_dim
+        )
+        return from_gpu_ptr(
+            self.arena.local_ptr("out_tok"), (self._recv_cap, cols), cdt
+        )
 
     def convert_dispatch_output(self):
         """mori ConvertDispatchOutput: repack recv tokens into per-local-expert

--- a/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
+++ b/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
@@ -838,7 +838,12 @@ class EpDispatchCombineOp:
         routing carries the mapping). Returns (out [ct,hidden], out_weights [ct,topk]).
         """
         out_tok_ptr = self.arena.local_ptr("out_tok")
-        if input.data_ptr() != out_tok_ptr:
+        # StdMoE: convert_combine_input() has already staged the weighted-reduced
+        # tokens into out_tok, so `input` is unused here — copying it in would
+        # clobber that result. (Non-StdMoE: `input` holds the post-expert tokens
+        # to combine; since the disp_out/out_tok split it no longer aliases out_tok,
+        # so the copy is required.)
+        if not self.cfg.enable_std_moe and input.data_ptr() != out_tok_ptr:
             # copy in the combine-dtype layout (not recv_tokens()'s dispatch view)
             dst = self.combine_in_view().view(-1)[: input.numel()]
             dst.copy_(input.reshape(-1))

--- a/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
+++ b/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
@@ -171,8 +171,9 @@ class EpDispatchCombineConfig:
                 f"token_nbytes={self.token_nbytes}"
             )
         if self.is_asymmetric_dtype:
-            # out_tok holds dispatch output then (post-expert) combine input; the
-            # two dtype layouts never coexist. gather/non-quant/non-StdMoE only.
+            # dispatch output (disp_out, dispatch dtype) and combine staging
+            # (out_tok, combine dtype) are separate buffers. gather/non-quant/
+            # non-StdMoE only (the asymmetric path is implemented for gather).
             if self.combine_mode != "gather" or self.quant_type != "none" or self.enable_std_moe:
                 raise ValueError(
                     "combine_data_type (asymmetric dtype) requires combine_mode=gather, "
@@ -400,8 +401,12 @@ class EpDispatchCombineOp:
             ("recv_to_src_token", recv_cap * 4),
             ("out_idx", recv_cap * topk * 4),
             ("out_wts", recv_cap * topk * 4),
-            # out_tok holds dispatch output then combine input — size to the larger.
-            ("out_tok", recv_cap * max(token_nbytes, cfg.combine_token_nbytes)),
+            # disp_out: dispatch scatter dest / expert-GEMM input (recv_x). Kept
+            # separate from out_tok so combine's copy-in never clobbers the
+            # dispatched tokens the expert still reads — callers can skip .clone().
+            ("disp_out", recv_cap * token_nbytes),
+            # out_tok: combine staging (post-expert results that peers gather).
+            ("out_tok", recv_cap * cfg.combine_token_nbytes),
             ("cross_device_barrier", cfg.world_size * 8),
         ]
         if self._enable_scales:
@@ -489,7 +494,7 @@ class EpDispatchCombineOp:
             off_tis=arena.offset("recv_to_src_token"),
             off_out_idx=arena.offset("out_idx"),
             off_out_wts=arena.offset("out_wts"),
-            off_out_tok=arena.offset("out_tok"),
+            off_out_tok=arena.offset("disp_out"),
             off_out_scales=arena.offset("out_scales") if self._enable_scales else 0,
             scale_dim=cfg.scale_dim,
             scale_type_size=cfg.scale_type_size,
@@ -604,11 +609,13 @@ class EpDispatchCombineOp:
             )
 
     def recv_tokens(self):
-        """Arena out_tok [max_recv, hidden] (dispatch dest / expert-GEMM input).
+        """Arena disp_out [max_recv, hidden] (dispatch dest / expert-GEMM input).
+        Separate from out_tok, so combine's copy-in never overwrites it — the
+        expert can read this in place without a defensive .clone().
         fp4 packs 2 e2m1 per float4_e2m1fn_x2 element -> last dim is hidden/2."""
         cols = self.cfg.hidden_dim // 2 if self.cfg.is_fp4 else self.cfg.hidden_dim
         return from_gpu_ptr(
-            self.arena.local_ptr("out_tok"), (self._recv_cap, cols), self.cfg.dispatch_dtype
+            self.arena.local_ptr("disp_out"), (self._recv_cap, cols), self.cfg.dispatch_dtype
         )
 
     def combine_in_view(self):
@@ -627,7 +634,7 @@ class EpDispatchCombineOp:
         arena = self.arena
         stream = fx.Stream(torch.cuda.current_stream())
         self._convert_dispatch(
-            arena.local_ptr("out_tok"),
+            arena.local_ptr("disp_out"),
             arena.local_ptr("out_idx"),
             arena.local_ptr("recv_to_src_token"),
             self.total_recv.data_ptr(),
@@ -724,7 +731,8 @@ class EpDispatchCombineOp:
         routing=: replay a prior handle (reuse cached dest-slot layout, skip
         atomic routing). return_routing=: also return the handle. Mutually
         exclusive. Returns (out, out_weights, out_scales, out_indices,
-        total_recv[, routing]); out == arena out_tok.
+        total_recv[, routing]); out == arena disp_out (safe to read without
+        .clone() — combine stages into a separate out_tok buffer).
         """
         if routing is not None and return_routing:
             raise ValueError(

--- a/python/mori/ops/dispatch_combine_v2/flydsl_prims.py
+++ b/python/mori/ops/dispatch_combine_v2/flydsl_prims.py
@@ -156,11 +156,12 @@ def _V4I32():
 
 def load_v4i32_nt(base_i64, offset):
     """Non-temporal global vec4 i32 load at base + offset*4 (addrspace 1).
-    Returns vector<4xi32> (16 bytes, codegen: global_load_dwordx4).
-    offset is in i32 units; caller must ensure 16-byte alignment."""
+    Returns vector<4xi32> (16 bytes, codegen: global_load_dwordx4). offset is in
+    i32 units; alignment=4 since the caller's per-warp offset is only 4B-aligned
+    (AMDGPU emits dwordx4 for a 4B-aligned global vector load)."""
     addr = _addr_plus(base_i64, offset, 4)
     gptr = _llvm_d.IntToPtrOp(_llvm_d.PointerType.get(address_space=1), addr).result
-    return _llvm_d.LoadOp(_V4I32(), gptr, alignment=16, nontemporal=True).res
+    return _llvm_d.LoadOp(_V4I32(), gptr, alignment=4, nontemporal=True).res
 
 
 def _spin(addr_i64, keep_waiting):

--- a/python/mori/ops/dispatch_combine_v2/flydsl_prims.py
+++ b/python/mori/ops/dispatch_combine_v2/flydsl_prims.py
@@ -150,6 +150,19 @@ def load_i32_nt(base_i64, offset):
     return _llvm_d.LoadOp(_I32(), gptr, alignment=4, nontemporal=True).res
 
 
+def _V4I32():
+    return ir.VectorType.get([4], _I32())
+
+
+def load_v4i32_nt(base_i64, offset):
+    """Non-temporal global vec4 i32 load at base + offset*4 (addrspace 1).
+    Returns vector<4xi32> (16 bytes, codegen: global_load_dwordx4).
+    offset is in i32 units; caller must ensure 16-byte alignment."""
+    addr = _addr_plus(base_i64, offset, 4)
+    gptr = _llvm_d.IntToPtrOp(_llvm_d.PointerType.get(address_space=1), addr).result
+    return _llvm_d.LoadOp(_V4I32(), gptr, alignment=16, nontemporal=True).res
+
+
 def _spin(addr_i64, keep_waiting):
     """Spin on a volatile/atomic i32 load at addr_i64; keep_waiting(cur_fx_i32)
     returns the fx-bool "should keep spinning". Returns the awaited fx.Int32.

--- a/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
+++ b/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
@@ -67,6 +67,32 @@ from flydsl.expr.typing import Int32, Int64
 import mori.cco.device.flydsl as cco
 import flydsl_prims as P
 
+# Wavefront size: gfx9 (MI300/MI350) = 64, gfx12 (MI400/gfx1250) = 32. Detected
+# once per process; override with MORI_WAVE_SIZE. get_warp_size(gfx1250) wrongly
+# reports 64, so key off the arch string.
+import os as _os
+
+
+def _detect_wave_size():
+    v = _os.environ.get("MORI_WAVE_SIZE")
+    if v:
+        return int(v)
+    try:
+        from mori.jit.config import detect_gpu_arch
+
+        return 32 if detect_gpu_arch().startswith("gfx12") else 64
+    except Exception:
+        return 64
+
+
+WAVE = _detect_wave_size()
+LANE_MASK = WAVE - 1
+LOG2_WAVE = WAVE.bit_length() - 1
+_BALLOT_INT = T.i64 if WAVE == 64 else T.i32
+_LANE_STRIDE_I32 = WAVE * 4          # one wave of lanes, vec4 (16B) each
+_MAIN_STRIDE_I32 = 2 * _LANE_STRIDE_I32
+_BUTTERFLY_OFFSETS = tuple(WAVE >> i for i in range(1, LOG2_WAVE + 1))
+
 # ── dispatch ──────────────────────────────────────────────────────────────
 
 
@@ -108,7 +134,7 @@ def make_dispatch(
     scale_num_i32 = (scale_bytes + 3) // 4
     enable_scales = scale_bytes > 0
 
-    @flyc.kernel(known_block_size=[warp_num_per_block * 64, 1, 1])
+    @flyc.kernel(known_block_size=[warp_num_per_block * WAVE, 1, 1])
     def ep_dispatch(
         arena: Int64,
         addr_inp_tok: Int64,
@@ -124,8 +150,8 @@ def make_dispatch(
     ):
         tid = fx.thread_idx.x
         bid = fx.block_idx.x
-        lane = tid & 63
-        warp = tid >> 6
+        lane = tid & LANE_MASK
+        warp = tid >> LOG2_WAVE
         global_warp_id = bid * warp_num_per_block + warp
         global_warp_num = block_num * warp_num_per_block
         work_limit = inp_cur_tok * experts_per_token
@@ -159,9 +185,9 @@ def make_dispatch(
             dest_pe = dest_expert // experts_per_rank
             lane_dest_pe = lane_expert // experts_per_rank
             dup_per_lane = arith.select(
-                lane_dest_pe == dest_pe, arith.select(lane < k_slot, lane, 64), 64
+                lane_dest_pe == dest_pe, arith.select(lane < k_slot, lane, WAVE), WAVE
             )
-            dup_ballot = ballot(T.i64(), dup_per_lane < 64)
+            dup_ballot = ballot(_BALLOT_INT(), dup_per_lane < WAVE)
             is_dup = dup_ballot != 0
 
             if const_expr(replay):
@@ -234,7 +260,7 @@ def make_dispatch(
                     rsrc_inp_scales = create_buffer_resource_from_addr(addr_inp_scales)
                     peer_scales = fx.Int64(window.lsa_ptr(dest_pe, off_out_scales))
                     rsrc_peer_scales = create_buffer_resource_from_addr(peer_scales)
-                    for k_off in range(lane, scale_num_i32, 64):
+                    for k_off in range(lane, scale_num_i32, WAVE):
                         scale_val = buffer_load(
                             rsrc_inp_scales,
                             src_tok * scale_num_i32 + k_off,
@@ -247,10 +273,9 @@ def make_dispatch(
                             dest_tok_id * scale_num_i32 + k_off,
                         )
 
-            # Token-embedding scatter: each lane owns 4 i32 (16B). The main body
-            # runs two independent vec4 load/store streams (this lane's chunk and
-            # chunk+256, stride 512 i32) so both are in flight together
-            # (memory-level parallelism); a stride-256 tail covers the remainder.
+            # Token-embedding scatter: each lane owns 4 i32 (16B). Two vec4 streams
+            # (chunk and chunk+_LANE_STRIDE_I32, stride _MAIN_STRIDE_I32) for
+            # memory-level parallelism; a one-stream tail covers the remainder.
             # Dropped slots (dup/overflow) set copy_end == lane_i32_off → no-op.
             peer_tok_base = fx.Int64(window.lsa_ptr(dest_pe, off_out_tok))
             remote_tok_addr = peer_tok_base + fx.Int64(dest_tok_id) * fx.Int64(nbytes)
@@ -260,26 +285,28 @@ def make_dispatch(
             rsrc_src = create_buffer_resource_from_addr(local_tok_addr)
             rsrc_dst = create_buffer_resource_from_addr(remote_tok_addr)
             lane_i32_off = lane * 4
-            safe_end_i32 = (n_i32 // 512) * 512
-            if const_expr(n_i32 >= 512 and safe_end_i32 > 0):
+            safe_end_i32 = (n_i32 // _MAIN_STRIDE_I32) * _MAIN_STRIDE_I32
+            if const_expr(n_i32 >= _MAIN_STRIDE_I32 and safe_end_i32 > 0):
                 copy_end_main = arith.select(
                     is_dup_or_overflow, lane_i32_off, safe_end_i32
                 )
-                for chunk in range(lane_i32_off, copy_end_main, 512):
+                for chunk in range(lane_i32_off, copy_end_main, _MAIN_STRIDE_I32):
                     vec_a = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32())
                     vec_b = buffer_load(
-                        rsrc_src, chunk + 256, vec_width=4, dtype=T.i32()
+                        rsrc_src, chunk + _LANE_STRIDE_I32, vec_width=4, dtype=T.i32()
                     )
                     buffer_store(vec_a, rsrc_dst, chunk)
-                    buffer_store(vec_b, rsrc_dst, chunk + 256)
+                    buffer_store(vec_b, rsrc_dst, chunk + _LANE_STRIDE_I32)
             if const_expr(safe_end_i32 < n_i32):
                 copy_end_tail = arith.select(is_dup_or_overflow, lane_i32_off, n_i32)
-                for chunk in range(lane_i32_off + safe_end_i32, copy_end_tail, 256):
+                for chunk in range(
+                    lane_i32_off + safe_end_i32, copy_end_tail, _LANE_STRIDE_I32
+                ):
                     vec_a = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32())
                     buffer_store(vec_a, rsrc_dst, chunk)
-            elif const_expr(n_i32 < 512):
+            elif const_expr(n_i32 < _MAIN_STRIDE_I32):
                 copy_end_small = arith.select(is_dup_or_overflow, lane_i32_off, n_i32)
-                for chunk in range(lane_i32_off, copy_end_small, 256):
+                for chunk in range(lane_i32_off, copy_end_small, _LANE_STRIDE_I32):
                     vec_a = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32())
                     buffer_store(vec_a, rsrc_dst, chunk)
 
@@ -304,7 +331,7 @@ def make_dispatch(
                 P.atomic_add_global(fx.Int64(addr_disp_bar), arith.constant(1))
 
             local_recv_num = fx.Int64(window.lsa_ptr(my_lsa_rank, off_recv_num))
-            for dest_pe in range(lane, npes, 64):
+            for dest_pe in range(lane, npes, WAVE):
                 if global_warp_id == 0:
                     P.spin_until_eq_i32(fx.Int64(addr_disp_bar), block_num)
                     P.fence_system_acquire()
@@ -321,7 +348,7 @@ def make_dispatch(
                     )
 
             # ── Phase 3: collect per-source counts into total_recv ──
-            for src_pe in range(lane, npes, 64):
+            for src_pe in range(lane, npes, WAVE):
                 if global_warp_id == 0:
                     recv_num_src_addr = local_recv_num + fx.Int64(src_pe) * fx.Int64(4)
                     signal_value = P.spin_until_gt_i32(recv_num_src_addr, 0)
@@ -367,7 +394,7 @@ def make_dispatch(
             my_lsa_rank,
             inp_cur_tok,
         ).launch(
-            grid=(block_num, 1, 1), block=[warp_num_per_block * 64, 1, 1], stream=stream
+            grid=(block_num, 1, 1), block=[warp_num_per_block * WAVE, 1, 1], stream=stream
         )
 
     return run
@@ -531,7 +558,7 @@ def make_combine(
     out_n_i32 = (hidden_dim * 2) // 4 if fp8_direct_cast else n_i32
     out_step_mult = 2 if fp8_direct_cast else 1
 
-    @flyc.kernel(known_block_size=[warp_num_per_block * 64, 1, 1])
+    @flyc.kernel(known_block_size=[warp_num_per_block * WAVE, 1, 1])
     def ep_combine(
         arena: Int64,
         addr_tok_map: Int64,
@@ -545,11 +572,11 @@ def make_combine(
     ):
         tid = fx.thread_idx.x
         bid = fx.block_idx.x
-        lane = tid & 63
-        warp = tid >> 6
+        lane = tid & LANE_MASK
+        warp = tid >> LOG2_WAVE
         global_warp_id = bid * warp_num_per_block + warp
         global_warp_num = block_num * warp_num_per_block
-        grid_thread_id = bid * (warp_num_per_block * 64) + tid
+        grid_thread_id = bid * (warp_num_per_block * WAVE) + tid
 
         window = cco.Window(arena)
         rsrc_tok_map = create_buffer_resource_from_addr(addr_tok_map)
@@ -599,7 +626,7 @@ def make_combine(
         # a warp hides xGMI read latency with fewer warps (mori WarpAccum,
         # VecBytes=4, Unroll=2). Partition each token's hidden across
         # warps_per_tok warps so small batches still fill the grid.
-        STEP = _unroll * 64
+        STEP = _unroll * WAVE
         safe_tok = arith.select(
             cur_rank_num_token == arith.constant(0),
             arith.constant(1),
@@ -700,7 +727,7 @@ def make_combine(
                 for u in range(lane, main_end, STEP):
                     base = unit_base + u
                     for r in range_constexpr(_unroll):
-                        off = base + r * 64
+                        off = base + r * WAVE
                         vals = []
                         for k_slot in range_constexpr(experts_per_token):
                             v = P.load_i32_nt(expert_bases[k_slot], off)
@@ -716,7 +743,7 @@ def make_combine(
                             _from_accum2(acc), rsrc_out, out_base + off * out_step_mult
                         )
                 # tail: leftover elements, one per lane
-                for u in range(main_end + lane, eff, 64):
+                for u in range(main_end + lane, eff, WAVE):
                     _one(unit_base + u)
 
             _accum_loop()
@@ -745,7 +772,7 @@ def make_combine(
             my_lsa_rank,
             cur_rank_num_token,
         ).launch(
-            grid=(block_num, 1, 1), block=[warp_num_per_block * 64, 1, 1], stream=stream
+            grid=(block_num, 1, 1), block=[warp_num_per_block * WAVE, 1, 1], stream=stream
         )
 
     return run
@@ -766,10 +793,9 @@ def _bf16x2(i32_scalar):  # i32 (2 bf16) -> v2f32
 
 
 def _warp_amax(lane, v):
-    """Max-reduce an f32 across all 64 lanes (butterfly via ds_bpermute, which
-    allows a per-lane gather index — unlike readlane's uniform-lane requirement).
-    Every lane returns the wavefront max. ``v`` and the result are raw values."""
-    for off in (32, 16, 8, 4, 2, 1):
+    """Max-reduce an f32 across the wavefront (butterfly via ds_bpermute, per-lane
+    gather index). Every lane returns the wavefront max; raw values in/out."""
+    for off in _BUTTERFLY_OFFSETS:
         idx = arith.unwrap((lane ^ off) * 4)  # byte addr = lane*4
         o = ds_bpermute(T.i32(), idx, arith.bitcast(T.i32(), arith.unwrap(v)))
         v = arith.maximumf(v, arith.bitcast(T.f32(), o))
@@ -813,6 +839,11 @@ def make_combine_scatter(
     vs the gather path: 2 passes (remote write + local read) but compresses the
     transport to fp8; the natural home for fp8_direct_cast (gather has no
     Stage-1 writer to compress at)."""
+    if fp8_blockwise and WAVE != 64:
+        raise NotImplementedError(
+            "fp8_blockwise combine's coalesced path assumes wave64 (one wave == one "
+            "128-elem block); wave32 (gfx12) port is TODO"
+        )
     # blockwise reuses the fp8->bf16 accum (output bf16, wire fp8) + per-block scale.
     _fp8_out = fp8_direct_cast or fp8_blockwise
     wire_elem_size = 1 if _fp8_out else hidden_elem_size
@@ -829,7 +860,7 @@ def make_combine_scatter(
         ), "blockwise (coalesced path): block_elems must be 128 (scale_dim = hidden/128)"
         block_i32_fp8 = block_elems // 4  # fp8 i32 units per block (=32)
 
-    @flyc.kernel(known_block_size=[warp_num_per_block * 64, 1, 1])
+    @flyc.kernel(known_block_size=[warp_num_per_block * WAVE, 1, 1])
     def ep_combine_s(
         arena: Int64,
         addr_tok_map: Int64,
@@ -843,11 +874,11 @@ def make_combine_scatter(
     ):
         tid = fx.thread_idx.x
         bid = fx.block_idx.x
-        lane = tid & 63
-        warp = tid >> 6
+        lane = tid & LANE_MASK
+        warp = tid >> LOG2_WAVE
         global_warp_id = bid * warp_num_per_block + warp
         global_warp_num = block_num * warp_num_per_block
-        grid_thread_id = bid * (warp_num_per_block * 64) + tid
+        grid_thread_id = bid * (warp_num_per_block * WAVE) + tid
 
         window = cco.Window(arena)
         rsrc_tok_map = create_buffer_resource_from_addr(addr_tok_map)
@@ -953,7 +984,7 @@ def make_combine_scatter(
                         buffer_store(arith.negf(s0), rsrc_scales, 0)
             elif const_expr(fp8_direct_cast):
                 # 2 bf16 i32 -> v4f32 -> cvt_pk_fp8 x2 -> 1 fp8 i32
-                for elem in range(lane, wire_n_i32, 64):
+                for elem in range(lane, wire_n_i32, WAVE):
                     bf = buffer_load(rsrc_src, elem * 2, vec_width=2, dtype=T.i32())
                     v4 = vector.bitcast(T.VectorType.get([4], T.bf16()), bf).extf(
                         _V4F32()
@@ -971,7 +1002,7 @@ def make_combine_scatter(
                     )
                     buffer_store(fp8, rsrc_dst, elem)
             else:
-                for elem in range(lane, wire_n_i32, 64):
+                for elem in range(lane, wire_n_i32, WAVE):
                     v = buffer_load(rsrc_src, elem, vec_width=1, dtype=T.i32())
                     buffer_store(v, rsrc_dst, elem)
             if const_expr(enable_weights):
@@ -1153,7 +1184,7 @@ def make_combine_scatter(
                 buffer_store(from_acc(acc), rsrc_out, out_base + off * out_step_mult)
 
             def _loop():
-                for u in range(lane, eff, 64):
+                for u in range(lane, eff, WAVE):
                     _one(unit_base + u)
 
             _loop()
@@ -1182,7 +1213,7 @@ def make_combine_scatter(
             my_lsa_rank,
             cur_rank_num_token,
         ).launch(
-            grid=(block_num, 1, 1), block=[warp_num_per_block * 64, 1, 1], stream=stream
+            grid=(block_num, 1, 1), block=[warp_num_per_block * WAVE, 1, 1], stream=stream
         )
 
     return run
@@ -1225,7 +1256,7 @@ def make_convert_dispatch_output(
     nbytes = hidden_dim * hidden_elem_size
     n_i32 = nbytes // 4
 
-    @flyc.kernel(known_block_size=[warp_num_per_block * 64, 1, 1])
+    @flyc.kernel(known_block_size=[warp_num_per_block * WAVE, 1, 1])
     def convert_disp(
         addr_out_tok: Int64,
         addr_out_idx: Int64,
@@ -1238,8 +1269,8 @@ def make_convert_dispatch_output(
     ):
         tid = fx.thread_idx.x
         bid = fx.block_idx.x
-        lane = tid & 63
-        warp = tid >> 6
+        lane = tid & LANE_MASK
+        warp = tid >> LOG2_WAVE
         global_warp_id = bid * warp_num_per_block + warp
         global_warp_num = block_num * warp_num_per_block
 
@@ -1291,7 +1322,7 @@ def make_convert_dispatch_output(
                 src_t = fx.Int64(addr_out_tok) + fx.Int64(recv_tok) * fx.Int64(nbytes)
                 rsrc_dst = create_buffer_resource_from_addr(dst)
                 rsrc_src = create_buffer_resource_from_addr(src_t)
-                for chunk in range(lane * 4, n_i32, 256):
+                for chunk in range(lane * 4, n_i32, _LANE_STRIDE_I32):
                     v = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32())
                     buffer_store(v, rsrc_dst, chunk)
 
@@ -1317,7 +1348,7 @@ def make_convert_dispatch_output(
             addr_packed_src,
             addr_slot_map,
         ).launch(
-            grid=(block_num, 1, 1), block=[warp_num_per_block * 64, 1, 1], stream=stream
+            grid=(block_num, 1, 1), block=[warp_num_per_block * WAVE, 1, 1], stream=stream
         )
 
     return run
@@ -1341,7 +1372,7 @@ def make_convert_combine_input(
     nbytes = hidden_dim * hidden_elem_size
     n_i32 = nbytes // 4
 
-    @flyc.kernel(known_block_size=[warp_num_per_block * 64, 1, 1])
+    @flyc.kernel(known_block_size=[warp_num_per_block * WAVE, 1, 1])
     def convert_comb(
         addr_out_tok: Int64,
         addr_out_wts: Int64,
@@ -1351,8 +1382,8 @@ def make_convert_combine_input(
     ):
         tid = fx.thread_idx.x
         bid = fx.block_idx.x
-        lane = tid & 63
-        warp = tid >> 6
+        lane = tid & LANE_MASK
+        warp = tid >> LOG2_WAVE
         global_warp_id = bid * warp_num_per_block + warp
         global_warp_num = block_num * warp_num_per_block
 
@@ -1416,7 +1447,7 @@ def make_convert_combine_input(
                 buffer_store(_from_accum2(acc), rsrc_out, off)
 
             def _loop():
-                for u in range(lane, eff, 64):
+                for u in range(lane, eff, WAVE):
                     _one(unit_base + u)
 
             _loop()
@@ -1433,7 +1464,7 @@ def make_convert_combine_input(
         convert_comb(
             addr_out_tok, addr_out_wts, addr_total_recv, addr_packed_x, addr_slot_map
         ).launch(
-            grid=(block_num, 1, 1), block=[warp_num_per_block * 64, 1, 1], stream=stream
+            grid=(block_num, 1, 1), block=[warp_num_per_block * WAVE, 1, 1], stream=stream
         )
 
     return run
@@ -1446,7 +1477,7 @@ def make_local_expert_count(
     *, rank, experts_per_rank, experts_per_token, block_num, warp_num_per_block
 ):
     expert_base = rank * experts_per_rank
-    block_size = warp_num_per_block * 64
+    block_size = warp_num_per_block * WAVE
 
     @flyc.kernel(known_block_size=[block_size, 1, 1])
     def local_expert_count_kernel(

--- a/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
+++ b/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
@@ -91,7 +91,7 @@ WAVE = _detect_wave_size()
 LANE_MASK = WAVE - 1
 LOG2_WAVE = WAVE.bit_length() - 1
 _BALLOT_INT = T.i64 if WAVE == 64 else T.i32
-_LANE_STRIDE_I32 = WAVE * 4          # one wave of lanes, vec4 (16B) each
+_LANE_STRIDE_I32 = WAVE * 4  # one wave of lanes, vec4 (16B) each
 _MAIN_STRIDE_I32 = 2 * _LANE_STRIDE_I32
 _BUTTERFLY_OFFSETS = tuple(WAVE >> i for i in range(1, LOG2_WAVE + 1))
 
@@ -396,7 +396,9 @@ def make_dispatch(
             my_lsa_rank,
             inp_cur_tok,
         ).launch(
-            grid=(block_num, 1, 1), block=[warp_num_per_block * WAVE, 1, 1], stream=stream
+            grid=(block_num, 1, 1),
+            block=[warp_num_per_block * WAVE, 1, 1],
+            stream=stream,
         )
 
     return run
@@ -451,6 +453,7 @@ def _accum_funcs(hidden_elem_size, fp8_direct_cast=False, fp4=False):
                 return arith.constant_vector(0.0, _V8F32())
 
             return to_accum, from_accum, zero_accum
+
         # NOTE: cvt_scalef32_pk_*_fp4 are gfx950-only (MI350). On gfx942
         # (MI300X) codegen fails "instruction not supported on this GPU".
         # Faithful port of the FlyDSL reference fp4 branch; opt-in (fp4=True).
@@ -764,15 +767,21 @@ def make_combine(
                             for j in range_constexpr(VEC):
                                 acc = _zero_accum()
                                 for k_slot in range_constexpr(experts_per_token):
-                                    elem = vector.extract(vecs[k_slot], static_position=[j])
-                                    v = arith.select(expert_valids[k_slot], elem, arith.constant(0))
+                                    elem = vector.extract(
+                                        vecs[k_slot], static_position=[j]
+                                    )
+                                    v = arith.select(
+                                        expert_valids[k_slot], elem, arith.constant(0)
+                                    )
                                     acc = acc + _to_accum2(v)
                                 buffer_store(
                                     _from_accum2(acc), rsrc_out, out_base + off + j
                                 )
                     for u in range(main_end + lane, eff, WAVE):
                         _one(unit_base + u)
+
             else:
+
                 def _accum_loop():
                     main_end = (eff // STEP) * STEP
                     for u in range(lane, main_end, STEP):
@@ -791,7 +800,9 @@ def make_combine(
                             for k_slot in range_constexpr(experts_per_token):
                                 acc = acc + _to_accum2(vals[k_slot])
                             buffer_store(
-                                _from_accum2(acc), rsrc_out, out_base + off * out_step_mult
+                                _from_accum2(acc),
+                                rsrc_out,
+                                out_base + off * out_step_mult,
                             )
                     for u in range(main_end + lane, eff, WAVE):
                         _one(unit_base + u)
@@ -822,7 +833,9 @@ def make_combine(
             my_lsa_rank,
             cur_rank_num_token,
         ).launch(
-            grid=(block_num, 1, 1), block=[warp_num_per_block * WAVE, 1, 1], stream=stream
+            grid=(block_num, 1, 1),
+            block=[warp_num_per_block * WAVE, 1, 1],
+            stream=stream,
         )
 
     return run
@@ -1263,7 +1276,9 @@ def make_combine_scatter(
             my_lsa_rank,
             cur_rank_num_token,
         ).launch(
-            grid=(block_num, 1, 1), block=[warp_num_per_block * WAVE, 1, 1], stream=stream
+            grid=(block_num, 1, 1),
+            block=[warp_num_per_block * WAVE, 1, 1],
+            stream=stream,
         )
 
     return run
@@ -1398,7 +1413,9 @@ def make_convert_dispatch_output(
             addr_packed_src,
             addr_slot_map,
         ).launch(
-            grid=(block_num, 1, 1), block=[warp_num_per_block * WAVE, 1, 1], stream=stream
+            grid=(block_num, 1, 1),
+            block=[warp_num_per_block * WAVE, 1, 1],
+            stream=stream,
         )
 
     return run
@@ -1514,7 +1531,9 @@ def make_convert_combine_input(
         convert_comb(
             addr_out_tok, addr_out_wts, addr_total_recv, addr_packed_x, addr_slot_map
         ).launch(
-            grid=(block_num, 1, 1), block=[warp_num_per_block * WAVE, 1, 1], stream=stream
+            grid=(block_num, 1, 1),
+            block=[warp_num_per_block * WAVE, 1, 1],
+            stream=stream,
         )
 
     return run

--- a/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
+++ b/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
@@ -61,6 +61,8 @@ from flydsl.expr.rocdl import (
     cvt_pk_fp8_f32,
     cvt_scalef32_pk_f32_fp4,
     cvt_scalef32_pk_fp4_f32,
+    cvt_scale_pk8_f32_fp4,
+    cvt_scalef32_pk8_fp4_f32,
 )
 from flydsl.expr.typing import Int32, Int64
 
@@ -425,6 +427,30 @@ def _V1I32():
 
 def _accum_funcs(hidden_elem_size, fp8_direct_cast=False, fp4=False):
     if fp4:  # fp4 e2m1: i32 = 8 packed fp4 -> v8f32
+        if WAVE == 32:
+            # gfx1250: one pack-8 instr converts all 8 fp4/i32 at once. The
+            # gfx950 pk-2 (cvt_scalef32_pk_*_fp4, src/dst_sel) don't exist here
+            # ("Cannot select"); dequant only has the E8M0 scale family
+            # (cvt_scale_pk8_f32_fp4), quant has scalef32 (cvt_scalef32_pk8_fp4_f32).
+            # Plain fp4 (no microscaling) => scale 1.0, scale_sel 0.
+            def to_accum(i32_scalar):
+                # dequant uses the E8M0 block-scale (i32); 1.0 == 2^(127-127) => 127.
+                return cvt_scale_pk8_f32_fp4(
+                    res=_V8F32(),
+                    src=i32_scalar,
+                    scale=arith.constant(127, type=T.i32()),
+                    scale_sel=0,
+                )
+
+            def from_accum(acc):
+                return cvt_scalef32_pk8_fp4_f32(
+                    res=T.i32(), src=acc, scale=arith.constant(1.0, type=T.f32())
+                )
+
+            def zero_accum():
+                return arith.constant_vector(0.0, _V8F32())
+
+            return to_accum, from_accum, zero_accum
         # NOTE: cvt_scalef32_pk_*_fp4 are gfx950-only (MI350). On gfx942
         # (MI300X) codegen fails "instruction not supported on this GPU".
         # Faithful port of the FlyDSL reference fp4 branch; opt-in (fp4=True).

--- a/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
+++ b/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
@@ -582,6 +582,8 @@ def make_combine(
     n_i32 = hidden_dim // 8 if fp4 else nbytes // 4
     # fp8_direct_cast: output stride is bf16 (2 i32 per fp8 unit) vs input fp8.
     out_n_i32 = (hidden_dim * 2) // 4 if fp8_direct_cast else n_i32
+    # vec4 gather: 4 i32 per load (global_load_dwordx4) when output is 1:1.
+    _use_vec4 = (n_i32 % 4 == 0) and not fp8_direct_cast
     out_step_mult = 2 if fp8_direct_cast else 1
 
     @flyc.kernel(known_block_size=[warp_num_per_block * WAVE, 1, 1])
@@ -731,7 +733,6 @@ def make_combine(
 
             # Nested fn: closure over expert_bases/valids (lists can't be loop-carried).
             def _one(off):  # reduce k contributions for one i32 unit
-                # Load all K experts, then reduce (K-deep MLP per lane).
                 vals = []
                 for k_slot in range_constexpr(experts_per_token):
                     v = P.load_i32_nt(expert_bases[k_slot], off)
@@ -745,32 +746,55 @@ def make_combine(
                     _from_accum2(acc), rsrc_out, out_base + off * out_step_mult
                 )
 
-            def _accum_loop():
-                # _unroll elements/lane per iter; per element load all K experts
-                # then reduce, so a lane keeps K loads in flight (unrolled
-                # r-blocks add more overlap) to hide xGMI read latency.
-                main_end = (eff // STEP) * STEP
-                for u in range(lane, main_end, STEP):
-                    base = unit_base + u
-                    for r in range_constexpr(_unroll):
-                        off = base + r * WAVE
-                        vals = []
-                        for k_slot in range_constexpr(experts_per_token):
-                            v = P.load_i32_nt(expert_bases[k_slot], off)
-                            vals.append(
-                                arith.select(
-                                    expert_valids[k_slot], v, arith.constant(0)
+            if const_expr(_use_vec4):
+                # Vec4 path: load 4 i32 (16B, global_load_dwordx4) per expert
+                # per iteration, reducing xGMI load count 4×.
+                VEC = 4
+                STEP_V4 = _unroll * WAVE * VEC
+
+                def _accum_loop():
+                    main_end = (eff // STEP_V4) * STEP_V4
+                    for u in range(lane * VEC, main_end, STEP_V4):
+                        base = unit_base + u
+                        for r in range_constexpr(_unroll):
+                            off = base + r * WAVE * VEC
+                            vecs = []
+                            for k_slot in range_constexpr(experts_per_token):
+                                vecs.append(P.load_v4i32_nt(expert_bases[k_slot], off))
+                            for j in range_constexpr(VEC):
+                                acc = _zero_accum()
+                                for k_slot in range_constexpr(experts_per_token):
+                                    elem = vector.extract(vecs[k_slot], static_position=[j])
+                                    v = arith.select(expert_valids[k_slot], elem, arith.constant(0))
+                                    acc = acc + _to_accum2(v)
+                                buffer_store(
+                                    _from_accum2(acc), rsrc_out, out_base + off + j
                                 )
+                    for u in range(main_end + lane, eff, WAVE):
+                        _one(unit_base + u)
+            else:
+                def _accum_loop():
+                    main_end = (eff // STEP) * STEP
+                    for u in range(lane, main_end, STEP):
+                        base = unit_base + u
+                        for r in range_constexpr(_unroll):
+                            off = base + r * WAVE
+                            vals = []
+                            for k_slot in range_constexpr(experts_per_token):
+                                v = P.load_i32_nt(expert_bases[k_slot], off)
+                                vals.append(
+                                    arith.select(
+                                        expert_valids[k_slot], v, arith.constant(0)
+                                    )
+                                )
+                            acc = _zero_accum()
+                            for k_slot in range_constexpr(experts_per_token):
+                                acc = acc + _to_accum2(vals[k_slot])
+                            buffer_store(
+                                _from_accum2(acc), rsrc_out, out_base + off * out_step_mult
                             )
-                        acc = _zero_accum()
-                        for k_slot in range_constexpr(experts_per_token):
-                            acc = acc + _to_accum2(vals[k_slot])
-                        buffer_store(
-                            _from_accum2(acc), rsrc_out, out_base + off * out_step_mult
-                        )
-                # tail: leftover elements, one per lane
-                for u in range(main_end + lane, eff, WAVE):
-                    _one(unit_base + u)
+                    for u in range(main_end + lane, eff, WAVE):
+                        _one(unit_base + u)
 
             _accum_loop()
 

--- a/python/mori/ops/dispatch_combine_v2/tuning_configs.py
+++ b/python/mori/ops/dispatch_combine_v2/tuning_configs.py
@@ -162,21 +162,21 @@ _GFX1250_SCHED_BF16_T6 = (
     (4096, 192, 32, 128, 16),  # <=4096: comb block 128 (bandwidth)
     (None, 192, 32, 192, 16),  # >4096 (peak): disp 360 / comb 141 GB/s
 )
-# EP8 (world_size=8) measured 2026-07-12 on gfx1250 CROSS-NODE (2 nodes x 4 GPUs
-# over the UALink fabric), bf16, full 2-pass block x warp sweep (tok 8..8192).
-# dispatch warp ramps 8->16->32 (block 128 near-optimal throughout, 192 only
-# marginally higher at 512); combine wants small block/warp early (64/4..64/16)
-# then block 128 warp 16 for bandwidth-bound large tok. Cross-node fabric caps
-# disp ~200 GB/s (vs intra-node xGMI ~335); geometry is world_size-independent so
-# this also serves single-node EP8. Measured GB/s (disp/comb): 8=5/4 64=36/17
-# 128=74/28 256=128/42 512=164/63 1024=189/96 2048=197/120 4096=200/151 8192=200/173.
+# EP8 (world_size=8) RE-TUNED 2026-07-13 on gfx1250 CROSS-NODE (2 nodes x 4 GPUs
+# over the UALink fabric), bf16, with the vec4 combine-gather kernel, full 2-pass
+# block x warp sweep (tok 8..8192). dispatch unchanged by vec4: block 128, warp
+# ramps 16->32. combine SHIFTED: block 64 is now uniformly best (128 loses even at
+# 8192 with vec4's wider loads), warp ramps 4->8->16. Cross-node fabric caps disp
+# ~200 GB/s; geometry is world_size-independent so this also serves single-node EP8.
+# Measured vec4 GB/s at scheduled geom (disp/comb): 8=5/3 64=17/23 128=71/47
+# 256=127/76 512=162/105 1024=187/135 2048=198/152 4096=200/176 8192=200/200
+# (<=64 disp is launch-latency noise). vs pre-vec4 scalar tuned comb 8192=173
+# 512=63 256=42 -> +15% / +67% / +80%. topk6 (384 exp) reuses this schedule,
+# comb 8192=198 512=99 256=68 (geometry is topk-independent).
 _GFX1250_SCHED_BF16_EP8 = (
-    (64, 128, 8, 64, 8),  # <=64:   latency-bound
-    (128, 128, 8, 64, 4),  # <=128
-    (256, 128, 16, 64, 8),  # <=256:  disp warp 16
-    (512, 128, 32, 128, 8),  # <=512:  disp warp 32; comb block 128
-    (1024, 128, 32, 64, 16),  # <=1024: comb warp 16
-    (None, 128, 32, 128, 16),  # >1024 (peak): disp ~200 / comb ~173 GB/s
+    (256, 128, 16, 64, 4),  # <=256:  disp warp 16, comb 64/4 (latency-bound)
+    (1024, 128, 32, 64, 8),  # <=1024: disp warp 32, comb 64/8
+    (None, 128, 32, 64, 16),  # >1024 (peak): disp ~200 / comb ~200 GB/s
 )
 # bf16-tuned (EP4 + EP8). fp8/fp4 fall back to the bf16 schedule until separately tuned.
 _GFX1250_TABLE = {

--- a/python/mori/ops/dispatch_combine_v2/tuning_configs.py
+++ b/python/mori/ops/dispatch_combine_v2/tuning_configs.py
@@ -149,9 +149,23 @@ _GFX1250_DEFAULT = dict(
     combine_warp_num_per_block=16,
     schedule=_GFX1250_SCHED_BF16,
 )
-# bf16-tuned (EP4). fp8/fp4 fall back to this bf16 schedule until separately tuned.
+# DeepSeek-V4-Pro shape (hidden 7168, topk 6, 384 experts) — measured 2026-07-11,
+# EP4 bf16, same 2D sweep. Same shape family as topk=8, geometry ~identical (block/
+# warp track token count, not topk); disp shifts to block 192 a notch earlier and
+# peaks higher (fewer recv copies at topk 6: 360/141 GB/s @8192). Measured GB/s
+# (disp/comb): 64=24/11 128=46/17 256=90/28 512=150/39 1024=227/57 2048=278/84
+# 4096=320/113 8192=360/141.
+_GFX1250_SCHED_BF16_T6 = (
+    (128, 128, 8, 64, 4),  # <=128:  latency-bound
+    (256, 192, 16, 64, 8),  # <=256
+    (1024, 192, 32, 64, 16),  # <=1024: disp peak warp; comb small block/warp16
+    (4096, 192, 32, 128, 16),  # <=4096: comb block 128 (bandwidth)
+    (None, 192, 32, 192, 16),  # >4096 (peak): disp 360 / comb 141 GB/s
+)
+# bf16-tuned (EP4). fp8/fp4 fall back to the bf16 schedule until separately tuned.
 _GFX1250_TABLE = {
     (4, 7168, 8): {"bf16": _GFX1250_SCHED_BF16},
+    (4, 7168, 6): {"bf16": _GFX1250_SCHED_BF16_T6},  # DeepSeek-V4-Pro
 }
 
 _DEVICES = {

--- a/python/mori/ops/dispatch_combine_v2/tuning_configs.py
+++ b/python/mori/ops/dispatch_combine_v2/tuning_configs.py
@@ -124,11 +124,42 @@ _MI355X_TABLE = {
     (8, 7168, 8): {"fp8": _MI355X_SCHED_FP8, "fp4": _MI355X_SCHED_FP4},
 }
 
+# ── gfx1250 (256 CU, wave32) — measured 2026-07-11, EP4, bf16, full block x warp
+# sweep (dispatch and combine tuned independently across tok 8..8192). Key lessons:
+# (a) dispatch loves more parallelism — warp grows 8->16->32 with tok, block 128
+#     (<=1024) then 192 (>=2048); warp 32 nearly 4x's large-tok dispatch BW.
+# (b) combine wants the OPPOSITE — few warps at small tok (over-parallelizing the
+#     gather+xdb barrier collapses it: block 64 warp 8 at small, warp grows to 16
+#     and block to 128/192 only for bandwidth-bound large tok.
+# (c) GUARDRAIL: block_num MUST stay < CU count (256). The dispatch Phase-2 grid
+#     barrier needs all blocks co-resident; block 256 deadlocks (100% spin). 192 is
+#     the safe ceiling here. Measured bf16 GB/s (disp/comb): 64=25/11 128=50/19
+#     256=93/28 512=161/41 1024=204/61 2048=259/90 4096=292/120 8192=335/149.
+_GFX1250_SCHED_BF16 = (
+    (64, 128, 8, 64, 8),  # <=64:   disp 128/8, comb 64/8 (latency-bound)
+    (256, 128, 16, 64, 8),  # <=256:  disp warp 16
+    (1024, 128, 32, 128, 8),  # <=1024: disp warp 32; comb block 128
+    (4096, 192, 32, 128, 16),  # <=4096: disp 0.75*CU; comb warp 16 (bandwidth)
+    (None, 192, 32, 192, 16),  # >4096 (peak): disp 335 / comb 149 GB/s
+)
+_GFX1250_DEFAULT = dict(
+    dispatch_block_num=192,
+    combine_block_num=192,
+    warp_num_per_block=32,
+    combine_warp_num_per_block=16,
+    schedule=_GFX1250_SCHED_BF16,
+)
+# bf16-tuned (EP4). fp8/fp4 fall back to this bf16 schedule until separately tuned.
+_GFX1250_TABLE = {
+    (4, 7168, 8): {"bf16": _GFX1250_SCHED_BF16},
+}
+
 _DEVICES = {
     "mi308x": (_MI308X_DEFAULT, _MI308X_TABLE),
     "mi325x": (_MI325X_DEFAULT, _MI325X_TABLE),
     "mi300x": (_MI300X_DEFAULT, _MI300X_TABLE),
     "mi355x": (_MI355X_DEFAULT, _MI355X_TABLE),
+    "gfx1250": (_GFX1250_DEFAULT, _GFX1250_TABLE),
 }
 
 
@@ -182,6 +213,8 @@ def _device_key():
         return key
     if gfx == 90500:  # gfx950 (MI350 / MI355X), DID varies
         return "mi355x"
+    if gfx == 120500:  # gfx1250 (256 CU, wave32), DID varies
+        return "gfx1250"
     return None
 
 

--- a/python/mori/ops/dispatch_combine_v2/tuning_configs.py
+++ b/python/mori/ops/dispatch_combine_v2/tuning_configs.py
@@ -163,26 +163,30 @@ _GFX1250_SCHED_BF16_T6 = (
     (None, 192, 32, 192, 16),  # >4096 (peak): disp 360 / comb 141 GB/s
 )
 # EP8 (world_size=8) measured 2026-07-12 on gfx1250 CROSS-NODE (2 nodes x 4 GPUs
-# over the UALink fabric), bf16, same 2-pass block x warp sweep. dispatch peaks at
-# block 128 warp 32 for >=512 (128/32 >= 192/32 here); combine wants 128/8 at 512
-# then 128/16 for bandwidth-bound large tok. Measured GB/s (disp/comb): 8=5/4
-# 64=36/17 512=160/63 2048=197/120 4096=200/151 8192=200/173. Cross-node fabric
-# caps disp ~200 (vs intra-node xGMI ~335); geometry is world_size-independent so
-# this also serves single-node EP8.
+# over the UALink fabric), bf16, full 2-pass block x warp sweep (tok 8..8192).
+# dispatch warp ramps 8->16->32 (block 128 near-optimal throughout, 192 only
+# marginally higher at 512); combine wants small block/warp early (64/4..64/16)
+# then block 128 warp 16 for bandwidth-bound large tok. Cross-node fabric caps
+# disp ~200 GB/s (vs intra-node xGMI ~335); geometry is world_size-independent so
+# this also serves single-node EP8. Measured GB/s (disp/comb): 8=5/4 64=36/17
+# 128=74/28 256=128/42 512=164/63 1024=189/96 2048=197/120 4096=200/151 8192=200/173.
 _GFX1250_SCHED_BF16_EP8 = (
-    (64, 128, 8, 64, 8),  # <=64:  latency-bound
-    (512, 128, 32, 128, 8),  # <=512: disp warp 32 peak; comb block 128 warp 8
-    (None, 128, 32, 128, 16),  # >512 (peak): disp ~200 / comb ~173 GB/s
+    (64, 128, 8, 64, 8),  # <=64:   latency-bound
+    (128, 128, 8, 64, 4),  # <=128
+    (256, 128, 16, 64, 8),  # <=256:  disp warp 16
+    (512, 128, 32, 128, 8),  # <=512:  disp warp 32; comb block 128
+    (1024, 128, 32, 64, 16),  # <=1024: comb warp 16
+    (None, 128, 32, 128, 16),  # >1024 (peak): disp ~200 / comb ~173 GB/s
 )
 # bf16-tuned (EP4 + EP8). fp8/fp4 fall back to the bf16 schedule until separately tuned.
 _GFX1250_TABLE = {
     (4, 7168, 8): {"bf16": _GFX1250_SCHED_BF16},
     (4, 7168, 6): {"bf16": _GFX1250_SCHED_BF16_T6},  # DeepSeek-V4-Pro
     (8, 7168, 8): {"bf16": _GFX1250_SCHED_BF16_EP8},  # cross-node / single-node EP8
-    # V4-Pro topk=6 EP8 cross-node (measured 2026-07-12): geometry is topk-
-    # independent (tracks token count) — optimum matches topk=8, so reuse it.
-    # Measured GB/s (disp/comb): 8=4/3 64=32/16 512=163/56 2048=199/113
-    # 4096=200/145 8192=206/171.
+    # V4-Pro topk=6 EP8 cross-node (measured 2026-07-12, full tok 8..8192 sweep):
+    # geometry is topk-independent (tracks token count) — per-size optimum matches
+    # topk=8, so reuse the same schedule. Measured GB/s (disp/comb): 8=4/3 64=32/16
+    # 128=65/25 256=119/39 512=163/56 1024=178/81 2048=199/113 4096=200/145 8192=206/171.
     (8, 7168, 6): {"bf16": _GFX1250_SCHED_BF16_EP8},
 }
 

--- a/python/mori/ops/dispatch_combine_v2/tuning_configs.py
+++ b/python/mori/ops/dispatch_combine_v2/tuning_configs.py
@@ -179,6 +179,11 @@ _GFX1250_TABLE = {
     (4, 7168, 8): {"bf16": _GFX1250_SCHED_BF16},
     (4, 7168, 6): {"bf16": _GFX1250_SCHED_BF16_T6},  # DeepSeek-V4-Pro
     (8, 7168, 8): {"bf16": _GFX1250_SCHED_BF16_EP8},  # cross-node / single-node EP8
+    # V4-Pro topk=6 EP8 cross-node (measured 2026-07-12): geometry is topk-
+    # independent (tracks token count) — optimum matches topk=8, so reuse it.
+    # Measured GB/s (disp/comb): 8=4/3 64=32/16 512=163/56 2048=199/113
+    # 4096=200/145 8192=206/171.
+    (8, 7168, 6): {"bf16": _GFX1250_SCHED_BF16_EP8},
 }
 
 _DEVICES = {

--- a/python/mori/ops/dispatch_combine_v2/tuning_configs.py
+++ b/python/mori/ops/dispatch_combine_v2/tuning_configs.py
@@ -162,10 +162,23 @@ _GFX1250_SCHED_BF16_T6 = (
     (4096, 192, 32, 128, 16),  # <=4096: comb block 128 (bandwidth)
     (None, 192, 32, 192, 16),  # >4096 (peak): disp 360 / comb 141 GB/s
 )
-# bf16-tuned (EP4). fp8/fp4 fall back to the bf16 schedule until separately tuned.
+# EP8 (world_size=8) measured 2026-07-12 on gfx1250 CROSS-NODE (2 nodes x 4 GPUs
+# over the UALink fabric), bf16, same 2-pass block x warp sweep. dispatch peaks at
+# block 128 warp 32 for >=512 (128/32 >= 192/32 here); combine wants 128/8 at 512
+# then 128/16 for bandwidth-bound large tok. Measured GB/s (disp/comb): 8=5/4
+# 64=36/17 512=160/63 2048=197/120 4096=200/151 8192=200/173. Cross-node fabric
+# caps disp ~200 (vs intra-node xGMI ~335); geometry is world_size-independent so
+# this also serves single-node EP8.
+_GFX1250_SCHED_BF16_EP8 = (
+    (64, 128, 8, 64, 8),  # <=64:  latency-bound
+    (512, 128, 32, 128, 8),  # <=512: disp warp 32 peak; comb block 128 warp 8
+    (None, 128, 32, 128, 16),  # >512 (peak): disp ~200 / comb ~173 GB/s
+)
+# bf16-tuned (EP4 + EP8). fp8/fp4 fall back to the bf16 schedule until separately tuned.
 _GFX1250_TABLE = {
     (4, 7168, 8): {"bf16": _GFX1250_SCHED_BF16},
     (4, 7168, 6): {"bf16": _GFX1250_SCHED_BF16_T6},  # DeepSeek-V4-Pro
+    (8, 7168, 8): {"bf16": _GFX1250_SCHED_BF16_EP8},  # cross-node / single-node EP8
 }
 
 _DEVICES = {

--- a/src/cco/cco_init.cpp
+++ b/src/cco/cco_init.cpp
@@ -189,6 +189,25 @@ static int CcoPeToLsaRank(const ccoComm* comm, int pe) {
   return comm->fabricCrossNodeLsa ? pe : (pe - comm->myNodeStart);
 }
 
+// Cross-node LSA (world-wide flat VA over the fabric) is opt-in: a successful
+// fabric-handle probe only proves LOCAL export works, not that a peer's imported
+// handle is load/store-reachable across nodes. Auto-enabling on an RDMA-only
+// fabric would map peer VAs that fault on first device access. Enable only on a
+// genuine scale-up fabric via MORI_CCO_FABRIC_CROSSNODE_LSA=1.
+static bool CcoFabricCrossNodeLsaEnabled() {
+  const char* e = getenv("MORI_CCO_FABRIC_CROSSNODE_LSA");
+  return e && atoi(e) != 0;
+}
+
+// By default a cross-node hipMemSetAccess failure is fatal at register time
+// (fail loudly instead of leaving a silently-unusable peer mapping that faults
+// mid-kernel). MORI_CCO_FABRIC_LENIENT=1 restores continue-on-failure, for
+// fabrics where the import itself already grants access.
+static bool CcoFabricLenient() {
+  const char* e = getenv("MORI_CCO_FABRIC_LENIENT");
+  return e && atoi(e) != 0;
+}
+
 static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perRankVmmSize,
                              ccoComm** outComm) {
   auto* comm = new ccoComm();
@@ -329,9 +348,10 @@ static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perR
     }
   }
 
-  // Hardcoded cross-node LSA: fabric handle + multi-node => world-wide flat VA.
+  // Cross-node LSA: fabric handle + multi-node => world-wide flat VA. Opt-in
+  // (MORI_CCO_FABRIC_CROSSNODE_LSA=1) — only safe on a scale-up fabric.
   if (comm->handleType == static_cast<int>(hipMemHandleTypeFabricCompat) &&
-      comm->worldSize > comm->lsaSize) {
+      comm->worldSize > comm->lsaSize && CcoFabricCrossNodeLsaEnabled()) {
     comm->fabricCrossNodeLsa = true;
     comm->lsaSize = comm->worldSize;
     comm->myNodeStart = 0;
@@ -757,14 +777,21 @@ int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin
         usleep(1000 * (1 << retry));
       }
       if (setErr != hipSuccess) {
-        if (crossNodePeer) {
+        if (crossNodePeer && CcoFabricLenient()) {
+          // Opt-in leniency: some fabrics grant load/store access at import time
+          // and return non-success from hipMemSetAccess. Trust the mapping.
           MORI_SHMEM_WARN(
               "ccoWindowRegister: hipMemSetAccess PE {} cross-node failed: {} "
-              "(continuing — fabric import may already grant access)",
+              "(MORI_CCO_FABRIC_LENIENT=1 — continuing, import may already grant access)",
               pe, static_cast<int>(setErr));
         } else {
-          MORI_SHMEM_ERROR("ccoWindowRegister: hipMemSetAccess PE {} failed after retries: {}", pe,
-                           static_cast<int>(setErr));
+          // Fail loudly at register time rather than leaving a peer VA that
+          // faults on first device access. For cross-node this most likely means
+          // the fabric is not a scale-up (load/store) domain.
+          MORI_SHMEM_ERROR(
+              "ccoWindowRegister: hipMemSetAccess PE {} failed after retries: {}{}", pe,
+              static_cast<int>(setErr),
+              crossNodePeer ? " (cross-node fabric not load/store-reachable?)" : "");
           {
             vmmProcessLock vmmLock;
             (void)hipMemUnmap(peerVa, alignedSize);

--- a/src/cco/cco_init.cpp
+++ b/src/cco/cco_init.cpp
@@ -392,8 +392,10 @@ static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perR
 
   int manualCnt = 0, fabricCnt = 0;
   for (const auto& k : allKeys) {
-    if (k.mode == CCO_LSA_MANUAL) manualCnt++;
-    else if (k.mode == CCO_LSA_FABRIC) fabricCnt++;
+    if (k.mode == CCO_LSA_MANUAL)
+      manualCnt++;
+    else if (k.mode == CCO_LSA_FABRIC)
+      fabricCnt++;
   }
   bool vpodMode;
   if (manualCnt > 0) {
@@ -484,8 +486,7 @@ static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perR
         "ccoCommCreate: lsa topology rank={} lsaSize={} lsaRank={} lsaStart={} "
         "mode={} spansHosts={}",
         comm->rank, comm->lsaSize, comm->lsaRank, comm->myNodeStart,
-        (myKey.mode == CCO_LSA_FABRIC ? "fabric" : (vpodMode ? "manual" : "host")),
-        lsaSpansHosts);
+        (myKey.mode == CCO_LSA_FABRIC ? "fabric" : (vpodMode ? "manual" : "host")), lsaSpansHosts);
   }
 
   // Step 3: reserve flat VA. Always 4GB-aligned so stride4G = perRankSize >> 32
@@ -513,16 +514,15 @@ static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perR
 #endif
 
     size_t probeGranularity = 0;
-    hipError_t probeErr =
-        hipMemGetAllocationGranularity(&probeGranularity, &probeProp,
-                                       hipMemAllocationGranularityRecommended);
+    hipError_t probeErr = hipMemGetAllocationGranularity(&probeGranularity, &probeProp,
+                                                         hipMemAllocationGranularityRecommended);
     if (probeErr == hipSuccess && probeGranularity > 0) {
       hipMemGenericAllocationHandle_t probeHandle = 0;
       probeErr = hipMemCreate(&probeHandle, probeGranularity, &probeProp, 0);
       if (probeErr == hipSuccess) {
         hipMemFabricHandle_compat_t probeFabric;
         probeErr = hipMemExportToShareableHandle(&probeFabric, probeHandle,
-                                                  hipMemHandleTypeFabricCompat, 0);
+                                                 hipMemHandleTypeFabricCompat, 0);
         (void)hipMemRelease(probeHandle);
         if (probeErr == hipSuccess) {
           comm->handleType = static_cast<int>(hipMemHandleTypeFabricCompat);
@@ -732,8 +732,7 @@ int ccoMemAlloc(ccoComm* comm, size_t size, void** outPtr) {
   // Return the reserved slot to the vaManager on any failure after this point.
   auto rollbackSlot = [&]() { (void)comm->vaManager->Free(slotAddr); };
 
-  const bool useFabric =
-      (comm->handleType == static_cast<int>(hipMemHandleTypeFabricCompat));
+  const bool useFabric = (comm->handleType == static_cast<int>(hipMemHandleTypeFabricCompat));
   hipMemAllocationProp allocProp = {};
   allocProp.type = CcoWindowAllocType();
   allocProp.requestedHandleType = static_cast<hipMemAllocationHandleType>(comm->handleType);
@@ -986,10 +985,9 @@ int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin
           // Fail loudly at register time rather than leaving a peer VA that
           // faults on first device access. For cross-node this most likely means
           // the fabric is not a scale-up (load/store) domain.
-          MORI_SHMEM_ERROR(
-              "ccoWindowRegister: hipMemSetAccess PE {} failed after retries: {}{}", pe,
-              static_cast<int>(setErr),
-              crossNodePeer ? " (cross-node fabric not load/store-reachable?)" : "");
+          MORI_SHMEM_ERROR("ccoWindowRegister: hipMemSetAccess PE {} failed after retries: {}{}",
+                           pe, static_cast<int>(setErr),
+                           crossNodePeer ? " (cross-node fabric not load/store-reachable?)" : "");
           {
             vmmProcessLock vmmLock;
             (void)hipMemUnmap(peerVa, alignedSize);
@@ -1012,8 +1010,8 @@ int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin
 
       for (int pe : p2pPeers) {
         hipMemGenericAllocationHandle_t importedHandle;
-        hipError_t err = hipMemImportFromShareableHandle(
-            &importedHandle, &allFabricHandles[pe], hipMemHandleTypeFabricCompat);
+        hipError_t err = hipMemImportFromShareableHandle(&importedHandle, &allFabricHandles[pe],
+                                                         hipMemHandleTypeFabricCompat);
         if (err != hipSuccess) {
           MORI_SHMEM_ERROR("ccoWindowRegister: fabric import from PE {} failed: {}", pe,
                            static_cast<int>(err));
@@ -1177,8 +1175,8 @@ int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin
 
   char* winBase = static_cast<char*>(comm->flatBase) + slotOffset;
   MORI_SHMEM_INFO(
-      "ccoWindowRegister: rank={} win={} winBase={} size={} slotOffset={} lkey={} fabric={}",
-      rank, (void*)devPtr, (void*)winBase, size, slotOffset, lkey, useFabric);
+      "ccoWindowRegister: rank={} win={} winBase={} size={} slotOffset={} lkey={} fabric={}", rank,
+      (void*)devPtr, (void*)winBase, size, slotOffset, lkey, useFabric);
   for (int lsa = 0; lsa < comm->lsaSize; lsa++) {
     int pe = comm->myNodeStart + lsa;
     void* peerVa = winBase + static_cast<size_t>(lsa) * comm->perRankSize;

--- a/src/cco/cco_init.cpp
+++ b/src/cco/cco_init.cpp
@@ -1246,7 +1246,7 @@ int ccoWindowDeregister(ccoComm* comm, ccoWindow_t win) {
     vmmProcessLock vmmLock;
     for (int lsa = 0; lsa < comm->lsaSize; lsa++) {
       if (lsa == comm->lsaRank) continue;
-      int pe = comm->fabricCrossNodeLsa ? lsa : (comm->myNodeStart + lsa);
+      int pe = comm->myNodeStart + lsa;  // global pe (matches register's p2pPeers)
       if (!CcoCanLsaMapPeer(comm, pe)) continue;
       void* peerVa = static_cast<char*>(comm->flatBase) +
                      static_cast<size_t>(lsa) * comm->perRankSize + slotOff;

--- a/src/cco/cco_init.cpp
+++ b/src/cco/cco_init.cpp
@@ -74,6 +74,11 @@ static_assert(static_cast<int>(CCO_PROVIDER_IBVERBS) ==
                   static_cast<int>(core::ProviderType::IBVERBS),
               "ccoProviderType drifted from core::ProviderType");
 
+// ccoFabricHandle_t (cco.hpp, self-contained) and hipMemFabricHandle_compat_t
+// (hip_compat.hpp) are both 64-byte PODs; guard layout compatibility.
+static_assert(sizeof(ccoFabricHandle_t) == sizeof(hipMemFabricHandle_compat_t),
+              "ccoFabricHandle_t / hipMemFabricHandle_compat_t size mismatch");
+
 // Out-of-line dtor for the unique_ptr<HeapVAManager> member: ccoComm is defined
 // in cco.hpp with HeapVAManager only forward-declared, so its destruction must
 // be emitted here where HeapVAManager (va_manager.hpp) is complete.
@@ -275,11 +280,45 @@ static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perR
   // the calling thread bound to this device for any later CCO API on this comm.
   HIP_RUNTIME_CHECK(hipGetDevice(&comm->hipDev));
 
+  // Probe fabric handle support: try to allocate + export with the fabric
+  // handle type. If it works, all subsequent allocations use fabric handles
+  // (64-byte tokens exchangeable via Allgather) instead of dma-buf FDs
+  // (which require Unix socket + SCM_RIGHTS).
+  {
+    hipMemAllocationProp probeProp = {};
+    probeProp.type = hipMemAllocationTypePinned;
+    probeProp.requestedHandleType = hipMemHandleTypeFabricCompat;
+    probeProp.location.type = hipMemLocationTypeDevice;
+    probeProp.location.id = comm->hipDev;
+
+    size_t probeGranularity = 0;
+    hipError_t probeErr =
+        hipMemGetAllocationGranularity(&probeGranularity, &probeProp,
+                                       hipMemAllocationGranularityRecommended);
+    if (probeErr == hipSuccess && probeGranularity > 0) {
+      hipMemGenericAllocationHandle_t probeHandle = 0;
+      probeErr = hipMemCreate(&probeHandle, probeGranularity, &probeProp, 0);
+      if (probeErr == hipSuccess) {
+        hipMemFabricHandle_compat_t probeFabric;
+        probeErr = hipMemExportToShareableHandle(&probeFabric, probeHandle,
+                                                  hipMemHandleTypeFabricCompat, 0);
+        (void)hipMemRelease(probeHandle);
+        if (probeErr == hipSuccess) {
+          comm->handleType = static_cast<int>(hipMemHandleTypeFabricCompat);
+          MORI_SHMEM_INFO("ccoCommCreate: fabric handle probe succeeded");
+        }
+      }
+    }
+    if (comm->handleType != static_cast<int>(hipMemHandleTypeFabricCompat)) {
+      MORI_SHMEM_INFO("ccoCommCreate: fabric handle probe failed, using FD path");
+    }
+  }
+
   // Query granularity with the SAME allocProp MemAlloc will use — granularity
-  // can shift when requestedHandleType (FD export) is enabled.
+  // can shift when requestedHandleType (FD export vs fabric) is enabled.
   hipMemAllocationProp allocProp = {};
   allocProp.type = CcoWindowAllocType();
-  allocProp.requestedHandleType = hipMemHandleTypePosixFileDescriptor;
+  allocProp.requestedHandleType = static_cast<hipMemAllocationHandleType>(comm->handleType);
   allocProp.location.type = hipMemLocationTypeDevice;
   allocProp.location.id = comm->hipDev;
 
@@ -348,10 +387,11 @@ static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perR
 
   MORI_SHMEM_INFO(
       "ccoCommCreate: rank={}/{} groupId={} flatBase={} perRankSize={} "
-      "granularity={} defaultNumQpPerPe={} sdmaNumQueue={} rdma={}",
+      "granularity={} defaultNumQpPerPe={} sdmaNumQueue={} rdma={} fabric={}",
       comm->rank, comm->worldSize, comm->groupId, comm->flatBase, comm->perRankSize,
       comm->vmmGranularity, comm->defaultNumQpPerPe, comm->sdmaNumQueue,
-      comm->ctx->RdmaTransportEnabled());
+      comm->ctx->RdmaTransportEnabled(),
+      comm->handleType == static_cast<int>(hipMemHandleTypeFabricCompat));
   return 0;
 }
 
@@ -390,7 +430,7 @@ int ccoCommDestroy(ccoComm* comm) {
     vmmProcessLock vmmLock;
     (void)hipMemUnmap(ptr, meta.size);
     (void)hipMemRelease(meta.physHandle);
-    if (meta.shareFd >= 0) close(meta.shareFd);
+    if (!meta.isFabric && meta.shareFd >= 0) close(meta.shareFd);
   }
   comm->allocTable.clear();
 
@@ -449,15 +489,16 @@ int ccoMemAlloc(ccoComm* comm, size_t size, void** outPtr) {
   // Return the reserved slot to the vaManager on any failure after this point.
   auto rollbackSlot = [&]() { (void)comm->vaManager->Free(slotAddr); };
 
+  const bool useFabric =
+      (comm->handleType == static_cast<int>(hipMemHandleTypeFabricCompat));
   hipMemAllocationProp allocProp = {};
   allocProp.type = CcoWindowAllocType();
-  allocProp.requestedHandleType = hipMemHandleTypePosixFileDescriptor;
+  allocProp.requestedHandleType = static_cast<hipMemAllocationHandleType>(comm->handleType);
   allocProp.location.type = hipMemLocationTypeDevice;
   allocProp.location.id = comm->hipDev;
 
   hipMemGenericAllocationHandle_t physHandle = 0;
   hipError_t err = hipSuccess;
-  int shareFd = -1;
   void* localVa = reinterpret_cast<void*>(slotAddr);
   {
     vmmProcessLock vmmLock;
@@ -503,8 +544,23 @@ int ccoMemAlloc(ccoComm* comm, size_t size, void** outPtr) {
     return -1;
   }
 
-  err = hipMemExportToShareableHandle(reinterpret_cast<void*>(&shareFd), physHandle,
-                                      hipMemHandleTypePosixFileDescriptor, 0);
+  // Export a shareable handle for WindowRegister (P2P mapping + RDMA MR).
+  // Fabric path: 64-byte token (exchangeable via Allgather — no Unix sockets).
+  // FD path: dma-buf FD (exchanged via LocalBootstrapNetwork + SCM_RIGHTS).
+  ccoComm::AllocMeta meta;
+  meta.physHandle = physHandle;
+  meta.isFabric = useFabric;
+  meta.slotOffset = slotOffset;
+  meta.size = alignedSize;
+
+  if (useFabric) {
+    err = hipMemExportToShareableHandle(&meta.fabricHandle, physHandle,
+                                        hipMemHandleTypeFabricCompat, 0);
+  } else {
+    meta.shareFd = -1;
+    err = hipMemExportToShareableHandle(reinterpret_cast<void*>(&meta.shareFd), physHandle,
+                                        hipMemHandleTypePosixFileDescriptor, 0);
+  }
   if (err != hipSuccess) {
     MORI_SHMEM_ERROR("ccoMemAlloc: hipMemExportToShareableHandle failed: {} ({})",
                      static_cast<int>(err), hipGetErrorString(err));
@@ -518,11 +574,6 @@ int ccoMemAlloc(ccoComm* comm, size_t size, void** outPtr) {
   }
   {
     std::lock_guard<std::mutex> lock(comm->allocMutex);
-    ccoComm::AllocMeta meta;
-    meta.physHandle = physHandle;
-    meta.shareFd = shareFd;
-    meta.slotOffset = slotOffset;
-    meta.size = alignedSize;
     comm->allocTable[localVa] = meta;
   }
 
@@ -573,7 +624,7 @@ int ccoMemFree(ccoComm* comm, void* ptr) {
     }
   }
 
-  if (meta.shareFd >= 0) close(meta.shareFd);
+  if (!meta.isFabric && meta.shareFd >= 0) close(meta.shareFd);
 
   return 0;
 }
@@ -591,21 +642,21 @@ int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin
 
   auto& meta = it->second;
   size_t slotOffset = meta.slotOffset;
-  int shareFd = meta.shareFd;
   void* localPtr = ptr;
   int worldSize = comm->worldSize;
   int rank = comm->rank;
+  const bool useFabric = meta.isFabric;
 
   size_t alignedSize = meta.size;
 
-  MORI_SHMEM_TRACE("ccoWindowRegister: rank={} ptr={} size={} slotOffset={}", rank, ptr, size,
-                   slotOffset);
+  MORI_SHMEM_TRACE("ccoWindowRegister: rank={} ptr={} size={} slotOffset={} fabric={}", rank, ptr,
+                   size, slotOffset, useFabric);
 
-  // P2P imported handles — collected during the FD-exchange loop below,
+  // P2P imported handles — collected during the exchange loop below,
   // ownership later transferred to ccoWindowHost so Deregister can release.
   std::vector<hipMemGenericAllocationHandle_t> p2pImportedHandles;
 
-  // P2P: exchange dma-buf FDs with same-node peers and map their slots into
+  // P2P: exchange handles with same-node peers and map their slots into
   // the LSA flat VA.
   std::vector<int> p2pPeers;
   for (int pe = 0; pe < worldSize; pe++) {
@@ -615,80 +666,12 @@ int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin
   }
 
   if (!p2pPeers.empty()) {
-    std::vector<int> sortedGroup = p2pPeers;
-    sortedGroup.push_back(rank);
-    std::sort(sortedGroup.begin(), sortedGroup.end());
-
-    int myPeerRank = 0;
-    for (int i = 0; i < static_cast<int>(sortedGroup.size()); i++) {
-      if (sortedGroup[i] == rank) {
-        myPeerRank = i;
-        break;
-      }
-    }
-    int p2pWorldSize = static_cast<int>(sortedGroup.size());
-
-    // Socket path must agree across the group but be unique per (group, window).
-    // groupId = rank 0's pid; slotOffset identifies the window. The clique
-    // leader (smallest GLOBAL rank in the group) must also be part of the path:
-    // a single node can host several disjoint P2P cliques (e.g. GPUs {0,1,2,3}
-    // and {4,5,6,7}). Every clique shares groupId + slotOffset and renumbers its
-    // members to 0..k-1 internally, so without the leader the cliques would
-    // generate identical socket/barrier filenames and clobber each other's
-    // sockets (manifesting as ENOENT during connect).
-    std::string socketPath = "/tmp/mori_cco_" + std::to_string(comm->groupId) + "_" +
-                             std::to_string(slotOffset) + "_g" + std::to_string(sortedGroup[0]) +
-                             "_";
-
-    // NOTE: do NOT blanket-unlink every i_j socket here (even guarded by
-    // myPeerRank == 0). Ranks bind their server sockets as soon as they enter
-    // ExchangeFileDescriptors, and they may do so at very different times (e.g.
-    // single-process multi-thread, where threads serialize on HIP locks). A
-    // leader-side sweep can therefore delete a socket a peer has already bound
-    // and is listening on, making a client connect() fail with ENOENT. Stale
-    // sockets from a prior crashed run are instead handled per-pairing inside
-    // ExchangeFileDescriptors, which unlinks each server path right before
-    // binding it (and groupId/leader/slotOffset make cross-run collisions
-    // effectively impossible).
-    application::LocalBootstrapNetwork localBoot(myPeerRank, p2pWorldSize, socketPath);
-    localBoot.Initialize();
-
-    std::vector<int> myFds = {shareFd};
-    std::vector<std::vector<int>> allFds;
-    if (!localBoot.ExchangeFileDescriptors(myFds, allFds)) {
-      MORI_SHMEM_ERROR("ccoWindowRegister: P2P FD exchange failed");
-      localBoot.Finalize();
-      return -1;
-    }
-
-    // All peer-supplied fds (everything in allFds except our own slot) must
-    // be close()'d exactly once — closing them at the very end on every
-    // exit path (success and bail) is the easiest invariant to enforce.
-    // hipMemImportFromShareableHandle already dup's the underlying dma-buf
-    // reference internally, so it's safe to delay the close to here.
-    auto closePeerFds = [&]() {
-      for (int i = 0; i < static_cast<int>(allFds.size()); i++) {
-        if (i == myPeerRank) continue;  // our own shareFd is owned by meta
-        for (int fd : allFds[i]) {
-          if (fd >= 0) close(fd);
-        }
-      }
-      allFds.clear();
-    };
-
-    std::vector<int> globalToPeer(worldSize, -1);
-    for (int i = 0; i < p2pWorldSize; i++) {
-      globalToPeer[sortedGroup[i]] = i;
-    }
-
+    // Common peer-mapping helpers shared by both fabric and FD paths.
     hipMemAccessDesc accessDesc = {};
     accessDesc.location.type = hipMemLocationTypeDevice;
     accessDesc.location.id = comm->hipDev;
     accessDesc.flags = hipMemAccessFlagsProtReadWrite;
 
-    // Track already-mapped peers so we can roll back if any later peer
-    // fails — partial success would leave the window with missing P2P
-    // links and silently segfault when a kernel touches a missing peer.
     struct MappedPeer {
       hipMemGenericAllocationHandle_t handle;
       void* peerVa;
@@ -705,51 +688,23 @@ int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin
       mappedPeers.clear();
     };
 
-    auto bail = [&]() {
-      rollbackMappedPeers();
-      closePeerFds();
-      localBoot.Finalize();
-    };
-
-    for (int pe : p2pPeers) {
-      int pr = globalToPeer[pe];
-      if (pr < 0 || pr >= static_cast<int>(allFds.size())) {
-        MORI_SHMEM_ERROR("ccoWindowRegister: PE {} missing in FD exchange result", pe);
-        bail();
-        return -1;
-      }
-      int peerFd = allFds[pr][0];
-      if (peerFd < 0) {
-        MORI_SHMEM_ERROR("ccoWindowRegister: PE {} delivered invalid FD ({})", pe, peerFd);
-        bail();
-        return -1;
-      }
-
-      hipMemGenericAllocationHandle_t importedHandle;
+    // Import + map a single peer's handle into our flat VA. Returns 0 on
+    // success, -1 on failure (rolls back all prior mappings).
+    auto mapPeer = [&](int pe, hipMemGenericAllocationHandle_t importedHandle) -> int {
       int peerLsaRank = pe - comm->myNodeStart;
       void* peerVa = static_cast<char*>(comm->flatBase) +
                      static_cast<size_t>(peerLsaRank) * comm->perRankSize + slotOffset;
       {
         vmmProcessLock vmmLock;
-        hipError_t err = hipMemImportFromShareableHandleCompat(&importedHandle, peerFd,
-                                                               hipMemHandleTypePosixFileDescriptor);
-        if (err != hipSuccess) {
-          MORI_SHMEM_ERROR("ccoWindowRegister: import from PE {} failed: {}", pe,
-                           static_cast<int>(err));
-          bail();
-          return -1;
-        }
-
         hipError_t mapErr = hipMemMap(peerVa, alignedSize, 0, importedHandle, 0);
         if (mapErr != hipSuccess) {
           MORI_SHMEM_ERROR("ccoWindowRegister: hipMemMap PE {} failed: {}", pe,
                            static_cast<int>(mapErr));
           (void)hipMemRelease(importedHandle);
-          bail();
+          rollbackMappedPeers();
           return -1;
         }
       }
-
       hipError_t setErr = hipSuccess;
       for (int retry = 0; retry < 5; retry++) {
         {
@@ -767,19 +722,122 @@ int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin
           (void)hipMemUnmap(peerVa, alignedSize);
           (void)hipMemRelease(importedHandle);
         }
-        bail();
+        rollbackMappedPeers();
+        return -1;
+      }
+      mappedPeers.push_back({importedHandle, peerVa});
+      return 0;
+    };
+
+    if (useFabric) {
+      // Fabric path: Allgather 64-byte fabric handles via the bootstrap
+      // network — no Unix sockets, no SCM_RIGHTS.
+      std::vector<hipMemFabricHandle_compat_t> allFabricHandles(worldSize);
+      comm->bootNet->Allgather(&meta.fabricHandle, allFabricHandles.data(),
+                               sizeof(hipMemFabricHandle_compat_t));
+
+      for (int pe : p2pPeers) {
+        hipMemGenericAllocationHandle_t importedHandle;
+        hipError_t err = hipMemImportFromShareableHandle(
+            &importedHandle, &allFabricHandles[pe], hipMemHandleTypeFabricCompat);
+        if (err != hipSuccess) {
+          MORI_SHMEM_ERROR("ccoWindowRegister: fabric import from PE {} failed: {}", pe,
+                           static_cast<int>(err));
+          rollbackMappedPeers();
+          return -1;
+        }
+        if (mapPeer(pe, importedHandle) != 0) return -1;
+      }
+    } else {
+      // FD path (fallback): exchange dma-buf FDs via LocalBootstrapNetwork +
+      // SCM_RIGHTS (one Unix socket pair per peer).
+      int shareFd = meta.shareFd;
+
+      std::vector<int> sortedGroup = p2pPeers;
+      sortedGroup.push_back(rank);
+      std::sort(sortedGroup.begin(), sortedGroup.end());
+
+      int myPeerRank = 0;
+      for (int i = 0; i < static_cast<int>(sortedGroup.size()); i++) {
+        if (sortedGroup[i] == rank) {
+          myPeerRank = i;
+          break;
+        }
+      }
+      int p2pWorldSize = static_cast<int>(sortedGroup.size());
+
+      std::string socketPath = "/tmp/mori_cco_" + std::to_string(comm->groupId) + "_" +
+                               std::to_string(slotOffset) + "_g" + std::to_string(sortedGroup[0]) +
+                               "_";
+
+      application::LocalBootstrapNetwork localBoot(myPeerRank, p2pWorldSize, socketPath);
+      localBoot.Initialize();
+
+      std::vector<int> myFds = {shareFd};
+      std::vector<std::vector<int>> allFds;
+      if (!localBoot.ExchangeFileDescriptors(myFds, allFds)) {
+        MORI_SHMEM_ERROR("ccoWindowRegister: P2P FD exchange failed");
+        localBoot.Finalize();
         return -1;
       }
 
-      mappedPeers.push_back({importedHandle, peerVa});
+      auto closePeerFds = [&]() {
+        for (int i = 0; i < static_cast<int>(allFds.size()); i++) {
+          if (i == myPeerRank) continue;
+          for (int fd : allFds[i]) {
+            if (fd >= 0) close(fd);
+          }
+        }
+        allFds.clear();
+      };
+
+      std::vector<int> globalToPeer(worldSize, -1);
+      for (int i = 0; i < p2pWorldSize; i++) {
+        globalToPeer[sortedGroup[i]] = i;
+      }
+
+      auto bailFd = [&]() {
+        rollbackMappedPeers();
+        closePeerFds();
+        localBoot.Finalize();
+      };
+
+      for (int pe : p2pPeers) {
+        int pr = globalToPeer[pe];
+        if (pr < 0 || pr >= static_cast<int>(allFds.size())) {
+          MORI_SHMEM_ERROR("ccoWindowRegister: PE {} missing in FD exchange result", pe);
+          bailFd();
+          return -1;
+        }
+        int peerFd = allFds[pr][0];
+        if (peerFd < 0) {
+          MORI_SHMEM_ERROR("ccoWindowRegister: PE {} delivered invalid FD ({})", pe, peerFd);
+          bailFd();
+          return -1;
+        }
+
+        hipMemGenericAllocationHandle_t importedHandle;
+        hipError_t err = hipMemImportFromShareableHandleCompat(&importedHandle, peerFd,
+                                                               hipMemHandleTypePosixFileDescriptor);
+        if (err != hipSuccess) {
+          MORI_SHMEM_ERROR("ccoWindowRegister: import from PE {} failed: {}", pe,
+                           static_cast<int>(err));
+          bailFd();
+          return -1;
+        }
+        if (mapPeer(pe, importedHandle) != 0) {
+          closePeerFds();
+          localBoot.Finalize();
+          return -1;
+        }
+      }
+
+      closePeerFds();
+      localBoot.Finalize();
     }
 
-    // Stash handles on the WindowHost so Deregister can release them.
     p2pImportedHandles.reserve(mappedPeers.size());
     for (auto& mp : mappedPeers) p2pImportedHandles.push_back(mp.handle);
-
-    closePeerFds();
-    localBoot.Finalize();
   }
 
   // RDMA MR registration + rkey Allgather.
@@ -787,12 +845,14 @@ int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin
   uint32_t localRkey = 0;
 
   application::RdmaDeviceContext* rdmaDevCtx = comm->ctx->GetRdmaDeviceContext();
-  if (rdmaDevCtx && shareFd >= 0) {
+  if (rdmaDevCtx) {
     application::RdmaMemoryRegion mr;
-    if (comm->iovaZeroMode) {
-      mr = rdmaDevCtx->RegisterRdmaMemoryRegionDmabufIova0(localPtr, size, shareFd);
+    if (useFabric) {
+      mr = rdmaDevCtx->RegisterRdmaMemoryRegionAuto(localPtr, size);
+    } else if (comm->iovaZeroMode) {
+      mr = rdmaDevCtx->RegisterRdmaMemoryRegionDmabufIova0(localPtr, size, meta.shareFd);
     } else {
-      mr = rdmaDevCtx->RegisterRdmaMemoryRegionDmabuf(localPtr, size, shareFd);
+      mr = rdmaDevCtx->RegisterRdmaMemoryRegionDmabuf(localPtr, size, meta.shareFd);
     }
     lkey = mr.lkey;
     localRkey = mr.rkey;
@@ -842,8 +902,9 @@ int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin
   *outWin = devPtr;
 
   char* winBase = static_cast<char*>(comm->flatBase) + slotOffset;
-  MORI_SHMEM_INFO("ccoWindowRegister: rank={} win={} winBase={} size={} slotOffset={} lkey={}",
-                  rank, (void*)devPtr, (void*)winBase, size, slotOffset, lkey);
+  MORI_SHMEM_INFO(
+      "ccoWindowRegister: rank={} win={} winBase={} size={} slotOffset={} lkey={} fabric={}",
+      rank, (void*)devPtr, (void*)winBase, size, slotOffset, lkey, useFabric);
   for (int lsa = 0; lsa < comm->lsaSize; lsa++) {
     int pe = comm->myNodeStart + lsa;
     void* peerVa = winBase + static_cast<size_t>(lsa) * comm->perRankSize;

--- a/src/cco/cco_init.cpp
+++ b/src/cco/cco_init.cpp
@@ -179,24 +179,29 @@ int ccoCommCreate(const ccoUniqueId& uniqueId, int nRanks, int rank, size_t perR
   return ccoCommCreateImpl(boot, perRankVmmSize, outComm);
 }
 
+// The LSA team is always the contiguous rank range [myNodeStart, myNodeStart+
+// lsaSize) — its width is set by the topology step (same host by default, same
+// vPOD when grouping is enabled). Membership + flat-VA index derive purely from
+// that range, so the same formula covers intra-node, cross-node-vPOD, and
+// whole-world layouts.
 static bool CcoCanLsaMapPeer(const ccoComm* comm, int pe) {
   if (pe == comm->rank) return false;
-  if (comm->fabricCrossNodeLsa) return true;
-  return comm->ctx->CanUseP2P(pe);
+  return pe >= comm->myNodeStart && pe < comm->myNodeStart + comm->lsaSize;
 }
 
-static int CcoPeToLsaRank(const ccoComm* comm, int pe) {
-  return comm->fabricCrossNodeLsa ? pe : (pe - comm->myNodeStart);
-}
+static int CcoPeToLsaRank(const ccoComm* comm, int pe) { return pe - comm->myNodeStart; }
 
-// Cross-node LSA (world-wide flat VA over the fabric) is opt-in: a successful
-// fabric-handle probe only proves LOCAL export works, not that a peer's imported
-// handle is load/store-reachable across nodes. Auto-enabling on an RDMA-only
-// fabric would map peer VAs that fault on first device access. Enable only on a
-// genuine scale-up fabric via MORI_CCO_FABRIC_CROSSNODE_LSA=1.
-static bool CcoFabricCrossNodeLsaEnabled() {
-  const char* e = getenv("MORI_CCO_FABRIC_CROSSNODE_LSA");
-  return e && atoi(e) != 0;
+// A vPOD is a scale-up fabric domain that may span multiple physical hosts: ranks
+// sharing it can LSA-interconnect (flat VA over the fabric) directly, not just
+// intra-node. Each rank declares its vPOD via MORI_VPOD_ID; ranks with the same
+// value form one LSA team. MORI_CCO_FABRIC_CROSSNODE_LSA=1 is shorthand for
+// "the whole world is one vPOD". Unset on all ranks => group by host (default).
+static int CcoLocalVpodId() {
+  const char* e = getenv("MORI_VPOD_ID");
+  if (e && *e) return atoi(e);
+  const char* w = getenv("MORI_CCO_FABRIC_CROSSNODE_LSA");
+  if (w && atoi(w) != 0) return 0;  // whole world = one vPOD
+  return -1;                        // group by host
 }
 
 // By default a cross-node hipMemSetAccess failure is fatal at register time
@@ -232,36 +237,64 @@ static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perR
   comm->ctx = new application::Context(*comm->bootNet);
   comm->defaultNumQpPerPe = comm->ctx->GetNumQpPerPe();
 
-  // Step 2.5: detect intra-node topology (LSA = Local Symmetric Access).
-  // Use Context's capability discovery (PeerCapabilities.sameHost) rather
-  // than the chosen transport — LSA membership is a hardware fact and must
-  // not flip even if policy routes intra-node traffic via RDMA.
+  // Step 2.5: detect LSA (Local Symmetric Access) team topology.
+  // Membership is a HARDWARE fact — peers whose memory this rank can load/store
+  // through a flat VA — captured before transport policy: same host by default,
+  // or the same vPOD (a scale-up fabric domain that may span hosts) when vPOD
+  // grouping is enabled (see CcoLocalVpodId).
   //
   // HARD CONTRACT — violations are fatal:
-  //   (a) node-major contiguous ranks (same-host peers form a single block)
+  //   (a) LSA-major contiguous ranks (team peers form a single block)
   //   (b) every rank observes the same lsaSize
   // Both are required by the flat-VA formula `lsaFlatBase + lsaRank * stride`.
+
+  // Resolve vPOD grouping (all-or-none across the job). vpodMode widens the LSA
+  // team from same-host to same-vPOD; lsaSpansHosts records whether the team
+  // actually crosses a host boundary (=> cross-node fabric mapping is required).
+  int myVpodId = CcoLocalVpodId();
+  std::vector<int> allVpodIds(comm->worldSize);
+  comm->bootNet->Allgather(&myVpodId, allVpodIds.data(), sizeof(int));
+  bool anyVpod = false, allVpod = true;
+  for (int v : allVpodIds) {
+    anyVpod |= (v >= 0);
+    allVpod &= (v >= 0);
+  }
+  if (anyVpod && !allVpod) {
+    MORI_SHMEM_ERROR(
+        "ccoCommCreate: MORI_VPOD_ID set on some ranks but not all — vPOD grouping "
+        "must be all-or-none across the job.");
+    delete comm->ctx;
+    comm->bootNet->Finalize();
+    delete comm;
+    *outComm = nullptr;
+    return -1;
+  }
+  const bool vpodMode = allVpod;
+  bool lsaSpansHosts = false;
   {
     int lsaCount = 0;
-    int firstSameNode = comm->rank;
-    int lastSameNode = comm->rank;
+    int firstInTeam = comm->rank;
+    int lastInTeam = comm->rank;
     for (int pe = 0; pe < comm->worldSize; pe++) {
       const auto& cap = comm->ctx->GetPeerCapabilities(pe);
-      const bool sameNode = (pe == comm->rank) || cap.sameHost;
-      if (sameNode) {
-        if (pe < firstSameNode) firstSameNode = pe;
-        if (pe > lastSameNode) lastSameNode = pe;
+      const bool sameHost = (pe == comm->rank) || cap.sameHost;
+      const bool inTeam = vpodMode ? (allVpodIds[pe] == myVpodId) : sameHost;
+      if (inTeam) {
+        if (pe < firstInTeam) firstInTeam = pe;
+        if (pe > lastInTeam) lastInTeam = pe;
         lsaCount++;
+        if (!sameHost) lsaSpansHosts = true;  // team member on another host
       }
     }
 
-    if (lastSameNode - firstSameNode + 1 != lsaCount) {
+    if (lastInTeam - firstInTeam + 1 != lsaCount) {
       MORI_SHMEM_ERROR(
           "ccoCommCreate: non-contiguous lsa membership "
           "(rank {}: first={} last={} count={}). CCO requires "
-          "node-major contiguous rank layout. Reorder ranks in your "
-          "launch (mpirun -host A:N,B:N or equivalent).",
-          comm->rank, firstSameNode, lastSameNode, lsaCount);
+          "LSA-major contiguous rank layout. Reorder ranks in your "
+          "launch (mpirun -host A:N,B:N or equivalent), or align MORI_VPOD_ID "
+          "with contiguous rank blocks.",
+          comm->rank, firstInTeam, lastInTeam, lsaCount);
       delete comm->ctx;
       comm->bootNet->Finalize();
       delete comm;
@@ -276,7 +309,7 @@ static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perR
         MORI_SHMEM_ERROR(
             "ccoCommCreate: heterogeneous lsa sizes detected "
             "(my rank {} sees lsaSize={}, rank {} sees lsaSize={}). "
-            "CCO requires uniform GPUs-per-node across all nodes.",
+            "CCO requires uniform LSA-team size across all ranks.",
             comm->rank, lsaCount, r, allLsaSizes[r]);
         delete comm->ctx;
         comm->bootNet->Finalize();
@@ -287,11 +320,13 @@ static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perR
     }
 
     comm->lsaSize = lsaCount;
-    comm->myNodeStart = firstSameNode;
-    comm->lsaRank = comm->rank - firstSameNode;
+    comm->myNodeStart = firstInTeam;
+    comm->lsaRank = comm->rank - firstInTeam;
 
-    MORI_SHMEM_INFO("ccoCommCreate: lsa topology rank={} lsaSize={} lsaRank={} myNodeStart={}",
-                    comm->rank, comm->lsaSize, comm->lsaRank, comm->myNodeStart);
+    MORI_SHMEM_INFO(
+        "ccoCommCreate: lsa topology rank={} lsaSize={} lsaRank={} lsaStart={} "
+        "vpodMode={} spansHosts={}",
+        comm->rank, comm->lsaSize, comm->lsaRank, comm->myNodeStart, vpodMode, lsaSpansHosts);
   }
 
   // Step 3: reserve flat VA. Always 4GB-aligned so stride4G = perRankSize >> 32
@@ -348,16 +383,27 @@ static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perR
     }
   }
 
-  // Cross-node LSA: fabric handle + multi-node => world-wide flat VA. Opt-in
-  // (MORI_CCO_FABRIC_CROSSNODE_LSA=1) — only safe on a scale-up fabric.
-  if (comm->handleType == static_cast<int>(hipMemHandleTypeFabricCompat) &&
-      comm->worldSize > comm->lsaSize && CcoFabricCrossNodeLsaEnabled()) {
+  // Cross-node LSA: when the LSA team (vPOD) spans hosts, its peers are only
+  // reachable through fabric handles mapped into the flat VA. lsaSize/myNodeStart
+  // already describe the (contiguous) team; here we just require fabric and flag
+  // that peer mapping must go cross-node (fabric import, no hipDeviceEnablePeer-
+  // Access). A scale-up fabric is mandatory — fail loudly if it's missing.
+  if (lsaSpansHosts) {
+    if (comm->handleType != static_cast<int>(hipMemHandleTypeFabricCompat)) {
+      MORI_SHMEM_ERROR(
+          "ccoCommCreate: LSA team spans hosts (cross-node vPOD, lsaSize={}) but fabric "
+          "handle support is unavailable — cannot map peer VAs across nodes. Fix the "
+          "fabric/driver, or scope MORI_VPOD_ID to a single host.",
+          comm->lsaSize);
+      delete comm->ctx;
+      comm->bootNet->Finalize();
+      delete comm;
+      *outComm = nullptr;
+      return -1;
+    }
     comm->fabricCrossNodeLsa = true;
-    comm->lsaSize = comm->worldSize;
-    comm->myNodeStart = 0;
-    comm->lsaRank = comm->rank;
-    MORI_SHMEM_INFO("ccoCommCreate: fabric cross-node LSA enabled (lsaSize=worldSize={})",
-                    comm->worldSize);
+    MORI_SHMEM_INFO("ccoCommCreate: cross-node vPOD LSA enabled (lsaSize={} spans hosts)",
+                    comm->lsaSize);
   }
 
   // Query granularity with the SAME allocProp MemAlloc will use — granularity
@@ -982,15 +1028,14 @@ int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin
       "ccoWindowRegister: rank={} win={} winBase={} size={} slotOffset={} lkey={} fabric={}",
       rank, (void*)devPtr, (void*)winBase, size, slotOffset, lkey, useFabric);
   for (int lsa = 0; lsa < comm->lsaSize; lsa++) {
-    int pe = comm->fabricCrossNodeLsa ? lsa : (comm->myNodeStart + lsa);
+    int pe = comm->myNodeStart + lsa;
     void* peerVa = winBase + static_cast<size_t>(lsa) * comm->perRankSize;
     MORI_SHMEM_INFO("  LSA[{}] (PE {}): flatVA={} rkey={}", lsa, pe, peerVa, peerRkeys_host[pe]);
   }
-  if (!comm->fabricCrossNodeLsa) {
-    for (int pe = 0; pe < worldSize; pe++) {
-      if (pe >= comm->myNodeStart && pe < comm->myNodeStart + comm->lsaSize) continue;
-      MORI_SHMEM_INFO("  XNODE PE {}: rkey={} (RDMA via iova=0)", pe, peerRkeys_host[pe]);
-    }
+  // Peers outside the LSA team (different vPOD / host) are reached via RDMA.
+  for (int pe = 0; pe < worldSize; pe++) {
+    if (pe >= comm->myNodeStart && pe < comm->myNodeStart + comm->lsaSize) continue;
+    MORI_SHMEM_INFO("  XNODE PE {}: rkey={} (RDMA via iova=0)", pe, peerRkeys_host[pe]);
   }
   // peerRkeys_host is std::vector — destructs cleanly at scope exit.
 

--- a/src/cco/cco_init.cpp
+++ b/src/cco/cco_init.cpp
@@ -179,6 +179,16 @@ int ccoCommCreate(const ccoUniqueId& uniqueId, int nRanks, int rank, size_t perR
   return ccoCommCreateImpl(boot, perRankVmmSize, outComm);
 }
 
+static bool CcoCanLsaMapPeer(const ccoComm* comm, int pe) {
+  if (pe == comm->rank) return false;
+  if (comm->fabricCrossNodeLsa) return true;
+  return comm->ctx->CanUseP2P(pe);
+}
+
+static int CcoPeToLsaRank(const ccoComm* comm, int pe) {
+  return comm->fabricCrossNodeLsa ? pe : (pe - comm->myNodeStart);
+}
+
 static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perRankVmmSize,
                              ccoComm** outComm) {
   auto* comm = new ccoComm();
@@ -279,6 +289,8 @@ static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perR
   // Register) reuse this without re-querying hipGetDevice. Callers MUST keep
   // the calling thread bound to this device for any later CCO API on this comm.
   HIP_RUNTIME_CHECK(hipGetDevice(&comm->hipDev));
+  comm->peerHipDevs.assign(comm->worldSize, comm->hipDev);
+  comm->bootNet->Allgather(&comm->hipDev, comm->peerHipDevs.data(), sizeof(int));
 
   // Probe fabric handle support: try to allocate + export with the fabric
   // handle type. If it works, all subsequent allocations use fabric handles
@@ -290,6 +302,9 @@ static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perR
     probeProp.requestedHandleType = hipMemHandleTypeFabricCompat;
     probeProp.location.type = hipMemLocationTypeDevice;
     probeProp.location.id = comm->hipDev;
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+    probeProp.allocFlags.gpuDirectRDMACapable = 1;
+#endif
 
     size_t probeGranularity = 0;
     hipError_t probeErr =
@@ -314,6 +329,17 @@ static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perR
     }
   }
 
+  // Hardcoded cross-node LSA: fabric handle + multi-node => world-wide flat VA.
+  if (comm->handleType == static_cast<int>(hipMemHandleTypeFabricCompat) &&
+      comm->worldSize > comm->lsaSize) {
+    comm->fabricCrossNodeLsa = true;
+    comm->lsaSize = comm->worldSize;
+    comm->myNodeStart = 0;
+    comm->lsaRank = comm->rank;
+    MORI_SHMEM_INFO("ccoCommCreate: fabric cross-node LSA enabled (lsaSize=worldSize={})",
+                    comm->worldSize);
+  }
+
   // Query granularity with the SAME allocProp MemAlloc will use — granularity
   // can shift when requestedHandleType (FD export vs fabric) is enabled.
   hipMemAllocationProp allocProp = {};
@@ -323,8 +349,7 @@ static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perR
   allocProp.location.id = comm->hipDev;
 
   size_t granularity = 0;
-  // Flat VA covers the LSA team only. Cross-node peers don't use VA — RDMA
-  // goes through iova=0 + offset.
+  // Flat VA covers the LSA team (world-wide when fabricCrossNodeLsa).
   size_t totalVaSize = static_cast<size_t>(comm->lsaSize) * perRankVmmSize;
   {
     vmmProcessLock vmmLock;
@@ -496,6 +521,9 @@ int ccoMemAlloc(ccoComm* comm, size_t size, void** outPtr) {
   allocProp.requestedHandleType = static_cast<hipMemAllocationHandleType>(comm->handleType);
   allocProp.location.type = hipMemLocationTypeDevice;
   allocProp.location.id = comm->hipDev;
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  allocProp.allocFlags.gpuDirectRDMACapable = 1;
+#endif
 
   hipMemGenericAllocationHandle_t physHandle = 0;
   hipError_t err = hipSuccess;
@@ -660,7 +688,7 @@ int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin
   // the LSA flat VA.
   std::vector<int> p2pPeers;
   for (int pe = 0; pe < worldSize; pe++) {
-    if (comm->ctx->CanUseP2P(pe)) {
+    if (CcoCanLsaMapPeer(comm, pe)) {
       p2pPeers.push_back(pe);
     }
   }
@@ -691,9 +719,23 @@ int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin
     // Import + map a single peer's handle into our flat VA. Returns 0 on
     // success, -1 on failure (rolls back all prior mappings).
     auto mapPeer = [&](int pe, hipMemGenericAllocationHandle_t importedHandle) -> int {
-      int peerLsaRank = pe - comm->myNodeStart;
+      int peerLsaRank = CcoPeToLsaRank(comm, pe);
       void* peerVa = static_cast<char*>(comm->flatBase) +
                      static_cast<size_t>(peerLsaRank) * comm->perRankSize + slotOffset;
+      const bool crossNodePeer =
+          comm->fabricCrossNodeLsa && !comm->ctx->GetPeerCapabilities(pe).sameHost;
+      // hipDeviceEnablePeerAccess is intra-node only; cross-node fabric P2P
+      // does not use this API (peerDev indices are local and collide across nodes).
+      if (!crossNodePeer && pe < static_cast<int>(comm->peerHipDevs.size())) {
+        int peerDev = comm->peerHipDevs[pe];
+        if (peerDev != comm->hipDev) {
+          hipError_t peerErr = hipDeviceEnablePeerAccess(peerDev, 0);
+          if (peerErr != hipSuccess && peerErr != hipErrorPeerAccessAlreadyEnabled) {
+            MORI_SHMEM_WARN("ccoWindowRegister: hipDeviceEnablePeerAccess PE {} dev {} failed: {}",
+                            pe, peerDev, static_cast<int>(peerErr));
+          }
+        }
+      }
       {
         vmmProcessLock vmmLock;
         hipError_t mapErr = hipMemMap(peerVa, alignedSize, 0, importedHandle, 0);
@@ -715,15 +757,22 @@ int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin
         usleep(1000 * (1 << retry));
       }
       if (setErr != hipSuccess) {
-        MORI_SHMEM_ERROR("ccoWindowRegister: hipMemSetAccess PE {} failed after retries: {}", pe,
-                         static_cast<int>(setErr));
-        {
-          vmmProcessLock vmmLock;
-          (void)hipMemUnmap(peerVa, alignedSize);
-          (void)hipMemRelease(importedHandle);
+        if (crossNodePeer) {
+          MORI_SHMEM_WARN(
+              "ccoWindowRegister: hipMemSetAccess PE {} cross-node failed: {} "
+              "(continuing — fabric import may already grant access)",
+              pe, static_cast<int>(setErr));
+        } else {
+          MORI_SHMEM_ERROR("ccoWindowRegister: hipMemSetAccess PE {} failed after retries: {}", pe,
+                           static_cast<int>(setErr));
+          {
+            vmmProcessLock vmmLock;
+            (void)hipMemUnmap(peerVa, alignedSize);
+            (void)hipMemRelease(importedHandle);
+          }
+          rollbackMappedPeers();
+          return -1;
         }
-        rollbackMappedPeers();
-        return -1;
       }
       mappedPeers.push_back({importedHandle, peerVa});
       return 0;
@@ -906,13 +955,15 @@ int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin
       "ccoWindowRegister: rank={} win={} winBase={} size={} slotOffset={} lkey={} fabric={}",
       rank, (void*)devPtr, (void*)winBase, size, slotOffset, lkey, useFabric);
   for (int lsa = 0; lsa < comm->lsaSize; lsa++) {
-    int pe = comm->myNodeStart + lsa;
+    int pe = comm->fabricCrossNodeLsa ? lsa : (comm->myNodeStart + lsa);
     void* peerVa = winBase + static_cast<size_t>(lsa) * comm->perRankSize;
     MORI_SHMEM_INFO("  LSA[{}] (PE {}): flatVA={} rkey={}", lsa, pe, peerVa, peerRkeys_host[pe]);
   }
-  for (int pe = 0; pe < worldSize; pe++) {
-    if (pe >= comm->myNodeStart && pe < comm->myNodeStart + comm->lsaSize) continue;
-    MORI_SHMEM_INFO("  XNODE PE {}: rkey={} (RDMA via iova=0)", pe, peerRkeys_host[pe]);
+  if (!comm->fabricCrossNodeLsa) {
+    for (int pe = 0; pe < worldSize; pe++) {
+      if (pe >= comm->myNodeStart && pe < comm->myNodeStart + comm->lsaSize) continue;
+      MORI_SHMEM_INFO("  XNODE PE {}: rkey={} (RDMA via iova=0)", pe, peerRkeys_host[pe]);
+    }
   }
   // peerRkeys_host is std::vector — destructs cleanly at scope exit.
 
@@ -967,8 +1018,8 @@ int ccoWindowDeregister(ccoComm* comm, ccoWindow_t win) {
     vmmProcessLock vmmLock;
     for (int lsa = 0; lsa < comm->lsaSize; lsa++) {
       if (lsa == comm->lsaRank) continue;
-      int pe = comm->myNodeStart + lsa;
-      if (!comm->ctx->CanUseP2P(pe)) continue;
+      int pe = comm->fabricCrossNodeLsa ? lsa : (comm->myNodeStart + lsa);
+      if (!CcoCanLsaMapPeer(comm, pe)) continue;
       void* peerVa = static_cast<char*>(comm->flatBase) +
                      static_cast<size_t>(lsa) * comm->perRankSize + slotOff;
       (void)hipMemUnmap(peerVa, allocSize);

--- a/src/cco/cco_init.cpp
+++ b/src/cco/cco_init.cpp
@@ -322,6 +322,23 @@ static bool CcoFabricLenient() {
   return e && atoi(e) != 0;
 }
 
+// Zero a symmetric-window buffer WITHOUT hipMemset. On UALink fabric-exportable
+// pools hipMemset returns hipErrorOutOfMemory (observed on ROCm 7.15), so we
+// initialize via chunked host->device copies from a small zeroed staging buffer
+// (host-only HIP runtime API — mori_cco links hip::host, not device code).
+static hipError_t CcoZeroWindowMem(void* ptr, size_t bytes) {
+  if (bytes == 0) return hipSuccess;
+  const size_t chunk = std::min<size_t>(bytes, 4u << 20);  // 4 MB staging
+  std::vector<char> zeros(chunk, 0);
+  char* dst = static_cast<char*>(ptr);
+  for (size_t off = 0; off < bytes; off += chunk) {
+    size_t n = std::min(chunk, bytes - off);
+    hipError_t e = hipMemcpy(dst + off, zeros.data(), n, hipMemcpyHostToDevice);
+    if (e != hipSuccess) return e;
+  }
+  return hipSuccess;
+}
+
 static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perRankVmmSize,
                              ccoComm** outComm) {
   auto* comm = new ccoComm();
@@ -1470,7 +1487,9 @@ int ccoDevCommCreate(ccoComm* comm, const ccoDevCommRequirements* reqs, ccoDevCo
       if (epsGpu) HIP_RUNTIME_CHECK(hipFree(epsGpu));
       return -1;
     }
-    HIP_RUNTIME_CHECK(hipMemset(resourceWindowPtr, 0, layout.totalSize));
+    // resourceWindowPtr is fabric-exportable (ccoMemAlloc) — avoid hipMemset,
+    // which returns OOM on UALink fabric pools (ROCm 7.15).
+    HIP_RUNTIME_CHECK(CcoZeroWindowMem(resourceWindowPtr, layout.totalSize));
     if (ccoWindowRegister(comm, resourceWindowPtr, layout.totalSize, &resourceWindow) != 0) {
       MORI_SHMEM_ERROR("ccoDevCommCreate: resource window Register failed");
       (void)ccoMemFree(comm, resourceWindowPtr);

--- a/src/cco/cco_init.cpp
+++ b/src/cco/cco_init.cpp
@@ -947,6 +947,12 @@ int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin
         int peerDev = comm->peerHipDevs[pe];
         if (peerDev != comm->hipDev) {
           hipError_t peerErr = hipDeviceEnablePeerAccess(peerDev, 0);
+          // Consume the sticky last-error: hipDeviceEnablePeerAccess leaves the
+          // runtime's last-error set (e.g. AlreadyEnabled / NotSupported), which
+          // a later torch op would pick up via hipGetLastError() and raise as
+          // "operation not supported" (observed on gfx950). Mirrors the sibling
+          // ccoDevCommCreate call site.
+          (void)hipGetLastError();
           if (peerErr != hipSuccess && peerErr != hipErrorPeerAccessAlreadyEnabled) {
             MORI_SHMEM_WARN("ccoWindowRegister: hipDeviceEnablePeerAccess PE {} dev {} failed: {}",
                             pe, peerDev, static_cast<int>(peerErr));

--- a/src/cco/cco_init.cpp
+++ b/src/cco/cco_init.cpp
@@ -22,6 +22,8 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <cctype>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <memory>
@@ -191,17 +193,124 @@ static bool CcoCanLsaMapPeer(const ccoComm* comm, int pe) {
 
 static int CcoPeToLsaRank(const ccoComm* comm, int pe) { return pe - comm->myNodeStart; }
 
-// A vPOD is a scale-up fabric domain that may span multiple physical hosts: ranks
-// sharing it can LSA-interconnect (flat VA over the fabric) directly, not just
-// intra-node. Each rank declares its vPOD via MORI_VPOD_ID; ranks with the same
-// value form one LSA team. MORI_CCO_FABRIC_CROSSNODE_LSA=1 is shorthand for
-// "the whole world is one vPOD". Unset on all ranks => group by host (default).
-static int CcoLocalVpodId() {
-  const char* e = getenv("MORI_VPOD_ID");
-  if (e && *e) return atoi(e);
+// ── LSA-team (vPOD) topology detection ───────────────────────────────────────
+// A vPOD is a scale-up fabric domain (AMD UALink) that may span multiple hosts;
+// its GPUs are directly flat-VA (P2P) interconnectable. We mirror RCCL's MNNVL
+// clique model: group ranks by (ppod_id UUID, vpod_id) read from the per-GPU
+// UALink sysfs, gated on the accelerator being ACTIVE/READY. ppod_id (a UUID) is
+// what makes the key globally unique — hive_id collides across hosts.
+//   Precedence: MORI_CCO_FABRIC_DISABLE=1 -> force host-only LSA
+//               MORI_VPOD_ID=<n>          -> explicit override (all-or-none)
+//               MORI_CCO_FABRIC_CROSSNODE_LSA=1 -> whole world is one team
+//               auto                      -> UALink (ppod_id, vpod_id)
+//               else                      -> group by host (default)
+enum CcoLsaMode { CCO_LSA_HOST = 0, CCO_LSA_MANUAL = 1, CCO_LSA_FABRIC = 2 };
+
+struct CcoLsaKey {
+  int mode;                  // CcoLsaMode
+  int vpodId;                // manual value or UALink vpod_id
+  int vpodSize;              // UALink vpod_size (0 if n/a)
+  unsigned char ppodId[16];  // UALink ppod_id UUID (zeros if n/a)
+};
+
+static bool CcoReadSysfsLine(const std::string& path, std::string& out) {
+  FILE* f = fopen(path.c_str(), "r");
+  if (!f) return false;
+  char buf[128] = {0};
+  bool ok = fgets(buf, sizeof(buf), f) != nullptr;
+  fclose(f);
+  if (!ok) return false;
+  out = buf;
+  while (!out.empty() && (out.back() == '\n' || out.back() == '\r' || out.back() == ' '))
+    out.pop_back();
+  return true;
+}
+
+// Parse "9217fed9-c6cf-4c9e-9d9c-7110b90917cc" into 16 bytes; false (zeros) if
+// it isn't a well-formed, non-zero UUID.
+static bool CcoParseUuid(const std::string& s, unsigned char out[16]) {
+  memset(out, 0, 16);
+  int b = 0;
+  unsigned hi = 0;
+  bool haveHi = false, any = false;
+  for (char c : s) {
+    if (c == '-') continue;
+    int v;
+    if (c >= '0' && c <= '9')
+      v = c - '0';
+    else if (c >= 'a' && c <= 'f')
+      v = c - 'a' + 10;
+    else if (c >= 'A' && c <= 'F')
+      v = c - 'A' + 10;
+    else
+      return false;
+    if (!haveHi) {
+      hi = v;
+      haveHi = true;
+    } else {
+      if (b >= 16) return false;
+      out[b] = static_cast<unsigned char>((hi << 4) | v);
+      if (out[b]) any = true;
+      b++;
+      haveHi = false;
+    }
+  }
+  return b == 16 && !haveHi && any;
+}
+
+// Read the local GPU's UALink fabric identity from sysfs, mirroring RCCL's
+// alt_rsmi ARSMI_get_fabric_info. True only if the fabric is present and the
+// accelerator is ACTIVE/READY (i.e. usable for cross-node LSA).
+static bool CcoReadFabricKey(int hipDev, CcoLsaKey* key) {
+  char bdf[32] = {0};
+  if (hipDeviceGetPCIBusId(bdf, sizeof(bdf), hipDev) != hipSuccess) return false;
+  for (char* p = bdf; *p; ++p) *p = static_cast<char>(tolower(*p));
+  std::string dir = std::string("/sys/bus/pci/devices/") + bdf + "/ualink";
+
+  std::string link, state, ppod;
+  if (!CcoReadSysfsLine(dir + "/link_type", link)) return false;  // not a UALink GPU
+  if (link != "UALoE" && link != "UALLink") return false;
+  if (!CcoReadSysfsLine(dir + "/accel_state", state)) return false;
+  if (state != "active" && state != "ready") return false;  // not usable yet
+  if (!CcoReadSysfsLine(dir + "/ppod_id", ppod)) return false;
+  if (!CcoParseUuid(ppod, key->ppodId)) return false;  // zero/garbage UUID
+
+  std::string v;
+  key->vpodId = CcoReadSysfsLine(dir + "/vpod_id", v) ? atoi(v.c_str()) : 0;
+  key->vpodSize = CcoReadSysfsLine(dir + "/vpod_size", v) ? atoi(v.c_str()) : 0;
+  key->mode = CCO_LSA_FABRIC;
+  return true;
+}
+
+// Compute this rank's LSA-team key by the precedence above.
+static void CcoComputeLsaKey(int hipDev, CcoLsaKey* key) {
+  memset(key, 0, sizeof(*key));
+  key->mode = CCO_LSA_HOST;
+  const char* dis = getenv("MORI_CCO_FABRIC_DISABLE");
+  if (dis && atoi(dis) != 0) return;  // forced host-only
+  const char* mv = getenv("MORI_VPOD_ID");
+  if (mv && *mv) {
+    key->mode = CCO_LSA_MANUAL;
+    key->vpodId = atoi(mv);
+    return;
+  }
   const char* w = getenv("MORI_CCO_FABRIC_CROSSNODE_LSA");
-  if (w && atoi(w) != 0) return 0;  // whole world = one vPOD
-  return -1;                        // group by host
+  if (w && atoi(w) != 0) {  // whole world = one team
+    key->mode = CCO_LSA_MANUAL;
+    key->vpodId = 0;
+    return;
+  }
+  CcoReadFabricKey(hipDev, key);  // sets FABRIC on success, leaves HOST otherwise
+}
+
+// Two ranks share an LSA team iff their keys match. HOST mode is resolved by the
+// sameHost predicate instead (this returns false for it).
+static bool CcoLsaKeySame(const CcoLsaKey& a, const CcoLsaKey& b) {
+  if (a.mode != b.mode) return false;
+  if (a.mode == CCO_LSA_MANUAL) return a.vpodId == b.vpodId;
+  if (a.mode == CCO_LSA_FABRIC)
+    return a.vpodId == b.vpodId && memcmp(a.ppodId, b.ppodId, sizeof(a.ppodId)) == 0;
+  return false;
 }
 
 // By default a cross-node hipMemSetAccess failure is fatal at register time
@@ -237,39 +346,61 @@ static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perR
   comm->ctx = new application::Context(*comm->bootNet);
   comm->defaultNumQpPerPe = comm->ctx->GetNumQpPerPe();
 
+  // Cache the bound device once (used by topology detection below and later by
+  // ccoMemAlloc / ccoWindowRegister). Callers MUST keep the calling thread bound
+  // to this device for any later CCO API on this comm.
+  HIP_RUNTIME_CHECK(hipGetDevice(&comm->hipDev));
+  comm->peerHipDevs.assign(comm->worldSize, comm->hipDev);
+  comm->bootNet->Allgather(&comm->hipDev, comm->peerHipDevs.data(), sizeof(int));
+
   // Step 2.5: detect LSA (Local Symmetric Access) team topology.
   // Membership is a HARDWARE fact — peers whose memory this rank can load/store
   // through a flat VA — captured before transport policy: same host by default,
-  // or the same vPOD (a scale-up fabric domain that may span hosts) when vPOD
-  // grouping is enabled (see CcoLocalVpodId).
+  // or the same vPOD (a scale-up UALink fabric domain that may span hosts) when
+  // fabric/manual grouping applies (see CcoComputeLsaKey).
   //
   // HARD CONTRACT — violations are fatal:
   //   (a) LSA-major contiguous ranks (team peers form a single block)
   //   (b) every rank observes the same lsaSize
   // Both are required by the flat-VA formula `lsaFlatBase + lsaRank * stride`.
 
-  // Resolve vPOD grouping (all-or-none across the job). vpodMode widens the LSA
-  // team from same-host to same-vPOD; lsaSpansHosts records whether the team
-  // actually crosses a host boundary (=> cross-node fabric mapping is required).
-  int myVpodId = CcoLocalVpodId();
-  std::vector<int> allVpodIds(comm->worldSize);
-  comm->bootNet->Allgather(&myVpodId, allVpodIds.data(), sizeof(int));
-  bool anyVpod = false, allVpod = true;
-  for (int v : allVpodIds) {
-    anyVpod |= (v >= 0);
-    allVpod &= (v >= 0);
+  // Each rank computes its LSA-team key (host / manual vPOD / UALink fabric),
+  // then we allgather + decide the job-wide grouping. Manual (MORI_VPOD_ID) is
+  // all-or-none; UALink fabric grouping only kicks in when EVERY rank reports a
+  // ready fabric (else fall back to host LSA + RDMA, like RCCL disabling MNNVL).
+  CcoLsaKey myKey;
+  CcoComputeLsaKey(comm->hipDev, &myKey);
+  std::vector<CcoLsaKey> allKeys(comm->worldSize);
+  comm->bootNet->Allgather(&myKey, allKeys.data(), sizeof(CcoLsaKey));
+
+  int manualCnt = 0, fabricCnt = 0;
+  for (const auto& k : allKeys) {
+    if (k.mode == CCO_LSA_MANUAL) manualCnt++;
+    else if (k.mode == CCO_LSA_FABRIC) fabricCnt++;
   }
-  if (anyVpod && !allVpod) {
-    MORI_SHMEM_ERROR(
-        "ccoCommCreate: MORI_VPOD_ID set on some ranks but not all — vPOD grouping "
-        "must be all-or-none across the job.");
-    delete comm->ctx;
-    comm->bootNet->Finalize();
-    delete comm;
-    *outComm = nullptr;
-    return -1;
+  bool vpodMode;
+  if (manualCnt > 0) {
+    if (manualCnt != comm->worldSize) {
+      MORI_SHMEM_ERROR(
+          "ccoCommCreate: MORI_VPOD_ID set on {}/{} ranks — manual vPOD grouping must "
+          "be all-or-none across the job.",
+          manualCnt, comm->worldSize);
+      delete comm->ctx;
+      comm->bootNet->Finalize();
+      delete comm;
+      *outComm = nullptr;
+      return -1;
+    }
+    vpodMode = true;
+  } else if (fabricCnt == comm->worldSize) {
+    vpodMode = true;  // every rank on a ready UALink fabric
+  } else {
+    vpodMode = false;  // host LSA + RDMA (default / no fabric / mixed readiness)
+    if (fabricCnt > 0)
+      MORI_SHMEM_INFO(
+          "ccoCommCreate: UALink fabric ready on only {}/{} ranks — using host LSA + RDMA",
+          fabricCnt, comm->worldSize);
   }
-  const bool vpodMode = allVpod;
   bool lsaSpansHosts = false;
   {
     int lsaCount = 0;
@@ -278,7 +409,7 @@ static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perR
     for (int pe = 0; pe < comm->worldSize; pe++) {
       const auto& cap = comm->ctx->GetPeerCapabilities(pe);
       const bool sameHost = (pe == comm->rank) || cap.sameHost;
-      const bool inTeam = vpodMode ? (allVpodIds[pe] == myVpodId) : sameHost;
+      const bool inTeam = vpodMode ? CcoLsaKeySame(allKeys[pe], myKey) : sameHost;
       if (inTeam) {
         if (pe < firstInTeam) firstInTeam = pe;
         if (pe > lastInTeam) lastInTeam = pe;
@@ -323,10 +454,21 @@ static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perR
     comm->myNodeStart = firstInTeam;
     comm->lsaRank = comm->rank - firstInTeam;
 
+    // Sanity: on a UALink fabric the team should match the reported vpod_size
+    // (a mismatch just means a subset of the vPOD was launched — informational).
+    if (myKey.mode == CCO_LSA_FABRIC && myKey.vpodSize > 0 && lsaCount != myKey.vpodSize) {
+      MORI_SHMEM_INFO(
+          "ccoCommCreate: LSA team size {} != UALink vpod_size {} (subset of the vPOD "
+          "launched?)",
+          lsaCount, myKey.vpodSize);
+    }
+
     MORI_SHMEM_INFO(
         "ccoCommCreate: lsa topology rank={} lsaSize={} lsaRank={} lsaStart={} "
-        "vpodMode={} spansHosts={}",
-        comm->rank, comm->lsaSize, comm->lsaRank, comm->myNodeStart, vpodMode, lsaSpansHosts);
+        "mode={} spansHosts={}",
+        comm->rank, comm->lsaSize, comm->lsaRank, comm->myNodeStart,
+        (myKey.mode == CCO_LSA_FABRIC ? "fabric" : (vpodMode ? "manual" : "host")),
+        lsaSpansHosts);
   }
 
   // Step 3: reserve flat VA. Always 4GB-aligned so stride4G = perRankSize >> 32
@@ -338,13 +480,6 @@ static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perR
   }
   perRankVmmSize = AlignUp(perRankVmmSize, 1ULL << 32);
   comm->perRankSize = perRankVmmSize;
-
-  // Cache the device once — subsequent API calls (ccoMemAlloc, ccoWindow-
-  // Register) reuse this without re-querying hipGetDevice. Callers MUST keep
-  // the calling thread bound to this device for any later CCO API on this comm.
-  HIP_RUNTIME_CHECK(hipGetDevice(&comm->hipDev));
-  comm->peerHipDevs.assign(comm->worldSize, comm->hipDev);
-  comm->bootNet->Allgather(&comm->hipDev, comm->peerHipDevs.data(), sizeof(int));
 
   // Probe fabric handle support: try to allocate + export with the fabric
   // handle type. If it works, all subsequent allocations use fabric handles

--- a/tests/python/ops/dispatch_combine_v2/bench_dispatch_combine.py
+++ b/tests/python/ops/dispatch_combine_v2/bench_dispatch_combine.py
@@ -325,9 +325,13 @@ def main():
             run_disp(ct)
             sync()
             comm.barrier()
-            if _ASYM:  # expert op converts dispatch dtype -> combine dtype
-                mock_fmoe()
-                sync()
+            # Identity expert: stage the dispatched tokens (disp_out) into out_tok,
+            # the combine input. Since the disp_out/out_tok arena split, dispatch no
+            # longer writes out_tok directly, so this copy is required for ALL dtypes
+            # (mock_fmoe also does the asym dispatch->combine dtype conversion). A
+            # real expert op would write its output into out_tok here instead.
+            mock_fmoe()
+            sync()
             comb_out.zero_()
             sync()
             run_comb(ct)

--- a/tests/python/ops/dispatch_combine_v2/bench_dispatch_combine.py
+++ b/tests/python/ops/dispatch_combine_v2/bench_dispatch_combine.py
@@ -109,10 +109,14 @@ QUANT = os.environ.get("QUANT", "none")  # none | fp8_direct_cast (scatter only)
 SCALE_DIM = int(os.environ.get("SCALE_DIM", 0))  # >0 = forward per-token scales
 SWEEP = [int(x) for x in os.environ.get("SWEEP", "128,512,2048").split(",")]
 
-# fp8 flavor is arch-specific: OCP e4m3 on gfx950, fnuz on gfx942.
+# fp8 flavor is arch-specific: OCP e4m3 on gfx950/gfx1250, fnuz on gfx942.
 import tuning_configs as _tc  # noqa: E402
 
-_FP8_DT = torch.float8_e4m3fn if _tc._topology()[1] == 90500 else torch.float8_e4m3fnuz
+_FP8_DT = (
+    torch.float8_e4m3fn
+    if _tc._topology()[1] in (90500, 120500)
+    else torch.float8_e4m3fnuz
+)
 # (torch token dtype, elem bytes). fp4 packs 2 e2m1/byte -> 0.5 B/elem;
 # per-token bytes handled via TOK_NB below.
 _DT = {

--- a/tests/python/ops/dispatch_combine_v2/bench_dispatch_combine.py
+++ b/tests/python/ops/dispatch_combine_v2/bench_dispatch_combine.py
@@ -129,6 +129,17 @@ TOK_DT, ESZ = _DT[DTYPE]
 _FP4 = DTYPE == "fp4"
 TOK_NB = HIDDEN // 2 if _FP4 else HIDDEN * ESZ  # per-token transport bytes
 
+# Asymmetric I/O: dispatch fp8 + combine bf16 (an expert op converts between the
+# two). DISPATCH_DT/COMBINE_DT override DTYPE per-op; unset => symmetric (DTYPE).
+DISPATCH_DT = os.environ.get("DISPATCH_DT")
+COMBINE_DT = os.environ.get("COMBINE_DT")
+_ASYM = (DISPATCH_DT is not None) or (COMBINE_DT is not None)
+_disp_s, _comb_s = DISPATCH_DT or DTYPE, COMBINE_DT or DTYPE
+DISP_DT, DISP_ESZ = _DT[_disp_s]
+COMB_DT, COMB_ESZ = _DT[_comb_s]
+DISP_NB = HIDDEN // 2 if _disp_s == "fp4" else HIDDEN * DISP_ESZ  # dispatch bytes/tok
+COMB_NB = HIDDEN // 2 if _comb_s == "fp4" else HIDDEN * COMB_ESZ  # combine bytes/tok
+
 
 def main():
     d = Dist()
@@ -154,7 +165,7 @@ def main():
     else:
         inp = (
             torch.randn(max_tok, HIDDEN, generator=g, dtype=torch.float32)
-            .to(TOK_DT)
+            .to(DISP_DT)
             .to(dev)
         )
     idx = torch.randint(
@@ -180,7 +191,8 @@ def main():
     uid = Communicator.get_unique_id() if rank == 0 else None
     uid = d.bcast_uid(uid)
 
-    win_bytes = max_recv * TOK_NB + npes * M * TOK_NB + (1 << 24)
+    _max_nb = max(DISP_NB, COMB_NB)  # out_tok sized to the larger (bf16) side
+    win_bytes = max_recv * _max_nb + npes * M * _max_nb + (1 << 24)
     with Communicator.init(
         npes, rank, uid, per_rank_vmm=2 * win_bytes + (1 << 28)
     ) as comm:
@@ -201,6 +213,9 @@ def main():
             num_experts_per_rank=EPR,
             num_experts_per_token=K,
             data_type=TOK_DT,
+            # asymmetric dispatch/combine dtype (all-or-none); None => symmetric
+            dispatch_data_type=(DISP_DT if _ASYM else None),
+            combine_data_type=(COMB_DT if _ASYM else None),
             combine_mode=COMBINE,
             quant_type=QUANT,
             dispatch_block_num=DISP_BLOCK,
@@ -255,6 +270,12 @@ def main():
                 fx.Stream(torch.cuda.current_stream()),
             )
 
+        def mock_fmoe():
+            # expert-op stand-in: dequant dispatched tokens to the combine dtype in
+            # out_tok. Via a scratch — in-place would alias (differing strides).
+            scratch = op.recv_tokens().to(COMB_DT)
+            op.combine_in_view().view(-1).copy_(scratch.view(-1))
+
         def time_eager(fn, ct):
             for _ in range(WARMUP):
                 fn(ct)
@@ -304,6 +325,9 @@ def main():
             run_disp(ct)
             sync()
             comm.barrier()
+            if _ASYM:  # expert op converts dispatch dtype -> combine dtype
+                mock_fmoe()
+                sync()
             comb_out.zero_()
             sync()
             run_comb(ct)
@@ -321,13 +345,13 @@ def main():
                 [len({int(idx_c[t, j]) // EPR for j in range(K)}) for t in range(ct)]
             )
             exp = (torch.from_numpy(U).view(ct, 1).float() * inp[:ct].float().cpu()).to(
-                TOK_DT
+                COMB_DT
             )
-            # fp8 (quant wire or plain fp8 token) is lossy (e4m3 ~6-12% rel).
-            lossy = _fp8 or _bw or DTYPE == "fp8"
+            # fp8 (quant wire, plain fp8 token, or asymmetric fp8 side) is lossy.
+            lossy = _fp8 or _bw or "fp8" in (DTYPE, _disp_s, _comb_s)
             _atol, _rtol = (1.0, 1.5e-1) if lossy else (2e-2, 2e-2)
             got_dt = (
-                torch.bfloat16 if (_fp8 or _bw) else TOK_DT
+                torch.bfloat16 if (_fp8 or _bw) else COMB_DT
             )  # quant paths output bf16
             got = comb_out[: ct * HIDDEN].cpu().view(got_dt).view(ct, HIDDEN)
             ok = torch.allclose(got.float(), exp.float(), atol=_atol, rtol=_rtol)
@@ -465,8 +489,11 @@ def main():
             sync()
             comm.barrier()
             recv = int(total_recv.cpu().item())
-            payload = recv * TOK_NB  # true per-token transport bytes (fp4 = hidden/2)
+            disp_payload, comb_payload = recv * DISP_NB, recv * COMB_NB
 
+            if _ASYM:  # expert op converts dispatch dtype -> combine dtype
+                mock_fmoe()
+                sync()
             # combine first (needs total_recv == recv; combine doesn't reset it)
             cb_e = time_eager(run_comb, ct) if eager else 0.0
             cb_g = time_graph(run_comb, ct) if graph else 0.0
@@ -475,18 +502,22 @@ def main():
             dp_g = time_graph(run_disp, ct) if graph else 0.0
 
             if rank == 0:
-                parts = [
-                    f"tok/rank {ct:5d}  recv {recv:6d}  payload {payload/1e6:7.2f}MB"
-                ]
+                # payload shown = disp/comb bytes (same unless asymmetric dtype)
+                pl = (
+                    f"payload {disp_payload/1e6:.2f}/{comb_payload/1e6:.2f}MB"
+                    if _ASYM
+                    else f"payload {comb_payload/1e6:7.2f}MB"
+                )
+                parts = [f"tok/rank {ct:5d}  recv {recv:6d}  {pl}"]
                 if eager:
                     parts.append(
-                        f"| EAGER disp {dp_e:8.2f}us/{bw(payload,dp_e):6.1f}GB/s "
-                        f"comb {cb_e:8.2f}us/{bw(payload,cb_e):6.1f}GB/s"
+                        f"| EAGER disp {dp_e:8.2f}us/{bw(disp_payload,dp_e):6.1f}GB/s "
+                        f"comb {cb_e:8.2f}us/{bw(comb_payload,cb_e):6.1f}GB/s"
                     )
                 if graph:
                     parts.append(
-                        f"| GRAPH disp {dp_g:8.2f}us/{bw(payload,dp_g):6.1f}GB/s "
-                        f"comb {cb_g:8.2f}us/{bw(payload,cb_g):6.1f}GB/s"
+                        f"| GRAPH disp {dp_g:8.2f}us/{bw(disp_payload,dp_g):6.1f}GB/s "
+                        f"comb {cb_g:8.2f}us/{bw(comb_payload,cb_g):6.1f}GB/s"
                     )
                 print("  ".join(parts), flush=True)
     d.shutdown()

--- a/tests/python/ops/dispatch_combine_v2/test_asym_dtype.py
+++ b/tests/python/ops/dispatch_combine_v2/test_asym_dtype.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Asymmetric dtype test: fp8 dispatch + bf16 combine.
+
+Models the fmoe use case where an expert op sits between dispatch and combine and
+converts dtype: dispatch moves fp8 tokens, the (mock) expert dequants fp8->bf16
+(identity), combine reduces bf16. Verifies dispatch and combine independently:
+
+  * ASYM-DISPATCH(fp8): local-expert-count routing sum + recv tokens are the
+    byte-exact source fp8 tokens (checked via the routing reverse map; every
+    rank's input is regenerated from its per-rank seed, no collective needed).
+  * ASYM-COMBINE(bf16): identity-expert telescoping — out == U * dequant(inp) * wt
+    (U = distinct dest PEs per token), weights == U * wt.
+
+    torchrun --nnodes=1 --nproc_per_node=4 --tee 3 ... test_asym_dtype.py
+"""
+import os
+import sys
+
+import numpy as np
+import torch
+import torch.distributed as dist
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.abspath(os.path.join(_HERE, "..", "..", "..", ".."))
+sys.path.insert(0, os.path.join(_ROOT, "python", "mori", "ops", "dispatch_combine_v2"))
+sys.path.insert(0, os.path.join(_ROOT, "examples", "cco", "python"))
+from cco_example_common import set_device, sync  # noqa: E402
+from dispatch_combine_op import EpDispatchCombineConfig, EpDispatchCombineOp  # noqa: E402
+from mori.cco import Communicator  # noqa: E402
+
+FP8 = torch.float8_e4m3fn  # gfx1250/gfx950 OCP e4m3
+HIDDEN = int(os.environ.get("HIDDEN", 512))  # 16 B aligned for both fp8 and bf16
+K = int(os.environ.get("TOPK", 6))
+EPR = int(os.environ.get("EPR", 8))
+SWEEP = [int(x) for x in os.environ.get("SWEEP", "8,64,512").split(",")]
+
+
+class Dist:
+    def __init__(self):
+        self.rank = int(os.environ["RANK"])
+        self.world = int(os.environ["WORLD_SIZE"])
+        self.local_rank = int(os.environ["LOCAL_RANK"])
+        if not dist.is_initialized():
+            dist.init_process_group(backend="gloo")
+        torch.cuda.set_device(self.local_rank)
+
+    def bcast_uid(self, uid):
+        objs = [uid if self.rank == 0 else None]
+        dist.broadcast_object_list(objs, src=0)
+        return objs[0]
+
+    def allreduce_sum(self, v):
+        t = torch.tensor([v], dtype=torch.int64)
+        dist.all_reduce(t, op=dist.ReduceOp.SUM)
+        return int(t.item())
+
+    def shutdown(self):
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def gen_inp_fp8(r, M):
+    """Rank r's fp8 input tokens — reproducible from the per-rank seed."""
+    g = torch.Generator(device="cpu").manual_seed(1234 + r)
+    return torch.randn(M, HIDDEN, generator=g, dtype=torch.float32).to(FP8)
+
+
+def main():
+    d = Dist()
+    rank, npes = d.rank, d.world
+    set_device(d.local_rank)
+    dev = torch.device("cuda", d.local_rank)
+    M = max(SWEEP)
+    num_experts = npes * EPR
+
+    inp = gen_inp_fp8(rank, M).to(dev)  # fp8 dispatch input
+    g2 = torch.Generator(device="cpu").manual_seed(4321 + rank)
+    idx = torch.randint(0, num_experts, (M, K), generator=g2, dtype=torch.int32).to(dev)
+    wts = torch.rand(M, K, generator=g2, dtype=torch.float32).to(dev)
+    # every rank's fp8 input, global token id = r*M + tok (for the recv-value check)
+    all_inp = torch.cat([gen_inp_fp8(r, M) for r in range(npes)], dim=0).float()
+
+    uid = Communicator.get_unique_id() if rank == 0 else None
+    uid = d.bcast_uid(uid)
+    win_bytes = npes * M * HIDDEN * 2 * 2 + (1 << 24)  # sized for bf16 (the larger)
+    with Communicator.init(npes, rank, uid, per_rank_vmm=2 * win_bytes + (1 << 28)) as comm:
+        cfg = EpDispatchCombineConfig(
+            rank=rank,
+            world_size=npes,
+            hidden_dim=HIDDEN,
+            max_num_inp_token_per_rank=M,
+            num_experts_per_rank=EPR,
+            num_experts_per_token=K,
+            dispatch_data_type=FP8,  # fp8 dispatch
+            combine_data_type=torch.bfloat16,  # bf16 combine
+            combine_mode="gather",
+        )
+        op = EpDispatchCombineOp(cfg, comm)
+        comm.barrier()
+
+        for ct in SWEEP:
+            recv_x, _w, _s, _i, total_recv_t, routing = op.dispatch(
+                inp[:ct], wts[:ct], None, idx[:ct], return_routing=True
+            )
+            total_recv = int(total_recv_t.cpu().item())
+            sync()
+            comm.barrier()
+
+            # ---- dispatch correctness ----
+            lec_sum = int(op.local_expert_count().sum().cpu().item())
+            sync()
+            comm.barrier()
+            ok_lec = d.allreduce_sum(lec_sum) == npes * ct * K
+            # recv tokens are the byte-exact fp8 source tokens (via reverse map)
+            tis = routing.disp_tok_id_to_src_tok_id_local[:total_recv].cpu().long()
+            recv_f = recv_x[:total_recv].float().cpu()  # fp8 -> f32 (exact)
+            exp_recv = all_inp[tis]  # source token per recv slot
+            ok_disp = bool(torch.equal(recv_f, exp_recv))
+            errs_disp = d.allreduce_sum(0 if (ok_lec and ok_disp) else 1)
+
+            # ---- mock fmoe: fp8 -> bf16 (identity dequant) ----
+            expert_out = recv_x.to(torch.bfloat16)
+
+            # ---- combine ----
+            out, out_w = op.combine(expert_out, routing=routing)
+            sync()
+            comm.barrier()
+
+            # ---- combine correctness (identity-expert telescoping) ----
+            idx_c = idx[:ct].cpu().numpy()
+            U = np.array(
+                [len({int(idx_c[t, j]) // EPR for j in range(K)}) for t in range(ct)]
+            )
+            exp = (
+                torch.from_numpy(U).view(ct, 1).float() * inp[:ct].float().cpu()
+            ).to(torch.bfloat16)
+            exp_w = torch.from_numpy(U).view(ct, 1).float() * wts[:ct].float().cpu()
+            ok_comb = torch.allclose(out.float().cpu(), exp.float(), atol=3e-1, rtol=1e-1)
+            ok_w = torch.allclose(out_w.cpu(), exp_w, atol=2e-3, rtol=2e-3)
+            # dtype sanity: dispatch recv is fp8, combine out is bf16
+            ok_dt = recv_x.dtype == FP8 and out.dtype == torch.bfloat16
+            errs_comb = d.allreduce_sum(0 if (ok_comb and ok_w and ok_dt) else 1)
+
+            if rank == 0:
+                print(
+                    f"# ASYM-DISPATCH(fp8) ct={ct}: {'PASS' if errs_disp == 0 else 'FAIL'} "
+                    f"(LEC={'ok' if ok_lec else 'BAD'} recv-values={'ok' if ok_disp else 'BAD'}; "
+                    f"recv={total_recv})",
+                    flush=True,
+                )
+                print(
+                    f"# ASYM-COMBINE(bf16) ct={ct}: {'PASS' if errs_comb == 0 else 'FAIL'} "
+                    f"(hidden={'ok' if ok_comb else 'BAD'} wts={'ok' if ok_w else 'BAD'} "
+                    f"dtype={'ok' if ok_dt else 'BAD'})",
+                    flush=True,
+                )
+    d.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/ops/dispatch_combine_v2/test_asym_dtype.py
+++ b/tests/python/ops/dispatch_combine_v2/test_asym_dtype.py
@@ -1,4 +1,25 @@
 #!/usr/bin/env python3
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 """Asymmetric dtype test: fp8 dispatch + bf16 combine.
 
 Models the fmoe use case where an expert op sits between dispatch and combine and
@@ -25,7 +46,10 @@ _ROOT = os.path.abspath(os.path.join(_HERE, "..", "..", "..", ".."))
 sys.path.insert(0, os.path.join(_ROOT, "python", "mori", "ops", "dispatch_combine_v2"))
 sys.path.insert(0, os.path.join(_ROOT, "examples", "cco", "python"))
 from cco_example_common import set_device, sync  # noqa: E402
-from dispatch_combine_op import EpDispatchCombineConfig, EpDispatchCombineOp  # noqa: E402
+from dispatch_combine_op import (  # noqa: E402
+    EpDispatchCombineConfig,
+    EpDispatchCombineOp,
+)
 from mori.cco import Communicator  # noqa: E402
 
 FP8 = torch.float8_e4m3fn  # gfx1250/gfx950 OCP e4m3
@@ -83,7 +107,9 @@ def main():
     uid = Communicator.get_unique_id() if rank == 0 else None
     uid = d.bcast_uid(uid)
     win_bytes = npes * M * HIDDEN * 2 * 2 + (1 << 24)  # sized for bf16 (the larger)
-    with Communicator.init(npes, rank, uid, per_rank_vmm=2 * win_bytes + (1 << 28)) as comm:
+    with Communicator.init(
+        npes, rank, uid, per_rank_vmm=2 * win_bytes + (1 << 28)
+    ) as comm:
         cfg = EpDispatchCombineConfig(
             rank=rank,
             world_size=npes,
@@ -131,11 +157,13 @@ def main():
             U = np.array(
                 [len({int(idx_c[t, j]) // EPR for j in range(K)}) for t in range(ct)]
             )
-            exp = (
-                torch.from_numpy(U).view(ct, 1).float() * inp[:ct].float().cpu()
-            ).to(torch.bfloat16)
+            exp = (torch.from_numpy(U).view(ct, 1).float() * inp[:ct].float().cpu()).to(
+                torch.bfloat16
+            )
             exp_w = torch.from_numpy(U).view(ct, 1).float() * wts[:ct].float().cpu()
-            ok_comb = torch.allclose(out.float().cpu(), exp.float(), atol=3e-1, rtol=1e-1)
+            ok_comb = torch.allclose(
+                out.float().cpu(), exp.float(), atol=3e-1, rtol=1e-1
+            )
             ok_w = torch.allclose(out_w.cpu(), exp_w, atol=2e-3, rtol=2e-3)
             # dtype sanity: dispatch recv is fp8, combine out is bf16
             ok_dt = recv_x.dtype == FP8 and out.dtype == torch.bfloat16

--- a/tests/python/ops/dispatch_combine_v2/test_op.py
+++ b/tests/python/ops/dispatch_combine_v2/test_op.py
@@ -82,10 +82,14 @@ class Dist:
 HIDDEN = int(os.environ.get("HIDDEN", 7168))
 K = int(os.environ.get("TOPK", 8))
 EPR = int(os.environ.get("EPR", 32))
-# fp8 flavor is arch-specific: OCP e4m3 on gfx950, fnuz on gfx942.
+# fp8 flavor is arch-specific: OCP e4m3 on gfx950/gfx1250, fnuz on gfx942.
 import tuning_configs as _tc  # noqa: E402
 
-_FP8_DT = torch.float8_e4m3fn if _tc._topology()[1] == 90500 else torch.float8_e4m3fnuz
+_FP8_DT = (
+    torch.float8_e4m3fn
+    if _tc._topology()[1] in (90500, 120500)
+    else torch.float8_e4m3fnuz
+)
 DTYPE = {
     "bf16": torch.bfloat16,
     "f32": torch.float32,


### PR DESCRIPTION
## Motivation

Bring the cco-LSA FlyDSL dispatch/combine MoE op up on gfx1250 (MI455X-class, wave32) and extend it to cross-node execution over the UALink scale-up fabric, then tune and harden it. The existing op targeted gfx9 (wave64) intra-node xGMI only; this PR ports the kernels to wave32, adds a cross-node LSA path over fabric-exportable VMM, tunes the block/warp schedule per shape, and fixes several correctness/perf issues found while validating on real MI455X (gfx1250) and MI355X (gfx950) hardware.

## Technical Details

**gfx1250 / wave32 port** — Wavefront size is detected per process (arch string, `MORI_WAVE_SIZE` override) since `get_warp_size(gfx1250)` misreports 64; all lane math (ballot int width, butterfly offsets, lane strides) keys off it. Adds gfx1250 fp4 pk8 dequant/quant (`cvt_scale_pk8_f32_fp4` / `cvt_scalef32_pk8_fp4_f32`) for the combine path, replacing the gfx950-only pk-2 instructions. Uses FlyDSL LSA put (JIT-compiled for the actual arch) instead of AOT `compile_genco`.

**Cross-node UALink fabric LSA** — Generalizes the LSA team from "same host" to "same vPOD" (a scale-up fabric domain that can span nodes with flat-VA P2P). Auto-detects the vPOD from `/sys/bus/pci/devices/<bdf>/ualink/` (`ppod_id` UUID + `vpod_id`), mirroring RCCL's MNNVL detection (`hive_id` collides across hosts and is not used). Cross-node peers are mapped via `hipMemHandleTypeFabricCompat` handles exchanged over the bootstrap network; the alloc path probes fabric-compat support and falls back to the POSIX-FD handle path when unavailable. Env precedence: `MORI_CCO_FABRIC_DISABLE` > `MORI_VPOD_ID` > `MORI_CCO_FABRIC_CROSSNODE_LSA` > auto UALink > per-host.

**vec4 combine gather** — The combine Stage-2 gather now issues vec4 i32 loads (16B, `global_load_dwordx4`) instead of scalar 4B loads, cutting the per-lane load count 4x. Applies when the output is 1:1 (bf16 / fp8-no-cast / fp4). Combine was the bottleneck; this lifts it substantially at the bandwidth-bound end.

**Asymmetric dispatch/combine dtype** — `dispatch_data_type` / `combine_data_type` override `data_type` per-op (all-or-none guard), enabling e.g. fp8 dispatch + bf16 combine with an expert op converting between them. `out_tok` is sized to the larger side.

**Arena split** — `disp_out` (dispatch scatter dest / expert-GEMM input) is separated from `out_tok` (combine staging) so combine's copy-in never clobbers the dispatched tokens; callers can read `recv_tokens()` in place without a defensive clone.

**Tuning** — Per-shape block/warp schedules for gfx1250 EP4/EP8, topk 8 and 6 (DeepSeek-V4-Pro, 384 experts). Geometry is topk-independent (tracks token count), so topk6 reuses the topk8 schedule. Re-tuned for the vec4 combine (its optimum shifts to block 64 uniformly).

**Fabric memory fixes** — `hipMemset` on a fabric-exportable pool returns OOM on ROCm 7.15, so window zeroing uses a chunked H2D memcpy (`CcoZeroWindowMem`); `hipMemcpy` DtoD on an imported fabric ptr livelocks (never add a DtoD reachability probe). `hipDeviceEnablePeerAccess` in `ccoWindowRegister` now consumes its sticky last-error (`hipGetLastError`) so a later torch op doesn't surface it as "operation not supported" (broke all Python dispatch/combine on gfx950).

## Test Plan

Validated on real hardware — MI455X/gfx1250 (slot2+slot14, 4 GPUs each, same vPOD over UALink) and MI355X/gfx950 (8x, single node, non-fabric):
- `tests/.../test_dispatch_combine_v2_intranode.py` full dtype matrix (bf16 / f32 / fp8 / fp4, gather + scatter, tuned, topk4/9, scales, StdMoE, fp8-direct-cast, fp8-blockwise).
- `test_asym_dtype.py` (fp8 dispatch + bf16 combine).
- cco init / LSA put / all-to-all / remote-atomic C++ + Python examples.
- Cross-node EP8 dispatch/combine + `bench_dispatch_combine.py` (eager + graph), two-pass block×warp sweep.
- Reproduced the cco CI flow (`docker/Dockerfile.cco`) on MI355X.

## Test Result

- MI355X/gfx950: intranode dispatch/combine suite **17/17 pass**; EP8 bench runs clean (8192 tok: disp 362 / comb 375 GB/s intra-node xGMI).
- gfx1250: EP4 bf16 gather + StdMoE pass; cross-node EP8 (slot2+slot14, vPOD 4) dispatch/combine + remote atomic pass. Tuned bf16 combine @8192: EP8 cross-node ~200 GB/s (vec4, up from 173 pre-vec4).
- pre-commit clean on the diff.

## Submission Checklist

- [x] Code compiles and runs on gfx1250 and gfx950.
- [x] Correctness verified on real hardware (numeric identity/telescoping checks).
- [x] pre-commit (black / ruff / clang-format / license) passing.
