### PR TITLE
fix(EPv2): correctness and perf fixes for the EPv2 intranode dispatch/combine

### DIFF
--- a/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
+++ b/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
@@ -702,7 +702,9 @@ class EpDispatchCombineOp:
         )
 
     def combine_in_view(self):
-        """Symmetric buffer [max_recv, hidden] that combine() reads from via P2P.
+        """Symmetric buffer [max_recv, hidden] that gather-mode combine reads
+        from via P2P.  Scatter mode uses a different staging layout (comb_inp)
+        and cannot use this buffer.
 
         To skip the d2d copy inside combine(), write expert output directly
         into this view (e.g. point the GEMM output pointer here), then pass
@@ -865,12 +867,17 @@ class EpDispatchCombineOp:
                 stream,
             )
         else:
+            dest_map = (
+                torch.full_like(self.token_dest_map, -1)
+                if return_routing
+                else self.token_dest_map
+            )
             self._dispatch_variants[disp_spec](
                 self.arena.handle,
                 input.data_ptr(),
                 indices.data_ptr(),
                 weight_ptr,
-                self.token_dest_map.data_ptr(),
+                dest_map.data_ptr(),
                 self.dest_pe_counter.data_ptr(),
                 self.dispatch_barrier.data_ptr(),
                 self.total_recv.data_ptr(),
@@ -888,13 +895,11 @@ class EpDispatchCombineOp:
         if not return_routing:
             return base
 
-        # Pass a live arena view; the reverse map is cloned lazily on first
-        # access (post-barrier), see EpDispatchRoutingHandle.
         recv_to_src_view = from_gpu_ptr(
             self.arena.local_ptr("recv_to_src_token"), (self._recv_cap,), torch.int32
         )
         routing = EpDispatchRoutingHandle(
-            disp_dest_tok_id_map=self.token_dest_map.clone(),
+            disp_dest_tok_id_map=dest_map,
             inter_node_disp_dest_tok_id_map=self._empty_i32,
             inter_node_disp_send_map=self._empty_i32,
             total_recv_token_num=self.total_recv,

--- a/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
+++ b/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
@@ -702,7 +702,12 @@ class EpDispatchCombineOp:
         )
 
     def combine_in_view(self):
-        """out_tok as combine dtype [max_recv, hidden] — combine()'s copy target."""
+        """Symmetric buffer [max_recv, hidden] that combine() reads from via P2P.
+
+        To skip the d2d copy inside combine(), write expert output directly
+        into this view (e.g. point the GEMM output pointer here), then pass
+        it as the ``input`` argument to combine().  combine() detects the
+        matching data_ptr and elides the copy."""
         cdt = self.cfg.combine_dtype
         cols = (
             self.cfg.hidden_dim // 2
@@ -914,7 +919,6 @@ class EpDispatchCombineOp:
             # copy in the combine-dtype layout (not recv_tokens()'s dispatch view)
             dst = self.combine_in_view().view(-1)[: input.numel()]
             dst.copy_(input.reshape(-1))
-        self.combine_out.zero_()
         stream = fx.Stream(torch.cuda.current_stream())
         _, comb_spec = self._pick(routing.cur_rank_num_token)
         self._combine_variants[comb_spec](

--- a/python/mori/ops/dispatch_combine_v2/flydsl_prims.py
+++ b/python/mori/ops/dispatch_combine_v2/flydsl_prims.py
@@ -28,6 +28,7 @@ peer pointers (cco.Window(h).lsa_ptr(pe, off)).
 """
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm as _llvm_d
+from flydsl._mlir.dialects import rocdl as _rocdl_d
 from flydsl._mlir.dialects import scf
 from flydsl.expr import arith
 from flydsl.expr.typing import T
@@ -96,6 +97,28 @@ def store_i64_system(addr_i64, offset, val):
         ordering=_llvm_d.AtomicOrdering.release,
         syncscope="one-as",
     )
+
+
+def _is_gfx12():
+    try:
+        from mori.jit.config import detect_gpu_arch
+
+        return detect_gpu_arch().startswith("gfx12")
+    except Exception:
+        return False
+
+
+def waitcnt_all():
+    """Drain all outstanding memory counters (no cache management, unlike a
+    release fence). gpu.barrier/s_barrier only syncs wavefronts and does NOT
+    wait for in-flight memory ops, so this must precede a grid barrier when the
+    stores before it need to be complete. gfx12/gfx1250 split the legacy
+    s_waitcnt into per-kind counters."""
+    if _is_gfx12():
+        _rocdl_d.s_wait_storecnt(0)
+        _rocdl_d.s_wait_loadcnt(0)
+    else:
+        _rocdl_d.s_waitcnt(0)
 
 
 def fence_system_acquire():

--- a/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
+++ b/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
@@ -315,10 +315,10 @@ def make_dispatch(
 
         if const_expr(enable_signal):
             # Self-reset total_recv (replaces the host-side total_recv.zero_()):
-            # only warp 0 accumulates into it in Phase 3, so warp 0 zeros it here
-            # and release-fences before the grid barrier; the Phase-2 acquire then
-            # orders the Phase-3 atomic adds after this zero. No other warp touches
-            # total_recv, so there is no cross-block race.
+            # only global warp 0 touches it — lane 0 zeros it here, all lanes
+            # accumulate into it in Phase 3. The waitcnt_all + grid barrier below
+            # drains this store before the Phase-3 adds; total_recv is local, so
+            # no release fence / L2 writeback is needed.
             if global_warp_id == 0:
                 if lane == 0:
                     buffer_store(
@@ -326,7 +326,6 @@ def make_dispatch(
                         create_buffer_resource_from_addr(addr_total_recv),
                         0,
                     )
-                P.fence_system_release()
 
             # ── Phase 2: grid barrier + per-peer count signal ──
             # s_barrier only syncs wavefronts; drain memory counters first so the

--- a/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
+++ b/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
@@ -331,6 +331,7 @@ def make_dispatch(
             # ── Phase 2: grid barrier + per-peer count signal ──
             fx.barrier()
             if tid == 0:
+                P.fence_system_release()
                 P.atomic_add_global(fx.Int64(addr_disp_bar), arith.constant(1))
 
             local_recv_num = fx.Int64(window.lsa_ptr(my_lsa_rank, off_recv_num))

--- a/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
+++ b/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
@@ -329,16 +329,19 @@ def make_dispatch(
                 P.fence_system_release()
 
             # ── Phase 2: grid barrier + per-peer count signal ──
+            # s_barrier only syncs wavefronts; drain memory counters first so the
+            # token/count stores above are complete before the grid barrier makes
+            # them visible to peers (unlike HIP __syncthreads, gpu.barrier has no
+            # implicit s_waitcnt).
+            P.waitcnt_all()
             fx.barrier()
             if tid == 0:
-                P.fence_system_release()
                 P.atomic_add_global(fx.Int64(addr_disp_bar), arith.constant(1))
 
             local_recv_num = fx.Int64(window.lsa_ptr(my_lsa_rank, off_recv_num))
             for dest_pe in range(lane, npes, WAVE):
                 if global_warp_id == 0:
                     P.spin_until_eq_i32(fx.Int64(addr_disp_bar), block_num)
-                    P.fence_system_acquire()
                     buffer_store(arith.constant(0), rsrc_disp_bar, 0)
                     signal_value = (
                         buffer_load(rsrc_dest_ctr, dest_pe, vec_width=1, dtype=T.i32())


### PR DESCRIPTION
  ## Summary
  Correctness and perf fixes for the EP V2 intranode dispatch/combine path, plus
  a zero-copy combine entry point.

  - **Fix dispatch store visibility before grid barrier.** `fx.barrier()` lowers to
    `s_barrier`, which only synchronizes wavefronts and (unlike HIP `__syncthreads`)
    carries no implicit `s_waitcnt`. Added `waitcnt_all()` before the grid barrier so
    P2P token/count stores are drained before peers are signaled. gfx12/gfx1250-aware
    (`s_wait_storecnt`/`s_wait_loadcnt` vs legacy `s_waitcnt`).
  - **Remove redundant system release fence.** The `fence_system_release()` guarding
    `total_recv` is unnecessary: the buffer is local, and the new `waitcnt_all()` +
    grid barrier already order the self-zero before the Phase-3 atomic adds. Relies on
    XGMI L2 coherence, matching the V1 kernel.
  - **Drop `combine_out.zero_()` from the combine critical path.** Combine uses a
    local FP32 accumulator and pure store, so pre-zeroing the output is dead work.
  - **Fix mem fault under HIP graph capture.** Allocate the routing dest-map
    independently (V1-style `torch.full_like`) instead of cloning `token_dest_map`,
    avoiding a clone in the captured region.
  - **Expose zero-copy combine.** Documented `combine_in_view()` so callers can point
    the expert/GEMM output directly at the symmetric buffer; combine detects the
    matching `data_ptr` and elides the internal d2d copy (gather mode only).