### PR TITLE
fix(EPv2):  scale i64 buffer offsets in the flydsl 0.3.0 compat shim

### DIFF
--- a/python/mori/ops/dispatch_combine_v2/flydsl_compat.py
+++ b/python/mori/ops/dispatch_combine_v2/flydsl_compat.py
@@ -121,17 +121,37 @@ except ModuleNotFoundError:  # flydsl >= 0.3.0
             inttoptr(pty, addr_i64), num_records_bytes=num_records_bytes
         )
 
+    def _dwords(elem):
+        # The base ptr is i32, so pointer arithmetic steps 4 bytes; 0.2.x
+        # buffer_ops instead took `offset` in ELEMENTS. Convert element offsets
+        # to i32 units. An i64 access (the per-block xdb flag counters) is 2
+        # units — without this it would index at half its stride, read a spliced
+        # garbage flag, and hang the combine entry barrier.
+        n = elem.width // 32
+        if n < 1:
+            raise NotImplementedError(
+                f"0.3.0 shim indexes in 4-byte units; {elem} is unsupported"
+            )
+        return n
+
+    def _elem_type_of(data):
+        ty = _arith.unwrap(data).type
+        try:
+            return _ir.VectorType(ty).element_type
+        except (ValueError, TypeError):
+            return ty
+
     def buffer_load(rsrc, offset, vec_width=4, dtype=None, mask=None, cache_modifier=0):
         """Load `vec_width` x `dtype` at element `offset` of `rsrc`."""
         elem = dtype if dtype is not None else T.i32()
         ty = elem if vec_width == 1 else T.VectorType.get([vec_width], elem)
         # unwrap to an ArithValue, as 0.2.x returned: callers do arithmetic on
         # the result and also feed it to arith.* ops, which need an ir.Value.
-        return _arith.unwrap(ptr_load(rsrc + offset, result_type=ty))
+        return _arith.unwrap(ptr_load(rsrc + offset * _dwords(elem), result_type=ty))
 
     def buffer_store(data, rsrc, offset, mask=None, cache_modifier=0):
         """Store `data` at element `offset` of `rsrc`."""
-        return ptr_store(data, rsrc + offset)
+        return ptr_store(data, rsrc + offset * _dwords(_elem_type_of(data)))
 
 
 logger.debug(

--- a/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
+++ b/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
@@ -596,6 +596,10 @@ def make_combine(
     _s3_cache=2,
     _unroll=4,
 ):
+    assert block_num <= xdb_flag_slots, (
+        f"combine block_num {block_num} exceeds xdb_flag_slots {xdb_flag_slots}: "
+        f"the per-block xdb flag array would overflow"
+    )
     # Transport dtype = external dtype, except fp8_direct_cast wires fp8 while
     # the output (comb_out) stays bf16 (2 i32 per fp8 i32 unit). fp4: i32 = 8 fp4.
     _to_accum2, _from_accum2, _zero_accum = _accum_funcs(


### PR DESCRIPTION
## Summary
  Fixes a hang in the EPv2 gather-combine entry barrier that reproduces on flydsl 0.3.0 for any block_num >= 2. Two commits:

  1. Root cause — i64 buffer offsets in the flydsl 0.3.0 compat shim. On flydsl 0.3.0 the flydsl.expr.buffer_ops submodule is gone, so flydsl_compat.py
  emulates buffer_load/buffer_store with an i32-typed pointer plus ptr_load/ptr_store(rsrc + offset). LLVM pointer arithmetic steps by the i32 pointee (4
  bytes), but the 0.2.x buffer_ops take the offset in elements and scale to bytes by element width. For i32 the two agree; for the i64 per-block xdb flag
  counters (added in #530) they diverge — block bid read/wrote byte bid*4 instead of bid*8, splicing two adjacent i64 slots. With the all-ones flag init,
  block 1 reads slot0.hi | slot1.lo = 0x1_0000_0000 and spins forever (peers only push 1). Fixed by scaling the offset by element_bytes/4 (i32 → 1, i64
  → 2), via a _dwords() helper that fails fast (NotImplementedError) on sub-4-byte element types.
  2. Guard rail — assert block_num <= xdb_flag_slots. The barrier shares one 256-slot cross_device_flag buffer across combine variants. Added an assert in
  make_combine so an oversized grid can't silently overflow the per-block xdb flag array.
