### PR TITLE
perf(EPv2): optimize epv2 disp/comb kernel performance

### DIFF
--- a/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
+++ b/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
@@ -138,6 +138,13 @@ class EpDispatchCombineConfig:
     # distinct (block, warp) variants and picks one at runtime from
     # cur_rank_num_token. None => auto (from tuning_configs) or single-shot fallback.
     schedule: tuple = None
+    # Dispatch algorithm switch by token count (host-side, at launch): tokens
+    # STRICTLY GREATER than this use the load-once/store-many + 4-way kernel
+    # (big win at large batches); tokens <= it use the original per-(token,
+    # expert) 2-way kernel (finer granularity fills the grid at small/mid
+    # batches). Both variants are precompiled lazily (compiled on first launch,
+    # so an unused algorithm never pays JIT cost).
+    load_once_threshold: int = 4096
     enable_std_moe: bool = False
     max_total_recv_tokens: int = 0  # mori maxTotalRecvTokens; 0 = worst-case ws*M
 
@@ -565,14 +572,21 @@ class EpDispatchCombineOp:
             scale_type_size=cfg.scale_type_size,
             fp4=is_fp4,
         )
-        # (block, warp) -> compiled dispatch / combine kernel.
+        # (block, warp, load_once) -> compiled dispatch kernel. Both algorithm
+        # variants are constructed here but JIT-compiled lazily (on first launch),
+        # so a token distribution that only ever hits one side of
+        # load_once_threshold never pays the other variant's compile cost.
         self._dispatch_variants = {
-            (b, w): make_dispatch(
-                block_num=b, warp_num_per_block=w, **self._dispatch_kwargs
+            (b, w, lo): make_dispatch(
+                block_num=b,
+                warp_num_per_block=w,
+                load_once=lo,
+                **self._dispatch_kwargs,
             )
             for (b, w) in dispatch_specs
+            for lo in (True, False)
         }
-        self._dispatch_replay_variants = {}  # lazily compiled per (block, warp)
+        self._dispatch_replay_variants = {}  # lazily built per (block, warp, load_once)
         if cfg.is_scatter:
             self._combine_variants = {
                 (b, w): make_combine_scatter(
@@ -787,27 +801,33 @@ class EpDispatchCombineOp:
         )
 
     def _pick(self, num_tokens):
-        """((disp_block, disp_warp), (comb_block, comb_warp)) for a runtime token
-        count via the per-token schedule; falls back to the single-shot specs
-        otherwise. Returned specs are clamped to the precompiled variants."""
+        """((disp_block, disp_warp, load_once), (comb_block, comb_warp)) for a
+        runtime token count. The (block, warp) geometry comes from the per-token
+        schedule (or single-shot specs), and load_once selects the dispatch
+        algorithm by token count (> cfg.load_once_threshold => load-once/4-way,
+        else the original per-(token,expert) path). Specs are clamped to the
+        precompiled variants."""
         schedule = self.cfg.schedule
-        disp_spec = comb_spec = None
+        disp_bw = comb_spec = None
         if schedule:
             for bucket in schedule:
                 max_tok = bucket[0]
                 if max_tok is None or num_tokens <= max_tok:
-                    disp_spec, comb_spec = (bucket[1], bucket[2]), (
+                    disp_bw, comb_spec = (bucket[1], bucket[2]), (
                         bucket[3],
                         bucket[4],
                     )
                     break
-            if disp_spec is None:
+            if disp_bw is None:
                 last = schedule[-1]
-                disp_spec, comb_spec = (last[1], last[2]), (last[3], last[4])
+                disp_bw, comb_spec = (last[1], last[2]), (last[3], last[4])
         else:
-            disp_spec, comb_spec = self._dispatch_specs[0], self._combine_specs[0]
+            disp_bw, comb_spec = self._dispatch_specs[0], self._combine_specs[0]
+        load_once = num_tokens > self.cfg.load_once_threshold
+        disp_spec = (disp_bw[0], disp_bw[1], load_once)
         if disp_spec not in self._dispatch_variants:
-            disp_spec = self._dispatch_specs[-1]
+            fallback = self._dispatch_specs[-1]
+            disp_spec = (fallback[0], fallback[1], load_once)
         if comb_spec not in self._combine_variants:
             comb_spec = self._combine_specs[-1]
         return disp_spec, comb_spec
@@ -843,6 +863,7 @@ class EpDispatchCombineOp:
                     replay=True,
                     block_num=disp_spec[0],
                     warp_num_per_block=disp_spec[1],
+                    load_once=disp_spec[2],
                     **self._dispatch_kwargs,
                 )
             dest_map_ptr = routing.disp_dest_tok_id_map.data_ptr()

--- a/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
+++ b/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
@@ -515,7 +515,17 @@ class EpDispatchCombineOp:
         self.dispatch_barrier = torch.zeros(1, dtype=torch.int32, device=device)
         self.total_recv = torch.zeros(1, dtype=torch.int32, device=device)
         self.combine_barrier = torch.zeros(1, dtype=torch.int32, device=device)
-        self.cross_device_flag = torch.ones(1, dtype=torch.int64, device=device)
+        # Per-block xdb flag counters for the gather combine entry barrier: one
+        # i64 per block, sized to the largest combine block_num across variants so
+        # every block owns a private counter and all stay in lockstep across calls
+        # that pick different block_num (the last block advances the tail).
+        if cfg.schedule:
+            self._max_comb_block = max(b[3] for b in cfg.schedule)
+        else:
+            self._max_comb_block = cfg.combine_block_num
+        self.cross_device_flag = torch.ones(
+            self._max_comb_block, dtype=torch.int64, device=device
+        )
         c_dt = cfg.combine_dtype  # combine output dtype
         c_elem = cfg.combine_elem_size
         if c_dt == torch.float4_e2m1fn_x2:  # fp4 combine outputs fp4 (hidden/2 B/token)
@@ -629,6 +639,7 @@ class EpDispatchCombineOp:
                     warp_num_per_block=w,
                     off_out_tok=arena.offset("out_tok"),
                     off_xdb_mem=arena.offset("cross_device_barrier"),
+                    max_block_num=self._max_comb_block,
                     off_out_wts=arena.offset("out_wts"),
                     reset_total_recv=True,
                     fp4=(cfg.combine_dtype == torch.float4_e2m1fn_x2),

--- a/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
+++ b/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
@@ -618,6 +618,7 @@ class EpDispatchCombineOp:
                     off_out_wts=arena.offset("out_wts"),
                     reset_total_recv=True,
                     fp4=(cfg.combine_dtype == torch.float4_e2m1fn_x2),
+                    _unroll=4,
                 )
                 for (b, w) in combine_specs
             }

--- a/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
+++ b/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
@@ -32,6 +32,7 @@ import flydsl.expr as fx
 from mori.tensor_utils import from_gpu_ptr
 
 from .intranode_kernels import (
+    xdb_flag_slots,
     make_dispatch,
     make_combine,
     make_combine_scatter,
@@ -516,15 +517,11 @@ class EpDispatchCombineOp:
         self.total_recv = torch.zeros(1, dtype=torch.int32, device=device)
         self.combine_barrier = torch.zeros(1, dtype=torch.int32, device=device)
         # Per-block xdb flag counters for the gather combine entry barrier: one
-        # i64 per block, sized to the largest combine block_num across variants so
-        # every block owns a private counter and all stay in lockstep across calls
-        # that pick different block_num (the last block advances the tail).
-        if cfg.schedule:
-            self._max_comb_block = max(b[3] for b in cfg.schedule)
-        else:
-            self._max_comb_block = cfg.combine_block_num
+        # i64 per block, fixed at xdb_flag_slots (== CU count, the max combine
+        # block_num). Every block owns a private counter and block 0 fills the
+        # unused tail so all stay in lockstep across calls with different block_num.
         self.cross_device_flag = torch.ones(
-            self._max_comb_block, dtype=torch.int64, device=device
+            xdb_flag_slots, dtype=torch.int64, device=device
         )
         c_dt = cfg.combine_dtype  # combine output dtype
         c_elem = cfg.combine_elem_size
@@ -639,7 +636,6 @@ class EpDispatchCombineOp:
                     warp_num_per_block=w,
                     off_out_tok=arena.offset("out_tok"),
                     off_xdb_mem=arena.offset("cross_device_barrier"),
-                    max_block_num=self._max_comb_block,
                     off_out_wts=arena.offset("out_wts"),
                     reset_total_recv=True,
                     fp4=(cfg.combine_dtype == torch.float4_e2m1fn_x2),

--- a/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
+++ b/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
@@ -39,6 +39,7 @@ from .intranode_kernels import (
     make_convert_dispatch_output,
     make_convert_combine_input,
     make_local_expert_count,
+    _COMB_NSTREAMS,
 )
 
 _QUANT_TYPES = ("none", "fp8_direct_cast", "fp8_blockwise")
@@ -619,6 +620,7 @@ class EpDispatchCombineOp:
                     fp8_blockwise=cfg.fp8_blockwise,
                     scale_dim=cfg.combine_scale_dim,
                     reset_total_recv=False,
+                    _unroll=_COMB_NSTREAMS,
                 )
                 for (b, w) in combine_specs
             }
@@ -639,7 +641,7 @@ class EpDispatchCombineOp:
                     off_out_wts=arena.offset("out_wts"),
                     reset_total_recv=True,
                     fp4=(cfg.combine_dtype == torch.float4_e2m1fn_x2),
-                    _unroll=4,
+                    _unroll=_COMB_NSTREAMS,
                 )
                 for (b, w) in combine_specs
             }

--- a/python/mori/ops/dispatch_combine_v2/flydsl_prims.py
+++ b/python/mori/ops/dispatch_combine_v2/flydsl_prims.py
@@ -206,6 +206,18 @@ def spin_until_eq_i64(addr_i64, val):
     return _spin64(addr_i64, lambda cur: cur != fx.Int64(val))
 
 
+def spin_until_ge_i64(addr_i64, val):
+    """Spin until *addr (i64) >= val (signed).
+
+    For a MONOTONIC cross-device flag this is deadlock-safe under lapping: if a
+    faster peer overwrites the slot with a higher call count before a slow rank
+    reads it, `>=` still passes (whereas `==` would spin forever). It only
+    releases early when the peer is *ahead* — the safe direction for a
+    wait-for-peer barrier.
+    """
+    return _spin64(addr_i64, lambda cur: cur < fx.Int64(val))
+
+
 def spin_until_eq_i32(addr_i64, val):
     """Spin until *addr == val."""
     return _spin(addr_i64, lambda cur: cur != fx.Int32(val))

--- a/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
+++ b/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
@@ -788,6 +788,7 @@ def make_combine(
     warp_num_per_block,
     off_out_tok,
     off_xdb_mem,
+    max_block_num=None,
     off_out_wts=0,
     enable_weights=True,
     fp8_direct_cast=False,
@@ -796,6 +797,11 @@ def make_combine(
     _s3_cache=2,
     _unroll=2,
 ):
+    # Size of the per-block xdb flag counter array (>= block_num). All variants
+    # sharing the flag buffer pass the same max_block_num so the tail counters
+    # stay in lockstep across calls that pick different block_num.
+    if max_block_num is None:
+        max_block_num = block_num
     # Transport dtype = external dtype, except fp8_direct_cast wires fp8 while
     # the output (comb_out) stays bf16 (2 i32 per fp8 i32 unit). fp4: i32 = 8 fp4.
     _to_accum2, _from_accum2, _zero_accum = _accum_funcs(
@@ -831,38 +837,59 @@ def make_combine(
 
         window = cco.Window(arena)
         rsrc_tok_map = create_buffer_resource_from_addr(addr_tok_map)
-        rsrc_comb_bar = create_buffer_resource_from_addr(addr_comb_bar)
         rsrc_total_recv = create_buffer_resource_from_addr(addr_total_recv)
         rsrc_out = create_buffer_resource_from_addr(addr_out)
-        xdb_cur_flag = P.load_i64_acquire(fx.Int64(addr_xdb_flag))
+        rsrc_xdb_flag = create_buffer_resource_from_addr(addr_xdb_flag)
 
-        # ── Stage 1: cross-device entry barrier (block 0 only) ──
-        # Block 0 handles the full xdb handshake, then signals other blocks
-        # via comb_bar. Eliminates the grid barrier and per-block xdb spin.
+        # ── Stage 1: per-block cross-device entry barrier ──
+        # Each block owns a PRIVATE flag counter xdb_flag[bid]; all counters stay
+        # in lockstep (== combine call count) because every block bumps its own
+        # once per call (single writer -> no atomic, no cross-block race). Block 0
+        # pushes this call's flag to every peer's shared xdb slot (npes posted
+        # writes); then EVERY block independently polls the SAME local slots for
+        # its own flag. No shared comb_bar (no atomic contention / reset /
+        # cross-call race) and no block-0 funnel; the monotonic flag needs no
+        # reset. Polling is local (peer pushes into our slots), so the extra
+        # per-block spins add no remote traffic.
+        phase = fx.Int64(
+            buffer_load(rsrc_xdb_flag, bid, vec_width=1, dtype=T.i64())
+        )
         if grid_thread_id < npes:
             xdb_remote = fx.Int64(
                 window.lsa_ptr(grid_thread_id, off_xdb_mem)
             ) + fx.Int64(rank) * fx.Int64(8)
-            P.store_i64_system(xdb_remote, arith.constant(0), xdb_cur_flag)
-        if grid_thread_id == 0:
-            P.atomic_add_global(
-                fx.Int64(addr_xdb_flag), arith.constant(1, type=T.i64())
+            P.store_i64_system(xdb_remote, arith.constant(0), phase)
+        # advance this block's private counter for the next call (single writer)
+        if tid == 0:
+            buffer_store(
+                phase + arith.constant(1, type=T.i64()), rsrc_xdb_flag, bid
             )
-        if grid_thread_id < npes:
+            # the last block also advances the unused tail counters so a later
+            # call that picks a larger block_num still reads synced counters.
+            if const_expr(max_block_num > block_num):
+                if bid == block_num - 1:
+                    for j in range_constexpr(max_block_num - block_num):
+                        buffer_store(
+                            phase + arith.constant(1, type=T.i64()),
+                            rsrc_xdb_flag,
+                            block_num + j,
+                        )
+        # every block independently polls the shared local slots (local reads).
+        # Use >= (not ==): every block — including late-scheduled ones — reads the
+        # slot, so a faster peer can lap us and overwrite its (monotonic) push with
+        # a higher call count before our late blocks read it. `>=` still releases
+        # (a peer being ahead is the safe direction); `==` would deadlock.
+        if tid < npes:
             xdb_peer_slot = fx.Int64(
                 window.lsa_ptr(my_lsa_rank, off_xdb_mem)
-            ) + fx.Int64(grid_thread_id) * fx.Int64(8)
-            P.spin_until_eq_i64(xdb_peer_slot, xdb_cur_flag)
-        if bid == 0:
-            fx.barrier()
-            if tid == 0:
-                P.store_i32_system(
-                    fx.Int64(addr_comb_bar), arith.constant(0), arith.constant(1)
-                )
-        if bid != 0:
-            if tid == 0:
-                P.spin_until_gt_i32(fx.Int64(addr_comb_bar), 0)
-            fx.barrier()
+            ) + fx.Int64(tid) * fx.Int64(8)
+            P.spin_until_ge_i64(xdb_peer_slot, phase)
+        fx.barrier()
+        # No acquire fence needed here: the gather reads peer out_tok via
+        # non-temporal loads (cache-bypassing, always fresh from HBM), and the
+        # spin above is a control dependency ordering the gather after the flag.
+        # Peer's out_tok is written before its flag push (kernel boundary), so
+        # observing the flag implies the data is ready.
         if const_expr(reset_total_recv):
             if tid == 0:
                 buffer_store(arith.constant(0), rsrc_total_recv, 0)
@@ -1045,16 +1072,10 @@ def make_combine(
 
             _accum_loop()
 
-        # Arrival ack moved to kernel end: each non-zero block signals
-        # completion here (after compute) instead of at entry.
-        if bid != 0:
-            fx.barrier()
-            if tid == 0:
-                P.atomic_add_global(fx.Int64(addr_comb_bar), arith.constant(1))
-        if global_warp_id == 0:
-            if lane == 0:
-                P.spin_until_gt_i32(fx.Int64(addr_comb_bar), block_num - 1)
-                buffer_store(arith.constant(0), rsrc_comb_bar, 0)
+        # No exit barrier: the per-block monotonic flag needs no reset, and gather
+        # does no post-completion work, so kernel retirement (stream-ordered) is
+        # the only completion signal the host needs. This removes the former
+        # (block_num-1)-way contended atomic_add on comb_bar.
 
     @flyc.jit
     def run(

--- a/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
+++ b/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
@@ -775,6 +775,12 @@ def _accum_funcs_int(hidden_elem_size, fp8_direct_cast=False):
     return to_accum, from_accum, zero_accum
 
 
+# Fixed size of the per-block xdb flag counter array for the gather combine entry
+# barrier: one i64 per block. 256 == the CU count (the max combine block_num), so
+# block_num never exceeds it. Deliberately a hard-coded compile-time constant.
+xdb_flag_slots = 256
+
+
 def make_combine(
     *,
     rank,
@@ -788,7 +794,6 @@ def make_combine(
     warp_num_per_block,
     off_out_tok,
     off_xdb_mem,
-    max_block_num=None,
     off_out_wts=0,
     enable_weights=True,
     fp8_direct_cast=False,
@@ -797,11 +802,6 @@ def make_combine(
     _s3_cache=2,
     _unroll=2,
 ):
-    # Size of the per-block xdb flag counter array (>= block_num). All variants
-    # sharing the flag buffer pass the same max_block_num so the tail counters
-    # stay in lockstep across calls that pick different block_num.
-    if max_block_num is None:
-        max_block_num = block_num
     # Transport dtype = external dtype, except fp8_direct_cast wires fp8 while
     # the output (comb_out) stays bf16 (2 i32 per fp8 i32 unit). fp4: i32 = 8 fp4.
     _to_accum2, _from_accum2, _zero_accum = _accum_funcs(
@@ -864,15 +864,23 @@ def make_combine(
             buffer_store(
                 phase + arith.constant(1, type=T.i64()), rsrc_xdb_flag, bid
             )
-            # the last block also advances the unused tail counters so a later
-            # call that picks a larger block_num still reads synced counters.
-            if const_expr(max_block_num > block_num):
-                if bid == block_num - 1:
-                    for j in range_constexpr(max_block_num - block_num):
+        # block 0 fills the unused tail counters [block_num, XDB_FLAG_SLOTS) in
+        # parallel so a later call that picks a larger block_num still reads
+        # synced counters. Nobody reads these slots this call => no cross-block
+        # race. block 0 has warp_num_per_block*WAVE threads, which can be < the
+        # tail (e.g. WAVE=32, warp=4 => 128 threads < 256-block_num), so stride
+        # over the tail in a compile-time-fixed number of rounds (1-2 in practice).
+        if const_expr(XDB_FLAG_SLOTS > block_num):
+            if bid == 0:
+                _tail = XDB_FLAG_SLOTS - block_num
+                _nthr = warp_num_per_block * WAVE
+                for r in range_constexpr((_tail + _nthr - 1) // _nthr):
+                    idx = tid + r * _nthr
+                    if idx < _tail:
                         buffer_store(
                             phase + arith.constant(1, type=T.i64()),
                             rsrc_xdb_flag,
-                            block_num + j,
+                            block_num + idx,
                         )
         # every block independently polls the shared local slots (local reads).
         # Use >= (not ==): every block — including late-scheduled ones — reads the

--- a/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
+++ b/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
@@ -93,7 +93,8 @@ LANE_MASK = WAVE - 1
 LOG2_WAVE = WAVE.bit_length() - 1
 _BALLOT_INT = T.i64 if WAVE == 64 else T.i32
 _LANE_STRIDE_I32 = WAVE * 4  # one wave of lanes, vec4 (16B) each
-_MAIN_STRIDE_I32 = 4 * _LANE_STRIDE_I32
+_DISP_NSTREAMS = 4 if WAVE == 32 else 2
+_MAIN_STRIDE_I32 = _DISP_NSTREAMS * _LANE_STRIDE_I32
 _BUTTERFLY_OFFSETS = tuple(WAVE >> i for i in range(1, LOG2_WAVE + 1))
 
 # ── dispatch ──────────────────────────────────────────────────────────────
@@ -323,11 +324,6 @@ def make_dispatch(
                                     dst_tok[s] * scale_num_i32 + k_off,
                                 )
 
-                # Token-embedding scatter: each lane owns 4 i32 (16B). Four vec4
-                # streams (chunk + k*_LANE_STRIDE_I32 for k in 0..3, stride
-                # _MAIN_STRIDE_I32) for memory-level parallelism; a one-stream tail
-                # covers the remainder. The local load happens ONCE per tile and
-                # fans out to every dest PE that published a slot (load-once).
                 local_tok_addr = fx.Int64(addr_inp_tok) + fx.Int64(src_tok) * fx.Int64(
                     nbytes
                 )
@@ -336,26 +332,16 @@ def make_dispatch(
                 safe_end_i32 = (n_i32 // _MAIN_STRIDE_I32) * _MAIN_STRIDE_I32
                 if const_expr(n_i32 >= _MAIN_STRIDE_I32 and safe_end_i32 > 0):
                     for chunk in range(lane_i32_off, safe_end_i32, _MAIN_STRIDE_I32):
-                        vec_a = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32())
-                        vec_b = buffer_load(
-                            rsrc_src, chunk + _LANE_STRIDE_I32, vec_width=4, dtype=T.i32()
-                        )
-                        vec_c = buffer_load(
-                            rsrc_src, chunk + 2 * _LANE_STRIDE_I32, vec_width=4, dtype=T.i32()
-                        )
-                        vec_d = buffer_load(
-                            rsrc_src, chunk + 3 * _LANE_STRIDE_I32, vec_width=4, dtype=T.i32()
-                        )
+                        vecs = [
+                            buffer_load(rsrc_src, chunk + k * _LANE_STRIDE_I32,
+                                        vec_width=4, dtype=T.i32())
+                            for k in range(_DISP_NSTREAMS)
+                        ]
                         for s in range_constexpr(experts_per_token):
                             if dst_pub[s]:
-                                buffer_store(vec_a, dst_rsrc[s], chunk)
-                                buffer_store(vec_b, dst_rsrc[s], chunk + _LANE_STRIDE_I32)
-                                buffer_store(
-                                    vec_c, dst_rsrc[s], chunk + 2 * _LANE_STRIDE_I32
-                                )
-                                buffer_store(
-                                    vec_d, dst_rsrc[s], chunk + 3 * _LANE_STRIDE_I32
-                                )
+                                for k in range(_DISP_NSTREAMS):
+                                    buffer_store(vecs[k], dst_rsrc[s],
+                                                 chunk + k * _LANE_STRIDE_I32)
                 if const_expr(safe_end_i32 < n_i32):
                     for chunk in range(
                         lane_i32_off + safe_end_i32, n_i32, _LANE_STRIDE_I32
@@ -484,13 +470,6 @@ def make_dispatch(
                                 dest_tok_id * scale_num_i32 + k_off,
                             )
 
-                # Token-embedding scatter: each lane owns 4 i32 (16B). Four vec4
-                # streams (chunk + k*_LANE_STRIDE_I32 for k in 0..3, stride
-                # _MAIN_STRIDE_I32) for memory-level parallelism, matching the
-                # load-once path's 4-way load width so the two variants differ ONLY
-                # in load-once/store-many vs per-work-item reload. A one-stream tail
-                # covers the remainder. Dropped slots (dup/overflow) set copy_end ==
-                # lane_i32_off → no-op.
                 peer_tok_base = fx.Int64(window.lsa_ptr(dest_pe, off_out_tok))
                 remote_tok_addr = peer_tok_base + fx.Int64(dest_tok_id) * fx.Int64(nbytes)
                 local_tok_addr = fx.Int64(addr_inp_tok) + fx.Int64(src_tok) * fx.Int64(
@@ -505,20 +484,14 @@ def make_dispatch(
                         is_dup_or_overflow, lane_i32_off, safe_end_i32
                     )
                     for chunk in range(lane_i32_off, copy_end_main, _MAIN_STRIDE_I32):
-                        vec_a = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32())
-                        vec_b = buffer_load(
-                            rsrc_src, chunk + _LANE_STRIDE_I32, vec_width=4, dtype=T.i32()
-                        )
-                        vec_c = buffer_load(
-                            rsrc_src, chunk + 2 * _LANE_STRIDE_I32, vec_width=4, dtype=T.i32()
-                        )
-                        vec_d = buffer_load(
-                            rsrc_src, chunk + 3 * _LANE_STRIDE_I32, vec_width=4, dtype=T.i32()
-                        )
-                        buffer_store(vec_a, rsrc_dst, chunk)
-                        buffer_store(vec_b, rsrc_dst, chunk + _LANE_STRIDE_I32)
-                        buffer_store(vec_c, rsrc_dst, chunk + 2 * _LANE_STRIDE_I32)
-                        buffer_store(vec_d, rsrc_dst, chunk + 3 * _LANE_STRIDE_I32)
+                        vecs = [
+                            buffer_load(rsrc_src, chunk + k * _LANE_STRIDE_I32,
+                                        vec_width=4, dtype=T.i32())
+                            for k in range(_DISP_NSTREAMS)
+                        ]
+                        for k in range(_DISP_NSTREAMS):
+                            buffer_store(vecs[k], rsrc_dst,
+                                         chunk + k * _LANE_STRIDE_I32)
                 if const_expr(safe_end_i32 < n_i32):
                     copy_end_tail = arith.select(is_dup_or_overflow, lane_i32_off, n_i32)
                     for chunk in range(

--- a/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
+++ b/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
@@ -93,7 +93,7 @@ LANE_MASK = WAVE - 1
 LOG2_WAVE = WAVE.bit_length() - 1
 _BALLOT_INT = T.i64 if WAVE == 64 else T.i32
 _LANE_STRIDE_I32 = WAVE * 4  # one wave of lanes, vec4 (16B) each
-_MAIN_STRIDE_I32 = 2 * _LANE_STRIDE_I32
+_MAIN_STRIDE_I32 = 4 * _LANE_STRIDE_I32
 _BUTTERFLY_OFFSETS = tuple(WAVE >> i for i in range(1, LOG2_WAVE + 1))
 
 # ── dispatch ──────────────────────────────────────────────────────────────
@@ -166,152 +166,200 @@ def make_dispatch(
         rsrc_dest_ctr = create_buffer_resource_from_addr(addr_dest_pe_ctr)
         rsrc_disp_bar = create_buffer_resource_from_addr(addr_disp_bar)
 
-        # ── Phase 1: P2P-scatter each (src_tok, k_slot) to its dest PE ──
-        for work_idx in range(global_warp_id, work_limit, global_warp_num):
-            src_tok = work_idx // experts_per_token
-            k_slot = work_idx % experts_per_token
-            dest_expert = buffer_load(
-                rsrc_inp_idx, work_idx, vec_width=1, dtype=T.i32()
-            )
-            # Dedup: one token routed to several experts on the SAME dest PE must
-            # be sent only once. Each lane l (< k) inspects this token's l-th
-            # expert; if a LOWER lane already targets our dest_pe, this
-            # (src_tok, k_slot) is a duplicate and gets dropped. safe_lane keeps
-            # the probe in-bounds for lanes >= k_slot.
-            safe_lane = arith.select(lane < k_slot, lane, 0)
-            lane_expert = buffer_load(
+        # ── Phase 1: P2P-scatter each src token to its (deduped) dest PEs ──
+        # One warp owns a whole src token. Lane l (< k) inspects this token's
+        # l-th expert; a slot is the "owner" of its dest PE iff no LOWER lane
+        # already targets that same dest PE (dedup: one token -> a dest PE once).
+        # Each owner allocates a recv slot on its dest PE and publishes metadata.
+        # The token embedding is then loaded from local HBM ONCE per tile and
+        # stored to every distinct dest (load-once / store-many), removing the
+        # per-k redundant local reloads of the same token.
+        for src_tok in range(global_warp_id, inp_cur_tok, global_warp_num):
+            in_k = lane < experts_per_token
+            safe_slot = arith.select(in_k, lane, 0)
+            expert_lane = buffer_load(
                 rsrc_inp_idx,
-                src_tok * experts_per_token + safe_lane,
+                src_tok * experts_per_token + safe_slot,
                 vec_width=1,
                 dtype=T.i32(),
             )
-            dest_pe = dest_expert // experts_per_rank
-            lane_dest_pe = lane_expert // experts_per_rank
-            dup_per_lane = arith.select(
-                lane_dest_pe == dest_pe, arith.select(lane < k_slot, lane, WAVE), WAVE
+            # dest PE of this lane's slot; lanes >= k use npes (never matches).
+            dest_pe_lane = arith.select(
+                in_k, expert_lane // experts_per_rank, arith.constant(npes)
             )
-            dup_ballot = ballot(_BALLOT_INT(), dup_per_lane < WAVE)
-            is_dup = dup_ballot != 0
 
             if const_expr(replay):
-                # decode dest_tok_id from cached tok_map (skip atomic alloc; same layout)
-                cached = buffer_load(rsrc_tok_map, work_idx, vec_width=1, dtype=T.i32())
-                is_dup_or_overflow = cached >= sentinel_val
-                do_publish = cached < sentinel_val
-                dest_tok_id = cached - dest_pe * max_recv
-            else:
-                dest_tok_lane0 = arith.constant(0)
-                if lane == 0:
-                    if dup_ballot == 0:
-                        peer_tok_off = fx.Int64(window.lsa_ptr(dest_pe, off_tok_off))
-                        dest_tok_lane0 = P.atomic_add_global(peer_tok_off, fx.Int32(1))
-                dest_tok_id = readlane(T.i32(), dest_tok_lane0, 0)
-                overflow = dest_tok_id >= max_recv
-                is_dup_or_overflow = arith.select(is_dup, is_dup, overflow)
-                no_dup = dup_ballot == 0
-                in_cap = dest_tok_id < max_recv
-                do_publish = arith.select(no_dup, in_cap, no_dup)
-                tok_map_entry = arith.select(
-                    is_dup_or_overflow, sentinel_val, dest_pe * max_recv + dest_tok_id
+                # decode each slot from cached tok_map (skip atomic alloc).
+                cached = buffer_load(
+                    rsrc_tok_map,
+                    src_tok * experts_per_token + safe_slot,
+                    vec_width=1,
+                    dtype=T.i32(),
                 )
-                if lane == 0:
-                    buffer_store(tok_map_entry, rsrc_tok_map, work_idx)
+            else:
+                # owner_l = no lower lane j (< l, j < k) shares dest_pe_lane.
+                dup_cnt = arith.constant(0)
+                for j in range_constexpr(experts_per_token):
+                    pe_j = readlane(T.i32(), dest_pe_lane, j)
+                    match_j = arith.select(
+                        pe_j == dest_pe_lane,
+                        arith.select(j < lane, arith.constant(1), arith.constant(0)),
+                        arith.constant(0),
+                    )
+                    dup_cnt = dup_cnt + match_j
+                owner_i32 = arith.select(
+                    dup_cnt == arith.constant(0), arith.constant(1), arith.constant(0)
+                )
 
-            if lane == 0:
-                if do_publish:
-                    # publish this recv slot's origin into the dest peer's tis
-                    # (recv slot -> global source token id) for combine routing.
-                    src_tok_encoded = rank * max_tok_per_rank + src_tok
-                    peer_tis = fx.Int64(window.lsa_ptr(dest_pe, off_tis))
-                    buffer_store(
-                        src_tok_encoded,
-                        create_buffer_resource_from_addr(peer_tis),
-                        dest_tok_id,
-                    )
-                    dest_ctr_addr = fx.Int64(addr_dest_pe_ctr) + fx.Int64(
-                        dest_pe
-                    ) * fx.Int64(4)
-                    P.atomic_add_global(dest_ctr_addr, fx.Int32(1))
-
-            # Per-lane (weight, expert-idx) scatter (lanes < k).
-            if lane < experts_per_token:
-                if do_publish:
-                    weight_src_off = src_tok * experts_per_token + lane
-                    weight_val = buffer_load(
-                        rsrc_inp_wts, weight_src_off, vec_width=1, dtype=T.f32()
-                    )
-                    idx_val = buffer_load(
-                        rsrc_inp_idx, weight_src_off, vec_width=1, dtype=T.i32()
-                    )
-                    dest_slot = dest_tok_id * experts_per_token + lane
-                    peer_wts = fx.Int64(window.lsa_ptr(dest_pe, off_out_wts))
-                    buffer_store(
-                        arith.bitcast(T.i32(), weight_val),
-                        create_buffer_resource_from_addr(peer_wts),
-                        dest_slot,
-                    )
-                    peer_idx = fx.Int64(window.lsa_ptr(dest_pe, off_out_idx))
-                    buffer_store(
-                        idx_val, create_buffer_resource_from_addr(peer_idx), dest_slot
-                    )
-
-            # Per-token scales scatter: forward the src token's scale_num_i32 dwords
-            # to the dest peer's out_scales[dest_tok_id] (lane-strided to cover
-            # scale_dim > one wavefront). Verbatim copy (opaque bytes).
-            if const_expr(enable_scales):
-                if do_publish:
-                    rsrc_inp_scales = create_buffer_resource_from_addr(addr_inp_scales)
-                    peer_scales = fx.Int64(window.lsa_ptr(dest_pe, off_out_scales))
-                    rsrc_peer_scales = create_buffer_resource_from_addr(peer_scales)
-                    for k_off in range(lane, scale_num_i32, WAVE):
-                        scale_val = buffer_load(
-                            rsrc_inp_scales,
-                            src_tok * scale_num_i32 + k_off,
-                            vec_width=1,
-                            dtype=T.i32(),
+            # Resolve to distinct dest PEs as warp-uniform per-slot lists. Slot
+            # alloc, tok_map and the tis/ctr publish stay lane-0-driven (the
+            # per-work-item baseline pattern); only weights/embedding fan out
+            # across lanes.
+            dst_pub = []
+            dst_pe = []
+            dst_tok = []
+            dst_rsrc = []
+            for s in range_constexpr(experts_per_token):
+                pe_s = readlane(T.i32(), dest_pe_lane, s)
+                if const_expr(replay):
+                    cached_s = readlane(T.i32(), cached, s)
+                    pub_s = cached_s < sentinel_val
+                    tok_s = cached_s - pe_s * max_recv
+                else:
+                    owner_s = readlane(T.i32(), owner_i32, s) == arith.constant(1)
+                    # lane 0 allocates one recv slot on this (distinct) dest PE.
+                    tok_lane0 = arith.constant(0)
+                    if owner_s:
+                        if lane == 0:
+                            peer_tok_off = fx.Int64(
+                                window.lsa_ptr(pe_s, off_tok_off)
+                            )
+                            tok_lane0 = P.atomic_add_global(peer_tok_off, fx.Int32(1))
+                    tok_s = readlane(T.i32(), tok_lane0, 0)
+                    in_cap_s = tok_s < max_recv
+                    pub_s = arith.select(owner_s, in_cap_s, owner_s)
+                    if lane == 0:
+                        entry_s = arith.select(
+                            pub_s, pe_s * max_recv + tok_s, sentinel_val
                         )
                         buffer_store(
-                            scale_val,
-                            rsrc_peer_scales,
-                            dest_tok_id * scale_num_i32 + k_off,
+                            entry_s, rsrc_tok_map, src_tok * experts_per_token + s
                         )
+                safe_tok_s = arith.select(pub_s, tok_s, arith.constant(0))
+                remote_tok_addr = fx.Int64(
+                    window.lsa_ptr(pe_s, off_out_tok)
+                ) + fx.Int64(safe_tok_s) * fx.Int64(nbytes)
+                dst_pub.append(pub_s)
+                dst_pe.append(pe_s)
+                dst_tok.append(safe_tok_s)
+                dst_rsrc.append(create_buffer_resource_from_addr(remote_tok_addr))
 
-            # Token-embedding scatter: each lane owns 4 i32 (16B). Two vec4 streams
-            # (chunk and chunk+_LANE_STRIDE_I32, stride _MAIN_STRIDE_I32) for
-            # memory-level parallelism; a one-stream tail covers the remainder.
-            # Dropped slots (dup/overflow) set copy_end == lane_i32_off → no-op.
-            peer_tok_base = fx.Int64(window.lsa_ptr(dest_pe, off_out_tok))
-            remote_tok_addr = peer_tok_base + fx.Int64(dest_tok_id) * fx.Int64(nbytes)
+            # Metadata fan-out: publish to each distinct dest PE.
+            for s in range_constexpr(experts_per_token):
+                if dst_pub[s]:
+                    if lane == 0:
+                        # recv slot -> global source token id (combine routing).
+                        src_tok_encoded = rank * max_tok_per_rank + src_tok
+                        peer_tis = fx.Int64(window.lsa_ptr(dst_pe[s], off_tis))
+                        buffer_store(
+                            src_tok_encoded,
+                            create_buffer_resource_from_addr(peer_tis),
+                            dst_tok[s],
+                        )
+                        dest_ctr_addr = fx.Int64(addr_dest_pe_ctr) + fx.Int64(
+                            dst_pe[s]
+                        ) * fx.Int64(4)
+                        P.atomic_add_global(dest_ctr_addr, fx.Int32(1))
+                    if lane < experts_per_token:
+                        weight_src_off = src_tok * experts_per_token + lane
+                        weight_val = buffer_load(
+                            rsrc_inp_wts, weight_src_off, vec_width=1, dtype=T.f32()
+                        )
+                        idx_val = buffer_load(
+                            rsrc_inp_idx, weight_src_off, vec_width=1, dtype=T.i32()
+                        )
+                        dest_slot = dst_tok[s] * experts_per_token + lane
+                        peer_wts = fx.Int64(window.lsa_ptr(dst_pe[s], off_out_wts))
+                        buffer_store(
+                            arith.bitcast(T.i32(), weight_val),
+                            create_buffer_resource_from_addr(peer_wts),
+                            dest_slot,
+                        )
+                        peer_idx = fx.Int64(window.lsa_ptr(dst_pe[s], off_out_idx))
+                        buffer_store(
+                            idx_val,
+                            create_buffer_resource_from_addr(peer_idx),
+                            dest_slot,
+                        )
+                    if const_expr(enable_scales):
+                        # Forward the src token's scale_num_i32 dwords verbatim.
+                        rsrc_inp_scales = create_buffer_resource_from_addr(
+                            addr_inp_scales
+                        )
+                        peer_scales = fx.Int64(
+                            window.lsa_ptr(dst_pe[s], off_out_scales)
+                        )
+                        rsrc_peer_scales = create_buffer_resource_from_addr(peer_scales)
+                        for k_off in range(lane, scale_num_i32, WAVE):
+                            scale_val = buffer_load(
+                                rsrc_inp_scales,
+                                src_tok * scale_num_i32 + k_off,
+                                vec_width=1,
+                                dtype=T.i32(),
+                            )
+                            buffer_store(
+                                scale_val,
+                                rsrc_peer_scales,
+                                dst_tok[s] * scale_num_i32 + k_off,
+                            )
+
+            # Token-embedding scatter: each lane owns 4 i32 (16B). Four vec4 streams
+            # (chunk + k*_LANE_STRIDE_I32 for k in 0..3, stride _MAIN_STRIDE_I32) for
+            # memory-level parallelism; a one-stream tail covers the remainder. The
+            # local load happens ONCE per tile and fans out to every dest PE that
+            # published a slot for this token (load-once / store-many).
             local_tok_addr = fx.Int64(addr_inp_tok) + fx.Int64(src_tok) * fx.Int64(
                 nbytes
             )
             rsrc_src = create_buffer_resource_from_addr(local_tok_addr)
-            rsrc_dst = create_buffer_resource_from_addr(remote_tok_addr)
             lane_i32_off = lane * 4
             safe_end_i32 = (n_i32 // _MAIN_STRIDE_I32) * _MAIN_STRIDE_I32
             if const_expr(n_i32 >= _MAIN_STRIDE_I32 and safe_end_i32 > 0):
-                copy_end_main = arith.select(
-                    is_dup_or_overflow, lane_i32_off, safe_end_i32
-                )
-                for chunk in range(lane_i32_off, copy_end_main, _MAIN_STRIDE_I32):
+                for chunk in range(lane_i32_off, safe_end_i32, _MAIN_STRIDE_I32):
                     vec_a = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32())
                     vec_b = buffer_load(
                         rsrc_src, chunk + _LANE_STRIDE_I32, vec_width=4, dtype=T.i32()
                     )
-                    buffer_store(vec_a, rsrc_dst, chunk)
-                    buffer_store(vec_b, rsrc_dst, chunk + _LANE_STRIDE_I32)
+                    vec_c = buffer_load(
+                        rsrc_src, chunk + 2 * _LANE_STRIDE_I32, vec_width=4, dtype=T.i32()
+                    )
+                    vec_d = buffer_load(
+                        rsrc_src, chunk + 3 * _LANE_STRIDE_I32, vec_width=4, dtype=T.i32()
+                    )
+                    for s in range_constexpr(experts_per_token):
+                        if dst_pub[s]:
+                            buffer_store(vec_a, dst_rsrc[s], chunk)
+                            buffer_store(vec_b, dst_rsrc[s], chunk + _LANE_STRIDE_I32)
+                            buffer_store(
+                                vec_c, dst_rsrc[s], chunk + 2 * _LANE_STRIDE_I32
+                            )
+                            buffer_store(
+                                vec_d, dst_rsrc[s], chunk + 3 * _LANE_STRIDE_I32
+                            )
             if const_expr(safe_end_i32 < n_i32):
-                copy_end_tail = arith.select(is_dup_or_overflow, lane_i32_off, n_i32)
                 for chunk in range(
-                    lane_i32_off + safe_end_i32, copy_end_tail, _LANE_STRIDE_I32
+                    lane_i32_off + safe_end_i32, n_i32, _LANE_STRIDE_I32
                 ):
                     vec_a = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32())
-                    buffer_store(vec_a, rsrc_dst, chunk)
+                    for s in range_constexpr(experts_per_token):
+                        if dst_pub[s]:
+                            buffer_store(vec_a, dst_rsrc[s], chunk)
             elif const_expr(n_i32 < _MAIN_STRIDE_I32):
-                copy_end_small = arith.select(is_dup_or_overflow, lane_i32_off, n_i32)
-                for chunk in range(lane_i32_off, copy_end_small, _LANE_STRIDE_I32):
+                for chunk in range(lane_i32_off, n_i32, _LANE_STRIDE_I32):
                     vec_a = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32())
-                    buffer_store(vec_a, rsrc_dst, chunk)
+                    for s in range_constexpr(experts_per_token):
+                        if dst_pub[s]:
+                            buffer_store(vec_a, dst_rsrc[s], chunk)
 
         if const_expr(enable_signal):
             # Self-reset total_recv (replaces the host-side total_recv.zero_()):
@@ -644,8 +692,6 @@ def make_combine(
             if tid == 0:
                 P.spin_until_gt_i32(fx.Int64(addr_comb_bar), 0)
             fx.barrier()
-            if tid == 0:
-                P.atomic_add_global(fx.Int64(addr_comb_bar), arith.constant(1))
         if const_expr(reset_total_recv):
             if tid == 0:
                 buffer_store(arith.constant(0), rsrc_total_recv, 0)
@@ -828,6 +874,12 @@ def make_combine(
 
             _accum_loop()
 
+        # Arrival ack moved to kernel end: each non-zero block signals
+        # completion here (after compute) instead of at entry.
+        if bid != 0:
+            fx.barrier()
+            if tid == 0:
+                P.atomic_add_global(fx.Int64(addr_comb_bar), arith.constant(1))
         if global_warp_id == 0:
             if lane == 0:
                 P.spin_until_gt_i32(fx.Int64(addr_comb_bar), block_num - 1)

--- a/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
+++ b/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
@@ -123,6 +123,7 @@ def make_dispatch(
     enable_signal=True,
     replay=False,
     fp4=False,
+    load_once=True,
 ):
     # fp4 (e2m1) packs 2 values per byte, so a token is hidden_dim/2 bytes; dispatch
     # is a pure byte mover (no fp4 decode), matching mori v1's plain-fp4 path.
@@ -166,111 +167,283 @@ def make_dispatch(
         rsrc_dest_ctr = create_buffer_resource_from_addr(addr_dest_pe_ctr)
         rsrc_disp_bar = create_buffer_resource_from_addr(addr_disp_bar)
 
-        # ── Phase 1: P2P-scatter each src token to its (deduped) dest PEs ──
-        # One warp owns a whole src token. Lane l (< k) inspects this token's
-        # l-th expert; a slot is the "owner" of its dest PE iff no LOWER lane
-        # already targets that same dest PE (dedup: one token -> a dest PE once).
-        # Each owner allocates a recv slot on its dest PE and publishes metadata.
-        # The token embedding is then loaded from local HBM ONCE per tile and
-        # stored to every distinct dest (load-once / store-many), removing the
-        # per-k redundant local reloads of the same token.
-        for src_tok in range(global_warp_id, inp_cur_tok, global_warp_num):
-            in_k = lane < experts_per_token
-            safe_slot = arith.select(in_k, lane, 0)
-            expert_lane = buffer_load(
-                rsrc_inp_idx,
-                src_tok * experts_per_token + safe_slot,
-                vec_width=1,
-                dtype=T.i32(),
-            )
-            # dest PE of this lane's slot; lanes >= k use npes (never matches).
-            dest_pe_lane = arith.select(
-                in_k, expert_lane // experts_per_rank, arith.constant(npes)
-            )
-
-            if const_expr(replay):
-                # decode each slot from cached tok_map (skip atomic alloc).
-                cached = buffer_load(
-                    rsrc_tok_map,
+        # ── Phase 1: algorithm chosen at COMPILE time via load_once ──
+        # load_once=True : warp-per-token load-once / store-many with 4-way load
+        #   MLP (local tile loaded ONCE, fanned out to every distinct dest). Big
+        #   win at large token counts.
+        # load_once=False: the original warp-per-(token,expert) path with 2-way
+        #   load (each work-item reloads its token). Better at small/mid token
+        #   counts (finer work granularity fills the grid). The host picks the
+        #   variant by token count; each compiled kernel contains only ONE path,
+        #   so there is no VGPR union / occupancy penalty.
+        if const_expr(load_once):
+            # One warp owns a whole src token. Lane l (< k) inspects this token's
+            # l-th expert; a slot is the "owner" of its dest PE iff no LOWER lane
+            # already targets that same dest PE (dedup: one token -> a dest PE once).
+            # Each owner allocates a recv slot on its dest PE and publishes metadata.
+            # The token embedding is then loaded from local HBM ONCE per tile and
+            # stored to every distinct dest (load-once / store-many), removing the
+            # per-k redundant local reloads of the same token.
+            for src_tok in range(global_warp_id, inp_cur_tok, global_warp_num):
+                in_k = lane < experts_per_token
+                safe_slot = arith.select(in_k, lane, 0)
+                expert_lane = buffer_load(
+                    rsrc_inp_idx,
                     src_tok * experts_per_token + safe_slot,
                     vec_width=1,
                     dtype=T.i32(),
                 )
-            else:
-                # owner_l = no lower lane j (< l, j < k) shares dest_pe_lane.
-                dup_cnt = arith.constant(0)
-                for j in range_constexpr(experts_per_token):
-                    pe_j = readlane(T.i32(), dest_pe_lane, j)
-                    match_j = arith.select(
-                        pe_j == dest_pe_lane,
-                        arith.select(j < lane, arith.constant(1), arith.constant(0)),
-                        arith.constant(0),
-                    )
-                    dup_cnt = dup_cnt + match_j
-                owner_i32 = arith.select(
-                    dup_cnt == arith.constant(0), arith.constant(1), arith.constant(0)
+                # dest PE of this lane's slot; lanes >= k use npes (never matches).
+                dest_pe_lane = arith.select(
+                    in_k, expert_lane // experts_per_rank, arith.constant(npes)
                 )
 
-            # Resolve to distinct dest PEs as warp-uniform per-slot lists. Slot
-            # alloc, tok_map and the tis/ctr publish stay lane-0-driven (the
-            # per-work-item baseline pattern); only weights/embedding fan out
-            # across lanes.
-            dst_pub = []
-            dst_pe = []
-            dst_tok = []
-            dst_rsrc = []
-            for s in range_constexpr(experts_per_token):
-                pe_s = readlane(T.i32(), dest_pe_lane, s)
                 if const_expr(replay):
-                    cached_s = readlane(T.i32(), cached, s)
-                    pub_s = cached_s < sentinel_val
-                    tok_s = cached_s - pe_s * max_recv
+                    # decode each slot from cached tok_map (skip atomic alloc).
+                    cached = buffer_load(
+                        rsrc_tok_map,
+                        src_tok * experts_per_token + safe_slot,
+                        vec_width=1,
+                        dtype=T.i32(),
+                    )
                 else:
-                    owner_s = readlane(T.i32(), owner_i32, s) == arith.constant(1)
-                    # lane 0 allocates one recv slot on this (distinct) dest PE.
-                    tok_lane0 = arith.constant(0)
-                    if owner_s:
-                        if lane == 0:
-                            peer_tok_off = fx.Int64(
-                                window.lsa_ptr(pe_s, off_tok_off)
-                            )
-                            tok_lane0 = P.atomic_add_global(peer_tok_off, fx.Int32(1))
-                    tok_s = readlane(T.i32(), tok_lane0, 0)
-                    in_cap_s = tok_s < max_recv
-                    pub_s = arith.select(owner_s, in_cap_s, owner_s)
-                    if lane == 0:
-                        entry_s = arith.select(
-                            pub_s, pe_s * max_recv + tok_s, sentinel_val
+                    # owner_l = no lower lane j (< l, j < k) shares dest_pe_lane.
+                    dup_cnt = arith.constant(0)
+                    for j in range_constexpr(experts_per_token):
+                        pe_j = readlane(T.i32(), dest_pe_lane, j)
+                        match_j = arith.select(
+                            pe_j == dest_pe_lane,
+                            arith.select(j < lane, arith.constant(1), arith.constant(0)),
+                            arith.constant(0),
                         )
-                        buffer_store(
-                            entry_s, rsrc_tok_map, src_tok * experts_per_token + s
-                        )
-                safe_tok_s = arith.select(pub_s, tok_s, arith.constant(0))
-                remote_tok_addr = fx.Int64(
-                    window.lsa_ptr(pe_s, off_out_tok)
-                ) + fx.Int64(safe_tok_s) * fx.Int64(nbytes)
-                dst_pub.append(pub_s)
-                dst_pe.append(pe_s)
-                dst_tok.append(safe_tok_s)
-                dst_rsrc.append(create_buffer_resource_from_addr(remote_tok_addr))
+                        dup_cnt = dup_cnt + match_j
+                    owner_i32 = arith.select(
+                        dup_cnt == arith.constant(0), arith.constant(1), arith.constant(0)
+                    )
 
-            # Metadata fan-out: publish to each distinct dest PE.
-            for s in range_constexpr(experts_per_token):
-                if dst_pub[s]:
+                # Resolve to distinct dest PEs as warp-uniform per-slot lists. Slot
+                # alloc, tok_map and the tis/ctr publish stay lane-0-driven (the
+                # per-work-item baseline pattern); only weights/embedding fan out
+                # across lanes.
+                dst_pub = []
+                dst_pe = []
+                dst_tok = []
+                dst_rsrc = []
+                for s in range_constexpr(experts_per_token):
+                    pe_s = readlane(T.i32(), dest_pe_lane, s)
+                    if const_expr(replay):
+                        cached_s = readlane(T.i32(), cached, s)
+                        pub_s = cached_s < sentinel_val
+                        tok_s = cached_s - pe_s * max_recv
+                    else:
+                        owner_s = readlane(T.i32(), owner_i32, s) == arith.constant(1)
+                        # lane 0 allocates one recv slot on this (distinct) dest PE.
+                        tok_lane0 = arith.constant(0)
+                        if owner_s:
+                            if lane == 0:
+                                peer_tok_off = fx.Int64(
+                                    window.lsa_ptr(pe_s, off_tok_off)
+                                )
+                                tok_lane0 = P.atomic_add_global(peer_tok_off, fx.Int32(1))
+                        tok_s = readlane(T.i32(), tok_lane0, 0)
+                        in_cap_s = tok_s < max_recv
+                        pub_s = arith.select(owner_s, in_cap_s, owner_s)
+                        if lane == 0:
+                            entry_s = arith.select(
+                                pub_s, pe_s * max_recv + tok_s, sentinel_val
+                            )
+                            buffer_store(
+                                entry_s, rsrc_tok_map, src_tok * experts_per_token + s
+                            )
+                    safe_tok_s = arith.select(pub_s, tok_s, arith.constant(0))
+                    remote_tok_addr = fx.Int64(
+                        window.lsa_ptr(pe_s, off_out_tok)
+                    ) + fx.Int64(safe_tok_s) * fx.Int64(nbytes)
+                    dst_pub.append(pub_s)
+                    dst_pe.append(pe_s)
+                    dst_tok.append(safe_tok_s)
+                    dst_rsrc.append(create_buffer_resource_from_addr(remote_tok_addr))
+
+                # Metadata fan-out: publish to each distinct dest PE.
+                for s in range_constexpr(experts_per_token):
+                    if dst_pub[s]:
+                        if lane == 0:
+                            # recv slot -> global source token id (combine routing).
+                            src_tok_encoded = rank * max_tok_per_rank + src_tok
+                            peer_tis = fx.Int64(window.lsa_ptr(dst_pe[s], off_tis))
+                            buffer_store(
+                                src_tok_encoded,
+                                create_buffer_resource_from_addr(peer_tis),
+                                dst_tok[s],
+                            )
+                            dest_ctr_addr = fx.Int64(addr_dest_pe_ctr) + fx.Int64(
+                                dst_pe[s]
+                            ) * fx.Int64(4)
+                            P.atomic_add_global(dest_ctr_addr, fx.Int32(1))
+                        if lane < experts_per_token:
+                            weight_src_off = src_tok * experts_per_token + lane
+                            weight_val = buffer_load(
+                                rsrc_inp_wts, weight_src_off, vec_width=1, dtype=T.f32()
+                            )
+                            idx_val = buffer_load(
+                                rsrc_inp_idx, weight_src_off, vec_width=1, dtype=T.i32()
+                            )
+                            dest_slot = dst_tok[s] * experts_per_token + lane
+                            peer_wts = fx.Int64(window.lsa_ptr(dst_pe[s], off_out_wts))
+                            buffer_store(
+                                arith.bitcast(T.i32(), weight_val),
+                                create_buffer_resource_from_addr(peer_wts),
+                                dest_slot,
+                            )
+                            peer_idx = fx.Int64(window.lsa_ptr(dst_pe[s], off_out_idx))
+                            buffer_store(
+                                idx_val,
+                                create_buffer_resource_from_addr(peer_idx),
+                                dest_slot,
+                            )
+                        if const_expr(enable_scales):
+                            # Forward the src token's scale_num_i32 dwords verbatim.
+                            rsrc_inp_scales = create_buffer_resource_from_addr(
+                                addr_inp_scales
+                            )
+                            peer_scales = fx.Int64(
+                                window.lsa_ptr(dst_pe[s], off_out_scales)
+                            )
+                            rsrc_peer_scales = create_buffer_resource_from_addr(peer_scales)
+                            for k_off in range(lane, scale_num_i32, WAVE):
+                                scale_val = buffer_load(
+                                    rsrc_inp_scales,
+                                    src_tok * scale_num_i32 + k_off,
+                                    vec_width=1,
+                                    dtype=T.i32(),
+                                )
+                                buffer_store(
+                                    scale_val,
+                                    rsrc_peer_scales,
+                                    dst_tok[s] * scale_num_i32 + k_off,
+                                )
+
+                # Token-embedding scatter: each lane owns 4 i32 (16B). Four vec4
+                # streams (chunk + k*_LANE_STRIDE_I32 for k in 0..3, stride
+                # _MAIN_STRIDE_I32) for memory-level parallelism; a one-stream tail
+                # covers the remainder. The local load happens ONCE per tile and
+                # fans out to every dest PE that published a slot (load-once).
+                local_tok_addr = fx.Int64(addr_inp_tok) + fx.Int64(src_tok) * fx.Int64(
+                    nbytes
+                )
+                rsrc_src = create_buffer_resource_from_addr(local_tok_addr)
+                lane_i32_off = lane * 4
+                safe_end_i32 = (n_i32 // _MAIN_STRIDE_I32) * _MAIN_STRIDE_I32
+                if const_expr(n_i32 >= _MAIN_STRIDE_I32 and safe_end_i32 > 0):
+                    for chunk in range(lane_i32_off, safe_end_i32, _MAIN_STRIDE_I32):
+                        vec_a = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32())
+                        vec_b = buffer_load(
+                            rsrc_src, chunk + _LANE_STRIDE_I32, vec_width=4, dtype=T.i32()
+                        )
+                        vec_c = buffer_load(
+                            rsrc_src, chunk + 2 * _LANE_STRIDE_I32, vec_width=4, dtype=T.i32()
+                        )
+                        vec_d = buffer_load(
+                            rsrc_src, chunk + 3 * _LANE_STRIDE_I32, vec_width=4, dtype=T.i32()
+                        )
+                        for s in range_constexpr(experts_per_token):
+                            if dst_pub[s]:
+                                buffer_store(vec_a, dst_rsrc[s], chunk)
+                                buffer_store(vec_b, dst_rsrc[s], chunk + _LANE_STRIDE_I32)
+                                buffer_store(
+                                    vec_c, dst_rsrc[s], chunk + 2 * _LANE_STRIDE_I32
+                                )
+                                buffer_store(
+                                    vec_d, dst_rsrc[s], chunk + 3 * _LANE_STRIDE_I32
+                                )
+                if const_expr(safe_end_i32 < n_i32):
+                    for chunk in range(
+                        lane_i32_off + safe_end_i32, n_i32, _LANE_STRIDE_I32
+                    ):
+                        vec_a = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32())
+                        for s in range_constexpr(experts_per_token):
+                            if dst_pub[s]:
+                                buffer_store(vec_a, dst_rsrc[s], chunk)
+                elif const_expr(n_i32 < _MAIN_STRIDE_I32):
+                    for chunk in range(lane_i32_off, n_i32, _LANE_STRIDE_I32):
+                        vec_a = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32())
+                        for s in range_constexpr(experts_per_token):
+                            if dst_pub[s]:
+                                buffer_store(vec_a, dst_rsrc[s], chunk)
+        else:
+            # ── Original path: P2P-scatter each (src_tok, k_slot) to its dest PE ──
+            # One warp owns a single (token, expert) work-item; the token embedding
+            # is reloaded per work-item (2-way load). Finer work granularity keeps
+            # small/mid token batches from underfilling the grid.
+            for work_idx in range(global_warp_id, work_limit, global_warp_num):
+                src_tok = work_idx // experts_per_token
+                k_slot = work_idx % experts_per_token
+                dest_expert = buffer_load(
+                    rsrc_inp_idx, work_idx, vec_width=1, dtype=T.i32()
+                )
+                # Dedup: one token routed to several experts on the SAME dest PE must
+                # be sent only once. Each lane l (< k) inspects this token's l-th
+                # expert; if a LOWER lane already targets our dest_pe, this
+                # (src_tok, k_slot) is a duplicate and gets dropped. safe_lane keeps
+                # the probe in-bounds for lanes >= k_slot.
+                safe_lane = arith.select(lane < k_slot, lane, 0)
+                lane_expert = buffer_load(
+                    rsrc_inp_idx,
+                    src_tok * experts_per_token + safe_lane,
+                    vec_width=1,
+                    dtype=T.i32(),
+                )
+                dest_pe = dest_expert // experts_per_rank
+                lane_dest_pe = lane_expert // experts_per_rank
+                dup_per_lane = arith.select(
+                    lane_dest_pe == dest_pe, arith.select(lane < k_slot, lane, WAVE), WAVE
+                )
+                dup_ballot = ballot(_BALLOT_INT(), dup_per_lane < WAVE)
+                is_dup = dup_ballot != 0
+
+                if const_expr(replay):
+                    # decode dest_tok_id from cached tok_map (skip atomic alloc; same layout)
+                    cached = buffer_load(rsrc_tok_map, work_idx, vec_width=1, dtype=T.i32())
+                    is_dup_or_overflow = cached >= sentinel_val
+                    do_publish = cached < sentinel_val
+                    dest_tok_id = cached - dest_pe * max_recv
+                else:
+                    dest_tok_lane0 = arith.constant(0)
                     if lane == 0:
-                        # recv slot -> global source token id (combine routing).
+                        if dup_ballot == 0:
+                            peer_tok_off = fx.Int64(window.lsa_ptr(dest_pe, off_tok_off))
+                            dest_tok_lane0 = P.atomic_add_global(peer_tok_off, fx.Int32(1))
+                    dest_tok_id = readlane(T.i32(), dest_tok_lane0, 0)
+                    overflow = dest_tok_id >= max_recv
+                    is_dup_or_overflow = arith.select(is_dup, is_dup, overflow)
+                    no_dup = dup_ballot == 0
+                    in_cap = dest_tok_id < max_recv
+                    do_publish = arith.select(no_dup, in_cap, no_dup)
+                    tok_map_entry = arith.select(
+                        is_dup_or_overflow, sentinel_val, dest_pe * max_recv + dest_tok_id
+                    )
+                    if lane == 0:
+                        buffer_store(tok_map_entry, rsrc_tok_map, work_idx)
+
+                if lane == 0:
+                    if do_publish:
+                        # publish this recv slot's origin into the dest peer's tis
+                        # (recv slot -> global source token id) for combine routing.
                         src_tok_encoded = rank * max_tok_per_rank + src_tok
-                        peer_tis = fx.Int64(window.lsa_ptr(dst_pe[s], off_tis))
+                        peer_tis = fx.Int64(window.lsa_ptr(dest_pe, off_tis))
                         buffer_store(
                             src_tok_encoded,
                             create_buffer_resource_from_addr(peer_tis),
-                            dst_tok[s],
+                            dest_tok_id,
                         )
                         dest_ctr_addr = fx.Int64(addr_dest_pe_ctr) + fx.Int64(
-                            dst_pe[s]
+                            dest_pe
                         ) * fx.Int64(4)
                         P.atomic_add_global(dest_ctr_addr, fx.Int32(1))
-                    if lane < experts_per_token:
+
+                # Per-lane (weight, expert-idx) scatter (lanes < k).
+                if lane < experts_per_token:
+                    if do_publish:
                         weight_src_off = src_tok * experts_per_token + lane
                         weight_val = buffer_load(
                             rsrc_inp_wts, weight_src_off, vec_width=1, dtype=T.f32()
@@ -278,27 +451,25 @@ def make_dispatch(
                         idx_val = buffer_load(
                             rsrc_inp_idx, weight_src_off, vec_width=1, dtype=T.i32()
                         )
-                        dest_slot = dst_tok[s] * experts_per_token + lane
-                        peer_wts = fx.Int64(window.lsa_ptr(dst_pe[s], off_out_wts))
+                        dest_slot = dest_tok_id * experts_per_token + lane
+                        peer_wts = fx.Int64(window.lsa_ptr(dest_pe, off_out_wts))
                         buffer_store(
                             arith.bitcast(T.i32(), weight_val),
                             create_buffer_resource_from_addr(peer_wts),
                             dest_slot,
                         )
-                        peer_idx = fx.Int64(window.lsa_ptr(dst_pe[s], off_out_idx))
+                        peer_idx = fx.Int64(window.lsa_ptr(dest_pe, off_out_idx))
                         buffer_store(
-                            idx_val,
-                            create_buffer_resource_from_addr(peer_idx),
-                            dest_slot,
+                            idx_val, create_buffer_resource_from_addr(peer_idx), dest_slot
                         )
-                    if const_expr(enable_scales):
-                        # Forward the src token's scale_num_i32 dwords verbatim.
-                        rsrc_inp_scales = create_buffer_resource_from_addr(
-                            addr_inp_scales
-                        )
-                        peer_scales = fx.Int64(
-                            window.lsa_ptr(dst_pe[s], off_out_scales)
-                        )
+
+                # Per-token scales scatter: forward the src token's scale_num_i32 dwords
+                # to the dest peer's out_scales[dest_tok_id] (lane-strided to cover
+                # scale_dim > one wavefront). Verbatim copy (opaque bytes).
+                if const_expr(enable_scales):
+                    if do_publish:
+                        rsrc_inp_scales = create_buffer_resource_from_addr(addr_inp_scales)
+                        peer_scales = fx.Int64(window.lsa_ptr(dest_pe, off_out_scales))
                         rsrc_peer_scales = create_buffer_resource_from_addr(peer_scales)
                         for k_off in range(lane, scale_num_i32, WAVE):
                             scale_val = buffer_load(
@@ -310,56 +481,56 @@ def make_dispatch(
                             buffer_store(
                                 scale_val,
                                 rsrc_peer_scales,
-                                dst_tok[s] * scale_num_i32 + k_off,
+                                dest_tok_id * scale_num_i32 + k_off,
                             )
 
-            # Token-embedding scatter: each lane owns 4 i32 (16B). Four vec4 streams
-            # (chunk + k*_LANE_STRIDE_I32 for k in 0..3, stride _MAIN_STRIDE_I32) for
-            # memory-level parallelism; a one-stream tail covers the remainder. The
-            # local load happens ONCE per tile and fans out to every dest PE that
-            # published a slot for this token (load-once / store-many).
-            local_tok_addr = fx.Int64(addr_inp_tok) + fx.Int64(src_tok) * fx.Int64(
-                nbytes
-            )
-            rsrc_src = create_buffer_resource_from_addr(local_tok_addr)
-            lane_i32_off = lane * 4
-            safe_end_i32 = (n_i32 // _MAIN_STRIDE_I32) * _MAIN_STRIDE_I32
-            if const_expr(n_i32 >= _MAIN_STRIDE_I32 and safe_end_i32 > 0):
-                for chunk in range(lane_i32_off, safe_end_i32, _MAIN_STRIDE_I32):
-                    vec_a = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32())
-                    vec_b = buffer_load(
-                        rsrc_src, chunk + _LANE_STRIDE_I32, vec_width=4, dtype=T.i32()
+                # Token-embedding scatter: each lane owns 4 i32 (16B). Four vec4
+                # streams (chunk + k*_LANE_STRIDE_I32 for k in 0..3, stride
+                # _MAIN_STRIDE_I32) for memory-level parallelism, matching the
+                # load-once path's 4-way load width so the two variants differ ONLY
+                # in load-once/store-many vs per-work-item reload. A one-stream tail
+                # covers the remainder. Dropped slots (dup/overflow) set copy_end ==
+                # lane_i32_off → no-op.
+                peer_tok_base = fx.Int64(window.lsa_ptr(dest_pe, off_out_tok))
+                remote_tok_addr = peer_tok_base + fx.Int64(dest_tok_id) * fx.Int64(nbytes)
+                local_tok_addr = fx.Int64(addr_inp_tok) + fx.Int64(src_tok) * fx.Int64(
+                    nbytes
+                )
+                rsrc_src = create_buffer_resource_from_addr(local_tok_addr)
+                rsrc_dst = create_buffer_resource_from_addr(remote_tok_addr)
+                lane_i32_off = lane * 4
+                safe_end_i32 = (n_i32 // _MAIN_STRIDE_I32) * _MAIN_STRIDE_I32
+                if const_expr(n_i32 >= _MAIN_STRIDE_I32 and safe_end_i32 > 0):
+                    copy_end_main = arith.select(
+                        is_dup_or_overflow, lane_i32_off, safe_end_i32
                     )
-                    vec_c = buffer_load(
-                        rsrc_src, chunk + 2 * _LANE_STRIDE_I32, vec_width=4, dtype=T.i32()
-                    )
-                    vec_d = buffer_load(
-                        rsrc_src, chunk + 3 * _LANE_STRIDE_I32, vec_width=4, dtype=T.i32()
-                    )
-                    for s in range_constexpr(experts_per_token):
-                        if dst_pub[s]:
-                            buffer_store(vec_a, dst_rsrc[s], chunk)
-                            buffer_store(vec_b, dst_rsrc[s], chunk + _LANE_STRIDE_I32)
-                            buffer_store(
-                                vec_c, dst_rsrc[s], chunk + 2 * _LANE_STRIDE_I32
-                            )
-                            buffer_store(
-                                vec_d, dst_rsrc[s], chunk + 3 * _LANE_STRIDE_I32
-                            )
-            if const_expr(safe_end_i32 < n_i32):
-                for chunk in range(
-                    lane_i32_off + safe_end_i32, n_i32, _LANE_STRIDE_I32
-                ):
-                    vec_a = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32())
-                    for s in range_constexpr(experts_per_token):
-                        if dst_pub[s]:
-                            buffer_store(vec_a, dst_rsrc[s], chunk)
-            elif const_expr(n_i32 < _MAIN_STRIDE_I32):
-                for chunk in range(lane_i32_off, n_i32, _LANE_STRIDE_I32):
-                    vec_a = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32())
-                    for s in range_constexpr(experts_per_token):
-                        if dst_pub[s]:
-                            buffer_store(vec_a, dst_rsrc[s], chunk)
+                    for chunk in range(lane_i32_off, copy_end_main, _MAIN_STRIDE_I32):
+                        vec_a = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32())
+                        vec_b = buffer_load(
+                            rsrc_src, chunk + _LANE_STRIDE_I32, vec_width=4, dtype=T.i32()
+                        )
+                        vec_c = buffer_load(
+                            rsrc_src, chunk + 2 * _LANE_STRIDE_I32, vec_width=4, dtype=T.i32()
+                        )
+                        vec_d = buffer_load(
+                            rsrc_src, chunk + 3 * _LANE_STRIDE_I32, vec_width=4, dtype=T.i32()
+                        )
+                        buffer_store(vec_a, rsrc_dst, chunk)
+                        buffer_store(vec_b, rsrc_dst, chunk + _LANE_STRIDE_I32)
+                        buffer_store(vec_c, rsrc_dst, chunk + 2 * _LANE_STRIDE_I32)
+                        buffer_store(vec_d, rsrc_dst, chunk + 3 * _LANE_STRIDE_I32)
+                if const_expr(safe_end_i32 < n_i32):
+                    copy_end_tail = arith.select(is_dup_or_overflow, lane_i32_off, n_i32)
+                    for chunk in range(
+                        lane_i32_off + safe_end_i32, copy_end_tail, _LANE_STRIDE_I32
+                    ):
+                        vec_a = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32())
+                        buffer_store(vec_a, rsrc_dst, chunk)
+                elif const_expr(n_i32 < _MAIN_STRIDE_I32):
+                    copy_end_small = arith.select(is_dup_or_overflow, lane_i32_off, n_i32)
+                    for chunk in range(lane_i32_off, copy_end_small, _LANE_STRIDE_I32):
+                        vec_a = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32())
+                        buffer_store(vec_a, rsrc_dst, chunk)
 
         if const_expr(enable_signal):
             # Self-reset total_recv (replaces the host-side total_recv.zero_()):

--- a/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
+++ b/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
@@ -94,6 +94,7 @@ LOG2_WAVE = WAVE.bit_length() - 1
 _BALLOT_INT = T.i64 if WAVE == 64 else T.i32
 _LANE_STRIDE_I32 = WAVE * 4  # one wave of lanes, vec4 (16B) each
 _DISP_NSTREAMS = 4 if WAVE == 32 else 2
+_COMB_NSTREAMS = 4 if WAVE == 32 else 2
 _MAIN_STRIDE_I32 = _DISP_NSTREAMS * _LANE_STRIDE_I32
 _BUTTERFLY_OFFSETS = tuple(WAVE >> i for i in range(1, LOG2_WAVE + 1))
 
@@ -1138,6 +1139,7 @@ def make_combine_scatter(
     scale_dim=0,
     reset_total_recv=True,
     _s3_cache=2,
+    _unroll=2,
 ):
     """Scatter combine (mori useExternalInpBuffer / _nop2p path).
 
@@ -1165,6 +1167,7 @@ def make_combine_scatter(
     wire_n_i32 = wire_nbytes // 4
     out_n_i32 = (hidden_dim * 2) // 4 if _fp8_out else wire_n_i32
     out_step_mult = 2 if _fp8_out else 1
+    _use_vec4_s = (wire_n_i32 % 4 == 0) and not _fp8_out
     if fp8_blockwise:
         block_elems = hidden_dim // scale_dim
         assert (
@@ -1314,9 +1317,15 @@ def make_combine_scatter(
                     )
                     buffer_store(fp8, rsrc_dst, elem)
             else:
-                for elem in range(lane, wire_n_i32, WAVE):
-                    v = buffer_load(rsrc_src, elem, vec_width=1, dtype=T.i32())
-                    buffer_store(v, rsrc_dst, elem)
+                for chunk in range(0, wire_n_i32, _MAIN_STRIDE_I32):
+                    vecs = [
+                        buffer_load(rsrc_src, chunk + k * _LANE_STRIDE_I32,
+                                    vec_width=4, dtype=T.i32())
+                        for k in range(_DISP_NSTREAMS)
+                    ]
+                    for k in range(_DISP_NSTREAMS):
+                        buffer_store(vecs[k], rsrc_dst,
+                                     chunk + k * _LANE_STRIDE_I32)
             if const_expr(enable_weights):
                 # forward this recv slot's weights (dispatch put them in out_wts[recv_slot])
                 # to the ORIGIN's comb_wts[computing_rank*M + lid] (dedicated
@@ -1405,6 +1414,7 @@ def make_combine_scatter(
             expert_rsrcs = []
             expert_valids = []
             expert_pes = []
+            expert_addrs = []
             expert_scales = []
             for k_slot in range_constexpr(experts_per_token):
                 encoded_k = buffer_load(
@@ -1418,6 +1428,7 @@ def make_combine_scatter(
                     fx.Int64(safe_pe) * fx.Int64(max_tok_per_rank) + fx.Int64(tok_id)
                 ) * fx.Int64(wire_nbytes)
                 expert_rsrcs.append(create_buffer_resource_from_addr(src_addr))
+                expert_addrs.append(src_addr)
                 expert_valids.append(valid)
                 expert_pes.append(safe_pe)
                 if const_expr(fp8_blockwise):
@@ -1505,11 +1516,55 @@ def make_combine_scatter(
                         acc = acc + to_acc(v)
                 buffer_store(from_acc(acc), rsrc_out, out_base + off * out_step_mult)
 
-            def _loop():
-                for u in range(lane, eff, WAVE):
-                    _one(unit_base + u)
+            if const_expr(_use_vec4_s):
+                VEC = 4
+                STEP_CHUNK = WAVE * VEC
+                STEP_V4 = _unroll * STEP_CHUNK
 
-            _loop()
+                def _load_expert_vecs(off):
+                    vecs = []
+                    valids = []
+                    for k_slot in range_constexpr(experts_per_token):
+                        vecs.append(P.load_v4i32_nt(expert_addrs[k_slot], off))
+                        valids.append(expert_valids[k_slot])
+                    return vecs, valids
+
+                def _accum_loop():
+                    main_end = (eff // STEP_V4) * STEP_V4
+                    for u in range(lane * VEC, main_end, STEP_V4):
+                        base = unit_base + u
+                        pre_vecs = []
+                        pre_valids = []
+                        for r in range_constexpr(_unroll):
+                            off_r = base + r * STEP_CHUNK
+                            vecs_r, valids_r = _load_expert_vecs(off_r)
+                            pre_vecs.append(vecs_r)
+                            pre_valids.append(valids_r)
+                        for j in range_constexpr(VEC):
+                            for r in range_constexpr(_unroll):
+                                off = base + r * STEP_CHUNK
+                                acc = zero_acc()
+                                for k_slot in range_constexpr(experts_per_token):
+                                    elem = vector.extract(
+                                        pre_vecs[r][k_slot], static_position=[j]
+                                    )
+                                    v = arith.select(
+                                        pre_valids[r][k_slot], elem, arith.constant(0)
+                                    )
+                                    acc = acc + to_acc(v)
+                                buffer_store(
+                                    from_acc(acc), rsrc_out, out_base + off + j
+                                )
+                    for u in range(main_end + lane, eff, WAVE):
+                        _one(unit_base + u)
+
+            else:
+
+                def _accum_loop():
+                    for u in range(lane, eff, WAVE):
+                        _one(unit_base + u)
+
+            _accum_loop()
 
         if global_warp_id == 0:
             if lane == 0:

--- a/python/mori/ops/dispatch_combine_v2/tuning_configs.py
+++ b/python/mori/ops/dispatch_combine_v2/tuning_configs.py
@@ -166,12 +166,27 @@ _GFX1250_DEFAULT = dict(
     combine_warp_num_per_block=16,
     schedule=_GFX1250_SCHED_BF16,
 )
-# DeepSeek-V4-Pro shape (hidden 7168, topk 6, 384 experts). RE-VALIDATED 2026-07-15
-# EP4 bf16 vec4 at the topk=8 schedule geometries: geometry is topk-independent
-# (tracks token count, not topk) — per-size optimum matches topk=8, so reuse the
-# same schedule. Measured vec4 GB/s (disp/comb): 16=6/4 256=95/67 512=164/93
-# 1024=212/116 2048=252/164 4096=281/200 8192=293/238 16384=300/272.
-_GFX1250_SCHED_BF16_T6 = _GFX1250_SCHED_BF16
+# DeepSeek-V4-Pro shape (hidden 7168, topk 6, 384 experts). RE-TUNED 2026-07-31 EP4
+# bf16 with the LOAD-ONCE/store-many + 4-way dispatch kernel (host-selected by
+# load_once_threshold=4096: tokens >4096 take load-once, tokens <=4096 the original
+# per-(token,expert) path). Full block x warp sweep (tok 256..16384), disp/comb each.
+# Key lessons: (a) dispatch load-once has a SHARP resonance at block=256 (== the
+# 256-CU grid, 1 block/CU) + warp 8 for large tok — 8192 256x8w=968, peaks ~1108 @16384;
+# the disp column flips 256x32 (original, many warps to fill the grid) -> 256x8
+# (load-once) exactly across the 4096 threshold. (b) below the threshold 256x32w wins
+# (4096=756, 1024=428); <=256 tok is latency-flat (~140, any geom). (c) COMBINE also
+# wants block=256 (=CU): the old "<CU, 192 ceiling" guardrail was too conservative —
+# 256 blocks stay co-resident (1/CU) and win big: 8192 256x8w=968 vs 192x16=816 (+19%),
+# 16384 256x8w=1149 vs 192x8=953 (+21%); warp ramps 4->8 (1024 wants 256x4=378). Only
+# tiny tok (<=256) still wants a small block (64x4=155; a 256-block starves it, ->92).
+# Measured GB/s (disp/comb): 256=140/155 1024=428/378 4096=756/741 8192=968/968
+# 16384=1108/1149.
+_GFX1250_SCHED_BF16_T6 = (
+    (256, 128, 16, 64, 4),  # <=256:  disp orig latency-flat ~140; comb small-block 64/4=156
+    (1024, 192, 32, 128, 8),  # <=1024: disp orig warp32=433 (192x32==256x32, min block); comb 128/8=409
+    (4096, 256, 32, 256, 16),  # <=4096: disp orig 256x32=756; comb 256/16=865
+    (None, 256, 8, 256, 16),  # >4096:  disp load-once 256x8; comb 256x16 (1062@8192, 1225@16384)
+)
 # EP8 (world_size=8) RE-TUNED 2026-07-13 on gfx1250 CROSS-NODE (2 nodes x 4 GPUs
 # over the UALink fabric), bf16, with the vec4 combine-gather kernel, full 2-pass
 # block x warp sweep (tok 8..8192). dispatch unchanged by vec4: block 128, warp

--- a/tests/python/ops/dispatch_combine_v2/bench_dispatch_combine.py
+++ b/tests/python/ops/dispatch_combine_v2/bench_dispatch_combine.py
@@ -96,6 +96,9 @@ COMB_BLOCK = int(os.environ.get("COMB_BLOCK", os.environ.get("BLOCK_NUM", 80)))
 WARP_NUM = int(os.environ.get("WARP_NUM", 16))
 # combine's K-deep per-lane MLP saturates with few warps.
 COMB_WARP = int(os.environ.get("COMB_WARP", WARP_NUM))
+# Non-AUTO dispatch algorithm: 1 = load-once/store-many + 4-way; 0 = original
+# per-(token,expert) 2-way. AUTO picks per token count via cfg.load_once_threshold.
+LOAD_ONCE = int(os.environ.get("LOAD_ONCE", 1))
 # AUTO=1: build the plain config (no pinned geometry) so __post_init__ auto-pulls
 # the tuned schedule, and pick the disp/comb variant per token count via op._pick.
 AUTO = int(os.environ.get("AUTO", 0))
@@ -255,7 +258,7 @@ def main():
                     flush=True,
                 )
         else:
-            disp_kern = op._dispatch_variants[(DISP_BLOCK, WARP_NUM)]
+            disp_kern = op._dispatch_variants[(DISP_BLOCK, WARP_NUM, bool(LOAD_ONCE))]
             comb_kern = op._combine_variants[(COMB_BLOCK, COMB_WARP)]
 
         # Launch on the CURRENT stream each call: under torch.cuda.graph capture


### PR DESCRIPTION
  ### Summary

  Kernel-level optimizations for EPv2 intranode dispatch and combine, targeting memory-level parallelism, synchronization overhead, and architecture-adaptive tuning.

  ### Changes
  #### 1. Dispatch load-once/store-many with multi-stream MLP

  Rework dispatch Phase-1 from per-(token, expert) redundant HBM reads to a **load-once / store-many** scheme: each warp loads the token tile once and fans out to all destination PEs. The copy loop issues **4 concurrent vec4 (16B) load streams** for MLP. Host-side algorithm selection: `load_once_threshold` (default 4096) picks between load-once (large batches) and the original per-work-item path (small batches) at launch time. Both variants share the same 4-way vec4 MLP. Variants are JIT-compiled lazily — unused algorithms never pay compile cost.

 #### 2. Combine gather: per-block flag entry barrier, exit barrier removed

  Replace `comb_bar` atomic sync with **per-block monotonic flag counters** — each block owns a private counter (single writer, no atomic). Exit barrier deleted entirely (was the dominant latency source).

  #### 3. Re-tune EP4 bf16 topk6 schedule
  Full block × warp sweep with new kernels. Combine now uses `block=256` (= CU count) with warp ramping 4→8.

  #### 4. Architecture-conditional stream count
  Dispatch and combine unroll counts adapt to wave size: **4 streams for gfx1250 (wave32)**, **2 for gfx942/gfx950 (wave64)**.

  #### 5. Scatter combine vec4 + unroll
  Apply the same vec4 + multi-stream optimizations to the scatter combine path (previously scalar-only): Stage 1 scatter copy uses vec4 × multi-stream loads; Stage 3 local reduce uses vec4 × unroll pre-load with batched accum.