### PR TITLE
fix(io): detect host vs device memory in RegisterMemory instead of assuming CPU

### DIFF
--- a/src/io/engine.cpp
+++ b/src/io/engine.cpp
@@ -101,6 +101,36 @@ int DetectNumaNode(void* addr) {
 #endif
 }
 
+// Classify a pointer as host or device so callers that do not track where a
+// buffer came from can pass MemoryLocationType::Unknown and get it right.
+// Registering device memory as CPU "works" on hardware whose HBM is host
+// readable over large-BAR, but it is a lie the rest of the stack acts on: NIC
+// selection, deviceBusId and the NUMA probe below all key off `loc`.
+//
+// `*device` is filled in only when it was left unset (< 0) and the pointer
+// turns out to be device memory, so an explicit caller-supplied ordinal always
+// wins.
+//
+// Managed and unified allocations are deliberately reported as host: they are
+// migratable, so the device ordinal attached to one now is not a durable fact,
+// and the host mapping is the one that is always valid.
+MemoryLocationType DetectMemoryLocation(void* data, int* device) {
+  hipPointerAttribute_t attr{};
+  const hipError_t err = hipPointerGetAttributes(&attr, data);
+  // A host pointer is not an error worth reporting, but it DOES leave the
+  // sticky per-thread error set, which would surface at whatever unrelated
+  // hipGetLastError() runs next.  Clear it here, as the other probe sites in
+  // this repo do.
+  (void)hipGetLastError();
+  if (err != hipSuccess) return MemoryLocationType::CPU;
+
+  if (attr.type == hipMemoryTypeDevice) {
+    if (device != nullptr && *device < 0) *device = attr.device;
+    return MemoryLocationType::GPU;
+  }
+  return MemoryLocationType::CPU;
+}
+
 }  // namespace
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -359,6 +389,14 @@ void IOEngine::DeregisterRemoteEngine(const EngineDesc& remote) {
 }
 
 MemoryDesc IOEngine::RegisterMemory(void* data, size_t size, int device, MemoryLocationType loc) {
+  // Unknown means "you work it out": callers that hold an opaque pointer (the
+  // UMBP pool client, say) can hand it over instead of guessing CPU.  An
+  // explicit CPU/GPU is always taken at face value, so this cannot change the
+  // behaviour of a caller that already knows.
+  if (loc == MemoryLocationType::Unknown && data != nullptr) {
+    loc = DetectMemoryLocation(data, &device);
+  }
+
   MemoryDesc memDesc;
   memDesc.engineKey = desc.key;
   memDesc.id = nextMemUid.fetch_add(1, std::memory_order_relaxed);

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -669,8 +669,23 @@ bool PoolClient::RegisterMemory(void* ptr, size_t size) {
   for (auto& reg : registered_regions_) {
     if (reg.base == ptr) return true;
   }
-  auto mem_desc = io_engine_->RegisterMemory(ptr, size, -1, mori::io::MemoryLocationType::CPU);
+  // Unknown, not CPU: this region is caller-owned and may well be GPU HBM (an
+  // engine handing us a device-side KV buffer).  The IO engine classifies it
+  // with hipPointerGetAttributes and fills in the device ordinal.  Registering
+  // HBM as CPU appears to work where HBM is host-readable, but it misinforms
+  // NIC selection and sends DetectNumaNode() off to probe a device VA.
+  auto mem_desc = io_engine_->RegisterMemory(ptr, size, -1, mori::io::MemoryLocationType::Unknown);
+  if (mem_desc.loc == mori::io::MemoryLocationType::GPU) {
+    MORI_UMBP_DEBUG("[PoolClient] RegisterMemory: {} ({}B) is device memory on GPU {}", ptr, size,
+                    mem_desc.deviceId);
+  }
   registered_regions_.push_back({ptr, size, mem_desc});
+  // NOTE: true here means "the region is recorded and will be used zero-copy",
+  // not "an MR exists".  RegisterMemory has no failure channel to forward --
+  // IOEngine::RegisterMemory always returns a desc and the backends'
+  // RegisterMemory is void -- and the actual ibv_reg_mr is lazy, happening on
+  // the first transfer that touches this {NIC, region} pair.  A pointer that
+  // cannot be pinned therefore fails at that transfer, not here.
   return true;
 }
 

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -47,6 +47,18 @@ if(BUILD_IO)
   target_include_directories(test_engine PUBLIC ${CMAKE_SOURCE_DIR})
   target_link_libraries(test_engine mori_application mori_io)
 
+  # gtest + ctest-registered, unlike the manual-run io tests above: it needs no
+  # NIC and no peer, so it can run in CI.
+  add_executable(test_memory_location_detect io/test_memory_location_detect.cpp)
+
+  target_include_directories(test_memory_location_detect
+                             PUBLIC ${CMAKE_SOURCE_DIR}/include)
+  target_include_directories(test_memory_location_detect
+                             PUBLIC ${CMAKE_SOURCE_DIR})
+  target_link_libraries(test_memory_location_detect mori_application mori_io
+                        hip::host GTest::gtest_main)
+  add_test(NAME test_memory_location_detect COMMAND test_memory_location_detect)
+
   add_executable(test_transfer_wait io/test_transfer_wait.cpp)
 
   target_include_directories(test_transfer_wait

--- a/tests/cpp/io/test_memory_location_detect.cpp
+++ b/tests/cpp/io/test_memory_location_detect.cpp
@@ -1,0 +1,142 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// IOEngine::RegisterMemory's MemoryLocationType::Unknown auto-detection.
+//
+// Callers that hold an opaque pointer (UMBP's PoolClient, for one) cannot say
+// whether it is host or device memory.  Passing Unknown makes the engine work
+// it out; the alternative -- guessing CPU -- silently misinforms NIC selection
+// and sends the NUMA probe at a device VA.
+
+#include <gtest/gtest.h>
+#include <hip/hip_runtime_api.h>
+
+#include <cstdlib>
+
+#include "mori/io/engine.hpp"
+
+using namespace mori::io;
+
+namespace {
+
+bool HasGpu() {
+  int n = 0;
+  const hipError_t err = hipGetDeviceCount(&n);
+  (void)hipGetLastError();
+  return err == hipSuccess && n > 0;
+}
+
+// No backend is created: registration is pure bookkeeping (the RDMA MR is built
+// lazily on first transfer), so classification is observable without a NIC.
+IOEngine MakeEngine() { return IOEngine("detect-test", IOEngineConfig{"127.0.0.1", 0}); }
+
+}  // namespace
+
+TEST(MemoryLocationDetect, HostPointerDetectedAsCpu) {
+  IOEngine engine = MakeEngine();
+  constexpr size_t kSize = 4096;
+  void* host = std::malloc(kSize);
+  ASSERT_NE(host, nullptr);
+
+  const MemoryDesc desc = engine.RegisterMemory(host, kSize, -1, MemoryLocationType::Unknown);
+  EXPECT_EQ(desc.loc, MemoryLocationType::CPU);
+
+  engine.DeregisterMemory(desc);
+  std::free(host);
+}
+
+// The probe fails on host pointers and leaves the sticky per-thread hip error
+// set.  If RegisterMemory does not clear it, the next unrelated hip call in the
+// process reports a failure it did not cause -- so assert the clear explicitly.
+TEST(MemoryLocationDetect, HostPointerLeavesNoStickyHipError) {
+  IOEngine engine = MakeEngine();
+  constexpr size_t kSize = 4096;
+  void* host = std::malloc(kSize);
+  ASSERT_NE(host, nullptr);
+
+  (void)hipGetLastError();  // start from a clean slate
+  const MemoryDesc desc = engine.RegisterMemory(host, kSize, -1, MemoryLocationType::Unknown);
+  EXPECT_EQ(hipGetLastError(), hipSuccess);
+
+  engine.DeregisterMemory(desc);
+  std::free(host);
+}
+
+TEST(MemoryLocationDetect, DevicePointerDetectedAsGpuWithOrdinal) {
+  if (!HasGpu()) GTEST_SKIP() << "no HIP device";
+  IOEngine engine = MakeEngine();
+  constexpr size_t kSize = 4096;
+  void* dev = nullptr;
+  ASSERT_EQ(hipMalloc(&dev, kSize), hipSuccess);
+
+  // device = -1: the ordinal is unknown to the caller too, and detection is
+  // expected to fill it in.
+  const MemoryDesc desc = engine.RegisterMemory(dev, kSize, -1, MemoryLocationType::Unknown);
+  EXPECT_EQ(desc.loc, MemoryLocationType::GPU);
+  EXPECT_GE(desc.deviceId, 0);
+  EXPECT_FALSE(desc.deviceBusId.empty());
+
+  engine.DeregisterMemory(desc);
+  ASSERT_EQ(hipFree(dev), hipSuccess);
+}
+
+// An explicitly-supplied ordinal must survive detection: only an unset (< 0)
+// one is filled in.
+TEST(MemoryLocationDetect, ExplicitDeviceOrdinalIsNotOverwritten) {
+  if (!HasGpu()) GTEST_SKIP() << "no HIP device";
+  IOEngine engine = MakeEngine();
+  constexpr size_t kSize = 4096;
+  void* dev = nullptr;
+  ASSERT_EQ(hipMalloc(&dev, kSize), hipSuccess);
+
+  const MemoryDesc desc = engine.RegisterMemory(dev, kSize, 0, MemoryLocationType::Unknown);
+  EXPECT_EQ(desc.loc, MemoryLocationType::GPU);
+  EXPECT_EQ(desc.deviceId, 0);
+
+  engine.DeregisterMemory(desc);
+  ASSERT_EQ(hipFree(dev), hipSuccess);
+}
+
+// Backward compatibility: an explicit location is taken at face value and never
+// re-derived, so no existing caller changes behaviour.  Registering device
+// memory as CPU stays possible -- that is exactly what UMBP did before this.
+TEST(MemoryLocationDetect, ExplicitLocationIsNotSecondGuessed) {
+  if (!HasGpu()) GTEST_SKIP() << "no HIP device";
+  IOEngine engine = MakeEngine();
+  constexpr size_t kSize = 4096;
+  void* dev = nullptr;
+  ASSERT_EQ(hipMalloc(&dev, kSize), hipSuccess);
+
+  const MemoryDesc desc = engine.RegisterMemory(dev, kSize, -1, MemoryLocationType::CPU);
+  EXPECT_EQ(desc.loc, MemoryLocationType::CPU);
+
+  engine.DeregisterMemory(desc);
+  ASSERT_EQ(hipFree(dev), hipSuccess);
+}
+
+TEST(MemoryLocationDetect, NullPointerWithUnknownStaysUnknown) {
+  IOEngine engine = MakeEngine();
+  // Nothing to probe, so detection is skipped rather than guessing.
+  const MemoryDesc desc = engine.RegisterMemory(nullptr, 0, -1, MemoryLocationType::Unknown);
+  EXPECT_EQ(desc.loc, MemoryLocationType::Unknown);
+  engine.DeregisterMemory(desc);
+}


### PR DESCRIPTION
Every `RegisterMemory` caller in UMBP passed `MemoryLocationType::CPU` with `device = -1`, including `PoolClient::RegisterMemory` — which pins a **caller-owned** region that may well be GPU HBM, e.g. an engine handing the pool a device-side KV buffer.

Registering HBM as CPU appears to work on hardware whose HBM is host-readable over large-BAR (measured byte-exact on MI355X), but it is a lie the rest of the stack acts on:

- `loc` drives NIC selection — `ResolveRequestedNics` restricts a GPU transfer to a single NIC.
- `deviceBusId` is only queried for GPU.
- The CPU branch sends `DetectNumaNode()` to run `get_mempolicy` on a device VA, where the answer is meaningless and feeds NIC choice anyway.

## Approach

Adds `MemoryLocationType::Unknown` as an *input* meaning "work it out": the engine classifies the pointer with `hipPointerGetAttributes` and fills in the device ordinal when the caller left it unset (`< 0`).

An explicit `CPU`/`GPU` is still taken at face value, **so no existing caller changes behaviour** — including callers that deliberately register device memory as CPU. `PoolClient`'s user-facing `RegisterMemory` now passes `Unknown`; its three internal staging buffers stay explicitly `CPU`, since those are known host allocations.

Two details worth naming:

- `hipPointerGetAttributes` fails on a host pointer **and** leaves the sticky per-thread hip error set, which would otherwise surface at whatever unrelated `hipGetLastError()` ran next. Cleared here, as the other two probe sites in this repo already do (`symmetric_memory.cpp`, `cco_init.cpp`). There is a regression test for exactly this.
- Managed and unified allocations are deliberately classified as **host**: they migrate, so the device ordinal attached to one now is not a durable fact, and the host mapping is the one that is always valid.

## Not changed

`PoolClient::RegisterMemory` still returns `true` unconditionally. That is not an ignored error code — `IOEngine::RegisterMemory` always returns a desc and the backends' `RegisterMemory` is `void`, so there is no failure channel to forward, and the real `ibv_reg_mr` is lazy (`RdmaManager::RegisterLocalMemory`, on the first transfer touching a given `{NIC, region}` pair). No synchronous bool could honestly report registrability. Documented at the call site rather than faked.

## Measurements

n06-21 (MI355X, ionic), 16 MiB values, median of 20 puts, remote put between two processes:

| | before | after |
|---|---|---|
| HBM | 0.8 ms / 21.0 GB/s | 0.8 ms / 21.6 GB/s |
| host | 0.6 ms / ~29 GB/s | unchanged |

The GPU→1-NIC rule costs nothing here because `numNicsPerTransfer` already defaults to 1; a deployment that raises `MORI_IO_NUM_NICS_PER_TRANSFER` should re-measure.

## Testing

New `test_memory_location_detect` — gtest + ctest-registered, unlike the manual-run io tests beside it, since it needs no NIC and no peer. Covers device-pointer detection with ordinal fill-in, an explicit ordinal not being overwritten, an explicit location not being second-guessed, null-with-Unknown staying Unknown, and the sticky-hip-error regression.

**6/6 pass** on a GPU-visible container. Without `/dev/kfd` the three device cases skip and the sticky-error case fails on `hipErrorNoDevice`, so it does need real hardware to be meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
