### PR TITLE
roctx ranges

### DIFF
--- a/docs/MORI-IO-GUIDE.md
+++ b/docs/MORI-IO-GUIDE.md
@@ -10,6 +10,7 @@ MORI-IO is AMD's point-to-point communication library that leverages GDR (GPU Di
 - [Python API Quick Reference](#python-api-quick-reference)
 - [Example: Basic Read/Write](#example-basic-readwrite)
 - [Environment & Configuration](#environment--configuration)
+- [Profiling MORI-IO with ROCTX Markers](#profiling-mori-io-with-roctx-markers)
 - [Source Files](#source-files)
 
 ## Design & Concepts
@@ -181,6 +182,38 @@ See `examples/io/example.py` for more complete examples including batch transfer
 UMBP (the upper-layer cache pool) exposes a separate set of runtime-tunable
 env vars for distributed master / pool client / SPDK proxy timing. Those are
 out of scope for MORI-IO; see [`src/umbp/doc/runtime-env-vars.md`](../src/umbp/doc/runtime-env-vars.md).
+
+## Profiling MORI-IO with ROCTX Markers
+
+MORI-IO provides optional, runtime-gated ROCTX timeline markers for use with
+`rocprofv3 --marker-trace`. The following variables are disabled by default and
+operate independently:
+
+- `MORI_ROCTX` enables same-thread host submission ranges around MORI-IO
+  batch-write dispatch and RDMA posting paths. They measure host-side submission
+  and post work only, not completion latency.
+- `MORI_ROCTX_TRANSFER` enables process-wide ranges that begin immediately
+  before posting a signaled RDMA work request and end on the CQ polling thread
+  after its CQE is observed. They measure post-to-completion latency.
+
+Marker fields `bytes=` and `id=` identify application payload bytes (not
+physical RoCE wire bytes) and MORI's logical transfer ID, respectively. Key host
+marker families are `mori.io.*` and `mori.rdma.batch_post.*`; transfer markers
+use `mori.rdma.io_transfer[.read]`.
+
+Although generic to MORI-IO, these markers can help observe KV-cache
+post-to-completion latency in prefill/decode-disaggregated vLLM or SGLang
+deployments configured to use MORI-IO.
+
+```bash
+export MORI_ROCTX=1
+export MORI_ROCTX_TRANSFER=1
+rocprofv3 --marker-trace -- <your MORI command>
+```
+
+Either variable can be enabled alone. Enabled values include `1`, `on`, and
+`true`; disable a variable by unsetting it or setting it to `0`, `off`, or
+`false`.
 
 ## Source Files
 

--- a/src/io/engine.cpp
+++ b/src/io/engine.cpp
@@ -41,6 +41,7 @@
 #include "src/io/fabric/backend_impl.hpp"
 #include "src/io/rdma/backend_impl.hpp"
 #include "src/io/xgmi/backend_impl.hpp"
+#include "src/io/roctx_mori.hpp"  // ADDITIVE: MORI_ROCTX-gated host-send roctx markers
 
 namespace mori {
 namespace io {
@@ -151,6 +152,8 @@ void IOEngineSession::BatchWrite(const SizeVec& localOffsets, const SizeVec& rem
                                  const SizeVec& sizes, TransferStatus* status,
                                  TransferUniqueId id) {
   MORI_IO_FUNCTION_TIMER;
+  // ADDITIVE (MORI_ROCTX=1): brackets the host KV-send dispatch for this transfer.
+  mori::io::MoriRoctxRange _mori_roctx_("mori.io.session_batch_write", static_cast<uint64_t>(id));
   std::shared_ptr<internal::IoCallDiagnostics> diagnostics;
   internal::ScopedIoCallDiagnosticsCapture capture(&diagnostics, "Session batch write");
   backendSess->BatchWrite(localOffsets, remoteOffsets, sizes, status, id);
@@ -529,6 +532,8 @@ void IOEngine::BatchWrite(const MemDescVec& localSrc, const BatchSizeVec& localO
                           const BatchSizeVec& sizes, TransferStatusPtrVec& status,
                           TransferUniqueIdVec& ids) {
   MORI_IO_FUNCTION_TIMER;
+  // ADDITIVE (MORI_ROCTX=1): brackets the host engine-level batch KV-send.
+  mori::io::MoriRoctxRange _mori_roctx_("mori.io.engine_batch_write");
   size_t batchSize = localSrc.size();
   assert(batchSize == remoteDest.size());
   assert(batchSize == localOffsets.size());

--- a/src/io/engine.cpp
+++ b/src/io/engine.cpp
@@ -40,8 +40,8 @@
 #include "src/io/call_diagnostics_internal.hpp"
 #include "src/io/fabric/backend_impl.hpp"
 #include "src/io/rdma/backend_impl.hpp"
-#include "src/io/xgmi/backend_impl.hpp"
 #include "src/io/roctx_mori.hpp"  // ADDITIVE: MORI_ROCTX-gated host-send roctx markers
+#include "src/io/xgmi/backend_impl.hpp"
 
 namespace mori {
 namespace io {
@@ -152,7 +152,7 @@ void IOEngineSession::BatchWrite(const SizeVec& localOffsets, const SizeVec& rem
                                  const SizeVec& sizes, TransferStatus* status,
                                  TransferUniqueId id) {
   MORI_IO_FUNCTION_TIMER;
-  // ADDITIVE (MORI_ROCTX=1): brackets the host KV-send dispatch for this transfer.
+  // ADDITIVE (MORI_ROCTX=1): brackets the host write dispatch for this transfer.
   mori::io::MoriRoctxRange _mori_roctx_("mori.io.session_batch_write", static_cast<uint64_t>(id));
   std::shared_ptr<internal::IoCallDiagnostics> diagnostics;
   internal::ScopedIoCallDiagnosticsCapture capture(&diagnostics, "Session batch write");
@@ -532,7 +532,7 @@ void IOEngine::BatchWrite(const MemDescVec& localSrc, const BatchSizeVec& localO
                           const BatchSizeVec& sizes, TransferStatusPtrVec& status,
                           TransferUniqueIdVec& ids) {
   MORI_IO_FUNCTION_TIMER;
-  // ADDITIVE (MORI_ROCTX=1): brackets the host engine-level batch KV-send.
+  // ADDITIVE (MORI_ROCTX=1): brackets the host engine-level batch write.
   mori::io::MoriRoctxRange _mori_roctx_("mori.io.engine_batch_write");
   size_t batchSize = localSrc.size();
   assert(batchSize == remoteDest.size());

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -39,7 +39,7 @@
 #include "mori/io/logging.hpp"
 #include "src/io/rdma/async_event_monitor.hpp"
 #include "src/io/rdma/protocol.hpp"
-#include "src/io/roctx_mori.hpp"  // ADDITIVE: MORI_ROCTX_TRANSFER async post->cq range stop
+#include "src/io/roctx_mori.hpp"  // ADDITIVE: async post-to-completion range stop
 namespace mori {
 namespace io {
 
@@ -750,7 +750,7 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
         auto meta = ep.ledger
                         ? ep.ledger->ReleaseByCqe(wc[i].wr_id, ep.sqDepth.get(), &mergedBatchSize)
                         : nullptr;
-        // ADDITIVE (MORI_ROCTX_TRANSFER=1): stop the async post->cq range for this
+        // ADDITIVE (MORI_ROCTX_TRANSFER=1): stop the post-to-completion range for this
         // signaled WR on a FAILED/flush CQE (no-op if none was started for it).
         mori::io::MoriRoctxTransferStop(ep.ledger ? ep.ledger.get() : nullptr, wc[i].wr_id);
         if (meta) {
@@ -857,8 +857,8 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
         auto meta = ep.ledger
                         ? ep.ledger->ReleaseByCqe(recordId, ep.sqDepth.get(), &mergedBatchSize)
                         : nullptr;
-        // ADDITIVE (MORI_ROCTX_TRANSFER=1): stop the async post->cq range for this
-        // signaled WR on its SUCCESS CQE -> this is the real KV transfer duration.
+        // ADDITIVE (MORI_ROCTX_TRANSFER=1): stop the post-to-completion range after
+        // processing the signaled WR's successful CQE.
         mori::io::MoriRoctxTransferStop(ep.ledger ? ep.ledger.get() : nullptr, recordId);
         if (meta) {
           NotifySqStateChanged(ep);

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -39,6 +39,7 @@
 #include "mori/io/logging.hpp"
 #include "src/io/rdma/async_event_monitor.hpp"
 #include "src/io/rdma/protocol.hpp"
+#include "src/io/roctx_mori.hpp"  // ADDITIVE: MORI_ROCTX_TRANSFER async post->cq range stop
 namespace mori {
 namespace io {
 
@@ -749,6 +750,9 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
         auto meta = ep.ledger
                         ? ep.ledger->ReleaseByCqe(wc[i].wr_id, ep.sqDepth.get(), &mergedBatchSize)
                         : nullptr;
+        // ADDITIVE (MORI_ROCTX_TRANSFER=1): stop the async post->cq range for this
+        // signaled WR on a FAILED/flush CQE (no-op if none was started for it).
+        mori::io::MoriRoctxTransferStop(ep.ledger ? ep.ledger.get() : nullptr, wc[i].wr_id);
         if (meta) {
           (void)meta->finishedBatchSize.fetch_add(mergedBatchSize);
           if (isFlush) {
@@ -853,6 +857,9 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
         auto meta = ep.ledger
                         ? ep.ledger->ReleaseByCqe(recordId, ep.sqDepth.get(), &mergedBatchSize)
                         : nullptr;
+        // ADDITIVE (MORI_ROCTX_TRANSFER=1): stop the async post->cq range for this
+        // signaled WR on its SUCCESS CQE -> this is the real KV transfer duration.
+        mori::io::MoriRoctxTransferStop(ep.ledger ? ep.ledger.get() : nullptr, recordId);
         if (meta) {
           NotifySqStateChanged(ep);
           uint32_t finishedBefore = meta->finishedBatchSize.fetch_add(mergedBatchSize);

--- a/src/io/rdma/common.cpp
+++ b/src/io/rdma/common.cpp
@@ -39,7 +39,7 @@
 
 #include "mori/io/env.hpp"
 #include "mori/io/logging.hpp"
-#include "src/io/roctx_mori.hpp"  // ADDITIVE: MORI_ROCTX-gated host-send roctx markers
+#include "src/io/roctx_mori.hpp"  // ADDITIVE: MORI_ROCTX-gated host-I/O markers
 
 namespace mori {
 namespace io {
@@ -607,13 +607,16 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
                              TransferUniqueId id, bool isRead, int postBatchSize,
                              const RdmaTransferControl& control) {
   MORI_IO_FUNCTION_TIMER;
-  // ADDITIVE (MORI_ROCTX=1): brackets the host ibv_post_send loop for this RDMA
-  // batch (write = the KV send on the prefill sender; read also routes here).
+  // ADDITIVE (MORI_ROCTX=1): brackets host submission for this generic RDMA I/O
+  // batch; both reads and writes route here.
   // bytes= carries the whole-call payload (sum of the per-request sizes).
+  const uint64_t roctxBytes =
+      mori::io::MoriRoctxPostEnabled()
+          ? std::accumulate(sizes.begin(), sizes.end(), static_cast<uint64_t>(0))
+          : 0;
   mori::io::MoriRoctxRange _mori_roctx_(
       isRead ? "mori.rdma.batch_post.read" : "mori.rdma.batch_post.write",
-      static_cast<uint64_t>(id),
-      std::accumulate(sizes.begin(), sizes.end(), static_cast<uint64_t>(0)));
+      static_cast<uint64_t>(id), roctxBytes);
 
   if ((localOffsets.size() != remoteOffsets.size()) || (sizes.size() != remoteOffsets.size())) {
     return {StatusCode::ERR_INVALID_ARGS,
@@ -891,13 +894,13 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
 
   epWrsSinceSignal.assign(epNum, 0);
   epMergedSinceSignal.assign(epNum, 0);
+  const bool roctxTransferEnabled = mori::io::MoriRoctxTransferEnabled();
   // ADDITIVE (MORI_ROCTX_TRANSFER=1): payload bytes accumulated since the last
   // signal on each EP (mirrors epMergedSinceSignal); attached to the signaled
-  // record's kv_transfer range and reset on signal. NOTE: not yet folded into
-  // the thread-local/pool reuse above (upstream perf optimization added after
-  // this instrumentation was written) -- allocated fresh per call, same as
-  // original fork behavior; gated OFF by default so this is not a hot path.
-  std::vector<size_t> epBytesSinceSignal(epNum, 0);
+  // record's io_transfer range and reset on signal. The empty vector does not
+  // allocate when transfer markers are disabled.
+  std::vector<size_t> epBytesSinceSignal;
+  if (roctxTransferEnabled) epBytesSinceSignal.assign(epNum, 0);
 
   // Rotate the starting EP by transfer id so single-segment (single WR)
   // transfers spread evenly across all QPs instead of always landing on eps[0].
@@ -920,7 +923,6 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
     const auto& localMr = localMrPerEp[epId];
     const auto& remoteMr = remoteMrPerEp[epId];
     size_t mergedReqSize = 0;
-    size_t batchBytes = 0;  // ADDITIVE: payload bytes for this post chunk
     for (int j = st; j < end; j++) {
       MergedWorkRequest& mergedWr = mergedWrs[j];
       for (auto& sge : mergedWr.sges) sge.lkey = localMr.lkey;
@@ -931,12 +933,17 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
       wr.wr_id = 0;
       wr.next = (j + 1 < end) ? &mergedWrs[j + 1].wr : nullptr;
       mergedReqSize += mergedWr.mergedRequests;
-      batchBytes += mergedWr.totalRemoteLength;  // ADDITIVE
     }
 
     epWrsSinceSignal[epId] += batchWrNum;
     epMergedSinceSignal[epId] += mergedReqSize;
-    epBytesSinceSignal[epId] += batchBytes;  // ADDITIVE
+    if (roctxTransferEnabled) {
+      size_t batchBytes = 0;
+      for (int j = st; j < end; ++j) {
+        batchBytes += mergedWrs[j].totalRemoteLength;
+      }
+      epBytesSinceSignal[epId] += batchBytes;
+    }
 
     bool isLastBatchForEp = ((i + epNum) >= numPostBatch);
     bool sqNearFull = eps[epId].sqDepth && (epWrsSinceSignal[epId] >= eps[epId].maxSqDepth);
@@ -954,14 +961,16 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
                                           static_cast<int>(epMergedSinceSignal[epId]));
       last.wr_id = recordId;
       last.send_flags = IBV_SEND_SIGNALED;
-      // ADDITIVE (MORI_ROCTX_TRANSFER=1): start an ASYNC post->cq range for this
-      // signaled WR, keyed by (ledger, recordId). Stopped when its CQE is reaped
-      // (NotifManager::ProcessOneCqe) or, if this WR fails to post, in the
-      // not-posted cleanup below. Measures real KV transfer/wire time (ms), unlike
-      // the synchronous host-post anchor above (us).
-      mori::io::MoriRoctxTransferStart(eps[epId].ledger.get(), recordId,
-                                       static_cast<uint64_t>(id), isRead,
-                                       static_cast<uint64_t>(epBytesSinceSignal[epId]));
+      // ADDITIVE (MORI_ROCTX_TRANSFER=1): start an ASYNC post-to-completion range
+      // for this signaled WR, keyed by (ledger, recordId). It stops when the CQE
+      // is processed or, if this WR fails to post, in the cleanup below. The
+      // range includes submission/ibv_post_send, NIC/SQ queueing, transfer, CQ
+      // availability/polling, and software processing through marker stop.
+      if (roctxTransferEnabled) {
+        mori::io::MoriRoctxTransferStart(eps[epId].ledger.get(), recordId,
+                                         static_cast<uint64_t>(id), isRead,
+                                         static_cast<uint64_t>(epBytesSinceSignal[epId]));
+      }
     }
 
     struct ibv_send_wr* badWr = nullptr;
@@ -998,9 +1007,11 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
       } else if (needSignal) {
         int dummy = 0;
         eps[epId].ledger->ReleaseByCqe(recordId, nullptr, &dummy);
-        // ADDITIVE (MORI_ROCTX_TRANSFER=1): the signaled WR never posted, so no CQE
-        // will arrive — stop its async range here to avoid a leaked range.
-        mori::io::MoriRoctxTransferStop(eps[epId].ledger.get(), recordId);
+        if (roctxTransferEnabled) {
+          // The signaled WR never posted, so no CQE will arrive. Stop its async
+          // range here to avoid a leaked range.
+          mori::io::MoriRoctxTransferStop(eps[epId].ledger.get(), recordId);
+        }
       }
 
       if (postedCount > 0 && (!needSignal || !lastWasPosted)) {
@@ -1051,7 +1062,7 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
     if (needSignal) {
       epWrsSinceSignal[epId] = 0;
       epMergedSinceSignal[epId] = 0;
-      epBytesSinceSignal[epId] = 0;  // ADDITIVE
+      if (roctxTransferEnabled) epBytesSinceSignal[epId] = 0;
     }
     MORI_IO_TRACE("ibv_post_send ep index {} batch index range [{}, {})", epId, st, end);
   }

--- a/src/io/rdma/common.cpp
+++ b/src/io/rdma/common.cpp
@@ -39,6 +39,7 @@
 
 #include "mori/io/env.hpp"
 #include "mori/io/logging.hpp"
+#include "src/io/roctx_mori.hpp"  // ADDITIVE: MORI_ROCTX-gated host-send roctx markers
 
 namespace mori {
 namespace io {
@@ -606,6 +607,13 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
                              TransferUniqueId id, bool isRead, int postBatchSize,
                              const RdmaTransferControl& control) {
   MORI_IO_FUNCTION_TIMER;
+  // ADDITIVE (MORI_ROCTX=1): brackets the host ibv_post_send loop for this RDMA
+  // batch (write = the KV send on the prefill sender; read also routes here).
+  // bytes= carries the whole-call payload (sum of the per-request sizes).
+  mori::io::MoriRoctxRange _mori_roctx_(
+      isRead ? "mori.rdma.batch_post.read" : "mori.rdma.batch_post.write",
+      static_cast<uint64_t>(id),
+      std::accumulate(sizes.begin(), sizes.end(), static_cast<uint64_t>(0)));
 
   if ((localOffsets.size() != remoteOffsets.size()) || (sizes.size() != remoteOffsets.size())) {
     return {StatusCode::ERR_INVALID_ARGS,
@@ -883,6 +891,13 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
 
   epWrsSinceSignal.assign(epNum, 0);
   epMergedSinceSignal.assign(epNum, 0);
+  // ADDITIVE (MORI_ROCTX_TRANSFER=1): payload bytes accumulated since the last
+  // signal on each EP (mirrors epMergedSinceSignal); attached to the signaled
+  // record's kv_transfer range and reset on signal. NOTE: not yet folded into
+  // the thread-local/pool reuse above (upstream perf optimization added after
+  // this instrumentation was written) -- allocated fresh per call, same as
+  // original fork behavior; gated OFF by default so this is not a hot path.
+  std::vector<size_t> epBytesSinceSignal(epNum, 0);
 
   // Rotate the starting EP by transfer id so single-segment (single WR)
   // transfers spread evenly across all QPs instead of always landing on eps[0].
@@ -905,6 +920,7 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
     const auto& localMr = localMrPerEp[epId];
     const auto& remoteMr = remoteMrPerEp[epId];
     size_t mergedReqSize = 0;
+    size_t batchBytes = 0;  // ADDITIVE: payload bytes for this post chunk
     for (int j = st; j < end; j++) {
       MergedWorkRequest& mergedWr = mergedWrs[j];
       for (auto& sge : mergedWr.sges) sge.lkey = localMr.lkey;
@@ -915,10 +931,12 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
       wr.wr_id = 0;
       wr.next = (j + 1 < end) ? &mergedWrs[j + 1].wr : nullptr;
       mergedReqSize += mergedWr.mergedRequests;
+      batchBytes += mergedWr.totalRemoteLength;  // ADDITIVE
     }
 
     epWrsSinceSignal[epId] += batchWrNum;
     epMergedSinceSignal[epId] += mergedReqSize;
+    epBytesSinceSignal[epId] += batchBytes;  // ADDITIVE
 
     bool isLastBatchForEp = ((i + epNum) >= numPostBatch);
     bool sqNearFull = eps[epId].sqDepth && (epWrsSinceSignal[epId] >= eps[epId].maxSqDepth);
@@ -936,6 +954,14 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
                                           static_cast<int>(epMergedSinceSignal[epId]));
       last.wr_id = recordId;
       last.send_flags = IBV_SEND_SIGNALED;
+      // ADDITIVE (MORI_ROCTX_TRANSFER=1): start an ASYNC post->cq range for this
+      // signaled WR, keyed by (ledger, recordId). Stopped when its CQE is reaped
+      // (NotifManager::ProcessOneCqe) or, if this WR fails to post, in the
+      // not-posted cleanup below. Measures real KV transfer/wire time (ms), unlike
+      // the synchronous host-post anchor above (us).
+      mori::io::MoriRoctxTransferStart(eps[epId].ledger.get(), recordId,
+                                       static_cast<uint64_t>(id), isRead,
+                                       static_cast<uint64_t>(epBytesSinceSignal[epId]));
     }
 
     struct ibv_send_wr* badWr = nullptr;
@@ -972,6 +998,9 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
       } else if (needSignal) {
         int dummy = 0;
         eps[epId].ledger->ReleaseByCqe(recordId, nullptr, &dummy);
+        // ADDITIVE (MORI_ROCTX_TRANSFER=1): the signaled WR never posted, so no CQE
+        // will arrive — stop its async range here to avoid a leaked range.
+        mori::io::MoriRoctxTransferStop(eps[epId].ledger.get(), recordId);
       }
 
       if (postedCount > 0 && (!needSignal || !lastWasPosted)) {
@@ -1022,6 +1051,7 @@ RdmaOpRet RdmaBatchReadWrite(const EpPairVec& eps,
     if (needSignal) {
       epWrsSinceSignal[epId] = 0;
       epMergedSinceSignal[epId] = 0;
+      epBytesSinceSignal[epId] = 0;  // ADDITIVE
     }
     MORI_IO_TRACE("ibv_post_send ep index {} batch index range [{}, {})", epId, st, end);
   }

--- a/src/io/roctx_mori.hpp
+++ b/src/io/roctx_mori.hpp
@@ -1,0 +1,220 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+// MIT License (see repository LICENSE).
+// ============================================================================
+// ADDITIVE, env-gated roctx markers for the MORI-IO HOST RDMA send path.
+//
+// TWO independent, additive instrumentations (each its own env gate; default OFF):
+//
+//   (1) MORI_ROCTX=1  -> SYNCHRONOUS push/pop ranges around the host ibv_post_send
+//       loop (IOEngine[Session]::BatchWrite + RdmaBatchReadWrite). These measure
+//       only the HOST POST cost (building WRs + ringing the NIC doorbell). They
+//       are stack/same-thread ranges (MoriRoctxRange RAII) and CANNOT span the
+//       async post->completion window. Marker names: mori.io.engine_batch_write,
+//       mori.rdma.batch_post.{write,read}.
+//
+//   (2) MORI_ROCTX_TRANSFER=1  -> ASYNCHRONOUS post->CQ ranges that measure the
+//       REAL KV transfer/wire duration: started when a *signaled* WR is posted
+//       (RdmaBatchReadWrite, needSignal branch) and stopped when its completion
+//       is reaped on the CQ (NotifManager::ProcessOneCqe -> ledger->ReleaseByCqe).
+//       Uses the PROCESS-WIDE async roctx API roctxRangeStartA/roctxRangeStop
+//       (start on the posting thread, stop on the CQ-poll thread). Marker name:
+//       mori.rdma.kv_transfer (its own dedicated trace lane).
+//
+//       RDMA uses SELECTIVE SIGNALING: only the tail WR of each post batch sets
+//       IBV_SEND_SIGNALED and receives a SubmissionLedger recordId (== wr_id).
+//       Only that signaled WR produces a CQE, so we start exactly ONE async range
+//       per signaled WR (keyed by the ledger recordId) -> every started range has
+//       a matching stop (the CQE, or the not-posted cleanup path). recordId is
+//       per-EP-ledger (not globally unique), so the range map is keyed by the
+//       PAIR (SubmissionLedger*, recordId), which is globally unique and identical
+//       at the post site (eps[i].ledger) and the CQ site (ep.ledger) because both
+//       hold the same shared SubmissionLedger instance.
+//
+// CRITICAL: rocprofv3 (rocprofiler-sdk) --marker-trace only intercepts the
+// rocprofiler-sdk ROCTx library librocprofiler-sdk-roctx.so, NOT legacy
+// libroctx64.so. We dlopen the sdk lib at runtime (RTLD_GLOBAL) and resolve the
+// roctx symbols from it (no link-time dependency added to libmori_io.so).
+//
+// Fully gated + exception-safe: when neither gate is set the lib is never dlopen'd
+// and every call is a no-op (a single bool check).
+// ============================================================================
+#pragma once
+
+#include <dlfcn.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+namespace mori {
+namespace io {
+namespace roctx_detail {
+
+using roctx_range_push_t = int (*)(const char*);
+using roctx_range_pop_t = int (*)();
+using roctx_mark_t = void (*)(const char*);
+// Process-wide async range API (start on one thread, stop from any other).
+using roctx_range_id_t = std::uint64_t;
+using roctx_range_start_t = roctx_range_id_t (*)(const char*);
+using roctx_range_stop_t = void (*)(roctx_range_id_t);
+
+inline bool GateOn(const char* name) {
+  const char* g = std::getenv(name);
+  if (g == nullptr) return false;
+  const char c = g[0];
+  return (c == '1' || c == 't' || c == 'T' || c == 'y' || c == 'Y' || c == 'o' || c == 'O');
+}
+
+struct RoctxApi {
+  bool enabled = false;           // MORI_ROCTX: push/pop host-post anchors
+  bool transfer_enabled = false;  // MORI_ROCTX_TRANSFER: async post->cq ranges
+  roctx_range_push_t push = nullptr;
+  roctx_range_pop_t pop = nullptr;
+  roctx_mark_t mark = nullptr;
+  roctx_range_start_t range_start = nullptr;
+  roctx_range_stop_t range_stop = nullptr;
+
+  RoctxApi() {
+    const bool want_post = GateOn("MORI_ROCTX");
+    const bool want_transfer = GateOn("MORI_ROCTX_TRANSFER");
+    if (!want_post && !want_transfer) return;
+    // sdk-roctx ONLY (the lib rocprofv3 --marker-trace intercepts).
+    void* h = dlopen("librocprofiler-sdk-roctx.so", RTLD_NOW | RTLD_GLOBAL);
+    if (h == nullptr) h = dlopen("librocprofiler-sdk-roctx.so.1", RTLD_NOW | RTLD_GLOBAL);
+    if (h == nullptr) return;
+    push = reinterpret_cast<roctx_range_push_t>(dlsym(h, "roctxRangePushA"));
+    pop = reinterpret_cast<roctx_range_pop_t>(dlsym(h, "roctxRangePop"));
+    mark = reinterpret_cast<roctx_mark_t>(dlsym(h, "roctxMarkA"));
+    range_start = reinterpret_cast<roctx_range_start_t>(dlsym(h, "roctxRangeStartA"));
+    range_stop = reinterpret_cast<roctx_range_stop_t>(dlsym(h, "roctxRangeStop"));
+    enabled = want_post && (push != nullptr && pop != nullptr);
+    transfer_enabled = want_transfer && (range_start != nullptr && range_stop != nullptr);
+  }
+};
+
+inline RoctxApi& api() {
+  static RoctxApi a;  // gate read + dlopen happen exactly once per process
+  return a;
+}
+
+// (SubmissionLedger*, recordId) -> async roctx range id. recordId is unique only
+// within one ledger, so the ledger pointer disambiguates across endpoints.
+using TransferKey = std::pair<std::uintptr_t, std::uint64_t>;
+struct TransferKeyHash {
+  std::size_t operator()(const TransferKey& k) const {
+    std::size_t h1 = std::hash<std::uintptr_t>{}(k.first);
+    std::size_t h2 = std::hash<std::uint64_t>{}(k.second);
+    return h1 ^ (h2 + 0x9e3779b9 + (h1 << 6) + (h1 >> 2));
+  }
+};
+struct TransferRanges {
+  std::mutex mu;
+  std::unordered_map<TransferKey, roctx_range_id_t, TransferKeyHash> ranges;
+};
+inline TransferRanges& transfer_ranges() {
+  static TransferRanges t;
+  return t;
+}
+
+}  // namespace roctx_detail
+
+// RAII range: pushes on construction, pops on destruction (handles every return
+// path + exception). No-op when MORI_ROCTX is off. (HOST-POST anchor only.)
+class MoriRoctxRange {
+ public:
+  explicit MoriRoctxRange(const char* name) {
+    auto& a = roctx_detail::api();
+    if (a.enabled) {
+      a.push(name);
+      active_ = true;
+    }
+  }
+  MoriRoctxRange(const char* name, uint64_t id) {
+    auto& a = roctx_detail::api();
+    if (a.enabled) {
+      std::string s = std::string(name) + " id=" + std::to_string(id);
+      a.push(s.c_str());
+      active_ = true;
+    }
+  }
+  // ADDITIVE: host-post anchor variant carrying the whole-call payload size.
+  // Keeps id= LAST so end-anchored id= parsers stay valid: "<name> bytes=<N> id=<id>".
+  MoriRoctxRange(const char* name, uint64_t id, uint64_t bytes) {
+    auto& a = roctx_detail::api();
+    if (a.enabled) {
+      std::string s = std::string(name) + " bytes=" + std::to_string(bytes) +
+                      " id=" + std::to_string(id);
+      a.push(s.c_str());
+      active_ = true;
+    }
+  }
+  ~MoriRoctxRange() {
+    if (active_) {
+      auto& a = roctx_detail::api();
+      if (a.pop != nullptr) a.pop();
+    }
+  }
+  MoriRoctxRange(const MoriRoctxRange&) = delete;
+  MoriRoctxRange& operator=(const MoriRoctxRange&) = delete;
+
+ private:
+  bool active_ = false;
+};
+
+inline void MoriRoctxMark(const std::string& msg) {
+  auto& a = roctx_detail::api();
+  if (a.enabled && a.mark != nullptr) a.mark(msg.c_str());
+}
+
+// --- ASYNC post->cq KV-transfer ranges (MORI_ROCTX_TRANSFER) ------------------
+// Start an async range for a SIGNALED WR at post time. Keyed by (ledger,recordId).
+inline void MoriRoctxTransferStart(const void* ledger, std::uint64_t recordId,
+                                   std::uint64_t transferId, bool isRead,
+                                   std::uint64_t bytes = 0) {
+  auto& a = roctx_detail::api();
+  if (!a.transfer_enabled || a.range_start == nullptr || ledger == nullptr) return;
+  // bytes= placed BEFORE id= so the end-anchored id= parsers keep matching.
+  std::string s =
+      std::string(isRead ? "mori.rdma.kv_transfer.read" : "mori.rdma.kv_transfer") +
+      " bytes=" + std::to_string(bytes) + " id=" + std::to_string(transferId);
+  roctx_detail::roctx_range_id_t rid = a.range_start(s.c_str());
+  auto& t = roctx_detail::transfer_ranges();
+  std::lock_guard<std::mutex> lk(t.mu);
+  t.ranges[{reinterpret_cast<std::uintptr_t>(ledger), recordId}] = rid;
+}
+
+// Stop the async range for a completed/cleaned-up signaled WR. Idempotent: a
+// no-op if no range was started for this (ledger,recordId) (e.g. unsignaled WRs,
+// notification CQEs). The roctxRangeStop call is made OUTSIDE the map lock.
+inline void MoriRoctxTransferStop(const void* ledger, std::uint64_t recordId) {
+  auto& a = roctx_detail::api();
+  if (!a.transfer_enabled || a.range_stop == nullptr || ledger == nullptr) return;
+  roctx_detail::roctx_range_id_t rid = 0;
+  bool found = false;
+  {
+    auto& t = roctx_detail::transfer_ranges();
+    std::lock_guard<std::mutex> lk(t.mu);
+    auto it = t.ranges.find({reinterpret_cast<std::uintptr_t>(ledger), recordId});
+    if (it != t.ranges.end()) {
+      rid = it->second;
+      t.ranges.erase(it);
+      found = true;
+    }
+  }
+  if (found) a.range_stop(rid);
+}
+
+// Diagnostics: number of started-but-not-stopped transfer ranges (leak counter).
+inline std::size_t MoriRoctxTransferOutstanding() {
+  auto& a = roctx_detail::api();
+  if (!a.transfer_enabled) return 0;
+  auto& t = roctx_detail::transfer_ranges();
+  std::lock_guard<std::mutex> lk(t.mu);
+  return t.ranges.size();
+}
+
+}  // namespace io
+}  // namespace mori

--- a/src/io/roctx_mori.hpp
+++ b/src/io/roctx_mori.hpp
@@ -66,11 +66,12 @@
 #include <dlfcn.h>
 
 #include <cstdint>
-#include <cstdlib>
 #include <mutex>
 #include <string>
 #include <unordered_map>
 #include <utility>
+
+#include "mori/utils/env_utils.hpp"
 
 namespace mori {
 namespace io {
@@ -84,13 +85,6 @@ using roctx_range_id_t = std::uint64_t;
 using roctx_range_start_t = roctx_range_id_t (*)(const char*);
 using roctx_range_stop_t = void (*)(roctx_range_id_t);
 
-inline bool GateOn(const char* name) {
-  const char* g = std::getenv(name);
-  if (g == nullptr) return false;
-  const char c = g[0];
-  return (c == '1' || c == 't' || c == 'T' || c == 'y' || c == 'Y' || c == 'o' || c == 'O');
-}
-
 struct RoctxApi {
   bool enabled = false;           // MORI_ROCTX: push/pop host-post anchors
   bool transfer_enabled = false;  // MORI_ROCTX_TRANSFER: post-to-completion ranges
@@ -101,8 +95,8 @@ struct RoctxApi {
   roctx_range_stop_t range_stop = nullptr;
 
   RoctxApi() {
-    const bool want_post = GateOn("MORI_ROCTX");
-    const bool want_transfer = GateOn("MORI_ROCTX_TRANSFER");
+    const bool want_post = mori::env::IsEnvVarEnabled("MORI_ROCTX");
+    const bool want_transfer = mori::env::IsEnvVarEnabled("MORI_ROCTX_TRANSFER");
     if (!want_post && !want_transfer) return;
     // sdk-roctx ONLY (the lib rocprofv3 --marker-trace intercepts).
     void* h = dlopen("librocprofiler-sdk-roctx.so", RTLD_NOW | RTLD_GLOBAL);

--- a/src/io/roctx_mori.hpp
+++ b/src/io/roctx_mori.hpp
@@ -1,7 +1,26 @@
 // Copyright © Advanced Micro Devices, Inc. All rights reserved.
-// MIT License (see repository LICENSE).
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 // ============================================================================
-// ADDITIVE, env-gated roctx markers for the MORI-IO HOST RDMA send path.
+// ADDITIVE, env-gated roctx markers for the MORI-IO host RDMA I/O path.
 //
 // TWO independent, additive instrumentations (each its own env gate; default OFF):
 //
@@ -9,16 +28,20 @@
 //       loop (IOEngine[Session]::BatchWrite + RdmaBatchReadWrite). These measure
 //       only the HOST POST cost (building WRs + ringing the NIC doorbell). They
 //       are stack/same-thread ranges (MoriRoctxRange RAII) and CANNOT span the
-//       async post->completion window. Marker names: mori.io.engine_batch_write,
-//       mori.rdma.batch_post.{write,read}.
+//       asynchronous post-to-completion interval. Marker names:
+//       mori.io.engine_batch_write, mori.rdma.batch_post.{write,read}.
 //
-//   (2) MORI_ROCTX_TRANSFER=1  -> ASYNCHRONOUS post->CQ ranges that measure the
-//       REAL KV transfer/wire duration: started when a *signaled* WR is posted
-//       (RdmaBatchReadWrite, needSignal branch) and stopped when its completion
-//       is reaped on the CQ (NotifManager::ProcessOneCqe -> ledger->ReleaseByCqe).
+//   (2) MORI_ROCTX_TRANSFER=1  -> ASYNCHRONOUS post-to-completion ranges. A range
+//       starts immediately before ibv_post_send for a *signaled* WR
+//       (RdmaBatchReadWrite, needSignal branch) and stops after its completion is
+//       reaped and its ledger record is processed
+//       (NotifManager::ProcessOneCqe -> ledger->ReleaseByCqe). This is
+//       post-to-completion latency, not wire-only time: it includes submission and
+//       ibv_post_send, NIC/SQ queueing, transfer, CQ availability/polling, and
+//       software processing through marker stop.
 //       Uses the PROCESS-WIDE async roctx API roctxRangeStartA/roctxRangeStop
 //       (start on the posting thread, stop on the CQ-poll thread). Marker name:
-//       mori.rdma.kv_transfer (its own dedicated trace lane).
+//       mori.rdma.io_transfer (reads use mori.rdma.io_transfer.read).
 //
 //       RDMA uses SELECTIVE SIGNALING: only the tail WR of each post batch sets
 //       IBV_SEND_SIGNALED and receives a SubmissionLedger recordId (== wr_id).
@@ -70,7 +93,7 @@ inline bool GateOn(const char* name) {
 
 struct RoctxApi {
   bool enabled = false;           // MORI_ROCTX: push/pop host-post anchors
-  bool transfer_enabled = false;  // MORI_ROCTX_TRANSFER: async post->cq ranges
+  bool transfer_enabled = false;  // MORI_ROCTX_TRANSFER: post-to-completion ranges
   roctx_range_push_t push = nullptr;
   roctx_range_pop_t pop = nullptr;
   roctx_mark_t mark = nullptr;
@@ -121,6 +144,11 @@ inline TransferRanges& transfer_ranges() {
 
 }  // namespace roctx_detail
 
+// Cheap, once-initialized gates for hot-path callers. When both environment
+// gates are off, api() reads them once and does not attempt to load ROCTx.
+inline bool MoriRoctxPostEnabled() noexcept { return roctx_detail::api().enabled; }
+inline bool MoriRoctxTransferEnabled() noexcept { return roctx_detail::api().transfer_enabled; }
+
 // RAII range: pushes on construction, pops on destruction (handles every return
 // path + exception). No-op when MORI_ROCTX is off. (HOST-POST anchor only.)
 class MoriRoctxRange {
@@ -145,8 +173,8 @@ class MoriRoctxRange {
   MoriRoctxRange(const char* name, uint64_t id, uint64_t bytes) {
     auto& a = roctx_detail::api();
     if (a.enabled) {
-      std::string s = std::string(name) + " bytes=" + std::to_string(bytes) +
-                      " id=" + std::to_string(id);
+      std::string s =
+          std::string(name) + " bytes=" + std::to_string(bytes) + " id=" + std::to_string(id);
       a.push(s.c_str());
       active_ = true;
     }
@@ -169,17 +197,16 @@ inline void MoriRoctxMark(const std::string& msg) {
   if (a.enabled && a.mark != nullptr) a.mark(msg.c_str());
 }
 
-// --- ASYNC post->cq KV-transfer ranges (MORI_ROCTX_TRANSFER) ------------------
-// Start an async range for a SIGNALED WR at post time. Keyed by (ledger,recordId).
+// --- ASYNC I/O post-to-completion ranges (MORI_ROCTX_TRANSFER) ---------------
+// Start an async range for a SIGNALED WR immediately before ibv_post_send.
+// Keyed by (ledger,recordId).
 inline void MoriRoctxTransferStart(const void* ledger, std::uint64_t recordId,
-                                   std::uint64_t transferId, bool isRead,
-                                   std::uint64_t bytes = 0) {
+                                   std::uint64_t transferId, bool isRead, std::uint64_t bytes = 0) {
   auto& a = roctx_detail::api();
   if (!a.transfer_enabled || a.range_start == nullptr || ledger == nullptr) return;
   // bytes= placed BEFORE id= so the end-anchored id= parsers keep matching.
-  std::string s =
-      std::string(isRead ? "mori.rdma.kv_transfer.read" : "mori.rdma.kv_transfer") +
-      " bytes=" + std::to_string(bytes) + " id=" + std::to_string(transferId);
+  std::string s = std::string(isRead ? "mori.rdma.io_transfer.read" : "mori.rdma.io_transfer") +
+                  " bytes=" + std::to_string(bytes) + " id=" + std::to_string(transferId);
   roctx_detail::roctx_range_id_t rid = a.range_start(s.c_str());
   auto& t = roctx_detail::transfer_ranges();
   std::lock_guard<std::mutex> lk(t.mu);


### PR DESCRIPTION
## Summary

Adds optional ROCTX instrumentation to the MORI-IO RDMA host send path for profiling with `rocprofv3`/rocprofiler-sdk. This change is **purely additive** — no existing logic is modified, removed, or renamed. When disabled (the default), it has zero runtime cost and introduces no new dependencies.

## What's added

- `src/io/roctx_mori.hpp` (new) — all ROCTX helper infrastructure: env-var gating, lazy `dlopen`/`dlsym` of `librocprofiler-sdk-roctx.so`, and thread-safe range/keyed-event handling.
- `src/io/engine.cpp` — wraps `IOEngine[Session]::BatchWrite` with sync host-post ranges.
- `src/io/rdma/common.cpp` — wraps `RdmaBatchReadWrite`'s host WR-posting loop; starts async post→CQE transfer ranges for signaled WRs.
- `src/io/rdma/backend_impl.cpp` — stops async transfer ranges when the CQ poller reaps the corresponding completion.

## Env vars (both OFF by default)

| Env Var | Default | Purpose |
|---|---|---|
| `MORI_ROCTX` | off | Synchronous push/pop ranges around the host `ibv_post_send` path. Measures **host post cost only** (building WRs + ringing the NIC doorbell). |
| `MORI_ROCTX_TRANSFER` | off | Asynchronous post→CQE ranges measuring the **real wire/transfer duration** — started at WR post time, stopped when the completion is reaped on the CQ thread. |

## Behavior when disabled

- No `dlopen` of the ROCTX library occurs.
- All marker call sites are no-ops, guarded by the resolved gate flags checked once at process start.
- No rebuild required to toggle — purely a runtime switch via env vars.
- No risk of missing-`.so` errors when disabled, since the library is never loaded in that path.

## Behavior when enabled

- `MORI_ROCTX=1` and/or `MORI_ROCTX_TRANSFER=1` trigger a lazy `dlopen("librocprofiler-sdk-roctx.so")` (falls back to `.so.1`) and resolve ROCTX function pointers via `dlsym`.
- Markers are visible in `rocprofv3 --marker-trace` (or any ROCTX-consuming tool) alongside GPU/kernel traces.
- Async transfer ranges are keyed by `(ledger, recordId)` to correctly pair post and completion events across threads (posting thread vs. CQ poller thread).

## Testing

- Verified marker emission and pairing with `rocprofv3 --marker-trace` under both env vars individually and together.
