### PR TITLE
Adapt mori check / mori setup for Mellanox NICs

### DIFF
--- a/.claude/skills/deploy-mori/SKILL.md
+++ b/.claude/skills/deploy-mori/SKILL.md
@@ -15,6 +15,19 @@ You are helping the user deploy MORI inside a Docker container.
 **Locate `MORI_REPO_DIR`**: default to the current working directory if it
 contains `pyproject.toml`; ask the user otherwise.
 
+**Detect whether `docker` needs `sudo`** — every `docker` command below is
+written with a `sudo` prefix, but on hosts where the calling user is already
+in the `docker` group, `sudo docker ...` fails non-interactively with `sudo:
+a password is required` (no TTY to prompt for a password). Check first:
+
+```bash
+docker ps &>/dev/null && echo "docker works without sudo" || echo "docker needs sudo"
+```
+
+If it works without `sudo`, drop the `sudo` prefix from **every** `docker`
+command in this skill (run/exec/inspect/start/cp/ps, …) for the rest of the
+session.
+
 **Detect NIC type** — determines whether Step 3 is needed:
 
 ```bash
@@ -110,6 +123,17 @@ sudo docker exec $CONTAINER_NAME bash -c "apt-get update && apt-get install -y -
     libgrpc++-dev protobuf-compiler-grpc libprotobuf-dev protobuf-compiler \
     libopenmpi-dev openmpi-bin"
 ```
+
+> **If `apt-get update` can't reach `archive.ubuntu.com`/`security.ubuntu.com`**
+> (`Network is unreachable` / `connection timed out`, often on cloud hosts
+> whose network only routes to a provider-internal mirror — e.g. seen on an
+> Oracle Cloud instance routed through `iad-ad-1.clouds.archive.ubuntu.com`):
+> the container's default `/etc/apt/sources.list` doesn't know about that
+> mirror even though the **host** does. Fix by copying the host's working
+> sources into the container before retrying:
+> ```bash
+> sudo docker cp /etc/apt/sources.list $CONTAINER_NAME:/etc/apt/sources.list
+> ```
 
 Non-obvious package roles:
 - `rdma-core` — version info `mori check` Step 1 reads. Without it, Step 1
@@ -295,16 +319,22 @@ works with no vendor repo at all. What's still missing for the full `mori
 check`/`mori setup` flow are two small, optional, standalone tools (**neither
 needs a full MLNX_OFED install**):
 
-- **`mlnx_qos`** (package `mlnx-tools`) — reads trust/PFC/DSCP state on RoCE ports.
-- **`mlxconfig`/`mst`** (NVIDIA MFT) — reads `ROCE_CC_PRIO_MASK_P1`/`CNP_DSCP_P1`
+- **`mlnx_qos`** (package `mlnx-tools`) — reads/sets trust/PFC/DSCP state on RoCE ports.
+- **`mlxconfig`/`mst`** (NVIDIA MFT) — reads/sets `ROCE_CC_PRIO_MASK_P1`/`CNP_DSCP_P1`
   from firmware NV config.
 
-Both optional: if missing, `mori check` logs `[WARN]` and skips those checks.
-If native IB ports outnumber RoCE ports, `mori check` treats RoCE port(s) as
-incidental and skips QoS/DCQCN anyway — Step 3c becomes unnecessary.
+Both optional: if missing, `mori check` logs `[WARN]` and skips those checks
+(and `mori setup` skips the corresponding fix). If native IB ports outnumber
+RoCE ports, `mori check` treats RoCE port(s) as incidental and skips
+QoS/DCQCN anyway — Step 3c becomes unnecessary.
 
-> **`mori setup` has no mlx5 auto-fix path** (only ionic/bnxt). On an mlx5
-> QoS/DCQCN `[FAIL]`, fix manually, e.g. `sudo mlnx_qos -i <netdev> --trust dscp`.
+> **`mori setup`'s mlx5 path** sets trust=dscp, maps the RoCE DSCP to its
+> priority, enables PFC no-drop on it, leaves TC arbitration on `vendor`
+> (no bandwidth split), and flips the `ROCE_CC_PRIO_MASK_P1` enable bit for
+> DCQCN via `mlxconfig` — CNP DSCP and the CC algorithm itself are left at
+> firmware defaults. A `mlxconfig` NV-config change needs a firmware reset
+> (`mlxfwreset -d <pci> -y reset`) or reboot to take effect; `mori setup`
+> only warns about this, it doesn't reset the NIC itself.
 
 ### 3c.1 — Detect host mlx5 driver/firmware version (informational only)
 
@@ -326,12 +356,25 @@ apt-get install -y --no-install-recommends make
 cd /tmp && rm -rf mlnx-tools
 git clone --depth 1 https://github.com/Mellanox/mlnx-tools.git
 cd mlnx-tools && make install
-mlnx_qos -i <netdev>   # sanity check; replace <netdev> with a real RoCE netdev
 '
 ```
 
 > `make install` places `mlnx_qos` at `/usr/bin/mlnx_qos`, helpers at
 > `/usr/share/mlnx-tools/python/` (script adds this to `sys.path` itself).
+
+**Sanity check — resolve a real netdev first.** `mlnx_qos -i <netdev>` needs
+an actual interface name; there's no way to hardcode one since it depends on
+which mlx5 device you pick. Resolve it from `/sys/class/infiniband/` instead
+of guessing:
+
+```bash
+sudo docker exec $CONTAINER_NAME bash -c '
+IB_DEV=$(ls /sys/class/infiniband/ | grep mlx5 | head -1)
+NETDEV=$(ls /sys/class/infiniband/$IB_DEV/device/net/ | head -1)
+echo "Using $IB_DEV -> $NETDEV"
+mlnx_qos -i "$NETDEV"
+'
+```
 
 ### 3c.3 — Install NVIDIA MFT (`mlxconfig`/`mst`)
 
@@ -452,18 +495,32 @@ RoCE ports (RoCE treated as an incidental management NIC). Steps 1/4/5/6 still
 cover every mlx5 device.
 
 > **Step 4 still probes incidental RoCE/management ports**, unlike 2/3 — the
-> full-mesh test tries every pair regardless, so a management NIC (e.g.
-> `mlx5_8`) on a separate Ethernet fabric shows unreachable (`✗`) against
-> every IB device both ways: `[WARN] intra-node BW: N/72 unreachable` where
-> `N = 2 × incidental_ports × fabric_ports`. Expected, not a fabric problem —
-> confirm the `✗` cells are only that port's row/column.
+> full-mesh test tries every pair regardless of link type or physical
+> network, so any port not on the main RDMA fabric shows unreachable (`✗`)
+> against every fabric port. This happens even with **zero native IB** —
+> e.g. a host with 8 ConnectX-7 fabric ports plus 2 ConnectX-6 Dx management
+> ports (`eth0`/`eth1` — a different HW generation, visible as its own
+> firmware-family group in Step 1's output) showed `[WARN] intra-node BW:
+> 34/90 unreachable`, with every `✗` confined to those two ports'
+> rows/columns — including the mgmt↔mgmt pair itself (also unreachable,
+> since the two management ports aren't on the same subnet as each other
+> either). Expected, not a fabric problem — confirm the `✗` cells are only
+> in incidental ports' rows/columns.
+>
+> General formula for the unreachable count: `N = n×(n-1) − f×(f-1)` where
+> `n` = total local RDMA devices and `f` = devices actually on the fabric
+> (equivalently `N = k×(k-1) + 2×k×f` for `k = n−f` incidental ports). This
+> is **not** `2 × incidental_ports × fabric_ports` — that simpler formula
+> only holds for exactly one incidental port; with 2+ incidental ports it
+> undercounts by missing the incidental↔incidental pairs (e.g. predicts 32
+> instead of the actual 34 in the example above).
 
 If any step shows `[FAIL]`:
 
 - `sudo docker exec $CONTAINER_NAME bash -c "mori setup"` auto-applies
-  QoS/PFC/DCQCN (ionic/bnxt only — on mlx5, fix manually per 3c then re-run
-  `mori check`). Env vars don't persist in the calling shell; use
-  `source $(mori setup --path)` to export them.
+  QoS/PFC/DCQCN on ionic/bnxt/mlx5. Env vars don't persist in the calling
+  shell; use `source $(mori setup --path)` to export them. On mlx5, a
+  DCQCN fix may need a firmware reset/reboot to take effect — see 3c.
 - Still failing: `sudo docker exec $CONTAINER_NAME bash -c "mori diagnose"`.
 
 ### mlx5 hardware faults (CQ errors / firmware health)

--- a/.claude/skills/deploy-mori/SKILL.md
+++ b/.claude/skills/deploy-mori/SKILL.md
@@ -3,9 +3,9 @@ name: deploy-mori
 description: >-
   Deploy and set up the MORI environment in a fresh Docker container or bare host:
   start the container, install ROCm dependencies, NIC userspace libraries
-  (AINIC/Broadcom), RDMA-core, and MORI itself. Use when the user asks
+  (AINIC/Broadcom/Mellanox-NVIDIA), RDMA-core, and MORI itself. Use when the user asks
   to deploy MORI, install MORI in a container, set up a fresh dev environment
-  for MORI, or prepare an AINIC / Thor2 box for MORI.
+  for MORI, or prepare an AINIC / Thor2 / mlx5 box for MORI.
 ---
 
 # Deploy MORI
@@ -18,9 +18,20 @@ contains `pyproject.toml`; ask the user otherwise.
 **Detect NIC type** — determines whether Step 3 is needed:
 
 ```bash
-lspci | grep -iE "pensando|ionic|dsc|pollara" && echo "→ ainic"
-lspci | grep -iE "broadcom.*thor|bnxt"         && echo "→ thor2"
-lspci | grep -iE "mellanox|connectx"           && echo "→ mlx5 (no Step 3 needed, works out of the box)"
+lspci | grep -iE "pensando|ionic|dsc|pollara"      && echo "→ ainic"
+lspci | grep -iE "broadcom.*thor|bnxt"             && echo "→ thor2"
+lspci | grep -iE "mellanox|connectx|nvidia.*bluefield" && echo "→ mlx5"
+```
+
+A host can have more than one type present — that's fine, `mori check`/`mori
+setup` only act on the vendor with the most matching RDMA devices.
+
+For mlx5, also check RoCE vs native InfiniBand (changes what Step 3c installs):
+
+```bash
+for d in /sys/class/infiniband/mlx5_*; do
+  echo "$(basename "$d"): $(cat "$d/ports/1/link_layer" 2>/dev/null)"
+done
 ```
 
 ---
@@ -28,11 +39,8 @@ lspci | grep -iE "mellanox|connectx"           && echo "→ mlx5 (no Step 3 need
 ## Step 1: Start the Docker container
 
 Use the container name from the user's args if provided; ask if not.
-
 Default image: `rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.10.0`
-(use this unless the user specifies another).
-
-Check if the container already exists:
+(use unless the user specifies another).
 
 ```bash
 if sudo docker inspect $CONTAINER_NAME &>/dev/null; then
@@ -42,7 +50,7 @@ else
 fi
 ```
 
-Probe optional mount paths on the host and only include ones that exist:
+Probe optional mount paths on the host, only include ones that exist:
 
 ```bash
 for p in /shared /apps /dev/infiniband /sys/kernel/config /sys/kernel/debug; do
@@ -80,13 +88,12 @@ sudo docker run \
 
 Notes:
 - `--network=host` + `--device=/dev/infiniband` required for RDMA visibility.
-- `--ulimit memlock=-1:-1` — RDMA pins memory when creating QPs; required for the
+- `--ulimit memlock=-1:-1` — RDMA pins memory on QP creation; needed for the
   parallel `mori check` bandwidth mesh.
-- `-v /sys/kernel/config` + `-v /sys/kernel/debug` — **required for bnxt (Broadcom)**:
-  `mori check` (DCQCN) and `mori setup` read/write congestion control via configfs.
-  `--privileged` does not propagate these kernel filesystems on its own. If the host
-  hasn't mounted them, mount on the host first:
-  `sudo mount -t configfs none /sys/kernel/config; sudo mount -t debugfs none /sys/kernel/debug`.
+- configfs/debugfs mounts are **required for bnxt** DCQCN (`mori check`/`mori
+  setup` read/write congestion control through them). `--privileged` alone
+  doesn't propagate them — if missing on the host: `sudo mount -t configfs
+  none /sys/kernel/config; sudo mount -t debugfs none /sys/kernel/debug`.
 - `--rm` — data outside mounted volumes is lost on stop.
 
 All subsequent steps run **inside** `$CONTAINER_NAME` via `docker exec`.
@@ -97,38 +104,34 @@ All subsequent steps run **inside** `$CONTAINER_NAME` via `docker exec`.
 
 ```bash
 sudo docker exec $CONTAINER_NAME bash -c "apt-get update && apt-get install -y --no-install-recommends \
-    git libpci-dev pciutils sudo libdw1 libibverbs-dev ibverbs-utils \
+    git libpci-dev pciutils sudo libdw1 libibverbs-dev ibverbs-utils rdma-core \
     locales iputils-ping iproute2 ethtool jq perftest \
     wget unzip ca-certificates curl \
     libgrpc++-dev protobuf-compiler-grpc libprotobuf-dev protobuf-compiler \
     libopenmpi-dev openmpi-bin"
 ```
 
-Package roles:
-- `jq` — required by `mori check`.
-- `pciutils` — provides `lspci`, which `nicctl` shells out to in order to enumerate
-  the NIC cards. Without it `nicctl` fails with `Invalid card handle` and the ionic
-  firmware / QoS / DCQCN checks in `mori check` / `mori setup` break.
-- `sudo` — the ionic and bnxt paths of `mori check` / `mori setup` invoke `nicctl`,
-  `dcb`, `ethtool`, and sysfs writes via `sudo`.
-- `perftest` — provides `ib_write_bw` / `ib_write_lat` for intra/inter-node bandwidth + latency checks.
-- `iproute2` — provides `dcb`, required by `mori setup` on bnxt NICs.
-- `wget unzip ca-certificates curl` — used by the NIC userspace install steps (Step 3a/3b).
-- `libgrpc++-dev protobuf-compiler-grpc libprotobuf-dev protobuf-compiler` — **mori build deps**:
-  the build defaults to `BUILD_UMBP=ON`, whose CMake step needs gRPC headers
-  (`grpcpp/grpcpp.h`). The remaining build tooling (`cmake`, `ninja`, `pybind11`) is
-  pulled in automatically by `pyproject.toml`'s build isolation, so it doesn't need
-  to be in the image.
-- `libopenmpi-dev openmpi-bin` — **MPI deps**: required for `MORI_WITH_MPI=ON` and
-  `BUILD_BENCHMARK=ON` (benchmark targets are gated behind `WITH_MPI`).
+Non-obvious package roles:
+- `rdma-core` — version info `mori check` Step 1 reads. Without it, Step 1
+  still passes but logs a cosmetic `[WARN] rdma-core package not found`.
+- `pciutils` (`lspci`) — `nicctl` shells out to it; missing it breaks the
+  ionic firmware/QoS/DCQCN checks with `Invalid card handle`.
+- `sudo` — ionic/bnxt paths of `mori check`/`mori setup` invoke `nicctl`,
+  `dcb`, `ethtool`, sysfs writes via `sudo`.
+- `perftest` — `ib_write_bw`/`ib_write_lat` for bandwidth/latency checks.
+- `iproute2` — provides `dcb`, needed by `mori setup` on bnxt.
+- `libgrpc++-dev` + protobuf packages — build defaults to `BUILD_UMBP=ON`,
+  whose CMake step needs gRPC headers. (`cmake`/`ninja`/`pybind11` come from
+  `pyproject.toml` build isolation automatically.)
+- `libopenmpi-dev openmpi-bin` — needed for `MORI_WITH_MPI=ON` /
+  `BUILD_BENCHMARK=ON` (benchmarks are gated behind `WITH_MPI`).
 
 ---
 
 ## Step 3: Install NIC userspace libraries
 
-Run the subsection matching the NIC type detected at the top:
-- `ainic` → **Step 3a** (AINIC / Pensando)
-- `thor2` / bnxt → **Step 3b** (Broadcom NetXtreme-E)
+Run the subsection matching the NIC type detected above:
+- `ainic` → **Step 3a**, `thor2`/bnxt → **Step 3b**, `mlx5` → **Step 3c**
 
 ---
 
@@ -143,7 +146,7 @@ Run the subsection matching the NIC type detected at the top:
 
 ### Detect host AINIC version and check against public repo
 
-Run on the **host** (outside container):
+Run on the **host**:
 
 ```bash
 IB_DEV=$(ls /sys/class/infiniband/ 2>/dev/null | head -1)
@@ -203,7 +206,7 @@ nicctl --version
 
 ## Step 3b: Install Broadcom (bnxt / thor2) userspace libraries + tools
 
-**Skip if NIC type is not `thor2` / bnxt.**
+**Skip if NIC type is not `thor2`/bnxt.**
 
 > **Recommended version**: for cross-node MORI (EP over RDMA / IBGDA), Broadcom firmware
 > is solid on `237.1.137.x` (official Broadcom release) and `235.2.86.x` (customer-specific
@@ -245,13 +248,13 @@ ldconfig
 '
 ```
 
-> Replace `235.2.86.0` with the version matching the host (3b.1). If that exact
-> version is gone from the repo, pick the nearest one from `apt-cache madison bnxt-rocelib`.
+> Replace `235.2.86.0` with the version matching the host (3b.1). If gone from
+> the repo, pick the nearest from `apt-cache madison bnxt-rocelib`.
 
 ### 3b.3 — Install a recent `niccli` (must support the `qos` subcommand)
 
-`mori check` Step 2 uses `niccli ... qos`, so install a niccli whose version tracks
-the firmware (236.x / 237.x for BCM57608). Parameterize the version:
+`mori check` Step 2 uses `niccli ... qos`, so install one tracking the
+firmware (236.x/237.x for BCM57608):
 
 ```bash
 sudo docker exec $CONTAINER_NAME bash -c '
@@ -266,29 +269,113 @@ niccli -i 1 qos --ingress --cosq --show | head   # should print the CoSQ table (
 '
 ```
 
-> Alternative (no download): the host usually already has a working niccli at
-> `/opt/niccli` (self-contained). You can `sudo docker cp /opt/niccli $CONTAINER_NAME:/opt/`
-> then `docker exec $CONTAINER_NAME ln -sf /opt/niccli/niccli /usr/bin/niccli`.
+> Alternative (no download): host usually has a working niccli at
+> `/opt/niccli`. `sudo docker cp /opt/niccli $CONTAINER_NAME:/opt/` then
+> `docker exec $CONTAINER_NAME ln -sf /opt/niccli/niccli /usr/bin/niccli`.
 
 ### 3b.4 — `dcb` (iproute2), needed by `mori setup`
-
-`mori setup` configures bnxt PFC/ETS via `dcb`, which ships with `iproute2`
-(installed in Step 2). Verify it's present:
 
 ```bash
 sudo docker exec $CONTAINER_NAME bash -c "command -v dcb"
 ```
 
-> `mori setup` does host-level NIC configuration (PFC/ETS on the netdev via `dcb`,
-> DCQCN via configfs). With `--network=host` the container shares the host's
-> netns, so it's equivalent to configure on the host. Either run `mori setup` on
-> the host, or ensure the container has `dcb` + configfs/debugfs (Step 1 mounts).
+> `mori setup` configures PFC/ETS via `dcb` and DCQCN via configfs, both at
+> host level. With `--network=host` the container shares the host netns, so
+> running it in-container is equivalent — just needs `dcb` + Step 1's mounts.
+
+---
+
+## Step 3c: Install Mellanox/NVIDIA (mlx5) userspace libraries + tools
+
+**Skip if NIC type is not `mlx5`.**
+
+The mlx5 RoCE userspace provider is **inbox** (Ubuntu's `rdma-core`/
+`ibverbs-providers`, already pulled in by Step 2, includes `libmlx5`) — RDMA
+works with no vendor repo at all. What's still missing for the full `mori
+check`/`mori setup` flow are two small, optional, standalone tools (**neither
+needs a full MLNX_OFED install**):
+
+- **`mlnx_qos`** (package `mlnx-tools`) — reads trust/PFC/DSCP state on RoCE ports.
+- **`mlxconfig`/`mst`** (NVIDIA MFT) — reads `ROCE_CC_PRIO_MASK_P1`/`CNP_DSCP_P1`
+  from firmware NV config.
+
+Both optional: if missing, `mori check` logs `[WARN]` and skips those checks.
+If native IB ports outnumber RoCE ports, `mori check` treats RoCE port(s) as
+incidental and skips QoS/DCQCN anyway — Step 3c becomes unnecessary.
+
+> **`mori setup` has no mlx5 auto-fix path** (only ionic/bnxt). On an mlx5
+> QoS/DCQCN `[FAIL]`, fix manually, e.g. `sudo mlnx_qos -i <netdev> --trust dscp`.
+
+### 3c.1 — Detect host mlx5 driver/firmware version (informational only)
+
+```bash
+cat /sys/class/infiniband/mlx5_*/fw_ver 2>/dev/null | sort -u   # firmware version(s)
+modinfo -F version mlx5_core 2>/dev/null                        # driver version
+```
+
+### 3c.2 — Install `mlnx_qos` (package: `mlnx-tools`)
+
+**Build from source from the upstream GitHub repo** — don't pull full
+MLNX_OFED just for this tiny, dependency-free, pure-Python tool. No version
+coupling to the host driver/firmware.
+
+```bash
+sudo docker exec $CONTAINER_NAME bash -c '
+set -e
+apt-get install -y --no-install-recommends make
+cd /tmp && rm -rf mlnx-tools
+git clone --depth 1 https://github.com/Mellanox/mlnx-tools.git
+cd mlnx-tools && make install
+mlnx_qos -i <netdev>   # sanity check; replace <netdev> with a real RoCE netdev
+'
+```
+
+> `make install` places `mlnx_qos` at `/usr/bin/mlnx_qos`, helpers at
+> `/usr/share/mlnx-tools/python/` (script adds this to `sys.path` itself).
+
+### 3c.3 — Install NVIDIA MFT (`mlxconfig`/`mst`)
+
+Proprietary/standalone, not in any apt repo — download the tarball and run
+its installer. **No firmware/driver version matching needed**: MFT is broadly
+backward/forward compatible across generations (verified: MFT 4.30.1 drives
+ConnectX-7 firmware 28.40.1702 fine). Just match arch/package type to the
+container OS; browse
+https://network.nvidia.com/products/adapter-software/firmware-tools/ if the
+URL below is stale.
+
+> **Prerequisite (fails silently without it):** `mst start` shells out to
+> `lsmod`/`modprobe`/`udevadm`. Minimal images (e.g. `rocm/pytorch`) lack
+> these — `install.sh` still reports success and `mst start` exits 0 despite
+> printing `No such file or directory`/`command not found`, but `mst status
+> -v` then shows `MST` column as `NA` and `/dev/mst/` stays empty (silently
+> broken `mlxconfig`/`mst`). Install first:
+> ```bash
+> sudo docker exec $CONTAINER_NAME bash -c "apt-get install -y --no-install-recommends kmod udev usbutils"
+> ```
+> Verify `mst status -v` shows real paths (e.g. `/dev/mst/mt4129_pciconf0`),
+> not `NA`, before trusting `mlxconfig`/`mst` output.
+
+```bash
+sudo docker exec $CONTAINER_NAME bash -c '
+set -e
+MFT_VER=4.30.1-1216
+ARCH=x86_64
+URL="https://www.mellanox.com/downloads/MFT/mft-${MFT_VER}-${ARCH}-deb.tgz"
+cd /tmp && curl -fsSL -O "$URL" && tar -xzf mft-*-deb.tgz
+cd mft-*-deb && ./install.sh --without-kernel
+mst start
+mst status -v
+'
+```
+
+> `--without-kernel` skips the optional `mst_pci` kernel module — MFT falls
+> back to plain PCI-config-space access, covered by Step 1's `--privileged`.
 
 ---
 
 ## Step 4: Install MORI
 
-`pybind11` is a required build dep missing from `pyproject.toml`. Run inside the container:
+`pybind11` is a required build dep missing from `pyproject.toml`:
 
 ```bash
 sudo docker exec -w $MORI_REPO_DIR $CONTAINER_NAME bash -c "
@@ -298,9 +385,8 @@ pip install .
 "
 ```
 
-**UMBP / gRPC:** the build defaults to `BUILD_UMBP=ON`, whose CMake step needs gRPC
-headers (installed in Step 2). To build without the UMBP storage component instead
-(no gRPC needed):
+**UMBP/gRPC:** build defaults to `BUILD_UMBP=ON` (needs gRPC headers from
+Step 2). To skip the storage component and its gRPC dep:
 
 ```bash
 sudo docker exec -w $MORI_REPO_DIR $CONTAINER_NAME bash -c "BUILD_UMBP=OFF pip install ."
@@ -347,37 +433,62 @@ ibv_devinfo | head -20
 sudo docker exec $CONTAINER_NAME bash -c "mori check"
 ```
 
-`mori check` validates the full RDMA stack in 6 steps (vendor-specific variants
-for ionic vs bnxt, same intent):
+`mori check` validates the RDMA stack in 6 steps (vendor-specific variants,
+same intent):
 
-1. **firmware & driver** — firmware/driver/userspace-lib versions consistent
-2. **QoS / SL / TC** — PFC + lossless TC; selects the SL/TC for MORI to use
+1. **firmware & driver** — versions consistent
+2. **QoS / SL / TC** — PFC + lossless TC; selects SL/TC for MORI
 3. **DCQCN** — congestion control enabled on all RoCE devices
-4. **intra-node bandwidth** — `ib_write_bw` between all local NIC pairs (requires `perftest`)
-5. **inter-node bandwidth** — `ib_write_bw` to a peer node; pass peer IP: `mori check <peer_ip>`
-6. **inter-node latency** — `ib_write_lat` to a peer node; same peer IP
+4. **intra-node bandwidth** — `ib_write_bw` full mesh (needs `perftest`)
+5. **inter-node bandwidth** — `ib_write_bw` to a peer: `mori check <peer_ip>`
+6. **inter-node latency** — `ib_write_lat` to a peer: same peer IP
 
-Steps 5 and 6 are skipped when no peer IP is given — run `mori check <peer_ip>` from both nodes to test cross-node connectivity.
+Steps 5/6 are skipped without a peer IP — run from both nodes to test cross-node connectivity.
+
+**mlx5 note:** native IB ports don't use PFC/DSCP/DCQCN (IB has its own
+credit-based flow control managed by the fabric SM) — steps 2/3 only run
+against Ethernet/RoCE ports, and are skipped entirely if IB ports outnumber
+RoCE ports (RoCE treated as an incidental management NIC). Steps 1/4/5/6 still
+cover every mlx5 device.
+
+> **Step 4 still probes incidental RoCE/management ports**, unlike 2/3 — the
+> full-mesh test tries every pair regardless, so a management NIC (e.g.
+> `mlx5_8`) on a separate Ethernet fabric shows unreachable (`✗`) against
+> every IB device both ways: `[WARN] intra-node BW: N/72 unreachable` where
+> `N = 2 × incidental_ports × fabric_ports`. Expected, not a fabric problem —
+> confirm the `✗` cells are only that port's row/column.
 
 If any step shows `[FAIL]`:
 
-- Run `mori setup` to auto-apply recommended QoS/PFC/DCQCN settings:
-  ```bash
-  sudo docker exec $CONTAINER_NAME bash -c "mori setup"
-  ```
-  Note: env vars (`MORI_RDMA_SL`/`TC`) do **not** persist in the calling shell. To export them, use `source $(mori setup --path)` instead.
+- `sudo docker exec $CONTAINER_NAME bash -c "mori setup"` auto-applies
+  QoS/PFC/DCQCN (ionic/bnxt only — on mlx5, fix manually per 3c then re-run
+  `mori check`). Env vars don't persist in the calling shell; use
+  `source $(mori setup --path)` to export them.
+- Still failing: `sudo docker exec $CONTAINER_NAME bash -c "mori diagnose"`.
 
-- If the issue persists, run `mori diagnose` for deeper diagnostics:
-  ```bash
-  sudo docker exec $CONTAINER_NAME bash -c "mori diagnose"
-  ```
+### mlx5 hardware faults (CQ errors / firmware health)
+
+`dmesg` repeating `cq_err_event_notifier: CQ error ..., syndrome 0x2`
+(LOCAL_QP_OP_ERR) or `poll_health: device's health compromised` means the
+card's *firmware* faulted. `mlxfwreset -d <mst_device> q` will likely show
+only `4: Warm Reboot` supported — a host reboot is the only recovery path.
+
+> **Caveat (hit on this box):** an OS-level `reboot` fixed the mlx5 fault but
+> left every GPU on the same baseboard (AMD MI300/Aqua Vanjaram) failing to
+> probe (`amdgpu: get invalid ip discovery binary signature`, all GPUs at
+> once) — a warm reboot doesn't fully power-cycle the GPU baseboard's PSP.
+> Neither `modprobe -r/+ amdgpu` nor per-device PCIe reset
+> (`echo 1 > /sys/bus/pci/devices/0000:XX:00.0/reset`) fixed it; only a real
+> BMC power cycle did: `sudo ipmitool chassis power cycle`. This is far more
+> disruptive than `reboot` (drops every user's session on a shared host) —
+> confirm no one else needs the box, or escalate to the hardware owner instead.
 
 ---
 
 ## Done — Report Back
 
 - Base image and OS
-- NIC library installed (`libionic` / `libbnxt_re` / none)
+- NIC library installed (`libionic` / `libbnxt_re` / mlx5 inbox `libmlx5` + optional `mlnx-tools`/MFT / none)
 - Install mode: source (`pip install .`)
 - GPU arch and NIC type as reported by MORI
 - Kernels: JIT on first use (`~/.mori/jit/`)

--- a/python/mori/cli.py
+++ b/python/mori/cli.py
@@ -94,10 +94,11 @@ def _cmd_setup(rest: List[str]) -> int:
 
     ``env_setup.sh`` does two things:
 
-    1. Configures PFC / DSCP / DCQCN on the ionic NICs via ``sudo
-       nicctl``. These are system-side changes that persist beyond the
-       calling process — running the script as a normal subprocess is
-       sufficient.
+    1. Configures PFC / DSCP / DCQCN on the detected NICs (ionic via
+       ``nicctl``, bnxt via ``dcb``/configfs, mlx5 via ``mlnx_qos``/
+       ``mlxconfig``). These are system-side changes that persist beyond
+       the calling process — running the script as a normal subprocess
+       is sufficient.
     2. Exports ``MORI_RDMA_SL`` / ``MORI_RDMA_TC`` for the calling
        shell. A Python entry point cannot mutate its parent shell's
        environment, so getting these into your current shell requires
@@ -114,10 +115,10 @@ def _cmd_setup(rest: List[str]) -> int:
     parser = argparse.ArgumentParser(
         prog="mori setup",
         description=(
-            "Run env_setup.sh to configure PFC / DSCP / DCQCN on ionic NICs. "
-            "To also pick up the exported MORI_RDMA_SL / MORI_RDMA_TC variables "
-            "in your current shell, source the script instead: "
-            "`source $(mori setup --path)`."
+            "Run env_setup.sh to configure PFC / DSCP / DCQCN on the detected "
+            "ionic/bnxt/mlx5 NICs. To also pick up the exported MORI_RDMA_SL / "
+            "MORI_RDMA_TC variables in your current shell, source the script "
+            "instead: `source $(mori setup --path)`."
         ),
         epilog=(
             "Examples:\n"

--- a/tools/env_check.sh
+++ b/tools/env_check.sh
@@ -53,6 +53,45 @@ require_cmd() {
     command -v "$1" > /dev/null 2>&1 || die "$1 not found. Please install it first."
 }
 
+# report_driver_version <kernel_module>
+#   Compares on-disk (modinfo) vs loaded (/sys/module or lsmod) version of a
+#   kernel module and logs ok/warn/fail accordingly. Shared by any vendor
+#   check that needs a "driver version sane?" line (bnxt_re/bnxt_en, mlx5_core).
+report_driver_version() {
+    local m="$1" disk_ver load_ver
+    disk_ver=$(modinfo -F version "$m" 2>/dev/null || true)
+    if [[ -r "/sys/module/$m/version" ]]; then
+        load_ver=$(cat "/sys/module/$m/version")
+    elif lsmod | awk '{print $1}' | grep -qx "$m"; then
+        load_ver="(loaded, no version node)"
+    else
+        load_ver="(not loaded)"
+    fi
+    if [[ "${load_ver:0:1}" != "(" ]]; then
+        log_ok "$m driver : $load_ver"
+        [[ -n "$disk_ver" && "$disk_ver" != "$load_ver" ]] \
+            && log_warn "$m on-disk ($disk_ver) differs from loaded ($load_ver) — reboot needed?"
+    else
+        [[ -n "$disk_ver" ]] && log_ok "$m driver (on-disk) : $disk_ver" \
+                             || log_fail "$m : not installed"
+    fi
+}
+
+# report_uniform <label> <value...>
+#   Logs ok if every value is identical, warn listing the distinct values
+#   otherwise. No-op if no values are given. Shared by any "same config
+#   across all NICs?" check (firmware versions, CNP DSCP, ...).
+report_uniform() {
+    local label="$1"; shift
+    [[ $# -gt 0 ]] || return 0
+    local uniq; uniq=$(printf '%s\n' "$@" | sort -u)
+    if [[ $(grep -c . <<<"$uniq") -gt 1 ]]; then
+        log_warn "$label inconsistent across NICs:"; printf '         %s\n' $uniq
+    else
+        log_ok "$label : $uniq (consistent across all $# NICs)"
+    fi
+}
+
 # =============== ssh: identity + connection multiplexing ========
 
 # SSH identity for peer access. Under sudo, $(whoami) is root (no authorized key),
@@ -926,6 +965,265 @@ check_bnxt_dcqcn() {
     [[ $fail -eq 0 ]]
 }
 
+# =================== mlx5 (Mellanox/NVIDIA) checks ==================
+# All three functions below skip gracefully on non-mlx5 hosts. QoS/DCQCN
+# checks only apply to ports running as Ethernet (RoCE) -- native
+# InfiniBand link layer ports use IB's own congestion control, not DCQCN,
+# and mlnx_qos/mlxconfig CC params don't apply to them.
+# They share the MLX5_ROCE_DEVS / MLX5_ROCE_ETH arrays populated by
+# check_mlx5_versions(); call that one first.
+
+MLX5_DEVS=()        # all mlx5 IB device names (IB + Ethernet link layer)
+MLX5_ROCE_DEVS=()   # subset of the above running as Ethernet (RoCE-capable)
+MLX5_ROCE_ETH=()    # corresponding net devices, same order as MLX5_ROCE_DEVS
+
+# Populate MLX5_DEVS / MLX5_ROCE_DEVS / MLX5_ROCE_ETH, check fw/driver versions.
+check_mlx5_versions() {
+    step "check mlx5 firmware and driver version (Mellanox/NVIDIA NICs)"
+    log_ok "Mellanox ConnectX (mlx5) — good backward compatibility, no known minimum version for IBGDA"
+
+    local ib_root="/sys/class/infiniband"
+    if [[ ! -d "$ib_root" ]]; then
+        log_skip "RDMA stack not loaded ($ib_root absent)"; return 0
+    fi
+
+    mapfile -t MLX5_DEVS < <(
+        find "$ib_root" -maxdepth 1 -mindepth 1 -type l -printf '%f\n' \
+        | grep '^mlx5_' | sort -V)
+
+    if [[ ${#MLX5_DEVS[@]} -eq 0 ]]; then
+        log_skip "no mlx5 devices found, skipping Mellanox checks"; return 0
+    fi
+    log_ok "mlx5 devices (${#MLX5_DEVS[@]}): ${MLX5_DEVS[*]}"
+
+    # --- kernel module version ---
+    report_driver_version mlx5_core
+
+    # mlx5_ib has no standalone `version:` field in modinfo (it's built from
+    # the same driver source/package as mlx5_core), so report_driver_version's
+    # modinfo-based approach doesn't apply -- confirm it's loaded and resolve
+    # its version via the owning package (e.g. mlnx-ofed-kernel-modules) instead.
+    if lsmod | awk '{print $1}' | grep -qx mlx5_ib; then
+        local mlx5_ib_ko mlx5_ib_pkg_ver
+        mlx5_ib_ko=$(modinfo -F filename mlx5_ib 2>/dev/null || true)
+        mlx5_ib_pkg_ver=$([[ -n "$mlx5_ib_ko" ]] && dpkg -S "$mlx5_ib_ko" 2>/dev/null \
+            | cut -d: -f1 | xargs -r dpkg-query -W -f='${Version}' 2>/dev/null || true)
+        if [[ -n "$mlx5_ib_pkg_ver" ]]; then
+            log_ok "mlx5_ib driver : $mlx5_ib_pkg_ver (bundled with mlx5_core, same driver package)"
+        else
+            log_ok "mlx5_ib driver : loaded (inbox kernel module, tied to kernel $(uname -r))"
+        fi
+    else
+        log_fail "mlx5_ib : not loaded"
+    fi
+
+    # --- RoCE userspace library (rdma-core ships libmlx5) ---
+    local rdma_core_ver
+    rdma_core_ver=$(dpkg-query -W -f='${Version}' rdma-core 2>/dev/null || true)
+    [[ -n "$rdma_core_ver" ]] && log_ok "rdma-core (libmlx5) userspace : $rdma_core_ver" \
+                              || log_warn "rdma-core package not found (libmlx5 version unknown)"
+
+    # --- per-device firmware version, link layer, port state, netdev ---
+    # fw_ver / link_layer / port state are all plain sysfs reads (no MFT
+    # needed). Only Ethernet/RoCE ports are required to be ACTIVE; native
+    # IB ports may legitimately be Down on a RoCE-only host.
+    local dev state link fw_ver eth_dev devid
+    local active_count=0 inactive_devs=()
+    local -A fw_by_model=()  # PCI device id -> space-separated fw versions seen
+    for dev in "${MLX5_DEVS[@]}"; do
+        state=$(awk -F': *' '{print $2}' "$ib_root/$dev/ports/1/state" 2>/dev/null || true)
+        link=$(cat "$ib_root/$dev/ports/1/link_layer" 2>/dev/null || true)
+        fw_ver=$(cat "$ib_root/$dev/fw_ver" 2>/dev/null || true)
+        eth_dev=$(basename "$(readlink -f "$ib_root/$dev/device/net/"* 2>/dev/null)" 2>/dev/null || true)
+        devid=$(cat "$ib_root/$dev/device/device" 2>/dev/null || echo "unknown")
+
+        [[ -n "$fw_ver" ]] && fw_by_model["$devid"]+="$fw_ver "
+
+        if [[ "$link" == "Ethernet" ]]; then
+            MLX5_ROCE_DEVS+=("$dev")
+            [[ -n "$eth_dev" ]] && MLX5_ROCE_ETH+=("$eth_dev")
+        fi
+
+        if [[ "${state:-}" == "ACTIVE" ]]; then
+            (( active_count++ ))
+            log_ok "$dev : fw=${fw_ver:-?}  link=${link:-?}  eth=${eth_dev:-none}  state=$state"
+        else
+            [[ "$link" == "Ethernet" ]] && inactive_devs+=("$dev")
+            log_warn "$dev : fw=${fw_ver:-?}  link=${link:-?}  eth=${eth_dev:-none}  state=${state:-?}"
+        fi
+    done
+
+    # --- firmware version consistency, grouped per card model (PCI device id) ---
+    # Different mlx5 card generations legitimately run different firmware
+    # baselines (e.g. a ConnectX-7 fleet plus a ConnectX-5 management NIC),
+    # so only flag inconsistency *within* the same model, not across models.
+    if [[ ${#fw_by_model[@]} -eq 0 ]]; then
+        log_warn "could not read firmware version from any mlx5 device"
+    else
+        local model devname fw_uniq n_devs
+        for model in "${!fw_by_model[@]}"; do
+            devname=$(lspci -d "15b3:$model" -mm 2>/dev/null | head -1 | awk -F'"' '{print $6}')
+            fw_uniq=$(tr ' ' '\n' <<<"${fw_by_model[$model]}" | sed '/^$/d' | sort -u)
+            n_devs=$(tr ' ' '\n' <<<"${fw_by_model[$model]}" | sed '/^$/d' | wc -l)
+            if [[ $(grep -c . <<<"$fw_uniq") -gt 1 ]]; then
+                log_warn "mlx5 firmware inconsistent across ${devname:-PCI id $model} devices:"
+                printf '         %s\n' $fw_uniq
+            else
+                log_ok "mlx5 firmware (${devname:-PCI id $model}) : $fw_uniq (consistent across $n_devs device(s))"
+            fi
+        done
+    fi
+
+    # If native IB ports outnumber RoCE ports, the RoCE port(s) are most
+    # likely an incidental management/other-purpose NIC rather than the
+    # fabric MORI actually runs its RDMA traffic over (e.g. 8 IB ports used
+    # for MORI + 1 RoCE port used only for SSH/management). In that case,
+    # skip QoS/DCQCN checks entirely instead of failing on a port that
+    # doesn't matter for MORI -- clearing MLX5_ROCE_DEVS routes both
+    # check_mlx5_qos and check_mlx5_dcqcn to their "nothing to check" skip.
+    local ib_count=$(( ${#MLX5_DEVS[@]} - ${#MLX5_ROCE_DEVS[@]} ))
+    if [[ ${#MLX5_ROCE_DEVS[@]} -eq 0 ]]; then
+        log_warn "no mlx5 ports running as Ethernet/RoCE — skipping QoS/DCQCN checks (native IB uses its own CC)"
+    elif (( ib_count > ${#MLX5_ROCE_DEVS[@]} )); then
+        log_skip "native IB ports ($ib_count) outnumber RoCE ports (${#MLX5_ROCE_DEVS[@]}: ${MLX5_ROCE_DEVS[*]}) — treating RoCE port(s) as incidental, not MORI's RDMA fabric; skipping QoS/DCQCN"
+        MLX5_ROCE_DEVS=()
+        MLX5_ROCE_ETH=()
+    else
+        log_ok "RoCE-capable mlx5 ports (${#MLX5_ROCE_DEVS[@]}): ${MLX5_ROCE_DEVS[*]}"
+        if [[ ${#inactive_devs[@]} -gt 0 ]]; then
+            log_fail "${#inactive_devs[@]} RoCE port(s) not ACTIVE: ${inactive_devs[*]}"
+        else
+            log_ok "all ${#MLX5_ROCE_DEVS[@]} RoCE ports ACTIVE"
+        fi
+    fi
+}
+
+# Check PFC and DSCP-based QoS for mlx5 RoCE ports via mlnx_qos; derive
+# MORI_RDMA_SL / MORI_RDMA_TC. Uses the first RoCE-capable port as the
+# representative (QoS config is expected to be homogeneous across NICs).
+check_mlx5_qos() {
+    step "check mlx5 QoS / PFC (Mellanox/NVIDIA NICs)"
+
+    if [[ ${#MLX5_ROCE_DEVS[@]} -eq 0 ]]; then
+        log_skip "no RoCE-capable mlx5 devices, run check_mlx5_versions first"; return 0
+    fi
+
+    if ! command -v mlnx_qos >/dev/null 2>&1; then
+        log_warn "mlnx_qos not found, cannot check QoS/PFC"; return 0
+    fi
+
+    local rep_dev="${MLX5_ROCE_DEVS[0]}" rep_eth="${MLX5_ROCE_ETH[0]:-}"
+    if [[ -z "$rep_eth" ]]; then
+        log_fail "$rep_dev : cannot resolve underlying net device"; return 1
+    fi
+
+    # mlnx_qos wants the *net device* name (e.g. ens14np0), NOT the RDMA
+    # device name (e.g. mlx5_8) -- passing the RDMA name fails with a
+    # netlink ENODEV that the tool masks as "not supported on your system".
+    local qos_output
+    qos_output=$(sudo mlnx_qos -i "$rep_eth" 2>&1)
+
+    # Non-fatal from here on (unlike ionic's check_qos): a misconfigured
+    # RoCE port must not abort the whole script when the host's actual RDMA
+    # fabric is native IB (or another RoCE port) -- the later intra/inter
+    # node mesh tests should still get a chance to run.
+    local trust
+    trust=$(echo "$qos_output" | grep "Priority trust state" | head -1 | awk '{print $NF}')
+    if [[ "$trust" != "dscp" ]]; then
+        log_fail "$rep_eth : trust state is '$trust', expected 'dscp'"; return 1
+    fi
+    log_ok "$rep_eth : trust state = dscp"
+
+    # PFC configuration table:
+    #   priority    0   1   2   3   4   5   6   7
+    #   enabled     0   0   1   1   0   0   0   0
+    local pfc_line enabled_arr=() nd_prios=()
+    pfc_line=$(echo "$qos_output" | grep -A2 "PFC configuration" | tail -1)
+    read -ra enabled_arr <<< "$(echo "$pfc_line" | awk '{$1=""; print}')"
+    local p
+    for p in "${!enabled_arr[@]}"; do
+        [[ "${enabled_arr[$p]}" == "1" ]] && nd_prios+=("$p")
+    done
+    if [[ ${#nd_prios[@]} -eq 0 ]]; then
+        log_fail "$rep_eth : PFC is not enabled on any priority"; return 1
+    fi
+    log_ok "$rep_eth : PFC enabled on priorities: ${nd_prios[*]}"
+
+    # dscp2prio mapping (only printed when trust=dscp):
+    #   prio:3 dscp:24,26,46,...
+    local -A prio_dscp=()
+    while IFS= read -r line; do
+        [[ "$line" =~ prio:([0-9]+)[[:space:]]+dscp:([0-9,]+) ]] || continue
+        prio_dscp["${BASH_REMATCH[1]}"]+="${BASH_REMATCH[2]}"
+    done < <(echo "$qos_output" | grep -E "^[[:space:]]*prio:[0-9]+[[:space:]]+dscp:")
+
+    # Pick a no-drop priority + DSCP. Preference order (mirrors check_qos):
+    #   1) DSCP 26 (RoCEv2 convention; also what env_setup.sh explicitly maps)
+    #      if it maps to any no-drop priority
+    #   2) otherwise the first no-drop priority's first mapped DSCP
+    local best_prio="" best_dscp=""
+    for p in "${nd_prios[@]}"; do
+        local dl="${prio_dscp[$p]:-}"
+        if [[ -z "$dl" ]]; then
+            log_warn "$rep_eth : no DSCP mapped to no-drop priority $p"; continue
+        fi
+        log_ok "$rep_eth : priority $p : DSCPs=[${dl%,}]"
+        if [[ ",$dl" == *",26,"* ]]; then
+            best_prio="$p"; best_dscp=26; break
+        fi
+        [[ -z "$best_prio" ]] && { best_prio="$p"; best_dscp="${dl%%,*}"; }
+    done
+    if [[ -z "$best_prio" ]]; then
+        log_fail "$rep_eth : could not derive SL/TC from QoS info"; return 1
+    fi
+
+    # TC = DSCP << 2 (DSCP occupies the upper 6 bits of the 8-bit TC/TOS field)
+    MORI_RDMA_SL="$best_prio"
+    MORI_RDMA_TC=$(( best_dscp * 4 ))
+    log_ok "selected SL=$MORI_RDMA_SL  TC=$MORI_RDMA_TC  (priority $best_prio, DSCP $best_dscp)"
+}
+
+# Check DCQCN (ECN-based congestion control) for mlx5 RoCE ports via
+# mlxconfig (firmware NV config: ROCE_CC_PRIO_MASK_P1 / CNP_DSCP_P1).
+# Requires NVIDIA MFT (mst/mlxconfig); skips gracefully if unavailable.
+check_mlx5_dcqcn() {
+    step "check mlx5 DCQCN (Mellanox/NVIDIA NICs)"
+
+    if [[ ${#MLX5_ROCE_DEVS[@]} -eq 0 ]]; then
+        log_skip "no RoCE-capable mlx5 devices, run check_mlx5_versions first"; return 0
+    fi
+
+    if ! command -v mlxconfig >/dev/null 2>&1; then
+        log_warn "mlxconfig not found (NVIDIA MFT not installed), cannot check DCQCN"; return 0
+    fi
+    command -v mst >/dev/null 2>&1 && sudo mst start >/dev/null 2>&1
+
+    local fail=0 cnp_dscps=()
+    local dev pci q mask cnp_dscp
+    for dev in "${MLX5_ROCE_DEVS[@]}"; do
+        pci=$(basename "$(readlink -f "/sys/class/infiniband/$dev/device")" 2>/dev/null)
+        if [[ -z "$pci" ]]; then
+            log_warn "$dev : cannot resolve PCI address"; continue
+        fi
+        q=$(sudo mlxconfig -d "$pci" q 2>/dev/null)
+        mask=$(echo "$q" | grep -i "ROCE_CC_PRIO_MASK_P1" | awk '{print $NF}')
+        cnp_dscp=$(echo "$q" | grep -i "CNP_DSCP_P1" | awk '{print $NF}')
+        if [[ -z "$mask" ]]; then
+            log_warn "$dev (pci=$pci) : cannot query ROCE_CC_PRIO_MASK_P1"; continue
+        fi
+        if [[ "$mask" == "0" ]]; then
+            log_fail "$dev (pci=$pci) : DCQCN disabled (ROCE_CC_PRIO_MASK_P1=0)"; fail=1
+        else
+            log_ok "$dev (pci=$pci) : DCQCN enabled (ROCE_CC_PRIO_MASK_P1=$mask, CNP_DSCP=${cnp_dscp:-?})"
+        fi
+        [[ -n "$cnp_dscp" ]] && cnp_dscps+=("$cnp_dscp")
+    done
+
+    report_uniform "CNP DSCP" "${cnp_dscps[@]}"
+
+    [[ $fail -eq 0 ]]
+}
+
 check_inter_node_lat() {
     step "inter-node latency check (full mesh)"
 
@@ -1018,8 +1316,9 @@ case "$_dominant_vendor" in
         check_bnxt_dcqcn
         ;;
     mlx)
-        step "check mlx5 (Mellanox) NIC"
-        log_ok "Mellanox ConnectX (mlx5) detected (${_dominant_count}) — good backward compatibility, no known minimum version for IBGDA"
+        check_mlx5_versions
+        check_mlx5_qos
+        check_mlx5_dcqcn
         ;;
     *)
         log_warn "no ionic, bnxt_re, or mlx5 NICs detected — skipping NIC-specific checks"

--- a/tools/env_check.sh
+++ b/tools/env_check.sh
@@ -966,16 +966,46 @@ check_bnxt_dcqcn() {
 }
 
 # =================== mlx5 (Mellanox/NVIDIA) checks ==================
-# All three functions below skip gracefully on non-mlx5 hosts. QoS/DCQCN
-# checks only apply to ports running as Ethernet (RoCE) -- native
-# InfiniBand link layer ports use IB's own congestion control, not DCQCN,
-# and mlnx_qos/mlxconfig CC params don't apply to them.
-# They share the MLX5_ROCE_DEVS / MLX5_ROCE_ETH arrays populated by
-# check_mlx5_versions(); call that one first.
+# QoS/DCQCN only apply to Ethernet/RoCE ports (native IB uses its own CC).
+# Call check_mlx5_versions() first; it populates the arrays below.
 
 MLX5_DEVS=()        # all mlx5 IB device names (IB + Ethernet link layer)
-MLX5_ROCE_DEVS=()   # subset of the above running as Ethernet (RoCE-capable)
+MLX5_ROCE_DEVS=()   # subset running as Ethernet (RoCE-capable)
 MLX5_ROCE_ETH=()    # corresponding net devices, same order as MLX5_ROCE_DEVS
+
+# dscp2prio + PFC-enabled map from mlnx_qos, filled by check_mlx5_qos() and
+# reused by check_mlx5_dcqcn() to resolve a DSCP's priority/PFC state.
+declare -A MLX5_QOS_PRIO_DSCP=()   # priority -> comma-list of DSCPs
+MLX5_QOS_PFC_ENABLED=()            # index=priority, "1"/"0"
+
+# mlx5_prio_pfc_for_dscp <dscp> -> prints "<priority> <enabled|disabled>".
+# Fails if check_mlx5_qos() hasn't populated the maps above.
+mlx5_prio_pfc_for_dscp() {
+    local dscp="$1" p
+    for p in "${!MLX5_QOS_PRIO_DSCP[@]}"; do
+        [[ ",${MLX5_QOS_PRIO_DSCP[$p]}," == *",$dscp,"* ]] || continue
+        local pfc="disabled"
+        [[ "${MLX5_QOS_PFC_ENABLED[$p]:-0}" == "1" ]] && pfc="enabled"
+        echo "$p $pfc"
+        return 0
+    done
+    return 1
+}
+
+# mlx5_report_dscp_prio <label> <dscp> -> logs the priority/PFC state for a
+# DSCP (via mlx5_prio_pfc_for_dscp) and sets MLX5_LAST_PFC to "enabled" /
+# "disabled" (empty if unresolvable) for the caller to act on. Must be
+# called directly (not via $(...)) so its log_* output isn't captured.
+mlx5_report_dscp_prio() {
+    local label="$1" dscp="$2" lookup
+    MLX5_LAST_PFC=""
+    if lookup=$(mlx5_prio_pfc_for_dscp "$dscp"); then
+        MLX5_LAST_PFC="${lookup#* }"
+        log_ok "$(printf '%-4s' "$label") DSCP=$dscp : priority ${lookup% *}, PFC $MLX5_LAST_PFC"
+    else
+        log_warn "$(printf '%-4s' "$label") DSCP=$dscp : priority/PFC unknown (check_mlx5_qos didn't run or has no dscp2prio mapping)"
+    fi
+}
 
 # Populate MLX5_DEVS / MLX5_ROCE_DEVS / MLX5_ROCE_ETH, check fw/driver versions.
 check_mlx5_versions() {
@@ -996,91 +1026,56 @@ check_mlx5_versions() {
     fi
     log_ok "mlx5 devices (${#MLX5_DEVS[@]}): ${MLX5_DEVS[*]}"
 
-    # --- kernel module version ---
     report_driver_version mlx5_core
-
-    # mlx5_ib has no standalone `version:` field in modinfo (it's built from
-    # the same driver source/package as mlx5_core), so report_driver_version's
-    # modinfo-based approach doesn't apply -- confirm it's loaded and resolve
-    # its version via the owning package (e.g. mlnx-ofed-kernel-modules) instead.
     if lsmod | awk '{print $1}' | grep -qx mlx5_ib; then
-        local mlx5_ib_ko mlx5_ib_pkg_ver
-        mlx5_ib_ko=$(modinfo -F filename mlx5_ib 2>/dev/null || true)
-        mlx5_ib_pkg_ver=$([[ -n "$mlx5_ib_ko" ]] && dpkg -S "$mlx5_ib_ko" 2>/dev/null \
-            | cut -d: -f1 | xargs -r dpkg-query -W -f='${Version}' 2>/dev/null || true)
-        if [[ -n "$mlx5_ib_pkg_ver" ]]; then
-            log_ok "mlx5_ib driver : $mlx5_ib_pkg_ver (bundled with mlx5_core, same driver package)"
-        else
-            log_ok "mlx5_ib driver : loaded (inbox kernel module, tied to kernel $(uname -r))"
-        fi
+        log_ok "mlx5_ib driver : loaded (same package as mlx5_core)"
     else
         log_fail "mlx5_ib : not loaded"
     fi
 
-    # --- RoCE userspace library (rdma-core ships libmlx5) ---
     local rdma_core_ver
     rdma_core_ver=$(dpkg-query -W -f='${Version}' rdma-core 2>/dev/null || true)
     [[ -n "$rdma_core_ver" ]] && log_ok "rdma-core (libmlx5) userspace : $rdma_core_ver" \
                               || log_warn "rdma-core package not found (libmlx5 version unknown)"
 
-    # --- per-device firmware version, link layer, port state, netdev ---
-    # fw_ver / link_layer / port state are all plain sysfs reads (no MFT
-    # needed). Only Ethernet/RoCE ports are required to be ACTIVE; native
-    # IB ports may legitimately be Down on a RoCE-only host.
-    local dev state link fw_ver eth_dev devid
-    local active_count=0 inactive_devs=()
-    local -A fw_by_model=()  # PCI device id -> space-separated fw versions seen
+    # Only Ethernet/RoCE ports must be ACTIVE; native IB ports may legitimately
+    # be Down on a RoCE-only host.
+    local dev state link fw_ver eth_dev devid inactive_devs=()
+    local -A fw_by_model=()  # PCI device id -> space-separated fw versions
     for dev in "${MLX5_DEVS[@]}"; do
-        state=$(awk -F': *' '{print $2}' "$ib_root/$dev/ports/1/state" 2>/dev/null || true)
-        link=$(cat "$ib_root/$dev/ports/1/link_layer" 2>/dev/null || true)
-        fw_ver=$(cat "$ib_root/$dev/fw_ver" 2>/dev/null || true)
-        eth_dev=$(basename "$(readlink -f "$ib_root/$dev/device/net/"* 2>/dev/null)" 2>/dev/null || true)
-        devid=$(cat "$ib_root/$dev/device/device" 2>/dev/null || echo "unknown")
+        state=$(awk -F': *' '{print $2}' "$ib_root/$dev/ports/1/state" 2>/dev/null)
+        link=$(cat "$ib_root/$dev/ports/1/link_layer" 2>/dev/null)
+        fw_ver=$(cat "$ib_root/$dev/fw_ver" 2>/dev/null)
+        eth_dev=$(basename "$(readlink -f "$ib_root/$dev/device/net/"* 2>/dev/null)" 2>/dev/null)
+        devid=$(cat "$ib_root/$dev/device/device" 2>/dev/null)
 
-        [[ -n "$fw_ver" ]] && fw_by_model["$devid"]+="$fw_ver "
-
+        [[ -n "$fw_ver" ]] && fw_by_model["${devid:-?}"]+="$fw_ver "
         if [[ "$link" == "Ethernet" ]]; then
             MLX5_ROCE_DEVS+=("$dev")
             [[ -n "$eth_dev" ]] && MLX5_ROCE_ETH+=("$eth_dev")
+            [[ "$state" == "ACTIVE" ]] || inactive_devs+=("$dev")
         fi
 
-        if [[ "${state:-}" == "ACTIVE" ]]; then
-            (( active_count++ ))
-            log_ok "$dev : fw=${fw_ver:-?}  link=${link:-?}  eth=${eth_dev:-none}  state=$state"
+        if [[ "$state" == "ACTIVE" ]]; then
+            log_ok   "$dev : fw=${fw_ver:-?}  link=${link:-?}  eth=${eth_dev:-none}  state=$state"
         else
-            [[ "$link" == "Ethernet" ]] && inactive_devs+=("$dev")
             log_warn "$dev : fw=${fw_ver:-?}  link=${link:-?}  eth=${eth_dev:-none}  state=${state:-?}"
         fi
     done
 
-    # --- firmware version consistency, grouped per card model (PCI device id) ---
-    # Different mlx5 card generations legitimately run different firmware
-    # baselines (e.g. a ConnectX-7 fleet plus a ConnectX-5 management NIC),
-    # so only flag inconsistency *within* the same model, not across models.
-    if [[ ${#fw_by_model[@]} -eq 0 ]]; then
-        log_warn "could not read firmware version from any mlx5 device"
-    else
-        local model devname fw_uniq n_devs
-        for model in "${!fw_by_model[@]}"; do
-            devname=$(lspci -d "15b3:$model" -mm 2>/dev/null | head -1 | awk -F'"' '{print $6}')
-            fw_uniq=$(tr ' ' '\n' <<<"${fw_by_model[$model]}" | sed '/^$/d' | sort -u)
-            n_devs=$(tr ' ' '\n' <<<"${fw_by_model[$model]}" | sed '/^$/d' | wc -l)
-            if [[ $(grep -c . <<<"$fw_uniq") -gt 1 ]]; then
-                log_warn "mlx5 firmware inconsistent across ${devname:-PCI id $model} devices:"
-                printf '         %s\n' $fw_uniq
-            else
-                log_ok "mlx5 firmware (${devname:-PCI id $model}) : $fw_uniq (consistent across $n_devs device(s))"
-            fi
-        done
-    fi
+    # Different card models legitimately run different firmware, so only check
+    # consistency within a model (PCI device id).
+    [[ ${#fw_by_model[@]} -gt 0 ]] || log_warn "could not read firmware version from any mlx5 device"
+    local model devname fws
+    for model in "${!fw_by_model[@]}"; do
+        devname=$(lspci -d "15b3:$model" -mm 2>/dev/null | head -1 | awk -F'"' '{print $6}')
+        read -ra fws <<< "${fw_by_model[$model]}"
+        report_uniform "mlx5 firmware (${devname:-PCI id $model})" "${fws[@]}"
+    done
 
-    # If native IB ports outnumber RoCE ports, the RoCE port(s) are most
-    # likely an incidental management/other-purpose NIC rather than the
-    # fabric MORI actually runs its RDMA traffic over (e.g. 8 IB ports used
-    # for MORI + 1 RoCE port used only for SSH/management). In that case,
-    # skip QoS/DCQCN checks entirely instead of failing on a port that
-    # doesn't matter for MORI -- clearing MLX5_ROCE_DEVS routes both
-    # check_mlx5_qos and check_mlx5_dcqcn to their "nothing to check" skip.
+    # If native IB ports outnumber RoCE ports, the RoCE port(s) are likely an
+    # incidental management NIC, not MORI's fabric. Clear MLX5_ROCE_DEVS so
+    # QoS/DCQCN are skipped rather than failing on a port that doesn't matter.
     local ib_count=$(( ${#MLX5_DEVS[@]} - ${#MLX5_ROCE_DEVS[@]} ))
     if [[ ${#MLX5_ROCE_DEVS[@]} -eq 0 ]]; then
         log_warn "no mlx5 ports running as Ethernet/RoCE — skipping QoS/DCQCN checks (native IB uses its own CC)"
@@ -1098,9 +1093,9 @@ check_mlx5_versions() {
     fi
 }
 
-# Check PFC and DSCP-based QoS for mlx5 RoCE ports via mlnx_qos; derive
-# MORI_RDMA_SL / MORI_RDMA_TC. Uses the first RoCE-capable port as the
-# representative (QoS config is expected to be homogeneous across NICs).
+# Check PFC and DSCP-based QoS on every mlx5 RoCE port via mlnx_qos, cross-
+# checking they all agree. Derives MORI_RDMA_SL/TC and publishes the
+# dscp2prio/PFC maps (MLX5_QOS_*) that check_mlx5_dcqcn() reuses.
 check_mlx5_qos() {
     step "check mlx5 QoS / PFC (Mellanox/NVIDIA NICs)"
 
@@ -1112,75 +1107,84 @@ check_mlx5_qos() {
         log_warn "mlnx_qos not found, cannot check QoS/PFC"; return 0
     fi
 
-    local rep_dev="${MLX5_ROCE_DEVS[0]}" rep_eth="${MLX5_ROCE_ETH[0]:-}"
-    if [[ -z "$rep_eth" ]]; then
-        log_fail "$rep_dev : cannot resolve underlying net device"; return 1
-    fi
-
-    # mlnx_qos wants the *net device* name (e.g. ens14np0), NOT the RDMA
-    # device name (e.g. mlx5_8) -- passing the RDMA name fails with a
-    # netlink ENODEV that the tool masks as "not supported on your system".
-    local qos_output
-    qos_output=$(sudo mlnx_qos -i "$rep_eth" 2>&1)
-
-    # Non-fatal from here on (unlike ionic's check_qos): a misconfigured
-    # RoCE port must not abort the whole script when the host's actual RDMA
-    # fabric is native IB (or another RoCE port) -- the later intra/inter
-    # node mesh tests should still get a chance to run.
-    local trust
-    trust=$(echo "$qos_output" | grep "Priority trust state" | head -1 | awk '{print $NF}')
-    if [[ "$trust" != "dscp" ]]; then
-        log_fail "$rep_eth : trust state is '$trust', expected 'dscp'"; return 1
-    fi
-    log_ok "$rep_eth : trust state = dscp"
-
-    # PFC configuration table:
-    #   priority    0   1   2   3   4   5   6   7
-    #   enabled     0   0   1   1   0   0   0   0
-    local pfc_line enabled_arr=() nd_prios=()
-    pfc_line=$(echo "$qos_output" | grep -A2 "PFC configuration" | tail -1)
-    read -ra enabled_arr <<< "$(echo "$pfc_line" | awk '{$1=""; print}')"
-    local p
-    for p in "${!enabled_arr[@]}"; do
-        [[ "${enabled_arr[$p]}" == "1" ]] && nd_prios+=("$p")
-    done
-    if [[ ${#nd_prios[@]} -eq 0 ]]; then
-        log_fail "$rep_eth : PFC is not enabled on any priority"; return 1
-    fi
-    log_ok "$rep_eth : PFC enabled on priorities: ${nd_prios[*]}"
-
-    # dscp2prio mapping (only printed when trust=dscp):
-    #   prio:3 dscp:24,26,46,...
-    local -A prio_dscp=()
-    while IFS= read -r line; do
-        [[ "$line" =~ prio:([0-9]+)[[:space:]]+dscp:([0-9,]+) ]] || continue
-        prio_dscp["${BASH_REMATCH[1]}"]+="${BASH_REMATCH[2]}"
-    done < <(echo "$qos_output" | grep -E "^[[:space:]]*prio:[0-9]+[[:space:]]+dscp:")
-
-    # Pick a no-drop priority + DSCP. Preference order (mirrors check_qos):
-    #   1) DSCP 26 (RoCEv2 convention; also what env_setup.sh explicitly maps)
-    #      if it maps to any no-drop priority
-    #   2) otherwise the first no-drop priority's first mapped DSCP
-    local best_prio="" best_dscp=""
-    for p in "${nd_prios[@]}"; do
-        local dl="${prio_dscp[$p]:-}"
-        if [[ -z "$dl" ]]; then
-            log_warn "$rep_eth : no DSCP mapped to no-drop priority $p"; continue
+    local fail=0 sl_derived=0
+    local trust_vals=() pfc_prio_vals=() data_map_vals=()
+    local i dev eth line
+    for i in "${!MLX5_ROCE_DEVS[@]}"; do
+        dev="${MLX5_ROCE_DEVS[$i]}"
+        eth="${MLX5_ROCE_ETH[$i]:-}"
+        if [[ -z "$eth" ]]; then
+            log_fail "$dev : cannot resolve underlying net device"; fail=1; continue
         fi
-        log_ok "$rep_eth : priority $p : DSCPs=[${dl%,}]"
-        if [[ ",$dl" == *",26,"* ]]; then
-            best_prio="$p"; best_dscp=26; break
-        fi
-        [[ -z "$best_prio" ]] && { best_prio="$p"; best_dscp="${dl%%,*}"; }
-    done
-    if [[ -z "$best_prio" ]]; then
-        log_fail "$rep_eth : could not derive SL/TC from QoS info"; return 1
-    fi
 
-    # TC = DSCP << 2 (DSCP occupies the upper 6 bits of the 8-bit TC/TOS field)
-    MORI_RDMA_SL="$best_prio"
-    MORI_RDMA_TC=$(( best_dscp * 4 ))
-    log_ok "selected SL=$MORI_RDMA_SL  TC=$MORI_RDMA_TC  (priority $best_prio, DSCP $best_dscp)"
+        # mlnx_qos wants the net device (not the RDMA name), else it errors as
+        # "not supported on your system".
+        local qos_output trust pfc_line data_dscp data_prio dl p pp
+        local -a enabled_arr=() nd_prios=()
+        local -A prio_dscp=()
+        qos_output=$(sudo mlnx_qos -i "$eth" 2>&1)
+
+        trust=$(echo "$qos_output" | grep "Priority trust state" | head -1 | awk '{print $NF}')
+        if [[ "$trust" != "dscp" ]]; then
+            log_fail "$dev ($eth) : trust state is '${trust:-?}', expected 'dscp'"; fail=1; continue
+        fi
+
+        # PFC config table: "priority 0 1 2.." / "enabled 0 0 1.."
+        pfc_line=$(echo "$qos_output" | grep -A2 "PFC configuration" | tail -1)
+        read -ra enabled_arr <<< "$(echo "$pfc_line" | awk '{$1=""; print}')"
+        for p in "${!enabled_arr[@]}"; do
+            [[ "${enabled_arr[$p]}" == "1" ]] && nd_prios+=("$p")
+        done
+        if [[ ${#nd_prios[@]} -eq 0 ]]; then
+            log_fail "$dev ($eth) : PFC is not enabled on any priority"; fail=1; continue
+        fi
+
+        # dscp2prio, e.g. "prio:3 dscp:24,26,46"
+        while IFS= read -r line; do
+            [[ "$line" =~ prio:([0-9]+)[[:space:]]+dscp:([0-9,]+) ]] || continue
+            prio_dscp["${BASH_REMATCH[1]}"]+="${BASH_REMATCH[2]}"
+        done < <(echo "$qos_output" | grep -E "^[[:space:]]*prio:[0-9]+[[:space:]]+dscp:")
+
+        # Discover this card's data lane: the PFC no-drop priority, and the
+        # DSCP mapped to it. dscp2prio is many-to-one (a whole DSCP block
+        # shares one priority), so when several DSCPs sit on the lossless
+        # priority we break the tie toward 26 (RoCEv2 data convention, and
+        # what env_setup programs); otherwise we take whatever is actually
+        # there. Nothing is assumed -- absent 26, the real DSCP is reported.
+        data_dscp=""; data_prio="unmapped"
+        for p in "${nd_prios[@]}"; do
+            dl="${prio_dscp[$p]:-}"; [[ -z "$dl" ]] && continue
+            if [[ ",$dl" == *",26,"* ]]; then data_prio="$p"; data_dscp=26; break; fi
+            [[ -z "$data_dscp" ]] && { data_prio="$p"; data_dscp="${dl%%,*}"; }
+        done
+
+        log_ok "$dev ($eth) : trust=dscp, PFC prio ${nd_prios[*]}, data DSCP ${data_dscp:-?}->prio ${data_prio}"
+
+        trust_vals+=("$trust")
+        pfc_prio_vals+=("${nd_prios[*]}")
+        data_map_vals+=("${data_dscp}->${data_prio}")
+
+        # Adopt the first usable card's mapping as MORI_RDMA_SL/TC and the
+        # MLX5_QOS_* maps (homogeneity is verified below via report_uniform).
+        if [[ $sl_derived -eq 0 ]]; then
+            for pp in "${!prio_dscp[@]}"; do MLX5_QOS_PRIO_DSCP["$pp"]="${prio_dscp[$pp]%,}"; done
+            MLX5_QOS_PFC_ENABLED=("${enabled_arr[@]}")
+            MORI_RDMA_SL="$data_prio"
+            MORI_RDMA_TC=$(( data_dscp * 4 ))  # TC = DSCP << 2
+            sl_derived=1
+        fi
+    done
+
+    report_uniform "trust state"     "${trust_vals[@]}"
+    report_uniform "PFC priorities"  "${pfc_prio_vals[@]}"
+    report_uniform "data DSCP->prio" "${data_map_vals[@]}"
+
+    if [[ $sl_derived -eq 0 ]]; then
+        log_fail "could not derive SL/TC from QoS info on any RoCE port"; return 1
+    fi
+    log_ok "selected SL=$MORI_RDMA_SL  TC=$MORI_RDMA_TC  (priority $MORI_RDMA_SL, DSCP $(( MORI_RDMA_TC / 4 )))"
+
+    [[ $fail -eq 0 ]]
 }
 
 # Check DCQCN (ECN-based congestion control) for mlx5 RoCE ports via
@@ -1196,16 +1200,19 @@ check_mlx5_dcqcn() {
     if ! command -v mlxconfig >/dev/null 2>&1; then
         log_warn "mlxconfig not found (NVIDIA MFT not installed), cannot check DCQCN"; return 0
     fi
-    command -v mst >/dev/null 2>&1 && sudo mst start >/dev/null 2>&1
+    command -v mst >/dev/null 2>&1 && sudo mst start >/dev/null 2>&1 </dev/null
 
-    local fail=0 cnp_dscps=()
-    local dev pci q mask cnp_dscp
+    # Query each device's firmware NV config serially. mlxconfig is slow
+    # (~4s/device, mostly /dev/mst re-enumeration), but running the queries
+    # in parallel barely helped, so keep it simple. </dev/null keeps
+    # mlxconfig from switching the TTY to raw mode for its progress display.
+    local fail=0 cnp_dscps=() dev pci q mask cnp_dscp
     for dev in "${MLX5_ROCE_DEVS[@]}"; do
         pci=$(basename "$(readlink -f "/sys/class/infiniband/$dev/device")" 2>/dev/null)
         if [[ -z "$pci" ]]; then
             log_warn "$dev : cannot resolve PCI address"; continue
         fi
-        q=$(sudo mlxconfig -d "$pci" q 2>/dev/null)
+        q=$(sudo mlxconfig -d "$pci" q 2>/dev/null </dev/null)
         mask=$(echo "$q" | grep -i "ROCE_CC_PRIO_MASK_P1" | awk '{print $NF}')
         cnp_dscp=$(echo "$q" | grep -i "CNP_DSCP_P1" | awk '{print $NF}')
         if [[ -z "$mask" ]]; then
@@ -1220,6 +1227,16 @@ check_mlx5_dcqcn() {
     done
 
     report_uniform "CNP DSCP" "${cnp_dscps[@]}"
+
+    # Data and CNP should normally sit on different priorities: CNP must
+    # get back to the sender fast, so sharing data's PFC (lossless) queue
+    # would let backpressure delay the very signal meant to relieve it.
+    mlx5_report_dscp_prio data "$(( MORI_RDMA_TC / 4 ))"
+    if [[ ${#cnp_dscps[@]} -gt 0 ]]; then
+        mlx5_report_dscp_prio CNP "${cnp_dscps[0]}"
+        [[ "$MLX5_LAST_PFC" == "enabled" ]] && \
+            log_warn "CNP shares a PFC (lossless) priority with data — congestion signal could be delayed by backpressure on that same queue"
+    fi
 
     [[ $fail -eq 0 ]]
 }

--- a/tools/env_setup.sh
+++ b/tools/env_setup.sh
@@ -1,28 +1,30 @@
 #!/bin/bash
 #
-# TODO: adapt for MLX (Mellanox/NVIDIA) NICs.
-#
 # env_setup.sh — setup the RDMA NIC environment for mori.
 #
-# Supports two NIC families with parallel, independent function sets selected by
-# vendor at the bottom (if vendor == bnxt ... elif vendor == ionic ...):
+# Supports three NIC families with parallel, independent function sets selected
+# by vendor at the bottom (if vendor == bnxt ... elif vendor == ionic ...):
 #
 #   ionic (AMD Pollara), via nicctl:
 #     ionic_setup_pfc / ionic_setup_dcqcn / ionic_mori_env_setup
 #   bnxt (Broadcom NetXtreme-E), via dcb + configfs:
 #     bnxt_setup_pfc  / bnxt_setup_dcqcn  / bnxt_mori_env_setup
+#   mlx5 (Mellanox/NVIDIA ConnectX), via mlnx_qos + mlxconfig:
+#     mlx5_setup_pfc  / mlx5_setup_dcqcn  / mlx5_mori_env_setup
 #
-# Both paths converge on the same RoCE QoS constants below, so MORI_RDMA_SL / TC
-# come out identical regardless of vendor.
+# All three paths converge on the same RoCE QoS constants below, so
+# MORI_RDMA_SL / TC come out identical regardless of vendor.
 #
 # Usage:  source env_setup.sh
 #
-# Requires: ionic -> nicctl, sudo; bnxt -> dcb (iproute2), ethtool, configfs, sudo
+# Requires: ionic -> nicctl, sudo; bnxt -> dcb (iproute2), ethtool, configfs,
+#           sudo; mlx5 -> mlnx_qos (mlnx-tools), mlxconfig/mst (NVIDIA MFT), sudo
 
 IONIC_VENDOR_ID="0x1dd8"
 BNXT_VENDOR_ID="0x14e4"   # Broadcom
+MLX_VENDOR_ID="0x15b3"    # Mellanox/NVIDIA
 
-# RoCE QoS constants — shared by the ionic and bnxt paths so MORI_RDMA_SL / TC
+# RoCE QoS constants — shared by the ionic/bnxt/mlx5 paths so MORI_RDMA_SL / TC
 # come out identical regardless of NIC vendor.
 #
 # NOTE: reference defaults only. PFC is hop-by-hop — the switch must use the same
@@ -50,8 +52,18 @@ query_by_vendor() {
 query_ionic_devices() { query_by_vendor "$IONIC_VENDOR_ID"; }
 query_bnxt_devices()  { query_by_vendor "$BNXT_VENDOR_ID"; }
 
+# Only Ethernet/RoCE mlx5 ports use mlnx_qos/mlxconfig (native IB has its own
+# flow control), so filter those in.
+query_mlx5_devices() {
+    local dev
+    for dev in $(query_by_vendor "$MLX_VENDOR_ID"); do
+        [[ "$(cat "/sys/class/infiniband/$dev/ports/1/link_layer" 2>/dev/null)" == "Ethernet" ]] && echo "$dev"
+    done
+}
+
 IONIC_DEVS=$(query_ionic_devices)
 BNXT_DEVS=$(query_bnxt_devices)
+MLX5_ROCE_DEVS=$(query_mlx5_devices)
 
 # Wipe all QoS configuration back to a clean "best-effort only" state.
 # Idiom adapted from the AMD Pollara 400 ops guide.
@@ -272,18 +284,94 @@ bnxt_mori_env_setup() {
     log_ok "export MORI_RDMA_TC=$MORI_RDMA_TC"
 }
 
+# ============================================================================
+# mlx5 (Mellanox/NVIDIA ConnectX) path — parallel to the ionic_*/bnxt_*
+# functions above. Only Ethernet/RoCE ports are touched (query_mlx5_devices).
+# ============================================================================
+
+# Configure trust/DSCP/PFC on every mlx5 RoCE port via `mlnx_qos`. TC
+# arbitration is left to the NIC's "vendor" algorithm (no bandwidth split);
+# only PFC no-drop on the RoCE priority is set up.
+mlx5_setup_pfc() {
+    command -v mlnx_qos &>/dev/null || { die "mlx5 devices found but mlnx_qos not available"; return 1; }
+
+    local p pfc_bits=""
+    for p in 0 1 2 3 4 5 6 7; do
+        [[ "$p" -eq "$ROCE_PRIO" ]] && pfc_bits+="1," || pfc_bits+="0,"
+    done
+    pfc_bits="${pfc_bits%,}"
+
+    local dev eth
+    for dev in $MLX5_ROCE_DEVS; do
+        eth=$(basename "$(readlink -f "/sys/class/infiniband/$dev/device/net/"* 2>/dev/null)" 2>/dev/null)
+        [[ -n "$eth" ]] || { log_warn "mlx5: no netdev for $dev, skipping"; continue; }
+
+        sudo mlnx_qos -i "$eth" --trust=dscp                              &>/dev/null \
+            || { die "mlx5: set trust dscp failed on $eth"; return 1; }
+        sudo mlnx_qos -i "$eth" --dscp2prio=set,"$ROCE_DSCP","$ROCE_PRIO"  &>/dev/null \
+            || { die "mlx5: map DSCP $ROCE_DSCP -> priority $ROCE_PRIO failed on $eth"; return 1; }
+        sudo mlnx_qos -i "$eth" --pfc="$pfc_bits"                          &>/dev/null \
+            || { die "mlx5: set PFC bitmap failed on $eth"; return 1; }
+        sudo mlnx_qos -i "$eth" --tsa=vendor,vendor,vendor,vendor,vendor,vendor,vendor,vendor &>/dev/null \
+            || log_warn "mlx5: set vendor TSA failed on $eth (continuing)"
+
+        log_ok "mlx5 PFC/DSCP on $dev ($eth): trust=dscp, DSCP $ROCE_DSCP -> priority $ROCE_PRIO (no-drop), TSA=vendor"
+    done
+}
+
+# Enable DCQCN on every mlx5 RoCE port via `mlxconfig` (NV config
+# ROCE_CC_PRIO_MASK_P1); CNP DSCP and the CC algorithm stay at firmware
+# default. NV config needs a firmware reset (mlxfwreset) or reboot to take
+# effect — we only warn, since a reset drops the link and can disrupt traffic.
+mlx5_setup_dcqcn() {
+    command -v mlxconfig &>/dev/null || { die "mlx5 devices found but mlxconfig (NVIDIA MFT) not available"; return 1; }
+    command -v mst &>/dev/null && sudo mst start &>/dev/null
+
+    local dev pci mask reset_needed=0
+    for dev in $MLX5_ROCE_DEVS; do
+        pci=$(basename "$(readlink -f "/sys/class/infiniband/$dev/device")" 2>/dev/null)
+        [[ -n "$pci" ]] || { log_warn "mlx5: cannot resolve PCI address for $dev, skipping"; continue; }
+
+        mask=$(sudo mlxconfig -d "$pci" q 2>/dev/null | grep -i "ROCE_CC_PRIO_MASK_P1" | awk '{print $NF}')
+        if [[ -n "$mask" && "$mask" != "0" ]]; then
+            log_ok "mlx5 DCQCN already enabled on $dev (pci=$pci, ROCE_CC_PRIO_MASK_P1=$mask)"
+            continue
+        fi
+
+        sudo mlxconfig -d "$pci" -y set ROCE_CC_PRIO_MASK_P1=0xff &>/dev/null \
+            || { die "mlx5: mlxconfig set ROCE_CC_PRIO_MASK_P1 failed on $dev (pci=$pci)"; return 1; }
+        log_ok "mlx5 DCQCN enabled on $dev (pci=$pci, ROCE_CC_PRIO_MASK_P1=0xff)"
+        reset_needed=1
+    done
+
+    [[ "$reset_needed" == "1" ]] && \
+        log_warn "mlx5: DCQCN NV config changed — run 'mlxfwreset -d <pci> -y reset' (or reboot) to apply"
+}
+
+# Export MORI_RDMA_SL / MORI_RDMA_TC for the mlx5 path (constants — same
+# rationale as bnxt_mori_env_setup: we just programmed these values ourselves).
+mlx5_mori_env_setup() {
+    export MORI_RDMA_SL="$ROCE_PRIO"
+    export MORI_RDMA_TC="$(( ROCE_DSCP << 2 ))"
+    log_ok "export MORI_RDMA_SL=$MORI_RDMA_SL"
+    log_ok "export MORI_RDMA_TC=$MORI_RDMA_TC"
+}
+
 # Dispatch by vendor.
 if [[ -n "$BNXT_DEVS" ]]; then
     bnxt_setup_pfc  && bnxt_setup_dcqcn  && bnxt_mori_env_setup
 elif [[ -n "$IONIC_DEVS" ]]; then
     ionic_setup_pfc && ionic_setup_dcqcn && ionic_mori_env_setup
+elif [[ -n "$MLX5_ROCE_DEVS" ]]; then
+    mlx5_setup_pfc  && mlx5_setup_dcqcn  && mlx5_mori_env_setup
 else
-    log_warn "no ionic or bnxt RDMA devices found"
+    log_warn "no ionic, bnxt, or mlx5 RoCE devices found"
 fi
 
 unset -f ionic_setup_pfc ionic_setup_dcqcn ionic_mori_env_setup \
          bnxt_setup_pfc bnxt_setup_dcqcn bnxt_mori_env_setup \
+         mlx5_setup_pfc mlx5_setup_dcqcn mlx5_mori_env_setup \
          _bnxt_cc_write _bnxt_cnp_service_type _bnxt_dcb_clear_app \
-         query_by_vendor query_ionic_devices query_bnxt_devices \
+         query_by_vendor query_ionic_devices query_bnxt_devices query_mlx5_devices \
          log_ok log_warn die
-unset IONIC_VENDOR_ID BNXT_VENDOR_ID IONIC_DEVS BNXT_DEVS GREEN RED YELLOW NC
+unset IONIC_VENDOR_ID BNXT_VENDOR_ID MLX_VENDOR_ID IONIC_DEVS BNXT_DEVS MLX5_ROCE_DEVS GREEN RED YELLOW NC


### PR DESCRIPTION
## Adapt `mori check` / `mori setup` for Mellanox/NVIDIA (mlx5) NICs

### Summary
Extends MORI's RDMA environment tooling to fully support mlx5 (ConnectX) NICs alongside the existing ionic (AMD Pollara) and bnxt (Broadcom) paths. Previously mlx5 hosts had no QoS/DCQCN checking or auto-configuration.

### Changes
- **`env_check.sh`** — adds three mlx5 checks: firmware/driver versions (grouped per card model, since mixed ConnectX-7/6 fleets legitimately differ), QoS/PFC via `mlnx_qos` across all RoCE ports, and DCQCN via `mlxconfig`. Derives `MORI_RDMA_SL/TC` from the discovered data DSCP (no hardcoded assumptions), reports CNP-vs-data DSCP/priority/PFC, and skips native-IB or incidental management ports.
- **`env_setup.sh`** — adds `mlx5_setup_pfc` / `mlx5_setup_dcqcn` / `mlx5_mori_env_setup`: sets trust=dscp, maps the RoCE DSCP, enables PFC no-drop, leaves TC arbitration to the vendor algorithm (no bandwidth split), and flips the DCQCN enable bit (warning that a firmware reset/reboot is required).
- **`cli.py`** — updates `mori setup` help text to cover ionic/bnxt/mlx5.
- **`deploy-mori` skill** — documents mlx5 deployment, tooling install, and gotchas.

### Testing
Verified end-to-end on a 10-port mixed ConnectX-7/6-Dx host; all checks pass and `mori setup` applies config correctly.