### PR TITLE
MORI-IO XGMI KV-Transfer Session Failure

### DIFF
--- a/include/mori/io/backend.hpp
+++ b/include/mori/io/backend.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 
 #include "mori/io/common.hpp"
 #include "mori/io/enum.hpp"
@@ -194,6 +195,11 @@ class Backend {
                                         TransferStatus* status) = 0;
 
   virtual bool CanHandle(const MemoryDesc& local, const MemoryDesc& remote) const { return true; }
+
+  // Why CanHandle() rejected this pair; empty when supported. Callers have no other error channel.
+  virtual std::string ExplainCannotHandle(const MemoryDesc& local, const MemoryDesc& remote) const {
+    return CanHandle(local, remote) ? std::string{} : std::string{"backend declined this pair"};
+  }
 };
 
 }  // namespace io

--- a/include/mori/io/engine.hpp
+++ b/include/mori/io/engine.hpp
@@ -108,6 +108,8 @@ class IOEngine {
   StatusCode WaitAll(const std::vector<TransferStatus*>& statuses, int timeoutMs = -1);
 
   std::optional<IOEngineSession> CreateSession(const MemoryDesc& local, const MemoryDesc& remote);
+  // Why CreateSession() could not build a session for this pair, empty when it can.
+  std::string ExplainSessionUnavailable(const MemoryDesc& local, const MemoryDesc& remote) const;
   void LoadScatterGatherModule(const std::string& hsacoPath);
   void LoadFabricCopyModule(const std::string& hsacoPath);
 
@@ -150,6 +152,8 @@ class IOEngine {
   };
 
   Backend* SelectBackend(const MemoryDesc& local, const MemoryDesc& remote);
+  // Install a backend and replay the registrations it missed by coming up late.
+  Backend* InsertBackend(BackendType type, std::unique_ptr<Backend> backend);
   bool SupportsXgmiBackendByP2P() const;
   void EnsureXgmiBackendCreatedIfSupported();
   void InvalidateRouteCache();
@@ -164,6 +168,8 @@ class IOEngine {
   std::atomic<uint32_t> nextTransferUid{0};
   std::atomic<uint32_t> nextMemUid{0};
   std::unordered_map<MemoryUniqueId, MemoryDesc> memPool;
+  // Remote engines registered so far, replayed into backends created later.
+  std::unordered_map<EngineKey, EngineDesc> remoteEngines;
   std::unordered_map<BackendType, std::unique_ptr<Backend>> backends;
   mutable std::shared_mutex routeCacheMu;
   std::unordered_map<RouteCacheKey, BackendType, RouteCacheKeyHash> routeCache;

--- a/python/mori/io/engine.py
+++ b/python/mori/io/engine.py
@@ -34,6 +34,10 @@ TORCH_DEVICE_TYPE_MAP = {
 }
 
 
+class SessionUnavailableError(RuntimeError):
+    """No backend could build a transfer session for a local/remote memory pair."""
+
+
 class IOEngineSession:
     def __init__(self, mori_sess):
         self._sess = mori_sess
@@ -223,7 +227,10 @@ class IOEngine:
     def create_session(self, local_mem, remote_mem):
         mori_sess = self._engine.CreateSession(local_mem, remote_mem)
         if mori_sess is None:
-            return None
+            # Returning None here pushed the failure to the first transfer call, surfacing as an unattributable AttributeError on NoneType.
+            raise SessionUnavailableError(
+                self._engine.ExplainSessionUnavailable(local_mem, remote_mem)
+            )
         return IOEngineSession(mori_sess)
 
     def pop_inbound_transfer_status(self, remote_key, transfer_uid):

--- a/src/io/engine.cpp
+++ b/src/io/engine.cpp
@@ -30,6 +30,7 @@
 #include <chrono>
 #include <cstdlib>
 #include <limits>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -213,9 +214,7 @@ void IOEngine::CreateBackend(BackendType type, const BackendConfig& beConfig) {
                    internal::kXgmiOnlyFallbackPlaceholderPort);
 
       XgmiBackendConfig xgmiConfig{};
-      auto backend = std::make_unique<XgmiBackend>(desc.key, config, xgmiConfig);
-      backends.insert({BackendType::XGMI, std::move(backend)});
-      InvalidateRouteCache();
+      InsertBackend(BackendType::XGMI, std::make_unique<XgmiBackend>(desc.key, config, xgmiConfig));
       return;
     }
 
@@ -246,23 +245,38 @@ void IOEngine::CreateBackend(BackendType type, const BackendConfig& beConfig) {
       }
     }
 
-    backends.insert({type, std::move(backend)});
-    InvalidateRouteCache();
+    InsertBackend(type, std::move(backend));
     EnsureXgmiBackendCreatedIfSupported();
   } else if (type == BackendType::XGMI) {
-    auto backend = std::make_unique<XgmiBackend>(desc.key, config,
-                                                 static_cast<const XgmiBackendConfig&>(beConfig));
-    backends.insert({type, std::move(backend)});
-    InvalidateRouteCache();
+    InsertBackend(type, std::make_unique<XgmiBackend>(
+                            desc.key, config, static_cast<const XgmiBackendConfig&>(beConfig)));
   } else if (type == BackendType::FABRIC) {
-    auto backend = std::make_unique<FabricBackend>(
-        desc.key, config, static_cast<const FabricBackendConfig&>(beConfig));
-    backends.insert({type, std::move(backend)});
-    InvalidateRouteCache();
+    InsertBackend(type, std::make_unique<FabricBackend>(
+                            desc.key, config, static_cast<const FabricBackendConfig&>(beConfig)));
   } else {
     assert(false && "not implemented");
   }
   MORI_IO_INFO("Create backend type {}", static_cast<uint32_t>(type));
+}
+
+Backend* IOEngine::InsertBackend(BackendType type, std::unique_ptr<Backend> backend) {
+  auto [it, inserted] = backends.insert({type, std::move(backend)});
+  Backend* raw = it->second.get();
+  InvalidateRouteCache();
+  if (!inserted) return raw;
+
+  // Replay registrations this late backend missed; without them it can route no prior pair.
+  for (const auto& [key, remoteDesc] : remoteEngines) {
+    raw->RegisterRemoteEngine(remoteDesc);
+  }
+  for (auto& [id, memDesc] : memPool) {
+    raw->RegisterMemory(memDesc);
+  }
+  if (!remoteEngines.empty() || !memPool.empty()) {
+    MORI_IO_INFO("Backend type {} replayed {} remote engine(s) and {} memory registration(s)",
+                 static_cast<uint32_t>(type), remoteEngines.size(), memPool.size());
+  }
+  return raw;
 }
 
 bool IOEngine::SupportsXgmiBackendByP2P() const {
@@ -325,9 +339,7 @@ void IOEngine::EnsureXgmiBackendCreatedIfSupported() {
 
   try {
     XgmiBackendConfig xgmiConfig{};
-    auto backend = std::make_unique<XgmiBackend>(desc.key, config, xgmiConfig);
-    backends.insert({BackendType::XGMI, std::move(backend)});
-    InvalidateRouteCache();
+    InsertBackend(BackendType::XGMI, std::make_unique<XgmiBackend>(desc.key, config, xgmiConfig));
     MORI_IO_INFO("Auto-created XGMI backend after RDMA initialization");
   } catch (const std::exception& e) {
     MORI_IO_WARN("Auto-create XGMI backend failed: {}", e.what());
@@ -342,6 +354,7 @@ void IOEngine::RemoveBackend(BackendType type) {
 }
 
 void IOEngine::RegisterRemoteEngine(const EngineDesc& remote) {
+  remoteEngines[remote.key] = remote;
   for (auto& it : backends) {
     it.second->RegisterRemoteEngine(remote);
   }
@@ -351,6 +364,7 @@ void IOEngine::RegisterRemoteEngine(const EngineDesc& remote) {
 }
 
 void IOEngine::DeregisterRemoteEngine(const EngineDesc& remote) {
+  remoteEngines.erase(remote.key);
   for (auto& it : backends) {
     it.second->DeregisterRemoteEngine(remote);
   }
@@ -371,6 +385,15 @@ MemoryDesc IOEngine::RegisterMemory(void* data, size_t size, int device, MemoryL
   memDesc.loc = loc;
   if (loc == MemoryLocationType::CPU && data != nullptr) {
     memDesc.numaNode = DetectNumaNode(data);
+  }
+
+  if (backends.empty()) {
+    // No backend yet: descriptor has no transport credentials and cannot be back-filled.
+    MORI_IO_WARN(
+        "Register memory id {} before any backend exists: the returned MemoryDesc has no "
+        "transport credentials and a peer given this descriptor cannot reach it. Call "
+        "CreateBackend() first, then register memory.",
+        memDesc.id);
   }
 
   for (auto& it : backends) {
@@ -558,14 +581,62 @@ std::optional<IOEngineSession> IOEngine::CreateSession(const MemoryDesc& local,
 
   Backend* backend = SelectBackend(local, remote);
   if (backend == nullptr) {
+    MORI_IO_ERROR("Create session failed, {}", ExplainSessionUnavailable(local, remote));
     return std::nullopt;
   }
   sess.backendSess.reset(backend->CreateSession(local, remote));
   if (sess.backendSess == nullptr) {
+    uint32_t backendType = 0;
+    for (const auto& [type, candidate] : backends) {
+      if (candidate.get() == backend) backendType = static_cast<uint32_t>(type);
+    }
+    MORI_IO_ERROR(
+        "Create session failed, backend type {} accepted local mem id {} (device {}) -> remote mem "
+        "id {} (device {}) on engine {} but could not set the session up; see the preceding "
+        "backend "
+        "warning for the failing step",
+        backendType, local.id, local.deviceId, remote.id, remote.deviceId, remote.engineKey);
     return std::nullopt;
   }
 
   return sess;
+}
+
+std::string IOEngine::ExplainSessionUnavailable(const MemoryDesc& local,
+                                                const MemoryDesc& remote) const {
+  std::ostringstream oss;
+  oss << "no backend can handle local mem id " << local.id << " (device " << local.deviceId
+      << ", bus " << (local.deviceBusId.empty() ? "unknown" : local.deviceBusId)
+      << ") -> remote mem id " << remote.id << " (device " << remote.deviceId << ", bus "
+      << (remote.deviceBusId.empty() ? "unknown" : remote.deviceBusId) << ") on engine "
+      << remote.engineKey << ". ";
+
+  if (backends.empty()) {
+    oss << "No backend has been created on engine " << desc.key << "; call CreateBackend() first.";
+    return oss.str();
+  }
+
+  std::ostringstream reasons;
+  bool anyDeclined = false;
+  bool first = true;
+  for (const auto& [type, backend] : backends) {
+    std::string reason = backend->ExplainCannotHandle(local, remote);
+    if (reason.empty()) continue;
+    anyDeclined = true;
+    if (!first) reasons << "; ";
+    first = false;
+    reasons << "backend type " << static_cast<uint32_t>(type) << ": " << reason;
+  }
+
+  if (!anyDeclined) {
+    // A backend accepted the pair; setup failed (e.g. XGMI hipIpcOpenMemHandle) and logs itself.
+    oss << "A backend accepted the pair but could not set the session up; see the preceding "
+           "backend warning for the failing step.";
+    return oss.str();
+  }
+
+  oss << "Backends declined it: " << reasons.str();
+  return oss.str();
 }
 
 void IOEngine::LoadScatterGatherModule(const std::string& hsacoPath) {

--- a/src/io/xgmi/backend_impl.cpp
+++ b/src/io/xgmi/backend_impl.cpp
@@ -1017,29 +1017,51 @@ bool XgmiBackend::PopInboundTransferStatus(EngineKey remote, TransferUniqueId id
 }
 
 bool XgmiBackend::CanHandle(const MemoryDesc& local, const MemoryDesc& remote) const {
+  return ExplainCannotHandle(local, remote).empty();
+}
+
+std::string XgmiBackend::ExplainCannotHandle(const MemoryDesc& local,
+                                             const MemoryDesc& remote) const {
   if (local.loc != MemoryLocationType::GPU || remote.loc != MemoryLocationType::GPU) {
-    return false;
+    return "XGMI moves GPU memory only (local loc " +
+           std::to_string(static_cast<uint32_t>(local.loc)) + ", remote loc " +
+           std::to_string(static_cast<uint32_t>(remote.loc)) + ")";
   }
 
   if (!IsSameNodeEngine(remote.engineKey)) {
-    return false;
+    std::lock_guard<std::mutex> lock(remoteEnginesMu);
+    if (remoteEngines.find(remote.engineKey) == remoteEngines.end()) {
+      return "remote engine " + remote.engineKey +
+             " is unknown to the XGMI backend; RegisterRemoteEngine() must run after the backend "
+             "is created";
+    }
+    return "remote engine " + remote.engineKey + " is on a different node (local node_id " +
+           (myNodeId.empty() ? "unset" : myNodeId) + ", hostname " + myHostname + ")";
   }
 
   if (remote.deviceBusId.empty()) {
-    return false;
+    return "remote mem id " + std::to_string(remote.id) +
+           " has no PCI bus id, so its GPU cannot be located on this node";
   }
 
   // Visible fast path: remote GPU is in this process's HIP_VISIBLE_DEVICES
   auto visibleRemote = LookupVisibleDevice(remote.deviceBusId);
   if (visibleRemote.has_value()) {
-    return IsP2PAccessible(local.deviceId, visibleRemote.value());
+    if (IsP2PAccessible(local.deviceId, visibleRemote.value())) return {};
+    return "no GPU P2P access between visible devices " + std::to_string(local.deviceId) + " and " +
+           std::to_string(visibleRemote.value());
   }
 
   // Hidden-device path: remote GPU is not visible but may be on the same XGMI hive
   if (IsIpcHandleEmpty(remote.ipcHandle)) {
-    return false;
+    return "remote mem id " + std::to_string(remote.id) + " on hidden GPU " + remote.deviceBusId +
+           " carries an empty IPC handle; the peer registered it before creating its XGMI backend";
   }
-  return IsTopologyEligible(local.deviceId, remote.deviceBusId);
+  if (!IsTopologyEligible(local.deviceId, remote.deviceBusId)) {
+    return "hidden GPU " + remote.deviceBusId + " is not on the same XGMI hive as visible device " +
+           std::to_string(local.deviceId);
+  }
+  return {};
 }
 
 }  // namespace io

--- a/src/io/xgmi/backend_impl.hpp
+++ b/src/io/xgmi/backend_impl.hpp
@@ -95,6 +95,7 @@ class XgmiBackend : public Backend {
   bool PopInboundTransferStatus(EngineKey remote, TransferUniqueId id,
                                 TransferStatus* status) override;
   bool CanHandle(const MemoryDesc& local, const MemoryDesc& remote) const override;
+  std::string ExplainCannotHandle(const MemoryDesc& local, const MemoryDesc& remote) const override;
 
   bool IsP2PAccessible(int srcDevice, int dstDevice) const;
   void LoadScatterGatherModule(const std::string& hsacoPath);

--- a/src/pybind/pybind_io.cpp
+++ b/src/pybind/pybind_io.cpp
@@ -214,6 +214,7 @@ void RegisterMoriIo(pybind11::module_& m) {
       .def("Write", &mori::io::IOEngine::Write, py::call_guard<py::gil_scoped_release>())
       .def("BatchWrite", &mori::io::IOEngine::BatchWrite, py::call_guard<py::gil_scoped_release>())
       .def("CreateSession", &mori::io::IOEngine::CreateSession)
+      .def("ExplainSessionUnavailable", &mori::io::IOEngine::ExplainSessionUnavailable)
       .def("PopInboundTransferStatus", &mori::io::IOEngine::PopInboundTransferStatus,
            py::call_guard<py::gil_scoped_release>())
       .def("WaitAll", &mori::io::IOEngine::WaitAll, py::arg("statuses"), py::arg("timeout_ms") = -1,

--- a/tests/python/io/benchmark.py
+++ b/tests/python/io/benchmark.py
@@ -920,12 +920,10 @@ class MoriIoBenchmark:
         else:
             target_mem_desc = self.recv_bytes(self.num_initiator_dev + self.role_rank)
             self.target_mem = MemoryDesc.unpack(target_mem_desc)
+            # create_session raises SessionUnavailableError naming the actual
+            # reason (e.g. peers not in the same vPOD, or remote memory not
+            # fabric-exportable).
             self.sess = self.engine.create_session(self.mem, self.target_mem)
-            if self.sess is None:
-                raise RuntimeError(
-                    "create_session returned None for fabric: peers likely not in the "
-                    "same vPOD, or remote memory is not fabric-exportable"
-                )
 
     def run_single_once(self, buffer_size, transfer_batch_size):
         assert buffer_size <= self.buffer_size

--- a/tests/python/io/test_engine.py
+++ b/tests/python/io/test_engine.py
@@ -33,6 +33,7 @@ from mori.io import (
     StatusCode,
     MemoryLocationType,
     RdmaBackendConfig,
+    SessionUnavailableError,
     XgmiBackendConfig,
     set_log_level,
 )
@@ -651,8 +652,12 @@ def test_no_backend():
     assert transfer_status.Failed()
     assert transfer_status.Code() == StatusCode.ERR_BAD_STATE
 
-    sess = initiator.create_session(initiator_mem, target_mem)
-    assert sess is None
+    # Session creation has no TransferStatus to report through, so it must raise
+    # and name the cause rather than hand back a bare None that only fails later
+    # on the first batch_read.
+    with pytest.raises(SessionUnavailableError) as excinfo:
+        initiator.create_session(initiator_mem, target_mem)
+    assert "No backend has been created" in str(excinfo.value)
 
 
 @pytest.fixture(scope="module")

--- a/tests/python/io/test_xgmi_split_visibility.py
+++ b/tests/python/io/test_xgmi_split_visibility.py
@@ -1,0 +1,284 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""XGMI sessions between processes whose HIP_VISIBLE_DEVICES sets are disjoint.
+
+Disaggregated serving runs prefill and decode as separate processes pinned to
+separate GPU ranges (e.g. HIP_VISIBLE_DEVICES=0,1,2,3 vs 4,5,6,7), so each side's
+GPUs are *hidden* from the other and XGMI must reach them through IPC handles
+plus KFD topology rather than a visible device index.
+
+These tests cover the two ways that used to end in a silent `None` from
+`create_session()`, which surfaced downstream as
+`AttributeError: 'NoneType' object has no attribute 'batch_read'`:
+
+  * the reader registers the remote engine before creating its XGMI backend --
+    registrations only reached backends that already existed, so the backend
+    never learned the remote engine and rejected every pair from it;
+  * the peer registers its memory before creating its XGMI backend -- its
+    MemoryDesc then carries no IPC handle, which the reader cannot repair, so
+    session creation must fail with a message that says exactly that.
+"""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from tests.python.utils import TorchDistContext, get_free_port
+
+pytestmark = pytest.mark.skipif(
+    torch.cuda.device_count() < 2, reason="requires at least 2 GPUs"
+)
+
+REGION_BYTES = 1 * 1024 * 1024
+
+READER, WRITER = 0, 1
+
+
+def _send_bytes(data: bytes, dst: int):
+    dist.send(torch.tensor([len(data)], dtype=torch.long), dst=dst)
+    dist.send(torch.ByteTensor(list(data)), dst=dst)
+
+
+def _recv_bytes(src: int) -> bytes:
+    n = torch.zeros(1, dtype=torch.long)
+    dist.recv(n, src=src)
+    buf = torch.zeros(int(n.item()), dtype=torch.uint8)
+    dist.recv(buf, src=src)
+    return bytes(buf.tolist())
+
+
+def _exchange(local_bytes: bytes, rank: int) -> bytes:
+    """Symmetric two-rank byte exchange."""
+    peer = 1 - rank
+    if rank == READER:
+        peer_bytes = _recv_bytes(src=peer)
+        _send_bytes(local_bytes, dst=peer)
+    else:
+        _send_bytes(local_bytes, dst=peer)
+        peer_bytes = _recv_bytes(src=peer)
+    return peer_bytes
+
+
+def _worker(rank, master_port, scenario, result_queue):
+    """rank 0 reads over XGMI from rank 1; each rank sees only its own GPU.
+
+    scenario:
+      "backend_first"    -- both sides create the backend before registering.
+      "late_backend"     -- the reader registers the remote engine first.
+      "peer_memory_first"-- the writer registers its memory first, so the reader
+                            must refuse the session and name the empty IPC handle.
+    """
+    try:
+        from mori.io import (
+            BackendType,
+            EngineDesc,
+            IOEngine,
+            IOEngineConfig,
+            MemoryDesc,
+            SessionUnavailableError,
+            XgmiBackendConfig,
+            set_log_level,
+        )
+
+        # The peer's GPU must not be visible here, so bail out loudly rather than silently testing the visible path.
+        visible = torch.cuda.device_count()
+        if visible != 1:
+            result_queue.put(
+                (
+                    "FAIL",
+                    f"rank {rank} sees {visible} GPUs, expected 1; "
+                    f"HIP_VISIBLE_DEVICES={os.environ.get('HIP_VISIBLE_DEVICES')!r} "
+                    "did not take effect",
+                )
+            )
+            return
+
+        with TorchDistContext(
+            rank=rank,
+            world_size=2,
+            master_addr="localhost",
+            master_port=str(master_port),
+            device_id=0,
+            backend="gloo",
+        ):
+            set_log_level("info")
+            device = torch.device("cuda", 0)
+
+            engine = IOEngine(
+                key=f"xgmi_split_vis_{rank}", config=IOEngineConfig(host="", port=0)
+            )
+
+            def create_backend():
+                engine.create_backend(BackendType.XGMI, XgmiBackendConfig())
+
+            pattern = ((torch.arange(REGION_BYTES, device=device) % 251) + 1).to(
+                torch.uint8
+            )
+            buf = torch.zeros(REGION_BYTES, dtype=torch.uint8, device=device)
+            if rank == WRITER:
+                buf.copy_(pattern)
+            torch.cuda.synchronize()
+
+            # The orderings under test differ only in when the backend comes up relative to the registrations it needs.
+            defer_backend = (scenario == "late_backend" and rank == READER) or (
+                scenario == "peer_memory_first" and rank == WRITER
+            )
+            if defer_backend:
+                if scenario == "peer_memory_first":
+                    mem = engine.register_torch_tensor(buf)
+                    create_backend()
+                    remote_engine_bytes = _exchange(
+                        engine.get_engine_desc().pack(), rank
+                    )
+                    engine.register_remote_engine(
+                        EngineDesc.unpack(remote_engine_bytes)
+                    )
+                else:
+                    remote_engine_bytes = _exchange(
+                        engine.get_engine_desc().pack(), rank
+                    )
+                    engine.register_remote_engine(
+                        EngineDesc.unpack(remote_engine_bytes)
+                    )
+                    create_backend()
+                    mem = engine.register_torch_tensor(buf)
+            else:
+                create_backend()
+                engine.register_remote_engine(
+                    EngineDesc.unpack(_exchange(engine.get_engine_desc().pack(), rank))
+                )
+                mem = engine.register_torch_tensor(buf)
+
+            remote_mem = MemoryDesc.unpack(_exchange(mem.pack(), rank))
+
+            ok, detail = True, ""
+            if rank == READER:
+                if scenario == "peer_memory_first":
+                    try:
+                        engine.create_session(mem, remote_mem)
+                        ok, detail = False, (
+                            "create_session succeeded even though the peer's "
+                            "MemoryDesc has no IPC handle"
+                        )
+                    except SessionUnavailableError as exc:
+                        message = str(exc)
+                        for expected in ("IPC handle", str(remote_mem.id)):
+                            if expected not in message:
+                                ok, detail = False, (
+                                    f"SessionUnavailableError message does not mention "
+                                    f"{expected!r}: {message}"
+                                )
+                else:
+                    sess = engine.create_session(mem, remote_mem)
+                    status = sess.batch_read(
+                        [0], [0], [REGION_BYTES], sess.allocate_transfer_uid()
+                    )
+                    status.Wait()
+                    if not status.Succeeded():
+                        ok, detail = False, f"batch_read failed: {status.Message()}"
+                    elif not torch.equal(buf.cpu(), pattern.cpu()):
+                        mismatched = int((buf != pattern).sum().item())
+                        ok, detail = False, (
+                            f"XGMI read across disjoint HIP_VISIBLE_DEVICES returned "
+                            f"{mismatched} wrong bytes"
+                        )
+
+            # Both ranks reach the barrier before reporting so a reader-side failure doesn't surface as a gloo teardown error on the writer.
+            dist.barrier()
+            result_queue.put(("PASS", "") if ok else ("FAIL", detail))
+    except Exception as e:
+        import traceback
+
+        result_queue.put(("FAIL", f"{e}\n{traceback.format_exc()}"))
+
+
+MASK_VARS = ("HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES")
+
+
+def _run(scenario):
+    master_port = get_free_port()
+    ctx = mp.get_context("spawn")
+    result_queue = ctx.Queue()
+
+    # A spawned child snapshots the environment at start() and initializes HIP on import, before _worker runs, so the mask must be set here per child, not inside the worker.
+    saved = {name: os.environ.get(name) for name in MASK_VARS}
+    procs = []
+    try:
+        for rank in (READER, WRITER):
+            os.environ["HIP_VISIBLE_DEVICES"] = str(rank)
+            os.environ.pop("ROCR_VISIBLE_DEVICES", None)
+            os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+            proc = ctx.Process(
+                target=_worker, args=(rank, master_port, scenario, result_queue)
+            )
+            proc.start()
+            procs.append(proc)
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+    results = [result_queue.get(timeout=180) for _ in procs]
+    for p in procs:
+        p.join(timeout=30)
+        if p.is_alive():
+            p.terminate()
+            p.join()
+            pytest.fail(f"worker {p.pid} timed out")
+
+    # Report every worker's message: a reader session refusal also fails the writer on a gloo barrier, whose message explains nothing on its own.
+    failures = [msg for status, msg in results if status != "PASS"]
+    assert not failures, "worker(s) failed:\n" + "\n".join(failures)
+    for p in procs:
+        assert p.exitcode == 0, f"worker exited with code {p.exitcode}"
+
+
+def test_xgmi_read_across_disjoint_visible_devices():
+    """XGMI read where the remote GPU is hidden from the reader's process."""
+    _run("backend_first")
+
+
+def test_xgmi_session_when_remote_engine_registered_before_backend():
+    """The reader registers the remote engine before creating its XGMI backend.
+
+    RegisterRemoteEngine only reached backends that existed at call time, so the
+    backend came up blind to the remote engine, CanHandle rejected every pair
+    from it, and create_session returned a bare None.
+    """
+    _run("late_backend")
+
+
+def test_create_session_names_reason_when_peer_memory_has_no_ipc_handle():
+    """Session creation must explain a peer descriptor it cannot use.
+
+    The peer registered its memory before creating its XGMI backend, so the
+    descriptor it sent carries no IPC handle. The reader cannot repair that, so
+    it must raise a message naming the cause instead of returning None and
+    failing later inside batch_read.
+    """
+    _run("peer_memory_first")


### PR DESCRIPTION
## Motivation
A bug was reported by Dell under the following environment.
- **Hardware**: Single node, 8x AMD MI300X GPUs, no RDMA NIC present (XGMI-interconnected, `rocm-smi --showtopo` confirms full XGMI mesh between all 8 GPUs).
- **Image**: `vllm/vllm-openai-rocm:nightly-dcfebf93f4eccf30f71872283331eee757915daf`
- **Model**: `Qwen/Qwen3-30B-A3B` (MoE, expert-parallel enabled)
- **Topology**: Disaggregated prefill/decode serving via vLLM's `MoRIIOConnector` (KV cache transfer library `mori`, version `amd_mori 1.0.0`, bundled in the image).
  - Proxy: routes client requests, handles push-based registration/discovery.
  - Prefill: GPUs 0-3, TP=4, `kv_role=kv_producer`.
  - Decode: GPUs 4-7, TP=4, `kv_role=kv_consumer`, `read_mode=true` (decode pulls KV blocks from prefill).
  - Transport backend: `xgmi` (no RDMA hardware available, so RDMA is not usable; XGMI fallback is intentional).

## Error Log
```
(Worker_TP2_EP2 pid=969) INFO [moriio_connector.py:1291] MoRIIO handshake: get metadata took: 0.0016591940002399497
(Worker_TP2_EP2 pid=969) INFO [moriio_connector.py:1357] MoRIIO handshake done for request chatcmpl-...
(Worker_TP2_EP2 pid=969) ERROR [multiproc_executor.py:1007] WorkerProc hit an exception.
(Worker_TP2_EP2 pid=969) ERROR [multiproc_executor.py:1007] Traceback (most recent call last):
  File ".../vllm/v1/executor/multiproc_executor.py", line 999, in worker_busy_loop
    output = func(*args, **kwargs)
  File ".../vllm/v1/worker/worker_base.py", line 351, in execute_model
    return self.worker.execute_model(scheduler_output)
  File ".../vllm/v1/worker/gpu_worker.py", line 1147, in execute_model
    output = self.model_runner.execute_model(...)
  File ".../vllm/v1/worker/gpu_model_runner.py", line 4389, in execute_model
    self.maybe_get_kv_connector_output(...)
  File ".../vllm/v1/worker/kv_connector_model_runner_mixin.py", line 95, in _get_kv_connector_output
    kv_connector.start_load_kv(get_forward_context())
  File ".../vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py", line 296, in start_load_kv
    self.connector_worker.start_load_kv(self._connector_metadata)
  File ".../vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py", line 1799, in start_load_kv
    self._read_blocks_for_req(*self._ready_requests.get_nowait())
  File ".../vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py", line 1818, in _read_blocks_for_req
    self._read_blocks(...)
  File ".../vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py", line 2012, in _read_blocks
    transfer_status = self.moriio_wrapper.read_remote_data(...)
  File ".../vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_engine.py", line 605, in read_remote_data
    transfer_status = session.batch_read(...)
AttributeError: 'NoneType' object has no attribute 'batch_read'

(EngineCore pid=673) ERROR [core.py:1332] RuntimeError: Worker failed with error
  ''NoneType' object has no attribute 'batch_read'', please check the stack trace above for the root cause
(APIServer pid=1) ERROR [async_llm.py:704] vllm.v1.engine.exceptions.EngineDeadError: EngineCore encountered an issue.
(APIServer pid=1) INFO: 127.0.0.1:xxxxx - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
```

## Problem

`IOEngine::RegisterRemoteEngine` and `IOEngine::RegisterMemory` only forward to the backends that exist at call time, and nothing back-fills a backend created later:

```c
void IOEngine::RegisterRemoteEngine(const EngineDesc& remote) {
  for (auto& it : backends) {          // whatever happens to exist right now
    it.second->RegisterRemoteEngine(remote);
  }
}
```

A backend installed after those calls is permanently blind to them: `XgmiBackend::CanHandle` rejects every pair whose `remote.engineKey` it never learned about, `SelectBackend` returns `nullptr`, and `CreateSession` yields `std::nullopt` forever.

This needs no misuse by the caller, because MORI creates XGMI backends late on its own — `EnsureXgmiBackendCreatedIfSupported` runs *after* RDMA init, and the XGMI-only fallback constructs one when no RDMA NIC is active. Registering peers before `CreateBackend`, the natural order when discovery precedes transport setup, yields an XGMI backend that can never route.

Neither `nullopt` branch of `CreateSession` logged anything, so the failure reached Python as a bare `None` and surfaced later on an unrelated line as `AttributeError: 'NoneType' object has no attribute 'batch_read'`. It is the one silent entry point; `Read`/`Write`/`BatchRead`/`BatchWrite` all go through `SELECT_BACKEND_AND_RETURN_IF_NONE`, which sets `ERR_BAD_STATE` and logs.

The XGMI hidden-device path itself is sound — I ran the split-visibility topology (disjoint `HIP_VISIBLE_DEVICES`, 1/8/48/128 KV-layer registrations, same- and cross-container) against `main` and it works. This is an ordering defect, not a capability gap.

## Fix

Install every backend through a new `IOEngine::InsertBackend`, which replays what was registered before it existed:

```c
Backend* IOEngine::InsertBackend(BackendType type, std::unique_ptr<Backend> backend) {
  auto [it, inserted] = backends.insert({type, std::move(backend)});
  Backend* raw = it->second.get();
  InvalidateRouteCache();
  if (!inserted) return raw;

  for (const auto& [key, remoteDesc] : remoteEngines) raw->RegisterRemoteEngine(remoteDesc);
  for (auto& [id, memDesc] : memPool) raw->RegisterMemory(memDesc);
  return raw;
}
```

`IOEngine` now tracks `remoteEngines` for this (memory was already in `memPool`). All four construction sites — RDMA, XGMI, FABRIC, XGMI-only fallback — route through it, so ordering stops mattering. Replay is idempotent and a no-op when nothing has been registered yet.

The rest makes the failures that remain explain themselves:

- **`Backend::ExplainCannotHandle(local, remote)`** — new virtual returning why a pair was declined, empty meaning accepted. Defaults to deriving from `CanHandle`, so other backends need no change.
- **`XgmiBackend`** implements it, and `CanHandle` becomes `ExplainCannotHandle(...).empty()` to keep one decision path. All seven rejection conditions now name themselves.
- **`IOEngine::CreateSession`** logs at `ERROR` on both `nullopt` branches via the new `ExplainSessionUnavailable`, which is also exported to Python.
- **Python `create_session`** raises `SessionUnavailableError` instead of returning `None`.
- **`RegisterMemory`** warns when no backend exists yet. That case is unrecoverable rather than merely late: backends supply the credentials a peer needs (IPC handle for XGMI, MR keys for RDMA), and a descriptor already returned to the caller cannot be back-filled.



## Test

`tests/python/io/test_xgmi_split_visibility.py` (new) runs two processes with disjoint `HIP_VISIBLE_DEVICES`, mirroring a disaggregated prefill/decode split, and adds three cases:

- `test_xgmi_read_across_disjoint_visible_devices` — an XGMI read completes across the split, guarding the hidden-device path.
- `test_xgmi_session_when_remote_engine_registered_before_backend` — the regression itself: a remote engine registered before the backend exists.
- `test_create_session_names_reason_when_peer_memory_has_no_ipc_handle` — the unrecoverable case raises and the message names its cause.

Verified on 8x MI300X. With the replay loop disabled the regression test fails; with the fix all three pass. The full `tests/python/io/` suite reports 71 failed, 91 passed, 3 skipped — the same 71 as the pre-change baseline on this node, which has no usable RDMA NIC (`ibv_create_qp` errno=22).

`test_engine.py::test_no_backend` asserted the old `None` contract and now asserts the raise; `benchmark.py` loses a dead `None` check.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
