### PR TITLE
fix(umbp): support N host regions per worker in standalone-process mode

### DIFF
--- a/src/umbp/distributed/proto/umbp_standalone.proto
+++ b/src/umbp/distributed/proto/umbp_standalone.proto
@@ -63,6 +63,9 @@ message PutRequest {
   string client_id = 2;
   uint64 shm_offset = 3;
   uint64 size = 4;
+  // Worker VA base of the region shm_offset is relative to (== the worker_base
+  // sent at RegisterMemory). 0 means single-region / legacy first-fit.
+  uint64 region_base = 5;
 }
 
 message GetRequest {
@@ -70,6 +73,7 @@ message GetRequest {
   string client_id = 2;
   uint64 shm_offset = 3;
   uint64 size = 4;
+  uint64 region_base = 5;
 }
 
 message BatchDataRequest {
@@ -77,6 +81,9 @@ message BatchDataRequest {
   string client_id = 2;
   repeated uint64 shm_offsets = 3;
   repeated uint64 sizes = 4;
+  // Parallel to shm_offsets: region_bases[i] is the worker VA base of the
+  // region shm_offsets[i] is relative to. Empty means single-region / legacy.
+  repeated uint64 region_bases = 5;
 }
 
 message BatchDataWithDepthRequest {
@@ -85,6 +92,7 @@ message BatchDataWithDepthRequest {
   repeated uint64 shm_offsets = 3;
   repeated uint64 sizes = 4;
   repeated int32 depths = 5;
+  repeated uint64 region_bases = 6;
 }
 
 message BatchBoolResponse {

--- a/src/umbp/include/umbp/standalone/standalone_process_client.h
+++ b/src/umbp/include/umbp/standalone/standalone_process_client.h
@@ -80,7 +80,9 @@ class StandaloneProcessClient : public IUMBPClient {
       const std::vector<std::string>& hashes) override;
 
  private:
-  bool OffsetFor(uintptr_t ptr, size_t size, uint64_t* offset) const;
+  // Resolves `ptr` against the registered host regions. On success writes the
+  // region-relative `offset` and the matched region's worker VA `region_base`.
+  bool OffsetFor(uintptr_t ptr, size_t size, uint64_t* offset, uint64_t* region_base) const;
   bool WaitReady(int timeout_ms) const;
   void MaybeAutoStart();
   std::string ClientId();
@@ -97,11 +99,19 @@ class StandaloneProcessClient : public IUMBPClient {
   std::atomic<bool> closing_{false};
   bool closed_ = false;
 
+  // One registered host shared-memory region. A hybrid HiCache worker (e.g.
+  // DeepSeek-V4) registers several non-contiguous host pools per rank, so the
+  // client tracks N regions and resolves each data op to the one that owns its
+  // pointer. `base` is the worker VA base (== allocation->base), `size` its
+  // mapped size.
+  struct RegisteredRegion {
+    uintptr_t base = 0;
+    size_t size = 0;
+  };
+
   mutable std::mutex registration_mu_;
   std::string client_id_;
-  uintptr_t registered_base_ = 0;
-  size_t registered_size_ = 0;
-  bool registered_ = false;
+  std::vector<RegisteredRegion> regions_;
 };
 
 }  // namespace mori::umbp::standalone

--- a/src/umbp/standalone/standalone_process_client.cpp
+++ b/src/umbp/standalone/standalone_process_client.cpp
@@ -30,6 +30,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstdlib>
@@ -248,13 +249,18 @@ void StandaloneProcessClient::MaybeAutoStart() {
       address_);
 }
 
-bool StandaloneProcessClient::OffsetFor(uintptr_t ptr, size_t size, uint64_t* offset) const {
+bool StandaloneProcessClient::OffsetFor(uintptr_t ptr, size_t size, uint64_t* offset,
+                                        uint64_t* region_base) const {
   std::lock_guard<std::mutex> lock(registration_mu_);
-  if (!registered_ || ptr < registered_base_) return false;
-  uintptr_t rel = ptr - registered_base_;
-  if (rel > registered_size_ || size > registered_size_ - rel) return false;
-  *offset = static_cast<uint64_t>(rel);
-  return true;
+  for (const auto& region : regions_) {
+    if (ptr < region.base) continue;
+    uintptr_t rel = ptr - region.base;
+    if (rel > region.size || size > region.size - rel) continue;
+    *offset = static_cast<uint64_t>(rel);
+    *region_base = static_cast<uint64_t>(region.base);
+    return true;
+  }
+  return false;
 }
 
 bool StandaloneProcessClient::Put(const std::string& key, uintptr_t src, size_t size) {
@@ -262,13 +268,15 @@ bool StandaloneProcessClient::Put(const std::string& key, uintptr_t src, size_t 
   std::shared_lock lk(op_mutex_);
   if (closed_) return false;
   uint64_t offset = 0;
-  if (!OffsetFor(src, size, &offset)) return false;
+  uint64_t region_base = 0;
+  if (!OffsetFor(src, size, &offset, &region_base)) return false;
   grpc::ClientContext ctx;
   ::umbp::PutRequest req;
   req.set_key(key);
   req.set_client_id(ClientId());
   req.set_shm_offset(offset);
   req.set_size(size);
+  req.set_region_base(region_base);
   ::umbp::BoolResponse resp;
   grpc::Status status = stub_->Put(&ctx, req, &resp);
   return status.ok() && resp.ok();
@@ -279,13 +287,15 @@ bool StandaloneProcessClient::Get(const std::string& key, uintptr_t dst, size_t 
   std::shared_lock lk(op_mutex_);
   if (closed_) return false;
   uint64_t offset = 0;
-  if (!OffsetFor(dst, size, &offset)) return false;
+  uint64_t region_base = 0;
+  if (!OffsetFor(dst, size, &offset, &region_base)) return false;
   grpc::ClientContext ctx;
   ::umbp::GetRequest req;
   req.set_key(key);
   req.set_client_id(ClientId());
   req.set_shm_offset(offset);
   req.set_size(size);
+  req.set_region_base(region_base);
   ::umbp::BoolResponse resp;
   grpc::Status status = stub_->Get(&ctx, req, &resp);
   return status.ok() && resp.ok();
@@ -315,9 +325,13 @@ std::vector<bool> StandaloneProcessClient::BatchPut(const std::vector<std::strin
   req.set_client_id(ClientId());
   for (size_t i = 0; i < keys.size(); ++i) {
     uint64_t offset = 0;
-    if (!OffsetFor(srcs[i], sizes[i], &offset)) return std::vector<bool>(keys.size(), false);
+    uint64_t region_base = 0;
+    if (!OffsetFor(srcs[i], sizes[i], &offset, &region_base)) {
+      return std::vector<bool>(keys.size(), false);
+    }
     req.add_keys(keys[i]);
     req.add_shm_offsets(offset);
+    req.add_region_bases(region_base);
     req.add_sizes(sizes[i]);
   }
   grpc::ClientContext ctx;
@@ -342,9 +356,13 @@ std::vector<bool> StandaloneProcessClient::BatchPutWithDepth(const std::vector<s
   req.set_client_id(ClientId());
   for (size_t i = 0; i < keys.size(); ++i) {
     uint64_t offset = 0;
-    if (!OffsetFor(srcs[i], sizes[i], &offset)) return std::vector<bool>(keys.size(), false);
+    uint64_t region_base = 0;
+    if (!OffsetFor(srcs[i], sizes[i], &offset, &region_base)) {
+      return std::vector<bool>(keys.size(), false);
+    }
     req.add_keys(keys[i]);
     req.add_shm_offsets(offset);
+    req.add_region_bases(region_base);
     req.add_sizes(sizes[i]);
     req.add_depths(i < depths.size() ? depths[i] : -1);
   }
@@ -369,9 +387,13 @@ std::vector<bool> StandaloneProcessClient::BatchGet(const std::vector<std::strin
   req.set_client_id(ClientId());
   for (size_t i = 0; i < keys.size(); ++i) {
     uint64_t offset = 0;
-    if (!OffsetFor(dsts[i], sizes[i], &offset)) return std::vector<bool>(keys.size(), false);
+    uint64_t region_base = 0;
+    if (!OffsetFor(dsts[i], sizes[i], &offset, &region_base)) {
+      return std::vector<bool>(keys.size(), false);
+    }
     req.add_keys(keys[i]);
     req.add_shm_offsets(offset);
+    req.add_region_bases(region_base);
     req.add_sizes(sizes[i]);
   }
   grpc::ClientContext ctx;
@@ -482,11 +504,18 @@ bool StandaloneProcessClient::RegisterMemory(uintptr_t ptr, size_t size) {
                                (rpc_status.ok() ? resp.error() : rpc_status.error_message()));
     }
 
+    const uintptr_t base = reinterpret_cast<uintptr_t>(allocation->base);
     std::lock_guard<std::mutex> lock(registration_mu_);
-    if (registered_) HostMemAllocator::ReleaseShmAllocation(registered_base_);
-    registered_base_ = reinterpret_cast<uintptr_t>(allocation->base);
-    registered_size_ = allocation->mapped_size;
-    registered_ = true;
+    auto existing = std::find_if(regions_.begin(), regions_.end(),
+                                 [&](const RegisteredRegion& r) { return r.base == base; });
+    if (existing != regions_.end()) {
+      // Same region re-registered: keep the existing entry and drop the freshly
+      // acquired duplicate allocation (its refcount is balanced by the Release).
+      existing->size = allocation->mapped_size;
+      HostMemAllocator::ReleaseShmAllocation(base);
+    } else {
+      regions_.push_back({base, allocation->mapped_size});
+    }
     acquired_kept = true;
   } catch (...) {
     if (!acquired_kept) {
@@ -499,23 +528,22 @@ bool StandaloneProcessClient::RegisterMemory(uintptr_t ptr, size_t size) {
 
 void StandaloneProcessClient::DeregisterMemoryLocked() {
   std::string client_id;
-  uintptr_t base = 0;
+  std::vector<RegisteredRegion> regions;
   {
     std::lock_guard<std::mutex> lock(registration_mu_);
-    if (!registered_) return;
+    if (regions_.empty()) return;
     client_id = client_id_;
-    base = registered_base_;
-    registered_ = false;
-    registered_base_ = 0;
-    registered_size_ = 0;
+    regions.swap(regions_);
   }
 
+  // One RPC tears down all of this client's regions server-side (UnmapClient),
+  // so a single DeregisterMemory call covers every region.
   grpc::ClientContext ctx;
   ::umbp::DeregisterMemoryRequest req;
   req.set_client_id(client_id);
   ::umbp::Empty resp;
   if (stub_) stub_->DeregisterMemory(&ctx, req, &resp);
-  HostMemAllocator::ReleaseShmAllocation(base);
+  for (const auto& region : regions) HostMemAllocator::ReleaseShmAllocation(region.base);
 }
 
 void StandaloneProcessClient::DeregisterMemory(uintptr_t /*ptr*/) {

--- a/src/umbp/standalone/standalone_server.cpp
+++ b/src/umbp/standalone/standalone_server.cpp
@@ -31,6 +31,7 @@
 #include <sys/un.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <atomic>
 #include <cerrno>
 #include <chrono>
@@ -228,7 +229,8 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
   grpc::Status Put(grpc::ServerContext*, const ::umbp::PutRequest* request,
                    ::umbp::BoolResponse* response) override {
     uintptr_t ptr = 0;
-    if (!ResolveRange(request->client_id(), request->shm_offset(), request->size(), &ptr)) {
+    if (!ResolveRange(request->client_id(), request->region_base(), request->shm_offset(),
+                      request->size(), &ptr)) {
       SetBool(response, false, "unregistered or out-of-range shm buffer");
       return grpc::Status::OK;
     }
@@ -244,7 +246,8 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
   grpc::Status Get(grpc::ServerContext*, const ::umbp::GetRequest* request,
                    ::umbp::BoolResponse* response) override {
     uintptr_t ptr = 0;
-    if (!ResolveRange(request->client_id(), request->shm_offset(), request->size(), &ptr)) {
+    if (!ResolveRange(request->client_id(), request->region_base(), request->shm_offset(),
+                      request->size(), &ptr)) {
       SetBool(response, false, "unregistered or out-of-range shm buffer");
       return grpc::Status::OK;
     }
@@ -278,8 +281,13 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
   grpc::Status BatchPutWithDepth(grpc::ServerContext*,
                                  const ::umbp::BatchDataWithDepthRequest* request,
                                  ::umbp::BatchBoolResponse* response) override {
+    // region_bases is optional for legacy single-region callers; when present it
+    // must be parallel to keys (BatchPutWithDepth resolves inline, not through
+    // ResolveBatch).
+    const bool has_region_bases = request->region_bases_size() > 0;
     if (request->keys_size() != request->shm_offsets_size() ||
-        request->keys_size() != request->sizes_size()) {
+        request->keys_size() != request->sizes_size() ||
+        (has_region_bases && request->keys_size() != request->region_bases_size())) {
       FillFalse(request->keys_size(), response);
       return grpc::Status::OK;
     }
@@ -287,7 +295,9 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
     ptrs.reserve(request->keys_size());
     for (int i = 0; i < request->keys_size(); ++i) {
       uintptr_t ptr = 0;
-      if (!ResolveRange(request->client_id(), request->shm_offsets(i), request->sizes(i), &ptr)) {
+      uint64_t region_base = has_region_bases ? request->region_bases(i) : 0;
+      if (!ResolveRange(request->client_id(), region_base, request->shm_offsets(i),
+                        request->sizes(i), &ptr)) {
         FillFalse(request->keys_size(), response);
         return grpc::Status::OK;
       }
@@ -393,8 +403,11 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
     {
       std::lock_guard<std::mutex> lock(memory_mu_);
       auto it = memory_.find(request->client_id());
-      ok = it != memory_.end() && it->second.worker_base == request->worker_base() &&
-           it->second.size >= request->size();
+      if (it != memory_.end()) {
+        ok = std::any_of(it->second.begin(), it->second.end(), [&](const RegisteredMemory& mem) {
+          return mem.worker_base == request->worker_base() && mem.size >= request->size();
+        });
+      }
     }
     if (!ok) {
       SetBool(response, false, "fd handoff registration was not found");
@@ -689,14 +702,25 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
     }
 
     std::string client_id(msg.client_id);
+    RegisteredMemory entry{mapped, static_cast<uint64_t>(msg.worker_base), msg.size};
     std::optional<RegisteredMemory> old_mem;
     {
       std::lock_guard<std::mutex> lock(memory_mu_);
-      auto old = memory_.find(client_id);
-      if (old != memory_.end()) old_mem = old->second;
-      memory_[client_id] =
-          RegisteredMemory{mapped, static_cast<uint64_t>(msg.worker_base), msg.size};
+      auto& regions = memory_[client_id];
+      auto existing = std::find_if(
+          regions.begin(), regions.end(),
+          [&](const RegisteredMemory& mem) { return mem.worker_base == entry.worker_base; });
+      if (existing != regions.end()) {
+        // Same region re-registered: replace the mapping, release the old one.
+        old_mem = *existing;
+        *existing = entry;
+      } else {
+        regions.push_back(entry);
+      }
     }
+    // Release outside the lock, and via ReleaseRegisteredMemory so the backend
+    // deregisters the region before its mapping is munmap'd (required by the
+    // distributed backend; see design-standalone-process-mode.md §5.3/§6.3).
     if (old_mem.has_value()) ReleaseRegisteredMemory(*old_mem);
     MORI_UMBP_INFO("[StandaloneServer] registered shm client_id={} worker_base=0x{:x} size={}MB",
                    client_id, msg.worker_base, msg.size / (1024 * 1024));
@@ -704,22 +728,24 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
   }
 
   void UnmapClient(const std::string& client_id) {
-    std::optional<RegisteredMemory> mem;
+    std::vector<RegisteredMemory> mems;
     {
       std::lock_guard<std::mutex> lock(memory_mu_);
       auto it = memory_.find(client_id);
       if (it == memory_.end()) return;
-      mem = it->second;
+      mems.swap(it->second);
       memory_.erase(it);
     }
-    ReleaseRegisteredMemory(*mem);
+    for (const auto& mem : mems) ReleaseRegisteredMemory(mem);
   }
 
   void UnmapAll() {
     std::vector<RegisteredMemory> entries;
     {
       std::lock_guard<std::mutex> lock(memory_mu_);
-      for (auto& kv : memory_) entries.push_back(kv.second);
+      for (auto& kv : memory_) {
+        for (const auto& mem : kv.second) entries.push_back(mem);
+      }
       memory_.clear();
     }
     for (const auto& mem : entries) ReleaseRegisteredMemory(mem);
@@ -740,28 +766,43 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
     munmap(mem.base, static_cast<size_t>(mem.size));
   }
 
-  bool ResolveRange(const std::string& client_id, uint64_t offset, uint64_t size,
-                    uintptr_t* out_ptr) {
+  // Resolves (client_id, region_base, offset) to a server-local pointer.
+  // region_base selects which of the client's regions the offset is relative to;
+  // 0 means legacy/single-region and falls back to the first region that fits.
+  bool ResolveRange(const std::string& client_id, uint64_t region_base, uint64_t offset,
+                    uint64_t size, uintptr_t* out_ptr) {
     if (!out_ptr || size == 0) return false;
     std::lock_guard<std::mutex> lock(memory_mu_);
     auto it = memory_.find(client_id);
     if (it == memory_.end()) return false;
-    const RegisteredMemory& mem = it->second;
-    if (offset > mem.size || size > mem.size - offset) return false;
-    *out_ptr = reinterpret_cast<uintptr_t>(mem.base) + static_cast<uintptr_t>(offset);
-    return true;
+    for (const auto& mem : it->second) {
+      if (region_base != 0 && mem.worker_base != region_base) continue;
+      if (offset > mem.size || size > mem.size - offset) {
+        if (region_base != 0) return false;
+        continue;
+      }
+      *out_ptr = reinterpret_cast<uintptr_t>(mem.base) + static_cast<uintptr_t>(offset);
+      return true;
+    }
+    return false;
   }
 
   bool ResolveBatch(const ::umbp::BatchDataRequest& request, std::vector<uintptr_t>* ptrs) {
+    // region_bases is optional for legacy single-region callers; when present it
+    // must be parallel to keys.
+    const bool has_region_bases = request.region_bases_size() > 0;
     if (!ptrs || request.keys_size() != request.shm_offsets_size() ||
-        request.keys_size() != request.sizes_size()) {
+        request.keys_size() != request.sizes_size() ||
+        (has_region_bases && request.keys_size() != request.region_bases_size())) {
       return false;
     }
     ptrs->clear();
     ptrs->reserve(request.keys_size());
     for (int i = 0; i < request.keys_size(); ++i) {
       uintptr_t ptr = 0;
-      if (!ResolveRange(request.client_id(), request.shm_offsets(i), request.sizes(i), &ptr)) {
+      uint64_t region_base = has_region_bases ? request.region_bases(i) : 0;
+      if (!ResolveRange(request.client_id(), region_base, request.shm_offsets(i), request.sizes(i),
+                        &ptr)) {
         return false;
       }
       ptrs->push_back(ptr);
@@ -819,7 +860,10 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
 
   std::mutex client_mu_;
   std::mutex memory_mu_;
-  std::map<std::string, RegisteredMemory> memory_;
+  // A worker registers N non-contiguous host regions (e.g. DeepSeek-V4's KV
+  // side pools), so each client_id maps to a list of regions, resolved by
+  // worker_base at data-op time.
+  std::map<std::string, std::vector<RegisteredMemory>> memory_;
   std::mutex external_identity_lifecycle_mu_;
   std::mutex external_identity_mu_;
   std::map<std::string, std::shared_ptr<ExternalKvIdentityClient>> external_identities_;

--- a/src/umbp/tests/test_standalone_shm_ipc.cpp
+++ b/src/umbp/tests/test_standalone_shm_ipc.cpp
@@ -236,6 +236,102 @@ TEST(StandaloneShmIpcTest, StandaloneClientUsesNonZeroOffsetsAndCanReregister) {
   unlink(fd_path.c_str());
 }
 
+TEST(StandaloneShmIpcTest, StandaloneClientResolvesAcrossMultipleRegions) {
+  const std::string address =
+      "unix:///tmp/umbp_standalone_multiregion_" + std::to_string(getpid()) + ".grpc.sock";
+  const std::string grpc_path = standalone::UnixPathFromGrpcAddress(address);
+  const std::string fd_path = standalone::DeriveFdSocketPath(address);
+  unlink(grpc_path.c_str());
+  unlink(fd_path.c_str());
+
+  UMBPConfig server_cfg;
+  server_cfg.dram.capacity_bytes = 1 << 20;
+  server_cfg.ssd.enabled = false;
+  UMBPStandaloneProcessConfig sp_cfg;
+  sp_cfg.address = address;
+  sp_cfg.startup_timeout_ms = 5000;
+  server_cfg.standalone_process = sp_cfg;
+
+  standalone::StandaloneServer server(server_cfg, address);
+  ASSERT_TRUE(server.Start());
+  std::thread server_thread([&]() { server.Run(); });
+
+  UMBPConfig client_cfg = server_cfg;
+  auto client = CreateUMBPClient(client_cfg);
+  ASSERT_EQ(client->GetDeploymentMode(), UMBPDeploymentMode::StandaloneProcess);
+
+  // Two distinct, non-contiguous host shm regions from one client, mirroring a
+  // hybrid HiCache worker registering several host KV pools per rank.
+  HostMemAllocator allocator;
+  HostBufferOptions opts;
+  opts.backing = HostBufferBacking::kAnonymousShm;
+  opts.prefault = false;
+  HostBufferHandle region_a = allocator.Alloc(4096, opts);
+  HostBufferHandle region_b = allocator.Alloc(8192, opts);
+  ASSERT_TRUE(region_a.valid());
+  ASSERT_TRUE(region_b.valid());
+  auto* bytes_a = static_cast<unsigned char*>(region_a.ptr);
+  auto* bytes_b = static_cast<unsigned char*>(region_b.ptr);
+
+  ASSERT_TRUE(
+      client->RegisterMemory(reinterpret_cast<uintptr_t>(region_a.ptr), region_a.mapped_size));
+  // Registering region B must NOT drop region A (the single-region bug).
+  ASSERT_TRUE(
+      client->RegisterMemory(reinterpret_cast<uintptr_t>(region_b.ptr), region_b.mapped_size));
+
+  // Put/Get resolve correctly in region A.
+  for (int i = 0; i < 16; ++i) bytes_a[32 + i] = static_cast<unsigned char>(i + 1);
+  ASSERT_TRUE(client->Put("key-a", reinterpret_cast<uintptr_t>(bytes_a + 32), 16));
+  std::memset(bytes_a + 96, 0, 16);
+  ASSERT_TRUE(client->Get("key-a", reinterpret_cast<uintptr_t>(bytes_a + 96), 16));
+  for (int i = 0; i < 16; ++i) EXPECT_EQ(bytes_a[96 + i], static_cast<unsigned char>(i + 1));
+
+  // Put/Get resolve correctly in region B.
+  for (int i = 0; i < 24; ++i) bytes_b[64 + i] = static_cast<unsigned char>(0x40 + i);
+  ASSERT_TRUE(client->Put("key-b", reinterpret_cast<uintptr_t>(bytes_b + 64), 24));
+  std::memset(bytes_b + 4096, 0, 24);
+  ASSERT_TRUE(client->Get("key-b", reinterpret_cast<uintptr_t>(bytes_b + 4096), 24));
+  for (int i = 0; i < 24; ++i) EXPECT_EQ(bytes_b[4096 + i], static_cast<unsigned char>(0x40 + i));
+
+  // A batch spanning both regions resolves per-element via region_bases.
+  for (int i = 0; i < 8; ++i) bytes_a[200 + i] = static_cast<unsigned char>(0xa0 + i);
+  for (int i = 0; i < 8; ++i) bytes_b[200 + i] = static_cast<unsigned char>(0xb0 + i);
+  std::vector<std::string> keys{"batch-a", "batch-b"};
+  std::vector<uintptr_t> srcs{reinterpret_cast<uintptr_t>(bytes_a + 200),
+                              reinterpret_cast<uintptr_t>(bytes_b + 200)};
+  std::vector<size_t> sizes{8, 8};
+  std::vector<bool> put_ok = client->BatchPut(keys, srcs, sizes);
+  ASSERT_EQ(put_ok.size(), 2u);
+  EXPECT_TRUE(put_ok[0]);
+  EXPECT_TRUE(put_ok[1]);
+  std::memset(bytes_a + 300, 0, 8);
+  std::memset(bytes_b + 300, 0, 8);
+  std::vector<uintptr_t> dsts{reinterpret_cast<uintptr_t>(bytes_a + 300),
+                              reinterpret_cast<uintptr_t>(bytes_b + 300)};
+  std::vector<bool> get_ok = client->BatchGet(keys, dsts, sizes);
+  ASSERT_EQ(get_ok.size(), 2u);
+  EXPECT_TRUE(get_ok[0]);
+  EXPECT_TRUE(get_ok[1]);
+  for (int i = 0; i < 8; ++i) EXPECT_EQ(bytes_a[300 + i], static_cast<unsigned char>(0xa0 + i));
+  for (int i = 0; i < 8; ++i) EXPECT_EQ(bytes_b[300 + i], static_cast<unsigned char>(0xb0 + i));
+
+  // A pointer outside every registered region fails cleanly (no crash, no hit).
+  HostBufferHandle unregistered = allocator.Alloc(4096, opts);
+  ASSERT_TRUE(unregistered.valid());
+  EXPECT_FALSE(client->Put("key-oob", reinterpret_cast<uintptr_t>(unregistered.ptr), 16));
+  EXPECT_FALSE(client->Get("key-oob", reinterpret_cast<uintptr_t>(unregistered.ptr), 16));
+
+  client->DeregisterMemory(reinterpret_cast<uintptr_t>(region_a.ptr));
+  client->Close();
+  allocator.Free(region_a);
+  allocator.Free(region_b);
+  allocator.Free(unregistered);
+  server.Shutdown();
+  server_thread.join();
+  unlink(grpc_path.c_str());
+  unlink(fd_path.c_str());
+}
+
 TEST(StandaloneShmIpcTest, ShutdownDoesNotHangOnHalfOpenFdConnection) {
   const std::string address =
       "unix:///tmp/umbp_standalone_halfopen_" + std::to_string(getpid()) + ".grpc.sock";


### PR DESCRIPTION
## Motivation

In UMBP standalone-process mode, `StandaloneProcessClient` tracked exactly **one**
registered host shared-memory region per worker (`registered_base_`/`registered_size_`,
overwritten on every `RegisterMemory`), and the server mirrored the same single-region
assumption (`client_id → RegisteredMemory`, overwritten on re-register).

An SGLang **DeepSeek-V4 hybrid HiCache** worker registers **multiple** non-contiguous
host KV buffers per rank (a logical KV anchor + several page_first side pools: SWA /
compressed-KV / indexer / state), each via its own `client.register_memory()` call.
With single-region tracking, only the **last-registered** pool resolved; every Put/Get
whose pointer fell in any other region silently returned all-false (`OffsetFor` /
`ResolveRange` miss → no throw, no log). Result: most L3 KV never reached the store, the
prefix-cache hit rate collapsed, and throughput cratered **with zero error signal** — a
silent correctness/perf failure.

The distributed backend is unaffected because RDMA `IOEngine` registration natively
supports multiple memory regions; the single-region assumption lived only in the
standalone client/server offset-resolution layer, which sits above `client_` and is
therefore backend-independent (present under both local- and distributed-backend).

## Modifications

Support **N** registered host regions per worker on both client and server, resolving
each data op to the correct region by its worker VA base. N=1 behavior is preserved.

- **Proto** (`umbp_standalone.proto`): add `region_base` to `PutRequest`/`GetRequest`
  and `region_bases` (parallel to `shm_offsets`) to `BatchDataRequest` /
  `BatchDataWithDepthRequest`. `0` / empty means single-region / legacy first-fit.
- **Client** (`standalone_process_client.{h,cpp}`): replace the single-region members
  with `std::vector<RegisteredRegion>`; `RegisterMemory` appends (idempotent on the same
  base) instead of overwrite-and-release; `OffsetFor` resolves across regions and returns
  the matched region base; `Put/Get/BatchPut/BatchPutWithDepth/BatchGet` carry
  `region_base(s)`; `DeregisterMemoryLocked` releases all regions.
- **Server** (`standalone_server.cpp`): `memory_` becomes
  `map<client_id, vector<RegisteredMemory>>`; `RegisterFd` appends / replaces by
  `worker_base` via `ReleaseRegisteredMemory` (backend `DeregisterMemory` **before**
  `munmap`, required by the distributed backend); `ResolveRange` resolves by
  `region_base`; all four resolution sites updated (`Put`, `Get`, `ResolveBatch`, and the
  inline `BatchPutWithDepth` loop); re-register identity check and `UnmapClient`/`UnmapAll`
  iterate the region list. Empty `region_bases` falls back to legacy first-fit.

No changes to `distributed/` or `local/` cores, and no sglang changes.

## Tests

Added `StandaloneShmIpcTest.StandaloneClientResolvesAcrossMultipleRegions`: registers two
distinct shm regions from one client, verifies registering the second does not drop the
first, that Put/Get resolve correctly in both regions, that a batch spanning both regions
resolves per-element, and that an out-of-range pointer fails cleanly. Also a regression
guard for the single-region (N=1) path.

```
[==========] 6 tests from 1 test suite ran.
[  PASSED  ] 6 tests.
```

Built with `BUILD_TESTS=1 pip install .`
