### PR TITLE
feat(cco): honor reqs.sdmaQueueCount, clamp to HW max, guard out-of-range queueId

### DIFF
--- a/include/mori/application/context/context.hpp
+++ b/include/mori/application/context/context.hpp
@@ -131,11 +131,14 @@ class Context {
   // initializes the SDMA queues if any peer was resolved to SDMA.
   void BuildInitialEndpoints();
 
-  // Idempotent setup of anvil SDMA queues for all canSDMA peers. Useful when
-  // SHMEM-style "BuildInitialEndpoints does it for me" is not in play — e.g.
-  // CCO chooses SDMA per-DevComm and needs the queues materialized on demand.
-  // No-op if already set up, or if no peer has canSDMA capability.
-  void EnsureSdmaTransport();
+  // Idempotent setup of anvil SDMA queues for all canSDMA peers. No-op if
+  // already set up or if no peer has canSDMA capability. requestedChannels is
+  // the SDMA channels per GPU pair (0 = MORI_SDMA_NUM_CHANNELS env default); the
+  // first call per Context fixes the count, query SdmaChannels() for it.
+  void EnsureSdmaTransport(int requestedChannels = 0);
+
+  // SDMA channels per pair connected by EnsureSdmaTransport (0 if never set up).
+  int SdmaChannels() const { return sdmaChannels_; }
 
   // Create a new independent set of QP endpoints. `peerMask[i] == true` means
   // peer i gets `numQpPerPe` real QPs; `false` peers get empty stub slots so
@@ -193,6 +196,7 @@ class Context {
   std::vector<RdmaEndpoint> rdmaEps;
   bool initialEndpointsBuilt{false};
   bool sdmaSetupDone{false};
+  int sdmaChannels_{0};  // channels/pair connected by EnsureSdmaTransport (first call wins)
 
   std::unique_ptr<TopoSystem> topo{nullptr};
 

--- a/include/mori/application/transport/sdma/anvil.hpp
+++ b/include/mori/application/transport/sdma/anvil.hpp
@@ -153,6 +153,10 @@ inline void EnablePeerAccess(int const deviceId, int const peerDeviceId) {
               << " (" << hipGetErrorString(error) << ")\n";
   }
 }
+// Hardware cap on SDMA channels per GPU pair on CDNA (4 queues/engine ×
+// 2 recommended engines). Requests above this are clamped, not failed.
+inline constexpr int kMaxSdmaChannelsPerPair = 8;
+
 inline int GetSdmaNumChannels(int defaultVal = 2) {
   const char* env = std::getenv("MORI_SDMA_NUM_CHANNELS");
   if (env != nullptr) {

--- a/include/mori/cco/cco.hpp
+++ b/include/mori/cco/cco.hpp
@@ -1338,7 +1338,8 @@ template <bool Signal = true>
 inline __device__ void ccoSdmaPutThread(void* srcBuf, void* dstBuf, size_t copy_size,
                                         ccoSdmaQueueDeviceHandle** deviceHandles,
                                         HSAuint64* signals, HSAuint64* expectedSignals,
-                                        uint32_t /*queNum*/, uint32_t qId, bool ring = true) {
+                                        uint32_t queNum, uint32_t qId, bool ring = true) {
+  if (qId >= queNum) return;  // out-of-range queue: no-op, not OOB
   ccoSdmaPostCopy<Signal>(deviceHandles, signals, expectedSignals, srcBuf, dstBuf, copy_size,
                           static_cast<int>(qId), ring);
 }
@@ -1367,7 +1368,8 @@ inline __device__ void ccoSdmaPutBlock(void* srcBuf, void* dstBuf, size_t copy_s
 
 // Commit (ring pending packets) per coop scope.
 inline __device__ void ccoSdmaCommitThread(ccoSdmaQueueDeviceHandle** deviceHandles,
-                                           uint32_t /*queNum*/, uint32_t qId) {
+                                           uint32_t queNum, uint32_t qId) {
+  if (qId >= queNum) return;  // out-of-range queue: no-op, not OOB
   ccoSdmaQueueDeviceHandle handle = **(deviceHandles + qId);
   ccoSdmaRingQueueDbr(handle);
 }
@@ -1499,6 +1501,7 @@ struct ccoSdma {
   __device__ inline void quietQueue(int peer, int queueId) {
     const ccoSdmaContext& s = comm.sdma;
     const uint32_t n = s.sdmaNumQueue;
+    if (queueId < 0 || static_cast<uint32_t>(queueId) >= n) return;
     ccoWaitForSignal(s.signalBuf + peer * n + queueId, s.expectSignals[peer * n + queueId]);
   }
 

--- a/src/application/context/context.cpp
+++ b/src/application/context/context.cpp
@@ -334,7 +334,7 @@ TransportType Context::DefaultPolicyResolve(const PeerCapabilities& cap, bool is
 /*  SDMA queues materialized but did not go through BuildInitialEndpoints.  */
 /* ------------------------------------------------------------------------ */
 
-void Context::EnsureSdmaTransport() {
+void Context::EnsureSdmaTransport(int requestedChannels) {
   if (sdmaSetupDone) return;
 
   // anvil global init: do it lazily here rather than at Context construction
@@ -343,10 +343,13 @@ void Context::EnsureSdmaTransport() {
   // SDMA engines — see PeerCapabilities doc for context.
   anvil::anvil.init();
 
-  // GetSdmaNumChannels is a configuration knob (env or default 2), not a
-  // hardware probe. The real check is whether the loop body below succeeds
-  // for every canSDMA peer.
-  int sdmaNumChannels = anvil::GetSdmaNumChannels();
+  // Explicit request (CCO's reqs.sdmaQueueCount) wins; else env default.
+  int sdmaNumChannels = requestedChannels > 0 ? requestedChannels : anvil::GetSdmaNumChannels();
+  if (sdmaNumChannels > anvil::kMaxSdmaChannelsPerPair) {
+    MORI_APP_WARN("SDMA channels {} exceeds hardware max, clamping to {}", sdmaNumChannels,
+                  anvil::kMaxSdmaChannelsPerPair);
+    sdmaNumChannels = anvil::kMaxSdmaChannelsPerPair;
+  }
   MORI_APP_INFO("SDMA num channels per GPU pair: {}", sdmaNumChannels);
 
   for (int i = 0; i < WorldSize(); i++) {
@@ -354,6 +357,7 @@ void Context::EnsureSdmaTransport() {
     if (i != LocalRank()) anvil::EnablePeerAccess(LocalRank() % 8, i % 8);
     anvil::anvil.connect(LocalRank() % 8, i % 8, sdmaNumChannels);
   }
+  sdmaChannels_ = sdmaNumChannels;
   sdmaSetupDone = true;
 }
 

--- a/src/cco/cco_init.cpp
+++ b/src/cco/cco_init.cpp
@@ -64,8 +64,11 @@ struct vmmProcessLock {
   std::lock_guard<std::recursive_mutex> guard{vmmProcessMutex()};
 };
 
-void ccoSdmaSetupCommQueues(ccoComm* comm) {
+void ccoSdmaSetupCommQueues(ccoComm* comm, int requestedChannels) {
 #if BUILD_CCO_SDMA
+  // Idempotent: first DevComm materializes queues; later ones reuse them.
+  if (comm->sdmaDevHandles != nullptr) return;
+
   bool anySdmaCapable = false;
   for (int pe = 0; pe < comm->worldSize; pe++) {
     if (comm->ctx->GetPeerCapabilities(pe).canSDMA) {
@@ -78,8 +81,10 @@ void ccoSdmaSetupCommQueues(ccoComm* comm) {
     return;
   }
 
-  comm->sdmaNumQueue = anvil::GetSdmaNumChannels();
-  comm->ctx->EnsureSdmaTransport();
+  // requestedChannels (reqs.sdmaQueueCount, 0 = env default) drives the connect;
+  // adopt the count actually connected so device-side indexing stays in bounds.
+  comm->ctx->EnsureSdmaTransport(requestedChannels);
+  comm->sdmaNumQueue = comm->ctx->SdmaChannels();
 
   // sdmaDevHandles is lsaSize × sdmaNumQueue, indexed by lsaRank. Assumes ranks
   // bind 1:1 to GPUs within a node (rank lsa ⇒ GPU lsa).
@@ -102,6 +107,7 @@ void ccoSdmaSetupCommQueues(ccoComm* comm) {
     }
   }
 #else
+  (void)requestedChannels;
   comm->sdmaNumQueue = 0;
 #endif  // BUILD_CCO_SDMA
 }
@@ -655,10 +661,8 @@ static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perR
   // HeapVAManager's invariants.
   comm->vaManager.reset(new application::HeapVAManager(LocalSlotBase(comm), perRankVmmSize, 0));
 
-  // Step 4: SDMA queue setup (intra-node copy engine). Delegated to the local
-  // ccoSdmaSetupCommQueues helper above, which confines the anvil dependency to
-  // this TU under BUILD_CCO_SDMA. Leaves sdmaNumQueue=0 when SDMA isn't used.
-  ccoSdmaSetupCommQueues(comm);
+  // SDMA queues are materialized lazily in ccoDevCommCreate, where
+  // reqs.sdmaQueueCount is known. sdmaNumQueue stays 0 until then.
 
   // RDMA QP endpoints are NOT pre-allocated here. ccoDevCommCreate builds
   // a fresh QP set per DevComm via ctx->CreateAdditionalEndpoints, sized by
@@ -1632,6 +1636,10 @@ int ccoDevCommCreate(ccoComm* comm, const ccoDevCommRequirements* reqs, ccoDevCo
   // handle was exported by the same process, so for SPMT we Allgather raw
   // VAs alongside IPC handles and pick per-peer based on SameProcessP2P.
   // (See shmem's SymmMemManager::Register for the same pattern.)
+  // Materialize comm SDMA queues now that reqs.sdmaQueueCount is known
+  // (0 = env default). First DevComm on this comm fixes the channel count.
+  ccoSdmaSetupCommQueues(comm, reqs != nullptr ? reqs->sdmaQueueCount : 0);
+
   ccoSdmaContext& sdma = hostShadow.sdma;
   sdma.sdmaNumQueue = static_cast<uint32_t>(comm->sdmaNumQueue);
   if (comm->sdmaNumQueue > 0) {

--- a/src/cco/cco_init.cpp
+++ b/src/cco/cco_init.cpp
@@ -66,8 +66,15 @@ struct vmmProcessLock {
 
 void ccoSdmaSetupCommQueues(ccoComm* comm, int requestedChannels) {
 #if BUILD_CCO_SDMA
-  // Idempotent: first DevComm materializes queues; later ones reuse them.
-  if (comm->sdmaDevHandles != nullptr) return;
+  // Idempotent: first DevComm fixes the channel count; later ones reuse it.
+  if (comm->sdmaDevHandles != nullptr) {
+    int want = std::min(requestedChannels, anvil::kMaxSdmaChannelsPerPair);
+    if (want > 0 && want != comm->sdmaNumQueue) {
+      MORI_SHMEM_WARN("sdmaQueueCount {} ignored; comm already has {}", requestedChannels,
+                      comm->sdmaNumQueue);
+    }
+    return;
+  }
 
   bool anySdmaCapable = false;
   for (int pe = 0; pe < comm->worldSize; pe++) {
@@ -81,8 +88,8 @@ void ccoSdmaSetupCommQueues(ccoComm* comm, int requestedChannels) {
     return;
   }
 
-  // requestedChannels (reqs.sdmaQueueCount, 0 = env default) drives the connect;
-  // adopt the count actually connected so device-side indexing stays in bounds.
+  // requestedChannels: reqs.sdmaQueueCount, 0 = env default. Adopt the count
+  // actually connected so device-side indexing stays in bounds.
   comm->ctx->EnsureSdmaTransport(requestedChannels);
   comm->sdmaNumQueue = comm->ctx->SdmaChannels();
 
@@ -661,8 +668,8 @@ static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perR
   // HeapVAManager's invariants.
   comm->vaManager.reset(new application::HeapVAManager(LocalSlotBase(comm), perRankVmmSize, 0));
 
-  // SDMA queues are materialized lazily in ccoDevCommCreate, where
-  // reqs.sdmaQueueCount is known. sdmaNumQueue stays 0 until then.
+  // SDMA queues are set up in ccoDevCommCreate, where reqs.sdmaQueueCount is
+  // known; sdmaNumQueue stays 0 until then.
 
   // RDMA QP endpoints are NOT pre-allocated here. ccoDevCommCreate builds
   // a fresh QP set per DevComm via ctx->CreateAdditionalEndpoints, sized by
@@ -671,10 +678,9 @@ static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perR
 
   MORI_SHMEM_INFO(
       "ccoCommCreate: rank={}/{} groupId={} flatBase={} perRankSize={} "
-      "granularity={} defaultNumQpPerPe={} sdmaNumQueue={} rdma={} fabric={}",
+      "granularity={} defaultNumQpPerPe={} rdma={} fabric={}",
       comm->rank, comm->worldSize, comm->groupId, comm->flatBase, comm->perRankSize,
-      comm->vmmGranularity, comm->defaultNumQpPerPe, comm->sdmaNumQueue,
-      comm->ctx->RdmaTransportEnabled(),
+      comm->vmmGranularity, comm->defaultNumQpPerPe, comm->ctx->RdmaTransportEnabled(),
       comm->handleType == static_cast<int>(hipMemHandleTypeFabricCompat));
   return 0;
 }
@@ -1636,8 +1642,7 @@ int ccoDevCommCreate(ccoComm* comm, const ccoDevCommRequirements* reqs, ccoDevCo
   // handle was exported by the same process, so for SPMT we Allgather raw
   // VAs alongside IPC handles and pick per-peer based on SameProcessP2P.
   // (See shmem's SymmMemManager::Register for the same pattern.)
-  // Materialize comm SDMA queues now that reqs.sdmaQueueCount is known
-  // (0 = env default). First DevComm on this comm fixes the channel count.
+  // Set up comm SDMA queues from reqs.sdmaQueueCount (0 = env default).
   ccoSdmaSetupCommQueues(comm, reqs != nullptr ? reqs->sdmaQueueCount : 0);
 
   ccoSdmaContext& sdma = hostShadow.sdma;


### PR DESCRIPTION
## Motivation

`ccoDevCommRequirements.sdmaQueueCount` was declared but never consumed. The
SDMA channel count could only be set via `MORI_SDMA_NUM_CHANNELS`, because the
queues were materialized in `ccoCommCreate` — before `reqs` is available — and
`ccoDevCommCreate` merely copied `comm->sdmaNumQueue`. Setting
`reqs.sdmaQueueCount` had no effect.

Additionally, thread-scope `put`/`commit`/`quietQueue` did no bounds check on
`queueId`, so a `queueId >= sdmaNumQueue` was undefined behavior (wrong-queue
use or an out-of-bounds handle/signal access).

## Changes

- **Wire `reqs.sdmaQueueCount`.** SDMA queue setup is deferred to
  `ccoDevCommCreate`, where `reqs` is known. `ccoSdmaSetupCommQueues` resolves
  the count from `reqs.sdmaQueueCount` (0 = env default) and is idempotent per
  comm (the first DevComm fixes the count; later ones reuse the handles).
- **`EnsureSdmaTransport(int requestedChannels = 0)`** connects with the
  requested count (0 = `MORI_SDMA_NUM_CHANNELS`) and exposes the count actually
  connected via `SdmaChannels()`; CCO adopts it so device-side indexing stays in
  bounds. SHMEM's existing no-arg call is unchanged (defaults to env).
- **Clamp instead of abort.** Requests above the CDNA per-pair hardware max
  (`kMaxSdmaChannelsPerPair = 8`, i.e. 4 queues/engine × 2 engines) are clamped
  with a warning rather than failing in `hsaKmtCreateQueueExt`.
- **Guard out-of-range `queueId`** in thread-scope `put`/`commit`/`quietQueue`:
  now a safe no-op. warp/block scope already clamp via the lane/thread → queue
  mapping.

## Test Plan

Validated on MI355X (gfx950, 2 GPU, own build) with a 2-rank harness that sets
`reqs.sdmaQueueCount` directly and probes `devComm.sdma.sdmaNumQueue`:

- `reqs.sdmaQueueCount = 8` → 8 distinct queues; put+quiet PASS.
- `= 0`, env unset → default 2; PASS.
- `= 0`, `MORI_SDMA_NUM_CHANNELS=4` → 4; PASS.
- `= 16` → clamped to 8 (warn, no crash); PASS.
- out-of-range `queueId` (n+3) → recv untouched, kernel returns (no hang/fault).
- Default path (no `sdmaQueueCount`) unchanged.
- `mori_cco` and `mori_shmem` both build with the new `EnsureSdmaTransport`
  signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)