### PR TITLE
feat(EPv2): enable fp4 dispatch feature in EPv2

### DIFF
--- a/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
+++ b/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
@@ -190,9 +190,14 @@ class EpDispatchCombineConfig:
                     "combine_data_type (asymmetric dtype) requires combine_mode=gather, "
                     "quant_type=none, enable_std_moe=False"
                 )
-            if torch.float4_e2m1fn_x2 in (self.dispatch_dtype, self.combine_dtype):
+            # fp4 DISPATCH + bf16 COMBINE (the SGLang/aiter fp4-asym path) is
+            # supported: dispatch is a plain byte-mover (hidden/2 B) with e8m0
+            # scales forwarded, combine stays bf16. fp4 on the combine side is
+            # not implemented for the asymmetric path.
+            if self.combine_dtype == torch.float4_e2m1fn_x2:
                 raise ValueError(
-                    "asymmetric dispatch/combine dtype does not support fp4"
+                    "asymmetric combine dtype does not support fp4 (fp4 dispatch "
+                    "+ bf16 combine is supported; fp4 combine is not)"
                 )
             if self.combine_token_nbytes % 16 != 0:
                 raise ValueError(
@@ -351,6 +356,11 @@ class EpDispatchCombineConfig:
     def dtype_str(self):
         """Token/dispatch dtype key for tuning_configs.lookup (fp4/fp8/default)."""
         if self.is_fp4:
+            # fp4 dispatch + non-fp4 combine (asymmetric) moves 2 B/elem on the
+            # combine side, so it needs the bf16 combine geometry, not the
+            # fp4-combine one -> its own "fp4_asym" tuning key.
+            if self.combine_dtype != torch.float4_e2m1fn_x2:
+                return "fp4_asym"
             return "fp4"
         if self.is_fp8:
             return "fp8"

--- a/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
+++ b/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
@@ -358,9 +358,9 @@ class EpDispatchCombineConfig:
         if self.is_fp4:
             # fp4 dispatch + non-fp4 combine (asymmetric) moves 2 B/elem on the
             # combine side, so it needs the bf16 combine geometry, not the
-            # fp4-combine one -> its own "fp4_asym" tuning key.
+            # fp4-combine one -> its own "fp4_disp_bf16_comb" tuning key.
             if self.combine_dtype != torch.float4_e2m1fn_x2:
-                return "fp4_asym"
+                return "fp4_disp_bf16_comb"
             return "fp4"
         if self.is_fp8:
             return "fp8"

--- a/python/mori/ops/dispatch_combine_v2/tuning_configs.py
+++ b/python/mori/ops/dispatch_combine_v2/tuning_configs.py
@@ -120,6 +120,39 @@ _MI355X_SCHED_FP4 = (
     (2048, 144, 4, 64, 16),
     (None, 128, 8, 64, 16),
 )
+# fp4 dispatch + bf16 combine (ASYMMETRIC, the SGLang/aiter path): dispatch
+# geometry from the fp4 sweep, combine geometry from bf16 -- combine moves 2 B/elem
+# here, not 0.5, so the fp4-combine geometry above does not apply. Thresholds are
+# the union of both schedules' buckets. Mirrors what _MI355X_SCHED_FP8 already does.
+_MI355X_SCHED_FP4_ASYM = (
+    # MEASURED 2026-08-03: 2-pass block x warp sweep, EP8 gfx950, fp4 dispatch +
+    # bf16 combine, hidden=7168 topk=6 (DSv4-Pro, 384 experts). Large buckets want
+    # dispatch warp=4 (not 8: 8192 551->481us, 4096 300->271us); small buckets need
+    # their own combine geometry (256: 197->114us, 128: 172->139us).
+    (128, 128, 4, 128, 16),
+    (256, 160, 4, 32, 8),
+    (2048, 144, 8, 32, 16),
+    (None, 128, 4, 48, 16),
+)
+# fp4 dispatch + bf16 combine, RE-TUNED 2026-08-04 specifically for topk=6
+# (DSv4-Pro, hidden=7168, 384 experts, EP8 gfx950). 2-pass block x warp sweep
+# (public op.dispatch/op.combine API, fp4-asym), 2x-unroll production kernel.
+# Supersedes the shared _MI355X_SCHED_FP4_ASYM for topk=6. Key fixes vs that table:
+#   ct=2048 dispatch 144x8 was the WORST geometry in-bucket (138 GB/s); 96x8 -> 205
+#           GB/s (+47%). ct=4096 dispatch 128x4 224 -> 96x8 265 GB/s (+18%): the
+#           large buckets want block 96 / warp 8, not block 128-144.
+#   ct=256  combine 32x8 was near-worst (240us); 48x8 -> 138us (-42%).
+#   combine 32x16 is peak at every large bucket (2048: 354, 4096: 360 GB/s).
+# Small buckets (<=128) are launch/barrier-overhead-bound (~135-140us, GB/s
+# meaningless) so their geometry is within measurement noise. Large buckets share
+# one plan (96,8,32,16) -> collapsed into the None bucket. Verified end-to-end on
+# DSv4-Pro 8k/1k c256: 32.8k tok/s (== baseline, tune is e2e-neutral since
+# dispatch/combine are BW-bound and a small fraction of the decode/prefill step).
+_MI355X_SCHED_FP4_ASYM_T6 = (
+    (128, 96, 4, 160, 16),
+    (256, 160, 4, 48, 8),
+    (None, 96, 8, 32, 16),
+)
 _MI355X_DEFAULT = dict(
     dispatch_block_num=128,
     combine_block_num=48,
@@ -132,11 +165,13 @@ _MI355X_TABLE = {
         "bf16": _MI355X_SCHED_BF16,
         "fp8": _MI355X_SCHED_FP8,
         "fp4": _MI355X_SCHED_FP4,
+        "fp4_asym": _MI355X_SCHED_FP4_ASYM,
     },
     (8, 7168, 6): {
         "bf16": _MI355X_SCHED_BF16,
         "fp8": _MI355X_SCHED_FP8,
         "fp4": _MI355X_SCHED_FP4,
+        "fp4_asym": _MI355X_SCHED_FP4_ASYM_T6,
     },
 }
 

--- a/python/mori/ops/dispatch_combine_v2/tuning_configs.py
+++ b/python/mori/ops/dispatch_combine_v2/tuning_configs.py
@@ -124,7 +124,7 @@ _MI355X_SCHED_FP4 = (
 # geometry from the fp4 sweep, combine geometry from bf16 -- combine moves 2 B/elem
 # here, not 0.5, so the fp4-combine geometry above does not apply. Thresholds are
 # the union of both schedules' buckets. Mirrors what _MI355X_SCHED_FP8 already does.
-_MI355X_SCHED_FP4_ASYM = (
+_MI355X_SCHED_FP4_DISP_BF16_COMB = (
     # MEASURED 2026-08-03: 2-pass block x warp sweep, EP8 gfx950, fp4 dispatch +
     # bf16 combine, hidden=7168 topk=6 (DSv4-Pro, 384 experts). Large buckets want
     # dispatch warp=4 (not 8: 8192 551->481us, 4096 300->271us); small buckets need
@@ -137,7 +137,7 @@ _MI355X_SCHED_FP4_ASYM = (
 # fp4 dispatch + bf16 combine, RE-TUNED 2026-08-04 specifically for topk=6
 # (DSv4-Pro, hidden=7168, 384 experts, EP8 gfx950). 2-pass block x warp sweep
 # (public op.dispatch/op.combine API, fp4-asym), 2x-unroll production kernel.
-# Supersedes the shared _MI355X_SCHED_FP4_ASYM for topk=6. Key fixes vs that table:
+# Supersedes the shared _MI355X_SCHED_FP4_DISP_BF16_COMB for topk=6. Key fixes vs that table:
 #   ct=2048 dispatch 144x8 was the WORST geometry in-bucket (138 GB/s); 96x8 -> 205
 #           GB/s (+47%). ct=4096 dispatch 128x4 224 -> 96x8 265 GB/s (+18%): the
 #           large buckets want block 96 / warp 8, not block 128-144.
@@ -148,7 +148,7 @@ _MI355X_SCHED_FP4_ASYM = (
 # one plan (96,8,32,16) -> collapsed into the None bucket. Verified end-to-end on
 # DSv4-Pro 8k/1k c256: 32.8k tok/s (== baseline, tune is e2e-neutral since
 # dispatch/combine are BW-bound and a small fraction of the decode/prefill step).
-_MI355X_SCHED_FP4_ASYM_T6 = (
+_MI355X_SCHED_FP4_DISP_BF16_COMB_T6 = (
     (128, 96, 4, 160, 16),
     (256, 160, 4, 48, 8),
     (None, 96, 8, 32, 16),
@@ -165,13 +165,13 @@ _MI355X_TABLE = {
         "bf16": _MI355X_SCHED_BF16,
         "fp8": _MI355X_SCHED_FP8,
         "fp4": _MI355X_SCHED_FP4,
-        "fp4_asym": _MI355X_SCHED_FP4_ASYM,
+        "fp4_disp_bf16_comb": _MI355X_SCHED_FP4_DISP_BF16_COMB,
     },
     (8, 7168, 6): {
         "bf16": _MI355X_SCHED_BF16,
         "fp8": _MI355X_SCHED_FP8,
         "fp4": _MI355X_SCHED_FP4,
-        "fp4_asym": _MI355X_SCHED_FP4_ASYM_T6,
+        "fp4_disp_bf16_comb": _MI355X_SCHED_FP4_DISP_BF16_COMB_T6,
     },
 }
 


### PR DESCRIPTION
  ## Summary

* **fp4 dispatch + bf16 combine (`fp4_disp_bf16_comb`)** — unblock the EPv2 fp4
     path and give it its own tuning key, plus measured MI355X schedules.
