### PR TITLE
MORI-IO CPU hot-path improvements + logging thread-safety

### DIFF
--- a/include/mori/io/backend.hpp
+++ b/include/mori/io/backend.hpp
@@ -25,6 +25,7 @@
 
 #include "mori/io/common.hpp"
 #include "mori/io/enum.hpp"
+#include "mori/io/telemetry.hpp"
 
 namespace mori {
 namespace io {
@@ -194,6 +195,8 @@ class Backend {
                                         TransferStatus* status) = 0;
 
   virtual bool CanHandle(const MemoryDesc& local, const MemoryDesc& remote) const { return true; }
+
+  virtual TelemetrySnapshot GetTelemetrySnapshot() const { return {}; }
 };
 
 }  // namespace io

--- a/include/mori/io/engine.hpp
+++ b/include/mori/io/engine.hpp
@@ -111,6 +111,8 @@ class IOEngine {
   void LoadScatterGatherModule(const std::string& hsacoPath);
   void LoadFabricCopyModule(const std::string& hsacoPath);
 
+  TelemetrySnapshot GetTelemetrySnapshot(BackendType type) const;
+
  private:
   struct RouteCacheKey {
     EngineKey remoteEngineKey;

--- a/include/mori/io/io.hpp
+++ b/include/mori/io/io.hpp
@@ -25,3 +25,4 @@
 #include "mori/io/engine.hpp"
 #include "mori/io/enum.hpp"
 #include "mori/io/logging.hpp"
+#include "mori/io/telemetry.hpp"

--- a/include/mori/io/telemetry.hpp
+++ b/include/mori/io/telemetry.hpp
@@ -1,0 +1,106 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "mori/io/common.hpp"
+#include "mori/io/enum.hpp"
+
+namespace mori {
+namespace io {
+
+struct TelemetryInitOptions {
+  std::optional<bool> enabled;
+};
+
+void InitTelemetry(const TelemetryInitOptions& opts = {});
+
+struct TelemetrySnapshot {
+  struct ApiStats {
+    uint64_t read_calls{0};
+    uint64_t write_calls{0};
+    uint64_t batch_read_calls{0};
+    uint64_t batch_write_calls{0};
+    uint64_t rejected_calls{0};
+    uint64_t total_bytes_read{0};
+    uint64_t total_bytes_written{0};
+    // Initiator-local JCT: API entry -> local CQE completion.
+    // Does NOT include notification round-trip to remote side.
+    // Values are 0.0 when jct_sample_count == 0.
+    double jct_ewma_us{0.0};
+    double jct_min_us{0.0};
+    double jct_max_us{0.0};
+    uint64_t jct_sample_count{0};
+  } api;
+
+  struct VerbsStats {
+    uint64_t bytes_posted{0};
+    uint64_t bytes_completed{0};
+    uint64_t ops_posted{0};
+    uint64_t ops_completed{0};
+    uint64_t cqe_errors{0};
+    uint64_t post_send_errors{0};
+    uint64_t sq_full_events{0};
+    uint64_t cq_polls{0};
+    uint64_t cq_empty_polls{0};
+    // Fraction of CQ polls that found work.
+    // Only meaningful in POLLING mode. In EVENT mode, value is ~1.0
+    // because polls only occur after completion channel notification.
+    double cq_utilization{0.0};
+    PollCqMode poll_mode{PollCqMode::POLLING};
+    int sq_depth{0};
+    int sq_depth_hwm{0};
+    int sq_depth_max{0};
+    // Per-signaled-WR post-to-CQE latency (NIC + wire time).
+    // Values are 0.0 when rdma_latency_sample_count == 0.
+    double rdma_latency_ewma_us{0.0};
+    double rdma_latency_min_us{0.0};
+    double rdma_latency_max_us{0.0};
+    uint64_t rdma_latency_sample_count{0};
+  } verbs;
+
+  // Latency breakdown (makespan-based, EWMA).
+  // Values are 0.0 when api.jct_sample_count == 0.
+  struct LatencyBreakdown {
+    double api_total_ewma_us{0.0};
+    double rdma_wall_ewma_us{0.0};
+    double sw_overhead_ewma_us{0.0};
+  } breakdown;
+
+  struct EpDetail {
+    uint64_t ep_id{0};
+    VerbsStats verbs;
+  };
+  std::vector<EpDetail> per_ep;
+
+  // TSC at snapshot time. Diff two snapshots' tsc values and divide by
+  // (tsc_freq_ghz * 1e9) to get elapsed seconds for bandwidth computation.
+  uint64_t snapshot_tsc{0};
+  double tsc_freq_ghz{0.0};
+};
+
+}  // namespace io
+}  // namespace mori

--- a/include/mori/utils/mori_log.hpp
+++ b/include/mori/utils/mori_log.hpp
@@ -24,8 +24,10 @@
 #include <algorithm>
 #include <cctype>
 #include <chrono>
+#include <cstdio>
 #include <cstdlib>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -53,11 +55,28 @@ class ModuleLogger {
       globalLevel_ = LevelFromString(std::string(globalEnvLevel));
       globalLevelSet_ = true;
     }
+    // Eagerly create every known module logger while we are still single
+    // threaded: the Meyers singleton guarantees this ctor runs exactly once and
+    // blocks other threads until it returns, so loggers_ is fully populated
+    // before any GetLogger() call can touch the map. This removes the
+    // write-during-read data race that otherwise hands back an empty
+    // shared_ptr under the multithreaded RDMA workload. No lock is needed here
+    // because no other thread can observe the instance yet.
+    for (const char* moduleName : kKnownModules) {
+      InitModuleLocked(moduleName);
+    }
   }
 
  public:
-  // Initialize a module-specific logger
+  // Initialize a module-specific logger.
   void InitModule(const std::string& moduleName, Level level = Level::ERROR) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    InitModuleLocked(moduleName, level);
+  }
+ private:
+  // Body of InitModule; callers must hold mutex_ (or be the constructor, which
+  // runs before the instance is observable).
+  void InitModuleLocked(const std::string& moduleName, Level level = Level::ERROR) {
     // Check if logger already exists
     auto existing_logger = spdlog::get(moduleName);
     std::shared_ptr<spdlog::logger> logger;
@@ -106,23 +125,23 @@ class ModuleLogger {
     loggers_[moduleName] = logger;
   }
 
-  // Get logger for a specific module
+ public:
+  // Get logger for a specific module. Never returns null: unknown modules are
+  // created on demand, and if creation ever fails we fall back to the
+  // (always-present) application logger so callers that cache the pointer can
+  // never latch a null.
   std::shared_ptr<spdlog::logger> GetLogger(const std::string& moduleName) {
-    auto it = loggers_.find(moduleName);
-    if (it != loggers_.end()) {
-      return it->second;
-    }
-    // If not found, create with default settings
-    InitModule(moduleName);
-    return loggers_[moduleName];
+    std::lock_guard<std::mutex> lock(mutex_);
+    return GetLoggerLocked(moduleName);
   }
 
   // Set log level for a specific module
   void SetModuleLevel(const std::string& moduleName, Level level) {
+    std::lock_guard<std::mutex> lock(mutex_);
     // Check if this module is protected by environment variable
-    if (HasEnvOverride(moduleName)) {
+    if (HasEnvOverrideLocked(moduleName)) {
       // Log a warning but don't change the level
-      auto logger = GetLogger("application");  // Use application logger for warnings
+      auto logger = GetLoggerLocked("application");  // Use application logger for warnings
       logger->warn(
           "Attempted to change log level for module '{}' which is controlled by environment "
           "variable. Use ForceSetModuleLevel() to override.",
@@ -130,19 +149,20 @@ class ModuleLogger {
       return;
     }
 
-    auto logger = GetLogger(moduleName);
+    auto logger = GetLoggerLocked(moduleName);
     logger->set_level(ConvertLevel(level));
   }
 
   // Set log level for all modules (global control)
   void SetGlobalLevel(Level level) {
+    std::lock_guard<std::mutex> lock(mutex_);
     globalLevel_ = level;
     globalLevelSet_ = true;
 
     // Apply to all existing loggers
     for (auto& [name, logger] : loggers_) {
       // Skip modules controlled by environment variables
-      if (!HasEnvOverride(name)) {
+      if (!HasEnvOverrideLocked(name)) {
         logger->set_level(ConvertLevel(level));
       }
     }
@@ -150,7 +170,8 @@ class ModuleLogger {
 
   // Set log level with priority check (used internally for env vars)
   void SetModuleLevelInternal(const std::string& moduleName, Level level, bool fromEnv = false) {
-    auto logger = GetLogger(moduleName);
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto logger = GetLoggerLocked(moduleName);
     logger->set_level(ConvertLevel(level));
     if (fromEnv) {
       envOverrides_[moduleName] = level;
@@ -159,26 +180,40 @@ class ModuleLogger {
 
   // Check if a module has environment override
   bool HasEnvOverride(const std::string& moduleName) const {
-    return envOverrides_.find(moduleName) != envOverrides_.end();
+    std::lock_guard<std::mutex> lock(mutex_);
+    return HasEnvOverrideLocked(moduleName);
   }
 
   // Clear environment overrides for a module
-  void ClearEnvOverride(const std::string& moduleName) { envOverrides_.erase(moduleName); }
+  void ClearEnvOverride(const std::string& moduleName) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    envOverrides_.erase(moduleName);
+  }
 
   // Force set log level (ignores env protection)
   void ForceSetModuleLevel(const std::string& moduleName, Level level) {
-    auto logger = GetLogger(moduleName);
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto logger = GetLoggerLocked(moduleName);
     logger->set_level(ConvertLevel(level));
   }
 
   // Get current global level
-  Level GetGlobalLevel() const { return globalLevel_; }
+  Level GetGlobalLevel() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return globalLevel_;
+  }
 
   // Check if global level is set
-  bool IsGlobalLevelSet() const { return globalLevelSet_; }
+  bool IsGlobalLevelSet() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return globalLevelSet_;
+  }
 
   // Clear global level setting (revert to individual module control)
-  void ClearGlobalLevel() { globalLevelSet_ = false; }
+  void ClearGlobalLevel() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    globalLevelSet_ = false;
+  }
 
   // Convert string to level
   Level LevelFromString(const std::string& strLevel) {
@@ -200,6 +235,37 @@ class ModuleLogger {
   }
 
  private:
+  // Body of GetLogger; callers must hold mutex_. Never returns null.
+  std::shared_ptr<spdlog::logger> GetLoggerLocked(const std::string& moduleName) {
+    for (int i = 0; i < 2; i++) {
+      auto it = loggers_.find(moduleName);
+      if (it != loggers_.end() && it->second) {
+        return it->second;
+      }
+      InitModuleLocked(moduleName); // Create on demand
+    }
+    // All known modules are created eagerly in the ctor and InitModuleLocked 
+    // creates any other name on demand. If we still have no logger after retrying, 
+    // the logging system is fundamentally broken, so abort loudly rather than 
+    // returning null and letting callers silently
+    std::fprintf(stderr,
+                 "FATAL: ModuleLogger failed to resolve or create a logger for module '%s' "
+                 "after retrying; aborting.\n",
+                 moduleName.c_str());
+    std::abort();
+  }
+
+  // Body of HasEnvOverride; callers must hold mutex_.
+  bool HasEnvOverrideLocked(const std::string& moduleName) const {
+    return envOverrides_.find(moduleName) != envOverrides_.end();
+  }
+
+  // Known modules created eagerly by the constructor. Kept in sync with the
+  // mori::modules namespace below (this class is defined before it).
+  static constexpr const char* kKnownModules[] = {"application", "io", "shmem", "core",
+                                                   "ops", "umbp", "metrics"};
+
+  mutable std::mutex mutex_;
   std::unordered_map<std::string, std::shared_ptr<spdlog::logger>> loggers_;
   std::unordered_map<std::string, Level> envOverrides_;  // Track env variable overrides
   Level globalLevel_ = Level::ERROR;
@@ -238,8 +304,22 @@ constexpr const char* METRICS = "metrics";
 // Macro helpers
 #define MORI_GET_LOGGER(module) mori::ModuleLogger::GetInstance().GetLogger(module)
 
-// General MORI logging macros
-#define MORI_LOG(module, level, ...) MORI_GET_LOGGER(module)->level(__VA_ARGS__)
+// General MORI logging macros.
+//
+// Hot-path note: MORI_GET_LOGGER() resolves the logger by a string-hashed
+// unordered_map lookup. Doing that on every call — even when the level is
+// disabled and spdlog drops the message — shows up on hot paths (e.g. a
+// per-batch MORI_IO_TRACE). We cache the resolved logger pointer in a
+// function-local static so the map lookup happens once per call-site, ever.
+// spdlog's own logger->level(...) already checks the level and skips
+// formatting when disabled, and it reads the level on each call, so runtime
+// level changes are still honored.
+#define MORI_LOG(module, level, ...)                                            \
+  do {                                                                          \
+    static ::spdlog::logger* _mori_log_logger =                                 \
+        ::mori::ModuleLogger::GetInstance().GetLogger(module).get();            \
+    _mori_log_logger->level(__VA_ARGS__);                                       \
+  } while (0)
 
 #define MORI_TRACE(module, ...) MORI_LOG(module, trace, __VA_ARGS__)
 #define MORI_DEBUG(module, ...) MORI_LOG(module, debug, __VA_ARGS__)
@@ -298,19 +378,55 @@ constexpr const char* METRICS = "metrics";
 #define MORI_METRICS_ERROR(...) MORI_ERROR(mori::modules::METRICS, __VA_ARGS__)
 #define MORI_METRICS_CRITICAL(...) MORI_CRITICAL(mori::modules::METRICS, __VA_ARGS__)
 
-// Scoped Timer class
+// Scoped Timer class.
+//
+// Hot-path note: the timer only logs at DEBUG level, so on any normal run
+// (INFO/WARN/ERROR) it must be a true no-op. We resolve the logger once and
+// check the level in the constructor; when disabled we skip the string copy,
+// both clock reads, the per-call GetLogger() hashtable lookup, and the log
+// call entirely. The macros cache the (module -> logger) lookup in a
+// function-local static so the hashtable probe happens once per call-site.
 class ScopedTimer {
  public:
   using Clock = std::chrono::steady_clock;
 
+  // Fast path used by the MORI_TIMER / MORI_FUNCTION_TIMER macros: the logger
+  // is pre-resolved and cached by the call-site, so nothing is allocated or
+  // sampled unless DEBUG logging is actually enabled for this module.
+  ScopedTimer(const char* name, spdlog::logger* logger)
+      : logger_(logger),
+        enabled_(logger != nullptr && logger->should_log(spdlog::level::debug)),
+        cname_(name) {
+    if (enabled_) start_ = Clock::now();
+  }
+
+  ScopedTimer(const std::string& name, spdlog::logger* logger)
+      : logger_(logger),
+        enabled_(logger != nullptr && logger->should_log(spdlog::level::debug)) {
+    if (enabled_) {
+      name_ = name;
+      start_ = Clock::now();
+    }
+  }
+
+  // Legacy path: resolves the logger by module name. Still early-outs when the
+  // level is disabled so it never copies strings or reads the clock needlessly.
   explicit ScopedTimer(const std::string& name,
                        const std::string& module = mori::modules::APPLICATION)
-      : name_(name), module_(module), start_(Clock::now()) {}
+      : logger_(ModuleLogger::GetInstance().GetLogger(module).get()),
+        enabled_(logger_ != nullptr && logger_->should_log(spdlog::level::debug)) {
+    if (enabled_) {
+      name_ = name;
+      start_ = Clock::now();
+    }
+  }
 
   ~ScopedTimer() {
+    if (!enabled_) return;
     auto end = Clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start_).count();
-    MORI_DEBUG(module_, "ScopedTimer [{}] took {} ns", name_, duration);
+    logger_->debug("ScopedTimer [{}] took {} ns", cname_ != nullptr ? cname_ : name_.c_str(),
+                   duration);
   }
 
   double ElapsedSeconds() const {
@@ -321,13 +437,24 @@ class ScopedTimer {
   ScopedTimer& operator=(const ScopedTimer&) = delete;
 
  private:
+  spdlog::logger* logger_ = nullptr;
+  bool enabled_ = false;
+  const char* cname_ = nullptr;
   std::string name_;
-  std::string module_;
-  Clock::time_point start_;
+  Clock::time_point start_{};
 };
 
-#define MORI_TIMER(name, module) ScopedTimer timer_instance(name, module)
-#define MORI_FUNCTION_TIMER(module) ScopedTimer timer_instance(__PRETTY_FUNCTION__, module)
+// Cache the (module -> logger) resolution in a function-local static so the
+// unordered_map<string, logger> lookup runs once per call-site instead of on
+// every invocation of the timed function.
+#define MORI_TIMER(name, module)                                            \
+  static const std::shared_ptr<spdlog::logger> _mori_timer_logger =         \
+      ::mori::ModuleLogger::GetInstance().GetLogger(module);                \
+  ::mori::ScopedTimer timer_instance(name, _mori_timer_logger.get())
+#define MORI_FUNCTION_TIMER(module)                                         \
+  static const std::shared_ptr<spdlog::logger> _mori_timer_logger =         \
+      ::mori::ModuleLogger::GetInstance().GetLogger(module);                \
+  ::mori::ScopedTimer timer_instance(__PRETTY_FUNCTION__, _mori_timer_logger.get())
 
 // Initialization helper functions
 inline void InitializeLogging() {

--- a/python/mori/io/engine.py
+++ b/python/mori/io/engine.py
@@ -237,3 +237,6 @@ class IOEngine:
 
     def wait_all(self, statuses, timeout_ms: int = -1) -> "mori_cpp.StatusCode":
         return self._engine.WaitAll(statuses, timeout_ms)
+
+    def get_telemetry_snapshot(self, backend_type=mori_cpp.BackendType.RDMA):
+        return self._engine.GetTelemetrySnapshot(backend_type)

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -5,6 +5,7 @@ set(MORI_IO_SOURCES
     rdma/executor.cpp
     rdma/common.cpp
     rdma/ledger.cpp
+    rdma/telemetry.cpp
     xgmi/backend_impl.cpp
     xgmi/hip_resource_pool.cpp
     fabric/backend_impl.cpp

--- a/src/io/engine.cpp
+++ b/src/io/engine.cpp
@@ -647,5 +647,11 @@ StatusCode IOEngine::WaitAll(const std::vector<TransferStatus*>& statuses, int t
   return firstError;
 }
 
+TelemetrySnapshot IOEngine::GetTelemetrySnapshot(BackendType type) const {
+  auto it = backends.find(type);
+  if (it == backends.end()) return {};
+  return it->second->GetTelemetrySnapshot();
+}
+
 }  // namespace io
 }  // namespace mori

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -30,6 +30,7 @@
 #include <cstring>
 #include <limits>
 #include <memory>
+#include <numeric>
 #include <optional>
 #include <shared_mutex>
 #include <stdexcept>
@@ -248,8 +249,9 @@ static CqeFailureAdvice DescribeCqeFailure(ibv_wc_status status, CqeFailureOrigi
 /*                                           RdmaManager                                          */
 /* ---------------------------------------------------------------------------------------------- */
 
-RdmaManager::RdmaManager(const RdmaBackendConfig cfg, application::RdmaContext* ctx)
-    : config(cfg), ctx(ctx) {
+RdmaManager::RdmaManager(const RdmaBackendConfig cfg, application::RdmaContext* ctx,
+                         TelemetryRegistry* telemetry)
+    : config(cfg), ctx(ctx), telemetry_(telemetry) {
   application::RdmaDeviceList devices = ctx->GetRdmaDeviceList();
   availDevices = GetActiveDevicePortList(devices);
   if (availDevices.empty()) {
@@ -572,9 +574,12 @@ EndpointId RdmaManager::ConnectEndpoint(EngineKey remoteKey, int devId,
             std::make_shared<std::atomic<bool>>(false),
             std::make_shared<SubmissionLedger>(config.notifPerQp),
             std::make_shared<SqAdmissionEvent>()};
-  meta.rTable[topoKey].push_back(ep);
-
   EndpointId id = nextEndpointId_.fetch_add(1);
+  if (TelemetryConfig::Enabled() && telemetry_) {
+    ep.telem = telemetry_->CreateEpTelemetry(id, ep.sqDepth, ep.maxSqDepth);
+  }
+
+  meta.rTable[topoKey].push_back(ep);
   auto rt = std::make_shared<EndpointRuntime>(id, ep);
   endpointsById_[id] = rt;
   return id;
@@ -626,8 +631,9 @@ application::RdmaDeviceContext* RdmaManager::GetOrCreateDeviceContext(int devId)
 /* ---------------------------------------------------------------------------------------------- */
 /*                                      Notification Manager                                      */
 /* ---------------------------------------------------------------------------------------------- */
-NotifManager::NotifManager(RdmaManager* rdmaMgr, const RdmaBackendConfig& cfg)
-    : rdma(rdmaMgr), config(cfg) {}
+NotifManager::NotifManager(RdmaManager* rdmaMgr, const RdmaBackendConfig& cfg,
+                           TelemetryRegistry* telemetry)
+    : rdma(rdmaMgr), config(cfg), telemetry_(telemetry) {}
 
 NotifManager::~NotifManager() { Shutdown(); }
 
@@ -638,6 +644,10 @@ void NotifManager::RegisterEndpoint(const std::shared_ptr<EndpointRuntime>& rt) 
     ev.data.u64 = rt->id;
     assert(rt->ep.local.ibvHandle.compCh);
     SYSCALL_RETURN_ZERO(epoll_ctl(epfd, EPOLL_CTL_ADD, rt->ep.local.ibvHandle.compCh->fd, &ev));
+  }
+
+  if (rt->ep.telem && rt->ep.ledger) {
+    rt->ep.ledger->EnableTimestamping();
   }
 
   // Skip notification setup if disabled
@@ -699,9 +709,15 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
 
   const int batchSize = 32;
   struct ibv_wc wc[batchSize];
-  int n = 0;
 
-  while ((n = ibv_poll_cq(cq, batchSize, wc)) > 0) {
+  int n = ibv_poll_cq(cq, batchSize, wc);
+
+  if (MORI_IO_TELEM_UNLIKELY(ep.telem)) {
+    ep.telem->counters.cq_poll_count.fetch_add(1, std::memory_order_relaxed);
+    if (n == 0) ep.telem->counters.cq_empty_poll_count.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  while (n > 0) {
     for (int i = 0; i < n; ++i) {
       if (wc[i].status != IBV_WC_SUCCESS) {
         const bool isFlush = (wc[i].status == IBV_WC_WR_FLUSH_ERR);
@@ -730,6 +746,10 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
                 wc[i].wr_id, static_cast<uint32_t>(wc[i].status), failureAdvice.statusText,
                 wc[i].qp_num, wc[i].vendor_err);
           }
+        }
+
+        if (MORI_IO_TELEM_UNLIKELY(ep.telem)) {
+          ep.telem->counters.cqe_errors.fetch_add(1, std::memory_order_relaxed);
         }
 
         int mergedBatchSize = 0;
@@ -837,15 +857,51 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
         // Batch path: wr_id carries a recordId from the SubmissionLedger.
         uint64_t recordId = wc[i].wr_id;
         int mergedBatchSize = 0;
-        auto meta = ep.ledger
-                        ? ep.ledger->ReleaseByCqe(recordId, ep.sqDepth.get(), &mergedBatchSize)
-                        : nullptr;
+        uint64_t recordBytes = 0;
+        uint64_t post_tsc = 0;
+        auto meta = ep.ledger ? ep.ledger->ReleaseByCqe(recordId, ep.sqDepth.get(),
+                                                        &mergedBatchSize, &recordBytes, &post_tsc)
+                              : nullptr;
         if (meta) {
           NotifySqStateChanged(ep);
+
+          if (MORI_IO_TELEM_UNLIKELY(ep.telem)) {
+            ep.telem->counters.ops_completed.fetch_add(mergedBatchSize, std::memory_order_relaxed);
+            ep.telem->counters.bytes_completed.fetch_add(recordBytes, std::memory_order_relaxed);
+
+            if (post_tsc != 0) {
+              uint64_t delta = __rdtsc() - post_tsc;
+              ep.telem->stats.Update(delta);
+            }
+          }
+
           uint32_t finishedBefore = meta->finishedBatchSize.fetch_add(mergedBatchSize);
           TransferStatus* statusPtr = meta->status;
-          if (statusPtr != nullptr && (finishedBefore + mergedBatchSize) == meta->totalBatchSize) {
+          if (statusPtr != nullptr &&
+              (finishedBefore + mergedBatchSize) == static_cast<uint32_t>(meta->totalBatchSize)) {
             statusPtr->Update(StatusCode::SUCCESS, ibv_wc_status_str(wc[i].status));
+
+            if (MORI_IO_TELEM_UNLIKELY(meta->telem) && meta->telem->api_start_tsc != 0) {
+              uint64_t now = __rdtsc();
+              uint64_t first_post = meta->telem->first_post_tsc.load(std::memory_order_relaxed);
+              uint64_t jct = now - meta->telem->api_start_tsc;
+              uint64_t rdma_wall =
+                  (first_post != UINT64_MAX && first_post <= now) ? (now - first_post) : 0;
+              uint64_t sw_overhead =
+                  (first_post != UINT64_MAX && first_post >= meta->telem->api_start_tsc)
+                      ? (first_post - meta->telem->api_start_tsc)
+                      : 0;
+              if (telemetry_) telemetry_->RecordJct(jct, rdma_wall, sw_overhead);
+
+              if (meta->telem->api_counters) {
+                if (meta->telem->is_read)
+                  meta->telem->api_counters->total_bytes_read.fetch_add(meta->telem->total_bytes,
+                                                                        std::memory_order_relaxed);
+                else
+                  meta->telem->api_counters->total_bytes_written.fetch_add(
+                      meta->telem->total_bytes, std::memory_order_relaxed);
+              }
+            }
           }
           MORI_IO_TRACE("ProcessOneCqe: batch CQE for task {} total={} finished={} cur={}",
                         meta->id, meta->totalBatchSize, finishedBefore, mergedBatchSize);
@@ -856,6 +912,7 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
         }
       }
     }
+    n = ibv_poll_cq(cq, batchSize, wc);
   }
 
   if (!flushDrain.Empty()) {
@@ -1312,13 +1369,14 @@ RdmaBackendSession::RdmaBackendSession(const RdmaBackendConfig& config,
                                        std::vector<application::RdmaMemoryRegion> localMrPerEp,
                                        std::vector<application::RdmaMemoryRegion> remoteMrPerEp,
                                        const EpPairVec& e, Executor* exec,
-                                       MemoryLocationType localLoc)
+                                       MemoryLocationType localLoc, TelemetryRegistry* telemetry)
     : config(config),
       localMrPerEp(std::move(localMrPerEp)),
       remoteMrPerEp(std::move(remoteMrPerEp)),
       eps(e),
       executor(exec),
-      localLoc_(localLoc) {}
+      localLoc_(localLoc),
+      telemetry_(telemetry) {}
 
 void RdmaBackendSession::ReadWrite(size_t localOffset, size_t remoteOffset, size_t size,
                                    TransferStatus* status, TransferUniqueId id, bool isRead) {
@@ -1326,6 +1384,21 @@ void RdmaBackendSession::ReadWrite(size_t localOffset, size_t remoteOffset, size
   status->SetCode(StatusCode::IN_PROGRESS);
   auto callbackMeta = std::make_shared<CqCallbackMeta>(status, id, 1);
   internal::PublishCurrentIoCallDiagnostics(callbackMeta);
+
+  if (MORI_IO_TELEM_UNLIKELY(telemetry_)) {
+    auto tm = std::make_unique<TelemetryMeta>();
+    tm->api_start_tsc = __rdtsc();
+    tm->total_bytes = size;
+    tm->is_read = isRead;
+    tm->api_counters = &telemetry_->ApiCounters();
+    callbackMeta->telem = std::move(tm);
+
+    auto& api = telemetry_->ApiCounters();
+    if (isRead)
+      api.read_calls.fetch_add(1, std::memory_order_relaxed);
+    else
+      api.write_calls.fetch_add(1, std::memory_order_relaxed);
+  }
 
   RdmaOpRet ret = RdmaBatchReadWrite(eps, localMrPerEp, remoteMrPerEp, {localOffset},
                                      {remoteOffset}, {size}, callbackMeta, id, isRead, 1,
@@ -1335,6 +1408,10 @@ void RdmaBackendSession::ReadWrite(size_t localOffset, size_t remoteOffset, size
   assert(!ret.Init());
   if (ret.Failed() || ret.Succeeded()) {
     status->Update(ret.code, ret.message);
+  }
+
+  if (MORI_IO_TELEM_UNLIKELY(callbackMeta->telem) && ret.code == StatusCode::ERR_INVALID_ARGS) {
+    callbackMeta->telem->api_counters->rejected_calls.fetch_add(1, std::memory_order_relaxed);
   }
   if (!ret.Failed() && config.enableNotification) {
     RdmaOpRet notifRet = RdmaNotifyTransfer(eps, status, id);
@@ -1394,6 +1471,22 @@ void RdmaBackendSession::BatchReadWrite(const SizeVec& localOffsets, const SizeV
 
   auto callbackMeta = std::make_shared<CqCallbackMeta>(status, id, totalCredit);
   internal::PublishCurrentIoCallDiagnostics(callbackMeta);
+
+  if (MORI_IO_TELEM_UNLIKELY(telemetry_)) {
+    auto tm = std::make_unique<TelemetryMeta>();
+    tm->api_start_tsc = __rdtsc();
+    tm->total_bytes = std::accumulate(sizes.begin(), sizes.end(), uint64_t{0});
+    tm->is_read = isRead;
+    tm->api_counters = &telemetry_->ApiCounters();
+    callbackMeta->telem = std::move(tm);
+
+    auto& api = telemetry_->ApiCounters();
+    if (isRead)
+      api.batch_read_calls.fetch_add(1, std::memory_order_relaxed);
+    else
+      api.batch_write_calls.fetch_add(1, std::memory_order_relaxed);
+  }
+
   RdmaOpRet ret;
   if (canUseWorkerChunking) {
     ExecutorReq req{eps,
@@ -1435,6 +1528,11 @@ void RdmaBackendSession::BatchReadWrite(const SizeVec& localOffsets, const SizeV
   if (ret.Failed() || ret.Succeeded()) {
     status->Update(ret.code, ret.message);
   }
+
+  if (MORI_IO_TELEM_UNLIKELY(callbackMeta->telem) && ret.code == StatusCode::ERR_INVALID_ARGS) {
+    callbackMeta->telem->api_counters->rejected_calls.fetch_add(1, std::memory_order_relaxed);
+  }
+
   if (!ret.Failed() && config.enableNotification) {
     RdmaOpRet notifRet = RdmaNotifyTransfer(eps, status, id);
     if (notifRet.Failed()) {
@@ -1479,11 +1577,17 @@ RdmaBackend::RdmaBackend(EngineKey k, const IOEngineConfig& engConfig,
   ValidateRdmaNotificationConfig(config);
   ValidateRdmaTransferConfig(config);
 
+  TelemetryConfig::Init();
+  if (TelemetryConfig::Enabled()) {
+    telemetry_ = std::make_unique<TelemetryRegistry>();
+    telemetry_->SetPollMode(config.pollCqMode);
+  }
+
   auto rdmaCtx = std::make_unique<application::RdmaContext>(application::RdmaBackendType::IBVerbs);
-  rdma.reset(new mori::io::RdmaManager(config, rdmaCtx.get()));
+  rdma.reset(new mori::io::RdmaManager(config, rdmaCtx.get(), telemetry_.get()));
   (void)rdmaCtx.release();
 
-  notif.reset(new NotifManager(rdma.get(), config));
+  notif.reset(new NotifManager(rdma.get(), config, telemetry_.get()));
   notif->Start();
 
   server.reset(new ControlPlaneServer(myEngKey, engConfig.host, engConfig.port, config, rdma.get(),
@@ -1685,12 +1789,17 @@ void RdmaBackend::CreateSession(const MemoryDesc& local, const MemoryDesc& remot
   }
 
   sess = RdmaBackendSession(config, std::move(localMrPerEp), std::move(remoteMrPerEp), epSet,
-                            executor.get(), local.loc);
+                            executor.get(), local.loc, telemetry_.get());
 }
 
 bool RdmaBackend::PopInboundTransferStatus(EngineKey remote, TransferUniqueId id,
                                            TransferStatus* status) {
   return notif->PopInboundTransferStatus(remote, id, status);
+}
+
+TelemetrySnapshot RdmaBackend::GetTelemetrySnapshot() const {
+  if (!telemetry_) return {};
+  return telemetry_->Snapshot();
 }
 
 RdmaBackendSession* RdmaBackend::GetOrCreateSessionCached(const MemoryDesc& local,

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -572,7 +572,8 @@ EndpointId RdmaManager::ConnectEndpoint(EngineKey remoteKey, int devId,
             std::make_shared<std::atomic<int>>(0),
             static_cast<int>(epConfig.maxMsgsNum),
             std::make_shared<std::atomic<bool>>(false),
-            std::make_shared<SubmissionLedger>(config.notifPerQp),
+            std::make_shared<SubmissionLedger>(config.notifPerQp,
+                                               static_cast<int>(epConfig.maxMsgsNum)),
             std::make_shared<SqAdmissionEvent>()};
   EndpointId id = nextEndpointId_.fetch_add(1);
   if (TelemetryConfig::Enabled() && telemetry_) {
@@ -582,6 +583,7 @@ EndpointId RdmaManager::ConnectEndpoint(EngineKey remoteKey, int devId,
   meta.rTable[topoKey].push_back(ep);
   auto rt = std::make_shared<EndpointRuntime>(id, ep);
   endpointsById_[id] = rt;
+  endpointsEpoch_.fetch_add(1, std::memory_order_release);
   return id;
 }
 
@@ -608,14 +610,14 @@ bool RdmaManager::HasIonicDevice() const {
   return false;
 }
 
-std::vector<std::shared_ptr<EndpointRuntime>> RdmaManager::SnapshotEndpointRuntimes() {
+void RdmaManager::SnapshotEndpointRuntimes(
+                       SnapshotVector& result) {
   std::shared_lock<std::shared_mutex> lock(mu);
-  std::vector<std::shared_ptr<EndpointRuntime>> result;
-  result.reserve(endpointsById_.size());
-  for (auto& [_, rt] : endpointsById_) {
-    result.push_back(rt);
+  result.resize(endpointsById_.size());
+  size_t i = 0;
+  for (const auto& [_, rt] : endpointsById_) {
+    result[i++] = rt;
   }
-  return result;
 }
 
 application::RdmaDeviceContext* RdmaManager::GetOrCreateDeviceContext(int devId) {
@@ -672,7 +674,10 @@ void NotifManager::RegisterEndpoint(const std::shared_ptr<EndpointRuntime>& rt) 
   application::RdmaMemoryRegion mr =
       devCtx->RegisterRdmaMemoryRegion(buf, config.notifPerQp * sizeof(NotifMessage));
 
-  notifCtxById_.insert({rt->id, {mr, buf}});
+  auto [notifIt, notifInserted] = notifCtxById_.insert({rt->id, {mr, buf}});
+  // Publish the (rehash-stable, node-based map) context pointer so the poll loop
+  // can read it locklessly. release pairs with the acquire load in ProcessOneCqe.
+  rt->notifCtx.store(&notifIt->second, std::memory_order_release);
 
   struct ibv_qp* qp = rt->ep.local.ibvHandle.qp;
   assert(qp);
@@ -699,13 +704,13 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
   ibv_cq* cq = ep.local.ibvHandle.cq;
   FlushDrainStats flushDrain;
 
-  // Resolve notif context once before the CQ drain loop.
-  QpNotifContext* notifCtxPtr = nullptr;
-  if (config.enableNotification) {
-    std::lock_guard<std::mutex> lock(mu);
-    auto nit = notifCtxById_.find(rt->id);
-    if (nit != notifCtxById_.end()) notifCtxPtr = &nit->second;
-  }
+  // Resolve notif context locklessly: it is published once at registration and
+  // the containing map is node-based, so the cached pointer stays valid. acquire
+  // pairs with the release store in RegisterEndpoint.
+  QpNotifContext* notifCtxPtr =
+      config.enableNotification
+          ? static_cast<QpNotifContext*>(rt->notifCtx.load(std::memory_order_acquire))
+          : nullptr;
 
   const int batchSize = 32;
   struct ibv_wc wc[batchSize];
@@ -911,7 +916,7 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
               wc[i].wr_id, recordId);
         }
       }
-    }
+    } // for n
     n = ibv_poll_cq(cq, batchSize, wc);
   }
 
@@ -993,8 +998,18 @@ void NotifManager::MainLoop() {
       }
     }
   } else {
+    // The endpoint set is effectively append-only and changes rarely, but this
+    // is a tight busy-poll loop. Rebuilding the snapshot every iteration would
+    // take a shared_lock and heap-allocate on every spin (a large fraction of
+    // this thread's CPU). Instead cache it and only rebuild when the epoch moves.
+    RdmaManager::SnapshotVector snapshot;
+    uint64_t snapshotEpoch = rdma->EndpointsEpoch() - 1;
     while (running.load()) {
-      auto snapshot = rdma->SnapshotEndpointRuntimes();
+      uint64_t curEpoch = rdma->EndpointsEpoch();
+      if (curEpoch != snapshotEpoch) {
+        rdma->SnapshotEndpointRuntimes(snapshot);
+        snapshotEpoch = curEpoch;
+      }
       if (snapshot.empty()) {
         EmitFlushSummaryIfNeeded(FlushRoundStats{});
         std::this_thread::yield();

--- a/src/io/rdma/backend_impl.hpp
+++ b/src/io/rdma/backend_impl.hpp
@@ -40,6 +40,7 @@
 #include "mori/io/engine.hpp"
 #include "src/io/rdma/common.hpp"
 #include "src/io/rdma/executor.hpp"
+#include "src/io/rdma/telemetry.hpp"
 
 namespace mori {
 namespace io {
@@ -66,7 +67,8 @@ EpPairVec InterleaveEndpointsByLocalDevice(const EpPairVec& eps,
 /* ---------------------------------------------------------------------------------------------- */
 class RdmaManager {
  public:
-  RdmaManager(const RdmaBackendConfig cfg, application::RdmaContext* ctx);
+  RdmaManager(const RdmaBackendConfig cfg, application::RdmaContext* ctx,
+              TelemetryRegistry* telemetry = nullptr);
   ~RdmaManager();
 
   application::RdmaEndpointConfig GetRdmaEndpointConfig(int devId);
@@ -120,6 +122,8 @@ class RdmaManager {
 
   std::unique_ptr<application::TopoSystem> topo{nullptr};
   std::atomic<uint32_t> roundRobinCounter{0};
+
+  TelemetryRegistry* telemetry_{nullptr};
 };
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -127,7 +131,7 @@ class RdmaManager {
 /* ---------------------------------------------------------------------------------------------- */
 class NotifManager {
  public:
-  NotifManager(RdmaManager*, const RdmaBackendConfig&);
+  NotifManager(RdmaManager*, const RdmaBackendConfig&, TelemetryRegistry* telemetry = nullptr);
   ~NotifManager();
 
   void RegisterEndpoint(const std::shared_ptr<EndpointRuntime>& rt);
@@ -200,6 +204,7 @@ class NotifManager {
   // Accessed only by the single NotifManager poll loop thread to rate-limit
   // repeated summaries for the same consecutive flush episode.
   uint64_t flushSummaryStreak_{0};
+  TelemetryRegistry* telemetry_{nullptr};
 };
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -266,7 +271,8 @@ class RdmaBackendSession : public BackendSession {
   RdmaBackendSession(const RdmaBackendConfig& config,
                      std::vector<application::RdmaMemoryRegion> localMrPerEp,
                      std::vector<application::RdmaMemoryRegion> remoteMrPerEp, const EpPairVec& eps,
-                     Executor* executor, MemoryLocationType localLoc = MemoryLocationType::CPU);
+                     Executor* executor, MemoryLocationType localLoc = MemoryLocationType::CPU,
+                     TelemetryRegistry* telemetry = nullptr);
   ~RdmaBackendSession() = default;
 
   void ReadWrite(size_t localOffset, size_t remoteOffset, size_t size, TransferStatus* status,
@@ -287,6 +293,7 @@ class RdmaBackendSession : public BackendSession {
   MemoryLocationType localLoc_{MemoryLocationType::CPU};
   std::shared_ptr<std::atomic<bool>> warnedChunkedWorkerFallback_{
       std::make_shared<std::atomic<bool>>(false)};
+  TelemetryRegistry* telemetry_{nullptr};
 };
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -320,6 +327,7 @@ class RdmaBackend : public Backend {
   bool PopInboundTransferStatus(EngineKey remote, TransferUniqueId id,
                                 TransferStatus* status) override;
   bool CanHandle(const MemoryDesc& local, const MemoryDesc& remote) const override;
+  TelemetrySnapshot GetTelemetrySnapshot() const override;
 
  private:
   void CreateSession(const MemoryDesc& local, const MemoryDesc& remote, RdmaBackendSession& sess);
@@ -378,6 +386,7 @@ class RdmaBackend : public Backend {
   std::mutex sessionCacheMu;
   std::mutex connBuildMapMu_;
   std::unordered_map<ConnBuildKey, std::shared_ptr<std::mutex>, ConnBuildKeyHash> connBuildMu_;
+  std::unique_ptr<TelemetryRegistry> telemetry_;
 };
 
 }  // namespace io

--- a/src/io/rdma/backend_impl.hpp
+++ b/src/io/rdma/backend_impl.hpp
@@ -67,6 +67,8 @@ EpPairVec InterleaveEndpointsByLocalDevice(const EpPairVec& eps,
 /* ---------------------------------------------------------------------------------------------- */
 class RdmaManager {
  public:
+  using SnapshotVector = std::vector<std::shared_ptr<EndpointRuntime>>;
+
   RdmaManager(const RdmaBackendConfig cfg, application::RdmaContext* ctx,
               TelemetryRegistry* telemetry = nullptr);
   ~RdmaManager();
@@ -98,7 +100,12 @@ class RdmaManager {
                              int rdevId, application::RdmaEndpointHandle remote, TopoKeyPair key,
                              int weight);
   std::shared_ptr<EndpointRuntime> GetEndpointRuntime(EndpointId id);
-  std::vector<std::shared_ptr<EndpointRuntime>> SnapshotEndpointRuntimes();
+  void SnapshotEndpointRuntimes(SnapshotVector& result);
+  // Monotonic generation counter bumped whenever the endpoint set changes.
+  // Lets hot pollers skip the locked snapshot rebuild when nothing changed.
+  uint64_t EndpointsEpoch() const noexcept {
+    return endpointsEpoch_.load(std::memory_order_acquire);
+  }
 
   application::RdmaDeviceContext* GetRdmaDeviceContext(int devId);
   size_t NumAvailDevices() const { return availDevices.size(); }
@@ -119,6 +126,7 @@ class RdmaManager {
   std::unordered_map<EngineKey, RemoteEngineMeta> remotes;
   std::atomic<EndpointId> nextEndpointId_{1};
   std::unordered_map<EndpointId, std::shared_ptr<EndpointRuntime>> endpointsById_;
+  std::atomic<uint64_t> endpointsEpoch_{0};
 
   std::unique_ptr<application::TopoSystem> topo{nullptr};
   std::atomic<uint32_t> roundRobinCounter{0};

--- a/src/io/rdma/common.cpp
+++ b/src/io/rdma/common.cpp
@@ -25,6 +25,7 @@
 #include <linux/futex.h>
 #include <sys/syscall.h>
 #include <unistd.h>
+#include <x86intrin.h>
 
 #include <algorithm>
 #include <cerrno>
@@ -39,6 +40,7 @@
 
 #include "mori/io/env.hpp"
 #include "mori/io/logging.hpp"
+#include "src/io/rdma/telemetry.hpp"
 
 namespace mori {
 namespace io {
@@ -303,6 +305,9 @@ static bool TryReserveSqDepthSpin(const EpPair& ep, int wrCount, int epId, const
       MORI_IO_WARN(
           "SQ full timeout ({}): ep={} depth={} requested={} max={} after {} us (backoff={})",
           opTag, epId, cur, wrCount, ep.maxSqDepth, kBackoffTimeoutUs, backoff);
+      if (MORI_IO_TELEM_UNLIKELY(ep.telem)) {
+        ep.telem->counters.sq_full_events.fetch_add(1, std::memory_order_relaxed);
+      }
       if (errMsg) {
         *errMsg = "SQ full (" + std::string(opTag) + "): ep=" + std::to_string(epId) +
                   " depth=" + std::to_string(cur) + " requested=" + std::to_string(wrCount) +
@@ -377,6 +382,9 @@ static bool TryReserveSqDepth(const EpPair& ep, int wrCount, int epId, const cha
       const int cur = ep.sqDepth->load(kSqAdmissionOrder);
       MORI_IO_WARN("SQ full timeout ({}): ep={} depth={} requested={} max={} after {} us", opTag,
                    epId, cur, wrCount, ep.maxSqDepth, timeoutUs);
+      if (MORI_IO_TELEM_UNLIKELY(ep.telem)) {
+        ep.telem->counters.sq_full_events.fetch_add(1, std::memory_order_relaxed);
+      }
       if (errMsg) {
         *errMsg = "SQ full (" + std::string(opTag) + "): ep=" + std::to_string(epId) +
                   " depth=" + std::to_string(cur) + " requested=" + std::to_string(wrCount) +
@@ -654,6 +662,7 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
   thread_local std::vector<ChunkedSgeSegment> tlChunkPlan;
   thread_local std::vector<int> tlEpWrsSinceSignal;
   thread_local std::vector<size_t> tlEpMergedSinceSignal;
+  thread_local std::vector<uint64_t> tlEpBytesSinceSignal;
   thread_local int reentryDepth = 0;
 
   struct ReentryGuard {
@@ -670,6 +679,7 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
   std::vector<ChunkedSgeSegment> localChunkPlan;
   std::vector<int> localEpWrsSinceSignal;
   std::vector<size_t> localEpMergedSinceSignal;
+  std::vector<uint64_t> localEpBytesSinceSignal;
 
   std::vector<size_t>& indices = usePool ? tlIndices : localIndices;
   std::vector<MergedWorkRequest>& mergedPool = usePool ? tlMergedPool : localMergedPool;
@@ -678,6 +688,8 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
   std::vector<int>& epWrsSinceSignal = usePool ? tlEpWrsSinceSignal : localEpWrsSinceSignal;
   std::vector<size_t>& epMergedSinceSignal =
       usePool ? tlEpMergedSinceSignal : localEpMergedSinceSignal;
+  std::vector<uint64_t>& epBytesSinceSignal =
+      usePool ? tlEpBytesSinceSignal : localEpBytesSinceSignal;
 
   // Bound peak retained memory: if an earlier very large batch grew the pools far
   // beyond the current need, release the excess so it doesn't stay resident.
@@ -881,8 +893,11 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
   if (postBatchSize <= 0) postBatchSize = 1;
   int numPostBatch = (mergedWrCount + postBatchSize - 1) / postBatchSize;
 
+  // Per-EP state for adaptive signaling: track WRs, merged requests, and bytes
+  // accumulated since the last signaled WR on each EP.
   epWrsSinceSignal.assign(epNum, 0);
   epMergedSinceSignal.assign(epNum, 0);
+  epBytesSinceSignal.assign(epNum, 0);
 
   // Rotate the starting EP by transfer id so single-segment (single WR)
   // transfers spread evenly across all QPs instead of always landing on eps[0].
@@ -905,6 +920,7 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
     const auto& localMr = localMrPerEp[epId];
     const auto& remoteMr = remoteMrPerEp[epId];
     size_t mergedReqSize = 0;
+    uint64_t batchBytes = 0;
     for (int j = st; j < end; j++) {
       MergedWorkRequest& mergedWr = mergedWrs[j];
       for (auto& sge : mergedWr.sges) sge.lkey = localMr.lkey;
@@ -915,10 +931,12 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
       wr.wr_id = 0;
       wr.next = (j + 1 < end) ? &mergedWrs[j + 1].wr : nullptr;
       mergedReqSize += mergedWr.mergedRequests;
+      batchBytes += mergedWr.totalRemoteLength;
     }
 
     epWrsSinceSignal[epId] += batchWrNum;
     epMergedSinceSignal[epId] += mergedReqSize;
+    epBytesSinceSignal[epId] += batchBytes;
 
     bool isLastBatchForEp = ((i + epNum) >= numPostBatch);
     bool sqNearFull = eps[epId].sqDepth && (epWrsSinceSignal[epId] >= eps[epId].maxSqDepth);
@@ -933,7 +951,8 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
                 "submission ledger is not initialized for signaled WR tracking"};
       }
       recordId = eps[epId].ledger->Insert(epWrsSinceSignal[epId], true, callbackMeta,
-                                          static_cast<int>(epMergedSinceSignal[epId]));
+                                          static_cast<int>(epMergedSinceSignal[epId]),
+                                          epBytesSinceSignal[epId]);
       last.wr_id = recordId;
       last.send_flags = IBV_SEND_SIGNALED;
     }
@@ -941,6 +960,10 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
     struct ibv_send_wr* badWr = nullptr;
     int ret = ibv_post_send(eps[epId].local.ibvHandle.qp, &mergedWrs[st].wr, &badWr);
     if (ret != 0) {
+      if (MORI_IO_TELEM_UNLIKELY(eps[epId].telem)) {
+        eps[epId].telem->counters.post_send_errors.fetch_add(1, std::memory_order_relaxed);
+      }
+
       int postedCount = 0;
       if (badWr != nullptr) {
         struct ibv_send_wr* cur = &mergedWrs[st].wr;
@@ -956,13 +979,20 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
         epWrsSinceSignal[epId] = std::max(0, epWrsSinceSignal[epId] - unpostedCount);
 
         size_t mergedUnposted = 0;
+        uint64_t bytesUnposted = 0;
         for (int j = st + postedCount; j < end; ++j) {
           mergedUnposted += mergedWrs[j].mergedRequests;
+          bytesUnposted += mergedWrs[j].totalRemoteLength;
         }
         if (epMergedSinceSignal[epId] >= mergedUnposted) {
           epMergedSinceSignal[epId] -= mergedUnposted;
         } else {
           epMergedSinceSignal[epId] = 0;
+        }
+        if (epBytesSinceSignal[epId] >= bytesUnposted) {
+          epBytesSinceSignal[epId] -= bytesUnposted;
+        } else {
+          epBytesSinceSignal[epId] = 0;
         }
       }
 
@@ -981,7 +1011,8 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
             postedCount, batchWrNum, epId);
         if (eps[epId].ledger) {
           eps[epId].ledger->InsertOrphaned(epWrsSinceSignal[epId], callbackMeta,
-                                           static_cast<int>(epMergedSinceSignal[epId]));
+                                           static_cast<int>(epMergedSinceSignal[epId]),
+                                           epBytesSinceSignal[epId]);
         }
         if (eps[epId].degraded) {
           eps[epId].degraded->store(true, kSqAdmissionOrder);
@@ -998,7 +1029,8 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
             epId, otherEpId, epWrsSinceSignal[otherEpId], epMergedSinceSignal[otherEpId]);
         if (eps[otherEpId].ledger) {
           eps[otherEpId].ledger->InsertOrphaned(epWrsSinceSignal[otherEpId], callbackMeta,
-                                                static_cast<int>(epMergedSinceSignal[otherEpId]));
+                                                static_cast<int>(epMergedSinceSignal[otherEpId]),
+                                                epBytesSinceSignal[otherEpId]);
         } else {
           MORI_IO_WARN(
               "EP {} has pending unsignaled WRs but no submission ledger; "
@@ -1019,9 +1051,34 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
       return {StatusCode::ERR_RDMA_OP, std::move(message)};
     }
 
+    // ── Telemetry: successful ibv_post_send ──
+    if (MORI_IO_TELEM_UNLIKELY(callbackMeta->telem)) {
+      uint64_t now = __rdtsc();
+      uint64_t cur = callbackMeta->telem->first_post_tsc.load(std::memory_order_relaxed);
+      while (now < cur && !callbackMeta->telem->first_post_tsc.compare_exchange_weak(
+                              cur, now, std::memory_order_relaxed)) {
+      }
+    }
+
+    if (EpTelemetryState* telem = eps[epId].telem.get(); needSignal && telem) {
+      telem->counters.bytes_posted.fetch_add(epBytesSinceSignal[epId], std::memory_order_relaxed);
+      telem->counters.ops_posted.fetch_add(epMergedSinceSignal[epId], std::memory_order_relaxed);
+
+      eps[epId].ledger->RecordPostTimestamp(recordId, __rdtsc());
+
+      if (eps[epId].sqDepth) {
+        int depth = eps[epId].sqDepth->load(std::memory_order_relaxed);
+        int hwm = telem->counters.sq_depth_hwm.load(std::memory_order_relaxed);
+        while (depth > hwm && !telem->counters.sq_depth_hwm.compare_exchange_weak(
+                                  hwm, depth, std::memory_order_relaxed)) {
+        }
+      }
+    }
+
     if (needSignal) {
       epWrsSinceSignal[epId] = 0;
       epMergedSinceSignal[epId] = 0;
+      epBytesSinceSignal[epId] = 0;
     }
     MORI_IO_TRACE("ibv_post_send ep index {} batch index range [{}, {})", epId, st, end);
   }

--- a/src/io/rdma/common.cpp
+++ b/src/io/rdma/common.cpp
@@ -1061,10 +1061,9 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
     }
 
     if (EpTelemetryState* telem = eps[epId].telem.get(); needSignal && telem) {
+      eps[epId].ledger->RecordPostTimestamp(recordId, __rdtsc());
       telem->counters.bytes_posted.fetch_add(epBytesSinceSignal[epId], std::memory_order_relaxed);
       telem->counters.ops_posted.fetch_add(epMergedSinceSignal[epId], std::memory_order_relaxed);
-
-      eps[epId].ledger->RecordPostTimestamp(recordId, __rdtsc());
 
       if (eps[epId].sqDepth) {
         int depth = eps[epId].sqDepth->load(std::memory_order_relaxed);

--- a/src/io/rdma/common.hpp
+++ b/src/io/rdma/common.hpp
@@ -38,6 +38,17 @@
 namespace mori {
 namespace io {
 
+struct EpTelemetryState;
+struct ApiCounterSet;
+
+struct TelemetryMeta {
+  uint64_t api_start_tsc{0};
+  std::atomic<uint64_t> first_post_tsc{UINT64_MAX};
+  ApiCounterSet* api_counters{nullptr};
+  uint64_t total_bytes{0};
+  bool is_read{false};
+};
+
 /* ---------------------------------------------------------------------------------------------- */
 /*                                     Common Data Structures                                     */
 /* ---------------------------------------------------------------------------------------------- */
@@ -158,12 +169,15 @@ void PlanSgeStreamChunks(std::vector<ChunkedSgeSegment>& plan, const std::vector
 struct CqCallbackMeta {
   CqCallbackMeta(TransferStatus* s, TransferUniqueId id_, int n)
       : status(s), id(id_), totalBatchSize(n) {}
+  ~CqCallbackMeta();
 
   TransferStatus* status{nullptr};
   TransferUniqueId id{0};
   int totalBatchSize{0};
   std::atomic<uint32_t> finishedBatchSize{0};
   internal::IoCallDiagnostics diagnostics{};
+
+  std::unique_ptr<TelemetryMeta> telem;
 };
 
 // SubmissionLedger: tracks per-EP WR submissions and enables precise sqDepth release.
@@ -179,23 +193,33 @@ struct SubmissionRecord {
   SubmissionState state{SubmissionState::Posted};
   std::shared_ptr<CqCallbackMeta> meta;
   int batchSize{0};
+  uint64_t totalBytes{0};
+  uint64_t post_tsc{0};
 };
 
 class SubmissionLedger {
  public:
   explicit SubmissionLedger(uint32_t notifPerQp) : nextId_{notifPerQp} {}
 
+  void EnableTimestamping() { timestamping_ = true; }
+
   // Allocate recordId, insert Posted record, return recordId.
   uint64_t Insert(int postedWr, bool hasSignaledTail, std::shared_ptr<CqCallbackMeta> meta,
-                  int batchSize);
+                  int batchSize, uint64_t totalBytes = 0);
 
   // Insert an Orphaned record (partial post, no signaled tail).
-  void InsertOrphaned(int postedWr, std::shared_ptr<CqCallbackMeta> meta, int batchSize);
+  void InsertOrphaned(int postedWr, std::shared_ptr<CqCallbackMeta> meta, int batchSize,
+                      uint64_t totalBytes = 0);
+
+  // Record post timestamp AFTER successful ibv_post_send.
+  // If the record has already been consumed by ReleaseByCqe, this is a no-op.
+  void RecordPostTimestamp(uint64_t recordId, uint64_t tsc);
 
   // CQE path: find record by recordId, release sqDepth, return CqCallbackMeta.
   // Returns nullptr if record not found.
   std::shared_ptr<CqCallbackMeta> ReleaseByCqe(uint64_t recordId, std::atomic<int>* sqDepth,
-                                               int* outBatchSize);
+                                               int* outBatchSize, uint64_t* outTotalBytes = nullptr,
+                                               uint64_t* out_post_tsc = nullptr);
 
   // Recovery path: release only Orphaned records and keep Posted records.
   int ReleaseOrphanedByRecovery(std::atomic<int>* sqDepth);
@@ -206,6 +230,7 @@ class SubmissionLedger {
   mutable std::mutex mu_;
   uint64_t nextId_;
   std::unordered_map<uint64_t, SubmissionRecord> records_;
+  bool timestamping_{false};
 };
 
 inline constexpr std::memory_order kSqAdmissionOrder = std::memory_order_seq_cst;
@@ -230,6 +255,7 @@ struct EpPair {
   std::shared_ptr<SubmissionLedger> ledger;
   // Shared across EpPair copies that refer to the same QP.
   std::shared_ptr<SqAdmissionEvent> sqAdmission;
+  std::shared_ptr<EpTelemetryState> telem;
 };
 
 using EndpointId = uint64_t;

--- a/src/io/rdma/common.hpp
+++ b/src/io/rdma/common.hpp
@@ -199,7 +199,11 @@ struct SubmissionRecord {
 
 class SubmissionLedger {
  public:
-  explicit SubmissionLedger(uint32_t notifPerQp) : nextId_{notifPerQp} {}
+  // maxSqDepth bounds the number of live records (admission control keeps the
+  // sum of in-flight postedWr <= maxSqDepth, and every record has postedWr >= 1),
+  // so a ring of capacity > maxSqDepth can be indexed by recordId with no
+  // aliasing of a live slot. See ledger.cpp for the correctness argument.
+  explicit SubmissionLedger(uint32_t notifPerQp, int maxSqDepth = 4096);
 
   void EnableTimestamping() { timestamping_ = true; }
 
@@ -207,13 +211,13 @@ class SubmissionLedger {
   uint64_t Insert(int postedWr, bool hasSignaledTail, std::shared_ptr<CqCallbackMeta> meta,
                   int batchSize, uint64_t totalBytes = 0);
 
+  // Stamp the post timestamp into an existing record (looked up by recordId).
+  // No-op if timestamping is disabled or the record is no longer live.
+  void RecordPostTimestamp(uint64_t recordId, uint64_t postTsc);
+
   // Insert an Orphaned record (partial post, no signaled tail).
   void InsertOrphaned(int postedWr, std::shared_ptr<CqCallbackMeta> meta, int batchSize,
                       uint64_t totalBytes = 0);
-
-  // Record post timestamp AFTER successful ibv_post_send.
-  // If the record has already been consumed by ReleaseByCqe, this is a no-op.
-  void RecordPostTimestamp(uint64_t recordId, uint64_t tsc);
 
   // CQE path: find record by recordId, release sqDepth, return CqCallbackMeta.
   // Returns nullptr if record not found.
@@ -227,9 +231,16 @@ class SubmissionLedger {
   bool HasOrphaned() const;
 
  private:
+  // Fixed, allocation-free ring keyed by recordId. A slot is empty iff its
+  // stored recordId is 0 (valid ledger ids start at notifPerQp > 0). Sized to a
+  // power of two so indexing is (recordId & capMask_). Memory footprint is
+  // capacity * sizeof(SubmissionRecord) per QP; sized from maxSqDepth, so very
+  // large maxSqDepth combined with many QPs increases per-QP memory.
+
   mutable std::mutex mu_;
   uint64_t nextId_;
-  std::unordered_map<uint64_t, SubmissionRecord> records_;
+  uint64_t capMask_{0};
+  std::vector<SubmissionRecord> ring_;
   bool timestamping_{false};
 };
 
@@ -266,6 +277,11 @@ struct EndpointRuntime {
 
   EndpointId id{0};
   EpPair ep;
+  // Cached pointer to this endpoint's NotifManager::QpNotifContext, published once
+  // at registration. Lets the hot CQ poller resolve the notif context without
+  // locking NotifManager::mu on every poll. Type-erased (void*) to avoid a header
+  // dependency on the NotifManager-private struct; nullptr until registered.
+  std::atomic<void*> notifCtx{nullptr};
 };
 
 using EpPairVec = std::vector<EpPair>;

--- a/src/io/rdma/ledger.cpp
+++ b/src/io/rdma/ledger.cpp
@@ -20,36 +20,65 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 #include "src/io/rdma/common.hpp"
+#include "src/io/rdma/telemetry.hpp"
 
 namespace mori {
 namespace io {
 
+CqCallbackMeta::~CqCallbackMeta() = default;
+
 uint64_t SubmissionLedger::Insert(int postedWr, bool hasSignaledTail,
-                                  std::shared_ptr<CqCallbackMeta> meta, int batchSize) {
+                                  std::shared_ptr<CqCallbackMeta> meta, int batchSize,
+                                  uint64_t totalBytes) {
   std::lock_guard<std::mutex> lock(mu_);
   uint64_t id = nextId_++;
-  records_[id] = SubmissionRecord{
-      id, postedWr, hasSignaledTail, SubmissionState::Posted, std::move(meta), batchSize};
+  records_[id] = SubmissionRecord{id,
+                                  postedWr,
+                                  hasSignaledTail,
+                                  SubmissionState::Posted,
+                                  std::move(meta),
+                                  batchSize,
+                                  totalBytes,
+                                  /*post_tsc=*/0};
   return id;
 }
 
 void SubmissionLedger::InsertOrphaned(int postedWr, std::shared_ptr<CqCallbackMeta> meta,
-                                      int batchSize) {
+                                      int batchSize, uint64_t totalBytes) {
   std::lock_guard<std::mutex> lock(mu_);
   uint64_t id = nextId_++;
-  records_[id] =
-      SubmissionRecord{id, postedWr, false, SubmissionState::Orphaned, std::move(meta), batchSize};
+  records_[id] = SubmissionRecord{id,
+                                  postedWr,
+                                  false,
+                                  SubmissionState::Orphaned,
+                                  std::move(meta),
+                                  batchSize,
+                                  totalBytes,
+                                  /*post_tsc=*/0};
+}
+
+void SubmissionLedger::RecordPostTimestamp(uint64_t recordId, uint64_t tsc) {
+  if (!timestamping_) return;
+  std::lock_guard<std::mutex> lock(mu_);
+  auto it = records_.find(recordId);
+  if (it != records_.end()) {
+    it->second.post_tsc = tsc;
+  }
 }
 
 std::shared_ptr<CqCallbackMeta> SubmissionLedger::ReleaseByCqe(uint64_t recordId,
                                                                std::atomic<int>* sqDepth,
-                                                               int* outBatchSize) {
+                                                               int* outBatchSize,
+                                                               uint64_t* outTotalBytes,
+                                                               uint64_t* out_post_tsc) {
   std::lock_guard<std::mutex> lock(mu_);
   auto it = records_.find(recordId);
   if (it == records_.end()) return nullptr;
   SubmissionRecord& rec = it->second;
   if (sqDepth && rec.postedWr > 0) sqDepth->fetch_sub(rec.postedWr, kSqAdmissionOrder);
   if (outBatchSize) *outBatchSize = rec.batchSize;
+  if (outTotalBytes) *outTotalBytes = rec.totalBytes;
+  if (out_post_tsc) *out_post_tsc = rec.post_tsc;
   auto meta = std::move(rec.meta);
   records_.erase(it);
   return meta;

--- a/src/io/rdma/ledger.cpp
+++ b/src/io/rdma/ledger.cpp
@@ -19,51 +19,89 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+#include <algorithm>
+
+#include "mori/io/logging.hpp"
 #include "src/io/rdma/common.hpp"
 #include "src/io/rdma/telemetry.hpp"
 
 namespace mori {
 namespace io {
 
+namespace {
+// Smallest power of two >= v, with a floor so tiny SQ depths still get a
+// reasonable ring. Capacity must be strictly greater than the max number of
+// live records (bounded by maxSqDepth) so recordId & (cap-1) never aliases a
+// still-live slot.
+uint64_t RingCapacityFor(int maxSqDepth) {
+  constexpr uint64_t kSlack = 64;    // headroom above maxSqDepth
+  constexpr uint64_t kFloor = 256;   // minimum ring size
+  uint64_t need = static_cast<uint64_t>(std::max(0, maxSqDepth)) + kSlack;
+  uint64_t cap = kFloor;
+  while (cap < need) cap <<= 1;
+  return cap;
+}
+}  // namespace
+
 CqCallbackMeta::~CqCallbackMeta() = default;
+
+SubmissionLedger::SubmissionLedger(uint32_t notifPerQp, int maxSqDepth)
+    : nextId_{notifPerQp} {
+  const uint64_t cap = RingCapacityFor(maxSqDepth);
+  capMask_ = cap - 1;
+  ring_.resize(cap);  // default-constructed records have recordId == 0 (empty)
+}
 
 uint64_t SubmissionLedger::Insert(int postedWr, bool hasSignaledTail,
                                   std::shared_ptr<CqCallbackMeta> meta, int batchSize,
                                   uint64_t totalBytes) {
-  std::lock_guard<std::mutex> lock(mu_);
+  std::lock_guard<SpinLock> lock(mu_);
   uint64_t id = nextId_++;
-  records_[id] = SubmissionRecord{id,
-                                  postedWr,
-                                  hasSignaledTail,
-                                  SubmissionState::Posted,
-                                  std::move(meta),
-                                  batchSize,
-                                  totalBytes,
-                                  /*post_tsc=*/0};
+  SubmissionRecord& slot = ring_[id & capMask_];
+  if (MORI_IO_TELEM_UNLIKELY(slot.recordId != 0)) {
+    // Should be unreachable: admission control caps live records at maxSqDepth < capacity.
+    MORI_IO_ERROR(
+        "SubmissionLedger::Insert ring overflow: slot for recordId {} still holds live recordId "
+        "{} (capacity {}); increase ring capacity",
+        id, slot.recordId, capMask_ + 1);
+  }
+  slot = SubmissionRecord{id,
+                          postedWr,
+                          hasSignaledTail,
+                          SubmissionState::Posted,
+                          std::move(meta),
+                          batchSize,
+                          totalBytes,
+                          /*post_tsc=*/0};
   return id;
+}
+
+void SubmissionLedger::RecordPostTimestamp(uint64_t recordId, uint64_t postTsc) {
+  if (!timestamping_) return;
+  std::lock_guard<SpinLock> lock(mu_);
+  SubmissionRecord& slot = ring_[recordId & capMask_];
+  if (slot.recordId == recordId) slot.post_tsc = postTsc;
 }
 
 void SubmissionLedger::InsertOrphaned(int postedWr, std::shared_ptr<CqCallbackMeta> meta,
                                       int batchSize, uint64_t totalBytes) {
-  std::lock_guard<std::mutex> lock(mu_);
+  std::lock_guard<SpinLock> lock(mu_);
   uint64_t id = nextId_++;
-  records_[id] = SubmissionRecord{id,
-                                  postedWr,
-                                  false,
-                                  SubmissionState::Orphaned,
-                                  std::move(meta),
-                                  batchSize,
-                                  totalBytes,
-                                  /*post_tsc=*/0};
-}
-
-void SubmissionLedger::RecordPostTimestamp(uint64_t recordId, uint64_t tsc) {
-  if (!timestamping_) return;
-  std::lock_guard<std::mutex> lock(mu_);
-  auto it = records_.find(recordId);
-  if (it != records_.end()) {
-    it->second.post_tsc = tsc;
+  SubmissionRecord& slot = ring_[id & capMask_];
+  if (MORI_IO_TELEM_UNLIKELY(slot.recordId != 0)) {
+    MORI_IO_ERROR(
+        "SubmissionLedger::InsertOrphaned ring overflow: slot for recordId {} still holds live "
+        "recordId {} (capacity {}); increase ring capacity",
+        id, slot.recordId, capMask_ + 1);
   }
+  slot = SubmissionRecord{id,
+                          postedWr,
+                          false,
+                          SubmissionState::Orphaned,
+                          std::move(meta),
+                          batchSize,
+                          totalBytes,
+                          /*post_tsc=*/0};
 }
 
 std::shared_ptr<CqCallbackMeta> SubmissionLedger::ReleaseByCqe(uint64_t recordId,
@@ -71,32 +109,36 @@ std::shared_ptr<CqCallbackMeta> SubmissionLedger::ReleaseByCqe(uint64_t recordId
                                                                int* outBatchSize,
                                                                uint64_t* outTotalBytes,
                                                                uint64_t* out_post_tsc) {
-  std::lock_guard<std::mutex> lock(mu_);
-  auto it = records_.find(recordId);
-  if (it == records_.end()) return nullptr;
-  SubmissionRecord& rec = it->second;
-  if (sqDepth && rec.postedWr > 0) sqDepth->fetch_sub(rec.postedWr, kSqAdmissionOrder);
-  if (outBatchSize) *outBatchSize = rec.batchSize;
-  if (outTotalBytes) *outTotalBytes = rec.totalBytes;
-  if (out_post_tsc) *out_post_tsc = rec.post_tsc;
-  auto meta = std::move(rec.meta);
-  records_.erase(it);
+  int postedWr = 0;
+  std::shared_ptr<CqCallbackMeta> meta;
+  {
+    std::lock_guard<SpinLock> lock(mu_);
+    SubmissionRecord& slot = ring_[recordId & capMask_];
+    if (slot.recordId != recordId) return nullptr;  // stale / already released
+    postedWr = slot.postedWr;
+    if (outBatchSize) *outBatchSize = slot.batchSize;
+    if (outTotalBytes) *outTotalBytes = slot.totalBytes;
+    if (out_post_tsc) *out_post_tsc = slot.post_tsc;
+    meta = std::move(slot.meta);
+    slot.recordId = 0;  // mark empty
+  }
+  if (sqDepth && postedWr > 0) sqDepth->fetch_sub(postedWr, kSqAdmissionOrder);
   return meta;
 }
 
 int SubmissionLedger::ReleaseOrphanedByRecovery(std::atomic<int>* sqDepth) {
-  std::lock_guard<std::mutex> lock(mu_);
   int total = 0;
-  // Only erase Orphaned records.  Posted records still have signaled WRs whose
-  // CQEs may arrive later; they must remain so ReleaseByCqe() can update the
-  // corresponding TransferStatus and release sqDepth normally.
-  auto it = records_.begin();
-  while (it != records_.end()) {
-    if (it->second.state == SubmissionState::Orphaned) {
-      total += it->second.postedWr;
-      it = records_.erase(it);
-    } else {
-      ++it;
+  {
+    std::lock_guard<SpinLock> lock(mu_);
+    // Only release Orphaned records.  Posted records still have signaled WRs
+    // whose CQEs may arrive later; they must remain so ReleaseByCqe() can update
+    // the corresponding TransferStatus and release sqDepth normally.
+    for (SubmissionRecord& slot : ring_) {
+      if (slot.recordId != 0 && slot.state == SubmissionState::Orphaned) {
+        total += slot.postedWr;
+        slot.meta.reset();
+        slot.recordId = 0;  // mark empty
+      }
     }
   }
   if (sqDepth && total > 0) sqDepth->fetch_sub(total, kSqAdmissionOrder);
@@ -104,9 +146,9 @@ int SubmissionLedger::ReleaseOrphanedByRecovery(std::atomic<int>* sqDepth) {
 }
 
 bool SubmissionLedger::HasOrphaned() const {
-  std::lock_guard<std::mutex> lock(mu_);
-  for (const auto& [id, rec] : records_) {
-    if (rec.state == SubmissionState::Orphaned) return true;
+  std::lock_guard<SpinLock> lock(mu_);
+  for (const SubmissionRecord& slot : ring_) {
+    if (slot.recordId != 0 && slot.state == SubmissionState::Orphaned) return true;
   }
   return false;
 }

--- a/src/io/rdma/telemetry.cpp
+++ b/src/io/rdma/telemetry.cpp
@@ -1,0 +1,289 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#include "src/io/rdma/telemetry.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <fstream>
+#include <string>
+#include <thread>
+
+#include "mori/io/logging.hpp"
+#include "mori/utils/env_utils.hpp"
+
+namespace mori {
+namespace io {
+
+// ── TelemetryConfig statics ─────────────────────────────────────
+
+std::atomic<bool> TelemetryConfig::enabled_{false};
+std::atomic<bool> TelemetryConfig::initialized_{false};
+double TelemetryConfig::tsc_ghz_{0.0};
+
+static void CalibrateIfNeeded() {
+  if (TelemetryConfig::TscGhz() > 0.0) return;
+
+  auto t0 = std::chrono::steady_clock::now();
+  uint64_t tsc0 = __rdtsc();
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  uint64_t tsc1 = __rdtsc();
+  auto t1 = std::chrono::steady_clock::now();
+
+  double elapsed_ns =
+      static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
+  TelemetryConfig::SetTscGhz(elapsed_ns > 0 ? static_cast<double>(tsc1 - tsc0) / elapsed_ns : 1.0);
+  MORI_IO_INFO("Telemetry: TSC calibrated at {:.3f} GHz", TelemetryConfig::TscGhz());
+}
+
+void TelemetryConfig::Init() {
+  bool expected = false;
+  if (!initialized_.compare_exchange_strong(expected, true)) return;
+
+  if (!env::IsEnvVarEnabled("MORI_IO_TELEMETRY_ENABLED")) return;
+  enabled_.store(true, std::memory_order_relaxed);
+
+  bool has_constant_tsc = false;
+  bool has_nonstop_tsc = false;
+  {
+    std::ifstream cpuinfo("/proc/cpuinfo");
+    std::string line;
+    while (std::getline(cpuinfo, line)) {
+      if (line.find("flags") == std::string::npos) continue;
+      has_constant_tsc = line.find("constant_tsc") != std::string::npos;
+      has_nonstop_tsc = line.find("nonstop_tsc") != std::string::npos;
+      break;
+    }
+  }
+  if (!has_constant_tsc || !has_nonstop_tsc) {
+    MORI_IO_WARN(
+        "Telemetry: CPU lacks constant_tsc ({}) or nonstop_tsc ({}); "
+        "TSC-based latency measurements may drift",
+        has_constant_tsc, has_nonstop_tsc);
+  }
+
+  CalibrateIfNeeded();
+}
+
+void TelemetryConfig::Apply(const TelemetryInitOptions& opts) {
+  if (opts.enabled.has_value()) {
+    enabled_.store(opts.enabled.value(), std::memory_order_relaxed);
+    if (opts.enabled.value()) {
+      CalibrateIfNeeded();
+    }
+  }
+}
+
+void InitTelemetry(const TelemetryInitOptions& opts) {
+  TelemetryConfig::Init();
+  TelemetryConfig::Apply(opts);
+}
+
+// ── LatencyStats ────────────────────────────────────────────────
+
+void LatencyStats::Update(uint64_t delta_tsc) {
+  uint64_t prev = ewma_tsc.load(std::memory_order_relaxed);
+  uint64_t next;
+  if (prev == 0) {
+    next = delta_tsc;
+  } else {
+    next = prev + (static_cast<int64_t>(delta_tsc - prev) >> 4);
+  }
+  ewma_tsc.store(next, std::memory_order_relaxed);
+
+  uint64_t cur_min = min_tsc.load(std::memory_order_relaxed);
+  while (delta_tsc < cur_min &&
+         !min_tsc.compare_exchange_weak(cur_min, delta_tsc, std::memory_order_relaxed)) {
+  }
+
+  uint64_t cur_max = max_tsc.load(std::memory_order_relaxed);
+  while (delta_tsc > cur_max &&
+         !max_tsc.compare_exchange_weak(cur_max, delta_tsc, std::memory_order_relaxed)) {
+  }
+
+  count.fetch_add(1, std::memory_order_relaxed);
+}
+
+// ── TelemetryRegistry ───────────────────────────────────────────
+
+void TelemetryRegistry::UpdateEwmaCas(std::atomic<uint64_t>& ewma, uint64_t sample) {
+  uint64_t prev = ewma.load(std::memory_order_relaxed);
+  uint64_t next;
+  do {
+    if (prev == 0) {
+      next = sample;
+    } else {
+      next = prev + (static_cast<int64_t>(sample - prev) >> 4);
+    }
+  } while (!ewma.compare_exchange_weak(prev, next, std::memory_order_relaxed));
+}
+
+void TelemetryRegistry::RecordJct(uint64_t jct_tsc, uint64_t rdma_wall_tsc,
+                                  uint64_t sw_overhead_tsc) {
+  UpdateEwmaCas(jct_ewma_tsc_, jct_tsc);
+  UpdateEwmaCas(rdma_wall_ewma_tsc_, rdma_wall_tsc);
+  UpdateEwmaCas(sw_overhead_ewma_tsc_, sw_overhead_tsc);
+
+  uint64_t cur_min = jct_min_tsc_.load(std::memory_order_relaxed);
+  while (jct_tsc < cur_min &&
+         !jct_min_tsc_.compare_exchange_weak(cur_min, jct_tsc, std::memory_order_relaxed)) {
+  }
+
+  uint64_t cur_max = jct_max_tsc_.load(std::memory_order_relaxed);
+  while (jct_tsc > cur_max &&
+         !jct_max_tsc_.compare_exchange_weak(cur_max, jct_tsc, std::memory_order_relaxed)) {
+  }
+
+  jct_count_.fetch_add(1, std::memory_order_relaxed);
+}
+
+std::shared_ptr<EpTelemetryState> TelemetryRegistry::CreateEpTelemetry(
+    EndpointId id, const std::shared_ptr<std::atomic<int>>& sq_depth, int sq_depth_max) {
+  auto state = std::make_shared<EpTelemetryState>();
+  state->id = id;
+  state->sq_depth = sq_depth;
+  state->sq_depth_max = sq_depth_max;
+
+  std::unique_lock lock(mu_);
+  ep_telemetry_[id] = state;
+  return state;
+}
+
+TelemetrySnapshot TelemetryRegistry::Snapshot() const {
+  TelemetrySnapshot snap{};
+  snap.snapshot_tsc = __rdtsc();
+  snap.tsc_freq_ghz = TelemetryConfig::TscGhz();
+  auto relaxed = std::memory_order_relaxed;
+
+  // API counters
+  snap.api.read_calls = api_counters_.read_calls.load(relaxed);
+  snap.api.write_calls = api_counters_.write_calls.load(relaxed);
+  snap.api.batch_read_calls = api_counters_.batch_read_calls.load(relaxed);
+  snap.api.batch_write_calls = api_counters_.batch_write_calls.load(relaxed);
+  snap.api.rejected_calls = api_counters_.rejected_calls.load(relaxed);
+  snap.api.total_bytes_read = api_counters_.total_bytes_read.load(relaxed);
+  snap.api.total_bytes_written = api_counters_.total_bytes_written.load(relaxed);
+
+  // JCT stats
+  uint64_t jc = jct_count_.load(relaxed);
+  snap.api.jct_sample_count = jc;
+  if (jc > 0) {
+    snap.api.jct_ewma_us = TscToUs(jct_ewma_tsc_.load(relaxed));
+    snap.api.jct_min_us = TscToUs(jct_min_tsc_.load(relaxed));
+    snap.api.jct_max_us = TscToUs(jct_max_tsc_.load(relaxed));
+  }
+
+  // JCT breakdown
+  if (jc > 0) {
+    snap.breakdown.api_total_ewma_us = snap.api.jct_ewma_us;
+    snap.breakdown.rdma_wall_ewma_us = TscToUs(rdma_wall_ewma_tsc_.load(relaxed));
+    snap.breakdown.sw_overhead_ewma_us = TscToUs(sw_overhead_ewma_tsc_.load(relaxed));
+  }
+
+  // Per-EP aggregation
+  snap.verbs.poll_mode = poll_mode_;
+
+  uint64_t total_latency_samples = 0;
+  double weighted_ewma_sum = 0.0;
+  double agg_min = 0.0;
+  double agg_max = 0.0;
+  bool has_any_latency = false;
+
+  {
+    std::shared_lock lock(mu_);
+    for (const auto& [id, ept] : ep_telemetry_) {
+      TelemetrySnapshot::EpDetail detail;
+      detail.ep_id = id;
+      detail.verbs.bytes_posted = ept->counters.bytes_posted.load(relaxed);
+      detail.verbs.bytes_completed = ept->counters.bytes_completed.load(relaxed);
+      detail.verbs.ops_posted = ept->counters.ops_posted.load(relaxed);
+      detail.verbs.ops_completed = ept->counters.ops_completed.load(relaxed);
+      detail.verbs.cqe_errors = ept->counters.cqe_errors.load(relaxed);
+      detail.verbs.sq_full_events = ept->counters.sq_full_events.load(relaxed);
+      detail.verbs.post_send_errors = ept->counters.post_send_errors.load(relaxed);
+      detail.verbs.cq_polls = ept->counters.cq_poll_count.load(relaxed);
+      detail.verbs.cq_empty_polls = ept->counters.cq_empty_poll_count.load(relaxed);
+      detail.verbs.poll_mode = poll_mode_;
+      detail.verbs.sq_depth = ept->sq_depth ? ept->sq_depth->load(relaxed) : 0;
+      detail.verbs.sq_depth_hwm = ept->counters.sq_depth_hwm.load(relaxed);
+      detail.verbs.sq_depth_max = ept->sq_depth_max;
+
+      if (detail.verbs.cq_polls > 0) {
+        detail.verbs.cq_utilization =
+            1.0 - static_cast<double>(detail.verbs.cq_empty_polls) / detail.verbs.cq_polls;
+      }
+
+      uint64_t sc = ept->stats.count.load(relaxed);
+      detail.verbs.rdma_latency_sample_count = sc;
+      if (sc > 0) {
+        detail.verbs.rdma_latency_ewma_us = TscToUs(ept->stats.ewma_tsc.load(relaxed));
+        detail.verbs.rdma_latency_min_us = TscToUs(ept->stats.min_tsc.load(relaxed));
+        detail.verbs.rdma_latency_max_us = TscToUs(ept->stats.max_tsc.load(relaxed));
+
+        weighted_ewma_sum += detail.verbs.rdma_latency_ewma_us * sc;
+        total_latency_samples += sc;
+        if (!has_any_latency) {
+          agg_min = detail.verbs.rdma_latency_min_us;
+          agg_max = detail.verbs.rdma_latency_max_us;
+          has_any_latency = true;
+        } else {
+          agg_min = std::min(agg_min, detail.verbs.rdma_latency_min_us);
+          agg_max = std::max(agg_max, detail.verbs.rdma_latency_max_us);
+        }
+      }
+
+      // Aggregate counters
+      snap.verbs.bytes_posted += detail.verbs.bytes_posted;
+      snap.verbs.bytes_completed += detail.verbs.bytes_completed;
+      snap.verbs.ops_posted += detail.verbs.ops_posted;
+      snap.verbs.ops_completed += detail.verbs.ops_completed;
+      snap.verbs.cqe_errors += detail.verbs.cqe_errors;
+      snap.verbs.sq_full_events += detail.verbs.sq_full_events;
+      snap.verbs.post_send_errors += detail.verbs.post_send_errors;
+      snap.verbs.cq_polls += detail.verbs.cq_polls;
+      snap.verbs.cq_empty_polls += detail.verbs.cq_empty_polls;
+      snap.verbs.sq_depth += detail.verbs.sq_depth;
+      snap.verbs.sq_depth_hwm += detail.verbs.sq_depth_hwm;
+      snap.verbs.sq_depth_max += detail.verbs.sq_depth_max;
+
+      snap.per_ep.push_back(detail);
+    }
+  }
+
+  // Aggregated CQ utilization
+  if (snap.verbs.cq_polls > 0) {
+    snap.verbs.cq_utilization =
+        1.0 - static_cast<double>(snap.verbs.cq_empty_polls) / snap.verbs.cq_polls;
+  }
+
+  // Aggregated RDMA latency
+  snap.verbs.rdma_latency_sample_count = total_latency_samples;
+  if (total_latency_samples > 0) {
+    snap.verbs.rdma_latency_ewma_us = weighted_ewma_sum / total_latency_samples;
+    snap.verbs.rdma_latency_min_us = agg_min;
+    snap.verbs.rdma_latency_max_us = agg_max;
+  }
+
+  return snap;
+}
+
+}  // namespace io
+}  // namespace mori

--- a/src/io/rdma/telemetry.hpp
+++ b/src/io/rdma/telemetry.hpp
@@ -1,0 +1,149 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+#include <x86intrin.h>
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <shared_mutex>
+#include <unordered_map>
+
+#include "mori/io/telemetry.hpp"
+#include "src/io/rdma/common.hpp"
+
+namespace mori {
+namespace io {
+
+// ── Global config (read-only after init) ─────────────────────────
+class TelemetryConfig {
+ public:
+  static void Init();
+  static void Apply(const TelemetryInitOptions& opts);
+  static bool Enabled() { return enabled_.load(std::memory_order_relaxed); }
+  static double TscGhz() { return tsc_ghz_; }
+  static void SetTscGhz(double v) { tsc_ghz_ = v; }
+
+ private:
+  static std::atomic<bool> enabled_;
+  static std::atomic<bool> initialized_;
+  static double tsc_ghz_;
+};
+
+#define MORI_IO_TELEM_UNLIKELY(expr) __builtin_expect(!!(expr), 0)
+
+// ── Per-EP verbs counters (cache-line aligned) ───────────────────
+struct alignas(64) VerbsCounterSet {
+  // --- cache line 1: post path (written by post threads) ---
+  std::atomic<uint64_t> bytes_posted{0};
+  std::atomic<uint64_t> ops_posted{0};
+  std::atomic<uint64_t> sq_full_events{0};
+  std::atomic<uint64_t> post_send_errors{0};
+  char pad0_[64 - 4 * sizeof(std::atomic<uint64_t>)];
+
+  // --- cache line 2: completion path (written by CQ poll thread) ---
+  std::atomic<uint64_t> bytes_completed{0};
+  std::atomic<uint64_t> ops_completed{0};
+  std::atomic<uint64_t> cqe_errors{0};
+  char pad1_[64 - 3 * sizeof(std::atomic<uint64_t>)];
+
+  // --- cache line 3: CQ poll stats (CQ poll thread only) ---
+  std::atomic<uint64_t> cq_poll_count{0};
+  std::atomic<uint64_t> cq_empty_poll_count{0};
+  char pad2_[64 - 2 * sizeof(std::atomic<uint64_t>)];
+
+  // --- cache line 4: SQ depth high watermark (written by post threads) ---
+  std::atomic<int> sq_depth_hwm{0};
+  char pad3_[64 - sizeof(std::atomic<int>)];
+};
+
+// ── API-level counters ───────────────────────────────────────────
+struct alignas(64) ApiCounterSet {
+  std::atomic<uint64_t> read_calls{0};
+  std::atomic<uint64_t> write_calls{0};
+  std::atomic<uint64_t> batch_read_calls{0};
+  std::atomic<uint64_t> batch_write_calls{0};
+  std::atomic<uint64_t> rejected_calls{0};
+  std::atomic<uint64_t> total_bytes_read{0};
+  std::atomic<uint64_t> total_bytes_written{0};
+};
+
+// ── Per-EP RDMA latency stats (EWMA + min/max) ──────────────────
+//    Updated by CQ poll thread only — no cross-thread contention.
+struct LatencyStats {
+  std::atomic<uint64_t> ewma_tsc{0};
+  std::atomic<uint64_t> min_tsc{UINT64_MAX};
+  std::atomic<uint64_t> max_tsc{0};
+  std::atomic<uint64_t> count{0};
+
+  void Update(uint64_t delta_tsc);
+};
+
+// ── Shared per-EP telemetry state ────────────────────────────────
+struct EpTelemetryState {
+  EndpointId id{0};
+  VerbsCounterSet counters;
+  LatencyStats stats;
+  std::shared_ptr<std::atomic<int>> sq_depth;
+  int sq_depth_max{0};
+};
+
+// ── Per-backend registry ─────────────────────────────────────────
+class TelemetryRegistry {
+ public:
+  ApiCounterSet& ApiCounters() { return api_counters_; }
+  PollCqMode GetPollMode() const { return poll_mode_; }
+  void SetPollMode(PollCqMode m) { poll_mode_ = m; }
+
+  std::shared_ptr<EpTelemetryState> CreateEpTelemetry(
+      EndpointId id, const std::shared_ptr<std::atomic<int>>& sq_depth, int sq_depth_max);
+
+  // May be called concurrently from multiple CQ poll threads.
+  void RecordJct(uint64_t jct_tsc, uint64_t rdma_wall_tsc, uint64_t sw_overhead_tsc);
+
+  TelemetrySnapshot Snapshot() const;
+
+ private:
+  ApiCounterSet api_counters_;
+  PollCqMode poll_mode_{PollCqMode::POLLING};
+
+  mutable std::shared_mutex mu_;
+  std::unordered_map<EndpointId, std::shared_ptr<EpTelemetryState>> ep_telemetry_;
+
+  std::atomic<uint64_t> jct_ewma_tsc_{0};
+  std::atomic<uint64_t> jct_min_tsc_{UINT64_MAX};
+  std::atomic<uint64_t> jct_max_tsc_{0};
+  std::atomic<uint64_t> jct_count_{0};
+
+  std::atomic<uint64_t> rdma_wall_ewma_tsc_{0};
+  std::atomic<uint64_t> sw_overhead_ewma_tsc_{0};
+
+  static void UpdateEwmaCas(std::atomic<uint64_t>& ewma, uint64_t sample);
+};
+
+inline double TscToUs(uint64_t tsc) {
+  return static_cast<double>(tsc) / (TelemetryConfig::TscGhz() * 1000.0);
+}
+
+}  // namespace io
+}  // namespace mori

--- a/src/pybind/pybind_io.cpp
+++ b/src/pybind/pybind_io.cpp
@@ -219,7 +219,77 @@ void RegisterMoriIo(pybind11::module_& m) {
       .def("WaitAll", &mori::io::IOEngine::WaitAll, py::arg("statuses"), py::arg("timeout_ms") = -1,
            py::call_guard<py::gil_scoped_release>())
       .def("LoadScatterGatherModule", &mori::io::IOEngine::LoadScatterGatherModule)
-      .def("LoadFabricCopyModule", &mori::io::IOEngine::LoadFabricCopyModule);
+      .def("LoadFabricCopyModule", &mori::io::IOEngine::LoadFabricCopyModule)
+      .def(
+          "GetTelemetrySnapshot",
+          [](const mori::io::IOEngine& self, mori::io::BackendType type) -> py::dict {
+            auto snap = self.GetTelemetrySnapshot(type);
+            auto verbs_to_dict = [](const mori::io::TelemetrySnapshot::VerbsStats& v) -> py::dict {
+              py::dict d;
+              d["bytes_posted"] = v.bytes_posted;
+              d["bytes_completed"] = v.bytes_completed;
+              d["ops_posted"] = v.ops_posted;
+              d["ops_completed"] = v.ops_completed;
+              d["cqe_errors"] = v.cqe_errors;
+              d["post_send_errors"] = v.post_send_errors;
+              d["sq_full_events"] = v.sq_full_events;
+              d["cq_polls"] = v.cq_polls;
+              d["cq_empty_polls"] = v.cq_empty_polls;
+              d["cq_utilization"] = v.cq_utilization;
+              d["poll_mode"] = v.poll_mode;
+              d["sq_depth"] = v.sq_depth;
+              d["sq_depth_hwm"] = v.sq_depth_hwm;
+              d["sq_depth_max"] = v.sq_depth_max;
+              d["rdma_latency_ewma_us"] = v.rdma_latency_ewma_us;
+              d["rdma_latency_min_us"] = v.rdma_latency_min_us;
+              d["rdma_latency_max_us"] = v.rdma_latency_max_us;
+              d["rdma_latency_sample_count"] = v.rdma_latency_sample_count;
+              return d;
+            };
+
+            py::dict result;
+
+            // API stats
+            py::dict api;
+            api["read_calls"] = snap.api.read_calls;
+            api["write_calls"] = snap.api.write_calls;
+            api["batch_read_calls"] = snap.api.batch_read_calls;
+            api["batch_write_calls"] = snap.api.batch_write_calls;
+            api["rejected_calls"] = snap.api.rejected_calls;
+            api["total_bytes_read"] = snap.api.total_bytes_read;
+            api["total_bytes_written"] = snap.api.total_bytes_written;
+            api["jct_ewma_us"] = snap.api.jct_ewma_us;
+            api["jct_min_us"] = snap.api.jct_min_us;
+            api["jct_max_us"] = snap.api.jct_max_us;
+            api["jct_sample_count"] = snap.api.jct_sample_count;
+            result["api"] = api;
+
+            // Verbs stats
+            result["verbs"] = verbs_to_dict(snap.verbs);
+
+            // Breakdown
+            py::dict breakdown;
+            breakdown["api_total_ewma_us"] = snap.breakdown.api_total_ewma_us;
+            breakdown["rdma_wall_ewma_us"] = snap.breakdown.rdma_wall_ewma_us;
+            breakdown["sw_overhead_ewma_us"] = snap.breakdown.sw_overhead_ewma_us;
+            result["breakdown"] = breakdown;
+
+            // Per-EP
+            py::list per_ep;
+            for (const auto& ep : snap.per_ep) {
+              py::dict ep_dict;
+              ep_dict["ep_id"] = ep.ep_id;
+              ep_dict["verbs"] = verbs_to_dict(ep.verbs);
+              per_ep.append(ep_dict);
+            }
+            result["per_ep"] = per_ep;
+
+            result["snapshot_tsc"] = snap.snapshot_tsc;
+            result["tsc_freq_ghz"] = snap.tsc_freq_ghz;
+
+            return result;
+          },
+          py::arg("backend_type") = mori::io::BackendType::RDMA);
 }
 
 }  // namespace mori

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -9,6 +9,14 @@ FetchContent_Declare(
   GIT_SHALLOW TRUE)
 FetchContent_MakeAvailable(googletest)
 
+# Core logging is header-only (spdlog); test its thread-safety independently of
+# BUILD_IO. Run under ThreadSanitizer to actually prove the maps are safe.
+add_executable(test_logging utils/test_logging.cpp)
+target_include_directories(test_logging PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(test_logging PUBLIC ${CMAKE_SOURCE_DIR})
+target_link_libraries(test_logging PRIVATE mori_logging gtest_main)
+add_test(NAME logging_concurrency COMMAND test_logging)
+
 add_executable(test_transport_tcp application/test_transport_tcp.cpp)
 
 target_include_directories(test_transport_tcp

--- a/tests/cpp/io/test_engine.cpp
+++ b/tests/cpp/io/test_engine.cpp
@@ -247,6 +247,59 @@ void CaseSubmissionLedgerBasic() {
   Require(sqDepth2.load(std::memory_order_relaxed) == 5, "sq depth after posted CQE release");
 }
 
+void CaseSubmissionLedgerRingWraparound() {
+  // Small SQ depth -> small ring, so a modest number of insert/release cycles
+  // laps the ring several times and exercises slot reuse.
+  constexpr uint32_t kNotifPerQp = 16;
+  constexpr int kMaxSqDepth = 32;
+  SubmissionLedger ledger(kNotifPerQp, kMaxSqDepth);
+  TransferStatus status;
+
+  // Insert then immediately release, one record at a time, across many laps of
+  // the ring. Each id must round-trip to the correct record.
+  uint64_t expectedId = kNotifPerQp;
+  for (int i = 0; i < 4096; ++i) {
+    std::atomic<int> sqDepth{1};
+    auto meta = std::make_shared<CqCallbackMeta>(&status, 1000 + i, 1);
+    const uint64_t id = ledger.Insert(1, true, meta, /*batchSize=*/i + 1);
+    Require(id == expectedId, "recordId must be monotonic across wraparound");
+    ++expectedId;
+
+    // Releasing a stale/never-inserted id (the slot's current occupant differs)
+    // must return nullptr without disturbing the live record.
+    Require(ledger.ReleaseByCqe(id + 1, &sqDepth, nullptr) == nullptr,
+            "stale recordId should not resolve to a live slot");
+
+    int batchSize = 0;
+    auto released = ledger.ReleaseByCqe(id, &sqDepth, &batchSize);
+    Require(released != nullptr, "wraparound release should find the live record");
+    Require(released->id == static_cast<uint64_t>(1000 + i),
+            "wraparound release returned the wrong record");
+    Require(batchSize == i + 1, "wraparound release batch size mismatch");
+    Require(sqDepth.load(std::memory_order_relaxed) == 0, "wraparound release should free 1 WR");
+
+    // Double release of the same id is a no-op (slot already empty).
+    Require(ledger.ReleaseByCqe(id, &sqDepth, nullptr) == nullptr,
+            "double release of the same recordId should return nullptr");
+  }
+
+  // Keep several records live simultaneously (up to the SQ depth), spanning a
+  // ring boundary, then release them out of order.
+  std::vector<uint64_t> liveIds;
+  for (int i = 0; i < kMaxSqDepth; ++i) {
+    auto meta = std::make_shared<CqCallbackMeta>(&status, 5000 + i, 1);
+    liveIds.push_back(ledger.Insert(1, true, meta, /*batchSize=*/1));
+  }
+  std::atomic<int> sqDepth{kMaxSqDepth};
+  // Release in reverse order.
+  for (auto it = liveIds.rbegin(); it != liveIds.rend(); ++it) {
+    Require(ledger.ReleaseByCqe(*it, &sqDepth, nullptr) != nullptr,
+            "each concurrently-live record should release cleanly");
+  }
+  Require(sqDepth.load(std::memory_order_relaxed) == 0,
+          "all concurrently-live records should be released");
+}
+
 EpPair MakeSqAdmissionEp(int maxSqDepth, int currentDepth, bool withAdmission = true) {
   EpPair ep{};
   ep.sqDepth = std::make_shared<std::atomic<int>>(currentDepth);
@@ -1728,6 +1781,7 @@ int main(int argc, char* argv[]) {
   SetLogLevel("info");
   std::vector<TestCase> cases = {
       {"submission_ledger_basic", CaseSubmissionLedgerBasic},
+      {"submission_ledger_ring_wraparound", CaseSubmissionLedgerRingWraparound},
       {"sq_admission_release_wakes_waiter", CaseSqAdmissionReleaseWakesWaiter},
       {"sq_admission_degraded_wakes_waiter", CaseSqAdmissionDegradedWakesWaiter},
       {"sq_admission_negative_depth_reserve_repairs_counter",

--- a/tests/cpp/utils/test_logging.cpp
+++ b/tests/cpp/utils/test_logging.cpp
@@ -1,0 +1,154 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Multi-threaded stress tests for the ModuleLogger wrapper in
+// include/mori/utils/mori_log.hpp.
+//
+// These guard against the previously-present data race on ModuleLogger's
+// internal std::unordered_maps (loggers_/envOverrides_), which under the
+// multithreaded RDMA workload could hand back an empty shared_ptr that callers
+// then cached forever. The functional asserts here catch null/crash
+// regressions; running this binary under ThreadSanitizer is what actually
+// proves the map access is synchronized (build with -fsanitize=thread; if the
+// container aborts with "unexpected memory mapping", run via
+// `setarch $(uname -m) -R ./test_logging`).
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "mori/utils/mori_log.hpp"
+
+namespace {
+
+// Spin barrier so all threads hit the racy window together.
+struct StartGate {
+  std::atomic<bool> go{false};
+  void wait() const {
+    while (!go.load(std::memory_order_acquire)) {
+    }
+  }
+  void open() { go.store(true, std::memory_order_release); }
+};
+
+const char* kKnown[] = {mori::modules::APPLICATION, mori::modules::IO,
+                        mori::modules::SHMEM,       mori::modules::CORE,
+                        mori::modules::OPS,         mori::modules::UMBP,
+                        mori::modules::METRICS};
+
+}  // namespace
+
+// Concurrent resolution of known + many distinct unknown modules. Unknown names
+// force on-demand InitModuleLocked() inserts, i.e. writes racing reads.
+TEST(ModuleLoggerConcurrency, ResolveNeverReturnsNull) {
+  constexpr int kThreads = 32;
+  constexpr int kIters = 5000;
+  StartGate gate;
+  std::atomic<int> nulls{0};
+
+  std::vector<std::thread> ts;
+  ts.reserve(kThreads);
+  for (int t = 0; t < kThreads; ++t) {
+    ts.emplace_back([&, t] {
+      gate.wait();
+      for (int i = 0; i < kIters; ++i) {
+        const char* known = kKnown[(t + i) % 7];
+        if (!mori::ModuleLogger::GetInstance().GetLogger(known)) nulls.fetch_add(1);
+        // Distinct (but bounded) unknown module -> exercises the insert path.
+        std::string unknown = "utmod_" + std::to_string((t * kIters + i) % 128);
+        if (!mori::ModuleLogger::GetInstance().GetLogger(unknown)) nulls.fetch_add(1);
+      }
+    });
+  }
+  gate.open();
+  for (auto& th : ts) th.join();
+  EXPECT_EQ(nulls.load(), 0);
+}
+
+// Many threads resolve the SAME brand-new module at once: the create-once path
+// (spdlog registry race handling) must yield one stable, non-null logger.
+TEST(ModuleLoggerConcurrency, ConcurrentFirstTouchSameModule) {
+  constexpr int kThreads = 64;
+  StartGate gate;
+  std::vector<spdlog::logger*> got(kThreads, nullptr);
+
+  std::vector<std::thread> ts;
+  ts.reserve(kThreads);
+  for (int t = 0; t < kThreads; ++t) {
+    ts.emplace_back([&, t] {
+      gate.wait();
+      got[t] = mori::ModuleLogger::GetInstance().GetLogger("ut_first_touch").get();
+    });
+  }
+  gate.open();
+  for (auto& th : ts) th.join();
+
+  ASSERT_NE(got[0], nullptr);
+  for (int t = 1; t < kThreads; ++t) {
+    EXPECT_NE(got[t], nullptr);
+    EXPECT_EQ(got[t], got[0]);  // all observe the same registered instance
+  }
+}
+
+// Logging while levels are reconfigured. Primarily a TSAN target; the functional
+// assert is just "no crash/hang". Kept quiet at 'critical' to avoid stdout spam.
+TEST(ModuleLoggerConcurrency, LogWhileReconfiguring) {
+  constexpr int kLoggers = 24;
+  constexpr int kIters = 5000;
+  StartGate gate;
+
+  const std::string savedGlobal = mori::GetGlobalLogLevel();
+  mori::SetGlobalLogLevel("critical");
+
+  std::vector<std::thread> ts;
+  ts.reserve(kLoggers + 4);
+  for (int t = 0; t < kLoggers; ++t) {
+    ts.emplace_back([&, t] {
+      gate.wait();
+      for (int i = 0; i < kIters; ++i) {
+        MORI_IO_TRACE("io {} {}", t, i);
+        MORI_APP_DEBUG("app {} {}", t, i);
+        MORI_CORE_INFO("core {} {}", t, i);
+      }
+    });
+  }
+  // Reconfigurer threads racing the loggers above.
+  for (int r = 0; r < 4; ++r) {
+    ts.emplace_back([&] {
+      gate.wait();
+      for (int i = 0; i < kIters; ++i) {
+        mori::SetGlobalLogLevel((i & 1) ? "trace" : "critical");
+        mori::SetModuleLogLevel(mori::modules::IO, (i & 2) ? "debug" : "warn");
+        mori::ForceSetModuleLogLevel(mori::modules::CORE, "info");
+        (void)mori::GetGlobalLogLevel();
+      }
+    });
+  }
+  gate.open();
+  for (auto& th : ts) th.join();
+
+  mori::SetGlobalLogLevel(savedGlobal);
+  SUCCEED();
+}


### PR DESCRIPTION
Profiling-guided reduction of CPU overhead on the MORI-IO submission/completion
hot paths, plus a correctness fix for the module logger under multithreading.

Commits:
- `c6fadb9` — CPU hot path improvements
- `e7213bf` — MORI IO improvements guided by prof

## Motivation

`perf` profiles of the high-IOPS workload showed the CPU cost concentrated in a
few places that were pure bookkeeping overhead rather than useful work:

- `SubmissionLedger::Insert` / `ReleaseByCqe` / `RecordPostTimestamp` were
  dominated by `malloc`/`unordered_map` (hashtable + rehash) frames and by
  `pthread_mutex_lock`/`unlock`, with the notif thread and worker threads
  actually colliding on the ledger mutex (descending into `futex_wait`).
- The notif thread's CQ poll loop rebuilt an endpoint snapshot (shared_lock +
  heap allocation) and took `NotifManager::mu` to resolve the notif context on
  every single poll.
- `ScopedTimer` / `MORI_*` logging resolved the logger via a string-hashed
  `unordered_map` lookup on every call, even when the level was disabled.

Separately, we tracked down repeated `logger for module ... is nullptr` spam to
a data race in the logger wrapper (details below).

## Changes

### 1. `SubmissionLedger`: allocation-free ring + spinlock

`src/io/rdma/common.hpp`, `src/io/rdma/ledger.cpp`, `src/io/rdma/common.cpp`,
`src/io/rdma/backend_impl.cpp`

- Replaced the mutex-guarded `std::unordered_map<recordId, SubmissionRecord>`
  with a fixed, power-of-two **ring buffer** (`std::vector<SubmissionRecord>`)
  indexed by `recordId & capMask_`. A slot is empty iff its stored `recordId`
  is 0. This removes all per-op allocation and hashing.
- The ring is sized from the endpoint's `maxSqDepth` (`maxMsgsNum`) as
  `next_pow2(maxSqDepth + slack)` with a floor. Admission control bounds the
  number of live records below capacity, so `recordId & capMask_` never aliases
  a still-live slot; a defensive check logs loudly if that invariant is ever
  violated.
- The ledger constructor gained a `maxSqDepth` parameter; `ConnectEndpoint`
  passes `epConfig.maxMsgsNum`.
- Swapped the `std::mutex` for a lightweight **TTAS `SpinLock`** (acquire/release
  ordering, `pause`/`yield` relax hint). The ledger critical sections are only a
  handful of instructions, so a spin is far cheaper than a futex under
  contention.
- `RecordPostTimestamp()` is kept as a separate O(1) ring lookup (stamps the
  post timestamp into the live slot under the lock) rather than folded into
  `Insert`.

### 2. NotifManager CQ-poll hot path

`src/io/rdma/backend_impl.cpp`, `src/io/rdma/backend_impl.hpp`,
`src/io/rdma/common.hpp`

- **Lockless notif-context resolution**: the `QpNotifContext*` is published once
  at registration into `EndpointRuntime::notifCtx` (an `std::atomic<void*>`,
  release store) and read locklessly in `ProcessOneCqe` (acquire load). The
  containing map is node-based, so the cached pointer stays valid. This removes
  the per-poll `NotifManager::mu` lock.
- **Cached endpoint snapshot with an epoch**: `RdmaManager` now exposes a
  monotonic `EndpointsEpoch()` bumped whenever the endpoint set changes. The
  busy-poll loop only rebuilds its snapshot (shared_lock + allocation) when the
  epoch moves instead of on every spin. `SnapshotEndpointRuntimes` now fills a
  caller-owned vector to avoid per-call heap churn.

### 3. Logging hot path (`ScopedTimer` / timer macros)

`include/mori/utils/mori_log.hpp`

- `ScopedTimer` now resolves the logger and checks the level up front; when
  DEBUG is disabled it is a true no-op (no string copy, no clock reads, no log
  call).
- `MORI_TIMER` / `MORI_FUNCTION_TIMER` cache the `(module -> logger)` resolution
  in a function-local `static`, so the hashtable probe happens once per
  call-site instead of on every invocation.

### 4. `ModuleLogger` thread-safety fix (nullptr spam)

`include/mori/utils/mori_log.hpp`

Root cause: `ModuleLogger`'s internal `std::unordered_map`s (`loggers_`,
`envOverrides_`) were read by `GetLogger` and mutated by `InitModule` /
`SetGlobalLevel` from many threads with **no synchronization**. Under the RDMA
workload, a concurrent insert/rehash racing a `find` could hand back an empty
`shared_ptr`; the `MORI_LOG` macro then cached that transient null in its
call-site `static` forever, producing permanent `logger ... is nullptr` spam.
(spdlog itself is thread-safe — the race was entirely in this wrapper.)

- Added a `std::mutex` guarding all map/level state.
- **Eagerly create all known module loggers in the constructor**; the Meyers
  singleton guarantees this runs once before any thread can call `GetLogger`, so
  the common read path never races a write.
- Split logic into `*_Locked` helpers to avoid recursive locking; all level/env
  mutators now lock.
- `GetLogger` never returns null: it retries on-demand creation and, if that
  ever genuinely fails, `abort()`s loudly rather than letting callers silently
  drop logs (preferred over a silent no-op).

### 5. Tests

- `tests/cpp/io/test_engine.cpp`: added a `SubmissionLedger` ring wraparound
  test (insert/release across more than `capacity` ids; stale ids return
  `nullptr`).
- `tests/cpp/utils/test_logging.cpp` (new) + `tests/cpp/CMakeLists.txt`:
  multi-threaded `ModuleLogger` stress tests — concurrent resolution of
  known/unknown modules (never null), concurrent first-touch of the same new
  module (one stable instance), and logging while levels are reconfigured.
  Intended to also run under ThreadSanitizer.

## Performance

Comparing `perf` self-samples on the ledger paths before/after (high-IOPS run):

| Path | Before | After |
| --- | --- | --- |
| `SubmissionLedger::Insert` | ~87M (body + malloc/hashtable + mutex) | ~1.5M |
| `SubmissionLedger::RecordPostTimestamp` | ~50M (mostly mutex) | ~2.6M |
| `SubmissionLedger::ReleaseByCqe` | ~41M (body + mutex + `futex_wait`) | ~2.9M |

All `malloc`/`unordered_map`/hashtable frames and all `pthread_mutex_*` /
`futex_wait` frames disappeared from the ledger paths (~25x lower ledger CPU),
and the notif/worker threads no longer contend on the ledger lock. After these
changes the profile is dominated by `ibv_poll_cq` and the mlx5 driver's internal
CQ spinlock (the driver, not MORI) — a good candidate for follow-up.

## Testing / validation

- `test_logging` built with the project ROCm toolchain: `3 tests PASSED`.
- Same test under **ThreadSanitizer** (`-fsanitize=thread`, `setarch -R` to work
  around a container ASLR/mapping quirk): `3 tests PASSED`, **0 data races**,
  0 TSAN warnings — confirming the logger maps are now properly synchronized.
- `SubmissionLedger` ring wraparound test passes; existing ledger test still
  green.

## Notes / risk

- The `SpinLock` is intended for the short, uncontended ledger critical
  sections. On an oversubscribed host (more busy threads than cores) a pure spin
  can waste cycles; the current deployment gives the notif thread and workers
  their own cores. If future profiles show time in `SpinLock::lock`, add a
  bounded spin + `sched_yield`/backoff fallback.
- Per-QP ring memory is `capacity * sizeof(SubmissionRecord)`; very large
  `maxSqDepth` combined with many QPs increases per-QP footprint.
- `ModuleLogger::GetLogger` now `abort()`s on a fundamentally broken logging
  subsystem instead of returning null. This is unreachable in practice (the
  application logger is created eagerly and `stdout_color_mt` creates any new
  name), and is the intended fail-loud behavior.

## Follow-ups (not in this PR)

- Reduce `ibv_poll_cq` + mlx5 CQ-spinlock cost (e.g., skip polling CQs with no
  outstanding completions, larger poll batch, adaptive backoff, or evaluate
  event-driven CQ mode).
