### PR TITLE
fix(cco): serialize handle import under the VMM process lock (SPMT race)

### DIFF
--- a/src/cco/cco_init.cpp
+++ b/src/cco/cco_init.cpp
@@ -1016,8 +1016,15 @@ int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin
 
       for (int pe : p2pPeers) {
         hipMemGenericAllocationHandle_t importedHandle;
-        hipError_t err = hipMemImportFromShareableHandle(&importedHandle, &allFabricHandles[pe],
-                                                         hipMemHandleTypeFabricCompat);
+        hipError_t err;
+        {
+          // Import must share the VMM serialization: ROCr races on concurrent
+          // import vs map/setaccess across SPMT threads -> hipMemSetAccess
+          // InvalidValue. #455 serialized map/setaccess but not import.
+          vmmProcessLock vmmLock;
+          err = hipMemImportFromShareableHandle(&importedHandle, &allFabricHandles[pe],
+                                                hipMemHandleTypeFabricCompat);
+        }
         if (err != hipSuccess) {
           MORI_SHMEM_ERROR("ccoWindowRegister: fabric import from PE {} failed: {}", pe,
                            static_cast<int>(err));
@@ -1095,8 +1102,12 @@ int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin
         }
 
         hipMemGenericAllocationHandle_t importedHandle;
-        hipError_t err = hipMemImportFromShareableHandleCompat(&importedHandle, peerFd,
-                                                               hipMemHandleTypePosixFileDescriptor);
+        hipError_t err;
+        {
+          vmmProcessLock vmmLock;  // serialize import w/ map/setaccess (SPMT race)
+          err = hipMemImportFromShareableHandleCompat(&importedHandle, peerFd,
+                                                      hipMemHandleTypePosixFileDescriptor);
+        }
         if (err != hipSuccess) {
           MORI_SHMEM_ERROR("ccoWindowRegister: import from PE {} failed: {}", pe,
                            static_cast<int>(err));


### PR DESCRIPTION
## Problem

`ccoWindowRegister` imports peer handles via `hipMemImportFromShareableHandle` /
`hipMemImportFromShareableHandleCompat` **outside** the process-wide VMM mutex
(`vmmProcessLock`) added in #455 — that mutex covers
`hipMemCreate/Map/Unmap/Release/SetAccess/AddressReserve/Free` but **not `Import`**.

Under **SPMT** (multiple threads registering windows in one process — e.g. the
`test_host` unit test, which spawns the ranks as `std::thread`s), a thread's
unlocked `import` races with another thread's `map`/`setAccess` inside ROCr,
surfacing as an intermittent:

```
ccoWindowRegister: hipMemSetAccess PE <x> failed after retries: 1   (hipErrorInvalidValue)
ccoDevCommCreate: resource window Register failed
what(): Allgather operation failed
```

The failure rate scales with the concurrent thread count, which pinned it to a
concurrency gap rather than the (already patched) CLR `hipMemSetAccess`
sub-buffer bug or a cross-process issue:

| threads (nranks) | fail rate |
|---|---|
| 1 | 0 % |
| 2 | 0 % |
| 4 | ~13 % |
| 8 | ~47 % |

## Fix

Wrap both `import` call sites in `vmmProcessLock` so import shares the same
serialization as the rest of the VMM critical section (i.e. complete #455).

## Verification (MI355X, gfx950, `test_host`)

| | before | after |
|---|---|---|
| nranks=4 | ~13 % fail | **20/20 pass** |
| nranks=8 | ~47 % fail | **20/20 pass** |

40 consecutive clean runs vs a ~26 % baseline fail rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)