### PR TITLE
perf(EPv2): update EPv2 combine tune config

### DIFF
--- a/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
+++ b/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
@@ -575,7 +575,7 @@ def make_combine(
     fp4=False,
     reset_total_recv=True,
     _s3_cache=2,
-    _unroll=2,
+    _unroll=4,
 ):
     # Transport dtype = external dtype, except fp8_direct_cast wires fp8 while
     # the output (comb_out) stays bf16 (2 i32 per fp8 i32 unit). fp4: i32 = 8 fp4.

--- a/python/mori/ops/dispatch_combine_v2/tuning_configs.py
+++ b/python/mori/ops/dispatch_combine_v2/tuning_configs.py
@@ -156,9 +156,10 @@ _GFX1250_SCHED_BF16 = (
     (128, 128, 8, 64, 2),  # <=128:  latency-bound; combine warp 2 (fewest warps win)
     (512, 192, 32, 64, 4),  # <=512:  disp peak; comb 64/4
     (1536, 192, 32, 96, 4),  # <=1536: comb block 96
-    (4096, 192, 32, 128, 4),  # <=4096: comb block 128
-    (None, 192, 32, 128, 8),  # >4096:  comb warp 8 (242/273 GB/s @8192/16384)
+    (4096, 192, 32, 128, 8),  # <=4096: comb block 128
+    (None, 192, 32, 192, 8),  # >4096:  comb warp 8 (242/273 GB/s @8192/16384)
 )
+
 _GFX1250_DEFAULT = dict(
     dispatch_block_num=192,
     combine_block_num=192,


### PR DESCRIPTION
 ## Summary
  - Increase combine kernel unroll factor from 2 to 4 for gfx1250
  - Adjust gfx1250 BF16 scheduling: bump combine warp count from 4→8 for ≤4096 tokens, and combine block from 128→192 for >4096 tokens
