### PR TITLE
fix(EPv2): resolve comb_bar cross-call race causing random combine hang

### DIFF
--- a/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
+++ b/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
@@ -642,8 +642,10 @@ def make_combine(
                 )
         if bid != 0:
             if tid == 0:
-                P.spin_until_eq_i32(fx.Int64(addr_comb_bar), 1)
+                P.spin_until_gt_i32(fx.Int64(addr_comb_bar), 0)
             fx.barrier()
+            if tid == 0:
+                P.atomic_add_global(fx.Int64(addr_comb_bar), arith.constant(1))
         if const_expr(reset_total_recv):
             if tid == 0:
                 buffer_store(arith.constant(0), rsrc_total_recv, 0)
@@ -828,6 +830,7 @@ def make_combine(
 
         if global_warp_id == 0:
             if lane == 0:
+                P.spin_until_gt_i32(fx.Int64(addr_comb_bar), block_num - 1)
                 buffer_store(arith.constant(0), rsrc_comb_bar, 0)
 
     @flyc.jit
@@ -1147,8 +1150,10 @@ def make_combine_scatter(
                 )
         if bid != 0:
             if tid == 0:
-                P.spin_until_eq_i32(fx.Int64(addr_comb_bar), block_num + 1)
+                P.spin_until_gt_i32(fx.Int64(addr_comb_bar), block_num)
             fx.barrier()
+            if tid == 0:
+                P.atomic_add_global(fx.Int64(addr_comb_bar), arith.constant(1))
         if const_expr(reset_total_recv):
             if tid == 0:
                 buffer_store(arith.constant(0), rsrc_total_recv, 0)
@@ -1283,6 +1288,7 @@ def make_combine_scatter(
 
         if global_warp_id == 0:
             if lane == 0:
+                P.spin_until_gt_i32(fx.Int64(addr_comb_bar), 2 * block_num - 1)
                 buffer_store(arith.constant(0), rsrc_comb_bar, 0)
 
     @flyc.jit


### PR DESCRIPTION
The block-0-only xdb barrier signalled other blocks by store-1/clear-0 on comb_bar. The kernel-end clear(0) of call N could be reordered past the set(1) of call N+1, zeroing the fresh signal and leaving non-zero blocks spinning forever (~2/20 random hangs in fp8-gather-tuned).

Make the handshake monotonic and clear-ordered:
- non-zero blocks spin `> threshold` (>=) instead of `== signal`
- after consuming the signal (before the gather/reduce work) each non-zero block atomic_add-acks comb_bar
- block 0 spins until all acks land, then clears

The ack is issued before the heavy accumulation loop, so block 0's end-of-kernel spin is a near-zero wait off the critical path. Applied symmetrically to the gather and scatter combine kernels.

**Verified: gather 20/20, scatter 10/10, zero hangs; no perf regression (gather combine within noise across 16/128/512/2048 tok).**

  | tok/rank | baseline (us) | fixed (us) | Δ (us) | Δ (%) |
  |---:|---:|---:|---:|---:|
  | 16   | 21.78  | 18.91  | −2.87 | −13.2% |
  | 128  | 42.15  | 41.92  | −0.23 | −0.5%  |
  | 512  | 127.32 | 125.39 | −1.93 | −1.5%  |
  | 2048 | 411.04 | 410.70 | −0.34 | −0.08% |

