### PR TITLE
rdma: fix dmabuf offset for sub-allocated GPU buffers (LOC_PROT on ionic RoCE)

### DIFF
--- a/src/application/transport/rdma/rdma.cpp
+++ b/src/application/transport/rdma/rdma.cpp
@@ -33,6 +33,10 @@
 #include <unordered_set>
 
 #include "infiniband/verbs.h"
+
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
+
 #include "mori/application/transport/rdma/providers/bnxt/bnxt.hpp"
 #include "mori/application/transport/rdma/providers/dv_loader.hpp"
 #include "mori/application/transport/rdma/providers/ibverbs/ibverbs.hpp"
@@ -437,15 +441,33 @@ application::RdmaMemoryRegion RdmaDeviceContext::RegisterRdmaMemoryRegionDmabufI
   return handle;
 }
 
-// Export a dmabuf fd for the GPU buffer at `ptr`. Returns -1 if unsupported.
-static int TryExportDmabufFd(void* ptr, size_t size) {
+// Export a dmabuf fd for the GPU buffer at `ptr`, and report the offset of `ptr`
+// within the exported dmabuf via `*offset`. Returns -1 if unsupported.
+//
+// hipMemGetHandleForAddressRange exports an fd for the *backing* allocation but
+// does not report where `ptr` sits inside it; callers previously assumed offset
+// 0. That is wrong when `ptr` is a sub-region of a larger allocation (e.g. a
+// pooled KV buffer): the dmabuf covers the whole backing block, so registering
+// with offset 0 produces an MR whose lkey/rkey resolve to the base of the pool
+// instead of `ptr`. On the wire this surfaces as IBV_WC_LOC_PROT_ERR (or, worse,
+// silent writes to the wrong address). hsa_amd_portable_export_dmabuf reports the
+// true byte offset, so prefer it and fall back to the hip path (offset 0, correct
+// only for whole-allocation exports) when HSA export is unavailable.
+static int TryExportDmabufFd(void* ptr, size_t size, uint64_t* offset) {
   int fd = -1;
+  uint64_t off = 0;
+  hsa_status_t hs = hsa_amd_portable_export_dmabuf(ptr, size, &fd, &off);
+  if (hs == HSA_STATUS_SUCCESS && fd >= 0) {
+    *offset = off;
+    return fd;
+  }
   hipError_t err = hipMemGetHandleForAddressRange(&fd, reinterpret_cast<hipDeviceptr_t>(ptr), size,
                                                   hipMemRangeHandleTypeDmaBufFd, 0);
   if (err != hipSuccess) {
     (void)hipGetLastError();
     return -1;
   }
+  *offset = 0;
   return fd;
 }
 
@@ -465,9 +487,10 @@ application::RdmaMemoryRegion RdmaDeviceContext::RegisterRdmaMemoryRegionAuto(vo
   };
   auto tryPlain = [&]() -> ibv_mr* { return ibv_reg_mr(pd, ptr, size, effectiveAccessFlag); };
   auto tryDmabuf = [&]() -> ibv_mr* {
-    int dmabufFd = TryExportDmabufFd(ptr, size);
+    uint64_t dmabufOffset = 0;
+    int dmabufFd = TryExportDmabufFd(ptr, size, &dmabufOffset);
     if (dmabufFd < 0) return nullptr;
-    ibv_mr* mr = ibv_reg_dmabuf_mr(pd, 0, size, reinterpret_cast<uint64_t>(ptr), dmabufFd,
+    ibv_mr* mr = ibv_reg_dmabuf_mr(pd, dmabufOffset, size, reinterpret_cast<uint64_t>(ptr), dmabufFd,
                                    effectiveAccessFlag);
     close(dmabufFd);
     return mr;

--- a/src/application/transport/rdma/rdma.cpp
+++ b/src/application/transport/rdma/rdma.cpp
@@ -21,6 +21,9 @@
 // SOFTWARE.
 #include "mori/application/transport/rdma/rdma.hpp"
 
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
+
 #include <algorithm>
 #include <cassert>
 #include <cctype>
@@ -33,10 +36,6 @@
 #include <unordered_set>
 
 #include "infiniband/verbs.h"
-
-#include <hsa/hsa.h>
-#include <hsa/hsa_ext_amd.h>
-
 #include "mori/application/transport/rdma/providers/bnxt/bnxt.hpp"
 #include "mori/application/transport/rdma/providers/dv_loader.hpp"
 #include "mori/application/transport/rdma/providers/ibverbs/ibverbs.hpp"
@@ -490,8 +489,8 @@ application::RdmaMemoryRegion RdmaDeviceContext::RegisterRdmaMemoryRegionAuto(vo
     uint64_t dmabufOffset = 0;
     int dmabufFd = TryExportDmabufFd(ptr, size, &dmabufOffset);
     if (dmabufFd < 0) return nullptr;
-    ibv_mr* mr = ibv_reg_dmabuf_mr(pd, dmabufOffset, size, reinterpret_cast<uint64_t>(ptr), dmabufFd,
-                                   effectiveAccessFlag);
+    ibv_mr* mr = ibv_reg_dmabuf_mr(pd, dmabufOffset, size, reinterpret_cast<uint64_t>(ptr),
+                                   dmabufFd, effectiveAccessFlag);
     close(dmabufFd);
     return mr;
   };

--- a/tests/cpp/io/test_engine.cpp
+++ b/tests/cpp/io/test_engine.cpp
@@ -1260,6 +1260,87 @@ void CaseRdmaTransferBasic() {
               inbound.Message() + "'");
 }
 
+void CaseRdmaDmabufInteriorRangeTransfer() {
+  if (GetGpuCount() < 1) throw TestSkip("requires at least one GPU");
+
+  // Force the dma-buf registration path (RegisterRdmaMemoryRegionAuto), which this
+  // fix touches. The regression: TryExportDmabufFd exports a dma-buf fd for the
+  // whole *backing* allocation, so registering an interior sub-range with offset 0
+  // pointed the MR at the allocation base instead of base+offset. Transfers then
+  // hit LOC_PROT or silently landed at the wrong address.
+  ScopedEnvVar enableDmabuf("MORI_ENABLE_DMABUF_REG", "1");
+  ScopedEnvVar disableAutoXgmi("MORI_DISABLE_AUTO_XGMI", "1");
+
+  ConnectedEnginePair pair = CreateConnectedRdmaPair("rdma_dmabuf_interior", true);
+
+  constexpr size_t kAlloc = 64 * 1024 * 1024;   // 64 MiB backing allocation
+  constexpr size_t kOffset = 32 * 1024 * 1024;  // nonzero interior offset
+  constexpr size_t kXfer = 1 * 1024 * 1024;     // transferred sub-range
+
+  HIP_RUNTIME_CHECK(hipSetDevice(0));
+  void* srcBase = nullptr;
+  void* dstBase = nullptr;
+  HIP_RUNTIME_CHECK(hipMalloc(&srcBase, kAlloc));
+  HIP_RUNTIME_CHECK(hipMalloc(&dstBase, kAlloc));
+  void* srcInterior = static_cast<char*>(srcBase) + kOffset;
+  void* dstInterior = static_cast<char*>(dstBase) + kOffset;
+
+  // Base regions get a sentinel (0x11); the src sub-range gets the payload (0xCD),
+  // the dst sub-range is cleared (0x00). If the MR wrongly resolves to the base,
+  // the write lands at dstBase and the checks below catch it two ways: the dst
+  // sub-range stays 0x00 (payload missing) and/or the dst base sentinel is clobbered.
+  HIP_RUNTIME_CHECK(hipMemset(srcBase, 0x11, kAlloc));
+  HIP_RUNTIME_CHECK(hipMemset(dstBase, 0x11, kAlloc));
+  HIP_RUNTIME_CHECK(hipMemset(srcInterior, 0xCD, kXfer));
+  HIP_RUNTIME_CHECK(hipMemset(dstInterior, 0x00, kXfer));
+  HIP_RUNTIME_CHECK(hipDeviceSynchronize());
+
+  MemoryDesc srcDesc =
+      pair.initiator->RegisterMemory(srcInterior, kXfer, 0, MemoryLocationType::GPU);
+  MemoryDesc dstDesc = pair.target->RegisterMemory(dstInterior, kXfer, 0, MemoryLocationType::GPU);
+
+  TransferStatus status;
+  TransferUniqueId uid = pair.initiator->AllocateTransferUniqueId();
+  pair.initiator->Write(srcDesc, 0, dstDesc, 0, kXfer, &status, uid);
+
+  std::string err;
+  Require(WaitTransferDone(&status, 5000, &err), "dmabuf interior transfer timeout: " + err);
+  Require(status.Succeeded(),
+          "dmabuf interior transfer failed: code=" + std::to_string(status.CodeUint32()) +
+              ", msg='" + status.Message() + "'");
+
+  std::vector<uint8_t> host(kXfer);
+  HIP_RUNTIME_CHECK(hipMemcpy(host.data(), dstInterior, kXfer, hipMemcpyDeviceToHost));
+  size_t badAt = kXfer;
+  for (size_t i = 0; i < kXfer; ++i) {
+    if (host[i] != 0xCD) {
+      badAt = i;
+      break;
+    }
+  }
+  Require(badAt == kXfer,
+          "dma-buf interior-range transfer wrote wrong data at byte " + std::to_string(badAt) +
+              " (a zero dma-buf offset lands the write at the allocation base, not base+offset)");
+
+  std::vector<uint8_t> hostBase(kXfer);
+  HIP_RUNTIME_CHECK(hipMemcpy(hostBase.data(), dstBase, kXfer, hipMemcpyDeviceToHost));
+  size_t clobberAt = kXfer;
+  for (size_t i = 0; i < kXfer; ++i) {
+    if (hostBase[i] != 0x11) {
+      clobberAt = i;
+      break;
+    }
+  }
+  Require(clobberAt == kXfer,
+          "dma-buf interior-range transfer clobbered the allocation base at byte " +
+              std::to_string(clobberAt) + " (indicates the MR resolved to offset 0)");
+
+  pair.initiator->DeregisterMemory(srcDesc);
+  pair.target->DeregisterMemory(dstDesc);
+  HIP_RUNTIME_CHECK(hipFree(srcBase));
+  HIP_RUNTIME_CHECK(hipFree(dstBase));
+}
+
 void CaseRdmaNotificationDisabledBehavior() {
   if (GetGpuCount() < 1) throw TestSkip("requires at least one GPU");
 
@@ -1776,6 +1857,7 @@ int main(int argc, char* argv[]) {
       {"rdma_backend_can_handle_rejects_sentinel_port_remote",
        CaseRdmaBackendCanHandleRejectsSentinelPortRemote},
       {"rdma_transfer_basic", CaseRdmaTransferBasic},
+      {"rdma_dmabuf_interior_range_transfer", CaseRdmaDmabufInteriorRangeTransfer},
       {"rdma_notification_disabled_behavior", CaseRdmaNotificationDisabledBehavior},
       {"rdma_notification_env_override_disables", CaseRdmaNotificationEnvOverrideDisables},
       {"rdma_notification_invalid_env_keeps_config", CaseRdmaNotificationInvalidEnvKeepsConfig},


### PR DESCRIPTION
## Problem

`RegisterRdmaMemoryRegionAuto` exports a dmabuf fd via `TryExportDmabufFd`
(`hipMemGetHandleForAddressRange`) and registers it with
`ibv_reg_dmabuf_mr(pd, /*offset=*/0, size, /*iova=*/ptr, fd, access)`.

`hipMemGetHandleForAddressRange` exports an fd for the **backing allocation** but
does not report where `ptr` sits inside it. Offset 0 is therefore only correct
when `ptr` is the base of its own allocation.

When `ptr` is a **sub-region of a larger allocation** — e.g. a pooled KV buffer
whose chunks are handed out from one big `hipMalloc`/VMM block, as SGLang does —
the exported dmabuf covers the whole backing block and `ptr` has a **nonzero
offset**. Registering with offset 0 yields an MR whose `lkey`/`rkey` resolve to
the base of the pool instead of `ptr`. On the wire this surfaces as
**`IBV_WC_LOC_PROT_ERR`** on every RDMA WR (or, worse, silent writes to the
wrong address).

This is what blocks MoRI KV transfer on AMD Pensando **ionic** RoCE NICs, which
require dmabuf registration for GPU memory (plain `ibv_reg_mr` returns `EINVAL`).

## Fix

Use `hsa_amd_portable_export_dmabuf`, which returns **both** the fd and the true
byte offset of `ptr` within the dmabuf, and pass that offset to
`ibv_reg_dmabuf_mr`. Fall back to the hip export (offset 0) when HSA export is
unavailable.

`hsa-runtime64` is already a link dependency of `mori_application`
(`src/application/CMakeLists.txt`), so **no build changes are required**.

The VMM symmetric-memory path (`RegisterRdmaMemoryRegionDmabuf`, offset 0) is
intentionally left unchanged: there each chunk's fd is exported for the chunk
base, so offset 0 is already correct.

## Validation

Reproduced and fixed end-to-end on **MI355X (gfx950) + ionic RoCE**, DeepSeek-V4
SGLang PD disaggregation (prefill TP8 / decode TP8, MoRI KV transfer):

- **Before:** every KV transfer fails — decode `KVTransferError`, prefill CQE
  `status=4 (local protection error) vendor_err=3` (`IBV_WC_LOC_PROT_ERR`).
- **After:** KV transfer completes cleanly; benchmark requests succeed (16/16 at
  concurrency 1, latencies matching the reference run). The exported offset is
  confirmed **nonzero** for the 512 MB KV buffers, exactly the case that offset 0
  got wrong.

(The fix was first proven via an `LD_PRELOAD` shim implementing the identical
`hsa_amd_portable_export_dmabuf` → `ibv_reg_dmabuf_mr(pd, offset, …)` logic, then
ported here.)