### PR TITLE
fix(build): cap setuptools before build_ext lifecycle change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
 requires = [
-    "setuptools>=61",
+    # setuptools 84 requires build_ext.run() to initialize the compiler, while
+    # CMakeBuild currently invokes build_extension() directly. Remove this cap
+    # after the custom build_ext lifecycle is fixed.
+    "setuptools>=61,<84",
     "setuptools_scm[toml]>=6.2",
     "wheel",
     "ninja",


### PR DESCRIPTION
## Motivation

Setuptools 84.0.0 introduced stricter `build_ext` lifecycle validation. MORI's custom `CMakeBuild.run()` invokes `build_extension()` directly, causing isolated wheel builds to fail with:

```text
AssertionError: run() must precede build_extension()
```

This PR restores wheel builds while a lifecycle-compatible implementation is developed.

## Technical Details

- Constrain the isolated build dependency to `setuptools>=61,<84`.
- Document why the temporary upper bound is required.
- Keep the restriction limited to the PEP 517 build environment; runtime dependencies are unaffected.
- A follow-up should update `CMakeBuild` to use the standard `build_ext.run()` lifecycle and then remove the upper bound.

## Test Plan

- Run the nightly wheel workflow with Python 3.10.
- Verify that the isolated build environment resolves setuptools 83.x.
- Build the gfx942/gfx950 fat binary in a no-GPU environment.
- Install the generated wheel and verify that `mori` and its CCO extension import successfully.

## Test Result

The failure was reproduced in CI with setuptools 84.0.0. This change forces isolated wheel builds to use setuptools 83.x. CI rerun is pending.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
