### PR TITLE
MORI-IO: CPU hot-path improvements (profile-guided)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,10 +220,23 @@ add_subdirectory(3rdparty/spdlog)
 # MORI's .so files.
 set_target_properties(spdlog PROPERTIES CXX_VISIBILITY_PRESET hidden
                                         VISIBILITY_INLINES_HIDDEN ON)
+# Silence the deprecated `operator"" _a` warning from the bundled fmt while
+# compiling spdlog's own sources (see mori_logging below for consumers).
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag("-Wno-deprecated-literal-operator"
+                        HAVE_WNO_DEPRECATED_LITERAL_OPERATOR)
+if(HAVE_WNO_DEPRECATED_LITERAL_OPERATOR)
+  target_compile_options(spdlog PRIVATE -Wno-deprecated-literal-operator)
+endif()
 
 add_library(mori_logging INTERFACE)
 target_include_directories(mori_logging INTERFACE include)
 target_link_libraries(mori_logging INTERFACE spdlog::spdlog)
+
+if(HAVE_WNO_DEPRECATED_LITERAL_OPERATOR)
+  target_compile_options(mori_logging
+                         INTERFACE -Wno-deprecated-literal-operator)
+endif()
 
 if(ENABLE_PROFILER)
   find_package(

--- a/include/mori/core/utils/utils.hpp
+++ b/include/mori/core/utils/utils.hpp
@@ -29,13 +29,14 @@
 // host (non-hipcc) parse working for the __device__/__host__-tagged helpers.
 #if defined(__HIPCC__) || defined(__CUDACC__)
 #include <hip/hip_runtime.h>
-#endif
-
+// `warpSize` is only used by the __device__ helpers below. Define it as a macro
+// solely under device compilation.
 #ifndef warpSize
 #if defined(__GFX8__) || defined(__GFX9__)
 #define warpSize 64
 #else
 #define warpSize 32
+#endif
 #endif
 #endif
 
@@ -46,6 +47,14 @@
 #define MORI_PRINTF(...) printf(__VA_ARGS__)
 #else
 #define MORI_PRINTF(...) ((void)0)
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#define MORI_LIKELY(expr) __builtin_expect(!!(expr), 1)
+#define MORI_UNLIKELY(expr) __builtin_expect(!!(expr), 0)
+#else
+#define MORI_LIKELY(expr) (!!(expr))
+#define MORI_UNLIKELY(expr) (!!(expr))
 #endif
 
 namespace mori {

--- a/include/mori/utils/mori_log.hpp
+++ b/include/mori/utils/mori_log.hpp
@@ -24,13 +24,16 @@
 #include <algorithm>
 #include <cctype>
 #include <chrono>
+#include <cstdio>
 #include <cstdlib>
 #include <memory>
+#include <mutex>
 #include <mutex>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 
+#include "mori/core/utils/utils.hpp"
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include "spdlog/spdlog.h"
@@ -54,12 +57,26 @@ class ModuleLogger {
       globalLevel_ = LevelFromString(std::string(globalEnvLevel));
       globalLevelSet_ = true;
     }
+    // Eagerly create every known module logger while we are still single
+    // threaded: the Meyers singleton guarantees this ctor runs exactly once and
+    // blocks other threads until it returns, so loggers_ is fully populated
+    // before any GetLogger() call can touch the map.
+    for (const char* moduleName : kKnownModules) {
+      InitModuleLocked(moduleName);
+    }
   }
 
  public:
-  // Initialize a module-specific logger
+  // Initialize a module-specific logger.
   void InitModule(const std::string& moduleName, Level level = Level::ERROR) {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
+    InitModuleLocked(moduleName, level);
+  }
+
+ private:
+  // Body of InitModule; callers must hold mutex_ (or be the constructor, which
+  // runs before the instance is observable).
+  void InitModuleLocked(const std::string& moduleName, Level level = Level::ERROR) {
     // Check if logger already exists
     auto existing_logger = spdlog::get(moduleName);
     std::shared_ptr<spdlog::logger> logger;
@@ -95,7 +112,6 @@ class ModuleLogger {
       std::transform(envVar.begin(), envVar.end(), envVar.begin(), ::toupper);
     }
     const char* envLevel = std::getenv(envVar.c_str());
-
     if (envLevel) {
       finalLevel = LevelFromString(std::string(envLevel));
       envOverrides_[moduleName] = finalLevel;
@@ -103,54 +119,47 @@ class ModuleLogger {
       // Use global setting if no env var and global level is set
       finalLevel = globalLevel_;
     }
-
     logger->set_level(ConvertLevel(finalLevel));
     loggers_[moduleName] = logger;
   }
 
-  // Get logger for a specific module
+ public:
+  // Get logger for a specific module. Never returns null: unknown modules are
+  // created on demand, and if creation ever fails we log a fatal message and
+  // abort(), rather than returning null and letting callers silently drop logs.
   std::shared_ptr<spdlog::logger> GetLogger(const std::string& moduleName) {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
-    auto it = loggers_.find(moduleName);
-    if (it != loggers_.end()) {
-      return it->second;
-    }
-    // If not found, create with default settings
-    InitModule(moduleName);
-    return loggers_[moduleName];
+    std::lock_guard<std::mutex> lock(mutex_);
+    return GetLoggerLocked(moduleName);
   }
 
   // Set log level for a specific module
   void SetModuleLevel(const std::string& moduleName, Level level) {
-    std::shared_ptr<spdlog::logger> appLogger;
-    {
-      std::lock_guard<std::recursive_mutex> lock(mutex_);
-      // Check if this module is protected by environment variable
-      if (HasEnvOverride(moduleName)) {
-        appLogger = GetLogger("application");  // Use application logger for warnings
-      } else {
-        auto logger = GetLogger(moduleName);
-        logger->set_level(ConvertLevel(level));
-        return;
-      }
+    std::lock_guard<std::mutex> lock(mutex_);
+    // Check if this module is protected by environment variable
+    if (HasEnvOverrideLocked(moduleName)) {
+      // Log a warning but don't change the level
+      auto logger = GetLoggerLocked("application");  // Use application logger for warnings
+      logger->warn(
+          "Attempted to change log level for module '{}' which is controlled by environment "
+          "variable. Use ForceSetModuleLevel() to override.",
+          moduleName);
+      return;
     }
-    // Warn outside the lock: this is I/O, not map access.
-    appLogger->warn(
-        "Attempted to change log level for module '{}' which is controlled by environment "
-        "variable. Use ForceSetModuleLevel() to override.",
-        moduleName);
+
+    auto logger = GetLoggerLocked(moduleName);
+    logger->set_level(ConvertLevel(level));
   }
 
   // Set log level for all modules (global control)
   void SetGlobalLevel(Level level) {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     globalLevel_ = level;
     globalLevelSet_ = true;
 
     // Apply to all existing loggers
     for (auto& [name, logger] : loggers_) {
       // Skip modules controlled by environment variables
-      if (!HasEnvOverride(name)) {
+      if (!HasEnvOverrideLocked(name)) {
         logger->set_level(ConvertLevel(level));
       }
     }
@@ -158,8 +167,8 @@ class ModuleLogger {
 
   // Set log level with priority check (used internally for env vars)
   void SetModuleLevelInternal(const std::string& moduleName, Level level, bool fromEnv = false) {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
-    auto logger = GetLogger(moduleName);
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto logger = GetLoggerLocked(moduleName);
     logger->set_level(ConvertLevel(level));
     if (fromEnv) {
       envOverrides_[moduleName] = level;
@@ -168,38 +177,38 @@ class ModuleLogger {
 
   // Check if a module has environment override
   bool HasEnvOverride(const std::string& moduleName) const {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
-    return envOverrides_.find(moduleName) != envOverrides_.end();
+    std::lock_guard<std::mutex> lock(mutex_);
+    return HasEnvOverrideLocked(moduleName);
   }
 
   // Clear environment overrides for a module
   void ClearEnvOverride(const std::string& moduleName) {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     envOverrides_.erase(moduleName);
   }
 
   // Force set log level (ignores env protection)
   void ForceSetModuleLevel(const std::string& moduleName, Level level) {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
-    auto logger = GetLogger(moduleName);
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto logger = GetLoggerLocked(moduleName);
     logger->set_level(ConvertLevel(level));
   }
 
   // Get current global level
   Level GetGlobalLevel() const {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     return globalLevel_;
   }
 
   // Check if global level is set
   bool IsGlobalLevelSet() const {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     return globalLevelSet_;
   }
 
   // Clear global level setting (revert to individual module control)
   void ClearGlobalLevel() {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     globalLevelSet_ = false;
   }
 
@@ -221,18 +230,43 @@ class ModuleLogger {
   // rehash mid-iteration.
   template <typename F>
   void ForEachLogger(F&& fn) {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     for (auto& [name, lg] : loggers_) fn(name, lg);
   }
 
  private:
+  // Body of GetLogger; callers must hold mutex_. Never returns null.
+  std::shared_ptr<spdlog::logger> GetLoggerLocked(const std::string& moduleName) {
+    for (int i = 0; i < 2; i++) {
+      auto it = loggers_.find(moduleName);
+      if (it != loggers_.end() && it->second) {
+        return it->second;
+      }
+      InitModuleLocked(moduleName);  // Create on demand
+    }
+    // The logging system is fundamentally broken, so we abort loudly.
+    std::fprintf(stderr,
+                 "FATAL: ModuleLogger failed to resolve or create a logger for module '%s' "
+                 "after retrying; aborting.\n",
+                 moduleName.c_str());
+    std::abort();
+  }
+
+  // Body of HasEnvOverride; callers must hold mutex_.
+  bool HasEnvOverrideLocked(const std::string& moduleName) const {
+    return envOverrides_.find(moduleName) != envOverrides_.end();
+  }
+
+  // Known modules created eagerly by the constructor. Kept in sync with the
+  // mori::modules namespace below (this class is defined before it).
+  static constexpr const char* kKnownModules[] = {"application", "io",   "shmem",  "core",
+                                                  "ops",         "umbp", "metrics"};
+
+  mutable std::mutex mutex_;
   std::unordered_map<std::string, std::shared_ptr<spdlog::logger>> loggers_;
   std::unordered_map<std::string, Level> envOverrides_;  // Track env variable overrides
   Level globalLevel_ = Level::ERROR;
   bool globalLevelSet_ = false;
-  // Guards loggers_, envOverrides_, globalLevel_, globalLevelSet_. Recursive
-  // since methods call each other while holding it (e.g. GetLogger -> InitModule).
-  mutable std::recursive_mutex mutex_;
 
   spdlog::level::level_enum ConvertLevel(Level level) {
     switch (level) {
@@ -267,8 +301,22 @@ constexpr const char* METRICS = "metrics";
 // Macro helpers
 #define MORI_GET_LOGGER(module) mori::ModuleLogger::GetInstance().GetLogger(module)
 
-// General MORI logging macros
-#define MORI_LOG(module, level, ...) MORI_GET_LOGGER(module)->level(__VA_ARGS__)
+// General MORI logging macros.
+//
+// Hot-path note: MORI_GET_LOGGER() resolves the logger by a string-hashed
+// unordered_map lookup. Doing that on every call — even when the level is
+// disabled and spdlog drops the message — shows up on hot paths (e.g. a
+// per-batch MORI_IO_TRACE). We cache the resolved logger pointer in a
+// function-local static so the map lookup happens once per call-site, ever.
+// spdlog's own logger->level(...) already checks the level and skips
+// formatting when disabled, and it reads the level on each call, so runtime
+// level changes are still honored.
+#define MORI_LOG(module, level, ...)                                 \
+  do {                                                               \
+    static ::spdlog::logger* _mori_log_logger =                      \
+        ::mori::ModuleLogger::GetInstance().GetLogger(module).get(); \
+    _mori_log_logger->level(__VA_ARGS__);                            \
+  } while (0)
 
 #define MORI_TRACE(module, ...) MORI_LOG(module, trace, __VA_ARGS__)
 #define MORI_DEBUG(module, ...) MORI_LOG(module, debug, __VA_ARGS__)
@@ -327,19 +375,55 @@ constexpr const char* METRICS = "metrics";
 #define MORI_METRICS_ERROR(...) MORI_ERROR(mori::modules::METRICS, __VA_ARGS__)
 #define MORI_METRICS_CRITICAL(...) MORI_CRITICAL(mori::modules::METRICS, __VA_ARGS__)
 
-// Scoped Timer class
+// Scoped Timer class.
+//
+// Hot-path note: the timer only logs at DEBUG level, so on any normal run
+// (INFO/WARN/ERROR) it must be a true no-op. We resolve the logger once and
+// check the level in the constructor; when disabled we skip the string copy,
+// both clock reads, the per-call GetLogger() hashtable lookup, and the log
+// call entirely. The macros cache the (module -> logger) lookup in a
+// function-local static so the hashtable probe happens once per call-site.
 class ScopedTimer {
  public:
   using Clock = std::chrono::steady_clock;
 
+  // Fast path used by the MORI_TIMER / MORI_FUNCTION_TIMER macros: the logger
+  // is pre-resolved and cached by the call-site, so nothing is allocated or
+  // sampled unless DEBUG logging is actually enabled for this module.
+  ScopedTimer(const char* name, spdlog::logger* logger)
+      : logger_(logger),
+        enabled_(logger != nullptr && logger->should_log(spdlog::level::debug)),
+        cname_(name) {
+    if (MORI_UNLIKELY(enabled_)) start_ = Clock::now();
+  }
+
+  ScopedTimer(const std::string& name, spdlog::logger* logger)
+      : logger_(logger), enabled_(logger != nullptr && logger->should_log(spdlog::level::debug)) {
+    if (MORI_UNLIKELY(enabled_)) {
+      name_ = name;
+      start_ = Clock::now();
+    }
+  }
+
+  // Legacy path: resolves the logger by module name. Still early-outs when the
+  // level is disabled so it never copies strings or reads the clock needlessly.
   explicit ScopedTimer(const std::string& name,
                        const std::string& module = mori::modules::APPLICATION)
-      : name_(name), module_(module), start_(Clock::now()) {}
+      : logger_(ModuleLogger::GetInstance().GetLogger(module).get()),
+        enabled_(logger_ != nullptr && logger_->should_log(spdlog::level::debug)) {
+    if (MORI_UNLIKELY(enabled_)) {
+      name_ = name;
+      start_ = Clock::now();
+    }
+  }
 
   ~ScopedTimer() {
-    auto end = Clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start_).count();
-    MORI_DEBUG(module_, "ScopedTimer [{}] took {} ns", name_, duration);
+    if (MORI_UNLIKELY(enabled_)) {
+      auto end = Clock::now();
+      auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start_).count();
+      logger_->debug("ScopedTimer [{}] took {} ns", cname_ != nullptr ? cname_ : name_.c_str(),
+                     duration);
+    }
   }
 
   double ElapsedSeconds() const {
@@ -350,13 +434,24 @@ class ScopedTimer {
   ScopedTimer& operator=(const ScopedTimer&) = delete;
 
  private:
+  spdlog::logger* logger_ = nullptr;
+  bool enabled_ = false;
+  const char* cname_ = nullptr;
   std::string name_;
-  std::string module_;
-  Clock::time_point start_;
+  Clock::time_point start_{};
 };
 
-#define MORI_TIMER(name, module) ScopedTimer timer_instance(name, module)
-#define MORI_FUNCTION_TIMER(module) ScopedTimer timer_instance(__PRETTY_FUNCTION__, module)
+// Cache the (module -> logger) resolution in a function-local static so the
+// unordered_map<string, logger> lookup runs once per call-site instead of on
+// every invocation of the timed function.
+#define MORI_TIMER(name, module)                                    \
+  static const std::shared_ptr<spdlog::logger> _mori_timer_logger = \
+      ::mori::ModuleLogger::GetInstance().GetLogger(module);        \
+  ::mori::ScopedTimer timer_instance(name, _mori_timer_logger.get())
+#define MORI_FUNCTION_TIMER(module)                                 \
+  static const std::shared_ptr<spdlog::logger> _mori_timer_logger = \
+      ::mori::ModuleLogger::GetInstance().GetLogger(module);        \
+  ::mori::ScopedTimer timer_instance(__PRETTY_FUNCTION__, _mori_timer_logger.get())
 
 // Initialization helper functions
 inline void InitializeLogging() {

--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -575,22 +575,24 @@ EndpointId RdmaManager::ConnectEndpoint(EngineKey remoteKey, int devId,
   deviceCtxs[devId]->ConnectEndpoint(local.handle, remote);
   RemoteEngineMeta& meta = remotes[remoteKey];
   auto epConfig = GetRdmaEndpointConfig(devId);
-  EpPair ep{weight,
-            devId,
-            rdevId,
-            remoteKey,
-            local,
-            remote,
-            std::make_shared<std::atomic<int>>(0),
-            static_cast<int>(epConfig.maxMsgsNum),
-            std::make_shared<std::atomic<bool>>(false),
-            std::make_shared<SubmissionLedger>(config.notifPerQp),
-            std::make_shared<SqAdmissionEvent>()};
+  EpPair ep{
+      weight,
+      devId,
+      rdevId,
+      remoteKey,
+      local,
+      remote,
+      std::make_shared<std::atomic<int>>(0),
+      static_cast<int>(epConfig.maxMsgsNum),
+      std::make_shared<std::atomic<bool>>(false),
+      std::make_shared<SubmissionLedger>(config.notifPerQp, static_cast<int>(epConfig.maxMsgsNum)),
+      std::make_shared<SqAdmissionEvent>()};
   meta.rTable[topoKey].push_back(ep);
 
   EndpointId id = nextEndpointId_.fetch_add(1);
   auto rt = std::make_shared<EndpointRuntime>(id, ep);
   endpointsById_[id] = rt;
+  endpointsEpoch_.fetch_add(1, std::memory_order_release);
   return id;
 }
 
@@ -617,14 +619,13 @@ bool RdmaManager::HasIonicDevice() const {
   return false;
 }
 
-std::vector<std::shared_ptr<EndpointRuntime>> RdmaManager::SnapshotEndpointRuntimes() {
+void RdmaManager::SnapshotEndpointRuntimes(SnapshotVector& result) {
   std::shared_lock<std::shared_mutex> lock(mu);
-  std::vector<std::shared_ptr<EndpointRuntime>> result;
-  result.reserve(endpointsById_.size());
-  for (auto& [_, rt] : endpointsById_) {
-    result.push_back(rt);
+  result.resize(endpointsById_.size());
+  size_t i = 0;
+  for (const auto& [_, rt] : endpointsById_) {
+    result[i++] = rt;
   }
-  return result;
 }
 
 application::RdmaDeviceContext* RdmaManager::GetOrCreateDeviceContext(int devId) {
@@ -676,7 +677,10 @@ void NotifManager::RegisterEndpoint(const std::shared_ptr<EndpointRuntime>& rt) 
   application::RdmaMemoryRegion mr =
       devCtx->RegisterRdmaMemoryRegionAuto(buf, config.notifPerQp * sizeof(NotifMessage));
 
-  notifCtxById_.insert({rt->id, {mr, buf}});
+  auto notifIt = notifCtxById_.insert({rt->id, {mr, buf}}).first;
+  // Publish the (rehash-stable, node-based map) context pointer so the poll loop
+  // can read it locklessly. release pairs with the acquire load in ProcessOneCqe.
+  rt->notifCtx.store(&notifIt->second, std::memory_order_release);
 
   struct ibv_qp* qp = rt->ep.local.ibvHandle.qp;
   assert(qp);
@@ -703,13 +707,13 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
   ibv_cq* cq = ep.local.ibvHandle.cq;
   FlushDrainStats flushDrain;
 
-  // Resolve notif context once before the CQ drain loop.
-  QpNotifContext* notifCtxPtr = nullptr;
-  if (config.enableNotification) {
-    std::lock_guard<std::mutex> lock(mu);
-    auto nit = notifCtxById_.find(rt->id);
-    if (nit != notifCtxById_.end()) notifCtxPtr = &nit->second;
-  }
+  // Resolve notif context locklessly: it is published once at registration and
+  // the containing map is node-based, so the cached pointer stays valid. acquire
+  // pairs with the release store in RegisterEndpoint.
+  QpNotifContext* notifCtxPtr =
+      config.enableNotification
+          ? static_cast<QpNotifContext*>(rt->notifCtx.load(std::memory_order_acquire))
+          : nullptr;
 
   const int batchSize = 32;
   struct ibv_wc wc[batchSize];
@@ -956,8 +960,18 @@ void NotifManager::MainLoop() {
       }
     }
   } else {
+    // The endpoint set is effectively append-only and changes rarely, but this
+    // is a tight busy-poll loop. Rebuilding the snapshot every iteration would
+    // take a shared_lock and heap-allocate on every spin (a large fraction of
+    // this thread's CPU). Instead cache it and only rebuild when the epoch moves.
+    RdmaManager::SnapshotVector snapshot;
+    uint64_t snapshotEpoch = rdma->EndpointsEpoch() - 1;
     while (running.load()) {
-      auto snapshot = rdma->SnapshotEndpointRuntimes();
+      uint64_t curEpoch = rdma->EndpointsEpoch();
+      if (curEpoch != snapshotEpoch) {
+        rdma->SnapshotEndpointRuntimes(snapshot);
+        snapshotEpoch = curEpoch;
+      }
       if (snapshot.empty()) {
         EmitFlushSummaryIfNeeded(FlushRoundStats{});
         std::this_thread::yield();

--- a/src/io/rdma/backend_impl.hpp
+++ b/src/io/rdma/backend_impl.hpp
@@ -68,6 +68,8 @@ EpPairVec InterleaveEndpointsByLocalDevice(const EpPairVec& eps,
 /* ---------------------------------------------------------------------------------------------- */
 class RdmaManager {
  public:
+  using SnapshotVector = std::vector<std::shared_ptr<EndpointRuntime>>;
+
   RdmaManager(const RdmaBackendConfig cfg, application::RdmaContext* ctx);
   ~RdmaManager();
 
@@ -98,7 +100,12 @@ class RdmaManager {
                              int rdevId, application::RdmaEndpointHandle remote, TopoKeyPair key,
                              int weight);
   std::shared_ptr<EndpointRuntime> GetEndpointRuntime(EndpointId id);
-  std::vector<std::shared_ptr<EndpointRuntime>> SnapshotEndpointRuntimes();
+  void SnapshotEndpointRuntimes(SnapshotVector& result);
+  // Monotonic generation counter bumped whenever the endpoint set changes.
+  // Lets hot pollers skip the locked snapshot rebuild when nothing changed.
+  uint64_t EndpointsEpoch() const noexcept {
+    return endpointsEpoch_.load(std::memory_order_acquire);
+  }
 
   application::RdmaDeviceContext* GetRdmaDeviceContext(int devId);
   size_t NumAvailDevices() const { return availDevices.size(); }
@@ -119,6 +126,7 @@ class RdmaManager {
   std::unordered_map<EngineKey, RemoteEngineMeta> remotes;
   std::atomic<EndpointId> nextEndpointId_{1};
   std::unordered_map<EndpointId, std::shared_ptr<EndpointRuntime>> endpointsById_;
+  std::atomic<uint64_t> endpointsEpoch_{0};
 
   std::unique_ptr<application::TopoSystem> topo{nullptr};
   std::atomic<uint32_t> roundRobinCounter{0};

--- a/src/io/rdma/common.hpp
+++ b/src/io/rdma/common.hpp
@@ -183,7 +183,11 @@ struct SubmissionRecord {
 
 class SubmissionLedger {
  public:
-  explicit SubmissionLedger(uint32_t notifPerQp) : nextId_{notifPerQp} {}
+  // maxSqDepth bounds the number of live records (admission control keeps the
+  // sum of in-flight postedWr <= maxSqDepth, and every record has postedWr >= 1),
+  // so a ring of capacity > maxSqDepth can be indexed by recordId with no
+  // aliasing of a live slot. See ledger.cpp for the correctness argument.
+  explicit SubmissionLedger(uint32_t notifPerQp, int maxSqDepth = 4096);
 
   // Allocate recordId, insert Posted record, return recordId.
   uint64_t Insert(int postedWr, bool hasSignaledTail, std::shared_ptr<CqCallbackMeta> meta,
@@ -203,9 +207,16 @@ class SubmissionLedger {
   bool HasOrphaned() const;
 
  private:
+  // Fixed, allocation-free ring keyed by recordId. A slot is empty iff its
+  // stored recordId is 0 (valid ledger ids start at notifPerQp > 0). Sized to a
+  // power of two so indexing is (recordId & capMask_). Memory footprint is
+  // capacity * sizeof(SubmissionRecord) per QP; sized from maxSqDepth, so very
+  // large maxSqDepth combined with many QPs increases per-QP memory.
+
   mutable std::mutex mu_;
   uint64_t nextId_;
-  std::unordered_map<uint64_t, SubmissionRecord> records_;
+  uint64_t capMask_{0};
+  std::vector<SubmissionRecord> ring_;
 };
 
 inline constexpr std::memory_order kSqAdmissionOrder = std::memory_order_seq_cst;
@@ -240,6 +251,11 @@ struct EndpointRuntime {
 
   EndpointId id{0};
   EpPair ep;
+  // Cached pointer to this endpoint's NotifManager::QpNotifContext, published once
+  // at registration. Lets the hot CQ poller resolve the notif context without
+  // locking NotifManager::mu on every poll. Type-erased (void*) to avoid a header
+  // dependency on the NotifManager-private struct; nullptr until registered.
+  std::atomic<void*> notifCtx{nullptr};
 };
 
 using EpPairVec = std::vector<EpPair>;

--- a/src/io/rdma/ledger.cpp
+++ b/src/io/rdma/ledger.cpp
@@ -19,16 +19,50 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+#include <algorithm>
+
+#include "mori/io/logging.hpp"
 #include "src/io/rdma/common.hpp"
 
 namespace mori {
 namespace io {
 
+namespace {
+// Smallest power of two >= v, with a floor so tiny SQ depths still get a
+// reasonable ring. Capacity must be strictly greater than the max number of
+// live records (bounded by maxSqDepth) so recordId & (cap-1) never aliases a
+// still-live slot.
+uint64_t RingCapacityFor(int maxSqDepth) {
+  constexpr uint64_t kSlack = 64;   // headroom above maxSqDepth
+  constexpr uint64_t kFloor = 256;  // minimum ring size
+  uint64_t need = static_cast<uint64_t>(std::max(0, maxSqDepth)) + kSlack;
+  uint64_t cap = kFloor;
+  while (cap < need) cap <<= 1;
+  return cap;
+}
+}  // namespace
+
+SubmissionLedger::SubmissionLedger(uint32_t notifPerQp, int maxSqDepth)
+    : nextId_{notifPerQp == 0 ? 1u : notifPerQp} {
+  const uint64_t cap = RingCapacityFor(maxSqDepth);
+  capMask_ = cap - 1;
+  ring_.resize(cap);  // default-constructed records have recordId == 0 (empty)
+}
+
 uint64_t SubmissionLedger::Insert(int postedWr, bool hasSignaledTail,
                                   std::shared_ptr<CqCallbackMeta> meta, int batchSize) {
   std::lock_guard<std::mutex> lock(mu_);
   uint64_t id = nextId_++;
-  records_[id] = SubmissionRecord{
+  SubmissionRecord& slot = ring_[id & capMask_];
+  if (MORI_UNLIKELY(slot.recordId != 0)) {
+    // Should be unreachable: admission control caps live records at maxSqDepth < capacity.
+    MORI_IO_CRITICAL(
+        "SubmissionLedger::Insert ring overflow: slot for recordId {} still holds live recordId "
+        "{} (capacity {}); increase ring capacity",
+        id, slot.recordId, capMask_ + 1);
+    std::abort();
+  }
+  slot = SubmissionRecord{
       id, postedWr, hasSignaledTail, SubmissionState::Posted, std::move(meta), batchSize};
   return id;
 }
@@ -37,37 +71,49 @@ void SubmissionLedger::InsertOrphaned(int postedWr, std::shared_ptr<CqCallbackMe
                                       int batchSize) {
   std::lock_guard<std::mutex> lock(mu_);
   uint64_t id = nextId_++;
-  records_[id] =
+  SubmissionRecord& slot = ring_[id & capMask_];
+  if (MORI_UNLIKELY(slot.recordId != 0)) {
+    MORI_IO_CRITICAL(
+        "SubmissionLedger::InsertOrphaned ring overflow: slot for recordId {} still holds live "
+        "recordId {} (capacity {}); increase ring capacity",
+        id, slot.recordId, capMask_ + 1);
+    std::abort();
+  }
+  slot =
       SubmissionRecord{id, postedWr, false, SubmissionState::Orphaned, std::move(meta), batchSize};
 }
 
 std::shared_ptr<CqCallbackMeta> SubmissionLedger::ReleaseByCqe(uint64_t recordId,
                                                                std::atomic<int>* sqDepth,
                                                                int* outBatchSize) {
-  std::lock_guard<std::mutex> lock(mu_);
-  auto it = records_.find(recordId);
-  if (it == records_.end()) return nullptr;
-  SubmissionRecord& rec = it->second;
-  if (sqDepth && rec.postedWr > 0) sqDepth->fetch_sub(rec.postedWr, kSqAdmissionOrder);
-  if (outBatchSize) *outBatchSize = rec.batchSize;
-  auto meta = std::move(rec.meta);
-  records_.erase(it);
+  int postedWr = 0;
+  std::shared_ptr<CqCallbackMeta> meta;
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    SubmissionRecord& slot = ring_[recordId & capMask_];
+    if (slot.recordId != recordId) return nullptr;  // stale / already released
+    postedWr = slot.postedWr;
+    if (outBatchSize) *outBatchSize = slot.batchSize;
+    meta = std::move(slot.meta);
+    slot.recordId = 0;  // mark empty
+  }
+  if (sqDepth && postedWr > 0) sqDepth->fetch_sub(postedWr, kSqAdmissionOrder);
   return meta;
 }
 
 int SubmissionLedger::ReleaseOrphanedByRecovery(std::atomic<int>* sqDepth) {
-  std::lock_guard<std::mutex> lock(mu_);
   int total = 0;
-  // Only erase Orphaned records.  Posted records still have signaled WRs whose
-  // CQEs may arrive later; they must remain so ReleaseByCqe() can update the
-  // corresponding TransferStatus and release sqDepth normally.
-  auto it = records_.begin();
-  while (it != records_.end()) {
-    if (it->second.state == SubmissionState::Orphaned) {
-      total += it->second.postedWr;
-      it = records_.erase(it);
-    } else {
-      ++it;
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    // Only release Orphaned records.  Posted records still have signaled WRs
+    // whose CQEs may arrive later; they must remain so ReleaseByCqe() can update
+    // the corresponding TransferStatus and release sqDepth normally.
+    for (SubmissionRecord& slot : ring_) {
+      if (slot.recordId != 0 && slot.state == SubmissionState::Orphaned) {
+        total += slot.postedWr;
+        slot.meta.reset();
+        slot.recordId = 0;  // mark empty
+      }
     }
   }
   if (sqDepth && total > 0) sqDepth->fetch_sub(total, kSqAdmissionOrder);
@@ -76,8 +122,8 @@ int SubmissionLedger::ReleaseOrphanedByRecovery(std::atomic<int>* sqDepth) {
 
 bool SubmissionLedger::HasOrphaned() const {
   std::lock_guard<std::mutex> lock(mu_);
-  for (const auto& [id, rec] : records_) {
-    if (rec.state == SubmissionState::Orphaned) return true;
+  for (const SubmissionRecord& slot : ring_) {
+    if (slot.recordId != 0 && slot.state == SubmissionState::Orphaned) return true;
   }
   return false;
 }

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -22,6 +22,14 @@ if(DEFINED GPU_TARGETS)
     PROPERTIES HIP_ARCHITECTURES "${GPU_TARGETS}")
 endif()
 
+# Core logging is header-only (spdlog); test its thread-safety independently of
+# BUILD_IO. Run under ThreadSanitizer to actually prove the maps are safe.
+add_executable(test_logging utils/test_logging.cpp)
+target_include_directories(test_logging PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(test_logging PUBLIC ${CMAKE_SOURCE_DIR})
+target_link_libraries(test_logging PRIVATE mori_logging gtest_main)
+add_test(NAME logging_concurrency COMMAND test_logging)
+
 add_executable(test_transport_tcp application/test_transport_tcp.cpp)
 
 target_include_directories(test_transport_tcp

--- a/tests/cpp/io/test_engine.cpp
+++ b/tests/cpp/io/test_engine.cpp
@@ -247,6 +247,59 @@ void CaseSubmissionLedgerBasic() {
   Require(sqDepth2.load(std::memory_order_relaxed) == 5, "sq depth after posted CQE release");
 }
 
+void CaseSubmissionLedgerRingWraparound() {
+  // Small SQ depth -> small ring, so a modest number of insert/release cycles
+  // laps the ring several times and exercises slot reuse.
+  constexpr uint32_t kNotifPerQp = 16;
+  constexpr int kMaxSqDepth = 32;
+  SubmissionLedger ledger(kNotifPerQp, kMaxSqDepth);
+  TransferStatus status;
+
+  // Insert then immediately release, one record at a time, across many laps of
+  // the ring. Each id must round-trip to the correct record.
+  uint64_t expectedId = kNotifPerQp;
+  for (int i = 0; i < 4096; ++i) {
+    std::atomic<int> sqDepth{1};
+    auto meta = std::make_shared<CqCallbackMeta>(&status, 1000 + i, 1);
+    const uint64_t id = ledger.Insert(1, true, meta, /*batchSize=*/i + 1);
+    Require(id == expectedId, "recordId must be monotonic across wraparound");
+    ++expectedId;
+
+    // Releasing a stale/never-inserted id (the slot's current occupant differs)
+    // must return nullptr without disturbing the live record.
+    Require(ledger.ReleaseByCqe(id + 1, &sqDepth, nullptr) == nullptr,
+            "stale recordId should not resolve to a live slot");
+
+    int batchSize = 0;
+    auto released = ledger.ReleaseByCqe(id, &sqDepth, &batchSize);
+    Require(released != nullptr, "wraparound release should find the live record");
+    Require(released->id == static_cast<uint64_t>(1000 + i),
+            "wraparound release returned the wrong record");
+    Require(batchSize == i + 1, "wraparound release batch size mismatch");
+    Require(sqDepth.load(std::memory_order_relaxed) == 0, "wraparound release should free 1 WR");
+
+    // Double release of the same id is a no-op (slot already empty).
+    Require(ledger.ReleaseByCqe(id, &sqDepth, nullptr) == nullptr,
+            "double release of the same recordId should return nullptr");
+  }
+
+  // Keep several records live simultaneously (up to the SQ depth), spanning a
+  // ring boundary, then release them out of order.
+  std::vector<uint64_t> liveIds;
+  for (int i = 0; i < kMaxSqDepth; ++i) {
+    auto meta = std::make_shared<CqCallbackMeta>(&status, 5000 + i, 1);
+    liveIds.push_back(ledger.Insert(1, true, meta, /*batchSize=*/1));
+  }
+  std::atomic<int> sqDepth{kMaxSqDepth};
+  // Release in reverse order.
+  for (auto it = liveIds.rbegin(); it != liveIds.rend(); ++it) {
+    Require(ledger.ReleaseByCqe(*it, &sqDepth, nullptr) != nullptr,
+            "each concurrently-live record should release cleanly");
+  }
+  Require(sqDepth.load(std::memory_order_relaxed) == 0,
+          "all concurrently-live records should be released");
+}
+
 EpPair MakeSqAdmissionEp(int maxSqDepth, int currentDepth, bool withAdmission = true) {
   EpPair ep{};
   ep.sqDepth = std::make_shared<std::atomic<int>>(currentDepth);
@@ -1809,6 +1862,7 @@ int main(int argc, char* argv[]) {
   SetLogLevel("info");
   std::vector<TestCase> cases = {
       {"submission_ledger_basic", CaseSubmissionLedgerBasic},
+      {"submission_ledger_ring_wraparound", CaseSubmissionLedgerRingWraparound},
       {"sq_admission_release_wakes_waiter", CaseSqAdmissionReleaseWakesWaiter},
       {"sq_admission_degraded_wakes_waiter", CaseSqAdmissionDegradedWakesWaiter},
       {"sq_admission_negative_depth_reserve_repairs_counter",

--- a/tests/cpp/utils/test_logging.cpp
+++ b/tests/cpp/utils/test_logging.cpp
@@ -1,0 +1,153 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Multi-threaded stress tests for the ModuleLogger wrapper in
+// include/mori/utils/mori_log.hpp.
+//
+// These guard against the previously-present data race on ModuleLogger's
+// internal std::unordered_maps (loggers_/envOverrides_), which under the
+// multithreaded RDMA workload could hand back an empty shared_ptr that callers
+// then cached forever. The functional asserts here catch null/crash
+// regressions; running this binary under ThreadSanitizer is what actually
+// proves the map access is synchronized (build with -fsanitize=thread; if the
+// container aborts with "unexpected memory mapping", run via
+// `setarch $(uname -m) -R ./test_logging`).
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "mori/utils/mori_log.hpp"
+
+namespace {
+
+// Spin barrier so all threads hit the racy window together.
+struct StartGate {
+  std::atomic<bool> go{false};
+  void wait() const {
+    while (!go.load(std::memory_order_acquire)) {
+    }
+  }
+  void open() { go.store(true, std::memory_order_release); }
+};
+
+const char* kKnown[] = {mori::modules::APPLICATION, mori::modules::IO,  mori::modules::SHMEM,
+                        mori::modules::CORE,        mori::modules::OPS, mori::modules::UMBP,
+                        mori::modules::METRICS};
+
+}  // namespace
+
+// Concurrent resolution of known + many distinct unknown modules. Unknown names
+// force on-demand InitModuleLocked() inserts, i.e. writes racing reads.
+TEST(ModuleLoggerConcurrency, ResolveNeverReturnsNull) {
+  constexpr int kThreads = 32;
+  constexpr int kIters = 5000;
+  StartGate gate;
+  std::atomic<int> nulls{0};
+
+  std::vector<std::thread> ts;
+  ts.reserve(kThreads);
+  for (int t = 0; t < kThreads; ++t) {
+    ts.emplace_back([&, t] {
+      gate.wait();
+      for (int i = 0; i < kIters; ++i) {
+        const char* known = kKnown[(t + i) % 7];
+        if (!mori::ModuleLogger::GetInstance().GetLogger(known)) nulls.fetch_add(1);
+        // Distinct (but bounded) unknown module -> exercises the insert path.
+        std::string unknown = "utmod_" + std::to_string((t * kIters + i) % 128);
+        if (!mori::ModuleLogger::GetInstance().GetLogger(unknown)) nulls.fetch_add(1);
+      }
+    });
+  }
+  gate.open();
+  for (auto& th : ts) th.join();
+  EXPECT_EQ(nulls.load(), 0);
+}
+
+// Many threads resolve the SAME brand-new module at once: the create-once path
+// (spdlog registry race handling) must yield one stable, non-null logger.
+TEST(ModuleLoggerConcurrency, ConcurrentFirstTouchSameModule) {
+  constexpr int kThreads = 64;
+  StartGate gate;
+  std::vector<spdlog::logger*> got(kThreads, nullptr);
+
+  std::vector<std::thread> ts;
+  ts.reserve(kThreads);
+  for (int t = 0; t < kThreads; ++t) {
+    ts.emplace_back([&, t] {
+      gate.wait();
+      got[t] = mori::ModuleLogger::GetInstance().GetLogger("ut_first_touch").get();
+    });
+  }
+  gate.open();
+  for (auto& th : ts) th.join();
+
+  ASSERT_NE(got[0], nullptr);
+  for (int t = 1; t < kThreads; ++t) {
+    EXPECT_NE(got[t], nullptr);
+    EXPECT_EQ(got[t], got[0]);  // all observe the same registered instance
+  }
+}
+
+// Logging while levels are reconfigured. Primarily a TSAN target; the functional
+// assert is just "no crash/hang". Kept quiet at 'critical' to avoid stdout spam.
+TEST(ModuleLoggerConcurrency, LogWhileReconfiguring) {
+  constexpr int kLoggers = 24;
+  constexpr int kIters = 5000;
+  StartGate gate;
+
+  const std::string savedGlobal = mori::GetGlobalLogLevel();
+  mori::SetGlobalLogLevel("critical");
+
+  std::vector<std::thread> ts;
+  ts.reserve(kLoggers + 4);
+  for (int t = 0; t < kLoggers; ++t) {
+    ts.emplace_back([&, t] {
+      gate.wait();
+      for (int i = 0; i < kIters; ++i) {
+        MORI_IO_TRACE("io {} {}", t, i);
+        MORI_APP_DEBUG("app {} {}", t, i);
+        MORI_CORE_INFO("core {} {}", t, i);
+      }
+    });
+  }
+  // Reconfigurer threads racing the loggers above.
+  for (int r = 0; r < 4; ++r) {
+    ts.emplace_back([&] {
+      gate.wait();
+      for (int i = 0; i < kIters; ++i) {
+        mori::SetGlobalLogLevel((i & 1) ? "trace" : "critical");
+        mori::SetModuleLogLevel(mori::modules::IO, (i & 2) ? "debug" : "warn");
+        mori::ForceSetModuleLogLevel(mori::modules::CORE, "info");
+        (void)mori::GetGlobalLogLevel();
+      }
+    });
+  }
+  gate.open();
+  for (auto& th : ts) th.join();
+
+  mori::SetGlobalLogLevel(savedGlobal);
+  SUCCEED();
+}


### PR DESCRIPTION
## Summary

Profile-guided reduction of per-operation CPU overhead on the RDMA IO path. A
CPU flame-graph of the completion/submission path surfaced several avoidable
costs on the busy-poll and submit hot paths: per-poll locking, per-spin heap
allocation + snapshot rebuilds, per-op hash-map churn in the submission ledger,
and always-on telemetry timing. This change removes all of them with no change
to the public API, ABI, or wire protocol.

The net effect is lower CPU cost per transfer, which shows up as higher
throughput (and correspondingly lower latency) in the CPU-overhead-bound
regimes, with no regressions elsewhere.

Extracted from https://github.com/ROCm/mori/pull/506 with minor adaptions

## What changed

1. **Lockless notif-context resolution in the CQ poller.**
   `ProcessOneCqe()` previously took `NotifManager::mu` on *every* poll just to
   look up the endpoint's `QpNotifContext`. The context is now published once at
   registration (`EndpointRuntime::notifCtx`, an `atomic<void*>` with
   release/acquire) and read locklessly in the poll loop. The backing map is
   node-based, so the cached pointer stays valid across rehashes.

2. **Epoch-gated endpoint snapshot (no per-spin lock/alloc).**
   The POLLING `MainLoop` rebuilt the endpoint snapshot every spin — taking a
   `shared_lock` and heap-allocating a vector on each iteration of a tight
   busy-poll. A monotonic `endpointsEpoch_` counter is bumped when the endpoint
   set changes; the loop now caches the snapshot and only rebuilds when the
   epoch moves. `SnapshotEndpointRuntimes()` fills a caller-owned vector to
   avoid the per-call allocation.

3. **Allocation-free submission ledger (ring instead of hash map).**
   `SubmissionLedger` replaced its `std::unordered_map<uint64_t,
   SubmissionRecord>` — which allocated/erased a node per WR — with a fixed
   power-of-two ring indexed by `recordId & capMask_`. Admission control bounds
   live records by `maxSqDepth`, and the ring is sized strictly above that (with
   slack + floor), so a slot never aliases a live record.
   `Insert`/`ReleaseByCqe`/`ReleaseOrphaned*` are now allocation-free; the
   `sqDepth` atomic update was also moved outside the lock.

4. **Sampled (near-zero-cost when off) telemetry timers.**
   `ScopedTimer` / `MORI_TIMER` / `MORI_FUNCTION_TIMER` now capture timestamps
   only when the module's debug logging is actually enabled, gated with
   `MORI_UNLIKELY`. When telemetry is off the timers compile down to a
   predicted-not-taken branch, so they no longer cost anything on the hot path.

5. **`MORI_LIKELY` / `MORI_UNLIKELY` branch hints.**
   Added portable `__builtin_expect` wrappers
   (`include/mori/core/utils/utils.hpp`) used on the cold paths above. Also
   fixed a `warpSize` macro collision so the header parses under host
   compilation.

## Benchmark setup

- Two-node RoCE cluster: `p20-05` (initiator) &harr; `p20-14` (target).
- 8 initiator ranks, telemetry **OFF**, **5 repetitions** (metrics averaged
  across all ranks and reps).
- Baseline = `34f17d69`, "improved" = this change (`13f6fcd9`).
- `avgBW` / `maxBW` in GB/s (higher is better); `avgLat` in µs (lower is
  better). `ΔBW%` positive = faster; `ΔLat%` negative = faster.

## Preset configurations

All presets are driven through `tools/run_telemetry_ab_cluster.sh` →
`tests/python/io/benchmark.py`. Common to all three: `--op-type write`,
`--enable-sess`, `--enable-batch-transfer`, `--num-initiator-dev 8`,
`--num-target-dev 8`, telemetry OFF, 8 initiator ranks.

| Parameter | mw-chunkoff | mw-chunkon | hi-iops |
|---|---|---|---|
| Chunking | OFF (`--disable-chunking`) | ON (default) | OFF (`--disable-chunking`) |
| Worker threads (`--num-worker-threads`) | 2 | 4 | 8 |
| QPs per transfer (`--num-qp-per-transfer`) | 4 | 4 | 8 |
| Transfer batch size (`--transfer-batch-size`) | 64 | 64 | 256 |
| Message size | sweep `--all` | sweep `--all` | fixed `--buffer-size 512` |
| Sweep range | 1 KB – 16 MB | 1 KB – 16 MB | (no sweep) |
| Iterations (`--iters`) | 128 | 256 | 512 |

What each stresses:
- **mw-chunkoff** — chunking off means every transfer is its own signaled WR,
  maximizing per-signaled-WR ledger-mutex round-trips and record churn.
- **mw-chunkon** — 4 workers × 4 QP is the highest cross-thread contention on
  the shared ledger/telemetry state; the most CPU-overhead-sensitive regime.
- **hi-iops** — tiny fixed 512 B messages, batch 256, chunking off ⇒ ~256 CQEs
  per transfer batch, maximizing completions/sec (completion-bound peak IOPS).

Exact benchmark argument vectors used for this dataset:

```text
mw-chunkoff:
  --op-type write --disable-chunking --transfer-batch-size 64 --all \
  --sweep-start-size 1024 --sweep-max-size 16777216 --iters 128 \
  --enable-sess --enable-batch-transfer \
  --num-qp-per-transfer 4 --num-worker-threads 2 \
  --num-initiator-dev 8 --num-target-dev 8

mw-chunkon:
  --op-type write --transfer-batch-size 64 --all \
  --sweep-start-size 1024 --sweep-max-size 16777216 --iters 256 \
  --enable-sess --enable-batch-transfer \
  --num-qp-per-transfer 4 --num-worker-threads 4 \
  --num-initiator-dev 8 --num-target-dev 8

hi-iops:
  --op-type write --disable-chunking --buffer-size 512 \
  --transfer-batch-size 256 --iters 512 \
  --enable-sess --enable-batch-transfer \
  --num-qp-per-transfer 8 --num-worker-threads 8 \
  --num-initiator-dev 8 --num-target-dev 8
```

---

## mw-chunkoff

2 workers, 4 QP, chunking OFF, `--iters 128`. Less CPU-bound; results are within
run-to-run noise — marginally positive at small sizes, flat elsewhere.

| MsgSize (B) | avgBW base | avgBW impr | ΔBW% | maxBW base | maxBW impr | avgLat base (µs) | avgLat impr (µs) | ΔLat% |
|------------:|-----------:|-----------:|-----:|-----------:|-----------:|-----------------:|-----------------:|------:|
|        1024 |       1.78 |       1.85 | +3.9 |       2.56 |       2.63 |            37.39 |            35.81 |  -4.2 |
|        2048 |       4.45 |       4.55 | +2.2 |       5.18 |       5.42 |            29.99 |            29.44 |  -1.8 |
|        4096 |       8.35 |       8.42 | +0.8 |       9.51 |       9.74 |            31.72 |            31.68 |  -0.1 |
|        8192 |      13.05 |      13.29 | +1.8 |      15.73 |      15.65 |            40.62 |            39.81 |  -2.0 |
|       16384 |      17.95 |      18.14 | +1.1 |      22.06 |      21.99 |            58.71 |            58.09 |  -1.1 |
|       32768 |      18.73 |      18.75 | +0.1 |      24.55 |      24.14 |           112.07 |           112.00 |  -0.1 |
|       65536 |      18.70 |      18.64 | -0.3 |      25.02 |      24.98 |           224.47 |           225.16 |  +0.3 |
|      131072 |      18.77 |      18.64 | -0.7 |      25.57 |      25.37 |           447.20 |           450.29 |  +0.7 |
|      262144 |      18.54 |      18.44 | -0.5 |      25.99 |      25.34 |           905.08 |           910.12 |  +0.6 |
|      524288 |      19.05 |      19.00 | -0.3 |      26.25 |      25.94 |          1761.70 |          1766.53 |  +0.3 |
|     1048576 |      20.89 |      21.17 | +1.3 |      26.31 |      26.34 |          3214.10 |          3172.37 |  -1.3 |
|     2097152 |      20.39 |      20.71 | +1.6 |      26.64 |      26.69 |          6585.92 |          6487.49 |  -1.5 |
|     4194304 |      19.53 |      19.57 | +0.2 |      25.99 |      25.93 |         13759.00 |         13724.53 |  -0.3 |
|     8388608 |      19.38 |      19.35 | -0.2 |      26.31 |      26.24 |         27702.51 |         27755.53 |  +0.2 |
|    16777216 |      19.54 |      19.67 | +0.7 |      26.46 |      26.40 |         54962.87 |         54621.20 |  -0.6 |

## mw-chunkon

4 workers, 4 QP, chunking ON, `--iters 256`. The CPU-overhead-bound regime and
the clearest win: **+2–7% throughput** (and matching latency reduction) across
almost all sizes; converges to the network limit only at the largest sizes.

| MsgSize (B) | avgBW base | avgBW impr | ΔBW% | maxBW base | maxBW impr | avgLat base (µs) | avgLat impr (µs) | ΔLat% |
|------------:|-----------:|-----------:|-----:|-----------:|-----------:|-----------------:|-----------------:|------:|
|        1024 |       1.74 |       1.81 | +4.0 |       2.33 |       2.41 |            38.13 |            36.77 |  -3.6 |
|        2048 |       3.85 |       4.03 | +4.7 |       4.64 |       4.86 |            34.66 |            33.17 |  -4.3 |
|        4096 |       7.47 |       7.82 | +4.7 |       8.79 |       9.07 |            35.66 |            34.07 |  -4.5 |
|        8192 |      13.64 |      14.01 | +2.7 |      15.72 |      16.14 |            38.79 |            37.77 |  -2.6 |
|       16384 |      18.13 |      18.51 | +2.1 |      22.91 |      23.01 |            58.11 |            56.93 |  -2.0 |
|       32768 |      22.54 |      23.54 | +4.4 |      30.43 |      30.86 |            93.98 |            89.81 |  -4.4 |
|       65536 |      26.70 |      28.29 | +6.0 |      38.08 |      38.38 |           158.38 |           149.38 |  -5.7 |
|      131072 |      27.59 |      28.76 | +4.2 |      42.20 |      42.61 |           307.17 |           294.08 |  -4.3 |
|      262144 |      29.71 |      30.90 | +4.0 |      44.87 |      45.02 |           575.32 |           553.31 |  -3.8 |
|      524288 |      27.74 |      29.76 | +7.3 |      46.37 |      46.17 |          1223.29 |          1145.98 |  -6.3 |
|     1048576 |      26.98 |      28.52 | +5.7 |      47.55 |      47.16 |          2511.93 |          2389.17 |  -4.9 |
|     2097152 |      24.87 |      25.59 | +2.9 |      47.88 |      47.80 |          5453.42 |          5294.91 |  -2.9 |
|     4194304 |      20.31 |      20.28 | -0.1 |      43.55 |      38.16 |         13221.64 |         13242.75 |  +0.2 |
|     8388608 |      20.07 |      20.08 | +0.0 |      34.36 |      34.92 |         26755.41 |         26741.47 |  -0.1 |
|    16777216 |      20.05 |      20.07 | +0.1 |      26.93 |      27.08 |         53566.64 |         53504.56 |  -0.1 |

## hi-iops

512 B messages, 8 workers, 8 QP, batch 256, chunking OFF, `--iters 512`.
Completion-bound peak-IOPS probe; flat (within noise).

| MsgSize (B) | avgBW base | avgBW impr | ΔBW% | maxBW base | maxBW impr | avgLat base (µs) | avgLat impr (µs) | ΔLat% |
|------------:|-----------:|-----------:|-----:|-----------:|-----------:|-----------------:|-----------------:|------:|
|         512 |       2.07 |       2.06 | -0.5 |       2.52 |       2.52 |            64.03 |            64.50 |  +0.7 |

---

## Takeaways

- **mw-chunkon** (the CPU-overhead-bound regime) is the headline: consistent
  **+2–7% bandwidth** and a matching **~2–6% average-latency reduction** across
  the mid-size band the workload spends most time in.
- **mw-chunkoff** and **hi-iops** are flat / within noise — expected, as those
  regimes are less gated on host-CPU overhead.
- No regressions in any preset.

## Testing

- `tests/cpp/io/test_engine.cpp`: added coverage for the ledger ring behavior.
- `tests/cpp/utils/test_logging.cpp`: new tests for the sampled `ScopedTimer`.
- Full two-node RDMA benchmark sweep above (5 reps × 3 presets, telemetry OFF).

## Risk / compatibility

- No public API, ABI, or wire-protocol changes.
- Ledger ring uses more memory per QP than the old map (capacity ≈ `maxSqDepth`
  rounded up to a power of two, min 256 slots); relevant only with very large
  `maxSqDepth` × many QPs.
- Lockless notif-context read relies on the node-based map keeping pointers
  stable across rehash (documented at the publish site).


https://cursor.com/dashboard/shared-canvases?shareId=canvas-eghrnfdog48yKE5SGxxfUXeM