### PR TITLE
fix(jit): invalidate kernel cache on #included source changes

### DIFF
--- a/python/mori/jit/cache.py
+++ b/python/mori/jit/cache.py
@@ -42,7 +42,8 @@ def get_cache_root() -> Path:
 def _hash_tree(paths: list[Path]) -> str:
     """Compute a short content hash over files and directories.
 
-    For directories, all ``.hpp``, ``.h``, and ``.cpp`` files are included.
+    For directories, all ``.hpp``, ``.h``, ``.cpp``, and ``.hip`` files are
+    included, so ``#include``d translation units invalidate the cache too.
     """
     h = hashlib.sha256()
     for p in sorted(paths):
@@ -50,7 +51,7 @@ def _hash_tree(paths: list[Path]) -> str:
             h.update(p.read_bytes())
         elif p.is_dir():
             for f in sorted(p.rglob("*")):
-                if f.suffix in (".hpp", ".h", ".cpp"):
+                if f.suffix in (".hpp", ".h", ".cpp", ".hip"):
                     h.update(f.read_bytes())
     return h.hexdigest()[:12]
 

--- a/python/mori/jit/core.py
+++ b/python/mori/jit/core.py
@@ -495,7 +495,7 @@ def compile_genco(
     sub_kernels = _PARALLEL_KERNEL_GROUPS.get(kernel_name)
     if sub_kernels:
         source_paths = [
-            mori_root / "src" / "ops" / "kernels",
+            mori_root / "src" / "ops",
             mori_root / "include" / "mori",
         ]
         cache_dir = get_cache_dir(
@@ -544,7 +544,11 @@ def compile_genco(
     if not source.is_file():
         raise FileNotFoundError(f"Kernel source not found: {source}")
 
-    source_paths = [source, mori_root / "include" / "mori"]
+    # The .hip translation unit #includes sibling sources from its subsystem
+    # (e.g. ops kernels pull in src/ops/dispatch_combine/*), so hash the whole
+    # subsystem source tree; hashing only the top-level .hip reuses a stale
+    # .hsaco when an included file changes.
+    source_paths = [(mori_root / source_dir).parent, mori_root / "include" / "mori"]
     cache_dir = get_cache_dir(cfg.arch, source_paths, nic, profiler=profiler, ccqe=ccqe)
     hsaco_path = cache_dir / f"{kernel_name}.hsaco"
 


### PR DESCRIPTION
## Problem
The JIT content hash for a kernel covers only its top-level `.hip` file plus `include/mori`. But the ops kernel `.hip` translation units `#include` sibling sources — `src/ops/dispatch_combine/*.cpp` (e.g. `internode_v1.cpp`, `low_latency_async.cpp`) and `src/ops/kernels/ep_common.hip`. Editing one of those included files leaves the hash unchanged, so a stale `.hsaco` is reused and the change silently has no effect. Today the only workaround is deleting `~/.mori/jit/<arch>_<nic>/` by hand.

## Fix
- `compile_genco`: hash the whole subsystem source tree (parent of the kernel dir) instead of only the top-level `.hip`.
- `_hash_tree`: include `.hip` files when hashing directories, so `#include`d translation units (e.g. `ep_common.hip`) are covered.

## Verification
Recomputing the hash over the source tree while editing an `#include`d file: before the change the hash is unchanged (stale reuse); after, it changes for both `dispatch_combine/*.cpp` and `ep_common.hip`. No tests reference the hashing functions.
