### PR TITLE
fix(EPv2): clamp idle lanes in gather-combine tok_map load to prevent OOB fault

### DIFF
--- a/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
+++ b/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
@@ -722,8 +722,14 @@ def make_combine(
             expert_valids = []
             expert_pes = []
             expert_toks = []
+            # Idle lanes (>= experts_per_token) are never read back by
+            # readlane, but their tok_map_base+lane can overrun the
+            # allocation on the last tokens of a batch. Fold onto slot 0.
+            tok_map_lane = arith.select(
+                lane < experts_per_token, lane, arith.constant(0)
+            )
             encoded_my = buffer_load(
-                rsrc_tok_map, tok_map_base + lane, vec_width=1, dtype=T.i32()
+                rsrc_tok_map, tok_map_base + tok_map_lane, vec_width=1, dtype=T.i32()
             )
             for k_slot in range_constexpr(experts_per_token):
                 encoded_k = readlane(T.i32(), encoded_my, k_slot)


### PR DESCRIPTION
 ## Summary

  Fix OOB memory fault in EPv2 gather-combine kernel when batch size approaches `max_tok_per_rank`.

  ## Problem

  All 64 lanes in a wave issue `buffer_load(tok_map_base + lane)`, but only lanes `[0, topk)` are consumed by `readlane`. `tok_map` is allocated as
  `max_tok_per_rank * topk` i32 slots — idle lanes overshoot the allocation on tail tokens, causing a GPU memory fault.

  | topk | Dangerous tail tokens | Triggers when batch > |
  |------|-----------------------|-----------------------|
  | 2 | 31 | max_tok - 30 |
  | 8 | 7 | max_tok - 6 |

  Any `topk < 64` with a full batch always faults.

  ## Fix

  Clamp idle lanes to slot 0 — their loaded values are never consumed:

  ```python
  tok_map_lane = arith.select(lane < experts_per_token, lane, arith.constant(0))
  encoded_my = buffer_load(rsrc_tok_map, tok_map_base + tok_map_lane, ...)

  Scatter-combine kernel is unaffected (indexes by k_slot, not lane).
  ```