### PR TITLE
MORI-IO nixl-style cpp bench script

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -510,6 +510,28 @@ jobs:
             --num-initiator-dev 8 --num-target-dev 8
           wait
 
+      - name: Build MORI-IO C++ bench_engine (both nodes)
+        run: |
+          BUILD_CMD="cd $GITHUB_WORKSPACE && cmake -B build -DBUILD_IO=ON -DBUILD_TESTS=ON -DBUILD_EXAMPLES=OFF && cmake --build build --target bench_engine -j && ls -la build/tests/cpp/bench_engine"
+          $CT exec $CONTAINER bash -c "$BUILD_CMD"
+          ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "$CT exec $CONTAINER bash -c \"$BUILD_CMD\""
+
+      - name: MORI-IO C++ bench_engine write sweep (batch 1 and 64)
+        run: |
+          BIN=$GITHUB_WORKSPACE/build/tests/cpp/bench_engine
+          LDP="LD_LIBRARY_PATH=$GITHUB_WORKSPACE/build/src/io:$GITHUB_WORKSPACE/build/src/application"
+          PORT=29130
+          for BATCH in 1 64; do
+            echo "=== C++ bench_engine GPU write sweep, batch=$BATCH, port=$PORT ==="
+            ARGS="--op write --mem-type gpu --all --sweep-start 1048576 --sweep-max 33554432 --sweep-step 1048576 --transfer-batch-size $BATCH --enable-sess --enable-batch-transfer --num-initiator-dev 1 --num-target-dev 1 --num-qp-per-transfer 8 --iters 200 --warmup-iters 5"
+            R1="cd $GITHUB_WORKSPACE && $LDP $BIN --rank 1 --master-ip $NODE1_HOST --self-ip $NODE2_HOST --port $PORT $ARGS"
+            R0="cd $GITHUB_WORKSPACE && $LDP $BIN --rank 0 --master-ip $NODE1_HOST --self-ip $NODE1_HOST --port $PORT $ARGS"
+            ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "$CT exec $CONTAINER bash -c \"$R1\"" &
+            $CT exec $CONTAINER bash -c "$R0"
+            wait
+            PORT=$((PORT + 1))
+          done
+
       - name: MORI-EP internode normal kernel bench
         run: |
           SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_test.sh"

--- a/docs/MORI-IO-BENCHMARK.md
+++ b/docs/MORI-IO-BENCHMARK.md
@@ -177,11 +177,14 @@ Most flags share names with the Python benchmark (`--op-type`/`--op`,
 | Python | C++ (nixl-style) | Notes |
 |--------|------------------|-------|
 | `torchrun ... --node_rank` | `--rank 0` / `--rank 1` | C++ rendezvous runs over MORI's socket bootstrap; rank 0 is the root, and the second process must arrive within `MORI_BOOTSTRAP_TIMEOUT`. |
-| `--host` | `--master-ip` + `--self-ip` | `--master-ip` = rank 0's IP, same on both ranks; `--self-ip` = the control-plane IP each rank advertises to the peer. |
+| `--host` | `--master-ip` + `--self-ip` | `--host` is accepted as a spelling of `--master-ip`. `--master-ip` = rank 0's IP, same on both ranks; `--self-ip` = the control-plane IP each rank advertises to the peer, which Python does not need because torchrun supplies it. |
+| `--src-gpu` / `--dst-gpu` | `--gpu` / `--target-dev-offset` | Python's names are accepted: `--src-gpu` is `--gpu`, and `--dst-gpu N` sets `--target-dev-offset` to `N - gpu` (passing both a conflicting `--dst-gpu` and `--target-dev-offset` is rejected). Under `--xgmi-single-process` they are the two local GPUs directly. |
+| `--num-initiator-dev` / `--num-target-dev` | same | One process per GPU on each side, forked before any HIP call; initiator local *i* pairs with target local *i*, driving GPU `--gpu + i`. The two counts must be equal, as Python asserts. Each pair prints its own `[gpu N]`-prefixed row and rank 0 adds an `[AGGREGATE]` line summing bandwidth across pairs — Python prints per-rank tables with no aggregate. |
 | `--enable-batch-transfer` (default OFF) | `--enable-batch-transfer` / `--disable-batch-transfer` (C++ default **ON**) | Same meaning as Python: **ON** = one N-descriptor batch request (the nixl-equivalent; nixl always batches); **OFF** = `--transfer-batch-size` N *individual* single-transfer submissions per iteration (Python `run_single_once`). The C++ tool defaults **ON** so the out-of-the-box run and `--all-batch` sweep are nixl-comparable; pass `--disable-batch-transfer` for the Python single-submission path. |
 | `--iters` (default `128`) | `--iters` (default `500`), plus `--warmup-iters` | Only the warmup flag is new: it runs untimed iterations before the timed region, matching nixl's `--warmup_iter`. |
 | `--sweep-start-size` / `--sweep-max-size` | `--sweep-start` / `--sweep-max` (long names also accepted) | Names only; `--sweep-step` (`0` = geometric ×2, `>0` = linear) behaves the same in both. |
-| `--backend rdma\|xgmi\|fabric` | `--backend rdma\|xgmi` | C++ has no `fabric` path. `--num-streams` / `--num-events` size the XGMI HIP pools, as in Python. |
+| `--backend rdma\|xgmi\|fabric` | same | `--num-streams` / `--num-events` size the XGMI **and** FABRIC HIP pools, as in Python. `fabric` (UALink scale-up, GPU memory only) needs a host whose GPUs expose `/sys/bus/pci/devices/*/ualink`; on RoCE-only hardware the engine reports `No available backend found` at the first transfer. |
+| `--xgmi-multiprocess` (default OFF) | `--xgmi-single-process` (default OFF, i.e. multiprocess) | The defaults are **opposite**. The C++ tool's two-rank path is already Python's `--xgmi-multiprocess`: two processes with distinct engine keys, so the backend takes its `hipIpc*` route. `--xgmi-single-process` adds Python's *default* instead — one process owning both GPUs, no rendezvous and no IPC. `--xgmi-multiprocess` is accepted to document intent but is a no-op. |
 | *(always on)* | `--skip-validate` | Both tools verify transferred data as part of the run. Python compares the target's buffer byte-for-byte over gloo; the C++ tool seeds a rank- and offset-dependent pattern and exchanges one checksum per transferred slot after the sweep (so the check is O(batch) on the wire but still covers every byte), printing `validation: OK` or naming the first mismatching slot and exiting non-zero. `--skip-validate` opts out; passing it to only one rank is safe — that rank contributes nothing and the run reports `validation: skipped` rather than hanging. |
 
 > `--self-ip` must be an address the peer can reach over TCP, since it becomes the
@@ -201,10 +204,19 @@ Most flags share names with the Python benchmark (`--op-type`/`--op`,
 > For `--backend xgmi`, run both ranks on the **same** host with different `--gpu`
 > (XGMI is intra-node) and the same `--master-ip`/`--self-ip`; their engine control
 > ports still differ because those are derived from the rank. The backend is
-> created explicitly, so no env var is needed. Note this measures the
-> *cross-process* XGMI path, since the C++ tool is always two processes; the Python
-> benchmark's default single-process mode avoids cross-process overhead entirely,
-> so the two are not directly comparable at small message sizes.
+> created explicitly, so no env var is needed. That two-rank form measures the
+> *cross-process* XGMI path (distinct engine keys ⇒ `hipIpc*`). To measure what the
+> Python benchmark measures by default, pass `--xgmi-single-process` with
+> `--src-gpu`/`--dst-gpu`: one process owns both GPUs, there is no rendezvous and no
+> IPC, so `--rank`/`--master-ip` are not needed and small-message numbers become
+> directly comparable to Python's.
+>
+> For multi-GPU runs (`--num-initiator-dev N --num-target-dev N`) the bootstrap
+> world is `2N` ranks, laid out initiators first. Engine control ports are derived
+> from the **global** rank, so `--port P` reserves `P` for the bootstrap and
+> `P+1 … P+2N` for the engines — leave that range free. Each side forks `N-1`
+> children before touching HIP, so a failure in one pair still reaps the others
+> rather than leaving them holding ports.
 
 ## Benchmark Arguments
 

--- a/docs/MORI-IO-BENCHMARK.md
+++ b/docs/MORI-IO-BENCHMARK.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 
 - [Benchmark Commands](#benchmark-commands)
+- [C++ Benchmark (nixlbench-matching)](#c-benchmark-nixlbench-matching)
 - [Benchmark Arguments](#benchmark-arguments)
 - [Results: Thor2 RDMA Read](#results-thor2-rdma-read)
 - [Results: Thor2 RDMA Write](#results-thor2-rdma-write)
@@ -47,6 +48,108 @@ torchrun --nnodes=2 --node_rank=0 --nproc_per_node=1 \
 > Requires ROCm ≥ 7.15 (HIP fabric VMM APIs). Only GPU memory is supported
 > (`--mem-type gpu`). If the two nodes are not in the same vPOD, session creation
 > fails fast with a clear error.
+
+## C++ Benchmark (nixlbench-matching)
+
+The commands above use the **Python** benchmark (`tests/python/io/benchmark.py`).
+There is also a native **C++** benchmark, `tests/cpp/io/bench_engine.cpp`, whose
+measurement loop is written to **match [nixlbench](https://github.com/ai-dynamo/nixl)**
+(NVIDIA NIXL's `xferbench`) exactly, so MORI-IO and NIXL RDMA numbers are
+apples-to-apples on the same fabric. Use it when you want a head-to-head
+comparison against NIXL, or a benchmark with zero Python-interpreter overhead
+(which biases the Python numbers by ~2 µs/iter at small message sizes).
+
+What "nixl-matching" means here:
+
+- **One whole-loop timer** around the entire iteration loop (not a per-iteration
+  sum), identical to nixlbench's `total_timer`.
+- **Latency is reported per single transfer**: `total_us / (iters × batch)`,
+  matching nixl's `avg_latency = total_duration / (per_thread_iter × batch_size)`.
+- **Bandwidth** `= msg × batch × iters / 1e9 / (total_us / 1e6)` (GB = 10⁹), same
+  units as nixl.
+- **Completion is always an inline spin-poll** in the benchmark thread (mirroring
+  nixl's `getXferStatus` scan); there is no cv-blocking wait that would add wakeup
+  latency and make numbers non-comparable.
+- **Strict stop-and-wait** (one request outstanding at a time, == nixl
+  `--pipeline_depth 1`): post one request, spin until it completes, then post the
+  next.
+- **Warmup** iterations are excluded from timing (`--warmup-iters`, nixl
+  `--warmup_iter`).
+
+### Build
+
+`bench_engine` builds with the C++ tests (both options default `ON`):
+
+```bash
+cd /path/to/mori
+cmake -B build -DBUILD_IO=ON -DBUILD_TESTS=ON
+cmake --build build --target bench_engine -j
+# binary: build/tests/cpp/bench_engine
+```
+
+The MORI shared libraries must be discoverable at runtime. After an editable
+install they live in `python/mori`:
+
+```bash
+export LD_LIBRARY_PATH=/path/to/mori/python/mori:$LD_LIBRARY_PATH
+```
+
+### Run (two nodes)
+
+Unlike the Python benchmark (which uses `torchrun` for the out-of-band
+rendezvous), the C++ benchmark does its own TCP rendezvous between two
+processes: **rank 1 is the target and must be started first**, then **rank 0 is
+the initiator** and drives all transfers. `--master-ip` is rank 0's IP; each
+process passes its own peer-reachable data-plane IP via `--self-ip`.
+
+```bash
+# On the TARGET node (rank 1) — start this FIRST:
+MORI_DISABLE_AUTO_XGMI=1 build/tests/cpp/bench_engine \
+    --rank 1 --master-ip 10.190.162.0 --self-ip 10.190.162.1 --port 18515 \
+    --op write --all --sweep-start 1048576 --sweep-max 33554432 --sweep-step 1048576 \
+    --iters 500 --warmup-iters 50 --num-qp-per-transfer 4 --enable-sess
+
+# On the INITIATOR node (rank 0) — start this SECOND (prints the results table):
+MORI_DISABLE_AUTO_XGMI=1 build/tests/cpp/bench_engine \
+    --rank 0 --master-ip 10.190.162.0 --self-ip 10.190.162.0 --port 18515 \
+    --op write --all --sweep-start 1048576 --sweep-max 33554432 --sweep-step 1048576 \
+    --iters 500 --warmup-iters 50 --num-qp-per-transfer 4 --enable-sess
+```
+
+Both ranks must be given the **same** benchmark args (op, sweep, batch, etc.).
+Only rank 0 (initiator) prints the results table:
+
+```
+MsgSize(B)  Batch  Iters  AvgBW(GB/s)  AvgLat(us)  TotalDur(us)
+```
+
+### Sweep modes
+
+- `--all` — sweep message size. Geometric ×2 by default, or linear when
+  `--sweep-step > 0`, from `--sweep-start` to `--sweep-max`; batch stays at
+  `--transfer-batch-size`.
+- `--all-batch` — fix message size at `--buffer-size` and sweep batch
+  `1,2,4,…,32768`.
+- neither — a single `(--buffer-size, --transfer-batch-size)` point.
+
+### Differences from the Python flags
+
+Most flags share names with the Python benchmark (`--op-type`/`--op`,
+`--num-qp-per-transfer`, `--num-worker-threads`, `--transfer-batch-size`,
+`--enable-sess`, `--batch-contiguous`, `--disable-chunking`, `--chunk-bytes`,
+`--poll_cq_mode`, `--mem-type`, `--all`, `--all-batch`), but note:
+
+| Python | C++ (nixl-style) | Notes |
+|--------|------------------|-------|
+| `torchrun ... --node_rank` | `--rank 0` / `--rank 1` | C++ uses its own TCP rendezvous; **start rank 1 first**. |
+| `--host` | `--master-ip` + `--self-ip` | `--master-ip` = rank 0's IP; `--self-ip` = each node's peer-reachable IP. |
+| `--enable-batch-transfer` (default OFF) | `--enable-batch-transfer` / `--disable-batch-transfer` (C++ default **ON**) | Same meaning as Python: **ON** = one N-descriptor batch request (the nixl-equivalent; nixl always batches); **OFF** = `--transfer-batch-size` N *individual* single-transfer submissions per iteration (Python `run_single_once`). The C++ tool defaults **ON** so the out-of-the-box run and `--all-batch` sweep are nixl-comparable; pass `--disable-batch-transfer` for the Python single-submission path. |
+| *(n/a)* | `--warmup-iters` / `--iters` | Explicit warmup (untimed) and timed iteration counts. |
+| `--sweep-start-size` / `--sweep-max-size` | `--sweep-start` / `--sweep-max` (aliases accepted) | Plus `--sweep-step` for a linear (vs geometric) sweep. |
+
+> Keep the process on the RDMA path with `MORI_DISABLE_AUTO_XGMI=1`. Use
+> `--self-ip` equal to the data-plane IP each node advertises for QP setup;
+> `0.0.0.0` will fail with `connect(...): Connection refused`.
 
 ## Benchmark Arguments
 

--- a/docs/MORI-IO-BENCHMARK.md
+++ b/docs/MORI-IO-BENCHMARK.md
@@ -3,7 +3,12 @@
 ## Table of Contents
 
 - [Benchmark Commands](#benchmark-commands)
+  - [Fabric (cross-node scale-up UALink super-node)](#fabric-cross-node-scale-up-ualink-super-node)
 - [C++ Benchmark (nixlbench-matching)](#c-benchmark-nixlbench-matching)
+  - [Build](#build)
+  - [Run (two nodes)](#run-two-nodes)
+  - [Sweep modes](#sweep-modes)
+  - [Differences from the Python flags](#differences-from-the-python-flags)
 - [Benchmark Arguments](#benchmark-arguments)
 - [Results: Thor2 RDMA Read](#results-thor2-rdma-read)
 - [Results: Thor2 RDMA Write](#results-thor2-rdma-write)
@@ -12,6 +17,12 @@
 - [Results: CX7 RDMA (Batch Size = 1)](#results-cx7-rdma-batch-size--1)
   - [Write](#write)
   - [Read](#read)
+- [Benchmark Tuning Guide](#benchmark-tuning-guide)
+  - [Recommended starting config](#recommended-starting-config)
+  - [Parameters that help](#parameters-that-help)
+  - [The merged-WR size limit](#the-merged-wr-size-limit)
+  - [Parameters that usually do not help (or can hurt)](#parameters-that-usually-do-not-help-or-can-hurt)
+  - [Host (CPU) vs GPU memory](#host-cpu-vs-gpu-memory)
 
 ## Benchmark Commands
 
@@ -56,8 +67,9 @@ There is also a native **C++** benchmark, `tests/cpp/io/bench_engine.cpp`, whose
 measurement loop is written to **match [nixlbench](https://github.com/ai-dynamo/nixl)**
 (NVIDIA NIXL's `xferbench`) exactly, so MORI-IO and NIXL RDMA numbers are
 apples-to-apples on the same fabric. Use it when you want a head-to-head
-comparison against NIXL, or a benchmark with zero Python-interpreter overhead
-(which biases the Python numbers by ~2 µs/iter at small message sizes).
+comparison against NIXL, or a benchmark with no Python-interpreter overhead in the
+measurement loop (which the Python bench pays per iteration, so it shows up most
+at small message sizes).
 
 What "nixl-matching" means here:
 
@@ -87,20 +99,30 @@ cmake --build build --target bench_engine -j
 # binary: build/tests/cpp/bench_engine
 ```
 
-The MORI shared libraries must be discoverable at runtime. After an editable
-install they live in `python/mori`:
+`bench_engine --help` prints the full flag list, grouped by rendezvous,
+workload, sweep, memory, and backend tuning.
+
+The MORI shared libraries must be discoverable at runtime — from the build tree
+above, or from `python/mori` after an editable install:
 
 ```bash
+export LD_LIBRARY_PATH=$PWD/build/src/io:$PWD/build/src/application:$LD_LIBRARY_PATH
+# or, after an editable install:
 export LD_LIBRARY_PATH=/path/to/mori/python/mori:$LD_LIBRARY_PATH
 ```
 
 ### Run (two nodes)
 
 Unlike the Python benchmark (which uses `torchrun` for the out-of-band
-rendezvous), the C++ benchmark does its own TCP rendezvous between two
-processes: **rank 1 is the target and must be started first**, then **rank 0 is
-the initiator** and drives all transfers. `--master-ip` is rank 0's IP; each
-process passes its own peer-reachable data-plane IP via `--self-ip`.
+rendezvous), the C++ benchmark brings the two processes together over MORI's own
+socket bootstrap — the same layer that starts multi-node CCO and SHMEM jobs, so
+connect and accept are retried over the `MORI_BOOTSTRAP_TIMEOUT` budget (seconds,
+default `300`). **Rank 0 is the initiator** and drives every transfer; **rank 1
+is the target** and only keeps its memory registered. Start the target first as a
+habit — rank 0 is the rendezvous root, so either order works and the two retry at
+each other, but the second process has to arrive within the budget.
+`--master-ip` is rank 0's IP and is passed identically on both ranks; `--self-ip`
+is the address each rank advertises to its peer.
 
 ```bash
 # On the TARGET node (rank 1) — start this FIRST:
@@ -123,6 +145,18 @@ Only rank 0 (initiator) prints the results table:
 MsgSize(B)  Batch  Iters  AvgBW(GB/s)  AvgLat(us)  TotalDur(us)
 ```
 
+`--port` is not the only TCP port in play, which matters behind a firewall:
+
+| Endpoint | Bound by | Address |
+|----------|----------|---------|
+| Bootstrap rendezvous | rank 0 only | `--master-ip` : `--port` (`18515` above) |
+| Engine control plane | both ranks | `--self-ip` : `--port + 1 + rank` (`18516` / `18517` above) |
+| Bootstrap ring / allgather | both ranks | chosen interface, kernel-assigned ephemeral port |
+
+The engine control plane is a plain TCP channel: the initiator dials the target's
+advertised `EngineDesc` address to run the QP handshake and to look up the remote
+memory region. No RDMA payload crosses it.
+
 ### Sweep modes
 
 - `--all` — sweep message size. Geometric ×2 by default, or linear when
@@ -137,19 +171,40 @@ MsgSize(B)  Batch  Iters  AvgBW(GB/s)  AvgLat(us)  TotalDur(us)
 Most flags share names with the Python benchmark (`--op-type`/`--op`,
 `--num-qp-per-transfer`, `--num-worker-threads`, `--transfer-batch-size`,
 `--enable-sess`, `--batch-contiguous`, `--disable-chunking`, `--chunk-bytes`,
-`--poll_cq_mode`, `--mem-type`, `--all`, `--all-batch`), but note:
+`--poll_cq_mode`, `--mem-type`, `--iters`, `--sweep-step`, `--all`,
+`--all-batch`), but note:
 
 | Python | C++ (nixl-style) | Notes |
 |--------|------------------|-------|
-| `torchrun ... --node_rank` | `--rank 0` / `--rank 1` | C++ uses its own TCP rendezvous; **start rank 1 first**. |
-| `--host` | `--master-ip` + `--self-ip` | `--master-ip` = rank 0's IP; `--self-ip` = each node's peer-reachable IP. |
+| `torchrun ... --node_rank` | `--rank 0` / `--rank 1` | C++ rendezvous runs over MORI's socket bootstrap; rank 0 is the root, and the second process must arrive within `MORI_BOOTSTRAP_TIMEOUT`. |
+| `--host` | `--master-ip` + `--self-ip` | `--master-ip` = rank 0's IP, same on both ranks; `--self-ip` = the control-plane IP each rank advertises to the peer. |
 | `--enable-batch-transfer` (default OFF) | `--enable-batch-transfer` / `--disable-batch-transfer` (C++ default **ON**) | Same meaning as Python: **ON** = one N-descriptor batch request (the nixl-equivalent; nixl always batches); **OFF** = `--transfer-batch-size` N *individual* single-transfer submissions per iteration (Python `run_single_once`). The C++ tool defaults **ON** so the out-of-the-box run and `--all-batch` sweep are nixl-comparable; pass `--disable-batch-transfer` for the Python single-submission path. |
-| *(n/a)* | `--warmup-iters` / `--iters` | Explicit warmup (untimed) and timed iteration counts. |
-| `--sweep-start-size` / `--sweep-max-size` | `--sweep-start` / `--sweep-max` (aliases accepted) | Plus `--sweep-step` for a linear (vs geometric) sweep. |
+| `--iters` (default `128`) | `--iters` (default `500`), plus `--warmup-iters` | Only the warmup flag is new: it runs untimed iterations before the timed region, matching nixl's `--warmup_iter`. |
+| `--sweep-start-size` / `--sweep-max-size` | `--sweep-start` / `--sweep-max` (long names also accepted) | Names only; `--sweep-step` (`0` = geometric ×2, `>0` = linear) behaves the same in both. |
+| `--backend rdma\|xgmi\|fabric` | `--backend rdma\|xgmi` | C++ has no `fabric` path. `--num-streams` / `--num-events` size the XGMI HIP pools, as in Python. |
+| *(always on)* | `--skip-validate` | Both tools verify transferred data as part of the run. Python compares the target's buffer byte-for-byte over gloo; the C++ tool seeds a rank- and offset-dependent pattern and exchanges one checksum per transferred slot after the sweep (so the check is O(batch) on the wire but still covers every byte), printing `validation: OK` or naming the first mismatching slot and exiting non-zero. `--skip-validate` opts out; passing it to only one rank is safe — that rank contributes nothing and the run reports `validation: skipped` rather than hanging. |
 
-> Keep the process on the RDMA path with `MORI_DISABLE_AUTO_XGMI=1`. Use
-> `--self-ip` equal to the data-plane IP each node advertises for QP setup;
-> `0.0.0.0` will fail with `connect(...): Connection refused`.
+> `--self-ip` must be an address the peer can reach over TCP, since it becomes the
+> `EngineDesc` host the peer dials for the QP handshake and remote-MR lookup.
+> `0.0.0.0` does not work: the peer ends up dialing its own loopback and fails with
+> `connect(...): Connection refused`. It does **not** choose the RDMA device that
+> carries the data — that stays rail/NUMA-aware (override with
+> `MORI_RDMA_DEVICES`) — so the control IP need not be the RoCE interface's. The
+> bootstrap picks its local interface independently of both, so set
+> `MORI_SOCKET_IFNAME` when that choice has no route to the peer.
+>
+> `MORI_DISABLE_AUTO_XGMI` gates only the RDMA→XGMI *fallback* for hosts with no
+> active RDMA device, and that fallback is off unless the variable is literally
+> `0`. The `=1` above is therefore belt-and-braces, worth keeping only where
+> something in the environment sets it to `0`.
+>
+> For `--backend xgmi`, run both ranks on the **same** host with different `--gpu`
+> (XGMI is intra-node) and the same `--master-ip`/`--self-ip`; their engine control
+> ports still differ because those are derived from the rank. The backend is
+> created explicitly, so no env var is needed. Note this measures the
+> *cross-process* XGMI path, since the C++ tool is always two processes; the Python
+> benchmark's default single-process mode avoids cross-process overhead entirely,
+> so the two are not directly comparable at small message sizes.
 
 ## Benchmark Arguments
 
@@ -380,6 +435,7 @@ torchrun --nnodes=2 --node_rank=0 --nproc_per_node=1 \
 |   67108864  |     1     |     67.11      |     44.81     |     44.78     |   1497.51    |   1498.58    |
 +-------------+-----------+----------------+---------------+---------------+--------------+--------------+
 ```
+
 ## Benchmark Tuning Guide
 
 This section is a practical starting point for maximizing **single-NIC internode
@@ -413,7 +469,9 @@ defaults. Tune from here.
 
 ### The merged-WR size limit
 
-A single RDMA WR cannot exceed the backend's `max_msg_sz` (commonly **2 GiB**).
+A single RDMA WR cannot exceed the NIC port's reported `max_msg_sz` (`ibv_port_attr`,
+**2 GiB** on the usual mlx5 and `bnxt_re` parts), taken as the minimum across the
+endpoints a transfer uses.
 With `--batch-contiguous --disable-chunking` and a **single** worker, an entire
 batch can merge into one WR of `message_size × transfer_batch_size`. If that
 exceeds `max_msg_sz` the run aborts with:

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -47,6 +47,12 @@ if(BUILD_IO)
   target_include_directories(test_engine PUBLIC ${CMAKE_SOURCE_DIR})
   target_link_libraries(test_engine mori_application mori_io)
 
+  add_executable(bench_engine io/bench_engine.cpp)
+
+  target_include_directories(bench_engine PUBLIC ${CMAKE_SOURCE_DIR}/include)
+  target_include_directories(bench_engine PUBLIC ${CMAKE_SOURCE_DIR})
+  target_link_libraries(bench_engine mori_application mori_io)
+
   add_executable(test_transfer_wait io/test_transfer_wait.cpp)
 
   target_include_directories(test_transfer_wait

--- a/tests/cpp/io/bench_engine.cpp
+++ b/tests/cpp/io/bench_engine.cpp
@@ -41,6 +41,7 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <cstring>
@@ -48,6 +49,7 @@
 #include <optional>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include <hip/hip_runtime.h>
@@ -158,10 +160,17 @@ struct Args {
   std::string self_ip;           // this rank's own reachable IP (advertised in EngineDesc)
   uint16_t port = 18515;
   int gpu = 0;
+  int target_dev_offset = 0;     // --target-dev-offset (target GPU = (gpu+offset)%ndev)
   std::string op = "write";      // write|read
-  size_t sweep_start = 1u << 20; // 1 MiB
-  size_t sweep_max = 32u << 20;  // 32 MiB
-  size_t sweep_step = 1u << 20;  // 1 MiB
+
+  // Sweep control (Python parity). --all sweeps message size; --all-batch sweeps
+  // batch size. Neither set => single run at (buffer_size, batch).
+  bool sweep_all = false;        // --all
+  bool sweep_batch = false;      // --all-batch
+  size_t buffer_size = 32768;    // --buffer-size (single message size when not sweeping)
+  size_t sweep_start = 8;        // --sweep-start-size (Python default 8)
+  size_t sweep_max = 1u << 20;   // --sweep-max-size (Python default 2^20)
+  size_t sweep_step = 0;         // --sweep-step (0 = geometric x2; >0 = linear +step)
   int iters = 500;
   int warmup = 50;               // --warmup-iters
   int inflight = 1;              // == nixl pipeline_depth (transfers/requests in flight)
@@ -187,6 +196,10 @@ struct Args {
   bool busy_wait = false;        // --busy-wait (WaitBusy spin); Python default: off
 
   std::string mem_type = "gpu";  // --mem-type gpu|cpu
+  std::string init_mem_type;     // --initiator-mem-type (empty => mem_type)
+  std::string target_mem_type;   // --target-mem-type   (empty => mem_type)
+
+  std::string log_level = "info";  // --log-level trace|debug|info|warning|error|critical
 };
 
 static Args ParseArgs(int argc, char** argv) {
@@ -199,7 +212,11 @@ static Args ParseArgs(int argc, char** argv) {
     else if (k == "--self-ip") a.self_ip = next();
     else if (k == "--port") a.port = static_cast<uint16_t>(std::stoi(next()));
     else if (k == "--gpu") a.gpu = std::stoi(next());
+    else if (k == "--target-dev-offset") a.target_dev_offset = std::stoi(next());
     else if (k == "--op" || k == "--op-type") a.op = next();
+    else if (k == "--all") a.sweep_all = true;
+    else if (k == "--all-batch") a.sweep_batch = true;
+    else if (k == "--buffer-size") a.buffer_size = std::stoull(next());
     else if (k == "--sweep-start" || k == "--sweep-start-size") a.sweep_start = std::stoull(next());
     else if (k == "--sweep-max" || k == "--sweep-max-size") a.sweep_max = std::stoull(next());
     else if (k == "--sweep-step") a.sweep_step = std::stoull(next());
@@ -224,6 +241,9 @@ static Args ParseArgs(int argc, char** argv) {
     else if (k == "--busy-wait") a.busy_wait = true;
     else if (k == "--no-busy-wait") a.busy_wait = false;
     else if (k == "--mem-type") a.mem_type = next();
+    else if (k == "--initiator-mem-type") a.init_mem_type = next();
+    else if (k == "--target-mem-type") a.target_mem_type = next();
+    else if (k == "--log-level") a.log_level = next();
     else { std::cerr << "unknown arg " << k << std::endl; std::exit(1); }
   }
   return a;
@@ -232,16 +252,55 @@ static Args ParseArgs(int argc, char** argv) {
 // ------------------------------ main ---------------------------------------
 int main(int argc, char** argv) {
   Args a = ParseArgs(argc, argv);
-  HIP_CHECK(hipSetDevice(a.gpu));
+  SetLogLevel(a.log_level);
 
-  // Buffer must hold the largest single REQUEST. Strided batch (default) needs
-  // (msg+1)*batch to keep slots non-adjacent; contiguous needs msg*batch. Round
-  // the strided case up to (sweep_max+1)*batch.
-  const bool batched = a.enable_batch_transfer && a.batch > 1;
-  const size_t slotStride = a.batch_contiguous ? a.sweep_max : (a.sweep_max + 1);
-  const size_t bufBytes = batched ? slotStride * static_cast<size_t>(a.batch) : a.sweep_max;
-  const bool cpuMem = (a.mem_type == "cpu");
+  // Per-role memory type: initiator (rank 0) / target (rank 1) may override the
+  // shared --mem-type, enabling mixed CPU<->GPU transfers. Each process only
+  // allocates its own side, so no cross-node coupling is needed.
+  const std::string myMem = (a.rank == 0)
+      ? (!a.init_mem_type.empty() ? a.init_mem_type : a.mem_type)
+      : (!a.target_mem_type.empty() ? a.target_mem_type : a.mem_type);
+  const bool cpuMem = (myMem == "cpu");
   const MemoryLocationType memLoc = cpuMem ? MemoryLocationType::CPU : MemoryLocationType::GPU;
+
+  // Target GPU shift for cross-rail pairing (GPU memory only, matches Python).
+  int gpu = a.gpu;
+  if (a.rank == 1 && !cpuMem && a.target_dev_offset != 0) {
+    int ndev = 0;
+    HIP_CHECK(hipGetDeviceCount(&ndev));
+    if (ndev > 0) gpu = (a.gpu + a.target_dev_offset) % ndev;
+  }
+  HIP_CHECK(hipSetDevice(gpu));  // valid device context needed even for host mem
+
+  // Build the run plan: a list of (msgSize, batch) points.
+  //   --all       => sweep message size (geometric x2, or linear when --sweep-step>0),
+  //                  batch fixed at --transfer-batch-size.
+  //   --all-batch => msg fixed at --buffer-size, batch = 1,2,4,...,32768.
+  //   neither     => single point (--buffer-size, --transfer-batch-size).
+  std::vector<std::pair<size_t, int>> plan;
+  if (a.sweep_all) {
+    for (size_t msg = a.sweep_start; msg <= a.sweep_max;
+         msg = (a.sweep_step > 0) ? msg + a.sweep_step : msg * 2) {
+      plan.emplace_back(msg, a.batch);
+    }
+  } else if (a.sweep_batch) {
+    for (int b = 1; b <= 32768; b *= 2) plan.emplace_back(a.buffer_size, b);
+  } else {
+    plan.emplace_back(a.buffer_size, a.batch);
+  }
+
+  // Buffer must hold the largest single REQUEST across the whole plan. Strided
+  // batch (default) needs (msg+1)*batch to keep slots non-adjacent; contiguous
+  // needs msg*batch.
+  size_t bufBytes = 0;
+  for (auto& planEntry : plan) {
+    const size_t msg = planEntry.first;
+    const int b = planEntry.second;
+    const bool pBatched = a.enable_batch_transfer && b > 1;
+    const size_t slotStride = a.batch_contiguous ? msg : (msg + 1);
+    const size_t need = pBatched ? slotStride * static_cast<size_t>(b) : msg;
+    bufBytes = std::max(bufBytes, need);
+  }
 
   void* buf = nullptr;
   if (cpuMem) {
@@ -274,7 +333,7 @@ int main(int argc, char** argv) {
   if (a.max_msg_sge > 0) rdmaCfg.maxMsgSge = a.max_msg_sge;
   engine.CreateBackend(BackendType::RDMA, rdmaCfg);
 
-  MemoryDesc localMem = engine.RegisterMemory(buf, bufBytes, a.gpu, memLoc);
+  MemoryDesc localMem = engine.RegisterMemory(buf, bufBytes, gpu, memLoc);
 
   // --- rendezvous over a side TCP socket -----------------------------------
   int sock = (a.rank == 0) ? TcpListenAccept(a.port) : TcpConnect(a.master_ip, a.port);
@@ -322,7 +381,10 @@ int main(int argc, char** argv) {
 
   std::cout << "MsgSize(B)  Batch  Iters  AvgBW(GB/s)  AvgLat(us)  TotalDur(us)" << std::endl;
 
-  for (size_t msg = a.sweep_start; msg <= a.sweep_max; msg += a.sweep_step) {
+  for (auto& planEntry : plan) {
+    const size_t msg = planEntry.first;
+    const int curBatch = planEntry.second;
+    const bool batched = a.enable_batch_transfer && curBatch > 1;
     const int depth = std::min(a.inflight, a.iters);
     std::vector<TransferStatus> st(depth);
     std::vector<TransferUniqueId> uid(depth);
@@ -333,8 +395,8 @@ int main(int argc, char** argv) {
     // merge them into one big WR (fast but not really batching, and hits the
     // 1 GiB max_msg_sz without chunking).
     const size_t stride = a.batch_contiguous ? msg : (msg + 1);
-    SizeVec offsets(a.batch), sizes(a.batch);
-    for (int i = 0; i < a.batch; ++i) {
+    SizeVec offsets(curBatch), sizes(curBatch);
+    for (int i = 0; i < curBatch; ++i) {
       offsets[i] = static_cast<size_t>(i) * stride;
       sizes[i] = msg;
     }
@@ -399,7 +461,7 @@ int main(int argc, char** argv) {
         std::chrono::duration_cast<std::chrono::duration<double, std::micro>>(t1 - t0).count();
     // Each of the `iters` requests moves msg*batch bytes when batching (nixl
     // counts block_size*batch_size*num_iter). avg_lat is per REQUEST.
-    const int effBatch = batched ? a.batch : 1;
+    const int effBatch = batched ? curBatch : 1;
     double total_bytes = static_cast<double>(msg) * effBatch * a.iters;
     double avg_bw = (total_bytes / 1e9) / (total_us / 1e6);   // GB/s, GB=10^9
     double avg_lat = total_us / a.iters;                       // us per request

--- a/tests/cpp/io/bench_engine.cpp
+++ b/tests/cpp/io/bench_engine.cpp
@@ -14,8 +14,12 @@
 //
 //   2. INLINE SPIN-POLL COMPLETION in the benchmark thread.
 //      nixlbench polls agent->getXferStatus() in a tight spin (NIXL_IN_PROG ->
-//      continue) directly in the bench thread. MORI's WaitBusy() spins on the
-//      completion flag (no cv wakeup) -> we use WaitBusy(), the closest analog.
+//      continue) directly in the bench thread. We mirror that exactly: the timed
+//      loop spins on the transfer status flag (stored by MORI's CQ worker
+//      thread). Completion is ALWAYS spin here -- never a cv-block Wait() -- so
+//      the measured latency matches nixl (a cv wakeup would add ~5-10us and make
+//      numbers non-comparable). MORI's blocking Wait() path is exercised only by
+//      the Python benchmark, not this nixl-parity tool.
 //
 //   3. PIPELINE DEPTH.
 //      nixlbench keeps `pipeline_depth` transfers in flight (default 1). We
@@ -25,7 +29,10 @@
 //   4. WARMUP excluded from timing (nixl: --warmup_iter, default 100).
 //
 //   5. throughput_gb = total_bytes / 1e9 / (total_duration_us / 1e6), GB=10^9,
-//      identical unit to nixl. avg_latency = total_duration / num_iter.
+//      identical unit to nixl. total_bytes = msg * batch * num_iter, and
+//      avg_latency = total_duration / (num_iter * batch) -- i.e. PER SINGLE
+//      TRANSFER, matching nixl's total_duration/(per_thread_iter*batch_size)
+//      (nixl counts block_size*batch_size descriptors per request).
 //
 // Rendezvous: 2 processes (one per node), TCP socket exchange of EngineDesc and
 // MemoryDesc (msgpack, same as MORI's pybind pack()/unpack()). Rank 0 =
@@ -189,11 +196,9 @@ struct Args {
 
   // batch / session
   int batch = 1;                 // --transfer-batch-size (transfers per request)
-  bool enable_batch_transfer = false;  // --enable-batch-transfer (use BatchWrite)
   bool batch_contiguous = false; // --batch-contiguous (adjacent offsets → merged WR);
                                  // default strided (each transfer a separate WR)
   bool enable_sess = false;      // --enable-sess (session fast-path); Python default: off
-  bool busy_wait = false;        // --busy-wait (WaitBusy spin); Python default: off
 
   std::string mem_type = "gpu";  // --mem-type gpu|cpu
   std::string init_mem_type;     // --initiator-mem-type (empty => mem_type)
@@ -234,12 +239,9 @@ static Args ParseArgs(int argc, char** argv) {
     else if (k == "--max-cqe-num") a.max_cqe_num = std::stoi(next());
     else if (k == "--max-msg-sge") a.max_msg_sge = std::stoi(next());
     else if (k == "--batch" || k == "--transfer-batch-size") a.batch = std::stoi(next());
-    else if (k == "--enable-batch-transfer") a.enable_batch_transfer = true;
     else if (k == "--batch-contiguous") a.batch_contiguous = true;
     else if (k == "--enable-sess") a.enable_sess = true;
     else if (k == "--disable-sess") a.enable_sess = false;
-    else if (k == "--busy-wait") a.busy_wait = true;
-    else if (k == "--no-busy-wait") a.busy_wait = false;
     else if (k == "--mem-type") a.mem_type = next();
     else if (k == "--initiator-mem-type") a.init_mem_type = next();
     else if (k == "--target-mem-type") a.target_mem_type = next();
@@ -296,7 +298,7 @@ int main(int argc, char** argv) {
   for (auto& planEntry : plan) {
     const size_t msg = planEntry.first;
     const int b = planEntry.second;
-    const bool pBatched = a.enable_batch_transfer && b > 1;
+    const bool pBatched = b > 1;
     const size_t slotStride = a.batch_contiguous ? msg : (msg + 1);
     const size_t need = pBatched ? slotStride * static_cast<size_t>(b) : msg;
     bufBytes = std::max(bufBytes, need);
@@ -311,10 +313,11 @@ int main(int argc, char** argv) {
   HIP_CHECK(hipMemset(buf, 0, bufBytes));
 
   // Out-of-band control endpoint for the MORI engine. host MUST be an IP the
-  // peer can reach (advertised via EngineDesc for RDMA QP setup); self_ip
-  // defaults to master_ip on rank 0.
+  // peer can reach (advertised via EngineDesc for RDMA QP setup). Defaults to
+  // master_ip: correct for rank 0 (it IS the master); rank 1 should pass
+  // --self-ip when its reachable IP differs from the master's.
   IOEngineConfig cfg;
-  cfg.host = !a.self_ip.empty() ? a.self_ip : (a.rank == 0 ? a.master_ip : a.master_ip);
+  cfg.host = !a.self_ip.empty() ? a.self_ip : a.master_ip;
   cfg.port = static_cast<uint16_t>(a.port + 1 + a.rank);  // distinct per rank
   std::string key = a.rank == 0 ? "initiator" : "target";
   IOEngine engine(key, cfg);
@@ -374,9 +377,15 @@ int main(int argc, char** argv) {
   }
   const bool isRead = (a.op == "read");
 
-  auto waitDone = [&](TransferStatus& s) {
-    if (a.busy_wait) { s.WaitBusy(); }              // spin on completion flag
-    else { s.Wait(); }                              // block on condition variable
+  // Spin to completion, same mechanism as the timed loop (status flag stored by
+  // MORI's CQ worker thread). Used for warmup; keeps warmup identical to the
+  // measured path so caches/QP state are primed the same way.
+  auto spinDone = [&](TransferStatus& s) {
+    while (s.InProgress() || s.Init()) { /* spin: CQ worker thread stores status */ }
+    if (s.Failed()) {
+      std::cerr << "warmup transfer failed: " << s.Message() << std::endl;
+      std::exit(1);
+    }
   };
 
   std::cout << "MsgSize(B)  Batch  Iters  AvgBW(GB/s)  AvgLat(us)  TotalDur(us)" << std::endl;
@@ -384,7 +393,9 @@ int main(int argc, char** argv) {
   for (auto& planEntry : plan) {
     const size_t msg = planEntry.first;
     const int curBatch = planEntry.second;
-    const bool batched = a.enable_batch_transfer && curBatch > 1;
+    // nixl-style: batch>1 always issues one N-descriptor batch request (no
+    // separate enable flag). batch==1 is the degenerate single-transfer case.
+    const bool batched = curBatch > 1;
     const int depth = std::min(a.inflight, a.iters);
     std::vector<TransferStatus> st(depth);
     std::vector<TransferUniqueId> uid(depth);
@@ -431,20 +442,24 @@ int main(int argc, char** argv) {
     // ---- warmup (excluded from timing) ----
     for (int w = 0; w < a.warmup; ++w) {
       post(0);
-      waitDone(st[0]);
+      spinDone(st[0]);
     }
 
     // ---- timed region: ONE whole-loop timer, nixl-style ----
     int completed = 0, issued = 0;
     auto t0 = Clock::now();
 
-    // prime the pipeline
+    // prime the pipeline. NOTE: all `depth` in-flight slots reuse the same buffer
+    // window (non-batched posts all target offset 0; batched slots share the same
+    // offsets vector), so with --inflight > 1 concurrent transfers overlap the
+    // same bytes. That's fine for a throughput/latency benchmark (data is not
+    // validated), matching nixl which likewise reuses its IOV across slots.
     for (int s = 0; s < depth; ++s) { post(s); ++issued; }
 
     while (completed < a.iters) {
       for (int s = 0; s < depth; ++s) {
-        // spin-poll this slot (WaitBusy with a single poll would also work, but
-        // we mirror nixl's "check status, if IN_PROG continue" scan)
+        // spin-poll this slot, mirroring nixl's "check status, if IN_PROG
+        // continue" scan (status flag is stored by MORI's CQ worker thread)
         if (st[s].InProgress() || st[s].Init()) continue;
         if (st[s].Failed()) {
           std::cerr << "transfer failed: " << st[s].Message() << std::endl;
@@ -459,12 +474,17 @@ int main(int argc, char** argv) {
 
     double total_us =
         std::chrono::duration_cast<std::chrono::duration<double, std::micro>>(t1 - t0).count();
-    // Each of the `iters` requests moves msg*batch bytes when batching (nixl
-    // counts block_size*batch_size*num_iter). avg_lat is per REQUEST.
+    // nixl parity (nixl_worker/utils.cpp): count block_size*batch_size*num_iter
+    // bytes over ONE whole-loop timer, and report latency PER SINGLE TRANSFER:
+    //   total_bytes  = msg * batch * iters
+    //   avg_bw       = total_bytes/1e9 / (total_us/1e6)                 [GB/s, GB=10^9]
+    //   avg_latency  = total_us / (iters * batch)                       [us per transfer]
+    // matching nixl's avg_latency = total_duration/(per_thread_iter*batch_size).
     const int effBatch = batched ? curBatch : 1;
-    double total_bytes = static_cast<double>(msg) * effBatch * a.iters;
+    const double numXfers = static_cast<double>(a.iters) * effBatch;
+    double total_bytes = static_cast<double>(msg) * numXfers;
     double avg_bw = (total_bytes / 1e9) / (total_us / 1e6);   // GB/s, GB=10^9
-    double avg_lat = total_us / a.iters;                       // us per request
+    double avg_lat = total_us / numXfers;                      // us per single transfer
 
     std::printf("%-11zu %-6d %-6d %-12.2f %-11.2f %-.1f\n", msg, effBatch, a.iters, avg_bw, avg_lat,
                 total_us);

--- a/tests/cpp/io/bench_engine.cpp
+++ b/tests/cpp/io/bench_engine.cpp
@@ -1,3 +1,24 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 // bench_engine.cpp
 //
 // A C++ benchmark for MORI-IO whose measurement methodology exactly matches
@@ -29,238 +50,545 @@
 //      TRANSFER, matching nixl's total_duration/(per_thread_iter*batch_size)
 //      (nixl counts block_size*batch_size descriptors per request).
 //
-// Rendezvous: 2 processes (one per node), TCP socket exchange of EngineDesc and
-// MemoryDesc (msgpack, same as MORI's pybind pack()/unpack()). Rank 0 =
-// initiator, rank 1 = target. Initiator drives all transfers (RDMA one-sided
-// WRITE/READ); target only registers memory and waits.
+// Rendezvous: 2 processes (one per node) exchange EngineDesc and MemoryDesc over
+// mori::application::SocketBootstrapNetwork (msgpack, same as MORI's pybind
+// pack()/unpack()).
+// Rank 0 = initiator, rank 1 = target. Initiator drives all transfers (RDMA
+// one-sided WRITE/READ); target only registers memory and waits.
 //
-// Build: see build.sh (links libmori_io + libmori_application from the editable
-// install, includes 3rdparty/msgpack-c + HIP).
+// Build: the `bench_engine` target in tests/cpp/CMakeLists.txt (needs
+// -DBUILD_IO=ON). Run `bench_engine --help` for the flag list, and see
+// docs/MORI-IO-BENCHMARK.md for the two-node walkthrough.
 
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <netinet/tcp.h>
-#include <sys/socket.h>
-#include <unistd.h>
+#include <hip/hip_runtime.h>
 
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <iostream>
+#include <msgpack.hpp>
 #include <optional>
+#include <stdexcept>
 #include <string>
-#include <thread>
 #include <utility>
 #include <vector>
 
-#include <hip/hip_runtime.h>
-#include <msgpack.hpp>
-
+#include "mori/application/bootstrap/socket_bootstrap.hpp"
 #include "mori/io/io.hpp"
 
 using namespace mori::io;
 using Clock = std::chrono::steady_clock;
 
-#define HIP_CHECK(expr)                                                                   \
-  do {                                                                                    \
-    hipError_t _e = (expr);                                                               \
-    if (_e != hipSuccess) {                                                               \
-      std::cerr << "HIP error " << hipGetErrorString(_e) << " at " << __FILE__ << ":"     \
-                << __LINE__ << std::endl;                                                 \
-      std::exit(1);                                                                       \
-    }                                                                                     \
+namespace {
+
+// A local HIP_CHECK, as in the other standalone tests and benchmarks. It throws
+// rather than terminating, like the one in examples/collective/intra_node, so a
+// failure unwinds through main() and releases the memory registration before the
+// pages it covers; mori::application::HIP_RUNTIME_CHECK cannot be used here
+// because it exits the process and would leave the MR behind.
+[[noreturn]] void ThrowHipError(hipError_t e, const char* file, int line) {
+  throw std::runtime_error(std::string("HIP error ") + hipGetErrorString(e) + " at " + file + ":" +
+                           std::to_string(line));
+}
+
+}  // namespace
+
+#define HIP_CHECK(expr)                                          \
+  do {                                                           \
+    hipError_t _e = (expr);                                      \
+    if (_e != hipSuccess) ThrowHipError(_e, __FILE__, __LINE__); \
   } while (0)
 
-// ------------------------- tiny TCP rendezvous -----------------------------
-// Rank 0 listens, rank 1 connects. Then symmetric length-prefixed blob swap.
+namespace {
 
-static int TcpListenAccept(uint16_t port) {
-  int lfd = socket(AF_INET, SOCK_STREAM, 0);
-  int opt = 1;
-  setsockopt(lfd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
-  sockaddr_in addr{};
-  addr.sin_family = AF_INET;
-  addr.sin_addr.s_addr = INADDR_ANY;
-  addr.sin_port = htons(port);
-  if (bind(lfd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
-    perror("bind");
-    std::exit(1);
+// --------------------------- buffer ownership -------------------------------
+// Owns the benchmark buffer together with its NIC registration. The backend
+// holds an MR over these pages, so the registration has to be dropped before
+// they are released -- on every exit path, including one taken by an exception
+// from the engine or the bootstrap. That ordering requirement is why this is a
+// scope guard instead of two calls at the end of the run.
+class BenchBuffer {
+ public:
+  BenchBuffer(IOEngine& engine, size_t bytes, int device, MemoryLocationType loc)
+      : engine(engine), cpu(loc == MemoryLocationType::CPU) {
+    if (cpu)
+      HIP_CHECK(hipHostMalloc(&ptr, bytes, 0));
+    else
+      HIP_CHECK(hipMalloc(&ptr, bytes));
+    try {
+      desc = engine.RegisterMemory(ptr, bytes, device, loc);
+    } catch (...) {
+      Free();
+      throw;
+    }
+    registered = true;
   }
-  listen(lfd, 1);
-  int fd = accept(lfd, nullptr, nullptr);
-  close(lfd);
-  return fd;
+
+  ~BenchBuffer() {
+    // Teardown of a failing run must not mask the original error, so both steps
+    // report instead of throwing.
+    if (registered) {
+      try {
+        engine.DeregisterMemory(desc);
+      } catch (const std::exception& e) {
+        std::cerr << "DeregisterMemory failed: " << e.what() << std::endl;
+      }
+    }
+    Free();
+  }
+
+  BenchBuffer(const BenchBuffer&) = delete;
+  BenchBuffer& operator=(const BenchBuffer&) = delete;
+
+  void* Data() const { return ptr; }
+  const MemoryDesc& Desc() const { return desc; }
+
+ private:
+  void Free() {
+    if (!ptr) return;
+    hipError_t e = cpu ? hipHostFree(ptr) : hipFree(ptr);
+    if (e != hipSuccess) {
+      std::cerr << "buffer free failed: " << hipGetErrorString(e) << std::endl;
+    }
+    ptr = nullptr;
+  }
+
+  IOEngine& engine;
+  const bool cpu;
+  void* ptr{nullptr};
+  bool registered{false};
+  MemoryDesc desc;
+};
+
+// ------------------------------ validation ---------------------------------
+// The Python benchmark checks correctness as part of the run (benchmark.py
+// _validate_rdma): it performs a transfer, ships the target's buffer back over
+// the control plane and byte-compares it against the initiator's source. We do
+// the same check here, but exchange a per-slot checksum instead of the payload,
+// so validating a multi-hundred-MiB sweep point stays O(batch) on the wire while
+// still covering every transferred byte.
+//
+// Both buffers are seeded with a rank-dependent, offset-dependent pattern, so an
+// un-issued transfer, a short transfer, or one landing at the wrong offset all
+// leave the two sides disagreeing.
+
+uint64_t Fnv1a(const uint8_t* p, size_t n, uint64_t h = 1469598103934665603ull) {
+  for (size_t i = 0; i < n; ++i) {
+    h ^= p[i];
+    h *= 1099511628211ull;
+  }
+  return h;
 }
 
-static int TcpConnect(const std::string& host, uint16_t port) {
-  int fd = socket(AF_INET, SOCK_STREAM, 0);
-  sockaddr_in addr{};
-  addr.sin_family = AF_INET;
-  addr.sin_port = htons(port);
-  inet_pton(AF_INET, host.c_str(), &addr.sin_addr);
-  for (int retry = 0; retry < 100; ++retry) {
-    if (connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0) return fd;
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+// Byte at absolute offset p is a function of (p, rank), so the two ranks start
+// out differing everywhere and every byte position is distinguishable.
+void FillPattern(void* buf, size_t bytes, int rank) {
+  constexpr size_t kTile = 1u << 20;
+  std::vector<uint8_t> tile(std::min(bytes, kTile));
+  for (size_t base = 0; base < bytes; base += tile.size()) {
+    const size_t n = std::min(tile.size(), bytes - base);
+    for (size_t i = 0; i < n; ++i) {
+      const uint64_t p = base + i;
+      tile[i] = static_cast<uint8_t>((p * 2654435761ull + rank * 0x9E3779B9ull) >> 13);
+    }
+    HIP_CHECK(hipMemcpy(static_cast<char*>(buf) + base, tile.data(), n, hipMemcpyHostToDevice));
   }
-  std::cerr << "connect failed to " << host << ":" << port << std::endl;
-  std::exit(1);
 }
 
-static void SendAll(int fd, const void* buf, size_t n) {
-  const char* p = static_cast<const char*>(buf);
-  while (n) {
-    ssize_t k = send(fd, p, n, 0);
-    if (k <= 0) { perror("send"); std::exit(1); }
-    p += k; n -= k;
+// One checksum per transferred slot, so a mismatch names the slot that differs
+// rather than just failing the whole point.
+std::vector<uint64_t> SlotChecksums(const void* buf, const SizeVec& offsets, size_t msg) {
+  std::vector<uint64_t> sums(offsets.size());
+  std::vector<uint8_t> host(msg);
+  for (size_t i = 0; i < offsets.size(); ++i) {
+    HIP_CHECK(hipMemcpy(host.data(), static_cast<const char*>(buf) + offsets[i], msg,
+                        hipMemcpyDeviceToHost));
+    sums[i] = Fnv1a(host.data(), msg);
   }
+  return sums;
 }
-static void RecvAll(int fd, void* buf, size_t n) {
-  char* p = static_cast<char*>(buf);
-  while (n) {
-    ssize_t k = recv(fd, p, n, 0);
-    if (k <= 0) { perror("recv"); std::exit(1); }
-    p += k; n -= k;
+
+// ------------------------- control-plane rendezvous -------------------------
+// Adapter over MORI's SocketBootstrapNetwork -- the same bootstrap layer
+// src/cco/cco_init.cpp and src/shmem/init.cpp use to bring up multi-node jobs --
+// so the benchmark inherits the library's rendezvous policy instead of carrying a
+// second one: connect and accept retried over the MORI_BOOTSTRAP_TIMEOUT budget
+// (300s default), a Barrier that blocks for as long as the initiator's sweep
+// takes, failures raised as exceptions, and Finalize() from the destructor.
+//
+// Both ranks derive the same UniqueId from the master endpoint, so nothing has to
+// carry it between them. The bootstrap picks its own local interface; set
+// MORI_SOCKET_IFNAME when that choice has no route to the peer.
+class Rendezvous {
+ public:
+  Rendezvous(int rank, const std::string& masterIp, uint16_t port)
+      : boot(mori::application::SocketBootstrapNetwork::GenerateUniqueId(masterIp, port), rank,
+             kWorldSize),
+        myRank(rank) {
+    boot.Initialize();
   }
-}
-static void SendBlob(int fd, const std::string& b) {
-  uint64_t len = b.size();
-  SendAll(fd, &len, sizeof(len));
-  SendAll(fd, b.data(), len);
-}
-static std::string RecvBlob(int fd) {
-  uint64_t len = 0;
-  RecvAll(fd, &len, sizeof(len));
-  std::string b(len, '\0');
-  RecvAll(fd, b.data(), len);
-  return b;
-}
-static void Barrier(int fd) {  // symmetric 1-byte ping-pong
-  char c = 'x';
-  SendAll(fd, &c, 1);
-  RecvAll(fd, &c, 1);
-}
+
+  // Contribute this rank's blob, return the peer's. Allgather is fixed-size while
+  // packed descriptors are not, so sizes go first and the payload round pads every
+  // rank up to the larger of the two.
+  std::string ExchangeBlob(const std::string& mine) {
+    uint64_t sizes[kWorldSize] = {};
+    uint64_t mySize = mine.size();
+    boot.Allgather(&mySize, sizes, sizeof(mySize));
+
+    const size_t stride = std::max(sizes[0], sizes[1]);
+    if (stride == 0) return {};
+
+    std::vector<char> sendBuf(stride, 0), recvBuf(stride * kWorldSize, 0);
+    std::memcpy(sendBuf.data(), mine.data(), mine.size());
+    boot.Allgather(sendBuf.data(), recvBuf.data(), stride);
+
+    const int peer = 1 - myRank;
+    return std::string(recvBuf.data() + peer * stride, sizes[peer]);
+  }
+
+  void Barrier() { boot.Barrier(); }
+
+ private:
+  // Rank 0 initiates, rank 1 targets.
+  static constexpr int kWorldSize = 2;
+
+  mori::application::SocketBootstrapNetwork boot;
+  const int myRank;
+};
 
 template <typename T>
-static std::string Pack(const T& v) {
+std::string Pack(const T& v) {
   msgpack::sbuffer buf;
   msgpack::pack(buf, v);
   return std::string(buf.data(), buf.size());
 }
 template <typename T>
-static T Unpack(const std::string& b) {
+T Unpack(const std::string& b) {
   auto oh = msgpack::unpack(b.data(), b.size());
   return oh.get().as<T>();
+}
+
+// Compare the transferred slots of both ranks' buffers after the sweep. Both
+// sides derive the geometry from the same args, so the only thing that crosses
+// the wire is one checksum per slot. Only the initiator reports.
+//
+// BOTH ranks must call this unconditionally, even when --skip-validate is set:
+// the exchange is a collective, so a rank that returned early would leave its
+// peer blocked in Allgather until the bootstrap timeout. Opting out therefore
+// contributes an empty checksum vector rather than skipping the call, which also
+// makes the flag safe to pass to only one side -- either empty vector downgrades
+// the run to "skipped" instead of hanging or reporting a bogus failure.
+bool ValidateTransfer(Rendezvous& rdv, const void* buf, size_t msg, int batch, bool batched,
+                      bool batchContiguous, int rank, bool wanted) {
+  std::vector<uint64_t> mine;
+  if (wanted) {
+    // Mirror the offsets the sweep actually used: the batched path strides by
+    // msg+1 unless --batch-contiguous, while the singles path is always
+    // contiguous (same asymmetry as the Python bench's run_single_once).
+    const size_t stride = batched ? (batchContiguous ? msg : msg + 1) : msg;
+    SizeVec offsets(static_cast<size_t>(batch));
+    for (int i = 0; i < batch; ++i) offsets[i] = static_cast<size_t>(i) * stride;
+    mine = SlotChecksums(buf, offsets, msg);
+  }
+
+  const auto peer = Unpack<std::vector<uint64_t>>(rdv.ExchangeBlob(Pack(mine)));
+  if (rank != 0) return true;
+
+  if (mine.empty() || peer.empty()) {
+    std::cout << "validation: skipped"
+              << (mine.empty() ? "" : " (peer opted out with --skip-validate)") << std::endl;
+    return true;
+  }
+  if (peer.size() != mine.size()) {
+    std::cerr << "VALIDATION FAILED: peer returned " << peer.size() << " checksums, expected "
+              << mine.size() << std::endl;
+    return false;
+  }
+  for (size_t i = 0; i < mine.size(); ++i) {
+    if (mine[i] != peer[i]) {
+      std::cerr << "VALIDATION FAILED: slot " << i << " of " << mine.size()
+                << " differs at msg=" << msg << " batch=" << batch << " (initiator " << std::hex
+                << mine[i] << " vs target " << peer[i] << std::dec << ")" << std::endl;
+      return false;
+    }
+  }
+  std::cout << "validation: OK (" << batch << " slot(s) x " << msg << " B byte-identical)"
+            << std::endl;
+  return true;
 }
 
 // ------------------------------- config ------------------------------------
 // Flags mirror MORI's Python benchmark (tests/python/io/benchmark.py) so runs
 // are directly comparable. Names use the Python spelling where they exist.
 struct Args {
-  int rank = 0;                  // 0=initiator, 1=target
-  std::string master_ip;         // rank 1 connects here (rank 0's data IP) for TCP rendezvous
-  std::string self_ip;           // this rank's own reachable IP (advertised in EngineDesc)
+  int rank = 0;           // 0=initiator, 1=target
+  std::string master_ip;  // bootstrap root (rank 0's data IP); both ranks pass the same
+  std::string self_ip;    // this rank's own reachable IP (advertised in EngineDesc)
   uint16_t port = 18515;
   int gpu = 0;
   int target_dev_offset = 0;     // --target-dev-offset (target GPU = (gpu+offset)%ndev)
   std::string op = "write";      // write|read
+  std::string backend = "rdma";  // --backend rdma|xgmi (xgmi = intra-node GPU<->GPU)
 
   // Sweep control (Python parity). --all sweeps message size; --all-batch sweeps
   // batch size. Neither set => single run at (buffer_size, batch).
-  bool sweep_all = false;        // --all
-  bool sweep_batch = false;      // --all-batch
-  size_t buffer_size = 32768;    // --buffer-size (single message size when not sweeping)
-  size_t sweep_start = 8;        // --sweep-start-size (Python default 8)
-  size_t sweep_max = 1u << 20;   // --sweep-max-size (Python default 2^20)
-  size_t sweep_step = 0;         // --sweep-step (0 = geometric x2; >0 = linear +step)
+  bool sweep_all = false;       // --all
+  bool sweep_batch = false;     // --all-batch
+  size_t buffer_size = 32768;   // --buffer-size (single message size when not sweeping)
+  size_t sweep_start = 8;       // --sweep-start-size (Python default 8)
+  size_t sweep_max = 1u << 20;  // --sweep-max-size (Python default 2^20)
+  size_t sweep_step = 0;        // --sweep-step (0 = geometric x2; >0 = linear +step)
   int iters = 500;
-  int warmup = 50;               // --warmup-iters
+  int warmup = 50;  // --warmup-iters
 
   // RdmaBackendConfig knobs
-  int qp_per_transfer = 4;       // --num-qp-per-transfer
-  int worker_threads = 1;        // --num-worker-threads
-  int post_batch_size = -1;      // --post-batch-size
+  int qp_per_transfer = 4;               // --num-qp-per-transfer
+  int worker_threads = 1;                // --num-worker-threads
+  int post_batch_size = -1;              // --post-batch-size
   std::string poll_cq_mode = "polling";  // polling|event
-  bool disable_chunking = false; // --disable-chunking (default: chunking ON, like Python)
-  size_t chunk_bytes = 65536;    // --chunk-bytes
-  int max_chunks = 64;           // --max-chunks
-  int max_send_wr = 0;           // --max-send-wr (0 = leave default)
-  int max_cqe_num = 0;           // --max-cqe-num
-  int max_msg_sge = 0;           // --max-msg-sge
+  bool disable_chunking = false;         // --disable-chunking (default: chunking ON, like Python)
+  size_t chunk_bytes = 65536;            // --chunk-bytes
+  int max_chunks = 64;                   // --max-chunks
+  int max_send_wr = 0;                   // --max-send-wr (0 = leave default)
+  int max_cqe_num = 0;                   // --max-cqe-num
+  int max_msg_sge = 0;                   // --max-msg-sge
+
+  // XgmiBackendConfig knobs (--backend xgmi)
+  int num_streams = 64;  // --num-streams
+  int num_events = 64;   // --num-events
 
   // batch / session
-  int batch = 1;                 // --transfer-batch-size (transfers per request)
+  int batch = 1;                      // --transfer-batch-size (transfers per request)
   bool enable_batch_transfer = true;  // --enable-batch-transfer / --disable-batch-transfer.
-                                 // ON (default): batch>1 => ONE N-descriptor batch request
-                                 // (nixl-equivalent). OFF: batch>1 => N individual single
-                                 // transfers per iteration (Python run_single_once path).
-  bool batch_contiguous = false; // --batch-contiguous (adjacent offsets → merged WR);
-                                 // default strided (each transfer a separate WR)
-  bool enable_sess = false;      // --enable-sess (session fast-path); Python default: off
+                                      // ON (default): batch>1 => ONE N-descriptor batch request
+                                      // (nixl-equivalent). OFF: batch>1 => N individual single
+                                      // transfers per iteration (Python run_single_once path).
+  bool batch_contiguous = false;      // --batch-contiguous (adjacent offsets → merged WR);
+                                      // default strided (each transfer a separate WR)
+  bool enable_sess = false;           // --enable-sess (session fast-path); Python default: off
 
   std::string mem_type = "gpu";  // --mem-type gpu|cpu
   std::string init_mem_type;     // --initiator-mem-type (empty => mem_type)
   std::string target_mem_type;   // --target-mem-type   (empty => mem_type)
 
   std::string log_level = "info";  // --log-level trace|debug|info|warning|error|critical
+
+  // Correctness check on the last sweep point, on by default to match the Python
+  // benchmark (which always validates). --skip-validate opts out.
+  bool skip_validate = false;  // --skip-validate
+
+  bool help = false;  // -h / --help
 };
 
-static Args ParseArgs(int argc, char** argv) {
+void PrintUsage(const char* argv0) {
+  std::printf(
+      "Usage: %s --rank <0|1> --master-ip <IP> [OPTIONS]\n"
+      "\n"
+      "nixlbench-matching MORI-IO transfer benchmark. Start rank 1 (the target)\n"
+      "first, then rank 0 (the initiator), which drives every transfer and prints\n"
+      "the results. Both ranks must be given the same workload arguments. See\n"
+      "docs/MORI-IO-BENCHMARK.md for the full walkthrough.\n"
+      "\n"
+      "Rendezvous:\n"
+      "  --rank N                 0 = initiator, 1 = target\n"
+      "  --master-ip IP           rank 0's IP; pass the same value on both ranks\n"
+      "  --self-ip IP             this rank's peer-reachable IP (default: --master-ip)\n"
+      "  --port N                 bootstrap port (default: 18515)\n"
+      "\n"
+      "Workload:\n"
+      "  --op <write|read>        transfer direction (default: write)\n"
+      "  --backend <rdma|xgmi>    (default: rdma)\n"
+      "  --buffer-size N          message size in bytes when not sweeping (default: 32768)\n"
+      "  --transfer-batch-size N  transfers per iteration (default: 1)\n"
+      "  --enable-batch-transfer  one N-descriptor batch request per iteration (default)\n"
+      "  --disable-batch-transfer N individual transfers per iteration instead\n"
+      "  --batch-contiguous       adjacent slot offsets (default: strided by msg+1)\n"
+      "  --iters N                timed iterations (default: 500)\n"
+      "  --warmup-iters N         untimed warmup iterations (default: 50)\n"
+      "  --enable-sess            use the session fast path (default: off)\n"
+      "  --disable-sess           call the engine APIs directly\n"
+      "\n"
+      "Sweeps (default: a single point at --buffer-size):\n"
+      "  --all                    sweep message size --sweep-start..--sweep-max\n"
+      "  --all-batch              sweep batch 1..32768 at --buffer-size\n"
+      "  --sweep-start N          (default: 8)\n"
+      "  --sweep-max N            (default: 1048576)\n"
+      "  --sweep-step N           0 = geometric x2, >0 = linear +N (default: 0)\n"
+      "\n"
+      "Memory:\n"
+      "  --mem-type <gpu|cpu>     (default: gpu)\n"
+      "  --initiator-mem-type T   overrides --mem-type on rank 0\n"
+      "  --target-mem-type T      overrides --mem-type on rank 1\n"
+      "  --gpu N                  local device ordinal (default: 0)\n"
+      "  --target-dev-offset N    target GPU = (gpu + offset) %% device count\n"
+      "\n"
+      "RDMA tuning:\n"
+      "  --num-qp-per-transfer N  (default: 4)\n"
+      "  --num-worker-threads N   (default: 1)\n"
+      "  --post-batch-size N      (default: -1, backend default)\n"
+      "  --poll_cq_mode <polling|event>   (default: polling)\n"
+      "  --disable-chunking       chunking is on by default\n"
+      "  --chunk-bytes N          (default: 65536)\n"
+      "  --max-chunks N           (default: 64)\n"
+      "  --max-send-wr N          0 = backend default\n"
+      "  --max-cqe-num N          0 = backend default\n"
+      "  --max-msg-sge N          0 = backend default\n"
+      "\n"
+      "XGMI tuning:\n"
+      "  --num-streams N          (default: 64)\n"
+      "  --num-events N           (default: 64)\n"
+      "\n"
+      "Other:\n"
+      "  --skip-validate          skip the post-sweep checksum comparison\n"
+      "  --log-level LEVEL        trace|debug|info|warning|error|critical (default: info)\n"
+      "  -h, --help               show this message\n",
+      argv0);
+}
+
+Args ParseArgs(int argc, char** argv) {
   Args a;
   for (int i = 1; i < argc; ++i) {
     std::string k = argv[i];
-    auto next = [&]() { return std::string(argv[++i]); };
-    if (k == "--rank") a.rank = std::stoi(next());
-    else if (k == "--master-ip") a.master_ip = next();
-    else if (k == "--self-ip") a.self_ip = next();
-    else if (k == "--port") a.port = static_cast<uint16_t>(std::stoi(next()));
-    else if (k == "--gpu") a.gpu = std::stoi(next());
-    else if (k == "--target-dev-offset") a.target_dev_offset = std::stoi(next());
-    else if (k == "--op" || k == "--op-type") a.op = next();
-    else if (k == "--all") a.sweep_all = true;
-    else if (k == "--all-batch") a.sweep_batch = true;
-    else if (k == "--buffer-size") a.buffer_size = std::stoull(next());
-    else if (k == "--sweep-start" || k == "--sweep-start-size") a.sweep_start = std::stoull(next());
-    else if (k == "--sweep-max" || k == "--sweep-max-size") a.sweep_max = std::stoull(next());
-    else if (k == "--sweep-step") a.sweep_step = std::stoull(next());
-    else if (k == "--iters") a.iters = std::stoi(next());
-    else if (k == "--warmup" || k == "--warmup-iters") a.warmup = std::stoi(next());
-    else if (k == "--qp-per-transfer" || k == "--num-qp-per-transfer") a.qp_per_transfer = std::stoi(next());
-    else if (k == "--worker-threads" || k == "--num-worker-threads") a.worker_threads = std::stoi(next());
-    else if (k == "--post-batch-size") a.post_batch_size = std::stoi(next());
-    else if (k == "--poll_cq_mode" || k == "--poll-cq-mode") a.poll_cq_mode = next();
-    else if (k == "--disable-chunking") a.disable_chunking = true;
-    else if (k == "--chunk-bytes") a.chunk_bytes = std::stoull(next());
-    else if (k == "--max-chunks") a.max_chunks = std::stoi(next());
-    else if (k == "--max-send-wr") a.max_send_wr = std::stoi(next());
-    else if (k == "--max-cqe-num") a.max_cqe_num = std::stoi(next());
-    else if (k == "--max-msg-sge") a.max_msg_sge = std::stoi(next());
-    else if (k == "--batch" || k == "--transfer-batch-size") a.batch = std::stoi(next());
-    else if (k == "--enable-batch-transfer") a.enable_batch_transfer = true;
-    else if (k == "--disable-batch-transfer") a.enable_batch_transfer = false;
-    else if (k == "--batch-contiguous") a.batch_contiguous = true;
-    else if (k == "--enable-sess") a.enable_sess = true;
-    else if (k == "--disable-sess") a.enable_sess = false;
-    else if (k == "--mem-type") a.mem_type = next();
-    else if (k == "--initiator-mem-type") a.init_mem_type = next();
-    else if (k == "--target-mem-type") a.target_mem_type = next();
-    else if (k == "--log-level") a.log_level = next();
-    else { std::cerr << "unknown arg " << k << std::endl; std::exit(1); }
+    // Checked rather than argv[++i] directly: a value-taking flag in last
+    // position would otherwise construct a std::string from argv[argc], which
+    // is null.
+    auto next = [&]() {
+      if (i + 1 >= argc) throw std::invalid_argument("missing value for " + k);
+      return std::string(argv[++i]);
+    };
+    if (k == "-h" || k == "--help")
+      a.help = true;
+    else if (k == "--rank")
+      a.rank = std::stoi(next());
+    else if (k == "--master-ip")
+      a.master_ip = next();
+    else if (k == "--self-ip")
+      a.self_ip = next();
+    else if (k == "--port")
+      a.port = static_cast<uint16_t>(std::stoi(next()));
+    else if (k == "--gpu")
+      a.gpu = std::stoi(next());
+    else if (k == "--target-dev-offset")
+      a.target_dev_offset = std::stoi(next());
+    else if (k == "--op" || k == "--op-type")
+      a.op = next();
+    else if (k == "--backend")
+      a.backend = next();
+    else if (k == "--all")
+      a.sweep_all = true;
+    else if (k == "--all-batch")
+      a.sweep_batch = true;
+    else if (k == "--buffer-size")
+      a.buffer_size = std::stoull(next());
+    else if (k == "--sweep-start" || k == "--sweep-start-size")
+      a.sweep_start = std::stoull(next());
+    else if (k == "--sweep-max" || k == "--sweep-max-size")
+      a.sweep_max = std::stoull(next());
+    else if (k == "--sweep-step")
+      a.sweep_step = std::stoull(next());
+    else if (k == "--iters")
+      a.iters = std::stoi(next());
+    else if (k == "--warmup" || k == "--warmup-iters")
+      a.warmup = std::stoi(next());
+    else if (k == "--qp-per-transfer" || k == "--num-qp-per-transfer")
+      a.qp_per_transfer = std::stoi(next());
+    else if (k == "--worker-threads" || k == "--num-worker-threads")
+      a.worker_threads = std::stoi(next());
+    else if (k == "--post-batch-size")
+      a.post_batch_size = std::stoi(next());
+    else if (k == "--poll_cq_mode" || k == "--poll-cq-mode")
+      a.poll_cq_mode = next();
+    else if (k == "--disable-chunking")
+      a.disable_chunking = true;
+    else if (k == "--chunk-bytes")
+      a.chunk_bytes = std::stoull(next());
+    else if (k == "--max-chunks")
+      a.max_chunks = std::stoi(next());
+    else if (k == "--max-send-wr")
+      a.max_send_wr = std::stoi(next());
+    else if (k == "--max-cqe-num")
+      a.max_cqe_num = std::stoi(next());
+    else if (k == "--max-msg-sge")
+      a.max_msg_sge = std::stoi(next());
+    else if (k == "--num-streams")
+      a.num_streams = std::stoi(next());
+    else if (k == "--num-events")
+      a.num_events = std::stoi(next());
+    else if (k == "--batch" || k == "--transfer-batch-size")
+      a.batch = std::stoi(next());
+    else if (k == "--enable-batch-transfer")
+      a.enable_batch_transfer = true;
+    else if (k == "--disable-batch-transfer")
+      a.enable_batch_transfer = false;
+    else if (k == "--batch-contiguous")
+      a.batch_contiguous = true;
+    else if (k == "--enable-sess")
+      a.enable_sess = true;
+    else if (k == "--disable-sess")
+      a.enable_sess = false;
+    else if (k == "--mem-type")
+      a.mem_type = next();
+    else if (k == "--initiator-mem-type")
+      a.init_mem_type = next();
+    else if (k == "--target-mem-type")
+      a.target_mem_type = next();
+    else if (k == "--skip-validate")
+      a.skip_validate = true;
+    else if (k == "--log-level")
+      a.log_level = next();
+    else
+      throw std::invalid_argument("unknown arg " + k + " (try --help)");
   }
   return a;
 }
 
 // ------------------------------ main ---------------------------------------
-int main(int argc, char** argv) {
+int RunBenchmark(int argc, char** argv) {
   Args a = ParseArgs(argc, argv);
+  if (a.help) {
+    PrintUsage(argv[0]);
+    return 0;
+  }
   SetLogLevel(a.log_level);
+
+  // Rejected up front because each of these either corrupts the run or reports a
+  // number for something the caller did not ask for: rank feeds the two-rank
+  // bootstrap's peer indexing, iters and batch are divisors of the reported
+  // latency, a zero message size makes the geometric sweep loop forever, and an
+  // unrecognised op or memory type would otherwise fall back silently to
+  // write/GPU.
+  if (a.rank != 0 && a.rank != 1) {
+    throw std::invalid_argument("--rank must be 0 (initiator) or 1 (target)");
+  }
+  if (a.backend != "rdma" && a.backend != "xgmi") {
+    throw std::invalid_argument("--backend must be rdma or xgmi (got " + a.backend + ")");
+  }
+  if (a.op != "read" && a.op != "write") {
+    throw std::invalid_argument("--op must be read or write (got " + a.op + ")");
+  }
+  if (a.iters <= 0) throw std::invalid_argument("--iters must be > 0");
+  if (a.batch <= 0) throw std::invalid_argument("--transfer-batch-size must be > 0");
+  if (a.warmup < 0) throw std::invalid_argument("--warmup-iters must be >= 0");
+  if (a.sweep_all ? a.sweep_start == 0 : a.buffer_size == 0) {
+    throw std::invalid_argument("message size must be > 0");
+  }
+  for (const std::string& m : {a.mem_type, a.init_mem_type, a.target_mem_type}) {
+    if (!m.empty() && m != "gpu" && m != "cpu") {
+      throw std::invalid_argument("memory type must be gpu or cpu (got " + m + ")");
+    }
+  }
 
   // Per-role memory type: initiator (rank 0) / target (rank 1) may override the
   // shared --mem-type, enabling mixed CPU<->GPU transfers. Each process only
   // allocates its own side, so no cross-node coupling is needed.
   const std::string myMem = (a.rank == 0)
-      ? (!a.init_mem_type.empty() ? a.init_mem_type : a.mem_type)
-      : (!a.target_mem_type.empty() ? a.target_mem_type : a.mem_type);
+                                ? (!a.init_mem_type.empty() ? a.init_mem_type : a.mem_type)
+                                : (!a.target_mem_type.empty() ? a.target_mem_type : a.mem_type);
   const bool cpuMem = (myMem == "cpu");
   const MemoryLocationType memLoc = cpuMem ? MemoryLocationType::CPU : MemoryLocationType::GPU;
 
@@ -289,6 +617,11 @@ int main(int argc, char** argv) {
   } else {
     plan.emplace_back(a.buffer_size, a.batch);
   }
+  // The last point is validated after the sweep, so an empty plan would read off
+  // the end of it.
+  if (plan.empty()) {
+    throw std::invalid_argument("empty sweep: --sweep-start exceeds --sweep-max");
+  }
 
   // Buffer must hold the largest single REQUEST across the whole plan. Strided
   // batch (default) needs (msg+1)*batch to keep slots non-adjacent; contiguous
@@ -303,14 +636,6 @@ int main(int argc, char** argv) {
     bufBytes = std::max(bufBytes, need);
   }
 
-  void* buf = nullptr;
-  if (cpuMem) {
-    HIP_CHECK(hipHostMalloc(&buf, bufBytes, 0));
-  } else {
-    HIP_CHECK(hipMalloc(&buf, bufBytes));
-  }
-  HIP_CHECK(hipMemset(buf, 0, bufBytes));
-
   // Out-of-band control endpoint for the MORI engine. host MUST be an IP the
   // peer can reach (advertised via EngineDesc for RDMA QP setup). Defaults to
   // master_ip: correct for rank 0 (it IS the master); rank 1 should pass
@@ -321,45 +646,66 @@ int main(int argc, char** argv) {
   std::string key = a.rank == 0 ? "initiator" : "target";
   IOEngine engine(key, cfg);
 
-  RdmaBackendConfig rdmaCfg{};
-  rdmaCfg.qpPerTransfer = a.qp_per_transfer;
-  rdmaCfg.postBatchSize = a.post_batch_size;
-  rdmaCfg.numWorkerThreads = a.worker_threads;
-  rdmaCfg.pollCqMode = (a.poll_cq_mode == "event") ? PollCqMode::EVENT : PollCqMode::POLLING;
-  rdmaCfg.enableNotification = false;         // match MORI Python bench RDMA path
-  rdmaCfg.enableTransferChunking = !a.disable_chunking;  // chunking ON by default (Python parity)
-  rdmaCfg.chunkBytes = a.chunk_bytes;
-  rdmaCfg.maxChunksPerTransfer = a.max_chunks;
-  if (a.max_send_wr > 0) rdmaCfg.maxSendWr = a.max_send_wr;
-  if (a.max_cqe_num > 0) rdmaCfg.maxCqeNum = a.max_cqe_num;
-  if (a.max_msg_sge > 0) rdmaCfg.maxMsgSge = a.max_msg_sge;
-  engine.CreateBackend(BackendType::RDMA, rdmaCfg);
+  // XGMI moves data over Infinity Fabric between two GPUs on the SAME host, so
+  // its knobs are stream/event depth rather than QPs and chunking. The RDMA-only
+  // flags above are simply unused on that path.
+  if (a.backend == "xgmi") {
+    XgmiBackendConfig xgmiCfg{};
+    xgmiCfg.numStreams = a.num_streams;
+    xgmiCfg.numEvents = a.num_events;
+    engine.CreateBackend(BackendType::XGMI, xgmiCfg);
+  } else {
+    RdmaBackendConfig rdmaCfg{};
+    rdmaCfg.qpPerTransfer = a.qp_per_transfer;
+    rdmaCfg.postBatchSize = a.post_batch_size;
+    rdmaCfg.numWorkerThreads = a.worker_threads;
+    rdmaCfg.pollCqMode = (a.poll_cq_mode == "event") ? PollCqMode::EVENT : PollCqMode::POLLING;
+    rdmaCfg.enableNotification = false;                    // match MORI Python bench RDMA path
+    rdmaCfg.enableTransferChunking = !a.disable_chunking;  // chunking ON by default (Python parity)
+    rdmaCfg.chunkBytes = a.chunk_bytes;
+    rdmaCfg.maxChunksPerTransfer = a.max_chunks;
+    if (a.max_send_wr > 0) rdmaCfg.maxSendWr = a.max_send_wr;
+    if (a.max_cqe_num > 0) rdmaCfg.maxCqeNum = a.max_cqe_num;
+    if (a.max_msg_sge > 0) rdmaCfg.maxMsgSge = a.max_msg_sge;
+    engine.CreateBackend(BackendType::RDMA, rdmaCfg);
+  }
 
-  MemoryDesc localMem = engine.RegisterMemory(buf, bufBytes, gpu, memLoc);
+  // Declared after the engine so it is destroyed first, i.e. the MR is dropped
+  // while the engine that owns it is still alive.
+  BenchBuffer buffer(engine, bufBytes, gpu, memLoc);
+  void* buf = buffer.Data();
+  const MemoryDesc& localMem = buffer.Desc();
 
-  // --- rendezvous over a side TCP socket -----------------------------------
-  int sock = (a.rank == 0) ? TcpListenAccept(a.port) : TcpConnect(a.master_ip, a.port);
-  int one = 1;
-  setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+  // Rank-dependent seed pattern rather than zeros, so the post-sweep validation
+  // can tell "the transfer moved my bytes" from "both buffers happened to match".
+  if (a.skip_validate) {
+    HIP_CHECK(hipMemset(buf, 0, bufBytes));
+  } else {
+    FillPattern(buf, bufBytes, a.rank);
+  }
+
+  // --- rendezvous over MORI's socket bootstrap ------------------------------
+  Rendezvous rdv(a.rank, a.master_ip, a.port);
 
   // Exchange EngineDesc then register the remote engine.
   EngineDesc myEng = engine.GetEngineDesc();
-  SendBlob(sock, Pack(myEng));
-  EngineDesc peerEng = Unpack<EngineDesc>(RecvBlob(sock));
+  EngineDesc peerEng = Unpack<EngineDesc>(rdv.ExchangeBlob(Pack(myEng)));
   engine.RegisterRemoteEngine(peerEng);
 
   // Exchange MemoryDesc.
-  SendBlob(sock, Pack(localMem));
-  MemoryDesc peerMem = Unpack<MemoryDesc>(RecvBlob(sock));
+  MemoryDesc peerMem = Unpack<MemoryDesc>(rdv.ExchangeBlob(Pack(localMem)));
 
-  Barrier(sock);
+  rdv.Barrier();
 
   if (a.rank == 1) {
     // Target: nothing to drive. RDMA one-sided ops complete without target CPU.
     // Just hold memory registered until the initiator says it's done.
-    Barrier(sock);   // wait for initiator to finish the whole sweep
-    if (cpuMem) HIP_CHECK(hipHostFree(buf)); else HIP_CHECK(hipFree(buf));
-    close(sock);
+    rdv.Barrier();  // wait for initiator to finish the whole sweep
+    // Collective with the initiator's call below, so it runs even under
+    // --skip-validate; the target only contributes checksums and does not report.
+    const auto& last = plan.back();
+    ValidateTransfer(rdv, buf, last.first, last.second, a.enable_batch_transfer && last.second > 1,
+                     a.batch_contiguous, a.rank, !a.skip_validate);
     return 0;
   }
 
@@ -371,7 +717,7 @@ int main(int argc, char** argv) {
   std::optional<IOEngineSession> sessOpt;
   if (useSess) {
     sessOpt = engine.CreateSession(localMem, peerMem);
-    if (!sessOpt) { std::cerr << "CreateSession failed" << std::endl; std::exit(1); }
+    if (!sessOpt) throw std::runtime_error("CreateSession failed");
     sessPtr = &*sessOpt;
   }
   const bool isRead = (a.op == "read");
@@ -388,7 +734,7 @@ int main(int argc, char** argv) {
     //     submissions per iteration (Python run_single_once), each its own status.
     // batch==1 is a single transfer either way.
     const bool batched = a.enable_batch_transfer && curBatch > 1;
-    const int perSlot = batched ? 1 : curBatch;    // statuses per request
+    const int perSlot = batched ? 1 : curBatch;  // statuses per request
     // Strict stop-and-wait: one request outstanding at a time (nixl
     // --pipeline_depth 1). [perSlot] status array (TransferStatus is
     // non-copyable, so a flat vector rather than nested).
@@ -405,9 +751,14 @@ int main(int argc, char** argv) {
       offsets[i] = static_cast<size_t>(i) * stride;
       sizes[i] = msg;
     }
-    // Engine (non-session) batch path needs vec-of-vec + desc vectors.
+    // Engine (non-session) batch path needs vec-of-vec + desc vectors. These and
+    // the status/id vectors below are built once per sweep point and reused every
+    // iteration: allocating them inside post() would charge two heap
+    // allocation/free pairs per iteration to the reported latency.
     MemDescVec locVec{localMem}, remVec{peerMem};
     BatchSizeVec offVec{offsets}, sizeVec{sizes};
+    TransferStatusPtrVec statusPtrs{&st[0]};
+    TransferUniqueIdVec batchIds(1);
 
     auto post = [&]() {
       TransferStatus* base = &st[0];
@@ -417,13 +768,17 @@ int main(int argc, char** argv) {
         TransferUniqueId id =
             useSess ? sessPtr->AllocateTransferUniqueId() : engine.AllocateTransferUniqueId();
         if (useSess) {
-          if (isRead) sessPtr->BatchRead(offsets, offsets, sizes, &base[0], id);
-          else        sessPtr->BatchWrite(offsets, offsets, sizes, &base[0], id);
+          if (isRead)
+            sessPtr->BatchRead(offsets, offsets, sizes, &base[0], id);
+          else
+            sessPtr->BatchWrite(offsets, offsets, sizes, &base[0], id);
         } else {
-          TransferStatusPtrVec sp{&base[0]};
-          TransferUniqueIdVec ids{id};
-          if (isRead) engine.BatchRead(locVec, offVec, remVec, offVec, sizeVec, sp, ids);
-          else        engine.BatchWrite(locVec, offVec, remVec, offVec, sizeVec, sp, ids);
+          statusPtrs[0] = &base[0];
+          batchIds[0] = id;
+          if (isRead)
+            engine.BatchRead(locVec, offVec, remVec, offVec, sizeVec, statusPtrs, batchIds);
+          else
+            engine.BatchWrite(locVec, offVec, remVec, offVec, sizeVec, statusPtrs, batchIds);
         }
       } else {
         // curBatch individual single-transfer submissions (Python run_single_once);
@@ -434,11 +789,15 @@ int main(int argc, char** argv) {
           TransferUniqueId id =
               useSess ? sessPtr->AllocateTransferUniqueId() : engine.AllocateTransferUniqueId();
           if (useSess) {
-            if (isRead) sessPtr->Read(off, off, msg, &base[i], id);
-            else        sessPtr->Write(off, off, msg, &base[i], id);
+            if (isRead)
+              sessPtr->Read(off, off, msg, &base[i], id);
+            else
+              sessPtr->Write(off, off, msg, &base[i], id);
           } else {
-            if (isRead) engine.Read(localMem, off, peerMem, off, msg, &base[i], id);
-            else        engine.Write(localMem, off, peerMem, off, msg, &base[i], id);
+            if (isRead)
+              engine.Read(localMem, off, peerMem, off, msg, &base[i], id);
+            else
+              engine.Write(localMem, off, peerMem, off, msg, &base[i], id);
           }
         }
       }
@@ -463,10 +822,10 @@ int main(int argc, char** argv) {
     // ---- warmup (excluded from timing) ----
     for (int w = 0; w < a.warmup; ++w) {
       post();
-      while (!reqDone()) { /* spin: CQ worker thread stores status */ }
+      while (!reqDone()) { /* spin: CQ worker thread stores status */
+      }
       if (TransferStatus* f = reqFailed()) {
-        std::cerr << "warmup transfer failed: " << f->Message() << std::endl;
-        std::exit(1);
+        throw std::runtime_error("warmup transfer failed: " + f->Message());
       }
     }
 
@@ -479,10 +838,10 @@ int main(int argc, char** argv) {
       post();
       // spin-poll, mirroring nixl's "check status, if IN_PROG continue" scan
       // (status flags stored by MORI's CQ worker thread)
-      while (!reqDone()) { /* spin */ }
+      while (!reqDone()) { /* spin */
+      }
       if (TransferStatus* f = reqFailed()) {
-        std::cerr << "transfer failed: " << f->Message() << std::endl;
-        std::exit(1);
+        throw std::runtime_error("transfer failed: " + f->Message());
       }
     }
     auto t1 = Clock::now();
@@ -496,19 +855,38 @@ int main(int argc, char** argv) {
     //   avg_bw       = total_bytes/1e9 / (total_us/1e6)                 [GB/s, GB=10^9]
     //   avg_latency  = total_us / (iters * curBatch)                    [us per transfer]
     // matching nixl's avg_latency = total_duration/(per_thread_iter*batch_size).
-    const int effBatch = curBatch;
-    const double numXfers = static_cast<double>(a.iters) * effBatch;
+    const double numXfers = static_cast<double>(a.iters) * curBatch;
     double total_bytes = static_cast<double>(msg) * numXfers;
-    double avg_bw = (total_bytes / 1e9) / (total_us / 1e6);   // GB/s, GB=10^9
-    double avg_lat = total_us / numXfers;                      // us per single transfer
+    double avg_bw = (total_bytes / 1e9) / (total_us / 1e6);  // GB/s, GB=10^9
+    double avg_lat = total_us / numXfers;                    // us per single transfer
 
-    std::printf("%-11zu %-6d %-6d %-12.2f %-11.2f %-.1f\n", msg, effBatch, a.iters, avg_bw, avg_lat,
+    std::printf("%-11zu %-6d %-6d %-12.2f %-11.2f %-.1f\n", msg, curBatch, a.iters, avg_bw, avg_lat,
                 total_us);
     std::fflush(stdout);
   }
 
-  Barrier(sock);   // tell target we're done
-  if (cpuMem) HIP_CHECK(hipHostFree(buf)); else HIP_CHECK(hipFree(buf));
-  close(sock);
-  return 0;
+  rdv.Barrier();  // tell target we're done
+
+  // Correctness check on the last sweep point, matching the Python benchmark's
+  // always-on validation. Runs after the timed region so it cannot perturb the
+  // reported numbers.
+  const auto& last = plan.back();
+  const bool valid = ValidateTransfer(rdv, buf, last.first, last.second,
+                                      a.enable_batch_transfer && last.second > 1,
+                                      a.batch_contiguous, a.rank, !a.skip_validate);
+  return valid ? 0 : 1;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  // Both the bootstrap layer and the IO engine report failures by throwing, so
+  // unwinding here runs the destructors instead of leaving teardown to an exit
+  // path.
+  try {
+    return RunBenchmark(argc, argv);
+  } catch (const std::exception& e) {
+    std::cerr << "bench_engine: " << e.what() << std::endl;
+    return 1;
+  }
 }

--- a/tests/cpp/io/bench_engine.cpp
+++ b/tests/cpp/io/bench_engine.cpp
@@ -21,14 +21,9 @@
 //      numbers non-comparable). MORI's blocking Wait() path is exercised only by
 //      the Python benchmark, not this nixl-parity tool.
 //
-//   3. PIPELINE DEPTH.
-//      nixlbench keeps `pipeline_depth` transfers in flight (default 1). We
-//      expose --inflight to match: default 1 = strict stop-and-wait, matching
-//      nixl --pipeline_depth 1.
+//   3. WARMUP excluded from timing (nixl: --warmup_iter, default 100).
 //
-//   4. WARMUP excluded from timing (nixl: --warmup_iter, default 100).
-//
-//   5. throughput_gb = total_bytes / 1e9 / (total_duration_us / 1e6), GB=10^9,
+//   4. throughput_gb = total_bytes / 1e9 / (total_duration_us / 1e6), GB=10^9,
 //      identical unit to nixl. total_bytes = msg * batch * num_iter, and
 //      avg_latency = total_duration / (num_iter * batch) -- i.e. PER SINGLE
 //      TRANSFER, matching nixl's total_duration/(per_thread_iter*batch_size)
@@ -180,7 +175,6 @@ struct Args {
   size_t sweep_step = 0;         // --sweep-step (0 = geometric x2; >0 = linear +step)
   int iters = 500;
   int warmup = 50;               // --warmup-iters
-  int inflight = 1;              // == nixl pipeline_depth (transfers/requests in flight)
 
   // RdmaBackendConfig knobs
   int qp_per_transfer = 4;       // --num-qp-per-transfer
@@ -196,6 +190,10 @@ struct Args {
 
   // batch / session
   int batch = 1;                 // --transfer-batch-size (transfers per request)
+  bool enable_batch_transfer = true;  // --enable-batch-transfer / --disable-batch-transfer.
+                                 // ON (default): batch>1 => ONE N-descriptor batch request
+                                 // (nixl-equivalent). OFF: batch>1 => N individual single
+                                 // transfers per iteration (Python run_single_once path).
   bool batch_contiguous = false; // --batch-contiguous (adjacent offsets → merged WR);
                                  // default strided (each transfer a separate WR)
   bool enable_sess = false;      // --enable-sess (session fast-path); Python default: off
@@ -227,7 +225,6 @@ static Args ParseArgs(int argc, char** argv) {
     else if (k == "--sweep-step") a.sweep_step = std::stoull(next());
     else if (k == "--iters") a.iters = std::stoi(next());
     else if (k == "--warmup" || k == "--warmup-iters") a.warmup = std::stoi(next());
-    else if (k == "--inflight") a.inflight = std::stoi(next());
     else if (k == "--qp-per-transfer" || k == "--num-qp-per-transfer") a.qp_per_transfer = std::stoi(next());
     else if (k == "--worker-threads" || k == "--num-worker-threads") a.worker_threads = std::stoi(next());
     else if (k == "--post-batch-size") a.post_batch_size = std::stoi(next());
@@ -239,6 +236,8 @@ static Args ParseArgs(int argc, char** argv) {
     else if (k == "--max-cqe-num") a.max_cqe_num = std::stoi(next());
     else if (k == "--max-msg-sge") a.max_msg_sge = std::stoi(next());
     else if (k == "--batch" || k == "--transfer-batch-size") a.batch = std::stoi(next());
+    else if (k == "--enable-batch-transfer") a.enable_batch_transfer = true;
+    else if (k == "--disable-batch-transfer") a.enable_batch_transfer = false;
     else if (k == "--batch-contiguous") a.batch_contiguous = true;
     else if (k == "--enable-sess") a.enable_sess = true;
     else if (k == "--disable-sess") a.enable_sess = false;
@@ -377,34 +376,29 @@ int main(int argc, char** argv) {
   }
   const bool isRead = (a.op == "read");
 
-  // Spin to completion, same mechanism as the timed loop (status flag stored by
-  // MORI's CQ worker thread). Used for warmup; keeps warmup identical to the
-  // measured path so caches/QP state are primed the same way.
-  auto spinDone = [&](TransferStatus& s) {
-    while (s.InProgress() || s.Init()) { /* spin: CQ worker thread stores status */ }
-    if (s.Failed()) {
-      std::cerr << "warmup transfer failed: " << s.Message() << std::endl;
-      std::exit(1);
-    }
-  };
-
   std::cout << "MsgSize(B)  Batch  Iters  AvgBW(GB/s)  AvgLat(us)  TotalDur(us)" << std::endl;
 
   for (auto& planEntry : plan) {
     const size_t msg = planEntry.first;
     const int curBatch = planEntry.second;
-    // nixl-style: batch>1 always issues one N-descriptor batch request (no
-    // separate enable flag). batch==1 is the degenerate single-transfer case.
-    const bool batched = curBatch > 1;
-    const int depth = std::min(a.inflight, a.iters);
-    std::vector<TransferStatus> st(depth);
-    std::vector<TransferUniqueId> uid(depth);
+    // Two ways to move curBatch transfers per iteration, mirroring the Python bench:
+    //   --enable-batch-transfer (default, batched): ONE N-descriptor batch request
+    //     (BatchWrite/BatchRead) -- the nixl-equivalent (nixl always batches).
+    //   --disable-batch-transfer (singles): curBatch INDIVIDUAL single-transfer
+    //     submissions per iteration (Python run_single_once), each its own status.
+    // batch==1 is a single transfer either way.
+    const bool batched = a.enable_batch_transfer && curBatch > 1;
+    const int perSlot = batched ? 1 : curBatch;    // statuses per request
+    // Strict stop-and-wait: one request outstanding at a time (nixl
+    // --pipeline_depth 1). [perSlot] status array (TransferStatus is
+    // non-copyable, so a flat vector rather than nested).
+    std::vector<TransferStatus> st(static_cast<size_t>(perSlot));
 
-    // Batch layout. Strided (default): slot i at (msg+1)*i so the N transfers
-    // stay SEPARATE WRs (stresses SQ, real batching) — matches Python default.
-    // Contiguous (--batch-contiguous): slot i at msg*i, adjacent, so MORI may
-    // merge them into one big WR (fast but not really batching, and hits the
-    // 1 GiB max_msg_sz without chunking).
+    // Batch layout for the batched path. Strided (default): transfer i at
+    // (msg+1)*i so the N transfers stay SEPARATE WRs (stresses SQ, real batching)
+    // -- matches Python default. Contiguous (--batch-contiguous): transfer i at
+    // msg*i, adjacent, so MORI may merge them into one big WR (fast but not really
+    // batching, and hits the 1 GiB max_msg_sz without chunking).
     const size_t stride = a.batch_contiguous ? msg : (msg + 1);
     SizeVec offsets(curBatch), sizes(curBatch);
     for (int i = 0; i < curBatch; ++i) {
@@ -415,59 +409,80 @@ int main(int argc, char** argv) {
     MemDescVec locVec{localMem}, remVec{peerMem};
     BatchSizeVec offVec{offsets}, sizeVec{sizes};
 
-    auto post = [&](int slot) {
-      st[slot].SetCode(StatusCode::INIT);
-      uid[slot] = useSess ? sessPtr->AllocateTransferUniqueId() : engine.AllocateTransferUniqueId();
+    auto post = [&]() {
+      TransferStatus* base = &st[0];
+      for (int i = 0; i < perSlot; ++i) base[i].SetCode(StatusCode::INIT);
       if (batched) {
+        // ONE N-descriptor batch request (nixl / Python --enable-batch-transfer).
+        TransferUniqueId id =
+            useSess ? sessPtr->AllocateTransferUniqueId() : engine.AllocateTransferUniqueId();
         if (useSess) {
-          if (isRead) sessPtr->BatchRead(offsets, offsets, sizes, &st[slot], uid[slot]);
-          else        sessPtr->BatchWrite(offsets, offsets, sizes, &st[slot], uid[slot]);
+          if (isRead) sessPtr->BatchRead(offsets, offsets, sizes, &base[0], id);
+          else        sessPtr->BatchWrite(offsets, offsets, sizes, &base[0], id);
         } else {
-          TransferStatusPtrVec sp{&st[slot]};
-          TransferUniqueIdVec ids{uid[slot]};
+          TransferStatusPtrVec sp{&base[0]};
+          TransferUniqueIdVec ids{id};
           if (isRead) engine.BatchRead(locVec, offVec, remVec, offVec, sizeVec, sp, ids);
           else        engine.BatchWrite(locVec, offVec, remVec, offVec, sizeVec, sp, ids);
         }
       } else {
-        if (useSess) {
-          if (isRead) sessPtr->Read(0, 0, msg, &st[slot], uid[slot]);
-          else        sessPtr->Write(0, 0, msg, &st[slot], uid[slot]);
-        } else {
-          if (isRead) engine.Read(localMem, 0, peerMem, 0, msg, &st[slot], uid[slot]);
-          else        engine.Write(localMem, 0, peerMem, 0, msg, &st[slot], uid[slot]);
+        // curBatch individual single-transfer submissions (Python run_single_once);
+        // contiguous offsets i*msg, matching Python's single path. curBatch==1 is a
+        // single transfer at offset 0.
+        for (int i = 0; i < curBatch; ++i) {
+          const size_t off = static_cast<size_t>(i) * msg;
+          TransferUniqueId id =
+              useSess ? sessPtr->AllocateTransferUniqueId() : engine.AllocateTransferUniqueId();
+          if (useSess) {
+            if (isRead) sessPtr->Read(off, off, msg, &base[i], id);
+            else        sessPtr->Write(off, off, msg, &base[i], id);
+          } else {
+            if (isRead) engine.Read(localMem, off, peerMem, off, msg, &base[i], id);
+            else        engine.Write(localMem, off, peerMem, off, msg, &base[i], id);
+          }
         }
       }
     };
 
+    // The request is complete only when ALL perSlot sub-transfers have left
+    // INIT/IN_PROGRESS (mirrors Python waiting on the whole status_list). Spin,
+    // like the timed loop. reqFailed returns the first failed status, or nullptr.
+    auto reqDone = [&]() {
+      TransferStatus* base = &st[0];
+      for (int i = 0; i < perSlot; ++i)
+        if (base[i].InProgress() || base[i].Init()) return false;
+      return true;
+    };
+    auto reqFailed = [&]() -> TransferStatus* {
+      TransferStatus* base = &st[0];
+      for (int i = 0; i < perSlot; ++i)
+        if (base[i].Failed()) return &base[i];
+      return nullptr;
+    };
+
     // ---- warmup (excluded from timing) ----
     for (int w = 0; w < a.warmup; ++w) {
-      post(0);
-      spinDone(st[0]);
+      post();
+      while (!reqDone()) { /* spin: CQ worker thread stores status */ }
+      if (TransferStatus* f = reqFailed()) {
+        std::cerr << "warmup transfer failed: " << f->Message() << std::endl;
+        std::exit(1);
+      }
     }
 
     // ---- timed region: ONE whole-loop timer, nixl-style ----
-    int completed = 0, issued = 0;
+    // Strict stop-and-wait (nixl --pipeline_depth 1): post one request, spin
+    // until it completes, then post the next.
     auto t0 = Clock::now();
 
-    // prime the pipeline. NOTE: all `depth` in-flight slots reuse the same buffer
-    // window (non-batched posts all target offset 0; batched slots share the same
-    // offsets vector), so with --inflight > 1 concurrent transfers overlap the
-    // same bytes. That's fine for a throughput/latency benchmark (data is not
-    // validated), matching nixl which likewise reuses its IOV across slots.
-    for (int s = 0; s < depth; ++s) { post(s); ++issued; }
-
-    while (completed < a.iters) {
-      for (int s = 0; s < depth; ++s) {
-        // spin-poll this slot, mirroring nixl's "check status, if IN_PROG
-        // continue" scan (status flag is stored by MORI's CQ worker thread)
-        if (st[s].InProgress() || st[s].Init()) continue;
-        if (st[s].Failed()) {
-          std::cerr << "transfer failed: " << st[s].Message() << std::endl;
-          std::exit(1);
-        }
-        // completed one
-        ++completed;
-        if (issued < a.iters) { post(s); ++issued; }
+    for (int completed = 0; completed < a.iters; ++completed) {
+      post();
+      // spin-poll, mirroring nixl's "check status, if IN_PROG continue" scan
+      // (status flags stored by MORI's CQ worker thread)
+      while (!reqDone()) { /* spin */ }
+      if (TransferStatus* f = reqFailed()) {
+        std::cerr << "transfer failed: " << f->Message() << std::endl;
+        std::exit(1);
       }
     }
     auto t1 = Clock::now();
@@ -475,12 +490,13 @@ int main(int argc, char** argv) {
     double total_us =
         std::chrono::duration_cast<std::chrono::duration<double, std::micro>>(t1 - t0).count();
     // nixl parity (nixl_worker/utils.cpp): count block_size*batch_size*num_iter
-    // bytes over ONE whole-loop timer, and report latency PER SINGLE TRANSFER:
-    //   total_bytes  = msg * batch * iters
+    // bytes over ONE whole-loop timer, and report latency PER SINGLE TRANSFER.
+    // Both batched and singles modes move curBatch transfers of `msg` per iter:
+    //   total_bytes  = msg * curBatch * iters
     //   avg_bw       = total_bytes/1e9 / (total_us/1e6)                 [GB/s, GB=10^9]
-    //   avg_latency  = total_us / (iters * batch)                       [us per transfer]
+    //   avg_latency  = total_us / (iters * curBatch)                    [us per transfer]
     // matching nixl's avg_latency = total_duration/(per_thread_iter*batch_size).
-    const int effBatch = batched ? curBatch : 1;
+    const int effBatch = curBatch;
     const double numXfers = static_cast<double>(a.iters) * effBatch;
     double total_bytes = static_cast<double>(msg) * numXfers;
     double avg_bw = (total_bytes / 1e9) / (total_us / 1e6);   // GB/s, GB=10^9

--- a/tests/cpp/io/bench_engine.cpp
+++ b/tests/cpp/io/bench_engine.cpp
@@ -1,0 +1,416 @@
+// bench_engine.cpp
+//
+// A C++ benchmark for MORI-IO whose measurement methodology exactly matches
+// nixlbench (NVIDIA NIXL's xferbench). The point is an apples-to-apples RDMA
+// throughput/latency comparison between MORI-IO and NIXL on the same fabric,
+// eliminating the gaps that exist between MORI's Python benchmark and nixlbench:
+//
+//   1. WHOLE-LOOP TIMER (not per-iteration sum).
+//      nixlbench wraps ONE timer around the entire num_iter loop
+//      (nixl_worker.cpp: total_timer -> total_duration = total_timer.lap()),
+//      then throughput = total_bytes / total_duration. MORI's Python bench
+//      instead times each iteration (launch+transfer) and SUMS them, which
+//      excludes the inter-iteration gap. Here we use a single whole-loop timer.
+//
+//   2. INLINE SPIN-POLL COMPLETION in the benchmark thread.
+//      nixlbench polls agent->getXferStatus() in a tight spin (NIXL_IN_PROG ->
+//      continue) directly in the bench thread. MORI's WaitBusy() spins on the
+//      completion flag (no cv wakeup) -> we use WaitBusy(), the closest analog.
+//
+//   3. PIPELINE DEPTH.
+//      nixlbench keeps `pipeline_depth` transfers in flight (default 1). We
+//      expose --inflight to match: default 1 = strict stop-and-wait, matching
+//      nixl --pipeline_depth 1.
+//
+//   4. WARMUP excluded from timing (nixl: --warmup_iter, default 100).
+//
+//   5. throughput_gb = total_bytes / 1e9 / (total_duration_us / 1e6), GB=10^9,
+//      identical unit to nixl. avg_latency = total_duration / num_iter.
+//
+// Rendezvous: 2 processes (one per node), TCP socket exchange of EngineDesc and
+// MemoryDesc (msgpack, same as MORI's pybind pack()/unpack()). Rank 0 =
+// initiator, rank 1 = target. Initiator drives all transfers (RDMA one-sided
+// WRITE/READ); target only registers memory and waits.
+//
+// Build: see build.sh (links libmori_io + libmori_application from the editable
+// install, includes 3rdparty/msgpack-c + HIP).
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <hip/hip_runtime.h>
+#include <msgpack.hpp>
+
+#include "mori/io/io.hpp"
+
+using namespace mori::io;
+using Clock = std::chrono::steady_clock;
+
+#define HIP_CHECK(expr)                                                                   \
+  do {                                                                                    \
+    hipError_t _e = (expr);                                                               \
+    if (_e != hipSuccess) {                                                               \
+      std::cerr << "HIP error " << hipGetErrorString(_e) << " at " << __FILE__ << ":"     \
+                << __LINE__ << std::endl;                                                 \
+      std::exit(1);                                                                       \
+    }                                                                                     \
+  } while (0)
+
+// ------------------------- tiny TCP rendezvous -----------------------------
+// Rank 0 listens, rank 1 connects. Then symmetric length-prefixed blob swap.
+
+static int TcpListenAccept(uint16_t port) {
+  int lfd = socket(AF_INET, SOCK_STREAM, 0);
+  int opt = 1;
+  setsockopt(lfd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = INADDR_ANY;
+  addr.sin_port = htons(port);
+  if (bind(lfd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+    perror("bind");
+    std::exit(1);
+  }
+  listen(lfd, 1);
+  int fd = accept(lfd, nullptr, nullptr);
+  close(lfd);
+  return fd;
+}
+
+static int TcpConnect(const std::string& host, uint16_t port) {
+  int fd = socket(AF_INET, SOCK_STREAM, 0);
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(port);
+  inet_pton(AF_INET, host.c_str(), &addr.sin_addr);
+  for (int retry = 0; retry < 100; ++retry) {
+    if (connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0) return fd;
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  }
+  std::cerr << "connect failed to " << host << ":" << port << std::endl;
+  std::exit(1);
+}
+
+static void SendAll(int fd, const void* buf, size_t n) {
+  const char* p = static_cast<const char*>(buf);
+  while (n) {
+    ssize_t k = send(fd, p, n, 0);
+    if (k <= 0) { perror("send"); std::exit(1); }
+    p += k; n -= k;
+  }
+}
+static void RecvAll(int fd, void* buf, size_t n) {
+  char* p = static_cast<char*>(buf);
+  while (n) {
+    ssize_t k = recv(fd, p, n, 0);
+    if (k <= 0) { perror("recv"); std::exit(1); }
+    p += k; n -= k;
+  }
+}
+static void SendBlob(int fd, const std::string& b) {
+  uint64_t len = b.size();
+  SendAll(fd, &len, sizeof(len));
+  SendAll(fd, b.data(), len);
+}
+static std::string RecvBlob(int fd) {
+  uint64_t len = 0;
+  RecvAll(fd, &len, sizeof(len));
+  std::string b(len, '\0');
+  RecvAll(fd, b.data(), len);
+  return b;
+}
+static void Barrier(int fd) {  // symmetric 1-byte ping-pong
+  char c = 'x';
+  SendAll(fd, &c, 1);
+  RecvAll(fd, &c, 1);
+}
+
+template <typename T>
+static std::string Pack(const T& v) {
+  msgpack::sbuffer buf;
+  msgpack::pack(buf, v);
+  return std::string(buf.data(), buf.size());
+}
+template <typename T>
+static T Unpack(const std::string& b) {
+  auto oh = msgpack::unpack(b.data(), b.size());
+  return oh.get().as<T>();
+}
+
+// ------------------------------- config ------------------------------------
+// Flags mirror MORI's Python benchmark (tests/python/io/benchmark.py) so runs
+// are directly comparable. Names use the Python spelling where they exist.
+struct Args {
+  int rank = 0;                  // 0=initiator, 1=target
+  std::string master_ip;         // rank 1 connects here (rank 0's data IP) for TCP rendezvous
+  std::string self_ip;           // this rank's own reachable IP (advertised in EngineDesc)
+  uint16_t port = 18515;
+  int gpu = 0;
+  std::string op = "write";      // write|read
+  size_t sweep_start = 1u << 20; // 1 MiB
+  size_t sweep_max = 32u << 20;  // 32 MiB
+  size_t sweep_step = 1u << 20;  // 1 MiB
+  int iters = 500;
+  int warmup = 50;               // --warmup-iters
+  int inflight = 1;              // == nixl pipeline_depth (transfers/requests in flight)
+
+  // RdmaBackendConfig knobs
+  int qp_per_transfer = 4;       // --num-qp-per-transfer
+  int worker_threads = 1;        // --num-worker-threads
+  int post_batch_size = -1;      // --post-batch-size
+  std::string poll_cq_mode = "polling";  // polling|event
+  bool disable_chunking = false; // --disable-chunking (default: chunking ON, like Python)
+  size_t chunk_bytes = 65536;    // --chunk-bytes
+  int max_chunks = 64;           // --max-chunks
+  int max_send_wr = 0;           // --max-send-wr (0 = leave default)
+  int max_cqe_num = 0;           // --max-cqe-num
+  int max_msg_sge = 0;           // --max-msg-sge
+
+  // batch / session
+  int batch = 1;                 // --transfer-batch-size (transfers per request)
+  bool enable_batch_transfer = false;  // --enable-batch-transfer (use BatchWrite)
+  bool batch_contiguous = false; // --batch-contiguous (adjacent offsets → merged WR);
+                                 // default strided (each transfer a separate WR)
+  bool enable_sess = false;      // --enable-sess (session fast-path); Python default: off
+  bool busy_wait = false;        // --busy-wait (WaitBusy spin); Python default: off
+
+  std::string mem_type = "gpu";  // --mem-type gpu|cpu
+};
+
+static Args ParseArgs(int argc, char** argv) {
+  Args a;
+  for (int i = 1; i < argc; ++i) {
+    std::string k = argv[i];
+    auto next = [&]() { return std::string(argv[++i]); };
+    if (k == "--rank") a.rank = std::stoi(next());
+    else if (k == "--master-ip") a.master_ip = next();
+    else if (k == "--self-ip") a.self_ip = next();
+    else if (k == "--port") a.port = static_cast<uint16_t>(std::stoi(next()));
+    else if (k == "--gpu") a.gpu = std::stoi(next());
+    else if (k == "--op" || k == "--op-type") a.op = next();
+    else if (k == "--sweep-start" || k == "--sweep-start-size") a.sweep_start = std::stoull(next());
+    else if (k == "--sweep-max" || k == "--sweep-max-size") a.sweep_max = std::stoull(next());
+    else if (k == "--sweep-step") a.sweep_step = std::stoull(next());
+    else if (k == "--iters") a.iters = std::stoi(next());
+    else if (k == "--warmup" || k == "--warmup-iters") a.warmup = std::stoi(next());
+    else if (k == "--inflight") a.inflight = std::stoi(next());
+    else if (k == "--qp-per-transfer" || k == "--num-qp-per-transfer") a.qp_per_transfer = std::stoi(next());
+    else if (k == "--worker-threads" || k == "--num-worker-threads") a.worker_threads = std::stoi(next());
+    else if (k == "--post-batch-size") a.post_batch_size = std::stoi(next());
+    else if (k == "--poll_cq_mode" || k == "--poll-cq-mode") a.poll_cq_mode = next();
+    else if (k == "--disable-chunking") a.disable_chunking = true;
+    else if (k == "--chunk-bytes") a.chunk_bytes = std::stoull(next());
+    else if (k == "--max-chunks") a.max_chunks = std::stoi(next());
+    else if (k == "--max-send-wr") a.max_send_wr = std::stoi(next());
+    else if (k == "--max-cqe-num") a.max_cqe_num = std::stoi(next());
+    else if (k == "--max-msg-sge") a.max_msg_sge = std::stoi(next());
+    else if (k == "--batch" || k == "--transfer-batch-size") a.batch = std::stoi(next());
+    else if (k == "--enable-batch-transfer") a.enable_batch_transfer = true;
+    else if (k == "--batch-contiguous") a.batch_contiguous = true;
+    else if (k == "--enable-sess") a.enable_sess = true;
+    else if (k == "--disable-sess") a.enable_sess = false;
+    else if (k == "--busy-wait") a.busy_wait = true;
+    else if (k == "--no-busy-wait") a.busy_wait = false;
+    else if (k == "--mem-type") a.mem_type = next();
+    else { std::cerr << "unknown arg " << k << std::endl; std::exit(1); }
+  }
+  return a;
+}
+
+// ------------------------------ main ---------------------------------------
+int main(int argc, char** argv) {
+  Args a = ParseArgs(argc, argv);
+  HIP_CHECK(hipSetDevice(a.gpu));
+
+  // Buffer must hold the largest single REQUEST. Strided batch (default) needs
+  // (msg+1)*batch to keep slots non-adjacent; contiguous needs msg*batch. Round
+  // the strided case up to (sweep_max+1)*batch.
+  const bool batched = a.enable_batch_transfer && a.batch > 1;
+  const size_t slotStride = a.batch_contiguous ? a.sweep_max : (a.sweep_max + 1);
+  const size_t bufBytes = batched ? slotStride * static_cast<size_t>(a.batch) : a.sweep_max;
+  const bool cpuMem = (a.mem_type == "cpu");
+  const MemoryLocationType memLoc = cpuMem ? MemoryLocationType::CPU : MemoryLocationType::GPU;
+
+  void* buf = nullptr;
+  if (cpuMem) {
+    HIP_CHECK(hipHostMalloc(&buf, bufBytes, 0));
+  } else {
+    HIP_CHECK(hipMalloc(&buf, bufBytes));
+  }
+  HIP_CHECK(hipMemset(buf, 0, bufBytes));
+
+  // Out-of-band control endpoint for the MORI engine. host MUST be an IP the
+  // peer can reach (advertised via EngineDesc for RDMA QP setup); self_ip
+  // defaults to master_ip on rank 0.
+  IOEngineConfig cfg;
+  cfg.host = !a.self_ip.empty() ? a.self_ip : (a.rank == 0 ? a.master_ip : a.master_ip);
+  cfg.port = static_cast<uint16_t>(a.port + 1 + a.rank);  // distinct per rank
+  std::string key = a.rank == 0 ? "initiator" : "target";
+  IOEngine engine(key, cfg);
+
+  RdmaBackendConfig rdmaCfg{};
+  rdmaCfg.qpPerTransfer = a.qp_per_transfer;
+  rdmaCfg.postBatchSize = a.post_batch_size;
+  rdmaCfg.numWorkerThreads = a.worker_threads;
+  rdmaCfg.pollCqMode = (a.poll_cq_mode == "event") ? PollCqMode::EVENT : PollCqMode::POLLING;
+  rdmaCfg.enableNotification = false;         // match MORI Python bench RDMA path
+  rdmaCfg.enableTransferChunking = !a.disable_chunking;  // chunking ON by default (Python parity)
+  rdmaCfg.chunkBytes = a.chunk_bytes;
+  rdmaCfg.maxChunksPerTransfer = a.max_chunks;
+  if (a.max_send_wr > 0) rdmaCfg.maxSendWr = a.max_send_wr;
+  if (a.max_cqe_num > 0) rdmaCfg.maxCqeNum = a.max_cqe_num;
+  if (a.max_msg_sge > 0) rdmaCfg.maxMsgSge = a.max_msg_sge;
+  engine.CreateBackend(BackendType::RDMA, rdmaCfg);
+
+  MemoryDesc localMem = engine.RegisterMemory(buf, bufBytes, a.gpu, memLoc);
+
+  // --- rendezvous over a side TCP socket -----------------------------------
+  int sock = (a.rank == 0) ? TcpListenAccept(a.port) : TcpConnect(a.master_ip, a.port);
+  int one = 1;
+  setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+
+  // Exchange EngineDesc then register the remote engine.
+  EngineDesc myEng = engine.GetEngineDesc();
+  SendBlob(sock, Pack(myEng));
+  EngineDesc peerEng = Unpack<EngineDesc>(RecvBlob(sock));
+  engine.RegisterRemoteEngine(peerEng);
+
+  // Exchange MemoryDesc.
+  SendBlob(sock, Pack(localMem));
+  MemoryDesc peerMem = Unpack<MemoryDesc>(RecvBlob(sock));
+
+  Barrier(sock);
+
+  if (a.rank == 1) {
+    // Target: nothing to drive. RDMA one-sided ops complete without target CPU.
+    // Just hold memory registered until the initiator says it's done.
+    Barrier(sock);   // wait for initiator to finish the whole sweep
+    if (cpuMem) HIP_CHECK(hipHostFree(buf)); else HIP_CHECK(hipFree(buf));
+    close(sock);
+    return 0;
+  }
+
+  // -------------------- initiator: run the sweep ---------------------------
+  // Session fast-path (matches MORI --enable-sess). When --disable-sess, we call
+  // the engine batch/single APIs directly with explicit MemoryDesc + uid vecs.
+  const bool useSess = a.enable_sess;
+  IOEngineSession* sessPtr = nullptr;
+  std::optional<IOEngineSession> sessOpt;
+  if (useSess) {
+    sessOpt = engine.CreateSession(localMem, peerMem);
+    if (!sessOpt) { std::cerr << "CreateSession failed" << std::endl; std::exit(1); }
+    sessPtr = &*sessOpt;
+  }
+  const bool isRead = (a.op == "read");
+
+  auto waitDone = [&](TransferStatus& s) {
+    if (a.busy_wait) { s.WaitBusy(); }              // spin on completion flag
+    else { s.Wait(); }                              // block on condition variable
+  };
+
+  std::cout << "MsgSize(B)  Batch  Iters  AvgBW(GB/s)  AvgLat(us)  TotalDur(us)" << std::endl;
+
+  for (size_t msg = a.sweep_start; msg <= a.sweep_max; msg += a.sweep_step) {
+    const int depth = std::min(a.inflight, a.iters);
+    std::vector<TransferStatus> st(depth);
+    std::vector<TransferUniqueId> uid(depth);
+
+    // Batch layout. Strided (default): slot i at (msg+1)*i so the N transfers
+    // stay SEPARATE WRs (stresses SQ, real batching) — matches Python default.
+    // Contiguous (--batch-contiguous): slot i at msg*i, adjacent, so MORI may
+    // merge them into one big WR (fast but not really batching, and hits the
+    // 1 GiB max_msg_sz without chunking).
+    const size_t stride = a.batch_contiguous ? msg : (msg + 1);
+    SizeVec offsets(a.batch), sizes(a.batch);
+    for (int i = 0; i < a.batch; ++i) {
+      offsets[i] = static_cast<size_t>(i) * stride;
+      sizes[i] = msg;
+    }
+    // Engine (non-session) batch path needs vec-of-vec + desc vectors.
+    MemDescVec locVec{localMem}, remVec{peerMem};
+    BatchSizeVec offVec{offsets}, sizeVec{sizes};
+
+    auto post = [&](int slot) {
+      st[slot].SetCode(StatusCode::INIT);
+      uid[slot] = useSess ? sessPtr->AllocateTransferUniqueId() : engine.AllocateTransferUniqueId();
+      if (batched) {
+        if (useSess) {
+          if (isRead) sessPtr->BatchRead(offsets, offsets, sizes, &st[slot], uid[slot]);
+          else        sessPtr->BatchWrite(offsets, offsets, sizes, &st[slot], uid[slot]);
+        } else {
+          TransferStatusPtrVec sp{&st[slot]};
+          TransferUniqueIdVec ids{uid[slot]};
+          if (isRead) engine.BatchRead(locVec, offVec, remVec, offVec, sizeVec, sp, ids);
+          else        engine.BatchWrite(locVec, offVec, remVec, offVec, sizeVec, sp, ids);
+        }
+      } else {
+        if (useSess) {
+          if (isRead) sessPtr->Read(0, 0, msg, &st[slot], uid[slot]);
+          else        sessPtr->Write(0, 0, msg, &st[slot], uid[slot]);
+        } else {
+          if (isRead) engine.Read(localMem, 0, peerMem, 0, msg, &st[slot], uid[slot]);
+          else        engine.Write(localMem, 0, peerMem, 0, msg, &st[slot], uid[slot]);
+        }
+      }
+    };
+
+    // ---- warmup (excluded from timing) ----
+    for (int w = 0; w < a.warmup; ++w) {
+      post(0);
+      waitDone(st[0]);
+    }
+
+    // ---- timed region: ONE whole-loop timer, nixl-style ----
+    int completed = 0, issued = 0;
+    auto t0 = Clock::now();
+
+    // prime the pipeline
+    for (int s = 0; s < depth; ++s) { post(s); ++issued; }
+
+    while (completed < a.iters) {
+      for (int s = 0; s < depth; ++s) {
+        // spin-poll this slot (WaitBusy with a single poll would also work, but
+        // we mirror nixl's "check status, if IN_PROG continue" scan)
+        if (st[s].InProgress() || st[s].Init()) continue;
+        if (st[s].Failed()) {
+          std::cerr << "transfer failed: " << st[s].Message() << std::endl;
+          std::exit(1);
+        }
+        // completed one
+        ++completed;
+        if (issued < a.iters) { post(s); ++issued; }
+      }
+    }
+    auto t1 = Clock::now();
+
+    double total_us =
+        std::chrono::duration_cast<std::chrono::duration<double, std::micro>>(t1 - t0).count();
+    // Each of the `iters` requests moves msg*batch bytes when batching (nixl
+    // counts block_size*batch_size*num_iter). avg_lat is per REQUEST.
+    const int effBatch = batched ? a.batch : 1;
+    double total_bytes = static_cast<double>(msg) * effBatch * a.iters;
+    double avg_bw = (total_bytes / 1e9) / (total_us / 1e6);   // GB/s, GB=10^9
+    double avg_lat = total_us / a.iters;                       // us per request
+
+    std::printf("%-11zu %-6d %-6d %-12.2f %-11.2f %-.1f\n", msg, effBatch, a.iters, avg_bw, avg_lat,
+                total_us);
+    std::fflush(stdout);
+  }
+
+  Barrier(sock);   // tell target we're done
+  if (cpuMem) HIP_CHECK(hipHostFree(buf)); else HIP_CHECK(hipFree(buf));
+  close(sock);
+  return 0;
+}

--- a/tests/cpp/io/bench_engine.cpp
+++ b/tests/cpp/io/bench_engine.cpp
@@ -61,8 +61,12 @@
 // docs/MORI-IO-BENCHMARK.md for the two-node walkthrough.
 
 #include <hip/hip_runtime.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include <algorithm>
+#include <cerrno>
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
@@ -114,7 +118,7 @@ namespace {
 class BenchBuffer {
  public:
   BenchBuffer(IOEngine& engine, size_t bytes, int device, MemoryLocationType loc)
-      : engine(engine), cpu(loc == MemoryLocationType::CPU) {
+      : engine(engine), cpu(loc == MemoryLocationType::CPU), device(device) {
     if (cpu)
       HIP_CHECK(hipHostMalloc(&ptr, bytes, 0));
     else
@@ -150,15 +154,24 @@ class BenchBuffer {
  private:
   void Free() {
     if (!ptr) return;
+    // Restore the owning device first. Allocation sets it explicitly, but the
+    // destructor runs at scope exit under whatever device is current then --
+    // with two buffers on two GPUs (--xgmi-single-process) that is the wrong one
+    // for at least one of them.
+    int prev = -1;
+    const bool switched = !cpu && hipGetDevice(&prev) == hipSuccess && prev != device &&
+                          hipSetDevice(device) == hipSuccess;
     hipError_t e = cpu ? hipHostFree(ptr) : hipFree(ptr);
     if (e != hipSuccess) {
       std::cerr << "buffer free failed: " << hipGetErrorString(e) << std::endl;
     }
+    if (switched) (void)hipSetDevice(prev);
     ptr = nullptr;
   }
 
   IOEngine& engine;
   const bool cpu;
+  const int device;
   void* ptr{nullptr};
   bool registered{false};
   MemoryDesc desc;
@@ -223,42 +236,63 @@ std::vector<uint64_t> SlotChecksums(const void* buf, const SizeVec& offsets, siz
 // Both ranks derive the same UniqueId from the master endpoint, so nothing has to
 // carry it between them. The bootstrap picks its own local interface; set
 // MORI_SOCKET_IFNAME when that choice has no route to the peer.
+//
+// World size is a runtime value, not a constant: with --num-initiator-dev N /
+// --num-target-dev N there are N processes per node, one per GPU, and the world
+// is numInitiatorDev + numTargetDev ranks. Global ranks are laid out initiators
+// first, so initiator local i is global i and target local i is global
+// numInitiatorDev + i -- the same numbering the Python bench gives torch.dist
+// (benchmark.py _setup_rdma), which keeps the two directly comparable.
 class Rendezvous {
  public:
-  Rendezvous(int rank, const std::string& masterIp, uint16_t port)
-      : boot(mori::application::SocketBootstrapNetwork::GenerateUniqueId(masterIp, port), rank,
-             kWorldSize),
-        myRank(rank) {
+  Rendezvous(int globalRank, int worldSize, int peerRank, const std::string& masterIp,
+             uint16_t port)
+      : boot(mori::application::SocketBootstrapNetwork::GenerateUniqueId(masterIp, port),
+             globalRank, worldSize),
+        myRank(globalRank),
+        worldSize(worldSize),
+        peerRank(peerRank) {
     boot.Initialize();
   }
 
-  // Contribute this rank's blob, return the peer's. Allgather is fixed-size while
-  // packed descriptors are not, so sizes go first and the payload round pads every
-  // rank up to the larger of the two.
-  std::string ExchangeBlob(const std::string& mine) {
-    uint64_t sizes[kWorldSize] = {};
+  // Contribute this rank's blob, return every rank's, indexed by global rank.
+  // Allgather is fixed-size while packed descriptors are not, so sizes go first
+  // and the payload round pads every rank up to the largest of them.
+  std::vector<std::string> AllgatherBlobs(const std::string& mine) {
+    std::vector<uint64_t> sizes(static_cast<size_t>(worldSize), 0);
     uint64_t mySize = mine.size();
-    boot.Allgather(&mySize, sizes, sizeof(mySize));
+    boot.Allgather(&mySize, sizes.data(), sizeof(mySize));
 
-    const size_t stride = std::max(sizes[0], sizes[1]);
-    if (stride == 0) return {};
+    const size_t stride = *std::max_element(sizes.begin(), sizes.end());
+    std::vector<std::string> out(static_cast<size_t>(worldSize));
+    if (stride == 0) return out;
 
-    std::vector<char> sendBuf(stride, 0), recvBuf(stride * kWorldSize, 0);
+    std::vector<char> sendBuf(stride, 0), recvBuf(stride * static_cast<size_t>(worldSize), 0);
     std::memcpy(sendBuf.data(), mine.data(), mine.size());
     boot.Allgather(sendBuf.data(), recvBuf.data(), stride);
 
-    const int peer = 1 - myRank;
-    return std::string(recvBuf.data() + peer * stride, sizes[peer]);
+    for (int r = 0; r < worldSize; ++r) {
+      out[static_cast<size_t>(r)] = std::string(recvBuf.data() + r * stride, sizes[r]);
+    }
+    return out;
+  }
+
+  // Contribute this rank's blob, return the paired rank's. Every rank still
+  // takes part in the underlying allgather -- it is a collective, so a rank that
+  // sat one out would leave the rest blocked until the bootstrap timeout.
+  std::string ExchangeBlob(const std::string& mine) {
+    return AllgatherBlobs(mine)[static_cast<size_t>(peerRank)];
   }
 
   void Barrier() { boot.Barrier(); }
 
- private:
-  // Rank 0 initiates, rank 1 targets.
-  static constexpr int kWorldSize = 2;
+  int WorldSize() const { return worldSize; }
 
+ private:
   mori::application::SocketBootstrapNetwork boot;
   const int myRank;
+  const int worldSize;
+  const int peerRank;
 };
 
 template <typename T>
@@ -283,43 +317,54 @@ T Unpack(const std::string& b) {
 // contributes an empty checksum vector rather than skipping the call, which also
 // makes the flag safe to pass to only one side -- either empty vector downgrades
 // the run to "skipped" instead of hanging or reporting a bogus failure.
-bool ValidateTransfer(Rendezvous& rdv, const void* buf, size_t msg, int batch, bool batched,
-                      bool batchContiguous, int rank, bool wanted) {
-  std::vector<uint64_t> mine;
-  if (wanted) {
-    // Mirror the offsets the sweep actually used: the batched path strides by
-    // msg+1 unless --batch-contiguous, while the singles path is always
-    // contiguous (same asymmetry as the Python bench's run_single_once).
-    const size_t stride = batched ? (batchContiguous ? msg : msg + 1) : msg;
-    SizeVec offsets(static_cast<size_t>(batch));
-    for (int i = 0; i < batch; ++i) offsets[i] = static_cast<size_t>(i) * stride;
-    mine = SlotChecksums(buf, offsets, msg);
-  }
+// Checksums of the slots the sweep actually touched, or an empty vector when the
+// caller opted out with --skip-validate.
+std::vector<uint64_t> TransferChecksums(const void* buf, size_t msg, int batch, bool batched,
+                                        bool batchContiguous, bool wanted) {
+  if (!wanted) return {};
+  // Mirror the offsets the sweep actually used: the batched path strides by
+  // msg+1 unless --batch-contiguous, while the singles path is always
+  // contiguous (same asymmetry as the Python bench's run_single_once).
+  const size_t stride = batched ? (batchContiguous ? msg : msg + 1) : msg;
+  SizeVec offsets(static_cast<size_t>(batch));
+  for (int i = 0; i < batch; ++i) offsets[i] = static_cast<size_t>(i) * stride;
+  return SlotChecksums(buf, offsets, msg);
+}
 
-  const auto peer = Unpack<std::vector<uint64_t>>(rdv.ExchangeBlob(Pack(mine)));
-  if (rank != 0) return true;
-
+// Compare two checksum vectors and report. `label` prefixes every line so the
+// output stays readable when N initiator ranks report concurrently.
+bool CompareChecksums(const std::vector<uint64_t>& mine, const std::vector<uint64_t>& peer,
+                      size_t msg, int batch, const std::string& label) {
   if (mine.empty() || peer.empty()) {
-    std::cout << "validation: skipped"
+    std::cout << label << "validation: skipped"
               << (mine.empty() ? "" : " (peer opted out with --skip-validate)") << std::endl;
     return true;
   }
   if (peer.size() != mine.size()) {
-    std::cerr << "VALIDATION FAILED: peer returned " << peer.size() << " checksums, expected "
-              << mine.size() << std::endl;
+    std::cerr << label << "VALIDATION FAILED: peer returned " << peer.size()
+              << " checksums, expected " << mine.size() << std::endl;
     return false;
   }
   for (size_t i = 0; i < mine.size(); ++i) {
     if (mine[i] != peer[i]) {
-      std::cerr << "VALIDATION FAILED: slot " << i << " of " << mine.size()
+      std::cerr << label << "VALIDATION FAILED: slot " << i << " of " << mine.size()
                 << " differs at msg=" << msg << " batch=" << batch << " (initiator " << std::hex
                 << mine[i] << " vs target " << peer[i] << std::dec << ")" << std::endl;
       return false;
     }
   }
-  std::cout << "validation: OK (" << batch << " slot(s) x " << msg << " B byte-identical)"
+  std::cout << label << "validation: OK (" << batch << " slot(s) x " << msg << " B byte-identical)"
             << std::endl;
   return true;
+}
+
+bool ValidateTransfer(Rendezvous& rdv, const void* buf, size_t msg, int batch, bool batched,
+                      bool batchContiguous, bool isInitiator, bool wanted,
+                      const std::string& label) {
+  const auto mine = TransferChecksums(buf, msg, batch, batched, batchContiguous, wanted);
+  const auto peer = Unpack<std::vector<uint64_t>>(rdv.ExchangeBlob(Pack(mine)));
+  if (!isInitiator) return true;
+  return CompareChecksums(mine, peer, msg, batch, label);
 }
 
 // ------------------------------- config ------------------------------------
@@ -330,10 +375,23 @@ struct Args {
   std::string master_ip;  // bootstrap root (rank 0's data IP); both ranks pass the same
   std::string self_ip;    // this rank's own reachable IP (advertised in EngineDesc)
   uint16_t port = 18515;
-  int gpu = 0;
-  int target_dev_offset = 0;     // --target-dev-offset (target GPU = (gpu+offset)%ndev)
+  int gpu = 0;                // --gpu / --src-gpu
+  int dst_gpu = -1;           // --dst-gpu (-1 = derive from --target-dev-offset)
+  int target_dev_offset = 0;  // --target-dev-offset (target GPU = (gpu+offset)%ndev)
+
+  // Multi-device fan-out (Python --num-initiator-dev / --num-target-dev): each
+  // side forks one process per GPU, initiator local i pairing with target local
+  // i. Must be equal, as in the Python bench.
+  int num_initiator_dev = 1;
+  int num_target_dev = 1;
+
   std::string op = "write";      // write|read
-  std::string backend = "rdma";  // --backend rdma|xgmi (xgmi = intra-node GPU<->GPU)
+  std::string backend = "rdma";  // --backend rdma|xgmi|fabric
+  // --xgmi-single-process: run BOTH sides in one process over two local GPUs, no
+  // rendezvous (the Python bench's default XGMI mode). The normal two-rank path
+  // is already what Python calls --xgmi-multiprocess.
+  bool xgmi_single_process = false;
+  bool xgmi_multiprocess = false;  // accepted for parity; already the default
 
   // Sweep control (Python parity). --all sweeps message size; --all-batch sweeps
   // batch size. Neither set => single run at (buffer_size, batch).
@@ -402,7 +460,7 @@ void PrintUsage(const char* argv0) {
       "\n"
       "Workload:\n"
       "  --op <write|read>        transfer direction (default: write)\n"
-      "  --backend <rdma|xgmi>    (default: rdma)\n"
+      "  --backend <rdma|xgmi|fabric>  (default: rdma; fabric = UALink scale-up vPOD)\n"
       "  --buffer-size N          message size in bytes when not sweeping (default: 32768)\n"
       "  --transfer-batch-size N  transfers per iteration (default: 1)\n"
       "  --enable-batch-transfer  one N-descriptor batch request per iteration (default)\n"
@@ -424,8 +482,16 @@ void PrintUsage(const char* argv0) {
       "  --mem-type <gpu|cpu>     (default: gpu)\n"
       "  --initiator-mem-type T   overrides --mem-type on rank 0\n"
       "  --target-mem-type T      overrides --mem-type on rank 1\n"
-      "  --gpu N                  local device ordinal (default: 0)\n"
+      "  --gpu N                  local device ordinal (default: 0); alias --src-gpu\n"
+      "  --dst-gpu N              peer device ordinal; sets --target-dev-offset (dst - gpu),\n"
+      "                           and is the destination GPU under --xgmi-single-process\n"
       "  --target-dev-offset N    target GPU = (gpu + offset) %% device count\n"
+      "\n"
+      "Multi-device (one process per GPU, initiator i <-> target i):\n"
+      "  --num-initiator-dev N    GPUs/processes on rank 0 (default: 1)\n"
+      "  --num-target-dev N       GPUs/processes on rank 1 (default: 1; must equal the above)\n"
+      "                           Rank r's process i drives GPU (gpu + i) and reports its own\n"
+      "                           row; rank 0 also prints an AGGREGATE line summing all pairs.\n"
       "\n"
       "RDMA tuning:\n"
       "  --num-qp-per-transfer N  (default: 4)\n"
@@ -439,9 +505,15 @@ void PrintUsage(const char* argv0) {
       "  --max-cqe-num N          0 = backend default\n"
       "  --max-msg-sge N          0 = backend default\n"
       "\n"
-      "XGMI tuning:\n"
+      "XGMI / FABRIC tuning:\n"
       "  --num-streams N          (default: 64)\n"
       "  --num-events N           (default: 64)\n"
+      "  --xgmi-single-process    run both sides in ONE process over --src-gpu/--dst-gpu with\n"
+      "                           no rendezvous (Python's default XGMI mode). Without it the\n"
+      "                           usual two-rank path runs, which is already Python's\n"
+      "                           --xgmi-multiprocess (distinct engine keys => HIP IPC).\n"
+      "  --xgmi-multiprocess      accepted for Python parity; this is the default, so it only\n"
+      "                           documents intent (rejected with --xgmi-single-process)\n"
       "\n"
       "Other:\n"
       "  --skip-validate          skip the post-sweep checksum comparison\n"
@@ -465,16 +537,26 @@ Args ParseArgs(int argc, char** argv) {
       a.help = true;
     else if (k == "--rank")
       a.rank = std::stoi(next());
-    else if (k == "--master-ip")
+    else if (k == "--master-ip" || k == "--host")  // --host: Python spelling
       a.master_ip = next();
     else if (k == "--self-ip")
       a.self_ip = next();
     else if (k == "--port")
       a.port = static_cast<uint16_t>(std::stoi(next()));
-    else if (k == "--gpu")
+    else if (k == "--gpu" || k == "--src-gpu")
       a.gpu = std::stoi(next());
+    else if (k == "--dst-gpu")
+      a.dst_gpu = std::stoi(next());
     else if (k == "--target-dev-offset")
       a.target_dev_offset = std::stoi(next());
+    else if (k == "--num-initiator-dev")
+      a.num_initiator_dev = std::stoi(next());
+    else if (k == "--num-target-dev")
+      a.num_target_dev = std::stoi(next());
+    else if (k == "--xgmi-single-process")
+      a.xgmi_single_process = true;
+    else if (k == "--xgmi-multiprocess")
+      a.xgmi_multiprocess = true;
     else if (k == "--op" || k == "--op-type")
       a.op = next();
     else if (k == "--backend")
@@ -547,26 +629,17 @@ Args ParseArgs(int argc, char** argv) {
   return a;
 }
 
-// ------------------------------ main ---------------------------------------
-int RunBenchmark(int argc, char** argv) {
-  Args a = ParseArgs(argc, argv);
-  if (a.help) {
-    PrintUsage(argv[0]);
-    return 0;
-  }
-  SetLogLevel(a.log_level);
-
-  // Rejected up front because each of these either corrupts the run or reports a
-  // number for something the caller did not ask for: rank feeds the two-rank
-  // bootstrap's peer indexing, iters and batch are divisors of the reported
-  // latency, a zero message size makes the geometric sweep loop forever, and an
-  // unrecognised op or memory type would otherwise fall back silently to
-  // write/GPU.
+// Rejected up front because each of these either corrupts the run or reports a
+// number for something the caller did not ask for: rank feeds the bootstrap's
+// peer indexing, iters and batch are divisors of the reported latency, a zero
+// message size makes the geometric sweep loop forever, and an unrecognised op or
+// memory type would otherwise fall back silently to write/GPU.
+void ValidateArgs(Args& a) {
   if (a.rank != 0 && a.rank != 1) {
     throw std::invalid_argument("--rank must be 0 (initiator) or 1 (target)");
   }
-  if (a.backend != "rdma" && a.backend != "xgmi") {
-    throw std::invalid_argument("--backend must be rdma or xgmi (got " + a.backend + ")");
+  if (a.backend != "rdma" && a.backend != "xgmi" && a.backend != "fabric") {
+    throw std::invalid_argument("--backend must be rdma, xgmi or fabric (got " + a.backend + ")");
   }
   if (a.op != "read" && a.op != "write") {
     throw std::invalid_argument("--op must be read or write (got " + a.op + ")");
@@ -582,26 +655,55 @@ int RunBenchmark(int argc, char** argv) {
       throw std::invalid_argument("memory type must be gpu or cpu (got " + m + ")");
     }
   }
-
-  // Per-role memory type: initiator (rank 0) / target (rank 1) may override the
-  // shared --mem-type, enabling mixed CPU<->GPU transfers. Each process only
-  // allocates its own side, so no cross-node coupling is needed.
-  const std::string myMem = (a.rank == 0)
-                                ? (!a.init_mem_type.empty() ? a.init_mem_type : a.mem_type)
-                                : (!a.target_mem_type.empty() ? a.target_mem_type : a.mem_type);
-  const bool cpuMem = (myMem == "cpu");
-  const MemoryLocationType memLoc = cpuMem ? MemoryLocationType::CPU : MemoryLocationType::GPU;
-
-  // Target GPU shift for cross-rail pairing (GPU memory only, matches Python).
-  int gpu = a.gpu;
-  if (a.rank == 1 && !cpuMem && a.target_dev_offset != 0) {
-    int ndev = 0;
-    HIP_CHECK(hipGetDeviceCount(&ndev));
-    if (ndev > 0) gpu = (a.gpu + a.target_dev_offset) % ndev;
+  // FABRIC is a GPU scale-up transport (UALink vPOD); it has no host-memory path,
+  // and the Python bench rejects the combination the same way.
+  if (a.backend == "fabric") {
+    for (const std::string& m : {a.mem_type, a.init_mem_type, a.target_mem_type}) {
+      if (m == "cpu") throw std::invalid_argument("--backend fabric supports GPU memory only");
+    }
   }
-  HIP_CHECK(hipSetDevice(gpu));  // valid device context needed even for host mem
+  if (a.num_initiator_dev < 1 || a.num_target_dev < 1) {
+    throw std::invalid_argument("--num-initiator-dev / --num-target-dev must be >= 1");
+  }
+  // Same restriction the Python bench asserts: the two sides pair up one-to-one,
+  // so an unequal split would leave processes without a partner, blocked in the
+  // bootstrap until it times out.
+  if (a.num_initiator_dev != a.num_target_dev) {
+    throw std::invalid_argument("--num-initiator-dev must equal --num-target-dev (got " +
+                                std::to_string(a.num_initiator_dev) + " vs " +
+                                std::to_string(a.num_target_dev) + ")");
+  }
+  if (a.xgmi_single_process && a.xgmi_multiprocess) {
+    throw std::invalid_argument("--xgmi-single-process and --xgmi-multiprocess are exclusive");
+  }
+  if (a.xgmi_single_process && a.backend != "xgmi") {
+    throw std::invalid_argument("--xgmi-single-process requires --backend xgmi");
+  }
+  if (a.xgmi_single_process && a.num_initiator_dev != 1) {
+    throw std::invalid_argument("--xgmi-single-process runs one process; drop --num-*-dev");
+  }
+  // Rejected rather than ignored: a two-node launcher that keeps --rank 1 on the
+  // second node would otherwise run a full, independent GPU0->GPU1 benchmark on
+  // BOTH hosts, print a plausible-looking table on each, and transfer nothing
+  // between them -- a wrong answer that reads as a successful run.
+  if (a.xgmi_single_process && a.rank != 0) {
+    throw std::invalid_argument(
+        "--xgmi-single-process is a single-node, single-process mode; --rank 1 is meaningless "
+        "(drop --rank, or drop --xgmi-single-process for the two-rank XGMI path)");
+  }
+  // --dst-gpu is the Python spelling of a destination ordinal; the two-rank path
+  // expresses the same thing as an offset, so fold one into the other rather than
+  // carrying two sources of truth into the run.
+  if (a.dst_gpu >= 0 && !a.xgmi_single_process) {
+    if (a.target_dev_offset != 0 && a.target_dev_offset != a.dst_gpu - a.gpu) {
+      throw std::invalid_argument("--dst-gpu and --target-dev-offset disagree");
+    }
+    a.target_dev_offset = a.dst_gpu - a.gpu;
+  }
+}
 
-  // Build the run plan: a list of (msgSize, batch) points.
+// Build the run plan: a list of (msgSize, batch) points.
+std::vector<std::pair<size_t, int>> BuildPlan(const Args& a) {
   //   --all       => sweep message size (geometric x2, or linear when --sweep-step>0),
   //                  batch fixed at --transfer-batch-size.
   //   --all-batch => msg fixed at --buffer-size, batch = 1,2,4,...,32768.
@@ -622,10 +724,13 @@ int RunBenchmark(int argc, char** argv) {
   if (plan.empty()) {
     throw std::invalid_argument("empty sweep: --sweep-start exceeds --sweep-max");
   }
+  return plan;
+}
 
-  // Buffer must hold the largest single REQUEST across the whole plan. Strided
-  // batch (default) needs (msg+1)*batch to keep slots non-adjacent; contiguous
-  // needs msg*batch.
+// Buffer must hold the largest single REQUEST across the whole plan. Strided
+// batch (default) needs (msg+1)*batch to keep slots non-adjacent; contiguous
+// needs msg*batch.
+size_t PlanBufferBytes(const Args& a, const std::vector<std::pair<size_t, int>>& plan) {
   size_t bufBytes = 0;
   for (auto& planEntry : plan) {
     const size_t msg = planEntry.first;
@@ -635,81 +740,60 @@ int RunBenchmark(int argc, char** argv) {
     const size_t need = pBatched ? slotStride * static_cast<size_t>(b) : msg;
     bufBytes = std::max(bufBytes, need);
   }
+  return bufBytes;
+}
 
-  // Out-of-band control endpoint for the MORI engine. host MUST be an IP the
-  // peer can reach (advertised via EngineDesc for RDMA QP setup). Defaults to
-  // master_ip: correct for rank 0 (it IS the master); rank 1 should pass
-  // --self-ip when its reachable IP differs from the master's.
-  IOEngineConfig cfg;
-  cfg.host = !a.self_ip.empty() ? a.self_ip : a.master_ip;
-  cfg.port = static_cast<uint16_t>(a.port + 1 + a.rank);  // distinct per rank
-  std::string key = a.rank == 0 ? "initiator" : "target";
-  IOEngine engine(key, cfg);
-
-  // XGMI moves data over Infinity Fabric between two GPUs on the SAME host, so
-  // its knobs are stream/event depth rather than QPs and chunking. The RDMA-only
-  // flags above are simply unused on that path.
-  if (a.backend == "xgmi") {
-    XgmiBackendConfig xgmiCfg{};
-    xgmiCfg.numStreams = a.num_streams;
-    xgmiCfg.numEvents = a.num_events;
-    engine.CreateBackend(BackendType::XGMI, xgmiCfg);
-  } else {
-    RdmaBackendConfig rdmaCfg{};
-    rdmaCfg.qpPerTransfer = a.qp_per_transfer;
-    rdmaCfg.postBatchSize = a.post_batch_size;
-    rdmaCfg.numWorkerThreads = a.worker_threads;
-    rdmaCfg.pollCqMode = (a.poll_cq_mode == "event") ? PollCqMode::EVENT : PollCqMode::POLLING;
-    rdmaCfg.enableNotification = false;                    // match MORI Python bench RDMA path
-    rdmaCfg.enableTransferChunking = !a.disable_chunking;  // chunking ON by default (Python parity)
-    rdmaCfg.chunkBytes = a.chunk_bytes;
-    rdmaCfg.maxChunksPerTransfer = a.max_chunks;
-    if (a.max_send_wr > 0) rdmaCfg.maxSendWr = a.max_send_wr;
-    if (a.max_cqe_num > 0) rdmaCfg.maxCqeNum = a.max_cqe_num;
-    if (a.max_msg_sge > 0) rdmaCfg.maxMsgSge = a.max_msg_sge;
-    engine.CreateBackend(BackendType::RDMA, rdmaCfg);
+// XGMI moves data over Infinity Fabric between two GPUs on the SAME host and
+// FABRIC over UALink between hosts in one vPOD, so both take stream/event depth
+// rather than QPs and chunking. The RDMA-only flags are simply unused there.
+void CreateBackendFor(IOEngine& engine, const Args& a) {
+  if (a.backend == "xgmi" || a.backend == "fabric") {
+    if (a.backend == "xgmi") {
+      XgmiBackendConfig xgmiCfg{};
+      xgmiCfg.numStreams = a.num_streams;
+      xgmiCfg.numEvents = a.num_events;
+      engine.CreateBackend(BackendType::XGMI, xgmiCfg);
+    } else {
+      FabricBackendConfig fabricCfg{};
+      fabricCfg.numStreams = a.num_streams;
+      fabricCfg.numEvents = a.num_events;
+      engine.CreateBackend(BackendType::FABRIC, fabricCfg);
+    }
+    return;
   }
+  RdmaBackendConfig rdmaCfg{};
+  rdmaCfg.qpPerTransfer = a.qp_per_transfer;
+  rdmaCfg.postBatchSize = a.post_batch_size;
+  rdmaCfg.numWorkerThreads = a.worker_threads;
+  rdmaCfg.pollCqMode = (a.poll_cq_mode == "event") ? PollCqMode::EVENT : PollCqMode::POLLING;
+  rdmaCfg.enableNotification = false;                    // match MORI Python bench RDMA path
+  rdmaCfg.enableTransferChunking = !a.disable_chunking;  // chunking ON by default (Python parity)
+  rdmaCfg.chunkBytes = a.chunk_bytes;
+  rdmaCfg.maxChunksPerTransfer = a.max_chunks;
+  if (a.max_send_wr > 0) rdmaCfg.maxSendWr = a.max_send_wr;
+  if (a.max_cqe_num > 0) rdmaCfg.maxCqeNum = a.max_cqe_num;
+  if (a.max_msg_sge > 0) rdmaCfg.maxMsgSge = a.max_msg_sge;
+  engine.CreateBackend(BackendType::RDMA, rdmaCfg);
+}
 
-  // Declared after the engine so it is destroyed first, i.e. the MR is dropped
-  // while the engine that owns it is still alive.
-  BenchBuffer buffer(engine, bufBytes, gpu, memLoc);
-  void* buf = buffer.Data();
-  const MemoryDesc& localMem = buffer.Desc();
+// One row of the report. Kept per sweep point so the multi-device path can sum
+// bandwidth across GPU pairs after the fact.
+struct SweepResult {
+  size_t msg;
+  int batch;
+  double bw;   // GB/s, GB=10^9
+  double lat;  // us per single transfer
+  double dur;  // us, whole timed loop
+  MSGPACK_DEFINE(msg, batch, bw, lat, dur);
+};
 
-  // Rank-dependent seed pattern rather than zeros, so the post-sweep validation
-  // can tell "the transfer moved my bytes" from "both buffers happened to match".
-  if (a.skip_validate) {
-    HIP_CHECK(hipMemset(buf, 0, bufBytes));
-  } else {
-    FillPattern(buf, bufBytes, a.rank);
-  }
-
-  // --- rendezvous over MORI's socket bootstrap ------------------------------
-  Rendezvous rdv(a.rank, a.master_ip, a.port);
-
-  // Exchange EngineDesc then register the remote engine.
-  EngineDesc myEng = engine.GetEngineDesc();
-  EngineDesc peerEng = Unpack<EngineDesc>(rdv.ExchangeBlob(Pack(myEng)));
-  engine.RegisterRemoteEngine(peerEng);
-
-  // Exchange MemoryDesc.
-  MemoryDesc peerMem = Unpack<MemoryDesc>(rdv.ExchangeBlob(Pack(localMem)));
-
-  rdv.Barrier();
-
-  if (a.rank == 1) {
-    // Target: nothing to drive. RDMA one-sided ops complete without target CPU.
-    // Just hold memory registered until the initiator says it's done.
-    rdv.Barrier();  // wait for initiator to finish the whole sweep
-    // Collective with the initiator's call below, so it runs even under
-    // --skip-validate; the target only contributes checksums and does not report.
-    const auto& last = plan.back();
-    ValidateTransfer(rdv, buf, last.first, last.second, a.enable_batch_transfer && last.second > 1,
-                     a.batch_contiguous, a.rank, !a.skip_validate);
-    return 0;
-  }
-
-  // -------------------- initiator: run the sweep ---------------------------
+// Drive every point in `plan` from localMem into peerMem and print one row each.
+// `label` prefixes every row, so N initiator processes writing to the same
+// terminal stay attributable.
+std::vector<SweepResult> RunSweep(const Args& a, IOEngine& engine, const MemoryDesc& localMem,
+                                  const MemoryDesc& peerMem,
+                                  const std::vector<std::pair<size_t, int>>& plan,
+                                  const std::string& label) {
   // Session fast-path (matches MORI --enable-sess). When --disable-sess, we call
   // the engine batch/single APIs directly with explicit MemoryDesc + uid vecs.
   const bool useSess = a.enable_sess;
@@ -722,7 +806,8 @@ int RunBenchmark(int argc, char** argv) {
   }
   const bool isRead = (a.op == "read");
 
-  std::cout << "MsgSize(B)  Batch  Iters  AvgBW(GB/s)  AvgLat(us)  TotalDur(us)" << std::endl;
+  std::vector<SweepResult> results;
+  results.reserve(plan.size());
 
   for (auto& planEntry : plan) {
     const size_t msg = planEntry.first;
@@ -860,12 +945,144 @@ int RunBenchmark(int argc, char** argv) {
     double avg_bw = (total_bytes / 1e9) / (total_us / 1e6);  // GB/s, GB=10^9
     double avg_lat = total_us / numXfers;                    // us per single transfer
 
-    std::printf("%-11zu %-6d %-6d %-12.2f %-11.2f %-.1f\n", msg, curBatch, a.iters, avg_bw, avg_lat,
-                total_us);
+    std::printf("%s%-11zu %-6d %-6d %-12.2f %-11.2f %-.1f\n", label.c_str(), msg, curBatch, a.iters,
+                avg_bw, avg_lat, total_us);
     std::fflush(stdout);
+    results.push_back(SweepResult{msg, curBatch, avg_bw, avg_lat, total_us});
   }
 
-  rdv.Barrier();  // tell target we're done
+  return results;
+}
+
+// ---------------------- driver: two-node, N GPUs a side ---------------------
+// One process per GPU. Global ranks are initiators first, so initiator local i
+// is global i and target local i is global numInitiatorDev + i, and the pair
+// (i, numInitiatorDev + i) shares a session. With the defaults this is exactly
+// the original two-rank run.
+int RunDistributed(const Args& a, int localRank) {
+  const bool isInitiator = (a.rank == 0);
+  const int worldSize = a.num_initiator_dev + a.num_target_dev;
+  const int globalRank = isInitiator ? localRank : a.num_initiator_dev + localRank;
+  const int peerRank = isInitiator ? a.num_initiator_dev + localRank : localRank;
+  const bool multiDev = worldSize > 2;
+
+  // Per-role memory type: initiator (rank 0) / target (rank 1) may override the
+  // shared --mem-type, enabling mixed CPU<->GPU transfers. Each process only
+  // allocates its own side, so no cross-node coupling is needed.
+  const std::string myMem = isInitiator
+                                ? (!a.init_mem_type.empty() ? a.init_mem_type : a.mem_type)
+                                : (!a.target_mem_type.empty() ? a.target_mem_type : a.mem_type);
+  const bool cpuMem = (myMem == "cpu");
+  const MemoryLocationType memLoc = cpuMem ? MemoryLocationType::CPU : MemoryLocationType::GPU;
+
+  // Process i of a side drives GPU (--gpu + i); the target additionally shifts by
+  // --target-dev-offset for cross-rail pairing (GPU memory only, matches Python).
+  int ndev = 0;
+  HIP_CHECK(hipGetDeviceCount(&ndev));
+  const int numDev = isInitiator ? a.num_initiator_dev : a.num_target_dev;
+  if (ndev > 0 && a.gpu + numDev > ndev) {
+    throw std::invalid_argument("--gpu " + std::to_string(a.gpu) + " + " + std::to_string(numDev) +
+                                " devices exceeds the " + std::to_string(ndev) + " visible GPUs");
+  }
+  int gpu = a.gpu + localRank;
+  if (!isInitiator && !cpuMem && a.target_dev_offset != 0 && ndev > 0) {
+    // Floored modulo: C++ % truncates toward zero, so a negative offset (legal,
+    // and what --dst-gpu produces when it names a lower ordinal) would otherwise
+    // yield a negative device and fail in hipSetDevice -- after the peer has
+    // already entered the bootstrap, leaving it to block until the timeout.
+    const int shifted = a.gpu + localRank + a.target_dev_offset;
+    gpu = ((shifted % ndev) + ndev) % ndev;
+  }
+  HIP_CHECK(hipSetDevice(gpu));  // valid device context needed even for host mem
+
+  const std::string label = multiDev ? ("[gpu " + std::to_string(gpu) + "] ") : std::string();
+
+  const auto plan = BuildPlan(a);
+  const size_t bufBytes = PlanBufferBytes(a, plan);
+
+  // Out-of-band control endpoint for the MORI engine. host MUST be an IP the
+  // peer can reach (advertised via EngineDesc for RDMA QP setup). Defaults to
+  // master_ip: correct for rank 0 (it IS the master); rank 1 should pass
+  // --self-ip when its reachable IP differs from the master's.
+  //
+  // Both the port and the engine key have to vary per process: with N processes
+  // per node, a per-side constant would have every local process binding the
+  // same port and advertising the same key, and peers would resolve to whichever
+  // registered last. The port uses the global rank so it is unique across both
+  // nodes; the key uses the local rank because the role prefix already separates
+  // the sides, which also matches the Python bench's f"{role.name}-{role_rank}".
+  IOEngineConfig cfg;
+  cfg.host = !a.self_ip.empty() ? a.self_ip : a.master_ip;
+  cfg.port = static_cast<uint16_t>(a.port + 1 + globalRank);
+  const std::string key = (isInitiator ? "initiator-" : "target-") + std::to_string(localRank);
+  IOEngine engine(key, cfg);
+
+  CreateBackendFor(engine, a);
+
+  // Declared after the engine so it is destroyed first, i.e. the MR is dropped
+  // while the engine that owns it is still alive.
+  BenchBuffer buffer(engine, bufBytes, gpu, memLoc);
+  void* buf = buffer.Data();
+  const MemoryDesc& localMem = buffer.Desc();
+
+  // Rank-dependent seed pattern rather than zeros, so the post-sweep validation
+  // can tell "the transfer moved my bytes" from "both buffers happened to match".
+  if (a.skip_validate) {
+    HIP_CHECK(hipMemset(buf, 0, bufBytes));
+  } else {
+    FillPattern(buf, bufBytes, a.rank);
+  }
+
+  // --- rendezvous over MORI's socket bootstrap ------------------------------
+  Rendezvous rdv(globalRank, worldSize, peerRank, a.master_ip, a.port);
+
+  // Exchange EngineDesc then register the remote engine.
+  EngineDesc myEng = engine.GetEngineDesc();
+  EngineDesc peerEng = Unpack<EngineDesc>(rdv.ExchangeBlob(Pack(myEng)));
+  engine.RegisterRemoteEngine(peerEng);
+
+  // Exchange MemoryDesc.
+  MemoryDesc peerMem = Unpack<MemoryDesc>(rdv.ExchangeBlob(Pack(localMem)));
+
+  rdv.Barrier();
+
+  // Every collective below runs on BOTH sides in the same order: the target has
+  // no transfers to drive, but skipping a barrier or an allgather would leave the
+  // initiators blocked until the bootstrap timeout.
+  std::vector<SweepResult> mine;
+  if (isInitiator) {
+    if (globalRank == 0) {
+      std::cout << "MsgSize(B)  Batch  Iters  AvgBW(GB/s)  AvgLat(us)  TotalDur(us)" << std::endl;
+    }
+    mine = RunSweep(a, engine, localMem, peerMem, plan, label);
+  }
+
+  rdv.Barrier();  // initiators done sweeping
+
+  // Aggregate: sum bandwidth over the initiator ranks, point by point. A single
+  // pair already reports its own number, so only fan-out runs print this.
+  const auto allBlobs = rdv.AllgatherBlobs(Pack(mine));
+  if (multiDev && globalRank == 0) {
+    std::vector<std::vector<SweepResult>> perRank;
+    for (int r = 0; r < a.num_initiator_dev; ++r) {
+      perRank.push_back(Unpack<std::vector<SweepResult>>(allBlobs[static_cast<size_t>(r)]));
+    }
+    std::cout << "--- AGGREGATE over " << a.num_initiator_dev << " GPU pairs ---" << std::endl;
+    for (size_t p = 0; p < plan.size(); ++p) {
+      double sumBw = 0, sumLat = 0;
+      int n = 0;
+      for (const auto& rows : perRank) {
+        if (p >= rows.size()) continue;
+        sumBw += rows[p].bw;
+        sumLat += rows[p].lat;
+        ++n;
+      }
+      if (n == 0) continue;
+      std::printf("[AGGREGATE] %-11zu %-6d %-6d %-12.2f %-11.2f (mean lat over %d pairs)\n",
+                  plan[p].first, plan[p].second, a.iters, sumBw, sumLat / n, n);
+    }
+    std::fflush(stdout);
+  }
 
   // Correctness check on the last sweep point, matching the Python benchmark's
   // always-on validation. Runs after the timed region so it cannot perturb the
@@ -873,8 +1090,146 @@ int RunBenchmark(int argc, char** argv) {
   const auto& last = plan.back();
   const bool valid = ValidateTransfer(rdv, buf, last.first, last.second,
                                       a.enable_batch_transfer && last.second > 1,
-                                      a.batch_contiguous, a.rank, !a.skip_validate);
+                                      a.batch_contiguous, isInitiator, !a.skip_validate, label);
   return valid ? 0 : 1;
+}
+
+// ------------------ driver: XGMI, both sides in one process -----------------
+// The Python bench's DEFAULT xgmi mode: one process owns both GPUs, so there is
+// no rendezvous, no remote engine, and no IPC -- source and destination are two
+// registrations against the same engine. (The two-rank path above is already
+// what Python calls --xgmi-multiprocess: distinct engine keys make the backend
+// take its hipIpc* route.)
+int RunXgmiSingleProcess(const Args& a) {
+  int ndev = 0;
+  HIP_CHECK(hipGetDeviceCount(&ndev));
+  const int src = a.gpu;
+  const int dst = (a.dst_gpu >= 0) ? a.dst_gpu : a.gpu + 1;
+  if (src == dst) throw std::invalid_argument("--src-gpu and --dst-gpu must differ");
+  if (src < 0 || dst < 0 || src >= ndev || dst >= ndev) {
+    throw std::invalid_argument("--src-gpu/--dst-gpu out of range (" + std::to_string(ndev) +
+                                " visible GPUs)");
+  }
+
+  const auto plan = BuildPlan(a);
+  const size_t bufBytes = PlanBufferBytes(a, plan);
+
+  HIP_CHECK(hipSetDevice(src));
+
+  // No peer ever dials in, but the engine still wants an endpoint; the XGMI
+  // backend never binds it.
+  IOEngineConfig cfg;
+  cfg.host = !a.self_ip.empty() ? a.self_ip : (!a.master_ip.empty() ? a.master_ip : "127.0.0.1");
+  cfg.port = static_cast<uint16_t>(a.port + 1);
+  IOEngine engine("xgmi-benchmark", cfg);
+  CreateBackendFor(engine, a);
+
+  // hipMalloc lands on the CURRENT device, so the device has to be switched
+  // around each allocation rather than set once up front.
+  HIP_CHECK(hipSetDevice(src));
+  BenchBuffer srcBuf(engine, bufBytes, src, MemoryLocationType::GPU);
+  HIP_CHECK(hipSetDevice(dst));
+  BenchBuffer dstBuf(engine, bufBytes, dst, MemoryLocationType::GPU);
+  HIP_CHECK(hipSetDevice(src));
+
+  // Same two-sided seeding as the distributed path, so a transfer that never
+  // happened cannot pass validation.
+  if (a.skip_validate) {
+    HIP_CHECK(hipMemset(srcBuf.Data(), 0, bufBytes));
+    HIP_CHECK(hipMemset(dstBuf.Data(), 0, bufBytes));
+  } else {
+    FillPattern(srcBuf.Data(), bufBytes, 0);
+    FillPattern(dstBuf.Data(), bufBytes, 1);
+  }
+
+  std::cout << "XGMI single-process: GPU" << src << " -> GPU" << dst << std::endl;
+  std::cout << "MsgSize(B)  Batch  Iters  AvgBW(GB/s)  AvgLat(us)  TotalDur(us)" << std::endl;
+  RunSweep(a, engine, srcBuf.Desc(), dstBuf.Desc(), plan, "");
+
+  // Both buffers are local, so the checksums compare directly -- no exchange.
+  const auto& last = plan.back();
+  const bool batched = a.enable_batch_transfer && last.second > 1;
+  const bool wanted = !a.skip_validate;
+  const auto mine = TransferChecksums(srcBuf.Data(), last.first, last.second, batched,
+                                      a.batch_contiguous, wanted);
+  const auto peer = TransferChecksums(dstBuf.Data(), last.first, last.second, batched,
+                                      a.batch_contiguous, wanted);
+  return CompareChecksums(mine, peer, last.first, last.second, "") ? 0 : 1;
+}
+
+// ------------------------------ main ---------------------------------------
+int RunBenchmark(int argc, char** argv) {
+  Args a = ParseArgs(argc, argv);
+  if (a.help) {
+    PrintUsage(argv[0]);
+    return 0;
+  }
+  SetLogLevel(a.log_level);
+  ValidateArgs(a);
+
+  if (a.xgmi_single_process) return RunXgmiSingleProcess(a);
+
+  const int numDev = (a.rank == 0) ? a.num_initiator_dev : a.num_target_dev;
+  if (numDev == 1) return RunDistributed(a, 0);
+
+  // One process per GPU, forked BEFORE any HIP call so each child builds its own
+  // device context and its own engine: the RDMA backend's queues, worker threads
+  // and MRs are per-process state that does not survive being shared, which is
+  // why this fans out with processes rather than threads (and why the Python
+  // bench uses mp.spawn rather than a thread pool).
+  std::vector<pid_t> kids;
+  kids.reserve(static_cast<size_t>(numDev - 1));
+  for (int i = 1; i < numDev; ++i) {
+    const pid_t pid = fork();
+    if (pid < 0) {
+      // Reap after signalling, for the same reason the loop below does: an
+      // unreaped child keeps its bootstrap port and fails the next launch with
+      // "Address already in use". The peer node still has to wait out its own
+      // bootstrap timeout -- nothing here can tell it the ring will never close.
+      const int err = errno;
+      for (pid_t k : kids) kill(k, SIGTERM);
+      for (pid_t k : kids) {
+        int status = 0;
+        waitpid(k, &status, 0);
+      }
+      throw std::runtime_error(std::string("fork failed: ") + std::strerror(err));
+    }
+    if (pid == 0) {
+      // Child. _exit rather than return: RunDistributed has already run its
+      // destructors, and unwinding back through main would flush the parent's
+      // inherited stdio buffers a second time.
+      int rc = 1;
+      try {
+        rc = RunDistributed(a, i);
+      } catch (const std::exception& e) {
+        // Labelled by local index, not GPU ordinal: the ordinal is only valid
+        // once the device-count check inside RunDistributed has passed, and
+        // naming a GPU that does not exist is exactly the confusing case.
+        std::cerr << "bench_engine[dev " << i << "]: " << e.what() << std::endl;
+      }
+      _exit(rc);
+    }
+    kids.push_back(pid);
+  }
+
+  int rc = 1;
+  try {
+    rc = RunDistributed(a, 0);
+  } catch (const std::exception& e) {
+    std::cerr << "bench_engine[dev 0]: " << e.what() << std::endl;
+  }
+
+  // Reap every child even after a local failure, so a partial run does not leave
+  // processes holding their bootstrap ports against the next launch.
+  for (pid_t k : kids) {
+    int status = 0;
+    if (waitpid(k, &status, 0) < 0) {
+      rc = 1;
+      continue;
+    }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) rc = 1;
+  }
+  return rc;
 }
 
 }  // namespace


### PR DESCRIPTION
# bench(io): nixlbench-matching C++ engine benchmark

Adds `tests/cpp/io/bench_engine.cpp`, a native C++ MORI-IO transfer benchmark
whose measurement loop matches **[nixlbench](https://github.com/ai-dynamo/nixl)**
(NVIDIA NIXL's `xferbench`), so MORI-IO and NIXL RDMA numbers are directly
comparable on the same fabric with no Python-interpreter overhead in the way.

Applies directly to `main`. The only files touched are the new benchmark, its
CMake target, and `docs/MORI-IO-BENCHMARK.md`; no existing source is modified,
and the Python benchmark is untouched.

## What "nixl-matching" means here

- **One whole-loop timer** around the entire iteration loop (nixlbench's
  `total_timer`), not the per-iteration `time.time()` sum the Python bench uses,
  which silently drops the inter-iteration gap.
- **Latency per single transfer**: `total_us / (iters x batch)`, matching nixl's
  `avg_latency = total_duration / (per_thread_iter x batch_size)`.
- **Bandwidth** `msg x batch x iters / 1e9 / (total_us / 1e6)` — GB = 10^9, as in
  nixl.
- **Inline spin-poll completion** in the benchmark thread, mirroring nixl's
  `getXferStatus` scan, so no condition-variable wakeup latency lands in the
  measurement.
- **Strict stop-and-wait**: one request outstanding at a time, equivalent to
  nixl `--pipeline_depth 1`.
- **Warmup excluded**, and memory registered **once** during setup — the buffer
  is sized to the largest request in the whole sweep and reused across every
  size point, so no allocation or registration happens inside the timed loop.

## Also included

- **`--backend rdma|xgmi`**, so the same harness covers intra-node GPU-to-GPU
  transfers, sized by `--num-streams` / `--num-events`.
- **Built-in correctness check** after the sweep, matching the Python benchmark,
  which always validates. Both ranks seed a rank- and offset-dependent pattern
  and exchange one FNV-1a checksum per transferred slot, so the check covers
  every transferred byte while staying O(batch) on the wire. `--skip-validate`
  opts out and is safe to pass on a single rank, since the exchange is a
  collective and an opted-out rank contributes an empty vector rather than
  returning early.
- **Rendezvous over `mori::application::SocketBootstrapNetwork`** rather than a
  second hand-rolled socket setup, so connect/accept retries, timeouts and
  barriers follow the library's policy.
- **Python-parity flags** so runs can be matched arg-for-arg against
  `tests/python/io/benchmark.py`: size and batch sweeps (`--all`, `--all-batch`,
  `--buffer-size`, `--sweep-start`/`--sweep-max`/`--sweep-step`),
  `--enable-batch-transfer` / `--disable-batch-transfer`, chunking, session
  fast path, per-side memory type, `--target-dev-offset`, and the QP tuning
  knobs.
- The buffer and its memory registration are owned by a scope guard and failures
  throw rather than calling `std::exit()`, so the MR is dropped before the pages
  it covers are released on every exit path.
- Unusable arguments are rejected up front instead of being read out of bounds,
  looped on forever or reported as a NaN, and `-h/--help` prints a grouped flag
  list.

## Results

Broadcom Thor2 `bnxt_re` RoCE, 2 nodes, gfx950. VRAM->VRAM WRITE, **1 QP / 1
worker thread**, chunking off, `--batch-contiguous`, session enabled. Bandwidth
in GB/s. **Single run per point — small deltas are directional.**

| Harness | 1 MiB x 1 | 4 KiB x 128 | 512 B x 128 |
|---|---|---|---|
| Python `benchmark.py` | 22.59 | 14.79 | 2.60 |
| C++ `bench_engine` | **24.64** | **16.46** | **2.98** |

The C++ tool reads +9.1% / +11.3% / +14.6% higher, and the gap widening as
messages shrink is what the methodology difference predicts: at 1 MiB the
transfer dominates, while at 512 B each iteration is mostly harness, so the
whole-loop timer, the absent interpreter overhead and the spin-poll instead of a
condition-variable wakeup all take a larger share. These are measurement
differences, not a claim that the transport got faster.

All C++ runs above passed the built-in validation.

## Reproduce

```bash
cmake -B build -DBUILD_IO=ON -DBUILD_TESTS=ON -DBUILD_EXAMPLES=OFF
cmake --build build --target bench_engine -j
export LD_LIBRARY_PATH=$PWD/build/src/io:$PWD/build/src/application:$LD_LIBRARY_PATH
```

Start **rank 1 (target) first**, then rank 0, which drives the transfers and
prints the table. Both ranks take the same workload arguments:

```bash
# TARGET (rank 1) — first
build/tests/cpp/bench_engine --rank 1 --master-ip <RANK0_IP> --self-ip <RANK1_IP> \
    --port 18527 --mem-type gpu --op write --enable-sess \
    --num-qp-per-transfer 1 --num-worker-threads 1 --transfer-batch-size 1 \
    --all --sweep-start 1048576 --sweep-max 1048576 --iters 500 --warmup-iters 50

# INITIATOR (rank 0) — second, prints results
build/tests/cpp/bench_engine --rank 0 --master-ip <RANK0_IP> --self-ip <RANK0_IP> \
    --port 18527 --mem-type gpu --op write --enable-sess \
    --num-qp-per-transfer 1 --num-worker-threads 1 --transfer-batch-size 1 \
    --all --sweep-start 1048576 --sweep-max 1048576 --iters 500 --warmup-iters 50
```

`bench_engine --help` lists every flag, and `docs/MORI-IO-BENCHMARK.md` has the
full walkthrough plus the Python-to-C++ flag mapping.

## Test plan

- [x] Builds and links against `libmori_io` + `libmori_application`
      (`-DBUILD_EXAMPLES=OFF` skips the MPI-only examples target).
- [x] 2-node VRAM WRITE run, batch 1 and batched, sane BW and latency, built-in
      validation passing across read and write, contiguous and strided offsets,
      chunking on and off, with a zero-iteration negative control confirming the
      check fails when nothing moves.
- [ ] Reviewer sanity-check on a second fabric (CX7/mlx5).


