### PR TITLE
Add libibverbs async event monitor to MORI-IO

### DIFF
--- a/src/application/transport/rdma/providers/ibverbs/ibv_shim.cpp
+++ b/src/application/transport/rdma/providers/ibverbs/ibv_shim.cpp
@@ -249,6 +249,20 @@ int _ibv_query_gid_ex(struct ibv_context* context, uint32_t port_num, uint32_t g
   return fn ? fn(context, port_num, gid_index, entry, flags, entry_size) : IbvUnavailable(-1);
 }
 
+// ---- async events -----------------------------------------------------------
+// get and ack must stay paired: retrieving an event that can never be acked
+// would wedge later ibv_destroy_*/ibv_close_device, so fail get when either
+// symbol is missing rather than hand back an unacknowledgeable event.
+int ibv_get_async_event(struct ibv_context* context, struct ibv_async_event* event) {
+  MORI_IBV_RESOLVE(ibv_get_async_event, "IBVERBS_1.1");
+  static void* ack = IbvSym("ibv_ack_async_event", "IBVERBS_1.1");
+  return (fn && ack) ? fn(context, event) : IbvUnavailable(-1);
+}
+void ibv_ack_async_event(struct ibv_async_event* event) {
+  MORI_IBV_RESOLVE(ibv_ack_async_event, "IBVERBS_1.1");
+  if (fn) fn(event);
+}
+
 // ---- misc -------------------------------------------------------------------
 const char* ibv_wc_status_str(enum ibv_wc_status status) {
   MORI_IBV_RESOLVE(ibv_wc_status_str, "IBVERBS_1.1");

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -2,6 +2,7 @@ set(MORI_IO_SOURCES
     engine.cpp
     rdma/protocol.cpp
     rdma/backend_impl.cpp
+    rdma/async_event_monitor.cpp
     rdma/executor.cpp
     rdma/common.cpp
     rdma/ledger.cpp

--- a/src/io/rdma/async_event_monitor.cpp
+++ b/src/io/rdma/async_event_monitor.cpp
@@ -1,0 +1,390 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#include "src/io/rdma/async_event_monitor.hpp"
+
+#include <fcntl.h>
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <unordered_set>
+
+namespace mori {
+namespace io {
+
+namespace {
+
+// Each async fd is drained up to this many events per readiness before yielding
+// back to epoll, so a single busy context can neither starve the others nor the
+// shutdown wake fd. Level-triggered epoll re-reports any remainder.
+constexpr int kFairnessCap = 32;
+
+enum class Severity { kInfo, kWarn, kError };
+enum class Category { kPort, kQp, kCq, kSrq, kDevice, kOther };
+
+struct EventDescriptor {
+  const char* name;  // nullptr for events not in the explicit table
+  Severity severity;
+  Category category;
+  bool queryPort;
+};
+
+// Single source of truth for event name, severity, which union member is valid
+// and whether a live ibv_query_port() is warranted. WQ_FATAL / speed-change and
+// any newer enum fall through to the numeric default without touching the union.
+EventDescriptor DescribeAsyncEvent(ibv_event_type type) {
+  switch (type) {
+    case IBV_EVENT_PORT_ERR:
+      return {"IBV_EVENT_PORT_ERR", Severity::kError, Category::kPort, true};
+    case IBV_EVENT_PORT_ACTIVE:
+      return {"IBV_EVENT_PORT_ACTIVE", Severity::kError, Category::kPort, true};
+    case IBV_EVENT_DEVICE_FATAL:
+      return {"IBV_EVENT_DEVICE_FATAL", Severity::kError, Category::kDevice, false};
+    case IBV_EVENT_CQ_ERR:
+      return {"IBV_EVENT_CQ_ERR", Severity::kError, Category::kCq, false};
+    case IBV_EVENT_QP_FATAL:
+      return {"IBV_EVENT_QP_FATAL", Severity::kError, Category::kQp, false};
+    case IBV_EVENT_QP_REQ_ERR:
+      return {"IBV_EVENT_QP_REQ_ERR", Severity::kError, Category::kQp, false};
+    case IBV_EVENT_QP_ACCESS_ERR:
+      return {"IBV_EVENT_QP_ACCESS_ERR", Severity::kError, Category::kQp, false};
+    case IBV_EVENT_SRQ_ERR:
+      return {"IBV_EVENT_SRQ_ERR", Severity::kError, Category::kSrq, false};
+    case IBV_EVENT_PATH_MIG_ERR:
+      return {"IBV_EVENT_PATH_MIG_ERR", Severity::kWarn, Category::kQp, false};
+    case IBV_EVENT_PATH_MIG:
+      return {"IBV_EVENT_PATH_MIG", Severity::kInfo, Category::kQp, false};
+    case IBV_EVENT_COMM_EST:
+      return {"IBV_EVENT_COMM_EST", Severity::kInfo, Category::kQp, false};
+    case IBV_EVENT_SQ_DRAINED:
+      return {"IBV_EVENT_SQ_DRAINED", Severity::kInfo, Category::kQp, false};
+    case IBV_EVENT_QP_LAST_WQE_REACHED:
+      return {"IBV_EVENT_QP_LAST_WQE_REACHED", Severity::kInfo, Category::kQp, false};
+    case IBV_EVENT_SRQ_LIMIT_REACHED:
+      return {"IBV_EVENT_SRQ_LIMIT_REACHED", Severity::kInfo, Category::kSrq, false};
+    case IBV_EVENT_LID_CHANGE:
+      return {"IBV_EVENT_LID_CHANGE", Severity::kInfo, Category::kPort, false};
+    case IBV_EVENT_PKEY_CHANGE:
+      return {"IBV_EVENT_PKEY_CHANGE", Severity::kInfo, Category::kPort, false};
+    case IBV_EVENT_SM_CHANGE:
+      return {"IBV_EVENT_SM_CHANGE", Severity::kInfo, Category::kPort, false};
+    case IBV_EVENT_GID_CHANGE:
+      return {"IBV_EVENT_GID_CHANGE", Severity::kInfo, Category::kPort, false};
+    case IBV_EVENT_CLIENT_REREGISTER:
+      return {"IBV_EVENT_CLIENT_REREGISTER", Severity::kInfo, Category::kPort, false};
+    default:
+      return {nullptr, Severity::kWarn, Category::kOther, false};
+  }
+}
+
+class AsyncEventAckGuard {
+ public:
+  explicit AsyncEventAckGuard(ibv_async_event* event) noexcept : event_(event) {}
+  ~AsyncEventAckGuard() { ibv_ack_async_event(event_); }
+
+  AsyncEventAckGuard(const AsyncEventAckGuard&) = delete;
+  AsyncEventAckGuard& operator=(const AsyncEventAckGuard&) = delete;
+
+ private:
+  ibv_async_event* event_;
+};
+
+}  // namespace
+
+std::unique_ptr<RdmaAsyncEventMonitor> RdmaAsyncEventMonitor::Create(
+    const application::RdmaDeviceList& devices, std::shared_ptr<spdlog::logger> logger) {
+  std::unique_ptr<RdmaAsyncEventMonitor> monitor(new RdmaAsyncEventMonitor(std::move(logger)));
+  if (!monitor->Start(devices)) return nullptr;
+  return monitor;
+}
+
+RdmaAsyncEventMonitor::RdmaAsyncEventMonitor(std::shared_ptr<spdlog::logger> logger)
+    : logger_(std::move(logger)) {}
+
+RdmaAsyncEventMonitor::~RdmaAsyncEventMonitor() { Shutdown(); }
+
+bool RdmaAsyncEventMonitor::Start(const application::RdmaDeviceList& devices) {
+  std::unordered_set<ibv_context*> seen;
+  for (application::RdmaDevice* device : devices) {
+    ibv_context* context = device->GetIbvContext();
+    if (context == nullptr || !seen.insert(context).second) continue;
+    watches_.push_back(Watch{device->Name(), static_cast<uint32_t>(device->GetDevicePortNum()),
+                             context, context->async_fd, 0, false, false});
+  }
+  if (watches_.empty()) return false;
+
+  for (Watch& watch : watches_) {
+    int flags = fcntl(watch.asyncFd, F_GETFL);
+    if (flags < 0) {
+      if (logger_)
+        logger_->error("RDMA async monitor: F_GETFL failed on {}: {}", watch.deviceName,
+                       std::strerror(errno));
+      return false;
+    }
+    watch.originalFdFlags = flags;
+    if (!(flags & O_NONBLOCK) && fcntl(watch.asyncFd, F_SETFL, flags | O_NONBLOCK) < 0) {
+      if (logger_)
+        logger_->error("RDMA async monitor: F_SETFL O_NONBLOCK failed on {}: {}", watch.deviceName,
+                       std::strerror(errno));
+      return false;
+    }
+    watch.changedFdFlags = !(flags & O_NONBLOCK);
+  }
+
+  epollFd_ = epoll_create1(EPOLL_CLOEXEC);
+  if (epollFd_ < 0) {
+    if (logger_)
+      logger_->error("RDMA async monitor: epoll_create1 failed: {}", std::strerror(errno));
+    return false;
+  }
+
+  wakeFd_ = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+  if (wakeFd_ < 0) {
+    if (logger_) logger_->error("RDMA async monitor: eventfd failed: {}", std::strerror(errno));
+    return false;
+  }
+
+  epoll_event wake{};
+  wake.events = EPOLLIN;
+  wake.data.u64 = 0;
+  if (epoll_ctl(epollFd_, EPOLL_CTL_ADD, wakeFd_, &wake) < 0) {
+    if (logger_)
+      logger_->error("RDMA async monitor: epoll_ctl(wake) failed: {}", std::strerror(errno));
+    return false;
+  }
+
+  for (size_t i = 0; i < watches_.size(); ++i) {
+    epoll_event ev{};
+    ev.events = EPOLLIN;
+    ev.data.u64 = i + 1;
+    if (epoll_ctl(epollFd_, EPOLL_CTL_ADD, watches_[i].asyncFd, &ev) < 0) {
+      if (logger_)
+        logger_->error("RDMA async monitor: epoll_ctl({}) failed: {}", watches_[i].deviceName,
+                       std::strerror(errno));
+      return false;
+    }
+    watches_[i].registered = true;
+  }
+
+  thread_ = std::thread([this] { MainLoop(); });
+  return true;
+}
+
+void RdmaAsyncEventMonitor::MainLoop() noexcept {
+  constexpr int kMaxEvents = 16;
+  epoll_event events[kMaxEvents];
+  while (!stopRequested_.load(std::memory_order_acquire)) {
+    int n = epoll_wait(epollFd_, events, kMaxEvents, -1);
+    if (n < 0) {
+      if (errno == EINTR) continue;
+      if (logger_)
+        logger_->error("RDMA async monitor: epoll_wait failed: {}; stopping", std::strerror(errno));
+      return;
+    }
+
+    for (int i = 0; i < n; ++i) {
+      uint64_t id = events[i].data.u64;
+      if (id == 0) {
+        DrainWake();
+        continue;
+      }
+
+      Watch& watch = watches_[id - 1];
+      if (!watch.registered) continue;
+
+      bool terminal = (events[i].events & (EPOLLERR | EPOLLHUP)) != 0;
+      bool drained = false;
+      for (int c = 0; c < kFairnessCap; ++c) {
+        GetResult result = ProcessOneEvent(watch);
+        if (result == GetResult::kDrained) {
+          drained = true;
+          break;
+        }
+        if (result == GetResult::kError) {
+          RemoveWatch(watch);
+          break;
+        }
+      }
+      if (terminal && watch.registered && drained) RemoveWatch(watch);
+    }
+
+    bool anyRegistered = false;
+    for (const Watch& watch : watches_) {
+      if (watch.registered) {
+        anyRegistered = true;
+        break;
+      }
+    }
+    if (!anyRegistered) {
+      if (logger_) logger_->error("RDMA async monitor: all async fds removed; stopping");
+      return;
+    }
+  }
+}
+
+RdmaAsyncEventMonitor::GetResult RdmaAsyncEventMonitor::ProcessOneEvent(Watch& watch) noexcept {
+  ibv_async_event event{};
+  if (ibv_get_async_event(watch.context, &event) != 0) {
+    if (errno == EINTR) return GetResult::kEvent;
+    if (errno == EAGAIN || errno == EWOULDBLOCK) return GetResult::kDrained;
+    if (logger_)
+      logger_->error("RDMA async monitor: ibv_get_async_event failed on {}: {}", watch.deviceName,
+                     std::strerror(errno));
+    return GetResult::kError;
+  }
+
+  EventInfo info{event.event_type, nullptr, 0, 0, -1};
+  {
+    // Snapshot the union while the guard keeps the event alive, then ack before
+    // the (slower) query and logging so ibv_destroy_* waits on us as little as
+    // possible. The union members must not be touched once ack returns.
+    AsyncEventAckGuard ack(&event);
+    switch (DescribeAsyncEvent(event.event_type).category) {
+      case Category::kCq:
+        if (event.element.cq != nullptr) {
+          info.objPtr = event.element.cq;
+          info.cqDepth = event.element.cq->cqe;
+        }
+        break;
+      case Category::kQp:
+        if (event.element.qp != nullptr) {
+          info.objPtr = event.element.qp;
+          info.qpNum = event.element.qp->qp_num;
+        }
+        break;
+      case Category::kSrq:
+        info.objPtr = event.element.srq;
+        break;
+      case Category::kPort:
+        info.portNum = event.element.port_num;
+        break;
+      default:
+        break;
+    }
+  }
+  DescribeAndLog(watch, info);
+  return GetResult::kEvent;
+}
+
+void RdmaAsyncEventMonitor::DescribeAndLog(const Watch& watch, const EventInfo& info) noexcept {
+  EventDescriptor desc = DescribeAsyncEvent(info.type);
+  const char* name = desc.name != nullptr ? desc.name : "IBV_EVENT_UNKNOWN";
+
+  char detail[256] = "";
+  switch (desc.category) {
+    case Category::kPort: {
+      if (info.portNum >= 1 && static_cast<uint32_t>(info.portNum) <= watch.physicalPortCount) {
+        int off = std::snprintf(detail, sizeof(detail), " port=%d", info.portNum);
+        if (desc.queryPort && off > 0) {
+          ibv_port_attr attr{};
+          if (ibv_query_port(watch.context, static_cast<uint8_t>(info.portNum), &attr) == 0) {
+            std::snprintf(detail + off, sizeof(detail) - off,
+                          " state=%d phys_state=%d link_layer=%d lid=%u active_speed=%u"
+                          " active_width=%u",
+                          static_cast<int>(attr.state), static_cast<int>(attr.phys_state),
+                          static_cast<int>(attr.link_layer), static_cast<unsigned>(attr.lid),
+                          static_cast<unsigned>(attr.active_speed),
+                          static_cast<unsigned>(attr.active_width));
+          } else {
+            std::snprintf(detail + off, sizeof(detail) - off, " query_port_failed errno=%d", errno);
+          }
+        }
+      } else {
+        std::snprintf(detail, sizeof(detail), " port=invalid(%d)", info.portNum);
+      }
+      break;
+    }
+    case Category::kQp:
+      std::snprintf(detail, sizeof(detail), " qp=%p qpn=%u", info.objPtr, info.qpNum);
+      break;
+    case Category::kCq:
+      std::snprintf(detail, sizeof(detail), " cq=%p cqe=%d", info.objPtr, info.cqDepth);
+      break;
+    case Category::kSrq:
+      std::snprintf(detail, sizeof(detail), " srq=%p", info.objPtr);
+      break;
+    default:
+      break;
+  }
+
+  const char* recovery = info.type == IBV_EVENT_PORT_ACTIVE ? " (recovery)" : "";
+  spdlog::level::level_enum level = desc.severity == Severity::kError  ? spdlog::level::err
+                                    : desc.severity == Severity::kWarn ? spdlog::level::warn
+                                                                       : spdlog::level::info;
+  if (logger_) {
+    logger_->log(level, "RDMA async event {}{} (type={}) dev={} ctx={} async_fd={}{}", name,
+                 recovery, static_cast<int>(info.type), watch.deviceName,
+                 static_cast<const void*>(watch.context), watch.asyncFd, detail);
+  }
+}
+
+void RdmaAsyncEventMonitor::RemoveWatch(Watch& watch) noexcept {
+  if (!watch.registered) return;
+  epoll_ctl(epollFd_, EPOLL_CTL_DEL, watch.asyncFd, nullptr);
+  watch.registered = false;
+  if (watch.changedFdFlags) {
+    fcntl(watch.asyncFd, F_SETFL, watch.originalFdFlags);
+    watch.changedFdFlags = false;
+  }
+}
+
+void RdmaAsyncEventMonitor::DrainWake() noexcept {
+  uint64_t value;
+  while (read(wakeFd_, &value, sizeof(value)) == sizeof(value)) {
+  }
+}
+
+void RdmaAsyncEventMonitor::RestoreFdFlags() noexcept {
+  for (Watch& watch : watches_) {
+    if (watch.changedFdFlags) {
+      fcntl(watch.asyncFd, F_SETFL, watch.originalFdFlags);
+      watch.changedFdFlags = false;
+    }
+  }
+}
+
+void RdmaAsyncEventMonitor::Shutdown() noexcept {
+  if (thread_.joinable()) {
+    stopRequested_.store(true, std::memory_order_release);
+    if (wakeFd_ >= 0) {
+      uint64_t one = 1;
+      while (write(wakeFd_, &one, sizeof(one)) < 0 && errno == EINTR) {
+      }
+    }
+    thread_.join();
+  }
+  RestoreFdFlags();
+  if (epollFd_ >= 0) {
+    close(epollFd_);
+    epollFd_ = -1;
+  }
+  if (wakeFd_ >= 0) {
+    close(wakeFd_);
+    wakeFd_ = -1;
+  }
+}
+
+}  // namespace io
+}  // namespace mori

--- a/src/io/rdma/async_event_monitor.cpp
+++ b/src/io/rdma/async_event_monitor.cpp
@@ -115,9 +115,16 @@ class AsyncEventAckGuard {
 
 std::unique_ptr<RdmaAsyncEventMonitor> RdmaAsyncEventMonitor::Create(
     const application::RdmaDeviceList& devices, std::shared_ptr<spdlog::logger> logger) {
-  std::unique_ptr<RdmaAsyncEventMonitor> monitor(new RdmaAsyncEventMonitor(std::move(logger)));
-  if (!monitor->Start(devices)) return nullptr;
-  return monitor;
+  // Thread creation and allocations can throw; a failed monitor must degrade to
+  // "no observability", never abort RDMA backend construction. On any throw the
+  // in-scope unique_ptr unwinds through Shutdown() and releases monitor fds.
+  try {
+    std::unique_ptr<RdmaAsyncEventMonitor> monitor(new RdmaAsyncEventMonitor(std::move(logger)));
+    if (!monitor->Start(devices)) return nullptr;
+    return monitor;
+  } catch (...) {
+    return nullptr;
+  }
 }
 
 RdmaAsyncEventMonitor::RdmaAsyncEventMonitor(std::shared_ptr<spdlog::logger> logger)
@@ -138,16 +145,14 @@ bool RdmaAsyncEventMonitor::Start(const application::RdmaDeviceList& devices) {
   for (Watch& watch : watches_) {
     int flags = fcntl(watch.asyncFd, F_GETFL);
     if (flags < 0) {
-      if (logger_)
-        logger_->error("RDMA async monitor: F_GETFL failed on {}: {}", watch.deviceName,
-                       std::strerror(errno));
+      SafeLog(spdlog::level::err, "RDMA async monitor: F_GETFL failed on {}: {}", watch.deviceName,
+              std::strerror(errno));
       return false;
     }
     watch.originalFdFlags = flags;
     if (!(flags & O_NONBLOCK) && fcntl(watch.asyncFd, F_SETFL, flags | O_NONBLOCK) < 0) {
-      if (logger_)
-        logger_->error("RDMA async monitor: F_SETFL O_NONBLOCK failed on {}: {}", watch.deviceName,
-                       std::strerror(errno));
+      SafeLog(spdlog::level::err, "RDMA async monitor: F_SETFL O_NONBLOCK failed on {}: {}",
+              watch.deviceName, std::strerror(errno));
       return false;
     }
     watch.changedFdFlags = !(flags & O_NONBLOCK);
@@ -155,14 +160,14 @@ bool RdmaAsyncEventMonitor::Start(const application::RdmaDeviceList& devices) {
 
   epollFd_ = epoll_create1(EPOLL_CLOEXEC);
   if (epollFd_ < 0) {
-    if (logger_)
-      logger_->error("RDMA async monitor: epoll_create1 failed: {}", std::strerror(errno));
+    SafeLog(spdlog::level::err, "RDMA async monitor: epoll_create1 failed: {}",
+            std::strerror(errno));
     return false;
   }
 
   wakeFd_ = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
   if (wakeFd_ < 0) {
-    if (logger_) logger_->error("RDMA async monitor: eventfd failed: {}", std::strerror(errno));
+    SafeLog(spdlog::level::err, "RDMA async monitor: eventfd failed: {}", std::strerror(errno));
     return false;
   }
 
@@ -170,8 +175,8 @@ bool RdmaAsyncEventMonitor::Start(const application::RdmaDeviceList& devices) {
   wake.events = EPOLLIN;
   wake.data.u64 = 0;
   if (epoll_ctl(epollFd_, EPOLL_CTL_ADD, wakeFd_, &wake) < 0) {
-    if (logger_)
-      logger_->error("RDMA async monitor: epoll_ctl(wake) failed: {}", std::strerror(errno));
+    SafeLog(spdlog::level::err, "RDMA async monitor: epoll_ctl(wake) failed: {}",
+            std::strerror(errno));
     return false;
   }
 
@@ -180,9 +185,8 @@ bool RdmaAsyncEventMonitor::Start(const application::RdmaDeviceList& devices) {
     ev.events = EPOLLIN;
     ev.data.u64 = i + 1;
     if (epoll_ctl(epollFd_, EPOLL_CTL_ADD, watches_[i].asyncFd, &ev) < 0) {
-      if (logger_)
-        logger_->error("RDMA async monitor: epoll_ctl({}) failed: {}", watches_[i].deviceName,
-                       std::strerror(errno));
+      SafeLog(spdlog::level::err, "RDMA async monitor: epoll_ctl({}) failed: {}",
+              watches_[i].deviceName, std::strerror(errno));
       return false;
     }
     watches_[i].registered = true;
@@ -199,8 +203,8 @@ void RdmaAsyncEventMonitor::MainLoop() noexcept {
     int n = epoll_wait(epollFd_, events, kMaxEvents, -1);
     if (n < 0) {
       if (errno == EINTR) continue;
-      if (logger_)
-        logger_->error("RDMA async monitor: epoll_wait failed: {}; stopping", std::strerror(errno));
+      SafeLog(spdlog::level::err, "RDMA async monitor: epoll_wait failed: {}; stopping",
+              std::strerror(errno));
       return;
     }
 
@@ -238,7 +242,7 @@ void RdmaAsyncEventMonitor::MainLoop() noexcept {
       }
     }
     if (!anyRegistered) {
-      if (logger_) logger_->error("RDMA async monitor: all async fds removed; stopping");
+      SafeLog(spdlog::level::err, "RDMA async monitor: all async fds removed; stopping");
       return;
     }
   }
@@ -249,9 +253,8 @@ RdmaAsyncEventMonitor::GetResult RdmaAsyncEventMonitor::ProcessOneEvent(Watch& w
   if (ibv_get_async_event(watch.context, &event) != 0) {
     if (errno == EINTR) return GetResult::kEvent;
     if (errno == EAGAIN || errno == EWOULDBLOCK) return GetResult::kDrained;
-    if (logger_)
-      logger_->error("RDMA async monitor: ibv_get_async_event failed on {}: {}", watch.deviceName,
-                     std::strerror(errno));
+    SafeLog(spdlog::level::err, "RDMA async monitor: ibv_get_async_event failed on {}: {}",
+            watch.deviceName, std::strerror(errno));
     return GetResult::kError;
   }
 
@@ -299,7 +302,8 @@ void RdmaAsyncEventMonitor::DescribeAndLog(const Watch& watch, const EventInfo& 
         int off = std::snprintf(detail, sizeof(detail), " port=%d", info.portNum);
         if (desc.queryPort && off > 0) {
           ibv_port_attr attr{};
-          if (ibv_query_port(watch.context, static_cast<uint8_t>(info.portNum), &attr) == 0) {
+          int qret = ibv_query_port(watch.context, static_cast<uint8_t>(info.portNum), &attr);
+          if (qret == 0) {
             std::snprintf(detail + off, sizeof(detail) - off,
                           " state=%d phys_state=%d link_layer=%d lid=%u active_speed=%u"
                           " active_width=%u",
@@ -308,7 +312,8 @@ void RdmaAsyncEventMonitor::DescribeAndLog(const Watch& watch, const EventInfo& 
                           static_cast<unsigned>(attr.active_speed),
                           static_cast<unsigned>(attr.active_width));
           } else {
-            std::snprintf(detail + off, sizeof(detail) - off, " query_port_failed errno=%d", errno);
+            std::snprintf(detail + off, sizeof(detail) - off, " query_port_failed ret=%d errno=%d",
+                          qret, errno);
           }
         }
       } else {
@@ -333,21 +338,30 @@ void RdmaAsyncEventMonitor::DescribeAndLog(const Watch& watch, const EventInfo& 
   spdlog::level::level_enum level = desc.severity == Severity::kError  ? spdlog::level::err
                                     : desc.severity == Severity::kWarn ? spdlog::level::warn
                                                                        : spdlog::level::info;
-  if (logger_) {
-    logger_->log(level, "RDMA async event {}{} (type={}) dev={} ctx={} async_fd={}{}", name,
-                 recovery, static_cast<int>(info.type), watch.deviceName,
-                 static_cast<const void*>(watch.context), watch.asyncFd, detail);
+  SafeLog(level, "RDMA async event {}{} (type={}) dev={} ctx={} async_fd={}{}", name, recovery,
+          static_cast<int>(info.type), watch.deviceName, static_cast<const void*>(watch.context),
+          watch.asyncFd, detail);
+}
+
+void RdmaAsyncEventMonitor::RestoreWatchFd(Watch& watch) noexcept {
+  if (!watch.changedFdFlags) return;
+  int ret;
+  do {
+    ret = fcntl(watch.asyncFd, F_SETFL, watch.originalFdFlags);
+  } while (ret < 0 && errno == EINTR);
+  if (ret < 0) {
+    SafeLog(spdlog::level::warn, "RDMA async monitor: failed to restore fd flags on {}: {}",
+            watch.deviceName, std::strerror(errno));
+    return;  // leave changedFdFlags set so a later restore attempt retries
   }
+  watch.changedFdFlags = false;
 }
 
 void RdmaAsyncEventMonitor::RemoveWatch(Watch& watch) noexcept {
   if (!watch.registered) return;
   epoll_ctl(epollFd_, EPOLL_CTL_DEL, watch.asyncFd, nullptr);
   watch.registered = false;
-  if (watch.changedFdFlags) {
-    fcntl(watch.asyncFd, F_SETFL, watch.originalFdFlags);
-    watch.changedFdFlags = false;
-  }
+  RestoreWatchFd(watch);
 }
 
 void RdmaAsyncEventMonitor::DrainWake() noexcept {
@@ -357,12 +371,7 @@ void RdmaAsyncEventMonitor::DrainWake() noexcept {
 }
 
 void RdmaAsyncEventMonitor::RestoreFdFlags() noexcept {
-  for (Watch& watch : watches_) {
-    if (watch.changedFdFlags) {
-      fcntl(watch.asyncFd, F_SETFL, watch.originalFdFlags);
-      watch.changedFdFlags = false;
-    }
-  }
+  for (Watch& watch : watches_) RestoreWatchFd(watch);
 }
 
 void RdmaAsyncEventMonitor::Shutdown() noexcept {

--- a/src/io/rdma/async_event_monitor.hpp
+++ b/src/io/rdma/async_event_monitor.hpp
@@ -79,9 +79,22 @@ class RdmaAsyncEventMonitor {
   GetResult ProcessOneEvent(Watch& watch) noexcept;
   void DescribeAndLog(const Watch& watch, const EventInfo& info) noexcept;
   void RemoveWatch(Watch& watch) noexcept;
+  void RestoreWatchFd(Watch& watch) noexcept;
   void DrainWake() noexcept;
   void RestoreFdFlags() noexcept;
   void Shutdown() noexcept;
+
+  // Logging on the monitor thread runs inside noexcept boundaries; swallow any
+  // spdlog exception so a formatting/sink failure can never call std::terminate.
+  template <typename FormatString, typename... Args>
+  void SafeLog(spdlog::level::level_enum level, const FormatString& fmt,
+               const Args&... args) noexcept {
+    if (!logger_) return;
+    try {
+      logger_->log(level, fmt, args...);
+    } catch (...) {
+    }
+  }
 
   std::shared_ptr<spdlog::logger> logger_;
   std::vector<Watch> watches_;

--- a/src/io/rdma/async_event_monitor.hpp
+++ b/src/io/rdma/async_event_monitor.hpp
@@ -1,0 +1,95 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+#include <infiniband/verbs.h>
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "mori/application/transport/rdma/rdma.hpp"
+#include "mori/utils/mori_log.hpp"
+
+namespace mori {
+namespace io {
+
+// Consumes verbs async events from each unique ibv_context owned by MORI-IO's
+// persistent RdmaContext and reports them through the cached IO logger. One
+// epoll thread drains all async fds plus an eventfd used for shutdown. The
+// monitor holds non-owning ibv_context* references and must be destroyed before
+// ibv_close_device().
+class RdmaAsyncEventMonitor {
+ public:
+  static std::unique_ptr<RdmaAsyncEventMonitor> Create(const application::RdmaDeviceList& devices,
+                                                       std::shared_ptr<spdlog::logger> logger);
+  ~RdmaAsyncEventMonitor();
+
+  RdmaAsyncEventMonitor(const RdmaAsyncEventMonitor&) = delete;
+  RdmaAsyncEventMonitor& operator=(const RdmaAsyncEventMonitor&) = delete;
+
+ private:
+  struct Watch {
+    std::string deviceName;
+    uint32_t physicalPortCount;
+    ibv_context* context;
+    int asyncFd;
+    int originalFdFlags;
+    bool registered;
+    bool changedFdFlags;
+  };
+
+  // POD copied out of ibv_async_event before it is acked; the union members are
+  // invalid to dereference once ibv_ack_async_event() returns.
+  struct EventInfo {
+    ibv_event_type type;
+    const void* objPtr;
+    uint32_t qpNum;
+    int cqDepth;
+    int portNum;
+  };
+
+  enum class GetResult { kEvent, kDrained, kError };
+
+  explicit RdmaAsyncEventMonitor(std::shared_ptr<spdlog::logger> logger);
+
+  bool Start(const application::RdmaDeviceList& devices);
+  void MainLoop() noexcept;
+  GetResult ProcessOneEvent(Watch& watch) noexcept;
+  void DescribeAndLog(const Watch& watch, const EventInfo& info) noexcept;
+  void RemoveWatch(Watch& watch) noexcept;
+  void DrainWake() noexcept;
+  void RestoreFdFlags() noexcept;
+  void Shutdown() noexcept;
+
+  std::shared_ptr<spdlog::logger> logger_;
+  std::vector<Watch> watches_;
+  int epollFd_{-1};
+  int wakeFd_{-1};
+  std::atomic<bool> stopRequested_{false};
+  std::thread thread_;
+};
+
+}  // namespace io
+}  // namespace mori

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -261,9 +261,7 @@ RdmaManager::RdmaManager(const RdmaBackendConfig cfg, application::RdmaContext* 
   topo.reset(new application::TopoSystem());
 
   bool enableAsyncEvents = true;
-  if (const char* val = std::getenv("MORI_IO_ENABLE_ASYNC_EVENTS");
-      val != nullptr && val[0] != '\0')
-    enableAsyncEvents = mori::env::detail::ParseBool(val).value_or(true);
+  env::Override("MORI_IO_ENABLE_ASYNC_EVENTS", enableAsyncEvents, mori::env::detail::ParseBool);
   if (enableAsyncEvents) {
     auto logger = mori::ModuleLogger::GetInstance().GetLogger(mori::modules::IO);
     asyncEventMonitor_ = RdmaAsyncEventMonitor::Create(devices, logger);

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -37,6 +37,7 @@
 
 #include "mori/io/env.hpp"
 #include "mori/io/logging.hpp"
+#include "src/io/rdma/async_event_monitor.hpp"
 #include "src/io/rdma/protocol.hpp"
 namespace mori {
 namespace io {
@@ -258,6 +259,18 @@ RdmaManager::RdmaManager(const RdmaBackendConfig cfg, application::RdmaContext* 
 
   deviceCtxs.resize(availDevices.size(), nullptr);
   topo.reset(new application::TopoSystem());
+
+  bool enableAsyncEvents = true;
+  if (const char* val = std::getenv("MORI_IO_ENABLE_ASYNC_EVENTS");
+      val != nullptr && val[0] != '\0')
+    enableAsyncEvents = mori::env::detail::ParseBool(val).value_or(true);
+  if (enableAsyncEvents) {
+    auto logger = mori::ModuleLogger::GetInstance().GetLogger(mori::modules::IO);
+    asyncEventMonitor_ = RdmaAsyncEventMonitor::Create(devices, logger);
+    if (!asyncEventMonitor_ && logger) {
+      logger->error("Failed to start RDMA async event monitor; continuing without it");
+    }
+  }
 }
 
 RdmaManager::~RdmaManager() {
@@ -267,6 +280,8 @@ RdmaManager::~RdmaManager() {
     }
   }
   deviceCtxs.clear();
+
+  asyncEventMonitor_.reset();
 
   if (ctx != nullptr) {
     delete ctx;

--- a/src/io/rdma/backend_impl.hpp
+++ b/src/io/rdma/backend_impl.hpp
@@ -44,6 +44,8 @@
 namespace mori {
 namespace io {
 
+class RdmaAsyncEventMonitor;
+
 namespace internal {
 
 // Placeholder written into engine_desc.port when an RDMA backend request is
@@ -120,6 +122,8 @@ class RdmaManager {
 
   std::unique_ptr<application::TopoSystem> topo{nullptr};
   std::atomic<uint32_t> roundRobinCounter{0};
+
+  std::unique_ptr<RdmaAsyncEventMonitor> asyncEventMonitor_;
 };
 
 /* ---------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
## What

Adds a verbs async-event monitor to MORI-IO so port down/up and device/CQ/QP/SRQ async conditions are reported proactively, rather than only surfacing once a CQE forms.

## Changes

- **ibv_shim**: forward `ibv_get_async_event` / `ibv_ack_async_event` (`IBVERBS_1.1`); `get` fails when either symbol is missing so no unackable event escapes.
- **RdmaAsyncEventMonitor** (MORI-IO private, no public `RdmaContext` ABI change): one epoll thread over every unique `ibv_context`'s async fd plus an eventfd for shutdown; `O_NONBLOCK` drain with a fairness cap; RAII ack in a short critical section before query/log; a single classification table drives severity and union access.
- **RdmaManager** owns the monitor, gated by `MORI_IO_ENABLE_ASYNC_EVENTS` (default on), and destroys it before `ibv_close_device()`.

## Scope

Observability only — no change to `Endpoint`, `TransferStatus`, `Alive()` or rail selection.

## Testing

- `build.sh` (full `pip install`) passes.
- Real IB/RoCE port-flap verification still needs to run on RDMA hardware (`PORT_ERR`/`PORT_ACTIVE` log at ERROR, visible by default).