### PR TITLE
io/rdma: use RegisterRdmaMemoryRegionAuto for local + notif MRs (fix GPUDirect on peermem-less clusters)

### DIFF
--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -353,7 +353,7 @@ application::RdmaMemoryRegion RdmaManager::RegisterLocalMemory(int devId, const 
   std::unique_lock<std::shared_mutex> lock(mu);
   MemoryKey key{devId, desc.id};
   application::RdmaDeviceContext* devCtx = GetOrCreateDeviceContext(devId);
-  mTable[key] = devCtx->RegisterRdmaMemoryRegion(reinterpret_cast<void*>(desc.data), desc.size);
+  mTable[key] = devCtx->RegisterRdmaMemoryRegionAuto(reinterpret_cast<void*>(desc.data), desc.size);
   return mTable[key];
 }
 
@@ -660,7 +660,7 @@ void NotifManager::RegisterEndpoint(const std::shared_ptr<EndpointRuntime>& rt) 
       posix_memalign(reinterpret_cast<void**>(&buf), PAGESIZE,
                      static_cast<size_t>(config.notifPerQp) * sizeof(NotifMessage)));
   application::RdmaMemoryRegion mr =
-      devCtx->RegisterRdmaMemoryRegion(buf, config.notifPerQp * sizeof(NotifMessage));
+      devCtx->RegisterRdmaMemoryRegionAuto(buf, config.notifPerQp * sizeof(NotifMessage));
 
   notifCtxById_.insert({rt->id, {mr, buf}});
 


### PR DESCRIPTION
## Summary

The IO RDMA backend registers GPU KV buffers and host notification buffers via the legacy `RegisterRdmaMemoryRegion`, which does a bare `ibv_reg_mr()` and `std::abort()`s on failure. That path depends on the `amdgpu_peermem` kernel module to register GPU virtual addresses. On clusters where `amdgpu_peermem` is **not** loaded (e.g. MI355X + Pensando Ionic AINIC nodes), every GPU KV registration fails and the engine aborts at the first prefill→decode transfer:

```
[application][error] RegisterRdmaMemoryRegion failed! addr:0x..., size:943718400, accessFlag:15, errno:22 (Invalid argument)
Fatal Python error: Aborted
```

`RegisterRdmaMemoryRegionAuto` already implements the correct behavior — dmabuf registration via `ibv_reg_dmabuf_mr` with an `ibv_reg_mr` fallback, gated by `MORI_ENABLE_DMABUF_REG` — but the IO backend was never wired to it. This PR switches the two IO call sites to `Auto`.

## Change

Two call sites in `src/io/rdma/backend_impl.cpp`:
- `RdmaManager::RegisterLocalMemory` (KV buffers, GPU memory)
- `NotifManager::RegisterEndpoint` (notification buffers, host memory)

Both now call `RegisterRdmaMemoryRegionAuto` instead of `RegisterRdmaMemoryRegion`.

`Auto` falls through to `ibv_reg_mr` when dmabuf export is unavailable, so there is **no behavior change** where the legacy path already succeeds (host memory, or GPU when `amdgpu_peermem` is present). On peermem-less clusters the dmabuf path (which the Ionic/ROCm stack supports) is used instead of aborting.

## Why not just set `MORI_ENABLE_DMABUF_REG=1`?

That env var is only consulted by `RegisterRdmaMemoryRegionAuto`. The plain `RegisterRdmaMemoryRegion` (which the IO backend called) ignores it and `std::abort()`s. Verified empirically: building current `main` and running with `MORI_ENABLE_DMABUF_REG=1` still aborts at the same registration, because the IO path never reaches the env-gated logic.

## Testing

- **Build:** `ninja mori_io` links clean (`libmori_io.so`), no new warnings.
- **Isolated ibverbs probes (MI355X + Ionic, no amdgpu_peermem):** legacy `ibv_reg_mr` on a GPU pointer fails at every size (errno 14/22); `ibv_reg_dmabuf_mr` succeeds up to 2 GiB/MR.
- **End-to-end (SGLang PD disaggregation, MoRI backend, Kimi-K2.6-MXFP4 on MI355X + Ionic):**
  - Before: aborts at the first KV transfer (`RegisterRdmaMemoryRegion failed! errno:22`).
  - After (equivalent dmabuf registration): prefill→decode KV transfer over RDMA succeeds; coherent output; 0 transfer errors; stable across repeated requests including a 1218-token prompt; 1P1D throughput sweep (ISL/OSL 1024/1024) scales cleanly to ~9K tok/s @ concurrency 128.

## Notes

- Base: `main` @ 33a903f.
- The dmabuf single-MR ceiling on Ionic is 2 GiB; callers registering a single buffer > 2 GiB must chunk (already true in practice).