### PR TITLE
perf(cco): preserve global address space in LSA pointer wrapper

### DIFF
--- a/include/mori/cco/cco.hpp
+++ b/include/mori/cco/cco.hpp
@@ -270,6 +270,9 @@ struct ccoIbgdaWin {
 };
 
 struct ccoWindowDevice {
+  // ccoWindowRegister allocates this metadata object with hipMalloc, so a
+  // ccoWindow_t always points into device global memory. winBase below is the
+  // separately reserved flat-VA slot containing the window payload.
   // LSA flat-VA addressing (intra-node only). winBase is the window's slot in
   // the LSA-sized flat VA reservation. Peer addressing uses LSA rank, not
   // world rank. Cross-node access goes through ibgdaWin (iova=0 + offset).

--- a/src/cco/device/cco_device_wrapper.cpp
+++ b/src/cco/device/cco_device_wrapper.cpp
@@ -53,6 +53,7 @@
 namespace {
 using namespace mori::cco;
 using Gda = ccoGda<CCO_GDA_BUILD_PROVIDER>;
+using GlobalWindowDevice = ccoWindowDevice __attribute__((address_space(1)));
 #if BUILD_CCO_SDMA
 using Sdma = ccoSdma;
 #endif
@@ -61,6 +62,9 @@ inline __device__ const ccoDevComm* AsDevComm(uint64_t h) {
   return reinterpret_cast<const ccoDevComm*>(h);
 }
 inline __device__ ccoWindow_t AsWindow(uint64_t h) { return reinterpret_cast<ccoWindow_t>(h); }
+inline __device__ const GlobalWindowDevice* AsGlobalWindow(uint64_t h) {
+  return reinterpret_cast<const GlobalWindowDevice*>(h);
+}
 inline __device__ ccoGdaSignal_t AsSig(int id) { return static_cast<ccoGdaSignal_t>(id); }
 }  // namespace
 
@@ -93,8 +97,11 @@ inline __device__ ccoGdaSignal_t AsSig(int id) { return static_cast<ccoGdaSignal
 //    done directly on this pointer in the DSL kernel (examples 04/05) — cco does
 //    NOT move data for LSA. GDA below is opaque RDMA, so it IS exposed as ops.
 //    peer_va = winBase + peerLsaRank*(stride4G<<32) + offset
+// ccoWindow_t handles are allocated by hipMalloc in ccoWindowRegister. The
+// scalar DSL ABI erases that pointer provenance, so restore addrspace(1) here;
+// this keeps the public API unchanged and lowers metadata reads to global_load.
 CCO_DEV uint64_t cco_lsa_ptr(uint64_t window, int peer, uint64_t offset) {
-  ccoWindowDevice* w = AsWindow(window);
+  const GlobalWindowDevice* w = AsGlobalWindow(window);
   uint64_t stride = static_cast<uint64_t>(w->stride4G) << 32;
   return reinterpret_cast<uint64_t>(w->winBase) + static_cast<uint64_t>(peer) * stride + offset;
 }


### PR DESCRIPTION
## Summary
- document that `ccoWindow_t` metadata objects are allocated in device global memory
- restore LLVM `addrspace(1)` after the scalar FlyDSL ABI converts the window handle to `uint64_t`
- keep the existing `cco_lsa_ptr` API while allowing AMDGPU to select `global_load` instead of conservative generic `flat_load`

## Performance
With the current EPv2 kernel held fixed and only the linked CCO bitcode switched:

- BF16 scatter-combine, 128 tokens/rank: 166.66 us -> 113.74 us (-31.75%)
- BF16 scatter-combine, 512 tokens/rank: 577.20 us -> 361.79 us (-37.32%)
- dispatch remained within 0.7%, confirming the change targets repeated LSA address formation in scatter-combine

Source-mapped ATT shows `flat_load_dwordx3` plus `vmcnt/lgkmcnt` waits becoming `global_load_dwordx3`; the scatter kernel also drops from 24 to 16 reported VGPRs with no scratch use.

## Test plan
- [x] compile `cco_device_wrapper.cpp` to gfx950 device bitcode
- [x] verify `cco_lsa_ptr` IR uses `ptr addrspace(1)` for metadata loads
- [x] run `examples/cco/python/04_flydsl_lsa_put` on 2 ranks
- [x] run EPv2 BF16 gather and scatter correctness with the PR bitcode (`2 passed`)
- [x] run isolated flat/global bitcode performance A/B and source-mapped ATT


Made with [Cursor](https://cursor.com)