### PR TITLE
fix(bootstrap): make rendezvous timeout configurable via MORI_BOOTSTRAP_TIMEOUT

### DIFF
--- a/src/application/bootstrap/socket_bootstrap.cpp
+++ b/src/application/bootstrap/socket_bootstrap.cpp
@@ -33,6 +33,7 @@
 #include <algorithm>
 #include <cassert>
 #include <chrono>
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <random>
@@ -43,6 +44,30 @@
 
 namespace mori {
 namespace application {
+
+namespace {
+// Total wall-clock budget (ms) for each bootstrap rendezvous step (non-root
+// connect-to-root, ring connect, and the root-side accepts). Historically these
+// were fixed at 50 retries x 200 ms ~= 10 s, which is too tight when the root
+// rank is slow to reach accept() (e.g. busy with model init in a large MoE
+// launch), producing spurious "failed to connect to root" bootstrap failures.
+// Configurable via MORI_BOOTSTRAP_TIMEOUT (seconds); defaults to 300 s to
+// tolerate slow-starting roots while still bounding the wait to prevent hangs.
+int BootstrapTimeoutMs() {
+  static const int kMs = [] {
+    int secs = 300;
+    if (const char* s = std::getenv("MORI_BOOTSTRAP_TIMEOUT")) {
+      try {
+        int v = std::stoi(s);
+        if (v > 0) secs = v;
+      } catch (...) {
+      }
+    }
+    return secs * 1000;
+  }();
+  return kMs;
+}
+}  // namespace
 
 SocketBootstrapNetwork::SocketBootstrapNetwork(const UniqueId& unique_id, int rank, int world_size)
     : unique_id_(unique_id), initialized_(false), unexpected_connections_(nullptr) {
@@ -662,10 +687,10 @@ bool SocketBootstrapNetwork::SetupCommunicationRing() {
   // Setup ring connections
   int next_rank = (localRank + 1) % worldSize;
 
-  // Allow up to 30 s total for the ring connect (50 retries × 200 ms back-off
-  // after the first immediate attempt).
-  constexpr int kRingMaxRetries = 50;
-  constexpr int kRingRetryDelayMs = 200;
+  // Retry the ring connect until BootstrapTimeoutMs() elapses (200 ms back-off
+  // after the first immediate attempt). Configurable via MORI_BOOTSTRAP_TIMEOUT.
+  const int kRingRetryDelayMs = 200;
+  const int kRingMaxRetries = std::max(1, BootstrapTimeoutMs() / kRingRetryDelayMs);
 
   // Connect to next rank in ring (with retries)
   bool ring_connected = false;
@@ -695,9 +720,10 @@ bool SocketBootstrapNetwork::SetupCommunicationRing() {
     return false;
   }
 
-  // Accept connection from previous rank. Use a 30 s timeout so that if the
-  // previous rank's connect loop exhausts its retries we don't hang forever.
-  constexpr int kRingAcceptTimeoutMs = 30000;
+  // Accept connection from previous rank. Bounded by the same bootstrap budget
+  // so that if the previous rank's connect loop exhausts its retries we don't
+  // hang forever.
+  const int kRingAcceptTimeoutMs = BootstrapTimeoutMs();
   if (!AcceptSocket(listen_socket_, ring_recv_socket_, kRingAcceptTimeoutMs)) {
     int prev_rank = (localRank - 1 + worldSize) % worldSize;
     MORI_APP_ERROR("Rank {}: failed to accept ring connection from rank {} (errno={})", localRank,
@@ -741,10 +767,10 @@ bool SocketBootstrapNetwork::PhoneHomeProtocol() {
     // Keep client sockets open to avoid race condition
     std::vector<Socket> client_sockets(worldSize);
 
-    // 30 s per-rank accept timeout: non-root ranks may start connecting after
-    // up to kConnectMaxRetries × kConnectRetryDelayMs = ~10 s, so 30 s gives
-    // plenty of headroom while still preventing an infinite hang.
-    constexpr int kPhoneHomeAcceptTimeoutMs = 30000;
+    // Per-rank accept timeout bounded by the shared bootstrap budget: non-root
+    // ranks retry their connect over the same window, so this gives them the
+    // full budget to arrive while still preventing an infinite hang.
+    const int kPhoneHomeAcceptTimeoutMs = BootstrapTimeoutMs();
 
     // Collect from other ranks - keep sockets open
     for (int i = 1; i < worldSize; i++) {
@@ -816,11 +842,12 @@ bool SocketBootstrapNetwork::PhoneHomeProtocol() {
     SocketAddress root_addr;
     ExtractAddressFromUniqueId(unique_id_, root_addr);
 
-    // Allow up to 30 s total: 50 retries × 200 ms back-off after the first
-    // immediate attempt.  The very first attempt is made without any sleep so
-    // that a fast-starting root is reached immediately.
-    constexpr int kConnectMaxRetries = 50;
-    constexpr int kConnectRetryDelayMs = 200;
+    // Retry until BootstrapTimeoutMs() elapses (200 ms back-off after the first
+    // immediate attempt). The very first attempt is made without any sleep so
+    // that a fast-starting root is reached immediately. Configurable via
+    // MORI_BOOTSTRAP_TIMEOUT to tolerate a root that is slow to reach accept().
+    const int kConnectRetryDelayMs = 200;
+    const int kConnectMaxRetries = std::max(1, BootstrapTimeoutMs() / kConnectRetryDelayMs);
 
     Socket sock;
     bool connected = false;

--- a/src/application/bootstrap/socket_bootstrap.cpp
+++ b/src/application/bootstrap/socket_bootstrap.cpp
@@ -36,6 +36,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <limits>
 #include <random>
 #include <stdexcept>
 #include <thread>
@@ -46,20 +47,17 @@ namespace mori {
 namespace application {
 
 namespace {
-// Total wall-clock budget (ms) for each bootstrap rendezvous step (non-root
-// connect-to-root, ring connect, and the root-side accepts). Historically these
-// were fixed at 50 retries x 200 ms ~= 10 s, which is too tight when the root
-// rank is slow to reach accept() (e.g. busy with model init in a large MoE
-// launch), producing spurious "failed to connect to root" bootstrap failures.
-// Configurable via MORI_BOOTSTRAP_TIMEOUT (seconds); defaults to 300 s to
-// tolerate slow-starting roots while still bounding the wait to prevent hangs.
+// Per-step bootstrap rendezvous budget (ms). Default 300 s (the old fixed
+// ~10 s was too tight when the root is slow to accept()); override with
+// MORI_BOOTSTRAP_TIMEOUT (seconds).
 int BootstrapTimeoutMs() {
   static const int kMs = [] {
+    constexpr int kMaxSecs = std::numeric_limits<int>::max() / 1000;
     int secs = 300;
     if (const char* s = std::getenv("MORI_BOOTSTRAP_TIMEOUT")) {
       try {
         int v = std::stoi(s);
-        if (v > 0) secs = v;
+        if (v > 0) secs = std::min(v, kMaxSecs);
       } catch (...) {
       }
     }


### PR DESCRIPTION
## Summary                                                                                                                                
                                                                                                                                            
  The socket bootstrap rendezvous has four hardcoded timeouts that together cap              
  each rank's wait for the root at roughly **10 s** (the retry-based sites are                                                              
  `50 retries x 200 ms`, despite in-code comments claiming `30 s`). When the root            
  rank is slow to reach `accept()` — e.g. it is busy with model initialization in                                                           
  a large MoE launch — non-root ranks exhaust their retries and die with               
  `failed to connect to root after 50 retries` / `PhoneHomeProtocol failed`, even                                                           
  though the root is healthy and would have been reachable moments later.                    
                                                                                                                                            
  This makes intra-node bootstrap a coin-flip under load: on a busy node the                                                                
  workers can lose the race against a slow-starting root.                              
                                                                                                                                            
  ## Change                                                                                  
                                                                                       
  All four bootstrap timeout sites in `socket_bootstrap.cpp` now derive from a                                                              
  single, env-configurable budget `MORI_BOOTSTRAP_TIMEOUT` (seconds, default           
  **300 s**):                                                                                                                               
                                                                                                                                            
  - `SetupCommunicationRing()` ring-connect retries                                                                                         
  - `SetupCommunicationRing()` ring-accept timeout                                                                                          
  - `PhoneHomeProtocol()` root-side per-rank accept timeout                                                                                 
  - `PhoneHomeProtocol()` non-root connect-to-root retries                                                                                  
                                                                                                                                            
  A small lazily-initialized helper reads the env var once, validates it (positive                                                          
  integer, else falls back to the default), and the retry-based sites compute their                                                         
  retry count from the budget. This also fixes the stale `30 s` comments, which                                                             
  never matched the actual `~10 s` retry behavior.                                
                                                                                                                                            
  The default of 300 s keeps behavior safe (bounded, no infinite hang) while giving          
  a slow-starting root plenty of headroom; unset env = default, so existing                                                                 
  deployments only see the larger budget, not a behavior change in the success path.         
                                                                                                                                            
  ## Validation                                                                              
                                                                                                                                            
  Built into `libmori_application.so` and hardware-tested on an 8-GPU-per-node                                                              
  MI35x MoE disaggregation launch (DeepSeek wide-EP16, mori for both MoE               
  all-to-all and KV): with the stock ~10 s budget, prefill engines intermittently                                                           
  lost the bootstrap race (both engines failed on a busy node in one run); with              
  `MORI_BOOTSTRAP_TIMEOUT=300` the same topology bootstrapped cleanly with zero                                                             
  races across all ranks and passed the end-to-end accuracy gate (GSM8K 0.927).