### PR TITLE
fix(io): bound EventPool free-list to avoid HSA signal exhaustion

### DIFF
--- a/src/io/xgmi/hip_resource_pool.cpp
+++ b/src/io/xgmi/hip_resource_pool.cpp
@@ -108,9 +108,24 @@ bool StreamPool::InitializeStreamsForDevice(int deviceId) {
 /*                                            EventPool                                           */
 /* ---------------------------------------------------------------------------------------------- */
 
-EventPool::EventPool(int numEventsPerDevice) : numEventsPerDevice_(numEventsPerDevice) {
+EventPool::EventPool(int numEventsPerDevice, int maxEventsPerDevice)
+    : numEventsPerDevice_(numEventsPerDevice), maxEventsPerDevice_(maxEventsPerDevice) {
   if (numEventsPerDevice_ <= 0) {
     numEventsPerDevice_ = 64;
+  }
+  // Bound the cached free-list so a bursty workload (e.g. PD KV-transfer under
+  // sustained load) cannot permanently inflate the pool and exhaust the
+  // per-process HSA signal / KFD event budget. That exhaustion surfaces as
+  // HSA_STATUS_ERROR_OUT_OF_RESOURCES on an unrelated queue op even though GPU
+  // memory is free. Events returned above this cap are destroyed, not retained.
+  if (maxEventsPerDevice_ <= 0) {
+    maxEventsPerDevice_ = numEventsPerDevice_ * 8;
+    if (maxEventsPerDevice_ < 512) {
+      maxEventsPerDevice_ = 512;
+    }
+  }
+  if (maxEventsPerDevice_ < numEventsPerDevice_) {
+    maxEventsPerDevice_ = numEventsPerDevice_;
   }
 }
 
@@ -155,8 +170,21 @@ void EventPool::PutEvent(hipEvent_t event, int deviceId) {
     return;
   }
 
-  std::lock_guard<std::mutex> lock(mutex_);
-  eventPools_[deviceId].push(event);
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto& pool = eventPools_[deviceId];
+    if (static_cast<int>(pool.size()) < maxEventsPerDevice_) {
+      pool.push(event);
+      return;
+    }
+  }
+
+  // Free-list already at capacity: destroy the surplus event rather than
+  // caching it, so the retained HSA signal count stays bounded across bursts.
+  hipError_t err = hipEventDestroy(event);
+  if (err != hipSuccess) {
+    MORI_IO_ERROR("EventPool: Failed to destroy surplus event: {}", hipGetErrorString(err));
+  }
 }
 
 hipEvent_t EventPool::CreateEvent() {

--- a/src/io/xgmi/hip_resource_pool.hpp
+++ b/src/io/xgmi/hip_resource_pool.hpp
@@ -54,7 +54,7 @@ class StreamPool {
 
 class EventPool {
  public:
-  explicit EventPool(int numEventsPerDevice = 64);
+  explicit EventPool(int numEventsPerDevice = 64, int maxEventsPerDevice = 0);
   ~EventPool();
 
   EventPool(const EventPool&) = delete;
@@ -71,6 +71,10 @@ class EventPool {
   bool InitializeEventsForDevice(int deviceId);
 
   int numEventsPerDevice_;
+  // Hard cap on the number of cached (free-list) events retained per device.
+  // Bounds the per-process HSA signal / KFD event footprint so a transient
+  // burst of concurrent transfers cannot permanently inflate the pool.
+  int maxEventsPerDevice_;
   std::mutex mutex_;
   std::unordered_map<int, std::queue<hipEvent_t>> eventPools_;
 };


### PR DESCRIPTION
## Summary
`EventPool` (used by the fabric/xgmi IO backends) can grow its cached free-list without bound: `GetEvent` allocates a new `hipEvent` when the pool is empty, and `PutEvent` returned it with no cap. Under a bursty workload the free-list inflates to the concurrency peak and is never reclaimed, so the per-process **HSA signal / KFD event** budget can be exhausted — reported by the ROCm runtime as `HSA_STATUS_ERROR_OUT_OF_RESOURCES` on an unrelated queue op **even though GPU memory is free**.

## Change
- Add a per-device hard cap on the retained free-list (`maxEventsPerDevice_`, default `max(8*numEvents, 512)`, never below `numEvents`).
- `PutEvent` destroys surplus events above the cap instead of caching them, bounding the steady-state signal footprint. `GetEvent` still allocates on demand so callers always get a valid event.
- No API break: the new constructor arg is optional/defaulted.

## Test plan
- [ ] Build mori; run MORI-IO fabric/xgmi transfer tests.
- [ ] Soak a bursty transfer workload; confirm cached event count plateaus at the cap and no `HSA_STATUS_ERROR_OUT_OF_RESOURCES`.

> Draft. Pairs with an sglang-side fix that pools the early-send CUDA events on the PD mori path.