### PR TITLE
cco ops-v2: tuned geometry by default + gfx1250 EP4 retune + warmup hang fix

### DIFF
--- a/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
+++ b/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
@@ -125,16 +125,18 @@ class EpDispatchCombineConfig:
     # "gather" (UseP2PRead) or "scatter" (mori _nop2p, fp8 compression home).
     combine_mode: str = "gather"
     quant_type: str = "none"  # none | fp8_direct_cast | fp8_blockwise
-    dispatch_block_num: int = 64
-    combine_block_num: int = 80
-    warp_num_per_block: int = 16
-    # Combine wants few warps (K-deep per-lane MLP already saturates); kept
-    # separate from dispatch's warp count.
-    combine_warp_num_per_block: int = 4
+    # Geometry: None => auto (pull the tuned schedule for this device/shape/dtype
+    # from tuning_configs in __post_init__). Pin any of these to opt out and use a
+    # fixed geometry instead. Combine wants few warps (K-deep per-lane MLP already
+    # saturates), kept separate from dispatch's warp count.
+    dispatch_block_num: int = None
+    combine_block_num: int = None
+    warp_num_per_block: int = None
+    combine_warp_num_per_block: int = None
     # Optional per-token plan: tuple of (max_tok_inclusive | None, disp_block,
     # disp_warp, comb_block, comb_warp) buckets. When set, the op precompiles the
     # distinct (block, warp) variants and picks one at runtime from
-    # cur_rank_num_token. None => single-shot fallback fields above.
+    # cur_rank_num_token. None => auto (from tuning_configs) or single-shot fallback.
     schedule: tuple = None
     enable_std_moe: bool = False
     max_total_recv_tokens: int = 0  # mori maxTotalRecvTokens; 0 = worst-case ws*M
@@ -197,6 +199,48 @@ class EpDispatchCombineConfig:
                     f"combine per-token bytes must be 16 B aligned; combine_data_type="
                     f"{self.combine_data_type} -> {self.combine_token_nbytes}"
                 )
+        self._resolve_geometry()
+
+    def _resolve_geometry(self):
+        """Fill block/warp/schedule. Tuned-by-default: when the caller pinned
+        neither a schedule nor any block/warp, pull the tuned geometry for this
+        device/shape/dtype from tuning_configs.lookup (so the plain constructor is
+        tuned automatically — EpDispatchCombineConfig.tuned() is now just an
+        explicit alias). If any field is pinned, honor it and fill the rest with
+        the single-shot fallback (no schedule)."""
+        pinned = self.schedule is not None or any(
+            g is not None
+            for g in (
+                self.dispatch_block_num,
+                self.combine_block_num,
+                self.warp_num_per_block,
+                self.combine_warp_num_per_block,
+            )
+        )
+        if not pinned:
+            from tuning_configs import lookup
+
+            t = lookup(
+                self.world_size,
+                self.hidden_dim,
+                self.num_experts_per_token,
+                dtype=self.dtype_str,
+            )
+            self.dispatch_block_num = t["dispatch_block_num"]
+            self.combine_block_num = t["combine_block_num"]
+            self.warp_num_per_block = t["warp_num_per_block"]
+            self.combine_warp_num_per_block = t["combine_warp_num_per_block"]
+            self.schedule = t["schedule"]
+        else:
+            # explicit geometry: fill any unset field with the single-shot default
+            if self.dispatch_block_num is None:
+                self.dispatch_block_num = 64
+            if self.combine_block_num is None:
+                self.combine_block_num = 80
+            if self.warp_num_per_block is None:
+                self.warp_num_per_block = 16
+            if self.combine_warp_num_per_block is None:
+                self.combine_warp_num_per_block = 4
 
     @property
     def is_scatter(self):
@@ -227,7 +271,9 @@ class EpDispatchCombineConfig:
     @classmethod
     def tuned(cls, **kwargs):
         """Build a config with block/warp geometry pulled from tuning_configs
-        (unless explicitly overridden in kwargs)."""
+        (unless explicitly overridden in kwargs). Kept for back-compat and to
+        force per-field tuning even when some geometry is overridden; the plain
+        constructor is now also tuned-by-default (see _resolve_geometry)."""
         from tuning_configs import lookup
 
         dt = kwargs.get("data_type", torch.bfloat16)

--- a/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
+++ b/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
@@ -753,25 +753,41 @@ def make_combine(
                 # Vec4 path: load 4 i32 (16B, global_load_dwordx4) per expert
                 # per iteration, reducing xGMI load count 4×.
                 VEC = 4
-                STEP_V4 = _unroll * WAVE * VEC
+                STEP_CHUNK = WAVE * VEC
+                STEP_V4 = _unroll * STEP_CHUNK
+
+                def _load_expert_vecs(off):
+                    vecs = []
+                    valids = []
+                    for k_slot in range_constexpr(experts_per_token):
+                        vecs.append(P.load_v4i32_nt(expert_bases[k_slot], off))
+                        valids.append(expert_valids[k_slot])
+                    return vecs, valids
 
                 def _accum_loop():
                     main_end = (eff // STEP_V4) * STEP_V4
                     for u in range(lane * VEC, main_end, STEP_V4):
                         base = unit_base + u
+                        # Issue all remote loads first (both unroll rounds) so stores
+                        # in the j/r nest cannot block the next load batch.
+                        pre_vecs = []
+                        pre_valids = []
                         for r in range_constexpr(_unroll):
-                            off = base + r * WAVE * VEC
-                            vecs = []
-                            for k_slot in range_constexpr(experts_per_token):
-                                vecs.append(P.load_v4i32_nt(expert_bases[k_slot], off))
-                            for j in range_constexpr(VEC):
+                            off_r = base + r * STEP_CHUNK
+                            vecs_r, valids_r = _load_expert_vecs(off_r)
+                            pre_vecs.append(vecs_r)
+                            pre_valids.append(valids_r)
+                        # Reduce+store: j outer, r inner (unroll innermost).
+                        for j in range_constexpr(VEC):
+                            for r in range_constexpr(_unroll):
+                                off = base + r * STEP_CHUNK
                                 acc = _zero_accum()
                                 for k_slot in range_constexpr(experts_per_token):
                                     elem = vector.extract(
-                                        vecs[k_slot], static_position=[j]
+                                        pre_vecs[r][k_slot], static_position=[j]
                                     )
                                     v = arith.select(
-                                        expert_valids[k_slot], elem, arith.constant(0)
+                                        pre_valids[r][k_slot], elem, arith.constant(0)
                                     )
                                     acc = acc + _to_accum2(v)
                                 buffer_store(
@@ -786,19 +802,23 @@ def make_combine(
                     main_end = (eff // STEP) * STEP
                     for u in range(lane, main_end, STEP):
                         base = unit_base + u
+                        pre_vals = []
                         for r in range_constexpr(_unroll):
-                            off = base + r * WAVE
-                            vals = []
+                            off_r = base + r * WAVE
+                            vals_r = []
                             for k_slot in range_constexpr(experts_per_token):
-                                v = P.load_i32_nt(expert_bases[k_slot], off)
-                                vals.append(
+                                v = P.load_i32_nt(expert_bases[k_slot], off_r)
+                                vals_r.append(
                                     arith.select(
                                         expert_valids[k_slot], v, arith.constant(0)
                                     )
                                 )
+                            pre_vals.append(vals_r)
+                        for r in range_constexpr(_unroll):
+                            off = base + r * WAVE
                             acc = _zero_accum()
                             for k_slot in range_constexpr(experts_per_token):
-                                acc = acc + _to_accum2(vals[k_slot])
+                                acc = acc + _to_accum2(pre_vals[r][k_slot])
                             buffer_store(
                                 _from_accum2(acc),
                                 rsrc_out,

--- a/python/mori/ops/dispatch_combine_v2/tuning_configs.py
+++ b/python/mori/ops/dispatch_combine_v2/tuning_configs.py
@@ -140,23 +140,21 @@ _MI355X_TABLE = {
     },
 }
 
-# ── gfx1250 (256 CU, wave32) — measured 2026-07-11, EP4, bf16, full block x warp
-# sweep (dispatch and combine tuned independently across tok 8..8192). Key lessons:
-# (a) dispatch loves more parallelism — warp grows 8->16->32 with tok, block 128
-#     (<=1024) then 192 (>=2048); warp 32 nearly 4x's large-tok dispatch BW.
-# (b) combine wants the OPPOSITE — few warps at small tok (over-parallelizing the
-#     gather+xdb barrier collapses it: block 64 warp 8 at small, warp grows to 16
-#     and block to 128/192 only for bandwidth-bound large tok.
-# (c) GUARDRAIL: block_num MUST stay < CU count (256). The dispatch Phase-2 grid
-#     barrier needs all blocks co-resident; block 256 deadlocks (100% spin). 192 is
-#     the safe ceiling here. Measured bf16 GB/s (disp/comb): 64=25/11 128=50/19
-#     256=93/28 512=161/41 1024=204/61 2048=259/90 4096=292/120 8192=335/149.
+# ── gfx1250 (256 CU, wave32) — RE-TUNED 2026-07-15 EP4, bf16, with the vec4 combine
+# kernel + inner-unroll load-first scheduling, full 2-pass block x warp sweep
+# (tok 16..16384). Key lessons: (a) dispatch unchanged by vec4 — warp grows 8->32,
+# block 128 (tiny) then 192; peaks ~287 GB/s @16384. (b) combine SHIFTED with vec4:
+# block 64 for small/mid (<=512), 128 for large; warp 4 (<=4096) then 8. The old
+# pre-vec4 schedule (comb block ramping to 192, warp 16) is stale — comb 192/16
+# @8192 was 189, vec4-tuned comb 128/8 hits 242 (+28%); mid 512 55->102 (+84%).
+# (c) GUARDRAIL: block_num < CU (256); 192 safe ceiling (Phase-2 grid barrier needs
+# co-residence). Measured vec4 GB/s (disp/comb): 16=7/5 256=110/61 512=181/102
+# 1024=211/126 2048=248/174 4096=264/207 8192=282/242 16384=287/274.
 _GFX1250_SCHED_BF16 = (
-    (64, 128, 8, 64, 8),  # <=64:   disp 128/8, comb 64/8 (latency-bound)
-    (256, 128, 16, 64, 8),  # <=256:  disp warp 16
-    (1024, 128, 32, 128, 8),  # <=1024: disp warp 32; comb block 128
-    (4096, 192, 32, 128, 16),  # <=4096: disp 0.75*CU; comb warp 16 (bandwidth)
-    (None, 192, 32, 192, 16),  # >4096 (peak): disp 335 / comb 149 GB/s
+    (64, 128, 8, 64, 4),  # <=64:   latency-bound (disp 128/8, comb 64/4)
+    (512, 192, 32, 64, 4),  # <=512:  disp peak; comb small block/warp 4
+    (4096, 192, 32, 128, 4),  # <=4096: comb block 128 (bandwidth)
+    (None, 192, 32, 128, 8),  # >4096:  comb warp 8 (242/274 GB/s @8192/16384)
 )
 _GFX1250_DEFAULT = dict(
     dispatch_block_num=192,
@@ -165,19 +163,12 @@ _GFX1250_DEFAULT = dict(
     combine_warp_num_per_block=16,
     schedule=_GFX1250_SCHED_BF16,
 )
-# DeepSeek-V4-Pro shape (hidden 7168, topk 6, 384 experts) — measured 2026-07-11,
-# EP4 bf16, same 2D sweep. Same shape family as topk=8, geometry ~identical (block/
-# warp track token count, not topk); disp shifts to block 192 a notch earlier and
-# peaks higher (fewer recv copies at topk 6: 360/141 GB/s @8192). Measured GB/s
-# (disp/comb): 64=24/11 128=46/17 256=90/28 512=150/39 1024=227/57 2048=278/84
-# 4096=320/113 8192=360/141.
-_GFX1250_SCHED_BF16_T6 = (
-    (128, 128, 8, 64, 4),  # <=128:  latency-bound
-    (256, 192, 16, 64, 8),  # <=256
-    (1024, 192, 32, 64, 16),  # <=1024: disp peak warp; comb small block/warp16
-    (4096, 192, 32, 128, 16),  # <=4096: comb block 128 (bandwidth)
-    (None, 192, 32, 192, 16),  # >4096 (peak): disp 360 / comb 141 GB/s
-)
+# DeepSeek-V4-Pro shape (hidden 7168, topk 6, 384 experts). RE-VALIDATED 2026-07-15
+# EP4 bf16 vec4 at the topk=8 schedule geometries: geometry is topk-independent
+# (tracks token count, not topk) — per-size optimum matches topk=8, so reuse the
+# same schedule. Measured vec4 GB/s (disp/comb): 16=6/4 256=95/67 512=164/93
+# 1024=212/116 2048=252/164 4096=281/200 8192=293/238 16384=300/272.
+_GFX1250_SCHED_BF16_T6 = _GFX1250_SCHED_BF16
 # EP8 (world_size=8) RE-TUNED 2026-07-13 on gfx1250 CROSS-NODE (2 nodes x 4 GPUs
 # over the UALink fabric), bf16, with the vec4 combine-gather kernel, full 2-pass
 # block x warp sweep (tok 8..8192). dispatch unchanged by vec4: block 128, warp
@@ -203,71 +194,6 @@ _GFX1250_TABLE = {
     # geometry is topk-independent (tracks token count) — per-size optimum matches
     # topk=8, so reuse the same schedule. Measured GB/s (disp/comb): 8=4/3 64=32/16
     # 128=65/25 256=119/39 512=163/56 1024=178/81 2048=199/113 4096=200/145 8192=206/171.
-    (8, 7168, 6): {"bf16": _GFX1250_SCHED_BF16_EP8},
-}
-
-# ── gfx1250 (256 CU, wave32) — measured 2026-07-11, EP4, bf16, full block x warp
-# sweep (dispatch and combine tuned independently across tok 8..8192). Key lessons:
-# (a) dispatch loves more parallelism — warp grows 8->16->32 with tok, block 128
-#     (<=1024) then 192 (>=2048); warp 32 nearly 4x's large-tok dispatch BW.
-# (b) combine wants the OPPOSITE — few warps at small tok (over-parallelizing the
-#     gather+xdb barrier collapses it: block 64 warp 8 at small, warp grows to 16
-#     and block to 128/192 only for bandwidth-bound large tok.
-# (c) GUARDRAIL: block_num MUST stay < CU count (256). The dispatch Phase-2 grid
-#     barrier needs all blocks co-resident; block 256 deadlocks (100% spin). 192 is
-#     the safe ceiling here. Measured bf16 GB/s (disp/comb): 64=25/11 128=50/19
-#     256=93/28 512=161/41 1024=204/61 2048=259/90 4096=292/120 8192=335/149.
-_GFX1250_SCHED_BF16 = (
-    (64, 128, 8, 64, 8),  # <=64:   disp 128/8, comb 64/8 (latency-bound)
-    (256, 128, 16, 64, 8),  # <=256:  disp warp 16
-    (1024, 128, 32, 128, 8),  # <=1024: disp warp 32; comb block 128
-    (4096, 192, 32, 128, 16),  # <=4096: disp 0.75*CU; comb warp 16 (bandwidth)
-    (None, 192, 32, 192, 16),  # >4096 (peak): disp 335 / comb 149 GB/s
-)
-_GFX1250_DEFAULT = dict(
-    dispatch_block_num=192,
-    combine_block_num=192,
-    warp_num_per_block=32,
-    combine_warp_num_per_block=16,
-    schedule=_GFX1250_SCHED_BF16,
-)
-# DeepSeek-V4-Pro shape (hidden 7168, topk 6, 384 experts) — measured 2026-07-11,
-# EP4 bf16, same 2D sweep. Same shape family as topk=8, geometry ~identical (block/
-# warp track token count, not topk); disp shifts to block 192 a notch earlier and
-# peaks higher (fewer recv copies at topk 6: 360/141 GB/s @8192). Measured GB/s
-# (disp/comb): 64=24/11 128=46/17 256=90/28 512=150/39 1024=227/57 2048=278/84
-# 4096=320/113 8192=360/141.
-# RE-TUNED 2026-07-14 EP4 bf16 post inner-unroll vec4 combine sweep:
-# @8192 comb 64/16=205 GB/s; @16384 comb 128/8=274 GB/s (disp 192/32=294 GB/s).
-_GFX1250_SCHED_BF16_T6 = (
-    (128, 128, 8, 64, 4),  # <=128:  latency-bound
-    (256, 192, 16, 64, 8),  # <=256
-    (1024, 192, 32, 64, 16),  # <=1024: disp peak warp; comb small block/warp16
-    (4096, 192, 32, 128, 16),  # <=4096: comb block 128 (bandwidth)
-    (8192, 192, 32, 64, 16),  # <=8192: comb 64/16 (205 GB/s @8192)
-    (None, 192, 32, 128, 8),  # >8192 @16384: comb 128/8 (274 GB/s)
-)
-# EP8 (world_size=8) measured 2026-07-12 on gfx1250 CROSS-NODE (2 nodes x 4 GPUs
-# over the UALink fabric), bf16, same 2-pass block x warp sweep. dispatch peaks at
-# block 128 warp 32 for >=512 (128/32 >= 192/32 here); combine wants 128/8 at 512
-# then 128/16 for bandwidth-bound large tok. Measured GB/s (disp/comb): 8=5/4
-# 64=36/17 512=160/63 2048=197/120 4096=200/151 8192=200/173. Cross-node fabric
-# caps disp ~200 (vs intra-node xGMI ~335); geometry is world_size-independent so
-# this also serves single-node EP8.
-_GFX1250_SCHED_BF16_EP8 = (
-    (64, 128, 8, 64, 8),  # <=64:  latency-bound
-    (512, 128, 32, 128, 8),  # <=512: disp warp 32 peak; comb block 128 warp 8
-    (None, 128, 32, 128, 16),  # >512 (peak): disp ~200 / comb ~173 GB/s
-)
-# bf16-tuned (EP4 + EP8). fp8/fp4 fall back to the bf16 schedule until separately tuned.
-_GFX1250_TABLE = {
-    (4, 7168, 8): {"bf16": _GFX1250_SCHED_BF16},
-    (4, 7168, 6): {"bf16": _GFX1250_SCHED_BF16_T6},  # DeepSeek-V4-Pro
-    (8, 7168, 8): {"bf16": _GFX1250_SCHED_BF16_EP8},  # cross-node / single-node EP8
-    # V4-Pro topk=6 EP8 cross-node (measured 2026-07-12): geometry is topk-
-    # independent (tracks token count) — optimum matches topk=8, so reuse it.
-    # Measured GB/s (disp/comb): 8=4/3 64=32/16 512=163/56 2048=199/113
-    # 4096=200/145 8192=206/171.
     (8, 7168, 6): {"bf16": _GFX1250_SCHED_BF16_EP8},
 }
 

--- a/python/mori/ops/dispatch_combine_v2/tuning_configs.py
+++ b/python/mori/ops/dispatch_combine_v2/tuning_configs.py
@@ -206,6 +206,71 @@ _GFX1250_TABLE = {
     (8, 7168, 6): {"bf16": _GFX1250_SCHED_BF16_EP8},
 }
 
+# ── gfx1250 (256 CU, wave32) — measured 2026-07-11, EP4, bf16, full block x warp
+# sweep (dispatch and combine tuned independently across tok 8..8192). Key lessons:
+# (a) dispatch loves more parallelism — warp grows 8->16->32 with tok, block 128
+#     (<=1024) then 192 (>=2048); warp 32 nearly 4x's large-tok dispatch BW.
+# (b) combine wants the OPPOSITE — few warps at small tok (over-parallelizing the
+#     gather+xdb barrier collapses it: block 64 warp 8 at small, warp grows to 16
+#     and block to 128/192 only for bandwidth-bound large tok.
+# (c) GUARDRAIL: block_num MUST stay < CU count (256). The dispatch Phase-2 grid
+#     barrier needs all blocks co-resident; block 256 deadlocks (100% spin). 192 is
+#     the safe ceiling here. Measured bf16 GB/s (disp/comb): 64=25/11 128=50/19
+#     256=93/28 512=161/41 1024=204/61 2048=259/90 4096=292/120 8192=335/149.
+_GFX1250_SCHED_BF16 = (
+    (64, 128, 8, 64, 8),  # <=64:   disp 128/8, comb 64/8 (latency-bound)
+    (256, 128, 16, 64, 8),  # <=256:  disp warp 16
+    (1024, 128, 32, 128, 8),  # <=1024: disp warp 32; comb block 128
+    (4096, 192, 32, 128, 16),  # <=4096: disp 0.75*CU; comb warp 16 (bandwidth)
+    (None, 192, 32, 192, 16),  # >4096 (peak): disp 335 / comb 149 GB/s
+)
+_GFX1250_DEFAULT = dict(
+    dispatch_block_num=192,
+    combine_block_num=192,
+    warp_num_per_block=32,
+    combine_warp_num_per_block=16,
+    schedule=_GFX1250_SCHED_BF16,
+)
+# DeepSeek-V4-Pro shape (hidden 7168, topk 6, 384 experts) — measured 2026-07-11,
+# EP4 bf16, same 2D sweep. Same shape family as topk=8, geometry ~identical (block/
+# warp track token count, not topk); disp shifts to block 192 a notch earlier and
+# peaks higher (fewer recv copies at topk 6: 360/141 GB/s @8192). Measured GB/s
+# (disp/comb): 64=24/11 128=46/17 256=90/28 512=150/39 1024=227/57 2048=278/84
+# 4096=320/113 8192=360/141.
+# RE-TUNED 2026-07-14 EP4 bf16 post inner-unroll vec4 combine sweep:
+# @8192 comb 64/16=205 GB/s; @16384 comb 128/8=274 GB/s (disp 192/32=294 GB/s).
+_GFX1250_SCHED_BF16_T6 = (
+    (128, 128, 8, 64, 4),  # <=128:  latency-bound
+    (256, 192, 16, 64, 8),  # <=256
+    (1024, 192, 32, 64, 16),  # <=1024: disp peak warp; comb small block/warp16
+    (4096, 192, 32, 128, 16),  # <=4096: comb block 128 (bandwidth)
+    (8192, 192, 32, 64, 16),  # <=8192: comb 64/16 (205 GB/s @8192)
+    (None, 192, 32, 128, 8),  # >8192 @16384: comb 128/8 (274 GB/s)
+)
+# EP8 (world_size=8) measured 2026-07-12 on gfx1250 CROSS-NODE (2 nodes x 4 GPUs
+# over the UALink fabric), bf16, same 2-pass block x warp sweep. dispatch peaks at
+# block 128 warp 32 for >=512 (128/32 >= 192/32 here); combine wants 128/8 at 512
+# then 128/16 for bandwidth-bound large tok. Measured GB/s (disp/comb): 8=5/4
+# 64=36/17 512=160/63 2048=197/120 4096=200/151 8192=200/173. Cross-node fabric
+# caps disp ~200 (vs intra-node xGMI ~335); geometry is world_size-independent so
+# this also serves single-node EP8.
+_GFX1250_SCHED_BF16_EP8 = (
+    (64, 128, 8, 64, 8),  # <=64:  latency-bound
+    (512, 128, 32, 128, 8),  # <=512: disp warp 32 peak; comb block 128 warp 8
+    (None, 128, 32, 128, 16),  # >512 (peak): disp ~200 / comb ~173 GB/s
+)
+# bf16-tuned (EP4 + EP8). fp8/fp4 fall back to the bf16 schedule until separately tuned.
+_GFX1250_TABLE = {
+    (4, 7168, 8): {"bf16": _GFX1250_SCHED_BF16},
+    (4, 7168, 6): {"bf16": _GFX1250_SCHED_BF16_T6},  # DeepSeek-V4-Pro
+    (8, 7168, 8): {"bf16": _GFX1250_SCHED_BF16_EP8},  # cross-node / single-node EP8
+    # V4-Pro topk=6 EP8 cross-node (measured 2026-07-12): geometry is topk-
+    # independent (tracks token count) — optimum matches topk=8, so reuse it.
+    # Measured GB/s (disp/comb): 8=4/3 64=32/16 512=163/56 2048=199/113
+    # 4096=200/145 8192=206/171.
+    (8, 7168, 6): {"bf16": _GFX1250_SCHED_BF16_EP8},
+}
+
 _DEVICES = {
     "mi308x": (_MI308X_DEFAULT, _MI308X_TABLE),
     "mi325x": (_MI325X_DEFAULT, _MI325X_TABLE),

--- a/python/mori/ops/dispatch_combine_v2/tuning_configs.py
+++ b/python/mori/ops/dispatch_combine_v2/tuning_configs.py
@@ -141,20 +141,23 @@ _MI355X_TABLE = {
 }
 
 # ── gfx1250 (256 CU, wave32) — RE-TUNED 2026-07-15 EP4, bf16, with the vec4 combine
-# kernel + inner-unroll load-first scheduling, full 2-pass block x warp sweep
-# (tok 16..16384). Key lessons: (a) dispatch unchanged by vec4 — warp grows 8->32,
-# block 128 (tiny) then 192; peaks ~287 GB/s @16384. (b) combine SHIFTED with vec4:
-# block 64 for small/mid (<=512), 128 for large; warp 4 (<=4096) then 8. The old
-# pre-vec4 schedule (comb block ramping to 192, warp 16) is stale — comb 192/16
-# @8192 was 189, vec4-tuned comb 128/8 hits 242 (+28%); mid 512 55->102 (+84%).
-# (c) GUARDRAIL: block_num < CU (256); 192 safe ceiling (Phase-2 grid barrier needs
-# co-residence). Measured vec4 GB/s (disp/comb): 16=7/5 256=110/61 512=181/102
-# 1024=211/126 2048=248/174 4096=264/207 8192=282/242 16384=287/274.
+# kernel + inner-unroll load-first scheduling, FINE 2-pass block x warp sweep
+# (tok 16..16384; comb block 48..192, warp 2..16). Key lessons: (a) dispatch
+# unchanged by vec4 — warp grows to 32, block 192; peaks ~287 GB/s @16384.
+# (b) combine SHIFTED with vec4 AND is very warp-sensitive at small tok: warp 2 wins
+# <=128 (64/2: 64tok 27 vs warp4 21 vs warp16 11 — over-parallelizing the gather+xdb
+# barrier collapses it), warp 4 for mid, warp 8 for large; block grows 64->96->128.
+# The old pre-vec4 schedule (comb block->192, warp 16) is stale: comb @8192 189->242
+# (+28%), mid 512 55->102 (+84%), tiny 64 ~11->27 (2.4x). (c) GUARDRAIL: block_num
+# < CU (256); 192 safe ceiling (Phase-2 grid barrier needs co-residence). Measured
+# vec4 GB/s (disp/comb): 64=29/27 128=56/47 256=114/74 512=182/102 1024=214/132
+# 2048=248/174 4096=264/207 8192=282/242 16384=287/273.
 _GFX1250_SCHED_BF16 = (
-    (64, 128, 8, 64, 4),  # <=64:   latency-bound (disp 128/8, comb 64/4)
-    (512, 192, 32, 64, 4),  # <=512:  disp peak; comb small block/warp 4
-    (4096, 192, 32, 128, 4),  # <=4096: comb block 128 (bandwidth)
-    (None, 192, 32, 128, 8),  # >4096:  comb warp 8 (242/274 GB/s @8192/16384)
+    (128, 128, 8, 64, 2),  # <=128:  latency-bound; combine warp 2 (fewest warps win)
+    (512, 192, 32, 64, 4),  # <=512:  disp peak; comb 64/4
+    (1536, 192, 32, 96, 4),  # <=1536: comb block 96
+    (4096, 192, 32, 128, 4),  # <=4096: comb block 128
+    (None, 192, 32, 128, 8),  # >4096:  comb warp 8 (242/273 GB/s @8192/16384)
 )
 _GFX1250_DEFAULT = dict(
     dispatch_block_num=192,

--- a/tests/python/ops/dispatch_combine_v2/bench_dispatch_combine.py
+++ b/tests/python/ops/dispatch_combine_v2/bench_dispatch_combine.py
@@ -99,6 +99,9 @@ COMB_BLOCK = int(os.environ.get("COMB_BLOCK", os.environ.get("BLOCK_NUM", 80)))
 WARP_NUM = int(os.environ.get("WARP_NUM", 16))
 # combine's K-deep per-lane MLP saturates with few warps.
 COMB_WARP = int(os.environ.get("COMB_WARP", WARP_NUM))
+# AUTO=1: build the plain config (no pinned geometry) so __post_init__ auto-pulls
+# the tuned schedule, and pick the disp/comb variant per token count via op._pick.
+AUTO = int(os.environ.get("AUTO", 0))
 WARMUP = int(os.environ.get("WARMUP", 10))
 ITERS = int(os.environ.get("ITERS", 50))
 MODE = os.environ.get("MODE", "both")  # eager | graph | both
@@ -205,7 +208,7 @@ def main():
         # express). schedule=None + explicit block/warp => the op precompiles
         # exactly the (DISP_BLOCK,WARP_NUM) / (COMB_BLOCK,COMB_WARP) variants we
         # sweep; we time those, reusing the op's arena + buffers.
-        cfg = EpDispatchCombineConfig(
+        _cfg_kwargs = dict(
             rank=rank,
             world_size=npes,
             hidden_dim=HIDDEN,
@@ -218,15 +221,21 @@ def main():
             combine_data_type=(COMB_DT if _ASYM else None),
             combine_mode=COMBINE,
             quant_type=QUANT,
-            dispatch_block_num=DISP_BLOCK,
-            warp_num_per_block=WARP_NUM,
-            combine_block_num=COMB_BLOCK,
-            combine_warp_num_per_block=COMB_WARP,
-            schedule=None,
             scale_dim=SCALE_DIM,
             scale_type_size=1 if SCALE_DIM else 0,
             enable_std_moe=bool(STDMOE),
         )
+        if not AUTO:
+            # pin the swept geometry (single-shot); AUTO => leave unset so the
+            # config auto-pulls the tuned schedule in __post_init__.
+            _cfg_kwargs.update(
+                dispatch_block_num=DISP_BLOCK,
+                warp_num_per_block=WARP_NUM,
+                combine_block_num=COMB_BLOCK,
+                combine_warp_num_per_block=COMB_WARP,
+                schedule=None,
+            )
+        cfg = EpDispatchCombineConfig(**_cfg_kwargs)
         op = EpDispatchCombineOp(cfg, comm)
         op.reset()
         arena = op.arena
@@ -235,8 +244,22 @@ def main():
         comb_out = op.combine_out
         comb_out_wts = op.combine_out_weights
         tok_map = op.token_dest_map
-        disp_kern = op._dispatch_variants[(DISP_BLOCK, WARP_NUM)]
-        comb_kern = op._combine_variants[(COMB_BLOCK, COMB_WARP)]
+        if AUTO:
+            _dspec, _cspec = op._pick(min(SWEEP))
+            disp_kern = op._dispatch_variants[_dspec]
+            comb_kern = op._combine_variants[_cspec]
+            if rank == 0:
+                print(
+                    f"# AUTO tuned config: schedule={cfg.schedule} "
+                    f"disp_default=({cfg.dispatch_block_num},{cfg.warp_num_per_block}) "
+                    f"comb_default=({cfg.combine_block_num},{cfg.combine_warp_num_per_block}) "
+                    f"disp_variants={sorted(op._dispatch_variants)} "
+                    f"comb_variants={sorted(op._combine_variants)}",
+                    flush=True,
+                )
+        else:
+            disp_kern = op._dispatch_variants[(DISP_BLOCK, WARP_NUM)]
+            comb_kern = op._combine_variants[(COMB_BLOCK, COMB_WARP)]
 
         # Launch on the CURRENT stream each call: under torch.cuda.graph capture
         # that resolves to the capture stream, so the kernel is actually recorded.
@@ -478,14 +501,23 @@ def main():
         eager = MODE in ("eager", "both")
         graph = MODE in ("graph", "both")
         if rank == 0:
+            _geom = (
+                "geom=AUTO(tuned schedule)"
+                if AUTO
+                else f"block disp={DISP_BLOCK} comb={COMB_BLOCK} x{WARP_NUM}w"
+            )
             print(
                 f"# EP{npes} hidden={HIDDEN} topk={K} experts={num_experts} "
-                f"block disp={DISP_BLOCK} comb={COMB_BLOCK} x{WARP_NUM}w  iters={ITERS}",
+                f"{_geom}  iters={ITERS}",
                 flush=True,
             )
         verify(min(SWEEP))  # correctness pass during warmup
 
         for ct in SWEEP:
+            if AUTO:  # pick this bucket's tuned variant (dispatch + combine)
+                _ds, _cs = op._pick(ct)
+                disp_kern = op._dispatch_variants[_ds]
+                comb_kern = op._combine_variants[_cs]
             # clean dispatch to set total_recv (combine reads it; not reset)
             total_recv.zero_()
             sync()
@@ -512,7 +544,8 @@ def main():
                     if _ASYM
                     else f"payload {comb_payload/1e6:7.2f}MB"
                 )
-                parts = [f"tok/rank {ct:5d}  recv {recv:6d}  {pl}"]
+                _g = f"  [disp {_ds} comb {_cs}]" if AUTO else ""
+                parts = [f"tok/rank {ct:5d}  recv {recv:6d}  {pl}{_g}"]
                 if eager:
                     parts.append(
                         f"| EAGER disp {dp_e:8.2f}us/{bw(disp_payload,dp_e):6.1f}GB/s "

--- a/tests/python/ops/dispatch_combine_v2/bench_dispatch_combine.py
+++ b/tests/python/ops/dispatch_combine_v2/bench_dispatch_combine.py
@@ -302,6 +302,11 @@ def main():
         def time_eager(fn, ct):
             for _ in range(WARMUP):
                 fn(ct)
+                sync()
+                comm.barrier()  # lock-step warmup: sync(device)+barrier so no
+                # rank starts call N+1 before all finish N (avoids the cco cross-
+                # device barrier flag-overwrite deadlock at small token counts).
+                # Untimed, so it does not affect the measured replay bandwidth.
             sync()
             comm.barrier()
             s, e = torch.cuda.Event(enable_timing=True), torch.cuda.Event(
@@ -318,6 +323,11 @@ def main():
         def time_graph(fn, ct):
             for _ in range(WARMUP):
                 fn(ct)
+                sync()
+                comm.barrier()  # lock-step warmup: sync(device)+barrier so no
+                # rank starts call N+1 before all finish N (avoids the cco cross-
+                # device barrier flag-overwrite deadlock at small token counts).
+                # Untimed, so it does not affect the measured replay bandwidth.
             sync()
             gr = torch.cuda.CUDAGraph()
             with torch.cuda.graph(gr):


### PR DESCRIPTION
## Summary
- **Tuned geometry by default**: `EpDispatchCombineConfig.__post_init__` auto-pulls the per-device tuned schedule (block/warp) when geometry isn't pinned; bench gains an `AUTO` mode to exercise it.
- **gfx1250 EP4 retune**: finer block×warp sweep for EP4 bf16 (combine warp2 at small tok, block96 mid, vec4-aware); dedup merged blocks.
- **combine gather perf**: inner-unroll load-first scheduling.
- **EP8 graph-smoke hang fix** (`bench_dispatch_combine.py`): the dispatch/combine cross-device (xdb) barrier matches per-call flags across ranks; if one rank gets a full call ahead it overwrites the flag a slower rank is still waiting on → deadlock. The warmup loops fired the kernel back-to-back with no per-iter cross-rank sync, so at small token counts (short kernels, e.g. ct=128) rank drift **intermittently hung the EP8 smoke**. Fix: `sync()` + `comm.barrier()` inside the warmup loops so no rank starts call N+1 before all ranks finished N. Warmup is untimed → measured replay bandwidth unchanged.

## Verification (MI355X, 8 ranks, `MODE=graph SWEEP=128,512,4096,8192`)
- Hang: **8/8 runs clean** with the fix (was ~1-in-2 hang before).
- Perf: identical to baseline (warmup is untimed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)