### PR TITLE
chore(EPv2): split dispatch/combine tuning schedules into independent tables

### DIFF
--- a/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
+++ b/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
@@ -134,11 +134,12 @@ class EpDispatchCombineConfig:
     combine_block_num: int = None
     warp_num_per_block: int = None
     combine_warp_num_per_block: int = None
-    # Optional per-token plan: tuple of (max_tok_inclusive | None, disp_block,
-    # disp_warp, comb_block, comb_warp) buckets. When set, the op precompiles the
-    # distinct (block, warp) variants and picks one at runtime from
+    # Optional per-token plans (dispatch and combine tuned independently): each a
+    # tuple of (max_tok_inclusive | None, block, warp) buckets. When set, the op
+    # precompiles the distinct (block, warp) variants and picks one at runtime from
     # cur_rank_num_token. None => auto (from tuning_configs) or single-shot fallback.
-    schedule: tuple = None
+    dispatch_schedule: tuple = None
+    combine_schedule: tuple = None
     enable_std_moe: bool = False
     max_total_recv_tokens: int = 0  # mori maxTotalRecvTokens; 0 = worst-case ws*M
 
@@ -209,13 +210,17 @@ class EpDispatchCombineConfig:
         tuned automatically — EpDispatchCombineConfig.tuned() is now just an
         explicit alias). If any field is pinned, honor it and fill the rest with
         the single-shot fallback (no schedule)."""
-        pinned = self.schedule is not None or any(
-            g is not None
-            for g in (
-                self.dispatch_block_num,
-                self.combine_block_num,
-                self.warp_num_per_block,
-                self.combine_warp_num_per_block,
+        pinned = (
+            self.dispatch_schedule is not None
+            or self.combine_schedule is not None
+            or any(
+                g is not None
+                for g in (
+                    self.dispatch_block_num,
+                    self.combine_block_num,
+                    self.warp_num_per_block,
+                    self.combine_warp_num_per_block,
+                )
             )
         )
         if not pinned:
@@ -231,7 +236,8 @@ class EpDispatchCombineConfig:
             self.combine_block_num = t["combine_block_num"]
             self.warp_num_per_block = t["warp_num_per_block"]
             self.combine_warp_num_per_block = t["combine_warp_num_per_block"]
-            self.schedule = t["schedule"]
+            self.dispatch_schedule = t["dispatch_schedule"]
+            self.combine_schedule = t["combine_schedule"]
         else:
             # explicit geometry: fill any unset field with the single-shot default
             if self.dispatch_block_num is None:
@@ -540,14 +546,15 @@ class EpDispatchCombineOp:
         # Distinct (block, warp) variants to precompile. With a per-token schedule
         # the op picks the best (block, warp) at runtime from cur_rank_num_token;
         # otherwise it is single-shot. Scatter combine is not schedule-tuned.
-        schedule = cfg.schedule
-        if schedule:
-            dispatch_specs = sorted({(db, dw) for (_, db, dw, _, _) in schedule})
-            combine_specs = sorted({(cb, cw) for (_, _, _, cb, cw) in schedule})
+        disp_sched = cfg.dispatch_schedule
+        comb_sched = cfg.combine_schedule
+        if disp_sched:
+            dispatch_specs = sorted({(b, w) for (_, b, w) in disp_sched})
         else:
             dispatch_specs = [(cfg.dispatch_block_num, cfg.warp_num_per_block)]
-            combine_specs = [(cfg.combine_block_num, cfg.combine_warp_num_per_block)]
-        if cfg.is_scatter:
+        if comb_sched and not cfg.is_scatter:
+            combine_specs = sorted({(b, w) for (_, b, w) in comb_sched})
+        else:
             combine_specs = [(cfg.combine_block_num, cfg.combine_warp_num_per_block)]
         self._dispatch_specs = dispatch_specs
         self._combine_specs = combine_specs
@@ -799,26 +806,28 @@ class EpDispatchCombineOp:
             torch.int32,
         )
 
+    @staticmethod
+    def _pick_bucket(schedule, num_tokens):
+        """(block, warp) for the first bucket whose max_tok covers num_tokens."""
+        for bucket in schedule:
+            max_tok = bucket[0]
+            if max_tok is None or num_tokens <= max_tok:
+                return (bucket[1], bucket[2])
+        return (schedule[-1][1], schedule[-1][2])
+
     def _pick(self, num_tokens):
         """((disp_block, disp_warp), (comb_block, comb_warp)) for a runtime token
-        count via the per-token schedule; falls back to the single-shot specs
-        otherwise. Returned specs are clamped to the precompiled variants."""
-        schedule = self.cfg.schedule
-        disp_spec = comb_spec = None
-        if schedule:
-            for bucket in schedule:
-                max_tok = bucket[0]
-                if max_tok is None or num_tokens <= max_tok:
-                    disp_spec, comb_spec = (bucket[1], bucket[2]), (
-                        bucket[3],
-                        bucket[4],
-                    )
-                    break
-            if disp_spec is None:
-                last = schedule[-1]
-                disp_spec, comb_spec = (last[1], last[2]), (last[3], last[4])
+        count. Dispatch and combine use their own per-token schedule (independent
+        buckets); each falls back to its single-shot spec otherwise. Returned specs
+        are clamped to the precompiled variants."""
+        if self.cfg.dispatch_schedule:
+            disp_spec = self._pick_bucket(self.cfg.dispatch_schedule, num_tokens)
         else:
-            disp_spec, comb_spec = self._dispatch_specs[0], self._combine_specs[0]
+            disp_spec = self._dispatch_specs[0]
+        if self.cfg.combine_schedule:
+            comb_spec = self._pick_bucket(self.cfg.combine_schedule, num_tokens)
+        else:
+            comb_spec = self._combine_specs[0]
         if disp_spec not in self._dispatch_variants:
             disp_spec = self._dispatch_specs[-1]
         if comb_spec not in self._combine_variants:

--- a/python/mori/ops/dispatch_combine_v2/tuning_configs.py
+++ b/python/mori/ops/dispatch_combine_v2/tuning_configs.py
@@ -32,12 +32,21 @@ gfx950 — all from KFD sysfs, no torch/HIP dependency. block_num must stay
 from mori.ops import utils as gpu_utils
 
 
-# ── MI308X (gfx942, 80 CU) — EP8. Per-token SCHEDULE of
-# (max_tok_inclusive | None, disp_block, disp_warp, comb_block, comb_warp) buckets.
-_MI308X_SCHEDULE = (
-    (256, 64, 8, 64, 4),
-    (2048, 64, 16, 64, 4),
-    (None, 64, 16, 80, 4),
+# Dispatch and combine are tuned independently: each phase has its own per-token
+# SCHEDULE of (max_tok_inclusive | None, block, warp) buckets and its own per-shape
+# table keyed by (world_size, hidden_dim, topk). The two tables are looked up
+# separately, so a phase may reuse a schedule across topk while the other doesn't.
+
+# ── MI308X (gfx942, 80 CU) — EP8.
+_MI308X_DISP = (
+    (256, 64, 8),
+    (2048, 64, 16),
+    (None, 64, 16),
+)
+_MI308X_COMB = (
+    (256, 64, 4),
+    (2048, 64, 4),
+    (None, 80, 4),
 )
 # Single-shot fallback (schedule ignored) = peak-optimal.
 _MI308X_DEFAULT = dict(
@@ -45,99 +54,136 @@ _MI308X_DEFAULT = dict(
     combine_block_num=80,
     warp_num_per_block=16,
     combine_warp_num_per_block=4,
-    schedule=_MI308X_SCHEDULE,
+    dispatch_schedule=_MI308X_DISP,
+    combine_schedule=_MI308X_COMB,
 )
 # Tuned as fp8-dispatch + bf16-combine, so filed under "fp8" (fallback for untuned
 # dtypes). hidden 4096 / 2048 reuse the 7168 schedule until separately tuned.
-_MI308X_TABLE = {
-    (8, 7168, 8): {"fp8": _MI308X_SCHEDULE},
-    (8, 4096, 8): {"fp8": _MI308X_SCHEDULE},
-    (8, 2048, 8): {"fp8": _MI308X_SCHEDULE},
+_MI308X_DISP_TABLE = {
+    (8, 7168, 8): {"fp8": _MI308X_DISP},
+    (8, 4096, 8): {"fp8": _MI308X_DISP},
+    (8, 2048, 8): {"fp8": _MI308X_DISP},
+}
+_MI308X_COMB_TABLE = {
+    (8, 7168, 8): {"fp8": _MI308X_COMB},
+    (8, 4096, 8): {"fp8": _MI308X_COMB},
+    (8, 2048, 8): {"fp8": _MI308X_COMB},
 }
 
 # ── MI325X (gfx942, 304 CU, DID 0x74a5) — EP8, selected by min latency. dispatch
 # wants warp 8, block grows with tok (64->304); combine is latency-bound at
 # small/mid tok (small block 64 + warp 4 wins), only large tok (>1024) want
 # block ~0.5*CU (152) + warp 2.
-_MI325X_SCHEDULE = (
-    (8, 64, 8, 64, 2),  # <=8 tok: tiny, combine warp 2
-    (64, 64, 8, 64, 4),  # <=64:   small block both
-    (1024, 152, 8, 64, 4),  # <=1024: disp 0.5*CU, comb small-block/warp4 (latency)
-    (4096, 228, 8, 152, 2),  # <=4096: comb 0.5*CU/warp2 (bandwidth)
-    (None, 304, 8, 152, 2),  # >4096 (peak)
+_MI325X_DISP = (
+    (8, 64, 8),  # <=8 tok: tiny
+    (64, 64, 8),  # <=64:   small block
+    (1024, 152, 8),  # <=1024: disp 0.5*CU
+    (4096, 228, 8),  # <=4096
+    (None, 304, 8),  # >4096 (peak)
+)
+_MI325X_COMB = (
+    (8, 64, 2),  # <=8 tok: warp 2
+    (64, 64, 4),  # <=64:   small block
+    (1024, 64, 4),  # <=1024: small-block/warp4 (latency)
+    (4096, 152, 2),  # <=4096: 0.5*CU/warp2 (bandwidth)
+    (None, 152, 2),  # >4096 (peak)
 )
 _MI325X_DEFAULT = dict(
     dispatch_block_num=304,
     combine_block_num=152,
     warp_num_per_block=8,
     combine_warp_num_per_block=2,
-    schedule=_MI325X_SCHEDULE,
+    dispatch_schedule=_MI325X_DISP,
+    combine_schedule=_MI325X_COMB,
 )
 # hidden 4096 / 2048 reuse the 7168 schedule until separately tuned.
-_MI325X_TABLE = {
-    (8, 7168, 8): {"fp8": _MI325X_SCHEDULE},
-    (8, 4096, 8): {"fp8": _MI325X_SCHEDULE},
-    (8, 2048, 8): {"fp8": _MI325X_SCHEDULE},
+_MI325X_DISP_TABLE = {
+    (8, 7168, 8): {"fp8": _MI325X_DISP},
+    (8, 4096, 8): {"fp8": _MI325X_DISP},
+    (8, 2048, 8): {"fp8": _MI325X_DISP},
+}
+_MI325X_COMB_TABLE = {
+    (8, 7168, 8): {"fp8": _MI325X_COMB},
+    (8, 4096, 8): {"fp8": _MI325X_COMB},
+    (8, 2048, 8): {"fp8": _MI325X_COMB},
 }
 
 # ── MI300X (gfx942, 304 CU) — TODO: re-tune. Falls back to CU-scaled default. ──
 _MI300X_DEFAULT = None  # None => derive from CU count (see _cu_scaled_default)
-_MI300X_TABLE = {}
+_MI300X_DISP_TABLE = {}
+_MI300X_COMB_TABLE = {}
 
 # ── MI355X (gfx950, wave64) — EP8, vec4 combine gather. combine wants a small
 # block (32-48) + warp up to 16; dispatch grows block 96->160. wave64 => warp <= 16
 # (1024-thread block). Geometry is topk-independent.
-# bf16 dispatch + bf16 combine:
-_MI355X_SCHED_BF16 = (
-    (128, 128, 8, 32, 8),
-    (256, 96, 8, 64, 8),
-    (1024, 96, 8, 32, 16),
-    (4096, 160, 8, 32, 16),
-    (None, 128, 16, 48, 16),
+# dispatch (bf16 token dtype):
+_MI355X_DISP_BF16 = (
+    (128, 128, 8),
+    (256, 96, 8),
+    (1024, 96, 8),
+    (4096, 160, 8),
+    (None, 128, 16),
 )
-# fp8 dispatch + bf16 combine (combine geometry shared with bf16):
-_MI355X_SCHED_FP8 = (
-    (128, 128, 8, 32, 8),
-    (256, 160, 8, 64, 8),
-    (1024, 128, 8, 32, 16),
-    (4096, 160, 8, 32, 16),
-    (None, 128, 16, 48, 16),
+# dispatch (fp8 token dtype):
+_MI355X_DISP_FP8 = (
+    (128, 128, 8),
+    (256, 160, 8),
+    (1024, 128, 8),
+    (4096, 160, 8),
+    (None, 128, 16),
 )
-# fp4 dispatch + fp4 combine (0.5 B/elem):
-_MI355X_SCHED_FP4 = (
-    (256, 128, 4, 32, 8),
-    (2048, 144, 4, 64, 16),
-    (None, 128, 8, 64, 16),
+# dispatch (fp4 token dtype, 0.5 B/elem):
+_MI355X_DISP_FP4 = (
+    (256, 128, 4),
+    (2048, 144, 4),
+    (None, 128, 8),
+)
+# combine (bf16 / fp8 dispatch share the same combine geometry):
+_MI355X_COMB = (
+    (128, 32, 8),
+    (256, 64, 8),
+    (1024, 32, 16),
+    (4096, 32, 16),
+    (None, 48, 16),
+)
+# combine (fp4):
+_MI355X_COMB_FP4 = (
+    (256, 32, 8),
+    (2048, 64, 16),
+    (None, 64, 16),
 )
 _MI355X_DEFAULT = dict(
     dispatch_block_num=128,
     combine_block_num=48,
     warp_num_per_block=16,
     combine_warp_num_per_block=16,
-    schedule=_MI355X_SCHED_BF16,
+    dispatch_schedule=_MI355X_DISP_BF16,
+    combine_schedule=_MI355X_COMB,
 )
-_MI355X_TABLE = {
+_MI355X_DISP_TABLE = {
     (8, 7168, 8): {
-        "bf16": _MI355X_SCHED_BF16,
-        "fp8": _MI355X_SCHED_FP8,
-        "fp4": _MI355X_SCHED_FP4,
+        "bf16": _MI355X_DISP_BF16,
+        "fp8": _MI355X_DISP_FP8,
+        "fp4": _MI355X_DISP_FP4,
     },
     (8, 7168, 6): {
-        "bf16": _MI355X_SCHED_BF16,
-        "fp8": _MI355X_SCHED_FP8,
-        "fp4": _MI355X_SCHED_FP4,
+        "bf16": _MI355X_DISP_BF16,
+        "fp8": _MI355X_DISP_FP8,
+        "fp4": _MI355X_DISP_FP4,
     },
 }
 
-# ── gfx1250 (256 CU, wave32) — EP4, bf16, vec4 combine + load-first scheduling.
-# dispatch warp grows to 32, block 192. combine is warp-sensitive at small tok
-# (warp 2 <=128, warp 4 mid, warp 8 large); block grows 64->128. GUARDRAIL:
-# block_num < CU (256); 192 safe ceiling (Phase-2 grid barrier needs co-residence).
-_GFX1250_SCHED_BF16 = (
-    (256, 128, 16, 64, 4),  # <=128:  latency-bound; combine warp 2 (fewest warps win)
-    (512, 192, 32, 128, 4),  # <=512:  disp peak; comb 128/4
-    (4096, 192, 32, 128, 8),  # <=4096: comb block 128
-    (None, 192, 32, 192, 8),  # >4096:  comb warp 8
+_GFX1250_DISP_BF16 = (
+    (256, 128, 16),  # <=128:  latency-bound
+    (512, 192, 32),  # <=512:  disp peak
+    (4096, 192, 32),  # <=4096
+    (None, 192, 32),  # >4096
+)
+_GFX1250_COMB_BF16 = (
+    (256, 64, 4),  # <=128:  combine warp 4 (fewest warps win)
+    (512, 128, 4),  # <=512:  comb 128/4
+    (4096, 128, 8),  # <=4096: comb block 128
+    (None, 192, 8),  # >4096:  comb warp 8
 )
 
 _GFX1250_DEFAULT = dict(
@@ -145,49 +191,62 @@ _GFX1250_DEFAULT = dict(
     combine_block_num=192,
     warp_num_per_block=32,
     combine_warp_num_per_block=16,
-    schedule=_GFX1250_SCHED_BF16,
+    dispatch_schedule=_GFX1250_DISP_BF16,
+    combine_schedule=_GFX1250_COMB_BF16,
 )
 # DeepSeek-V4-Pro shape (hidden 7168, topk 6, 384 experts). EP4 bf16, load-once/
 # store-many + 4-way dispatch kernel (host-selected by load_once_threshold=4096).
 # dispatch wants block=256 + warp 32 above 1024 tok (<=256 tok is latency-flat).
 # combine also wants block=256 (=CU, blocks stay co-resident 1/CU), warp ramps 4->16;
 # only tiny tok (<=256) wants a small block (256 starves it).
-_GFX1250_SCHED_BF16_T6 = (
-    (256, 128, 16, 64, 4),  # <=256:  disp latency-flat; comb small-block 64/4
-    (
-        512,
-        192,
-        32,
-        128,
-        4,
-    ),  # <=512:  disp warp32 (192x32==256x32, min block); comb 128/4
-    (1024, 192, 32, 128, 8),  # <=1024: comb 128/8
-    (None, 256, 32, 256, 16),  # >1024: disp 256x32; comb 256x16
+_GFX1250_DISP_BF16_T6 = (
+    (256, 128, 16),  # <=256:  disp latency-flat
+    (512, 192, 32),  # <=512:  disp warp32 (192x32==256x32, min block)
+    (1024, 192, 32),  # <=1024
+    (None, 256, 32),  # >1024:  disp 256x32
+)
+_GFX1250_COMB_BF16_T6 = (
+    (256, 64, 4),  # <=256:  comb small-block 64/4
+    (512, 128, 4),  # <=512:  comb 128/4
+    (1024, 128, 8),  # <=1024: comb 128/8
+    (None, 256, 16),  # >1024:  comb 256x16
 )
 # EP8 cross-node (2 nodes x 4 GPUs over UALink), bf16, vec4 combine-gather.
 # dispatch block 128, warp ramps 16->32. combine block 64 uniformly best, warp
 # ramps 4->16. Fabric caps disp ~200 GB/s; geometry is world_size-independent so
 # this also serves single-node EP8. topk6 reuses this schedule (topk-independent).
-_GFX1250_SCHED_BF16_EP8 = (
-    (256, 128, 16, 64, 4),  # <=256:  disp warp 16, comb 64/4 (latency-bound)
-    (1024, 128, 32, 64, 8),  # <=1024: disp warp 32, comb 64/8
-    (None, 128, 32, 64, 16),  # >1024 (peak)
+_GFX1250_DISP_BF16_EP8 = (
+    (256, 128, 16),  # <=256:  disp warp 16 (latency-bound)
+    (1024, 128, 32),  # <=1024: disp warp 32
+    (None, 128, 32),  # >1024 (peak)
+)
+_GFX1250_COMB_BF16_EP8 = (
+    (256, 64, 4),  # <=256:  comb 64/4 (latency-bound)
+    (1024, 64, 8),  # <=1024: comb 64/8
+    (None, 64, 16),  # >1024 (peak)
 )
 # bf16-tuned (EP4 + EP8). fp8/fp4 fall back to the bf16 schedule until separately tuned.
-_GFX1250_TABLE = {
-    (4, 7168, 8): {"bf16": _GFX1250_SCHED_BF16},
-    (4, 7168, 6): {"bf16": _GFX1250_SCHED_BF16_T6},  # DeepSeek-V4-Pro
-    (8, 7168, 8): {"bf16": _GFX1250_SCHED_BF16_EP8},  # cross-node / single-node EP8
+_GFX1250_DISP_TABLE = {
+    (4, 7168, 8): {"bf16": _GFX1250_DISP_BF16},
+    (4, 7168, 6): {"bf16": _GFX1250_DISP_BF16_T6},  # DeepSeek-V4-Pro
+    (8, 7168, 8): {"bf16": _GFX1250_DISP_BF16_EP8},  # cross-node / single-node EP8
     # V4-Pro topk=6 EP8: topk-independent, reuse the topk=8 schedule.
-    (8, 7168, 6): {"bf16": _GFX1250_SCHED_BF16_EP8},
+    (8, 7168, 6): {"bf16": _GFX1250_DISP_BF16_EP8},
+}
+_GFX1250_COMB_TABLE = {
+    (4, 7168, 8): {"bf16": _GFX1250_COMB_BF16},
+    (4, 7168, 6): {"bf16": _GFX1250_COMB_BF16_T6},  # DeepSeek-V4-Pro
+    (8, 7168, 8): {"bf16": _GFX1250_COMB_BF16_EP8},  # cross-node / single-node EP8
+    (8, 7168, 6): {"bf16": _GFX1250_COMB_BF16_EP8},
 }
 
+# key -> (single-shot default, dispatch table, combine table)
 _DEVICES = {
-    "mi308x": (_MI308X_DEFAULT, _MI308X_TABLE),
-    "mi325x": (_MI325X_DEFAULT, _MI325X_TABLE),
-    "mi300x": (_MI300X_DEFAULT, _MI300X_TABLE),
-    "mi355x": (_MI355X_DEFAULT, _MI355X_TABLE),
-    "gfx1250": (_GFX1250_DEFAULT, _GFX1250_TABLE),
+    "mi308x": (_MI308X_DEFAULT, _MI308X_DISP_TABLE, _MI308X_COMB_TABLE),
+    "mi325x": (_MI325X_DEFAULT, _MI325X_DISP_TABLE, _MI325X_COMB_TABLE),
+    "mi300x": (_MI300X_DEFAULT, _MI300X_DISP_TABLE, _MI300X_COMB_TABLE),
+    "mi355x": (_MI355X_DEFAULT, _MI355X_DISP_TABLE, _MI355X_COMB_TABLE),
+    "gfx1250": (_GFX1250_DEFAULT, _GFX1250_DISP_TABLE, _GFX1250_COMB_TABLE),
 }
 
 
@@ -224,32 +283,45 @@ def _cu_scaled_default():
         combine_block_num=cu,
         warp_num_per_block=16,
         combine_warp_num_per_block=4,
-        schedule=None,
+        dispatch_schedule=None,
+        combine_schedule=None,
     )
 
 
 def lookup(world_size, hidden_dim, topk, dtype="fp8"):
     """Return {dispatch_block_num, combine_block_num, warp_num_per_block,
-    combine_warp_num_per_block, schedule} for the current GPU, shape, and dtype.
+    combine_warp_num_per_block, dispatch_schedule, combine_schedule} for the
+    current GPU, shape, and dtype.
 
     `dtype` (the token / dispatch dtype: "bf16" | "fp8" | "fp4") selects the
     per-dtype schedule, because dtype sets the communication volume (fp4 = 0.5 B,
     fp8 = 1 B, bf16 = 2 B per element) and thus the best block/warp. It falls back
     to the "fp8" schedule, then to the device default, when a dtype isn't tuned.
 
-    `schedule` (or None) is a per-token-count launch plan: a tuple of
-    (max_tok_inclusive | None, disp_block, disp_warp, comb_block, comb_warp)
-    buckets, ascending; the op precompiles the distinct (block, warp) variants
-    and picks a bucket at runtime from cur_rank_num_token. dispatch_block_num /
-    warp_num_per_block / combine_block_num / combine_warp_num_per_block are the
-    single-shot fallback used when schedule is None."""
+    dispatch_schedule / combine_schedule (or None) are independent per-token-count
+    launch plans: a tuple of (max_tok_inclusive | None, block, warp) buckets,
+    ascending; the op precompiles the distinct (block, warp) variants and picks a
+    bucket at runtime from cur_rank_num_token. The two phases have separate tables
+    (each keyed by (world_size, hidden_dim, topk)) and are looked up independently.
+    dispatch_block_num / warp_num_per_block / combine_block_num /
+    combine_warp_num_per_block are the single-shot fallback used when a schedule
+    is None."""
     key = _device_key()
     if key is None or key not in _DEVICES:
         return _cu_scaled_default()
-    dev_default, dev_table = _DEVICES[key]
+    dev_default, disp_table, comb_table = _DEVICES[key]
     base = dict(dev_default) if dev_default is not None else _cu_scaled_default()
-    base.setdefault("schedule", None)
-    entry = dev_table.get((world_size, hidden_dim, topk))
-    if entry:
-        base["schedule"] = entry.get(dtype) or entry.get("fp8") or base["schedule"]
+    base.setdefault("dispatch_schedule", None)
+    base.setdefault("combine_schedule", None)
+    shape = (world_size, hidden_dim, topk)
+    d_entry = disp_table.get(shape)
+    if d_entry:
+        base["dispatch_schedule"] = (
+            d_entry.get(dtype) or d_entry.get("fp8") or base["dispatch_schedule"]
+        )
+    c_entry = comb_table.get(shape)
+    if c_entry:
+        base["combine_schedule"] = (
+            c_entry.get(dtype) or c_entry.get("fp8") or base["combine_schedule"]
+        )
     return base

--- a/python/mori/ops/dispatch_combine_v2/tuning_configs.py
+++ b/python/mori/ops/dispatch_combine_v2/tuning_configs.py
@@ -172,6 +172,18 @@ _MI355X_DISP_TABLE = {
         "fp4": _MI355X_DISP_FP4,
     },
 }
+_MI355X_COMB_TABLE = {
+    (8, 7168, 8): {
+        "bf16": _MI355X_COMB,
+        "fp8": _MI355X_COMB,
+        "fp4": _MI355X_COMB_FP4,
+    },
+    (8, 7168, 6): {
+        "bf16": _MI355X_COMB,
+        "fp8": _MI355X_COMB,
+        "fp4": _MI355X_COMB_FP4,
+    },
+}
 
 _GFX1250_DISP_BF16 = (
     (256, 128, 16),  # <=128:  latency-bound

--- a/tests/python/ops/dispatch_combine_v2/bench_dispatch_combine.py
+++ b/tests/python/ops/dispatch_combine_v2/bench_dispatch_combine.py
@@ -230,7 +230,8 @@ def main():
                 warp_num_per_block=WARP_NUM,
                 combine_block_num=COMB_BLOCK,
                 combine_warp_num_per_block=COMB_WARP,
-                schedule=None,
+                dispatch_schedule=None,
+                combine_schedule=None,
             )
         cfg = EpDispatchCombineConfig(**_cfg_kwargs)
         op = EpDispatchCombineOp(cfg, comm)
@@ -247,7 +248,8 @@ def main():
             comb_kern = op._combine_variants[_cspec]
             if rank == 0:
                 print(
-                    f"# AUTO tuned config: schedule={cfg.schedule} "
+                    f"# AUTO tuned config: disp_schedule={cfg.dispatch_schedule} "
+                    f"comb_schedule={cfg.combine_schedule} "
                     f"disp_default=({cfg.dispatch_block_num},{cfg.warp_num_per_block}) "
                     f"comb_default=({cfg.combine_block_num},{cfg.combine_warp_num_per_block}) "
                     f"disp_variants={sorted(op._dispatch_variants)} "

--- a/tests/python/ops/dispatch_combine_v2/test_op.py
+++ b/tests/python/ops/dispatch_combine_v2/test_op.py
@@ -166,7 +166,9 @@ def main():
             from mori.ops.dispatch_combine_v2.tuning_configs import lookup
 
             _dt = "fp4" if _IS_FP4 else ("fp8" if _IS_FP8 else "bf16")
-            cfg.schedule = lookup(npes, HIDDEN, K, dtype=_dt)["schedule"]
+            _t = lookup(npes, HIDDEN, K, dtype=_dt)
+            cfg.dispatch_schedule = _t["dispatch_schedule"]
+            cfg.combine_schedule = _t["combine_schedule"]
         op = EpDispatchCombineOp(cfg, comm)
         comm.barrier()
 


### PR DESCRIPTION
  ### Summary

  - Split the unified 5-tuple per-token schedule (max_tok, disp_block, disp_warp, comb_block, comb_warp) into two independent 3-tuple schedules:
  dispatch_schedule and combine_schedule, each (max_tok, block, warp)
  - Each phase now has its own per-shape lookup table (_DISP_TABLE / _COMB_TABLE), keyed independently by (world_size, hidden_dim, topk)
  - lookup() queries the two tables separately, enabling one phase to reuse a schedule across topk/dtype while the other varies
  - Refactored _pick() into a shared _pick_bucket() static method + independent dispatch/combine bucket selection
  - Trimmed measurement dump comments (GB/s, us, sweep methodology) from schedule definitions; kept structural notes and guardrails