### PR TITLE
perf(EPv2): optimize control plane latency in epv2 combine kernels

### DIFF
--- a/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
+++ b/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
@@ -636,7 +636,6 @@ def make_combine(
             P.spin_until_eq_i64(xdb_peer_slot, xdb_cur_flag)
         if bid == 0:
             fx.barrier()
-            P.fence_system_acquire()
             if tid == 0:
                 P.store_i32_system(
                     fx.Int64(addr_comb_bar), arith.constant(0), arith.constant(1)
@@ -645,7 +644,6 @@ def make_combine(
             if tid == 0:
                 P.spin_until_eq_i32(fx.Int64(addr_comb_bar), 1)
             fx.barrier()
-            P.fence_system_acquire()
         if const_expr(reset_total_recv):
             if tid == 0:
                 buffer_store(arith.constant(0), rsrc_total_recv, 0)
@@ -1141,7 +1139,6 @@ def make_combine_scatter(
             P.spin_until_eq_i64(xdb_slot, xdb_cur_flag)
         if bid == 0:
             fx.barrier()
-            P.fence_system_acquire()
             if tid == 0:
                 P.store_i32_system(
                     fx.Int64(addr_comb_bar),
@@ -1152,7 +1149,6 @@ def make_combine_scatter(
             if tid == 0:
                 P.spin_until_eq_i32(fx.Int64(addr_comb_bar), block_num + 1)
             fx.barrier()
-            P.fence_system_acquire()
         if const_expr(reset_total_recv):
             if tid == 0:
                 buffer_store(arith.constant(0), rsrc_total_recv, 0)

--- a/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
+++ b/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
@@ -617,19 +617,10 @@ def make_combine(
         rsrc_out = create_buffer_resource_from_addr(addr_out)
         xdb_cur_flag = P.load_i64_acquire(fx.Int64(addr_xdb_flag))
 
-        # ── Stage 1: cross-device entry barrier (xdb, see module docstring) ──
-        # Gather reads only out_tok from the prior dispatch/expert kernel, so a
-        # cross-device barrier suffices (no Stage-1 scatter). The grid barrier
-        # (comb_bar) is REQUIRED: it guarantees every block has already read
-        # xdb_cur_flag before block 0 increments xdb_flag — otherwise a slow
-        # block reads the bumped flag and the per-peer == handshake deadlocks.
-        fx.barrier()
-        if tid == 0:
-            P.atomic_add_global(fx.Int64(addr_comb_bar), arith.constant(1))
+        # ── Stage 1: cross-device entry barrier (block 0 only) ──
+        # Block 0 handles the full xdb handshake, then signals other blocks
+        # via comb_bar. Eliminates the grid barrier and per-block xdb spin.
         if grid_thread_id < npes:
-            P.spin_until_eq_i32(fx.Int64(addr_comb_bar), block_num)
-            P.fence_system_acquire()
-            buffer_store(arith.constant(0), rsrc_comb_bar, 0)
             xdb_remote = fx.Int64(
                 window.lsa_ptr(grid_thread_id, off_xdb_mem)
             ) + fx.Int64(rank) * fx.Int64(8)
@@ -638,14 +629,23 @@ def make_combine(
             P.atomic_add_global(
                 fx.Int64(addr_xdb_flag), arith.constant(1, type=T.i64())
             )
-        if tid < npes:
+        if grid_thread_id < npes:
             xdb_peer_slot = fx.Int64(
                 window.lsa_ptr(my_lsa_rank, off_xdb_mem)
-            ) + fx.Int64(tid) * fx.Int64(8)
+            ) + fx.Int64(grid_thread_id) * fx.Int64(8)
             P.spin_until_eq_i64(xdb_peer_slot, xdb_cur_flag)
+        if bid == 0:
+            fx.barrier()
             P.fence_system_acquire()
-        fx.barrier()
-        P.fence_system_acquire()  # ALL threads: peers' out_tok visible
+            if tid == 0:
+                P.store_i32_system(
+                    fx.Int64(addr_comb_bar), arith.constant(0), arith.constant(1)
+                )
+        if bid != 0:
+            if tid == 0:
+                P.spin_until_eq_i32(fx.Int64(addr_comb_bar), 1)
+            fx.barrier()
+            P.fence_system_acquire()
         if const_expr(reset_total_recv):
             if tid == 0:
                 buffer_store(arith.constant(0), rsrc_total_recv, 0)
@@ -827,6 +827,10 @@ def make_combine(
                         _one(unit_base + u)
 
             _accum_loop()
+
+        if global_warp_id == 0:
+            if lane == 0:
+                buffer_store(arith.constant(0), rsrc_comb_bar, 0)
 
     @flyc.jit
     def run(
@@ -1113,8 +1117,8 @@ def make_combine_scatter(
                     )
 
         # ── Stage 2: cross-device barrier ──
-        # release Stage-1's P2P comb_inp writes before signaling peers (else
-        # Stage-3's acquire races them -> dropped contributions)
+        # Grid sync ensures all blocks finished Stage-1 scatter writes.
+        # Block 0 then handles xdb and signals completion via comb_bar.
         P.fence_system_release()
         fx.barrier()
         if tid == 0:
@@ -1122,7 +1126,6 @@ def make_combine_scatter(
         if grid_thread_id < npes:
             P.spin_until_eq_i32(fx.Int64(addr_comb_bar), block_num)
             P.fence_system_acquire()
-            buffer_store(arith.constant(0), rsrc_comb_bar, 0)
             xdb_remote = fx.Int64(
                 window.lsa_ptr(grid_thread_id, off_xdb_mem)
             ) + fx.Int64(rank) * fx.Int64(8)
@@ -1131,14 +1134,25 @@ def make_combine_scatter(
             P.atomic_add_global(
                 fx.Int64(addr_xdb_flag), arith.constant(1, type=T.i64())
             )
-        if tid < npes:
+        if grid_thread_id < npes:
             xdb_slot = fx.Int64(window.lsa_ptr(my_lsa_rank, off_xdb_mem)) + fx.Int64(
-                tid
+                grid_thread_id
             ) * fx.Int64(8)
             P.spin_until_eq_i64(xdb_slot, xdb_cur_flag)
+        if bid == 0:
+            fx.barrier()
             P.fence_system_acquire()
-        fx.barrier()
-        P.fence_system_acquire()
+            if tid == 0:
+                P.store_i32_system(
+                    fx.Int64(addr_comb_bar),
+                    arith.constant(0),
+                    arith.constant(block_num + 1),
+                )
+        if bid != 0:
+            if tid == 0:
+                P.spin_until_eq_i32(fx.Int64(addr_comb_bar), block_num + 1)
+            fx.barrier()
+            P.fence_system_acquire()
         if const_expr(reset_total_recv):
             if tid == 0:
                 buffer_store(arith.constant(0), rsrc_total_recv, 0)
@@ -1270,6 +1284,10 @@ def make_combine_scatter(
                     _one(unit_base + u)
 
             _loop()
+
+        if global_warp_id == 0:
+            if lane == 0:
+                buffer_store(arith.constant(0), rsrc_comb_bar, 0)
 
     @flyc.jit
     def run(

--- a/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
+++ b/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
@@ -680,18 +680,16 @@ def make_combine(
             expert_valids = []
             expert_pes = []
             expert_toks = []
+            encoded_my = buffer_load(
+                rsrc_tok_map, tok_map_base + lane, vec_width=1, dtype=T.i32()
+            )
             for k_slot in range_constexpr(experts_per_token):
-                encoded_k = buffer_load(
-                    rsrc_tok_map, tok_map_base + k_slot, vec_width=1, dtype=T.i32()
-                )
-                dest_pe_k = encoded_k // max_recv  # sentinel: dest_pe == npes
-                dest_tok_k = encoded_k % max_recv  # peer-local recv slot
+                encoded_k = readlane(T.i32(), encoded_my, k_slot)
+                dest_pe_k = encoded_k // max_recv
+                dest_tok_k = encoded_k % max_recv
                 valid_k = dest_pe_k < npes
                 safe_pe = arith.select(valid_k, dest_pe_k, arith.constant(rank))
                 safe_tok_k = arith.select(valid_k, dest_tok_k, arith.constant(0))
-                # Remote base peer[dest_pe].out_tok[dest_tok]; gather via global
-                # loads (no per-expert buffer descriptor) to keep all K loads in
-                # flight — see P.load_i32_nt.
                 slot_addr = fx.Int64(window.lsa_ptr(safe_pe, off_out_tok)) + fx.Int64(
                     safe_tok_k
                 ) * fx.Int64(nbytes)


### PR DESCRIPTION
## Summary

  Optimize the cross-device barrier (xdb) in FlyDSL combine kernels by restricting xdb handling to block 0 only.

  - **Gather combine**: eliminate the grid barrier entirely; block 0 performs the full xdb handshake and signals other blocks via a single `comb_bar` store
  - **Scatter combine**: keep the grid sync (Stage-1 scatter requires all-block completion) but replace per-block xdb spin with block 0's `comb_bar` signal
  - **Both**: reduce per-block sync overhead (fewer barriers, fences, atomics) and remove xdb spin redundancy across blocks

  ## Changes

  - `intranode_kernels.py`: refactor `ep_combine` Stage 1 and `ep_combine_s` Stage 2 xdb barriers to block-0-only pattern with `comb_bar` signaling; add end-of-kernel `comb_bar` reset for next invocation.
  - `intranode_kernels.py`: use `readlane` to broadcast `tok_map` entries in gather combine, reducing redundant buffer loads across lanes.

 ##  Performance
  **Platform**: MI355X, EP8, hidden=7168, topk=8, bf16.
  **Methodology**: Round-robin A/B (4–8 rounds), 100–200 iters/round, median reported.

  ### GRAPH mode (combine kernel)

  | tok/rank | baseline (μs) | latest (μs) | speedup | Δ (μs) |
  |---:|---:|---:|---:|---:|
  | 16 | 28.72 | 21.10 | **+26.5%** | −7.6 |
  | 32 | 32.49 | 23.75 | **+26.9%** | −8.7 |
  | 64 | 38.68 | 29.84 | **+22.9%** | −8.8 |
  | 128 | 52.25 | 43.69 | **+16.4%** | −8.6 |
  | 256 | 74.92 | 65.75 | **+12.3%** | −9.2 |
  | 512 | 136.27 | 127.60 | **+6.4%** | −8.7 |
  | 1024 | 227.40 | 217.78 | **+4.2%** | −9.6 |
  | 2048 | 423.86 | 410.54 | **+3.1%** | −13.3 |

