### PR TITLE
feat(umbp): support the UMBP tree connector on a distributed backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,20 +439,6 @@ jobs:
               -R '^(umbp_|test_dummy_ssd_tier|test_prefix_aware_eviction|test_ssd_tier)'
           "
 
-      # The GPU gather path needs the DRAM tier registered for GPU access, which
-      # is best-effort: where the registration does not take, the tier falls back
-      # to the copy engine and the gather tests skip rather than fail. Report the
-      # outcome either way, so a runner losing the path shows up here instead of
-      # as an unexplained performance difference later.
-      - name: UMBP GPU gather path availability
-        if: always()
-        run: |
-          $CT exec -e MORI_UMBP_LOG_LEVEL=warn $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE/build
-            timeout 120 ctest -V -R umbp_dram_tier_gather -E kernel_off > /tmp/gather.log 2>&1 || true
-            grep -E 'DRAMTier|SKIPPED|OK \]' /tmp/gather.log || cat /tmp/gather.log
-          "
-
       - name: Cleanup
         if: always()
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,10 +433,24 @@ jobs:
 
       - name: UMBP C++ unit tests (local + distributed)
         run: |
-          $CT exec $CONTAINER bash -c "
+          $CT exec -e MORI_UMBP_LOG_LEVEL=warn $CONTAINER bash -c "
             cd $GITHUB_WORKSPACE/build
             timeout 300 ctest --output-on-failure \
               -R '^(umbp_|test_dummy_ssd_tier|test_prefix_aware_eviction|test_ssd_tier)'
+          "
+
+      # The GPU gather path needs the DRAM tier registered for GPU access, which
+      # is best-effort: where the registration does not take, the tier falls back
+      # to the copy engine and the gather tests skip rather than fail. Report the
+      # outcome either way, so a runner losing the path shows up here instead of
+      # as an unexplained performance difference later.
+      - name: UMBP GPU gather path availability
+        if: always()
+        run: |
+          $CT exec -e MORI_UMBP_LOG_LEVEL=warn $CONTAINER bash -c "
+            cd $GITHUB_WORKSPACE/build
+            timeout 120 ctest -V -R umbp_dram_tier_gather -E kernel_off > /tmp/gather.log 2>&1 || true
+            grep -E 'DRAMTier|SKIPPED|OK \]' /tmp/gather.log || cat /tmp/gather.log
           "
 
       - name: Cleanup

--- a/src/pybind/pybind_umbp.cpp
+++ b/src/pybind/pybind_umbp.cpp
@@ -228,6 +228,7 @@ void RegisterMoriUmbp(py::module_& m) {
       .def_readwrite("master_config", &UMBPDistributedConfig::master_config)
       .def_readwrite("io_engine", &UMBPDistributedConfig::io_engine)
       .def_readwrite("staging_buffer_size", &UMBPDistributedConfig::staging_buffer_size)
+      .def_readwrite("ranged_scratch_size", &UMBPDistributedConfig::ranged_scratch_size)
       .def_readwrite("ssd_staging_buffer_size", &UMBPDistributedConfig::ssd_staging_buffer_size)
       .def_readwrite("ssd_staging_buffer_slots", &UMBPDistributedConfig::ssd_staging_buffer_slots)
       .def_readwrite("peer_service_port", &UMBPDistributedConfig::peer_service_port)
@@ -289,6 +290,8 @@ void RegisterMoriUmbp(py::module_& m) {
       .def("flush", &IUMBPClient::Flush, py::call_guard<py::gil_scoped_release>())
       .def("is_distributed", &IUMBPClient::IsDistributed)           // pure getter, no I/O
       .def("get_deployment_mode", &IUMBPClient::GetDeploymentMode)  // pure getter, no I/O
+      .def("get_backend_mode", &IUMBPClient::GetBackendMode)        // pure getter, no I/O
+      .def("supports_ranged_io", &IUMBPClient::SupportsRangedIO)    // pure getter, no I/O
       .def("register_memory", &IUMBPClient::RegisterMemory, py::arg("ptr"), py::arg("size"),
            py::call_guard<py::gil_scoped_release>())
       .def("deregister_memory", &IUMBPClient::DeregisterMemory, py::arg("ptr"),

--- a/src/pybind/pybind_umbp.cpp
+++ b/src/pybind/pybind_umbp.cpp
@@ -275,6 +275,12 @@ void RegisterMoriUmbp(py::module_& m) {
            py::call_guard<py::gil_scoped_release>())
       .def("batch_get_into_ptr", &IUMBPClient::BatchGet, py::arg("keys"), py::arg("ptrs"),
            py::arg("sizes"), py::call_guard<py::gil_scoped_release>())
+      .def("batch_get_ranges_into_ptr", &IUMBPClient::BatchGetRanges, py::arg("keys"),
+           py::arg("ptrs"), py::arg("sizes"), py::arg("src_offsets"),
+           py::call_guard<py::gil_scoped_release>())
+      .def("batch_put_ranges_from_ptr", &IUMBPClient::BatchPutRanges, py::arg("keys"),
+           py::arg("object_sizes"), py::arg("ptrs"), py::arg("sizes"), py::arg("dst_offsets"),
+           py::call_guard<py::gil_scoped_release>())
       .def("batch_exists", &IUMBPClient::BatchExists, py::arg("keys"),
            py::call_guard<py::gil_scoped_release>())
       .def("batch_exists_consecutive", &IUMBPClient::BatchExistsConsecutive, py::arg("keys"),

--- a/src/umbp/CMakeLists.txt
+++ b/src/umbp/CMakeLists.txt
@@ -104,6 +104,7 @@ set(UMBP_CORE_SRCS
     local/tiers/tier_backend.cpp
     local/tiers/dram_tier.cpp
     local/tiers/host_registration.cpp
+    local/tiers/device_gather.hip
     local/host_mem_allocator.cpp
     local/tiers/ssd_tier.cpp
     local/tiers/dummy_ssd_tier.cpp

--- a/src/umbp/CMakeLists.txt
+++ b/src/umbp/CMakeLists.txt
@@ -103,6 +103,7 @@ set(UMBP_CORE_SRCS
     local/tiers/segment/segment_writer.cpp
     local/tiers/tier_backend.cpp
     local/tiers/dram_tier.cpp
+    local/tiers/host_registration.cpp
     local/host_mem_allocator.cpp
     local/tiers/ssd_tier.cpp
     local/tiers/dummy_ssd_tier.cpp

--- a/src/umbp/CMakeLists.txt
+++ b/src/umbp/CMakeLists.txt
@@ -91,6 +91,7 @@ endif()
 
 # Core static library
 set(UMBP_CORE_SRCS
+    common/device_copy.cpp
     local/block_index/local_block_index.cpp
     storage/io/storage_io_driver.cpp
     storage/io/posix_storage_io_driver.cpp
@@ -123,6 +124,7 @@ endif()
 add_library(umbp_core STATIC ${UMBP_CORE_SRCS})
 target_include_directories(umbp_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(umbp_core PRIVATE pthread)
+target_link_libraries(umbp_core PUBLIC hip::host)
 if(UNIX)
   target_link_libraries(umbp_core PRIVATE rt)
 endif()

--- a/src/umbp/common/device_copy.cpp
+++ b/src/umbp/common/device_copy.cpp
@@ -1,0 +1,80 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+#include "umbp/common/device_copy.h"
+
+#include "mori/utils/mori_log.hpp"
+
+namespace mori::umbp {
+
+PointerLocation DetectPointerLocation(const void* ptr) {
+  if (ptr == nullptr) return {};
+
+  hipPointerAttribute_t attributes{};
+  const hipError_t status = hipPointerGetAttributes(&attributes, ptr);
+  if (status == hipSuccess) {
+    if (attributes.type == hipMemoryTypeDevice && attributes.device >= 0) {
+      return {true, attributes.device};
+    }
+    return {};
+  }
+
+  // An attribute miss is normal for malloc/mmap memory. Clear HIP's
+  // thread-local error so it cannot affect a later runtime call.
+  (void)hipGetLastError();
+  return {};
+}
+
+ScopedHipDevice::ScopedHipDevice(int device_id) {
+  if (device_id < 0) return;
+  if (hipGetDevice(&previous_device_) != hipSuccess) {
+    (void)hipGetLastError();
+    return;
+  }
+  if (previous_device_ != device_id) {
+    if (hipSetDevice(device_id) != hipSuccess) {
+      (void)hipGetLastError();
+      return;
+    }
+    changed_ = true;
+  }
+  valid_ = true;
+}
+
+ScopedHipDevice::~ScopedHipDevice() {
+  if (!changed_) return;
+  if (hipSetDevice(previous_device_) != hipSuccess) (void)hipGetLastError();
+}
+
+bool DeviceCopy(void* dst, const void* src, size_t size, hipMemcpyKind kind, int device_id) {
+  const hipError_t status = hipMemcpy(dst, src, size, kind);
+  if (status != hipSuccess) {
+    MORI_UMBP_ERROR("[UMBP] hipMemcpy failed on device {}: {}", device_id,
+                    hipGetErrorString(status));
+    return false;
+  }
+  return true;
+}
+
+}  // namespace mori::umbp

--- a/src/umbp/distributed/distributed_client.cpp
+++ b/src/umbp/distributed/distributed_client.cpp
@@ -63,6 +63,16 @@ DistributedClient::DistributedClient(const UMBPConfig& config) : config_(config)
   // 2 MiB, so this only matters with non-default page size combinations.
   dram_pool_size_ = dram_pool_handle_.mapped_size;
 
+  ranged_scratch_handle_ = allocator.Alloc(dc.ranged_scratch_size, opts);
+  if (!ranged_scratch_handle_.valid()) {
+    allocator.Free(dram_pool_handle_);
+    dram_pool_ = nullptr;
+    dram_pool_size_ = 0;
+    throw std::runtime_error("DistributedClient: memory allocation failed for ranged scratch");
+  }
+  ranged_scratch_ = ranged_scratch_handle_.ptr;
+  ranged_scratch_size_ = ranged_scratch_handle_.mapped_size;
+
   // Lower SSD config to the peer.  When ssd.enabled, the peer builds a
   // PeerSsdManager (SSDTier backend) from the SSD config (UMBPSsdConfig) and
   // reports SSD capacity via TierType::SSD; when disabled, behavior is exactly
@@ -79,16 +89,33 @@ DistributedClient::DistributedClient(const UMBPConfig& config) : config_(config)
   auto pc_config = ToPoolClientConfig(dc,
                                       /*dram_buffers=*/{{dram_pool_, dram_pool_size_}},
                                       std::move(tier_capacities), std::move(ssd_cfg));
+  pc_config.ranged_scratch_buffer = ranged_scratch_;
+  pc_config.ranged_scratch_size = ranged_scratch_size_;
   pc_config.copy_pipeline = config_.copy_pipeline;
 
   pool_client_ = std::make_unique<PoolClient>(std::move(pc_config));
   if (!pool_client_->Init()) {
     pool_client_.reset();
     HostMemAllocator cleanup_allocator;
+    cleanup_allocator.Free(ranged_scratch_handle_);
+    ranged_scratch_ = nullptr;
+    ranged_scratch_size_ = 0;
     cleanup_allocator.Free(dram_pool_handle_);
     dram_pool_ = nullptr;
     dram_pool_size_ = 0;
     throw std::runtime_error("DistributedClient: PoolClient::Init() failed");
+  }
+  if (!pool_client_->RegisterMemory(ranged_scratch_, ranged_scratch_size_)) {
+    pool_client_->Shutdown();
+    pool_client_.reset();
+    HostMemAllocator cleanup_allocator;
+    cleanup_allocator.Free(ranged_scratch_handle_);
+    ranged_scratch_ = nullptr;
+    ranged_scratch_size_ = 0;
+    cleanup_allocator.Free(dram_pool_handle_);
+    dram_pool_ = nullptr;
+    dram_pool_size_ = 0;
+    throw std::runtime_error("DistributedClient: ranged scratch registration failed");
   }
 
   std::string tags_str;
@@ -101,13 +128,14 @@ DistributedClient::DistributedClient(const UMBPConfig& config) : config_(config)
       "[DistributedClient] initialized — "
       "node_id={} node_address={} master={} "
       "dram_pool={}MB hugepages={} hugepage_size={}MB numa_node={} "
-      "dram_page_size={}KB staging_buffer={}MB peer_port={} cache_remote={} "
+      "dram_page_size={}KB staging_buffer={}MB ranged_scratch={}MB peer_port={} cache_remote={} "
       "io_engine={}:{} tags=[{}]",
       dc.master_config.node_id, dc.master_config.node_address, dc.master_config.master_address,
       dram_pool_size_ / (1024 * 1024), config_.dram.use_hugepages,
       config_.dram.hugepage_size / (1024 * 1024), config_.dram.numa_node, dc.dram_page_size / 1024,
-      dc.staging_buffer_size / (1024 * 1024), dc.peer_service_port, dc.cache_remote_fetches,
-      dc.io_engine.host, dc.io_engine.port, tags_str);
+      dc.staging_buffer_size / (1024 * 1024), ranged_scratch_size_ / (1024 * 1024),
+      dc.peer_service_port, dc.cache_remote_fetches, dc.io_engine.host, dc.io_engine.port,
+      tags_str);
 }
 
 DistributedClient::~DistributedClient() { Close(); }
@@ -187,26 +215,33 @@ std::vector<bool> DistributedClient::BatchGet(const std::vector<std::string>& ke
 }
 
 std::vector<bool> DistributedClient::BatchGetRanges(
-    const std::vector<std::string>& keys, const std::vector<std::vector<uintptr_t>>& /*dsts*/,
-    const std::vector<std::vector<size_t>>& /*sizes*/,
-    const std::vector<std::vector<size_t>>& /*src_offsets*/) {
-  static std::once_flag once;
-  std::call_once(once, [] {
-    MORI_UMBP_WARN("[DistributedClient] ranged multi-buffer get is not supported yet");
-  });
-  return std::vector<bool>(keys.size(), false);
+    const std::vector<std::string>& keys, const std::vector<std::vector<uintptr_t>>& dsts,
+    const std::vector<std::vector<size_t>>& sizes,
+    const std::vector<std::vector<size_t>>& src_offsets) {
+  if (closing_) return std::vector<bool>(keys.size(), false);
+  std::shared_lock lk(op_mutex_);
+  if (closed_ || !pool_client_) return std::vector<bool>(keys.size(), false);
+  std::vector<std::vector<void*>> dst_ptrs(dsts.size());
+  for (size_t i = 0; i < dsts.size(); ++i) {
+    dst_ptrs[i].reserve(dsts[i].size());
+    for (uintptr_t ptr : dsts[i]) dst_ptrs[i].push_back(reinterpret_cast<void*>(ptr));
+  }
+  return pool_client_->BatchGetRanges(keys, dst_ptrs, sizes, src_offsets);
 }
 
 std::vector<bool> DistributedClient::BatchPutRanges(
-    const std::vector<std::string>& keys, const std::vector<size_t>& /*object_sizes*/,
-    const std::vector<std::vector<uintptr_t>>& /*srcs*/,
-    const std::vector<std::vector<size_t>>& /*sizes*/,
-    const std::vector<std::vector<size_t>>& /*dst_offsets*/) {
-  static std::once_flag once;
-  std::call_once(once, [] {
-    MORI_UMBP_WARN("[DistributedClient] ranged multi-buffer put is not supported yet");
-  });
-  return std::vector<bool>(keys.size(), false);
+    const std::vector<std::string>& keys, const std::vector<size_t>& object_sizes,
+    const std::vector<std::vector<uintptr_t>>& srcs, const std::vector<std::vector<size_t>>& sizes,
+    const std::vector<std::vector<size_t>>& dst_offsets) {
+  if (closing_) return std::vector<bool>(keys.size(), false);
+  std::shared_lock lk(op_mutex_);
+  if (closed_ || !pool_client_) return std::vector<bool>(keys.size(), false);
+  std::vector<std::vector<const void*>> src_ptrs(srcs.size());
+  for (size_t i = 0; i < srcs.size(); ++i) {
+    src_ptrs[i].reserve(srcs[i].size());
+    for (uintptr_t ptr : srcs[i]) src_ptrs[i].push_back(reinterpret_cast<const void*>(ptr));
+  }
+  return pool_client_->BatchPutRanges(keys, object_sizes, src_ptrs, sizes, dst_offsets);
 }
 
 std::vector<bool> DistributedClient::BatchExists(const std::vector<std::string>& keys) const {
@@ -296,6 +331,13 @@ void DistributedClient::Close() {
   if (pool_client_) {
     pool_client_->Shutdown();
     pool_client_.reset();
+  }
+
+  if (ranged_scratch_) {
+    HostMemAllocator allocator;
+    allocator.Free(ranged_scratch_handle_);
+    ranged_scratch_ = nullptr;
+    ranged_scratch_size_ = 0;
   }
 
   if (dram_pool_) {

--- a/src/umbp/distributed/distributed_client.cpp
+++ b/src/umbp/distributed/distributed_client.cpp
@@ -22,6 +22,7 @@
 #include "umbp/distributed/distributed_client.h"
 
 #include <map>
+#include <mutex>
 #include <stdexcept>
 
 #include "mori/io/engine.hpp"
@@ -183,6 +184,29 @@ std::vector<bool> DistributedClient::BatchGet(const std::vector<std::string>& ke
     dst_ptrs[i] = reinterpret_cast<void*>(dsts[i]);
   }
   return pool_client_->BatchGet(keys, dst_ptrs, sizes);
+}
+
+std::vector<bool> DistributedClient::BatchGetRanges(
+    const std::vector<std::string>& keys, const std::vector<std::vector<uintptr_t>>& /*dsts*/,
+    const std::vector<std::vector<size_t>>& /*sizes*/,
+    const std::vector<std::vector<size_t>>& /*src_offsets*/) {
+  static std::once_flag once;
+  std::call_once(once, [] {
+    MORI_UMBP_WARN("[DistributedClient] ranged multi-buffer get is not supported yet");
+  });
+  return std::vector<bool>(keys.size(), false);
+}
+
+std::vector<bool> DistributedClient::BatchPutRanges(
+    const std::vector<std::string>& keys, const std::vector<size_t>& /*object_sizes*/,
+    const std::vector<std::vector<uintptr_t>>& /*srcs*/,
+    const std::vector<std::vector<size_t>>& /*sizes*/,
+    const std::vector<std::vector<size_t>>& /*dst_offsets*/) {
+  static std::once_flag once;
+  std::call_once(once, [] {
+    MORI_UMBP_WARN("[DistributedClient] ranged multi-buffer put is not supported yet");
+  });
+  return std::vector<bool>(keys.size(), false);
 }
 
 std::vector<bool> DistributedClient::BatchExists(const std::vector<std::string>& keys) const {

--- a/src/umbp/distributed/distributed_client.cpp
+++ b/src/umbp/distributed/distributed_client.cpp
@@ -63,15 +63,17 @@ DistributedClient::DistributedClient(const UMBPConfig& config) : config_(config)
   // 2 MiB, so this only matters with non-default page size combinations.
   dram_pool_size_ = dram_pool_handle_.mapped_size;
 
-  ranged_scratch_handle_ = allocator.Alloc(dc.ranged_scratch_size, opts);
-  if (!ranged_scratch_handle_.valid()) {
-    allocator.Free(dram_pool_handle_);
-    dram_pool_ = nullptr;
-    dram_pool_size_ = 0;
-    throw std::runtime_error("DistributedClient: memory allocation failed for ranged scratch");
+  if (dc.ranged_scratch_size > 0) {
+    ranged_scratch_handle_ = allocator.Alloc(dc.ranged_scratch_size, opts);
+    if (!ranged_scratch_handle_.valid()) {
+      allocator.Free(dram_pool_handle_);
+      dram_pool_ = nullptr;
+      dram_pool_size_ = 0;
+      throw std::runtime_error("DistributedClient: memory allocation failed for ranged scratch");
+    }
+    ranged_scratch_ = ranged_scratch_handle_.ptr;
+    ranged_scratch_size_ = ranged_scratch_handle_.mapped_size;
   }
-  ranged_scratch_ = ranged_scratch_handle_.ptr;
-  ranged_scratch_size_ = ranged_scratch_handle_.mapped_size;
 
   // Lower SSD config to the peer.  When ssd.enabled, the peer builds a
   // PeerSsdManager (SSDTier backend) from the SSD config (UMBPSsdConfig) and
@@ -97,15 +99,17 @@ DistributedClient::DistributedClient(const UMBPConfig& config) : config_(config)
   if (!pool_client_->Init()) {
     pool_client_.reset();
     HostMemAllocator cleanup_allocator;
-    cleanup_allocator.Free(ranged_scratch_handle_);
-    ranged_scratch_ = nullptr;
-    ranged_scratch_size_ = 0;
+    if (ranged_scratch_) {
+      cleanup_allocator.Free(ranged_scratch_handle_);
+      ranged_scratch_ = nullptr;
+      ranged_scratch_size_ = 0;
+    }
     cleanup_allocator.Free(dram_pool_handle_);
     dram_pool_ = nullptr;
     dram_pool_size_ = 0;
     throw std::runtime_error("DistributedClient: PoolClient::Init() failed");
   }
-  if (!pool_client_->RegisterMemory(ranged_scratch_, ranged_scratch_size_)) {
+  if (ranged_scratch_ && !pool_client_->RegisterMemory(ranged_scratch_, ranged_scratch_size_)) {
     pool_client_->Shutdown();
     pool_client_.reset();
     HostMemAllocator cleanup_allocator;

--- a/src/umbp/distributed/master/master_client.cpp
+++ b/src/umbp/distributed/master/master_client.cpp
@@ -53,6 +53,36 @@ int RpcShutdownTimeoutMs() {
   return v;
 }
 
+int HeartbeatRpcTimeoutMs() {
+  static const int timeout = [] {
+    const char* raw = std::getenv("UMBP_HEARTBEAT_RPC_TIMEOUT_MS");
+    if (!raw || raw[0] == '\0') return 3000;
+    const int parsed = std::atoi(raw);
+    return parsed > 0 ? parsed : 3000;
+  }();
+  return timeout;
+}
+
+size_t HeartbeatEventsPerBundle() {
+  static const size_t value = [] {
+    const char* raw = std::getenv("UMBP_HEARTBEAT_EVENTS_PER_BUNDLE");
+    if (!raw || raw[0] == '\0') return size_t{1024};
+    const unsigned long long parsed = std::strtoull(raw, nullptr, 10);
+    return parsed > 0 ? static_cast<size_t>(parsed) : size_t{1024};
+  }();
+  return value;
+}
+
+size_t HeartbeatMaxBundlesPerRpc() {
+  static const size_t value = [] {
+    const char* raw = std::getenv("UMBP_HEARTBEAT_MAX_BUNDLES_PER_RPC");
+    if (!raw || raw[0] == '\0') return size_t{16};
+    const unsigned long long parsed = std::strtoull(raw, nullptr, 10);
+    return parsed > 0 ? static_cast<size_t>(parsed) : size_t{16};
+  }();
+  return value;
+}
+
 uint64_t MetricsReportIntervalMs() {
   static const uint64_t v =
       static_cast<uint64_t>(GetEnvMilliseconds("UMBP_METRICS_REPORT_INTERVAL_MS",
@@ -588,7 +618,16 @@ bool MasterClient::SendDeltaHeartbeatLocked(const std::map<TierType, TierCapacit
   auto new_events = DrainAllSources(owned_sources_);
   if (!new_events.empty()) {
     std::lock_guard state_lock(hb_state_mutex_);
-    outbox_.push_back(EventBundle{next_bundle_seq_++, std::move(new_events)});
+    const size_t per_bundle = HeartbeatEventsPerBundle();
+    for (size_t begin = 0; begin < new_events.size(); begin += per_bundle) {
+      const size_t end = std::min(new_events.size(), begin + per_bundle);
+      EventBundle bundle;
+      bundle.seq = next_bundle_seq_++;
+      bundle.events.reserve(end - begin);
+      std::move(new_events.begin() + begin, new_events.begin() + end,
+                std::back_inserter(bundle.events));
+      outbox_.push_back(std::move(bundle));
+    }
   }
 
   ::umbp::HeartbeatRequest req;
@@ -598,8 +637,12 @@ bool MasterClient::SendDeltaHeartbeatLocked(const std::map<TierType, TierCapacit
   FillTierKvCounts(req.mutable_tier_kv_counts(), kv_counts);
   {
     std::lock_guard state_lock(hb_state_mutex_);
+    size_t added = 0;
     for (const auto& bundle : outbox_) {
-      if (bundle.seq > hb_last_acked_seq_) FillBundle(req.add_bundles(), bundle);
+      if (bundle.seq <= hb_last_acked_seq_) continue;
+      if (added >= HeartbeatMaxBundlesPerRpc()) break;
+      FillBundle(req.add_bundles(), bundle);
+      ++added;
     }
   }
 
@@ -654,7 +697,7 @@ grpc::Status MasterClient::SendHeartbeatRpcLocked(::umbp::HeartbeatRequest& req,
                                                   ::umbp::HeartbeatResponse* resp) {
   grpc::ClientContext ctx;
   ctx.set_deadline(std::chrono::system_clock::now() +
-                   std::chrono::milliseconds(RpcShutdownTimeoutMs()));
+                   std::chrono::milliseconds(HeartbeatRpcTimeoutMs()));
   grpc::Status status;
   {
     ScopedRpcTimer _rpc_timer(this, "Heartbeat");
@@ -662,10 +705,23 @@ grpc::Status MasterClient::SendHeartbeatRpcLocked(::umbp::HeartbeatRequest& req,
     _rpc_timer.SetStatus(status);
   }
   if (!status.ok()) return status;
-  std::lock_guard state_lock(hb_state_mutex_);
-  hb_last_acked_seq_ = resp->acked_seq();
-  while (!outbox_.empty() && outbox_.front().seq <= hb_last_acked_seq_) {
-    outbox_.pop_front();
+  bool more_pending = false;
+  bool made_progress = false;
+  {
+    std::lock_guard state_lock(hb_state_mutex_);
+    const uint64_t previous_ack = hb_last_acked_seq_;
+    hb_last_acked_seq_ = std::max(hb_last_acked_seq_, resp->acked_seq());
+    made_progress = hb_last_acked_seq_ > previous_ack;
+    while (!outbox_.empty() && outbox_.front().seq <= hb_last_acked_seq_) {
+      outbox_.pop_front();
+    }
+    more_pending = !outbox_.empty();
+  }
+  // Drain a bounded backlog immediately in consecutive RPCs instead of paying
+  // one heartbeat interval per chunk. Each RPC remains independently bounded.
+  if (more_pending && made_progress && heartbeat_running_) {
+    flush_requested_ = true;
+    hb_cv_.notify_one();
   }
   return status;
 }

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -44,6 +44,7 @@
 
 #include "mori/io/backend.hpp"
 #include "mori/utils/mori_log.hpp"
+#include "umbp/common/device_copy.h"
 #include "umbp/common/env_time.h"
 #include "umbp/distributed/master/master_metrics.h"
 #include "umbp/distributed/peer/batch_resolve_codec.h"
@@ -59,78 +60,6 @@ namespace mori::umbp {
 namespace {
 
 bool IsValidMemoryDesc(const mori::io::MemoryDesc& desc) { return desc.size > 0; }
-
-struct PointerLocation {
-  mori::io::MemoryLocationType location{mori::io::MemoryLocationType::CPU};
-  int device_id{-1};
-
-  bool IsDevice() const { return location == mori::io::MemoryLocationType::GPU; }
-};
-
-// hipPointerGetAttributes reports ordinary malloc/mmap memory as either
-// hipMemoryTypeUnregistered or an invalid-value lookup, depending on the ROCm
-// runtime version. Both mean CPU memory here. Managed memory is intentionally
-// not treated as a stable GPU RDMA region because its backing pages may move.
-PointerLocation DetectPointerLocation(const void* ptr) {
-  if (ptr == nullptr) return {};
-
-  hipPointerAttribute_t attributes{};
-  const hipError_t status = hipPointerGetAttributes(&attributes, ptr);
-  if (status == hipSuccess) {
-    if (attributes.type == hipMemoryTypeDevice && attributes.device >= 0) {
-      return {mori::io::MemoryLocationType::GPU, attributes.device};
-    }
-    return {};
-  }
-
-  // An attribute miss is normal for unregistered host memory. Clear HIP's
-  // thread-local error so it cannot poison a later runtime call.
-  (void)hipGetLastError();
-  return {};
-}
-
-class ScopedHipDevice {
- public:
-  explicit ScopedHipDevice(int device_id) {
-    if (device_id < 0) return;
-    if (hipGetDevice(&previous_device_) != hipSuccess) {
-      (void)hipGetLastError();
-      return;
-    }
-    if (previous_device_ != device_id) {
-      if (hipSetDevice(device_id) != hipSuccess) {
-        (void)hipGetLastError();
-        return;
-      }
-      changed_ = true;
-    }
-    valid_ = true;
-  }
-
-  ~ScopedHipDevice() {
-    if (changed_) {
-      const hipError_t status = hipSetDevice(previous_device_);
-      if (status != hipSuccess) (void)hipGetLastError();
-    }
-  }
-
-  bool IsValid() const { return valid_; }
-
- private:
-  int previous_device_{-1};
-  bool changed_{false};
-  bool valid_{false};
-};
-
-bool DeviceCopy(void* dst, const void* src, size_t size, hipMemcpyKind kind, int device_id) {
-  const hipError_t status = hipMemcpy(dst, src, size, kind);
-  if (status != hipSuccess) {
-    MORI_UMBP_ERROR("[PoolClient] hipMemcpy failed on device {}: {}", device_id,
-                    hipGetErrorString(status));
-    return false;
-  }
-  return true;
-}
 
 // Key for grouping page transfers by their (local MR, remote MR) pair.
 struct PairKey {
@@ -750,15 +679,17 @@ bool PoolClient::RegisterMemory(void* ptr, size_t size) {
   }
 
   const PointerLocation pointer_location = DetectPointerLocation(ptr);
+  const auto memory_location = pointer_location.IsDevice() ? mori::io::MemoryLocationType::GPU
+                                                           : mori::io::MemoryLocationType::CPU;
   try {
-    auto mem_desc = io_engine_->RegisterMemory(ptr, size, pointer_location.device_id,
-                                               pointer_location.location);
+    auto mem_desc =
+        io_engine_->RegisterMemory(ptr, size, pointer_location.device_id, memory_location);
     if (!IsValidMemoryDesc(mem_desc) || mem_desc.data != reinterpret_cast<uintptr_t>(ptr) ||
-        mem_desc.size < size || mem_desc.loc != pointer_location.location ||
+        mem_desc.size < size || mem_desc.loc != memory_location ||
         (pointer_location.IsDevice() && mem_desc.deviceId != pointer_location.device_id)) {
       MORI_UMBP_ERROR(
           "[PoolClient] RegisterMemory: invalid descriptor for ptr={}, size={}, device={}, loc={}",
-          ptr, size, pointer_location.device_id, static_cast<uint32_t>(pointer_location.location));
+          ptr, size, pointer_location.device_id, static_cast<uint32_t>(memory_location));
       if (IsValidMemoryDesc(mem_desc)) io_engine_->DeregisterMemory(mem_desc);
       return false;
     }
@@ -809,7 +740,8 @@ bool PoolClient::LocalPutPages(const std::vector<PageLocation>& pages, uint64_t 
   const auto registered_source = FindRegisteredMemory(src, size);
   const PointerLocation source_location =
       registered_source.has_value()
-          ? PointerLocation{registered_source->first.loc, registered_source->first.deviceId}
+          ? PointerLocation{registered_source->first.loc == mori::io::MemoryLocationType::GPU,
+                            registered_source->first.deviceId}
           : DetectPointerLocation(src);
   ScopedHipDevice device_guard(source_location.IsDevice() ? source_location.device_id : -1);
   if (source_location.IsDevice() && !device_guard.IsValid()) {
@@ -848,9 +780,10 @@ bool PoolClient::LocalGetPages(const std::vector<PageLocation>& pages, uint64_t 
   char* dst_bytes = static_cast<char*>(dst);
   const auto registered_destination = FindRegisteredMemory(dst, size);
   const PointerLocation destination_location =
-      registered_destination.has_value() ? PointerLocation{registered_destination->first.loc,
-                                                           registered_destination->first.deviceId}
-                                         : DetectPointerLocation(dst);
+      registered_destination.has_value()
+          ? PointerLocation{registered_destination->first.loc == mori::io::MemoryLocationType::GPU,
+                            registered_destination->first.deviceId}
+          : DetectPointerLocation(dst);
   ScopedHipDevice device_guard(destination_location.IsDevice() ? destination_location.device_id
                                                                : -1);
   if (destination_location.IsDevice() && !device_guard.IsValid()) {

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -42,10 +42,14 @@
 #endif
 #include <unordered_map>
 
+#include "../local/tiers/device_copy_run.h"
 #include "mori/io/backend.hpp"
 #include "mori/utils/mori_log.hpp"
 #include "umbp/common/device_copy.h"
+#include "umbp/common/device_gather.h"
 #include "umbp/common/env_time.h"
+#include "umbp/common/host_registration.h"
+#include "umbp/common/range_utils.h"
 #include "umbp/distributed/master/master_metrics.h"
 #include "umbp/distributed/peer/batch_resolve_codec.h"
 #include "umbp/distributed/peer/peer_dram_allocator.h"
@@ -243,6 +247,21 @@ uint64_t AlignUp(uint64_t value, uint64_t alignment) {
   return remainder == 0 ? value : (value + alignment - remainder);
 }
 
+bool AlignUpChecked(size_t value, size_t alignment, size_t* out) {
+  if (!out || alignment == 0) return false;
+  const size_t remainder = value % alignment;
+  if (remainder == 0) {
+    *out = value;
+    return true;
+  }
+  const size_t add = alignment - remainder;
+  if (value > std::numeric_limits<size_t>::max() - add) return false;
+  *out = value + add;
+  return true;
+}
+
+constexpr size_t kRangedScratchAlignment = 64;
+
 // Group `pages` by buffer_index, preserving first-seen ordering so
 // IOEngine BatchWrite/BatchRead pair indexing stays predictable.
 struct ScatterGroup {
@@ -405,6 +424,19 @@ bool PoolClient::Init() {
   if (!initialized_.compare_exchange_strong(expected, true)) return true;
 
   master_client_ = std::make_unique<MasterClient>(config_.master_config);
+
+  // Register each exported host tier for device access before data-plane use.
+  // Registration may complete asynchronously for large pools; ranged copies
+  // safely fall back to the copy engine until Covers() starts returning true.
+  dram_host_registrations_.reserve(config_.dram_buffers.size());
+  for (const auto& dram : config_.dram_buffers) {
+    dram_host_registrations_.push_back(
+        std::make_unique<HostTierRegistration>(dram.buffer, dram.size));
+  }
+  if (config_.ranged_scratch_buffer && config_.ranged_scratch_size > 0) {
+    dram_host_registrations_.push_back(std::make_unique<HostTierRegistration>(
+        config_.ranged_scratch_buffer, config_.ranged_scratch_size));
+  }
 
   // IO Engine setup (RDMA data plane).
   if (!config_.io_engine.host.empty()) {
@@ -622,6 +654,11 @@ void PoolClient::Shutdown() {
     staging_buffer_.reset();
   }
 
+  // The backing buffers are caller-owned and still alive here. Unregister only
+  // after RDMA has been quiesced/deregistered, before DistributedClient frees
+  // its HostBufferHandle.
+  dram_host_registrations_.clear();
+
   master_client_.reset();
 }
 
@@ -741,11 +778,162 @@ std::optional<std::pair<mori::io::MemoryDesc, size_t>> PoolClient::FindRegistere
 // strategy 1), so in the common case an object collapses to exactly one run --
 // turning ceil(size / page_size) synchronous hipMemcpy round trips into one.
 struct TierPageRun {
-  size_t first_page = 0;      // index into `pages`, also the user-side page index
+  size_t first_page = 0;  // index into `pages`, also the user-side page index
   uint32_t buffer_index = 0;
-  uint64_t tier_offset = 0;   // byte offset inside that tier buffer
+  uint64_t tier_offset = 0;  // byte offset inside that tier buffer
   uint64_t bytes = 0;
 };
+
+struct RangeCopyRun {
+  const void* src = nullptr;
+  void* dst = nullptr;
+  size_t size = 0;
+};
+
+bool LocalPageMergeEnabled();
+
+uintptr_t AddressOf(const void* ptr) { return reinterpret_cast<uintptr_t>(ptr); }
+
+void AppendRangeCopyRun(std::vector<RangeCopyRun>* runs, const void* src, void* dst, size_t bytes) {
+  if (bytes == 0) return;
+  if (!runs->empty() && LocalPageMergeEnabled()) {
+    RangeCopyRun& last = runs->back();
+    const uintptr_t last_src = AddressOf(last.src);
+    const uintptr_t last_dst = AddressOf(last.dst);
+    if (last.size <= std::numeric_limits<uintptr_t>::max() - last_src &&
+        last.size <= std::numeric_limits<uintptr_t>::max() - last_dst &&
+        last_src + last.size == AddressOf(src) && last_dst + last.size == AddressOf(dst)) {
+      last.size += bytes;
+      return;
+    }
+  }
+  runs->push_back({src, dst, bytes});
+}
+
+std::map<int, hipStream_t>& RangedDeviceStreams() {
+  static thread_local std::map<int, hipStream_t>* streams = new std::map<int, hipStream_t>();
+  return *streams;
+}
+
+hipStream_t RangedDeviceStream(int device_id) {
+  auto& streams = RangedDeviceStreams();
+  auto it = streams.find(device_id);
+  if (it != streams.end()) return it->second;
+  hipStream_t stream = nullptr;
+  if (hipStreamCreateWithFlags(&stream, hipStreamNonBlocking) != hipSuccess) {
+    (void)hipGetLastError();
+    return nullptr;
+  }
+  streams.emplace(device_id, stream);
+  return stream;
+}
+
+std::atomic<bool>& RangedGatherDisabled() {
+  static std::atomic<bool> disabled{false};
+  return disabled;
+}
+
+bool CoveredByRegistration(
+    const void* ptr, size_t size,
+    const std::vector<std::unique_ptr<HostTierRegistration>>& registrations) {
+  for (const auto& registration : registrations) {
+    if (registration && registration->Covers(ptr, size)) return true;
+  }
+  return false;
+}
+
+bool ExecuteRangeCopyRuns(const std::vector<RangeCopyRun>& runs, hipMemcpyKind device_kind,
+                          bool classify_source,
+                          const std::vector<std::unique_ptr<HostTierRegistration>>& registrations) {
+  std::vector<const RangeCopyRun*> host_runs;
+  std::map<int, std::vector<RangeCopyRun*>> device_runs;
+  // The executor never mutates run fields, but the shared run planner accepts
+  // pointer-to-non-const jobs. Keep one local view rather than const_casting the
+  // caller-owned vector.
+  std::vector<RangeCopyRun> jobs(runs.begin(), runs.end());
+  for (auto& run : jobs) {
+    const PointerLocation location = DetectPointerLocation(classify_source ? run.src : run.dst);
+    if (location.IsDevice()) {
+      device_runs[location.device_id].push_back(&run);
+    } else {
+      host_runs.push_back(&run);
+    }
+  }
+  for (const auto* run : host_runs) LocalCopyBlock(run->dst, run->src, run->size);
+
+  constexpr size_t kGatherThreshold = 128ULL << 10;
+  for (auto& [device_id, grouped] : device_runs) {
+    ScopedHipDevice device_guard(device_id);
+    if (!device_guard.IsValid()) return false;
+    hipStream_t stream = RangedDeviceStream(device_id);
+    if (!stream) return false;
+    std::sort(grouped.begin(), grouped.end(), [](const RangeCopyRun* a, const RangeCopyRun* b) {
+      return detail::PointerAddress(a->src) < detail::PointerAddress(b->src);
+    });
+
+    std::vector<DeviceGatherFragment> fragments;
+    size_t total_bytes = 0;
+    bool host_covered = true;
+    for (size_t begin = 0; begin < grouped.size();) {
+      const auto run = detail::FindDeviceCopyRun(grouped, begin, /*allow_pitched=*/false);
+      const RangeCopyRun* first = grouped[begin];
+      const void* tier_side = device_kind == hipMemcpyDeviceToHost ? first->dst : first->src;
+      host_covered = host_covered && CoveredByRegistration(tier_side, run.bytes, registrations);
+      fragments.push_back({first->src, first->dst, run.bytes});
+      total_bytes += run.bytes;
+      begin = run.end;
+    }
+
+    const bool use_gather = !RangedGatherDisabled().load(std::memory_order_relaxed) &&
+                            DeviceGatherEnabled() && host_covered && fragments.size() > 1 &&
+                            total_bytes / fragments.size() < kGatherThreshold;
+    bool enqueued = false;
+    if (use_gather) {
+      enqueued = LaunchDeviceGather(fragments.data(), fragments.size(), device_id, stream);
+    }
+    if (!enqueued) {
+      enqueued = true;
+      for (size_t begin = 0; begin < grouped.size();) {
+        const auto run = detail::FindDeviceCopyRun(grouped, begin, /*allow_pitched=*/false);
+        if (hipMemcpyAsync(grouped[begin]->dst, grouped[begin]->src, run.bytes, device_kind,
+                           stream) != hipSuccess) {
+          (void)hipGetLastError();
+          enqueued = false;
+          break;
+        }
+        begin = run.end;
+      }
+    }
+    const hipError_t sync = hipStreamSynchronize(stream);
+    if (!enqueued || sync != hipSuccess) {
+      (void)hipGetLastError();
+      if (use_gather) RangedGatherDisabled().store(true, std::memory_order_relaxed);
+      RangedDeviceStreams().erase(device_id);
+      return false;
+    }
+  }
+  return true;
+}
+
+bool RangesAreDisjointAndInBounds(size_t object_size, const std::vector<size_t>& sizes,
+                                  const std::vector<size_t>& offsets) {
+  if (object_size == 0 || sizes.empty() || sizes.size() != offsets.size()) return false;
+  std::vector<size_t> order(sizes.size());
+  std::iota(order.begin(), order.end(), size_t{0});
+  std::sort(order.begin(), order.end(),
+            [&](size_t a, size_t b) { return offsets[a] < offsets[b]; });
+  size_t previous_end = 0;
+  bool first = true;
+  for (size_t index : order) {
+    if (sizes[index] == 0 || IsObjectRangeOverflow(offsets[index], sizes[index], object_size)) {
+      return false;
+    }
+    if (!first && offsets[index] < previous_end) return false;
+    previous_end = offsets[index] + sizes[index];
+    first = false;
+  }
+  return true;
+}
 
 // Merging can be turned off with UMBP_LOCAL_PAGE_MERGE=0 to A/B the win
 // without rebuilding, mirroring UMBP_DRAM_NT_COPY in the DRAM tier.
@@ -815,8 +1003,7 @@ bool PoolClient::LocalPutPages(const std::vector<PageLocation>& pages, uint64_t 
     void* dst = static_cast<char*>(config_.dram_buffers[run.buffer_index].buffer) + run.tier_offset;
     const void* page_src = src_bytes + run.first_page * page_size;
     if (source_location.IsDevice()) {
-      if (!DeviceCopy(dst, page_src, run.bytes, hipMemcpyDeviceToHost,
-                      source_location.device_id)) {
+      if (!DeviceCopy(dst, page_src, run.bytes, hipMemcpyDeviceToHost, source_location.device_id)) {
         return false;
       }
     } else {
@@ -859,6 +1046,217 @@ bool PoolClient::LocalGetPages(const std::vector<PageLocation>& pages, uint64_t 
     }
   }
   return true;
+}
+
+bool PoolClient::LocalGetRanges(const std::vector<PageLocation>& pages, uint64_t page_size,
+                                uint64_t stored_size, const std::vector<void*>& dsts,
+                                const std::vector<size_t>& sizes,
+                                const std::vector<size_t>& src_offsets) {
+  LocalRangeReadRequest request{&pages, stored_size, &dsts, &sizes, &src_offsets};
+  return LocalGetRangesBatch({request}, page_size);
+}
+
+bool PoolClient::LocalGetRangesBatch(const std::vector<LocalRangeReadRequest>& requests,
+                                     uint64_t page_size) {
+  std::vector<RangeCopyRun> runs;
+  for (const auto& request : requests) {
+    if (!request.pages || !request.dsts || !request.sizes || !request.src_offsets ||
+        request.dsts->size() != request.sizes->size() ||
+        request.dsts->size() != request.src_offsets->size() ||
+        !SizeMatchesAllocation(request.stored_size, request.pages->size(), page_size) ||
+        !RangesAreDisjointAndInBounds(request.stored_size, *request.sizes, *request.src_offsets)) {
+      return false;
+    }
+    runs.reserve(runs.size() + request.sizes->size() + request.pages->size());
+    for (size_t r = 0; r < request.sizes->size(); ++r) {
+      size_t object_offset = (*request.src_offsets)[r];
+      size_t copied = 0;
+      while (copied < (*request.sizes)[r]) {
+        const size_t page_index = object_offset / page_size;
+        const size_t within_page = object_offset % page_size;
+        if (page_index >= request.pages->size()) return false;
+        const auto& page = (*request.pages)[page_index];
+        if (page.buffer_index >= config_.dram_buffers.size()) return false;
+        const auto& dram = config_.dram_buffers[page.buffer_index];
+        const uint64_t tier_page_offset = static_cast<uint64_t>(page.page_index) * page_size;
+        if (!dram.buffer || page_size > dram.size || tier_page_offset > dram.size - page_size) {
+          return false;
+        }
+        const size_t fragment = std::min<size_t>((*request.sizes)[r] - copied,
+                                                 static_cast<size_t>(page_size - within_page));
+        const void* src = static_cast<const char*>(dram.buffer) + tier_page_offset + within_page;
+        void* dst = static_cast<char*>((*request.dsts)[r]) + copied;
+        AppendRangeCopyRun(&runs, src, dst, fragment);
+        object_offset += fragment;
+        copied += fragment;
+      }
+    }
+  }
+  if (runs.empty()) {
+    if (requests.empty()) return true;
+    for (const auto& request : requests) {
+      if (request.sizes && !request.sizes->empty()) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return ExecuteRangeCopyRuns(runs, hipMemcpyHostToDevice, /*classify_source=*/false,
+                              dram_host_registrations_);
+}
+
+PoolClient::PutAttemptOutcome PoolClient::ExecuteLocalPutRanges(
+    const std::string& key, size_t object_size, const std::vector<const void*>& srcs,
+    const std::vector<size_t>& sizes, const std::vector<size_t>& dst_offsets, TierType tier) {
+  LocalRangeWriteRequest request{&key, object_size, &srcs, &sizes, &dst_offsets, tier};
+  auto outcomes = ExecuteLocalPutRangesBatch({request});
+  return outcomes.empty() ? PutAttemptOutcome::kFatal : outcomes.front();
+}
+
+std::vector<PoolClient::PutAttemptOutcome> PoolClient::ExecuteLocalPutRangesBatch(
+    const std::vector<LocalRangeWriteRequest>& requests) {
+  std::vector<PutAttemptOutcome> outcomes(requests.size(), PutAttemptOutcome::kFatal);
+  if (!peer_alloc_) return outcomes;
+  struct PendingRangeWrite {
+    size_t request_index;
+    uint64_t slot_id;
+  };
+  std::vector<PendingRangeWrite> pending_writes;
+  std::vector<RangeCopyRun> runs;
+  const uint64_t page_size = peer_alloc_->PageSize();
+
+  for (size_t i = 0; i < requests.size(); ++i) {
+    const auto& request = requests[i];
+    if (!request.key || !request.srcs || !request.sizes || !request.dst_offsets ||
+        request.srcs->size() != request.sizes->size() ||
+        request.srcs->size() != request.dst_offsets->size() ||
+        !RangesTileObject(request.object_size, *request.sizes, *request.dst_offsets)) {
+      continue;
+    }
+    auto alloc_res = peer_alloc_->Allocate(*request.key, request.object_size, request.tier);
+    if (alloc_res.outcome == PeerDramAllocator::Outcome::kSuccessAlreadyExists) {
+      outcomes[i] = PutAttemptOutcome::kSuccessAlreadyExists;
+      continue;
+    }
+    if (alloc_res.outcome == PeerDramAllocator::Outcome::kFailed ||
+        alloc_res.outcome == PeerDramAllocator::Outcome::kFailedNoSpace) {
+      outcomes[i] = PutAttemptOutcome::kRetry;
+      continue;
+    }
+    auto slot = std::move(*alloc_res.slot);
+    if (!SizeMatchesAllocation(request.object_size, slot.pages.size(), page_size)) {
+      peer_alloc_->Abort(slot.slot_id);
+      continue;
+    }
+
+    const size_t run_begin = runs.size();
+    bool valid = true;
+    for (size_t r = 0; r < request.sizes->size() && valid; ++r) {
+      size_t object_offset = (*request.dst_offsets)[r];
+      size_t copied = 0;
+      while (copied < (*request.sizes)[r]) {
+        const size_t page_index = object_offset / page_size;
+        const size_t within_page = object_offset % page_size;
+        if (page_index >= slot.pages.size()) {
+          valid = false;
+          break;
+        }
+        const auto& page = slot.pages[page_index];
+        if (page.buffer_index >= config_.dram_buffers.size()) {
+          valid = false;
+          break;
+        }
+        const auto& dram = config_.dram_buffers[page.buffer_index];
+        const uint64_t tier_page_offset = static_cast<uint64_t>(page.page_index) * page_size;
+        if (!dram.buffer || page_size > dram.size || tier_page_offset > dram.size - page_size) {
+          valid = false;
+          break;
+        }
+        const size_t fragment = std::min<size_t>((*request.sizes)[r] - copied,
+                                                 static_cast<size_t>(page_size - within_page));
+        const void* src = static_cast<const char*>((*request.srcs)[r]) + copied;
+        void* dst = static_cast<char*>(dram.buffer) + tier_page_offset + within_page;
+        AppendRangeCopyRun(&runs, src, dst, fragment);
+        object_offset += fragment;
+        copied += fragment;
+      }
+    }
+    if (!valid) {
+      runs.resize(run_begin);
+      peer_alloc_->Abort(slot.slot_id);
+      continue;
+    }
+    pending_writes.push_back({i, slot.slot_id});
+  }
+
+  if (!pending_writes.empty() &&
+      !ExecuteRangeCopyRuns(runs, hipMemcpyDeviceToHost, /*classify_source=*/true,
+                            dram_host_registrations_)) {
+    for (const auto& pending : pending_writes) peer_alloc_->Abort(pending.slot_id);
+    return outcomes;
+  }
+
+  for (const auto& pending : pending_writes) {
+    const auto& request = requests[pending.request_index];
+    uint64_t committed_bytes = 0;
+    if (!peer_alloc_->Commit(pending.slot_id, *request.key, committed_bytes)) {
+      peer_alloc_->Abort(pending.slot_id);
+      continue;
+    }
+    outcomes[pending.request_index] = PutAttemptOutcome::kSuccess;
+    master_client_->AddCounter(MORI_UMBP_METRIC_CLIENT_OUTBOUND_PUT_BYTES_TOTAL,
+                               MORI_UMBP_METRIC_CLIENT_OUTBOUND_PUT_BYTES_TOTAL_HELP,
+                               {{"traffic", "local"}}, static_cast<double>(request.object_size));
+    master_client_->AddCounter(MORI_UMBP_METRIC_CLIENT_INBOUND_PUT_BYTES_TOTAL,
+                               MORI_UMBP_METRIC_CLIENT_INBOUND_PUT_BYTES_TOTAL_HELP,
+                               {{"traffic", "local"}}, static_cast<double>(request.object_size));
+  }
+  return outcomes;
+}
+
+bool PoolClient::CopyContiguousToRanges(const void* src, size_t object_size,
+                                        const std::vector<void*>& dsts,
+                                        const std::vector<size_t>& sizes,
+                                        const std::vector<size_t>& src_offsets) {
+  if (dsts.size() != sizes.size() || dsts.size() != src_offsets.size() ||
+      !RangesAreDisjointAndInBounds(object_size, sizes, src_offsets)) {
+    return false;
+  }
+  std::vector<RangeCopyRun> runs;
+  runs.reserve(sizes.size());
+  for (size_t i = 0; i < sizes.size(); ++i) {
+    AppendRangeCopyRun(&runs, static_cast<const char*>(src) + src_offsets[i], dsts[i], sizes[i]);
+  }
+  return ExecuteRangeCopyRuns(runs, hipMemcpyHostToDevice, /*classify_source=*/false,
+                              dram_host_registrations_);
+}
+
+bool PoolClient::CopyRangesToContiguous(const std::vector<const void*>& srcs,
+                                        const std::vector<size_t>& sizes,
+                                        const std::vector<size_t>& dst_offsets, void* dst,
+                                        size_t object_size) {
+  RangeAssemblyRequest request{&srcs, &sizes, &dst_offsets, dst, object_size};
+  return CopyRangesToContiguousBatch({request});
+}
+
+bool PoolClient::CopyRangesToContiguousBatch(const std::vector<RangeAssemblyRequest>& requests) {
+  std::vector<RangeCopyRun> runs;
+  for (const auto& request : requests) {
+    if (!request.srcs || !request.sizes || !request.dst_offsets || !request.dst ||
+        request.srcs->size() != request.sizes->size() ||
+        request.srcs->size() != request.dst_offsets->size() ||
+        !RangesTileObject(request.object_size, *request.sizes, *request.dst_offsets)) {
+      return false;
+    }
+    runs.reserve(runs.size() + request.sizes->size());
+    for (size_t i = 0; i < request.sizes->size(); ++i) {
+      AppendRangeCopyRun(&runs, (*request.srcs)[i],
+                         static_cast<char*>(request.dst) + (*request.dst_offsets)[i],
+                         (*request.sizes)[i]);
+    }
+  }
+  return ExecuteRangeCopyRuns(runs, hipMemcpyDeviceToHost, /*classify_source=*/true,
+                              dram_host_registrations_);
 }
 
 PoolClient::PutAttemptOutcome PoolClient::ExecuteLocalPut(const std::string& key, const void* src,
@@ -1706,6 +2104,365 @@ std::vector<bool> PoolClient::BatchGet(const std::vector<std::string>& keys,
   return results;
 }
 
+std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& keys,
+                                             const std::vector<std::vector<void*>>& dsts,
+                                             const std::vector<std::vector<size_t>>& sizes,
+                                             const std::vector<std::vector<size_t>>& src_offsets) {
+  const size_t n = keys.size();
+  std::vector<bool> results(n, false);
+  if (!initialized_ || !RangeBatchShapeValid(n, dsts, sizes, src_offsets) || n == 0 ||
+      !peer_alloc_) {
+    return results;
+  }
+
+  auto record_local_get = [&](size_t index) {
+    const size_t bytes = std::accumulate(sizes[index].begin(), sizes[index].end(), size_t{0});
+    master_client_->AddCounter(MORI_UMBP_METRIC_CLIENT_OUTBOUND_GET_BYTES_TOTAL,
+                               MORI_UMBP_METRIC_CLIENT_OUTBOUND_GET_BYTES_TOTAL_HELP,
+                               {{"traffic", "local"}}, static_cast<double>(bytes));
+    master_client_->AddCounter(MORI_UMBP_METRIC_CLIENT_INBOUND_GET_BYTES_TOTAL,
+                               MORI_UMBP_METRIC_CLIENT_INBOUND_GET_BYTES_TOTAL_HELP,
+                               {{"traffic", "local"}}, static_cast<double>(bytes));
+  };
+
+  std::vector<size_t> missed;
+  missed.reserve(n);
+  std::vector<size_t> local_indices;
+  std::vector<PeerDramAllocator::ResolveResult> local_resolved;
+  local_indices.reserve(n);
+  local_resolved.reserve(n);
+  for (size_t i = 0; i < n; ++i) {
+    if (sizes[i].empty()) continue;
+    auto resolved = peer_alloc_->Resolve(keys[i]);
+    if (!resolved.found) {
+      missed.push_back(i);
+      continue;
+    }
+    if (!RangesAreDisjointAndInBounds(resolved.size, sizes[i], src_offsets[i])) {
+      MORI_UMBP_ERROR("[PoolClient] BatchGetRanges: invalid local ranges for key='{}' size={}",
+                      keys[i], resolved.size);
+      continue;
+    }
+    local_indices.push_back(i);
+    local_resolved.push_back(std::move(resolved));
+  }
+  if (!local_indices.empty()) {
+    std::vector<LocalRangeReadRequest> local_requests;
+    local_requests.reserve(local_indices.size());
+    for (size_t k = 0; k < local_indices.size(); ++k) {
+      const size_t i = local_indices[k];
+      local_requests.push_back(
+          {&local_resolved[k].pages, local_resolved[k].size, &dsts[i], &sizes[i], &src_offsets[i]});
+    }
+    if (LocalGetRangesBatch(local_requests, peer_alloc_->PageSize())) {
+      for (size_t i : local_indices) {
+        results[i] = true;
+        record_local_get(i);
+      }
+    }
+  }
+  if (missed.empty()) return results;
+
+  if (!config_.ranged_scratch_buffer || config_.ranged_scratch_size == 0 ||
+      !FindRegisteredMemory(config_.ranged_scratch_buffer, config_.ranged_scratch_size)
+           .has_value()) {
+    MORI_UMBP_ERROR("[PoolClient] BatchGetRanges: ranged scratch is absent or not registered");
+    return results;
+  }
+
+  // Serialize only the remote portion. Local hits above remain fully concurrent.
+  std::unique_lock<std::mutex> scratch_lock(ranged_scratch_mutex_);
+
+  std::vector<std::string> route_keys;
+  route_keys.reserve(missed.size());
+  for (size_t index : missed) route_keys.push_back(keys[index]);
+  std::vector<std::optional<RouteGetResult>> routes;
+  std::unordered_set<std::string> excludes{config_.master_config.node_id};
+  auto route_status = master_client_->BatchRouteGet(route_keys, excludes, &routes);
+  if (!route_status.ok()) {
+    MORI_UMBP_ERROR("[PoolClient] BatchGetRanges: BatchRouteGet failed: {}",
+                    route_status.error_message());
+    return results;
+  }
+  routes.resize(route_keys.size());
+
+  std::vector<size_t> eligible;
+  eligible.reserve(missed.size());
+  for (size_t r = 0; r < missed.size(); ++r) {
+    const size_t original = missed[r];
+    if (!routes[r].has_value()) continue;
+    const auto& route = *routes[r];
+    if (route.node_id == config_.master_config.node_id ||
+        (route.tier != TierType::DRAM && route.tier != TierType::HBM) || route.size == 0 ||
+        route.size > std::numeric_limits<size_t>::max() ||
+        !RangesAreDisjointAndInBounds(static_cast<size_t>(route.size), sizes[original],
+                                      src_offsets[original])) {
+      MORI_UMBP_ERROR("[PoolClient] BatchGetRanges: invalid route/ranges for key='{}' size={}",
+                      keys[original], route.size);
+      continue;
+    }
+    eligible.push_back(r);
+  }
+
+  size_t pos = 0;
+  while (pos < eligible.size()) {
+    std::vector<size_t> scratch_offsets;
+    size_t cursor = 0;
+    size_t end = pos;
+    for (; end < eligible.size(); ++end) {
+      const auto& route = *routes[eligible[end]];
+      const size_t object_size = static_cast<size_t>(route.size);
+      size_t aligned = 0;
+      if (!AlignUpChecked(cursor, kRangedScratchAlignment, &aligned) ||
+          object_size > config_.ranged_scratch_size ||
+          aligned > config_.ranged_scratch_size - object_size) {
+        break;
+      }
+      scratch_offsets.push_back(aligned);
+      cursor = aligned + object_size;
+    }
+    if (end == pos) {
+      const size_t original = missed[eligible[pos]];
+      MORI_UMBP_ERROR(
+          "[PoolClient] BatchGetRanges: object exceeds ranged scratch key='{}' size={} "
+          "scratch={}",
+          keys[original], routes[eligible[pos]]->size, config_.ranged_scratch_size);
+      ++pos;
+      continue;
+    }
+
+    const size_t count = end - pos;
+    std::vector<std::string> sub_keys;
+    std::vector<void*> sub_dsts;
+    std::vector<size_t> sub_sizes;
+    std::vector<std::optional<RouteGetResult>> sub_routes;
+    sub_keys.reserve(count);
+    sub_dsts.reserve(count);
+    sub_sizes.reserve(count);
+    sub_routes.reserve(count);
+    for (size_t j = 0; j < count; ++j) {
+      const size_t route_index = eligible[pos + j];
+      const size_t original = missed[route_index];
+      sub_keys.push_back(keys[original]);
+      sub_dsts.push_back(static_cast<char*>(config_.ranged_scratch_buffer) + scratch_offsets[j]);
+      sub_sizes.push_back(static_cast<size_t>(routes[route_index]->size));
+      sub_routes.push_back(routes[route_index]);
+    }
+
+    std::vector<bool> fetched(count, false);
+    BatchGetPlan plan = PartitionBatchGetTargets(sub_keys, sub_dsts, sub_sizes, sub_routes);
+    ExecuteBatchGetPlan(plan, sub_keys, sub_dsts, sub_sizes, &fetched,
+                        /*recache_remote=*/false);
+
+    std::vector<size_t> installed_js;
+    std::vector<PeerDramAllocator::ResolveResult> installed_resolved;
+    installed_js.reserve(count);
+    installed_resolved.reserve(count);
+    for (size_t j = 0; j < count; ++j) {
+      const size_t route_index = eligible[pos + j];
+      const size_t original = missed[route_index];
+      if (!fetched[j]) continue;
+
+      const void* object = sub_dsts[j];
+      const auto installed = ExecuteLocalPut(sub_keys[j], object, sub_sizes[j], TierType::DRAM,
+                                             /*enqueue_ssd_copy=*/false);
+      if (installed == PutAttemptOutcome::kSuccess ||
+          installed == PutAttemptOutcome::kSuccessAlreadyExists) {
+        auto resolved = peer_alloc_->Resolve(sub_keys[j]);
+        if (resolved.found && resolved.size == sub_sizes[j]) {
+          installed_js.push_back(j);
+          installed_resolved.push_back(std::move(resolved));
+          continue;
+        }
+      }
+      if (installed != PutAttemptOutcome::kSuccess &&
+          installed != PutAttemptOutcome::kSuccessAlreadyExists) {
+        master_client_->AddCounter(MORI_UMBP_METRIC_RANGED_REMOTE_INSTALL_FAILURES_TOTAL,
+                                   MORI_UMBP_METRIC_RANGED_REMOTE_INSTALL_FAILURES_TOTAL_HELP, {},
+                                   1.0);
+      }
+      results[original] = CopyContiguousToRanges(object, sub_sizes[j], dsts[original],
+                                                 sizes[original], src_offsets[original]);
+    }
+
+    if (!installed_js.empty()) {
+      std::vector<LocalRangeReadRequest> requests;
+      requests.reserve(installed_js.size());
+      for (size_t k = 0; k < installed_js.size(); ++k) {
+        const size_t j = installed_js[k];
+        const size_t original = missed[eligible[pos + j]];
+        requests.push_back({&installed_resolved[k].pages, installed_resolved[k].size,
+                            &dsts[original], &sizes[original], &src_offsets[original]});
+      }
+      const bool copied_batch = LocalGetRangesBatch(requests, peer_alloc_->PageSize());
+      for (size_t k = 0; k < installed_js.size(); ++k) {
+        const size_t j = installed_js[k];
+        const size_t original = missed[eligible[pos + j]];
+        results[original] = copied_batch;
+        if (copied_batch) {
+          record_local_get(original);
+        } else {
+          results[original] = CopyContiguousToRanges(sub_dsts[j], sub_sizes[j], dsts[original],
+                                                     sizes[original], src_offsets[original]);
+        }
+      }
+    }
+    pos = end;
+  }
+  return results;
+}
+
+std::vector<bool> PoolClient::BatchPutRanges(const std::vector<std::string>& keys,
+                                             const std::vector<size_t>& object_sizes,
+                                             const std::vector<std::vector<const void*>>& srcs,
+                                             const std::vector<std::vector<size_t>>& sizes,
+                                             const std::vector<std::vector<size_t>>& dst_offsets) {
+  const size_t n = keys.size();
+  std::vector<bool> results(n, false);
+  if (!initialized_ || object_sizes.size() != n ||
+      !RangeBatchShapeValid(n, srcs, sizes, dst_offsets) || n == 0 || !peer_alloc_) {
+    return results;
+  }
+
+  std::vector<size_t> valid;
+  std::vector<std::string> route_keys;
+  std::vector<uint64_t> route_sizes;
+  valid.reserve(n);
+  route_keys.reserve(n);
+  route_sizes.reserve(n);
+  for (size_t i = 0; i < n; ++i) {
+    if (!RangesTileObject(object_sizes[i], sizes[i], dst_offsets[i])) {
+      MORI_UMBP_ERROR("[PoolClient] BatchPutRanges: ranges do not tile key='{}' size={}", keys[i],
+                      object_sizes[i]);
+      continue;
+    }
+    valid.push_back(i);
+    route_keys.push_back(keys[i]);
+    route_sizes.push_back(object_sizes[i]);
+  }
+  if (valid.empty()) return results;
+
+  std::vector<std::optional<RoutePutResult>> routes;
+  std::unordered_set<std::string> excludes;
+  auto route_status = master_client_->BatchRoutePut(route_keys, route_sizes, excludes, &routes);
+  if (!route_status.ok()) {
+    MORI_UMBP_ERROR("[PoolClient] BatchPutRanges: BatchRoutePut failed: {}",
+                    route_status.error_message());
+    return results;
+  }
+  routes.resize(valid.size());
+
+  std::vector<size_t> remote;
+  std::vector<size_t> local_originals;
+  std::vector<LocalRangeWriteRequest> local_requests;
+  remote.reserve(valid.size());
+  local_originals.reserve(valid.size());
+  local_requests.reserve(valid.size());
+  for (size_t r = 0; r < valid.size(); ++r) {
+    const size_t original = valid[r];
+    if (!routes[r].has_value()) continue;
+    const auto& route = *routes[r];
+    if (route.outcome == RoutePutOutcome::kAlreadyExists) {
+      results[original] = true;
+      continue;
+    }
+    if (route.node_id == config_.master_config.node_id) {
+      local_originals.push_back(original);
+      local_requests.push_back({&keys[original], object_sizes[original], &srcs[original],
+                                &sizes[original], &dst_offsets[original], route.tier});
+      continue;
+    }
+    if (route.tier == TierType::DRAM || route.tier == TierType::HBM) remote.push_back(r);
+  }
+  if (!local_requests.empty()) {
+    auto local_outcomes = ExecuteLocalPutRangesBatch(local_requests);
+    for (size_t i = 0; i < local_outcomes.size(); ++i) {
+      results[local_originals[i]] = local_outcomes[i] == PutAttemptOutcome::kSuccess ||
+                                    local_outcomes[i] == PutAttemptOutcome::kSuccessAlreadyExists;
+    }
+  }
+  if (remote.empty()) return results;
+
+  if (!config_.ranged_scratch_buffer || config_.ranged_scratch_size == 0 ||
+      !FindRegisteredMemory(config_.ranged_scratch_buffer, config_.ranged_scratch_size)
+           .has_value()) {
+    MORI_UMBP_ERROR("[PoolClient] BatchPutRanges: ranged scratch is absent or not registered");
+    return results;
+  }
+  std::unique_lock<std::mutex> scratch_lock(ranged_scratch_mutex_);
+
+  size_t pos = 0;
+  while (pos < remote.size()) {
+    std::vector<size_t> scratch_offsets;
+    size_t cursor = 0;
+    size_t end = pos;
+    for (; end < remote.size(); ++end) {
+      const size_t original = valid[remote[end]];
+      const size_t object_size = object_sizes[original];
+      size_t aligned = 0;
+      if (!AlignUpChecked(cursor, kRangedScratchAlignment, &aligned) ||
+          object_size > config_.ranged_scratch_size ||
+          aligned > config_.ranged_scratch_size - object_size) {
+        break;
+      }
+      scratch_offsets.push_back(aligned);
+      cursor = aligned + object_size;
+    }
+    if (end == pos) {
+      const size_t original = valid[remote[pos]];
+      MORI_UMBP_ERROR(
+          "[PoolClient] BatchPutRanges: object exceeds ranged scratch key='{}' size={} "
+          "scratch={}",
+          keys[original], object_sizes[original], config_.ranged_scratch_size);
+      ++pos;
+      continue;
+    }
+
+    std::vector<std::string> sub_keys;
+    std::vector<const void*> sub_srcs;
+    std::vector<size_t> sub_sizes;
+    std::vector<std::optional<RoutePutResult>> sub_routes;
+    std::vector<size_t> sub_originals;
+    std::vector<RangeAssemblyRequest> assemblies;
+    std::vector<const void*> assembled_slices;
+    assemblies.reserve(end - pos);
+    assembled_slices.reserve(end - pos);
+    for (size_t j = 0; j < end - pos; ++j) {
+      const size_t route_index = remote[pos + j];
+      const size_t original = valid[route_index];
+      void* slice = static_cast<char*>(config_.ranged_scratch_buffer) + scratch_offsets[j];
+      assemblies.push_back({&srcs[original], &sizes[original], &dst_offsets[original], slice,
+                            object_sizes[original]});
+      assembled_slices.push_back(slice);
+      sub_originals.push_back(original);
+    }
+
+    if (CopyRangesToContiguousBatch(assemblies)) {
+      sub_keys.reserve(sub_originals.size());
+      sub_srcs.reserve(sub_originals.size());
+      sub_sizes.reserve(sub_originals.size());
+      sub_routes.reserve(sub_originals.size());
+      for (size_t j = 0; j < sub_originals.size(); ++j) {
+        const size_t route_index = remote[pos + j];
+        const size_t original = sub_originals[j];
+        sub_keys.push_back(keys[original]);
+        sub_srcs.push_back(assembled_slices[j]);
+        sub_sizes.push_back(object_sizes[original]);
+        sub_routes.push_back(routes[route_index]);
+      }
+      std::vector<PutEntryOutcome> outcomes(sub_keys.size(), PutEntryOutcome::kFailed);
+      BatchPutPlan plan =
+          PartitionBatchPutTargets(sub_keys, sub_srcs, sub_sizes, sub_routes, &outcomes);
+      ExecuteBatchPutPlan(plan, &outcomes);
+      for (size_t j = 0; j < outcomes.size(); ++j) {
+        results[sub_originals[j]] = outcomes[j] != PutEntryOutcome::kFailed;
+      }
+    }
+    pos = end;
+  }
+  return results;
+}
+
 PoolClient::BatchGetPlan PoolClient::PartitionBatchGetTargets(
     const std::vector<std::string>& keys, const std::vector<void*>& dsts,
     const std::vector<size_t>& sizes, const std::vector<std::optional<RouteGetResult>>& routes) {
@@ -1750,7 +2507,8 @@ PoolClient::BatchGetPlan PoolClient::PartitionBatchGetTargets(
 
 void PoolClient::ExecuteBatchGetPlan(const BatchGetPlan& plan, const std::vector<std::string>& keys,
                                      const std::vector<void*>& dsts,
-                                     const std::vector<size_t>& sizes, std::vector<bool>* results) {
+                                     const std::vector<size_t>& sizes, std::vector<bool>* results,
+                                     bool recache_remote) {
   // Parallel local DRAM reads: different threads handle different keys. Resolve
   // is mutex-serialized in the allocator; the per-key memcpy in
   // ExecuteLocalGet->LocalGetPages runs lock-free in parallel. results is
@@ -1823,7 +2581,7 @@ void PoolClient::ExecuteBatchGetPlan(const BatchGetPlan& plan, const std::vector
     run_local_dram();
     for (const auto& [node_id, items] : remote_dram_groups) {
       if (auto f = SubmitRemoteBatchGet(items, results, /*permit_staging=*/true)) {
-        WaitRemoteBatchGet(*f, results);  // immediate; releases staging_mutex_
+        WaitRemoteBatchGet(*f, results, recache_remote);  // immediate; releases staging_mutex_
       }
     }
     run_remote_ssd();
@@ -1846,7 +2604,7 @@ void PoolClient::ExecuteBatchGetPlan(const BatchGetPlan& plan, const std::vector
   run_local_ssd();
   // TODO(perf): remote SSD is still per-key serial (not yet optimized).
   run_remote_ssd();
-  for (auto& f : inflights) WaitRemoteBatchGet(*f, results);
+  for (auto& f : inflights) WaitRemoteBatchGet(*f, results, recache_remote);
 }
 
 std::unique_ptr<PoolClient::RemoteDramGetInFlight> PoolClient::SubmitRemoteBatchGet(
@@ -1959,7 +2717,8 @@ std::unique_ptr<PoolClient::RemoteDramGetInFlight> PoolClient::SubmitRemoteBatch
   return inflight;
 }
 
-void PoolClient::WaitRemoteBatchGet(RemoteDramGetInFlight& f, std::vector<bool>* results) {
+void PoolClient::WaitRemoteBatchGet(RemoteDramGetInFlight& f, std::vector<bool>* results,
+                                    bool recache_remote) {
   if (f.drained) return;
   f.drained = true;
   // Wait every group (never break early): IN_PROGRESS groups complete here;
@@ -1999,7 +2758,7 @@ void PoolClient::WaitRemoteBatchGet(RemoteDramGetInFlight& f, std::vector<bool>*
     f.staging_lock.unlock();
   }
 
-  FinalizeRemoteGetEntries(f.entries, results);
+  FinalizeRemoteGetEntries(f.entries, results, recache_remote);
 }
 
 bool PoolClient::PrepareRemoteGetEntries(const std::vector<BatchGetItem>& items,
@@ -2180,7 +2939,7 @@ bool PoolClient::BuildRemoteGetTransfers(std::vector<RemoteGetEntry>& entries, P
 }
 
 void PoolClient::FinalizeRemoteGetEntries(std::vector<RemoteGetEntry>& entries,
-                                          std::vector<bool>* results) {
+                                          std::vector<bool>* results, bool recache_remote) {
   for (auto& entry : entries) {
     if (entry.failed) {
       (*results)[entry.result_index] = false;
@@ -2197,7 +2956,7 @@ void PoolClient::FinalizeRemoteGetEntries(std::vector<RemoteGetEntry>& entries,
     // Re-cache the remotely-fetched block into local DRAM (best-effort): the
     // user dst is already populated (staging copy-out and zero-copy both land
     // before Finalize runs), so subsequent reads of this key route local.
-    if (entry.item) {
+    if (recache_remote && entry.item) {
       MaybeReCacheAfterRemote(*entry.item->key, entry.item->dst, entry.item->size);
     }
   }

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -734,6 +734,65 @@ std::optional<std::pair<mori::io::MemoryDesc, size_t>> PoolClient::FindRegistere
 //  Self-target fast paths
 // ---------------------------------------------------------------------------
 
+// One object occupies ceil(size / page_size) tier pages. The user-side buffer is
+// contiguous by construction (page i sits at i * page_size), so whenever the
+// tier side is also contiguous the whole run can move in a single copy.
+// PageBitmapAllocator::Allocate prefers a same-buffer continuous run (its
+// strategy 1), so in the common case an object collapses to exactly one run --
+// turning ceil(size / page_size) synchronous hipMemcpy round trips into one.
+struct TierPageRun {
+  size_t first_page = 0;      // index into `pages`, also the user-side page index
+  uint32_t buffer_index = 0;
+  uint64_t tier_offset = 0;   // byte offset inside that tier buffer
+  uint64_t bytes = 0;
+};
+
+// Merging can be turned off with UMBP_LOCAL_PAGE_MERGE=0 to A/B the win
+// without rebuilding, mirroring UMBP_DRAM_NT_COPY in the DRAM tier.
+bool LocalPageMergeEnabled() {
+  static const bool enabled = [] {
+    const char* raw = std::getenv("UMBP_LOCAL_PAGE_MERGE");
+    return !(raw != nullptr && raw[0] == '0');
+  }();
+  return enabled;
+}
+
+// Validates every page and groups them into maximal tier-contiguous runs.
+// Returns false (after logging) on the same conditions the per-page loop used
+// to reject: unknown buffer index, unmapped buffer, or an out-of-range offset.
+bool BuildTierPageRuns(const std::vector<PageLocation>& pages, uint64_t page_size, size_t size,
+                       const std::vector<ExportableDram>& dram_buffers, const char* op,
+                       std::vector<TierPageRun>* runs) {
+  runs->clear();
+  for (size_t i = 0; i < pages.size(); ++i) {
+    const auto& p = pages[i];
+    if (p.buffer_index >= dram_buffers.size()) {
+      MORI_UMBP_ERROR("[PoolClient] local {}: invalid buffer_index {}", op, p.buffer_index);
+      return false;
+    }
+    const auto& dram = dram_buffers[p.buffer_index];
+    const uint64_t off = static_cast<uint64_t>(p.page_index) * page_size;
+    if (!dram.buffer || page_size > dram.size || off > dram.size - page_size) {
+      MORI_UMBP_ERROR("[PoolClient] local {}: OOB buf={} off={}", op, p.buffer_index, off);
+      return false;
+    }
+    const uint64_t bytes = LogicalPageBytes(i, pages.size(), page_size, size);
+
+    // Extend the open run only if this page continues it on the tier side. The
+    // user side needs no check: only the final page can be short, so every
+    // interior page is exactly page_size and the user offsets stay dense.
+    if (!runs->empty() && LocalPageMergeEnabled()) {
+      TierPageRun& last = runs->back();
+      if (last.buffer_index == p.buffer_index && last.tier_offset + last.bytes == off) {
+        last.bytes += bytes;
+        continue;
+      }
+    }
+    runs->push_back({i, p.buffer_index, off, bytes});
+  }
+  return true;
+}
+
 bool PoolClient::LocalPutPages(const std::vector<PageLocation>& pages, uint64_t page_size,
                                const void* src, size_t size) {
   const char* src_bytes = static_cast<const char*>(src);
@@ -749,27 +808,19 @@ bool PoolClient::LocalPutPages(const std::vector<PageLocation>& pages, uint64_t 
                     source_location.device_id);
     return false;
   }
-  for (size_t i = 0; i < pages.size(); ++i) {
-    const auto& p = pages[i];
-    if (p.buffer_index >= config_.dram_buffers.size()) {
-      MORI_UMBP_ERROR("[PoolClient] local Put: invalid buffer_index {}", p.buffer_index);
-      return false;
-    }
-    auto& dram = config_.dram_buffers[p.buffer_index];
-    const uint64_t off = static_cast<uint64_t>(p.page_index) * page_size;
-    if (!dram.buffer || page_size > dram.size || off > dram.size - page_size) {
-      MORI_UMBP_ERROR("[PoolClient] local Put: OOB buf={} off={}", p.buffer_index, off);
-      return false;
-    }
-    const uint64_t bytes = LogicalPageBytes(i, pages.size(), page_size, size);
-    void* dst = static_cast<char*>(dram.buffer) + off;
-    const void* page_src = src_bytes + i * page_size;
+  std::vector<TierPageRun> runs;
+  if (!BuildTierPageRuns(pages, page_size, size, config_.dram_buffers, "Put", &runs)) return false;
+
+  for (const auto& run : runs) {
+    void* dst = static_cast<char*>(config_.dram_buffers[run.buffer_index].buffer) + run.tier_offset;
+    const void* page_src = src_bytes + run.first_page * page_size;
     if (source_location.IsDevice()) {
-      if (!DeviceCopy(dst, page_src, bytes, hipMemcpyDeviceToHost, source_location.device_id)) {
+      if (!DeviceCopy(dst, page_src, run.bytes, hipMemcpyDeviceToHost,
+                      source_location.device_id)) {
         return false;
       }
     } else {
-      LocalCopyBlock(dst, page_src, bytes);
+      LocalCopyBlock(dst, page_src, run.bytes);
     }
   }
   return true;
@@ -791,28 +842,20 @@ bool PoolClient::LocalGetPages(const std::vector<PageLocation>& pages, uint64_t 
                     destination_location.device_id);
     return false;
   }
-  for (size_t i = 0; i < pages.size(); ++i) {
-    const auto& p = pages[i];
-    if (p.buffer_index >= config_.dram_buffers.size()) {
-      MORI_UMBP_ERROR("[PoolClient] local Get: invalid buffer_index {}", p.buffer_index);
-      return false;
-    }
-    auto& dram = config_.dram_buffers[p.buffer_index];
-    const uint64_t off = static_cast<uint64_t>(p.page_index) * page_size;
-    if (!dram.buffer || page_size > dram.size || off > dram.size - page_size) {
-      MORI_UMBP_ERROR("[PoolClient] local Get: OOB buf={} off={}", p.buffer_index, off);
-      return false;
-    }
-    const uint64_t bytes = LogicalPageBytes(i, pages.size(), page_size, size);
-    void* page_dst = dst_bytes + i * page_size;
-    const void* src = static_cast<const char*>(dram.buffer) + off;
+  std::vector<TierPageRun> runs;
+  if (!BuildTierPageRuns(pages, page_size, size, config_.dram_buffers, "Get", &runs)) return false;
+
+  for (const auto& run : runs) {
+    void* page_dst = dst_bytes + run.first_page * page_size;
+    const void* src =
+        static_cast<const char*>(config_.dram_buffers[run.buffer_index].buffer) + run.tier_offset;
     if (destination_location.IsDevice()) {
-      if (!DeviceCopy(page_dst, src, bytes, hipMemcpyHostToDevice,
+      if (!DeviceCopy(page_dst, src, run.bytes, hipMemcpyHostToDevice,
                       destination_location.device_id)) {
         return false;
       }
     } else {
-      LocalCopyBlock(page_dst, src, bytes);
+      LocalCopyBlock(page_dst, src, run.bytes);
     }
   }
   return true;

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -22,6 +22,7 @@
 #include "umbp/distributed/pool_client.h"
 
 #include <grpcpp/grpcpp.h>
+#include <hip/hip_runtime_api.h>
 
 #include <algorithm>
 #include <chrono>
@@ -58,6 +59,78 @@ namespace mori::umbp {
 namespace {
 
 bool IsValidMemoryDesc(const mori::io::MemoryDesc& desc) { return desc.size > 0; }
+
+struct PointerLocation {
+  mori::io::MemoryLocationType location{mori::io::MemoryLocationType::CPU};
+  int device_id{-1};
+
+  bool IsDevice() const { return location == mori::io::MemoryLocationType::GPU; }
+};
+
+// hipPointerGetAttributes reports ordinary malloc/mmap memory as either
+// hipMemoryTypeUnregistered or an invalid-value lookup, depending on the ROCm
+// runtime version. Both mean CPU memory here. Managed memory is intentionally
+// not treated as a stable GPU RDMA region because its backing pages may move.
+PointerLocation DetectPointerLocation(const void* ptr) {
+  if (ptr == nullptr) return {};
+
+  hipPointerAttribute_t attributes{};
+  const hipError_t status = hipPointerGetAttributes(&attributes, ptr);
+  if (status == hipSuccess) {
+    if (attributes.type == hipMemoryTypeDevice && attributes.device >= 0) {
+      return {mori::io::MemoryLocationType::GPU, attributes.device};
+    }
+    return {};
+  }
+
+  // An attribute miss is normal for unregistered host memory. Clear HIP's
+  // thread-local error so it cannot poison a later runtime call.
+  (void)hipGetLastError();
+  return {};
+}
+
+class ScopedHipDevice {
+ public:
+  explicit ScopedHipDevice(int device_id) {
+    if (device_id < 0) return;
+    if (hipGetDevice(&previous_device_) != hipSuccess) {
+      (void)hipGetLastError();
+      return;
+    }
+    if (previous_device_ != device_id) {
+      if (hipSetDevice(device_id) != hipSuccess) {
+        (void)hipGetLastError();
+        return;
+      }
+      changed_ = true;
+    }
+    valid_ = true;
+  }
+
+  ~ScopedHipDevice() {
+    if (changed_) {
+      const hipError_t status = hipSetDevice(previous_device_);
+      if (status != hipSuccess) (void)hipGetLastError();
+    }
+  }
+
+  bool IsValid() const { return valid_; }
+
+ private:
+  int previous_device_{-1};
+  bool changed_{false};
+  bool valid_{false};
+};
+
+bool DeviceCopy(void* dst, const void* src, size_t size, hipMemcpyKind kind, int device_id) {
+  const hipError_t status = hipMemcpy(dst, src, size, kind);
+  if (status != hipSuccess) {
+    MORI_UMBP_ERROR("[PoolClient] hipMemcpy failed on device {}: {}", device_id,
+                    hipGetErrorString(status));
+    return false;
+  }
+  return true;
+}
 
 // Key for grouping page transfers by their (local MR, remote MR) pair.
 struct PairKey {
@@ -667,10 +740,38 @@ bool PoolClient::RegisterMemory(void* ptr, size_t size) {
   }
   std::lock_guard<std::mutex> lock(registered_mem_mutex_);
   for (auto& reg : registered_regions_) {
-    if (reg.base == ptr) return true;
+    if (reg.base == ptr) {
+      if (size <= reg.size) return true;
+      MORI_UMBP_ERROR(
+          "[PoolClient] RegisterMemory: ptr={} already registered with smaller size {} < {}", ptr,
+          reg.size, size);
+      return false;
+    }
   }
-  auto mem_desc = io_engine_->RegisterMemory(ptr, size, -1, mori::io::MemoryLocationType::CPU);
-  registered_regions_.push_back({ptr, size, mem_desc});
+
+  const PointerLocation pointer_location = DetectPointerLocation(ptr);
+  try {
+    auto mem_desc = io_engine_->RegisterMemory(ptr, size, pointer_location.device_id,
+                                               pointer_location.location);
+    if (!IsValidMemoryDesc(mem_desc) || mem_desc.data != reinterpret_cast<uintptr_t>(ptr) ||
+        mem_desc.size < size || mem_desc.loc != pointer_location.location ||
+        (pointer_location.IsDevice() && mem_desc.deviceId != pointer_location.device_id)) {
+      MORI_UMBP_ERROR(
+          "[PoolClient] RegisterMemory: invalid descriptor for ptr={}, size={}, device={}, loc={}",
+          ptr, size, pointer_location.device_id, static_cast<uint32_t>(pointer_location.location));
+      if (IsValidMemoryDesc(mem_desc)) io_engine_->DeregisterMemory(mem_desc);
+      return false;
+    }
+    registered_regions_.push_back({ptr, size, mem_desc});
+  } catch (const std::exception& error) {
+    MORI_UMBP_ERROR("[PoolClient] RegisterMemory failed for ptr={}, size={}: {}", ptr, size,
+                    error.what());
+    return false;
+  } catch (...) {
+    MORI_UMBP_ERROR("[PoolClient] RegisterMemory failed for ptr={}, size={}: unknown error", ptr,
+                    size);
+    return false;
+  }
   return true;
 }
 
@@ -705,6 +806,17 @@ std::optional<std::pair<mori::io::MemoryDesc, size_t>> PoolClient::FindRegistere
 bool PoolClient::LocalPutPages(const std::vector<PageLocation>& pages, uint64_t page_size,
                                const void* src, size_t size) {
   const char* src_bytes = static_cast<const char*>(src);
+  const auto registered_source = FindRegisteredMemory(src, size);
+  const PointerLocation source_location =
+      registered_source.has_value()
+          ? PointerLocation{registered_source->first.loc, registered_source->first.deviceId}
+          : DetectPointerLocation(src);
+  ScopedHipDevice device_guard(source_location.IsDevice() ? source_location.device_id : -1);
+  if (source_location.IsDevice() && !device_guard.IsValid()) {
+    MORI_UMBP_ERROR("[PoolClient] failed to select GPU device {} for local Put",
+                    source_location.device_id);
+    return false;
+  }
   for (size_t i = 0; i < pages.size(); ++i) {
     const auto& p = pages[i];
     if (p.buffer_index >= config_.dram_buffers.size()) {
@@ -718,7 +830,15 @@ bool PoolClient::LocalPutPages(const std::vector<PageLocation>& pages, uint64_t 
       return false;
     }
     const uint64_t bytes = LogicalPageBytes(i, pages.size(), page_size, size);
-    LocalCopyBlock(static_cast<char*>(dram.buffer) + off, src_bytes + i * page_size, bytes);
+    void* dst = static_cast<char*>(dram.buffer) + off;
+    const void* page_src = src_bytes + i * page_size;
+    if (source_location.IsDevice()) {
+      if (!DeviceCopy(dst, page_src, bytes, hipMemcpyDeviceToHost, source_location.device_id)) {
+        return false;
+      }
+    } else {
+      LocalCopyBlock(dst, page_src, bytes);
+    }
   }
   return true;
 }
@@ -726,6 +846,18 @@ bool PoolClient::LocalPutPages(const std::vector<PageLocation>& pages, uint64_t 
 bool PoolClient::LocalGetPages(const std::vector<PageLocation>& pages, uint64_t page_size,
                                void* dst, size_t size) {
   char* dst_bytes = static_cast<char*>(dst);
+  const auto registered_destination = FindRegisteredMemory(dst, size);
+  const PointerLocation destination_location =
+      registered_destination.has_value() ? PointerLocation{registered_destination->first.loc,
+                                                           registered_destination->first.deviceId}
+                                         : DetectPointerLocation(dst);
+  ScopedHipDevice device_guard(destination_location.IsDevice() ? destination_location.device_id
+                                                               : -1);
+  if (destination_location.IsDevice() && !device_guard.IsValid()) {
+    MORI_UMBP_ERROR("[PoolClient] failed to select GPU device {} for local Get",
+                    destination_location.device_id);
+    return false;
+  }
   for (size_t i = 0; i < pages.size(); ++i) {
     const auto& p = pages[i];
     if (p.buffer_index >= config_.dram_buffers.size()) {
@@ -739,7 +871,16 @@ bool PoolClient::LocalGetPages(const std::vector<PageLocation>& pages, uint64_t 
       return false;
     }
     const uint64_t bytes = LogicalPageBytes(i, pages.size(), page_size, size);
-    LocalCopyBlock(dst_bytes + i * page_size, static_cast<const char*>(dram.buffer) + off, bytes);
+    void* page_dst = dst_bytes + i * page_size;
+    const void* src = static_cast<const char*>(dram.buffer) + off;
+    if (destination_location.IsDevice()) {
+      if (!DeviceCopy(page_dst, src, bytes, hipMemcpyHostToDevice,
+                      destination_location.device_id)) {
+        return false;
+      }
+    } else {
+      LocalCopyBlock(page_dst, src, bytes);
+    }
   }
   return true;
 }
@@ -1383,6 +1524,15 @@ bool PoolClient::BuildRemotePutTransfers(std::vector<RemotePutEntry>& entries, P
       entry.zero_copy = zero_copy;
       entry.use_staging = false;
       entry.staging_offset = 0;
+    } else if (DetectPointerLocation(entry.item->src).IsDevice()) {
+      MORI_UMBP_ERROR(
+          "[PoolClient] BuildRemotePutTransfers: GPU source for key='{}' is not registered; "
+          "refusing host staging fallback",
+          (entry.item && entry.item->key) ? *entry.item->key : std::string{"<null>"});
+      entry.zero_copy.reset();
+      entry.use_staging = false;
+      entry.failed = true;
+      continue;
     } else {
       entry.zero_copy.reset();
       entry.use_staging = true;
@@ -1972,6 +2122,15 @@ bool PoolClient::BuildRemoteGetTransfers(std::vector<RemoteGetEntry>& entries, P
       entry.zero_copy = zero_copy;
       entry.use_staging = false;
       entry.staging_offset = 0;
+    } else if (DetectPointerLocation(entry.item->dst).IsDevice()) {
+      MORI_UMBP_ERROR(
+          "[PoolClient] BuildRemoteGetTransfers: GPU destination for key='{}' is not registered; "
+          "refusing host staging fallback",
+          (entry.item && entry.item->key) ? *entry.item->key : std::string{"<null>"});
+      entry.zero_copy.reset();
+      entry.use_staging = false;
+      entry.failed = true;
+      continue;
     } else {
       entry.zero_copy.reset();
       entry.use_staging = true;
@@ -2244,6 +2403,10 @@ bool PoolClient::RemoteDramScatterWrite(PeerConnection& peer,
     }
   }
   if (!used_zero_copy) {
+    if (DetectPointerLocation(src).IsDevice()) {
+      MORI_UMBP_ERROR("[PoolClient] RemoteDramScatterWrite: refusing host staging for GPU source");
+      return false;
+    }
     if (size > config_.staging_buffer_size) return false;
     staging_lock.lock();
     std::memcpy(staging_buffer_.get(), src, size);
@@ -2318,6 +2481,11 @@ bool PoolClient::RemoteDramScatterRead(PeerConnection& peer, const std::vector<P
     }
   }
   if (!used_zero_copy) {
+    if (DetectPointerLocation(dst).IsDevice()) {
+      MORI_UMBP_ERROR(
+          "[PoolClient] RemoteDramScatterRead: refusing host staging for GPU destination");
+      return false;
+    }
     if (size > config_.staging_buffer_size) return false;
     staging_lock.lock();
     local_mem = staging_mem_;
@@ -2540,7 +2708,13 @@ PoolClient::SsdGetOutcome PoolClient::RemoteSsdReadOnce(PeerConnection& peer,
     status.Wait();
     rdma_ok = status.Succeeded();
   }
-  if (!rdma_ok && size <= config_.staging_buffer_size) {
+  const bool device_destination = DetectPointerLocation(dst).IsDevice();
+  if (!rdma_ok && device_destination) {
+    MORI_UMBP_ERROR(
+        "[PoolClient] RemoteSsdRead key='{}': GPU destination is not registered or RDMA failed; "
+        "refusing host staging fallback",
+        key);
+  } else if (!rdma_ok && size <= config_.staging_buffer_size) {
     std::lock_guard<std::mutex> lock(staging_mutex_);
     auto uid = io_engine_->AllocateTransferUniqueId();
     mori::io::TransferStatus status;

--- a/src/umbp/distributed/proto/umbp_standalone.proto
+++ b/src/umbp/distributed/proto/umbp_standalone.proto
@@ -9,8 +9,10 @@ service UMBPStandalone {
   rpc Put(PutRequest) returns (BoolResponse);
   rpc Get(GetRequest) returns (BoolResponse);
   rpc BatchPut(BatchDataRequest) returns (BatchBoolResponse);
+  rpc BatchPutRanges(BatchRangeDataRequest) returns (BatchBoolResponse);
   rpc BatchPutWithDepth(BatchDataWithDepthRequest) returns (BatchBoolResponse);
   rpc BatchGet(BatchDataRequest) returns (BatchBoolResponse);
+  rpc BatchGetRanges(BatchRangeDataRequest) returns (BatchBoolResponse);
   rpc Exists(KeyRequest) returns (BoolResponse);
   rpc BatchExists(BatchKeysRequest) returns (BatchBoolResponse);
   rpc BatchExistsConsecutive(BatchKeysRequest) returns (CountResponse);
@@ -84,6 +86,20 @@ message BatchDataRequest {
   // Parallel to shm_offsets: region_bases[i] is the worker VA base of the
   // region shm_offsets[i] is relative to. Empty means single-region / legacy.
   repeated uint64 region_bases = 5;
+}
+
+message BatchRangeDataRequest {
+  repeated string keys = 1;
+  string client_id = 2;
+  // The remaining fields are flattened over entries. range_counts[i] records
+  // how many ranges belong to keys[i].
+  repeated uint32 range_counts = 3;
+  repeated uint64 shm_offsets = 4;
+  repeated uint64 region_bases = 5;
+  repeated uint64 sizes = 6;
+  repeated uint64 object_offsets = 7;
+  // Put only: the expected full object size, one per key. Empty for get.
+  repeated uint64 object_sizes = 8;
 }
 
 message BatchDataWithDepthRequest {

--- a/src/umbp/distributed/proto/umbp_standalone.proto
+++ b/src/umbp/distributed/proto/umbp_standalone.proto
@@ -35,6 +35,7 @@ message Empty {}
 message PingResponse {
   bool ready = 1;
   StandaloneBackendMode deployment_mode = 2;
+  bool supports_ranged_io = 3;
 }
 
 message BoolResponse {

--- a/src/umbp/distributed/proto/umbp_standalone.proto
+++ b/src/umbp/distributed/proto/umbp_standalone.proto
@@ -99,6 +99,11 @@ message BatchBoolResponse {
   repeated bool ok = 1;
 }
 
+enum MemoryKind {
+  MEMORY_KIND_HOST_SHM = 0;
+  MEMORY_KIND_GPU_IPC = 1;
+}
+
 message RegisterMemoryRequest {
   string client_id = 1;
   uint64 worker_base = 2;
@@ -106,6 +111,11 @@ message RegisterMemoryRequest {
   string worker_node_id = 4;
   string worker_node_address = 5;
   repeated string tags = 6;
+  MemoryKind kind = 7;
+  int32 device_id = 8;
+  bytes ipc_handle = 9;
+  uint64 ipc_offset = 10;
+  uint64 alloc_base = 11;
 }
 
 message DeregisterMemoryRequest {

--- a/src/umbp/include/umbp/common/config.h
+++ b/src/umbp/include/umbp/common/config.h
@@ -218,7 +218,9 @@ struct UMBPDistributedConfig {
   // Registered host arena used by ranged multi-buffer I/O. Remote objects are
   // fetched into disjoint slices here before being installed into the local
   // tier; ranged puts assemble their scattered GPU ranges into the same arena.
-  size_t ranged_scratch_size = 256ULL * 1024 * 1024;  // 256 MiB
+  // Zero keeps ranged remote I/O disabled without allocating or registering
+  // additional host memory; callers that need it must opt in explicitly.
+  size_t ranged_scratch_size = 0;
 
   // Dedicated SSD read staging, allocated only when ssd.enabled. Per-slot
   // (this / ssd_staging_buffer_slots) must be >= the largest single-key page KV
@@ -339,10 +341,6 @@ struct UMBPConfig {
     }
     if (distributed.has_value()) {
       const auto& d = distributed.value();
-      if (d.ranged_scratch_size == 0) {
-        if (error_message) *error_message = "distributed.ranged_scratch_size must be > 0";
-        return false;
-      }
       if (d.master_config.master_address.empty()) {
         if (error_message)
           *error_message = "distributed.master_config.master_address must not be empty";

--- a/src/umbp/include/umbp/common/config.h
+++ b/src/umbp/include/umbp/common/config.h
@@ -215,6 +215,11 @@ struct UMBPDistributedConfig {
 
   size_t staging_buffer_size = 64ULL * 1024 * 1024;  // 64 MB
 
+  // Registered host arena used by ranged multi-buffer I/O. Remote objects are
+  // fetched into disjoint slices here before being installed into the local
+  // tier; ranged puts assemble their scattered GPU ranges into the same arena.
+  size_t ranged_scratch_size = 256ULL * 1024 * 1024;  // 256 MiB
+
   // Dedicated SSD read staging, allocated only when ssd.enabled. Per-slot
   // (this / ssd_staging_buffer_slots) must be >= the largest single-key page KV
   // (61-layer MLA page ~= 4.5 MB).
@@ -334,6 +339,10 @@ struct UMBPConfig {
     }
     if (distributed.has_value()) {
       const auto& d = distributed.value();
+      if (d.ranged_scratch_size == 0) {
+        if (error_message) *error_message = "distributed.ranged_scratch_size must be > 0";
+        return false;
+      }
       if (d.master_config.master_address.empty()) {
         if (error_message)
           *error_message = "distributed.master_config.master_address must not be empty";

--- a/src/umbp/include/umbp/common/device_copy.h
+++ b/src/umbp/include/umbp/common/device_copy.h
@@ -1,0 +1,62 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+#pragma once
+
+#include <hip/hip_runtime_api.h>
+
+#include <cstddef>
+
+namespace mori::umbp {
+
+struct PointerLocation {
+  bool is_device{false};
+  int device_id{-1};
+
+  bool IsDevice() const { return is_device; }
+};
+
+// Managed memory is intentionally reported as host memory: it is not a stable
+// GPU registration target because its backing pages may migrate.
+PointerLocation DetectPointerLocation(const void* ptr);
+
+class ScopedHipDevice {
+ public:
+  explicit ScopedHipDevice(int device_id);
+  ~ScopedHipDevice();
+
+  ScopedHipDevice(const ScopedHipDevice&) = delete;
+  ScopedHipDevice& operator=(const ScopedHipDevice&) = delete;
+
+  bool IsValid() const { return valid_; }
+
+ private:
+  int previous_device_{-1};
+  bool changed_{false};
+  bool valid_{false};
+};
+
+bool DeviceCopy(void* dst, const void* src, size_t size, hipMemcpyKind kind, int device_id);
+
+}  // namespace mori::umbp

--- a/src/umbp/include/umbp/common/device_gather.h
+++ b/src/umbp/include/umbp/common/device_gather.h
@@ -21,6 +21,25 @@
 // SOFTWARE.
 #pragma once
 
-// Backward-compatible source-tree include. New shared users include the common
-// header directly.
-#include "umbp/common/host_registration.h"
+#include <hip/hip_runtime_api.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace mori::umbp {
+
+struct DeviceGatherFragment {
+  const void* src;
+  void* dst;
+  size_t bytes;
+};
+
+// Copies independent fragments between a HostTierRegistration-covered region
+// and one GPU in a single kernel launch. Returns false before enqueueing work
+// when the kernel path is unavailable, allowing a hipMemcpy fallback.
+bool LaunchDeviceGather(const DeviceGatherFragment* fragments, size_t count, int device_id,
+                        hipStream_t stream);
+bool DeviceGatherEnabled();
+uint64_t DeviceGatherLaunchCount();
+
+}  // namespace mori::umbp

--- a/src/umbp/include/umbp/common/host_registration.h
+++ b/src/umbp/include/umbp/common/host_registration.h
@@ -21,6 +21,33 @@
 // SOFTWARE.
 #pragma once
 
-// Backward-compatible source-tree include. New shared users include the common
-// header directly.
-#include "umbp/common/host_registration.h"
+#include <atomic>
+#include <cstddef>
+#include <thread>
+
+namespace mori::umbp {
+
+// Makes a host tier addressable from GPU kernels via one whole-region
+// hipHostRegister call. Registration is best-effort: Covers() remains false
+// until it succeeds, allowing callers to fall back to the copy engine.
+class HostTierRegistration {
+ public:
+  HostTierRegistration(void* base, size_t bytes);
+  ~HostTierRegistration();
+
+  HostTierRegistration(const HostTierRegistration&) = delete;
+  HostTierRegistration& operator=(const HostTierRegistration&) = delete;
+
+  bool Covers(const void* ptr, size_t size) const;
+  size_t RegisteredBytes() const { return registered_bytes_.load(std::memory_order_acquire); }
+
+ private:
+  void Register();
+
+  char* base_{nullptr};
+  size_t bytes_{0};
+  std::atomic<size_t> registered_bytes_{0};
+  std::thread worker_;
+};
+
+}  // namespace mori::umbp

--- a/src/umbp/include/umbp/common/range_utils.h
+++ b/src/umbp/include/umbp/common/range_utils.h
@@ -1,0 +1,71 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <numeric>
+#include <vector>
+
+namespace mori::umbp {
+
+inline bool IsObjectRangeOverflow(size_t offset, size_t size, size_t limit) {
+  return size > limit || offset > limit - size;
+}
+
+template <typename Ptr>
+inline bool RangeBatchShapeValid(size_t entry_count, const std::vector<std::vector<Ptr>>& ptrs,
+                                 const std::vector<std::vector<size_t>>& sizes,
+                                 const std::vector<std::vector<size_t>>& offsets) {
+  if (ptrs.size() != entry_count || sizes.size() != entry_count || offsets.size() != entry_count) {
+    return false;
+  }
+  for (size_t i = 0; i < entry_count; ++i) {
+    if (ptrs[i].size() != sizes[i].size() || ptrs[i].size() != offsets[i].size()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+inline bool RangesTileObject(size_t object_size, const std::vector<size_t>& sizes,
+                             const std::vector<size_t>& offsets) {
+  if (object_size == 0 || sizes.empty() || sizes.size() != offsets.size()) return false;
+
+  std::vector<size_t> order(sizes.size());
+  std::iota(order.begin(), order.end(), size_t{0});
+  std::sort(order.begin(), order.end(),
+            [&](size_t a, size_t b) { return offsets[a] < offsets[b]; });
+
+  size_t cursor = 0;
+  for (size_t index : order) {
+    const size_t size = sizes[index];
+    const size_t offset = offsets[index];
+    if (size == 0 || offset != cursor || IsObjectRangeOverflow(offset, size, object_size)) {
+      return false;
+    }
+    cursor = offset + size;  // Safe after IsObjectRangeOverflow.
+  }
+  return cursor == object_size;
+}
+
+}  // namespace mori::umbp

--- a/src/umbp/include/umbp/distributed/config.h
+++ b/src/umbp/include/umbp/distributed/config.h
@@ -153,6 +153,12 @@ struct PoolClientConfig {
 
   size_t staging_buffer_size = 64ULL * 1024 * 1024;
 
+  // Caller-owned, RDMA-registered host arena for ranged I/O. DistributedClient
+  // owns the backing mapping and frees it only after PoolClient::Shutdown has
+  // deregistered the region. Direct PoolClient tests may provide their own.
+  void* ranged_scratch_buffer = nullptr;
+  size_t ranged_scratch_size = 0;
+
   // SSD read-staging tuning (peer side).  More slots reduce NO_SLOT under large
   // concurrent prefetch batches, but shrink per-slot size (= staging_buffer_size
   // / slots), which must stay >= the largest single SSD block.  The slot lease
@@ -207,6 +213,7 @@ inline PoolClientConfig ToPoolClientConfig(const UMBPDistributedConfig& dc,
   pc.master_config = dc.master_config;
   pc.io_engine = dc.io_engine;
   pc.staging_buffer_size = dc.staging_buffer_size;
+  pc.ranged_scratch_size = dc.ranged_scratch_size;
   pc.ssd_staging_buffer_size = dc.ssd_staging_buffer_size;
   pc.ssd_staging_buffer_slots = dc.ssd_staging_buffer_slots;
   pc.peer_service_port = dc.peer_service_port;

--- a/src/umbp/include/umbp/distributed/distributed_client.h
+++ b/src/umbp/include/umbp/distributed/distributed_client.h
@@ -75,6 +75,7 @@ class DistributedClient : public IUMBPClient {
   void Close() override;
   bool IsDistributed() const override;
   UMBPDeploymentMode GetDeploymentMode() const override { return UMBPDeploymentMode::Distributed; }
+  bool SupportsRangedIO() const override { return true; }
 
   bool RegisterMemory(uintptr_t ptr, size_t size) override;
   void DeregisterMemory(uintptr_t ptr) override;
@@ -92,6 +93,9 @@ class DistributedClient : public IUMBPClient {
   void* dram_pool_ = nullptr;
   size_t dram_pool_size_ = 0;
   HostBufferHandle dram_pool_handle_;
+  void* ranged_scratch_ = nullptr;
+  size_t ranged_scratch_size_ = 0;
+  HostBufferHandle ranged_scratch_handle_;
   std::unique_ptr<PoolClient> pool_client_;
   std::atomic<bool> closing_{false};
   mutable std::shared_mutex op_mutex_;

--- a/src/umbp/include/umbp/distributed/distributed_client.h
+++ b/src/umbp/include/umbp/distributed/distributed_client.h
@@ -58,6 +58,15 @@ class DistributedClient : public IUMBPClient {
   std::vector<bool> BatchGet(const std::vector<std::string>& keys,
                              const std::vector<uintptr_t>& dsts,
                              const std::vector<size_t>& sizes) override;
+  std::vector<bool> BatchGetRanges(const std::vector<std::string>& keys,
+                                   const std::vector<std::vector<uintptr_t>>& dsts,
+                                   const std::vector<std::vector<size_t>>& sizes,
+                                   const std::vector<std::vector<size_t>>& src_offsets) override;
+  std::vector<bool> BatchPutRanges(const std::vector<std::string>& keys,
+                                   const std::vector<size_t>& object_sizes,
+                                   const std::vector<std::vector<uintptr_t>>& srcs,
+                                   const std::vector<std::vector<size_t>>& sizes,
+                                   const std::vector<std::vector<size_t>>& dst_offsets) override;
   std::vector<bool> BatchExists(const std::vector<std::string>& keys) const override;
   size_t BatchExistsConsecutive(const std::vector<std::string>& keys) const override;
 

--- a/src/umbp/include/umbp/distributed/distributed_client.h
+++ b/src/umbp/include/umbp/distributed/distributed_client.h
@@ -75,7 +75,7 @@ class DistributedClient : public IUMBPClient {
   void Close() override;
   bool IsDistributed() const override;
   UMBPDeploymentMode GetDeploymentMode() const override { return UMBPDeploymentMode::Distributed; }
-  bool SupportsRangedIO() const override { return true; }
+  bool SupportsRangedIO() const override { return ranged_scratch_size_ > 0; }
 
   bool RegisterMemory(uintptr_t ptr, size_t size) override;
   void DeregisterMemory(uintptr_t ptr) override;

--- a/src/umbp/include/umbp/distributed/master/master_metrics.h
+++ b/src/umbp/include/umbp/distributed/master/master_metrics.h
@@ -166,6 +166,11 @@
 #define MORI_UMBP_METRIC_CLIENT_INBOUND_GET_BYTES_TOTAL_HELP \
   "Total bytes delivered to this client (inbound reads) split by local/remote traffic"
 
+#define MORI_UMBP_METRIC_RANGED_REMOTE_INSTALL_FAILURES_TOTAL \
+  "mori_umbp_ranged_remote_install_failures_total"
+#define MORI_UMBP_METRIC_RANGED_REMOTE_INSTALL_FAILURES_TOTAL_HELP \
+  "Remote ranged objects that could not be synchronously installed in the local DRAM tier"
+
 // --- Heartbeat / event-shipping counters (master-as-advisor) ----------------
 
 #define MORI_UMBP_METRIC_HEARTBEAT_EVENTS_APPLIED_TOTAL "mori_umbp_heartbeat_events_applied_total"

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -48,6 +48,7 @@ class PeerDramAllocator;
 class PeerServiceServer;
 class PeerSsdManager;
 class SsdCopyPipeline;
+class HostTierRegistration;
 
 // Short name for log output. Generic FAILED maps to "FAILED" — the
 // detailed reason for that case lives in the peer's allocator log.
@@ -117,6 +118,21 @@ class PoolClient {
   std::vector<bool> BatchGet(const std::vector<std::string>& keys, const std::vector<void*>& dsts,
                              const std::vector<size_t>& sizes);
 
+  // Ranged multi-buffer I/O. One stored object may be backed by scattered tier
+  // pages while each caller supplies multiple disjoint ranges. Ranged gets
+  // probe the local peer allocator first; remote misses are fetched as whole
+  // objects into the registered host scratch arena, synchronously installed in
+  // the local tier, then served through the same local range-copy routine.
+  std::vector<bool> BatchGetRanges(const std::vector<std::string>& keys,
+                                   const std::vector<std::vector<void*>>& dsts,
+                                   const std::vector<std::vector<size_t>>& sizes,
+                                   const std::vector<std::vector<size_t>>& src_offsets);
+  std::vector<bool> BatchPutRanges(const std::vector<std::string>& keys,
+                                   const std::vector<size_t>& object_sizes,
+                                   const std::vector<std::vector<const void*>>& srcs,
+                                   const std::vector<std::vector<size_t>>& sizes,
+                                   const std::vector<std::vector<size_t>>& dst_offsets);
+
   // Cluster-wide existence check — issues a RouteGet and reports
   // whether master surfaced any replica.  No RDMA, no lease bump.
   bool Exists(const std::string& key);
@@ -178,10 +194,16 @@ class PoolClient {
   std::unique_ptr<PeerServiceServer> peer_service_;
 
   std::unique_ptr<mori::io::IOEngine> io_engine_;
+  std::vector<std::unique_ptr<HostTierRegistration>> dram_host_registrations_;
   mori::io::MemoryDesc staging_mem_{};
   std::vector<mori::io::MemoryDesc> export_dram_mems_;
   std::unique_ptr<char[]> staging_buffer_;
   std::mutex staging_mutex_;
+
+  // Caller-owned, registered host arena used only by ranged operations. One
+  // mutex deliberately serializes arena users in phase 1; local-only ranged
+  // reads do not take it and remain concurrent.
+  std::mutex ranged_scratch_mutex_;
 
   std::unique_ptr<char[]> ssd_staging_buffer_;
   mori::io::MemoryDesc ssd_staging_mem_{};
@@ -228,6 +250,32 @@ class PoolClient {
                      size_t size);
   bool LocalGetPages(const std::vector<PageLocation>& pages, uint64_t page_size, void* dst,
                      size_t size);
+  bool LocalGetRanges(const std::vector<PageLocation>& pages, uint64_t page_size,
+                      uint64_t stored_size, const std::vector<void*>& dsts,
+                      const std::vector<size_t>& sizes, const std::vector<size_t>& src_offsets);
+  struct LocalRangeReadRequest {
+    const std::vector<PageLocation>* pages = nullptr;
+    uint64_t stored_size = 0;
+    const std::vector<void*>* dsts = nullptr;
+    const std::vector<size_t>* sizes = nullptr;
+    const std::vector<size_t>* src_offsets = nullptr;
+  };
+  bool LocalGetRangesBatch(const std::vector<LocalRangeReadRequest>& requests, uint64_t page_size);
+  bool CopyContiguousToRanges(const void* src, size_t object_size, const std::vector<void*>& dsts,
+                              const std::vector<size_t>& sizes,
+                              const std::vector<size_t>& src_offsets);
+  bool CopyRangesToContiguous(const std::vector<const void*>& srcs,
+                              const std::vector<size_t>& sizes,
+                              const std::vector<size_t>& dst_offsets, void* dst,
+                              size_t object_size);
+  struct RangeAssemblyRequest {
+    const std::vector<const void*>* srcs = nullptr;
+    const std::vector<size_t>* sizes = nullptr;
+    const std::vector<size_t>* dst_offsets = nullptr;
+    void* dst = nullptr;
+    size_t object_size = 0;
+  };
+  bool CopyRangesToContiguousBatch(const std::vector<RangeAssemblyRequest>& requests);
 
   bool EnsurePeerServiceConnection(PeerConnection& peer);
 
@@ -263,6 +311,20 @@ class PoolClient {
 
   PutAttemptOutcome ExecuteLocalPut(const std::string& key, const void* src, size_t size,
                                     TierType tier, bool enqueue_ssd_copy = true);
+  PutAttemptOutcome ExecuteLocalPutRanges(const std::string& key, size_t object_size,
+                                          const std::vector<const void*>& srcs,
+                                          const std::vector<size_t>& sizes,
+                                          const std::vector<size_t>& dst_offsets, TierType tier);
+  struct LocalRangeWriteRequest {
+    const std::string* key = nullptr;
+    size_t object_size = 0;
+    const std::vector<const void*>* srcs = nullptr;
+    const std::vector<size_t>* sizes = nullptr;
+    const std::vector<size_t>* dst_offsets = nullptr;
+    TierType tier = TierType::UNKNOWN;
+  };
+  std::vector<PutAttemptOutcome> ExecuteLocalPutRangesBatch(
+      const std::vector<LocalRangeWriteRequest>& requests);
   GetAttemptOutcome ExecuteLocalGet(const std::string& key, void* dst, size_t size);
   // After a successful remote DRAM fetch, if cache_remote_fetches is enabled and
   // the admission gate admits the block, enqueue it for asynchronous install into
@@ -357,7 +419,7 @@ class PoolClient {
   // (submit -> wait).  Reads the plan; writes per-key outcomes into *results.
   void ExecuteBatchGetPlan(const BatchGetPlan& plan, const std::vector<std::string>& keys,
                            const std::vector<void*>& dsts, const std::vector<size_t>& sizes,
-                           std::vector<bool>* results);
+                           std::vector<bool>* results, bool recache_remote = true);
 
   struct TransferInstruction {
     size_t entry_index;
@@ -449,7 +511,8 @@ class PoolClient {
   bool BuildRemoteGetTransfers(std::vector<RemoteGetEntry>& entries, PeerConnection& peer,
                                std::vector<TransferInstruction>* transfers,
                                uint64_t* staging_bytes);
-  void FinalizeRemoteGetEntries(std::vector<RemoteGetEntry>& entries, std::vector<bool>* results);
+  void FinalizeRemoteGetEntries(std::vector<RemoteGetEntry>& entries, std::vector<bool>* results,
+                                bool recache_remote);
 
   // One posted-but-not-yet-waited remote-DRAM read for a single peer; the
   // scheduler waits it later. Owned by a unique_ptr and never moved after
@@ -497,7 +560,8 @@ class PoolClient {
   // Wait half: wait every group (never break early), aggregate per-pair failure
   // back to per-key (per-item AND); for a staging in-flight, copy staging_buffer_
   // -> user dst and release staging_mutex_; then FinalizeRemoteGetEntries.
-  void WaitRemoteBatchGet(RemoteDramGetInFlight& inflight, std::vector<bool>* results);
+  void WaitRemoteBatchGet(RemoteDramGetInFlight& inflight, std::vector<bool>* results,
+                          bool recache_remote);
 
   // One posted-but-not-yet-waited remote-DRAM write for a single peer (same
   // lifetime contract as RemoteDramGetInFlight: unique_ptr-owned, never moved

--- a/src/umbp/include/umbp/local/standalone_client.h
+++ b/src/umbp/include/umbp/local/standalone_client.h
@@ -73,6 +73,7 @@ class StandaloneClient : public IUMBPClient {
   void Close() override;
   bool IsDistributed() const override;
   UMBPDeploymentMode GetDeploymentMode() const override { return UMBPDeploymentMode::Local; }
+  bool SupportsRangedIO() const override { return !config_.ssd.enabled; }
 
   bool ReportExternalKvBlocks(const std::vector<std::string>& /*hashes*/,
                               TierType /*tier*/) override {

--- a/src/umbp/include/umbp/local/standalone_client.h
+++ b/src/umbp/include/umbp/local/standalone_client.h
@@ -56,6 +56,15 @@ class StandaloneClient : public IUMBPClient {
   std::vector<bool> BatchGet(const std::vector<std::string>& keys,
                              const std::vector<uintptr_t>& dsts,
                              const std::vector<size_t>& sizes) override;
+  std::vector<bool> BatchGetRanges(const std::vector<std::string>& keys,
+                                   const std::vector<std::vector<uintptr_t>>& dsts,
+                                   const std::vector<std::vector<size_t>>& sizes,
+                                   const std::vector<std::vector<size_t>>& src_offsets) override;
+  std::vector<bool> BatchPutRanges(const std::vector<std::string>& keys,
+                                   const std::vector<size_t>& object_sizes,
+                                   const std::vector<std::vector<uintptr_t>>& srcs,
+                                   const std::vector<std::vector<size_t>>& sizes,
+                                   const std::vector<std::vector<size_t>>& dst_offsets) override;
   std::vector<bool> BatchExists(const std::vector<std::string>& keys) const override;
   size_t BatchExistsConsecutive(const std::vector<std::string>& keys) const override;
 

--- a/src/umbp/include/umbp/local/tiers/dram_tier.h
+++ b/src/umbp/include/umbp/local/tiers/dram_tier.h
@@ -68,6 +68,10 @@ class DRAMTier : public TierBackend {
   std::vector<bool> ReadBatchIntoPtr(const std::vector<std::string>& keys,
                                      const std::vector<uintptr_t>& dst_ptrs,
                                      const std::vector<size_t>& sizes) override;
+  std::vector<bool> ReadBatchRangesIntoPtr(
+      const std::vector<std::string>& keys, const std::vector<std::vector<uintptr_t>>& dst_ptrs,
+      const std::vector<std::vector<size_t>>& sizes,
+      const std::vector<std::vector<size_t>>& src_offsets) override;
   // Multi-threaded batch write: serial slot allocation (mutates free_list_)
   // followed by parallel non-temporal CopyBlock of each payload into its slot.
   // Mirrors ReadBatchIntoPtr to break the single-core memcpy ceiling on the
@@ -76,6 +80,11 @@ class DRAMTier : public TierBackend {
   std::vector<bool> BatchWrite(const std::vector<std::string>& keys,
                                const std::vector<const void*>& data_ptrs,
                                const std::vector<size_t>& sizes) override;
+  std::vector<bool> BatchWriteRanges(const std::vector<std::string>& keys,
+                                     const std::vector<size_t>& object_sizes,
+                                     const std::vector<std::vector<const void*>>& src_ptrs,
+                                     const std::vector<std::vector<size_t>>& sizes,
+                                     const std::vector<std::vector<size_t>>& dst_offsets) override;
   bool Exists(const std::string& key) const override;
   bool Evict(const std::string& key) override;
   std::pair<size_t, size_t> Capacity() const override;

--- a/src/umbp/include/umbp/local/tiers/dram_tier.h
+++ b/src/umbp/include/umbp/local/tiers/dram_tier.h
@@ -24,6 +24,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <list>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <shared_mutex>
@@ -36,6 +37,11 @@
 #include "umbp/local/tiers/tier_backend.h"
 
 namespace mori::umbp {
+
+// Implementation detail of this tier, declared in a source-private header so it
+// stays out of the installed API. `~DRAMTier` is defined out of line, which is
+// what lets the unique_ptr below hold an incomplete type.
+class HostTierRegistration;
 
 // DRAM Tier: mmap pre-allocated large memory block with offset allocator
 class DRAMTier : public TierBackend {
@@ -117,6 +123,10 @@ class DRAMTier : public TierBackend {
   bool use_shm_;
   std::string shm_name_;
   HostBufferHandle host_buf_handle_;  // owned handle for non-shm path
+
+  // Makes the region above addressable from GPU kernels. Destroyed first so it
+  // unregisters while the mapping is still alive.
+  std::unique_ptr<HostTierRegistration> host_registration_;
 
   // Simple offset allocator: key -> (offset, size)
   struct SlotInfo {

--- a/src/umbp/include/umbp/local/tiers/dram_tier.h
+++ b/src/umbp/include/umbp/local/tiers/dram_tier.h
@@ -26,6 +26,7 @@
 #include <list>
 #include <mutex>
 #include <optional>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -126,7 +127,8 @@ class DRAMTier : public TierBackend {
   };
   std::list<FreeBlock> free_list_;
 
-  mutable std::mutex mu_;
+  mutable std::shared_mutex mu_;  // slots_, free_list_, used_
+  mutable std::mutex lru_mu_;     // lru_list_, lru_map_
 
   // Threads used by ReadBatchIntoPtr for parallel CopyBlock. Default 8, override
   // via env UMBP_DRAM_READ_THREADS, capped to hardware concurrency. >1 breaks
@@ -140,8 +142,8 @@ class DRAMTier : public TierBackend {
 
   size_t Allocate(size_t size);                 // Allocate from free_list_
   void Deallocate(size_t offset, size_t size);  // Return to free_list_
-  void EvictLRU();                              // Evict least recently used
-  void TouchLRU(const std::string& key);        // Update LRU position
+  void EvictLRU();                              // mu_ held; locks lru_mu_
+  void TouchLRU(const std::string& key);        // Caller holds lru_mu_
 };
 
 }  // namespace mori::umbp

--- a/src/umbp/include/umbp/local/tiers/local_storage_manager.h
+++ b/src/umbp/include/umbp/local/tiers/local_storage_manager.h
@@ -72,12 +72,22 @@ class LocalStorageManager {
                                       const std::vector<uintptr_t>& srcs,
                                       const std::vector<size_t>& sizes,
                                       StorageTier tier = StorageTier::CPU_DRAM);
+  std::vector<bool> WriteBatchRangesFromPtr(const std::vector<std::string>& keys,
+                                            const std::vector<size_t>& object_sizes,
+                                            const std::vector<std::vector<uintptr_t>>& srcs,
+                                            const std::vector<std::vector<size_t>>& sizes,
+                                            const std::vector<std::vector<size_t>>& dst_offsets,
+                                            StorageTier tier = StorageTier::CPU_DRAM);
 
   bool ReadIntoPtr(const std::string& key, uintptr_t dst, size_t size);
   bool ReadIntoPtrNoPromote(const std::string& key, uintptr_t dst, size_t size);
   std::vector<bool> ReadBatchIntoPtr(const std::vector<std::string>& keys,
                                      const std::vector<uintptr_t>& dst_ptrs,
                                      const std::vector<size_t>& sizes);
+  std::vector<bool> ReadBatchRangesIntoPtr(const std::vector<std::string>& keys,
+                                           const std::vector<std::vector<uintptr_t>>& dst_ptrs,
+                                           const std::vector<std::vector<size_t>>& sizes,
+                                           const std::vector<std::vector<size_t>>& src_offsets);
   bool Exists(const std::string& key) const;
   bool Evict(const std::string& key);
   std::pair<size_t, size_t> Capacity(StorageTier tier) const;
@@ -155,6 +165,10 @@ class LocalStorageManager {
   // if no metadata is available.
   // Returns empty string if the tier is empty.
   std::string SelectVictim(TierBackend* tier);
+
+  bool WriteRangesFromPtr(const std::string& key, size_t object_size,
+                          const std::vector<uintptr_t>& srcs, const std::vector<size_t>& sizes,
+                          const std::vector<size_t>& dst_offsets, StorageTier tier);
 
   // -----------------------------------------------------------------------
   // Existing helpers

--- a/src/umbp/include/umbp/local/tiers/tier_backend.h
+++ b/src/umbp/include/umbp/local/tiers/tier_backend.h
@@ -85,6 +85,10 @@ class TierBackend {
   virtual std::vector<bool> ReadBatchIntoPtr(const std::vector<std::string>& keys,
                                              const std::vector<uintptr_t>& dst_ptrs,
                                              const std::vector<size_t>& sizes);
+  virtual std::vector<bool> ReadBatchRangesIntoPtr(
+      const std::vector<std::string>& keys, const std::vector<std::vector<uintptr_t>>& dst_ptrs,
+      const std::vector<std::vector<size_t>>& sizes,
+      const std::vector<std::vector<size_t>>& src_offsets);
 
   // Return the LRU key, or empty string if empty.
   // Default returns "". Override in tiers with LRU tracking.
@@ -99,6 +103,11 @@ class TierBackend {
   virtual std::vector<bool> BatchWrite(const std::vector<std::string>& keys,
                                        const std::vector<const void*>& data_ptrs,
                                        const std::vector<size_t>& sizes);
+  virtual std::vector<bool> BatchWriteRanges(const std::vector<std::string>& keys,
+                                             const std::vector<size_t>& object_sizes,
+                                             const std::vector<std::vector<const void*>>& src_ptrs,
+                                             const std::vector<std::vector<size_t>>& sizes,
+                                             const std::vector<std::vector<size_t>>& dst_offsets);
 
   // Batch read into user pointers. Default loops over ReadIntoPtr().
   virtual std::vector<bool> BatchReadIntoPtr(const std::vector<std::string>& keys,

--- a/src/umbp/include/umbp/standalone/standalone_process_client.h
+++ b/src/umbp/include/umbp/standalone/standalone_process_client.h
@@ -76,6 +76,8 @@ class StandaloneProcessClient : public IUMBPClient {
   UMBPDeploymentMode GetDeploymentMode() const override {
     return UMBPDeploymentMode::StandaloneProcess;
   }
+  UMBPDeploymentMode GetBackendMode() const override { return backend_mode_; }
+  bool SupportsRangedIO() const override { return supports_ranged_io_; }
 
   bool RegisterMemory(uintptr_t ptr, size_t size) override;
   void DeregisterMemory(uintptr_t ptr) override;
@@ -92,7 +94,7 @@ class StandaloneProcessClient : public IUMBPClient {
   // Resolves `ptr` against the registered host regions. On success writes the
   // region-relative `offset` and the matched region's worker VA `region_base`.
   bool OffsetFor(uintptr_t ptr, size_t size, uint64_t* offset, uint64_t* region_base) const;
-  bool WaitReady(int timeout_ms) const;
+  bool WaitReady(int timeout_ms);
   void MaybeAutoStart();
   std::string ClientId();
   void DeregisterMemoryLocked();
@@ -109,6 +111,8 @@ class StandaloneProcessClient : public IUMBPClient {
   mutable std::shared_mutex op_mutex_;
   std::atomic<bool> closing_{false};
   bool closed_ = false;
+  UMBPDeploymentMode backend_mode_ = UMBPDeploymentMode::StandaloneProcess;
+  bool supports_ranged_io_ = false;
 
   enum class RegionKind { kHostShm, kGpuIpc };
 

--- a/src/umbp/include/umbp/standalone/standalone_process_client.h
+++ b/src/umbp/include/umbp/standalone/standalone_process_client.h
@@ -57,6 +57,15 @@ class StandaloneProcessClient : public IUMBPClient {
   std::vector<bool> BatchGet(const std::vector<std::string>& keys,
                              const std::vector<uintptr_t>& dsts,
                              const std::vector<size_t>& sizes) override;
+  std::vector<bool> BatchGetRanges(const std::vector<std::string>& keys,
+                                   const std::vector<std::vector<uintptr_t>>& dsts,
+                                   const std::vector<std::vector<size_t>>& sizes,
+                                   const std::vector<std::vector<size_t>>& src_offsets) override;
+  std::vector<bool> BatchPutRanges(const std::vector<std::string>& keys,
+                                   const std::vector<size_t>& object_sizes,
+                                   const std::vector<std::vector<uintptr_t>>& srcs,
+                                   const std::vector<std::vector<size_t>>& sizes,
+                                   const std::vector<std::vector<size_t>>& dst_offsets) override;
   std::vector<bool> BatchExists(const std::vector<std::string>& keys) const override;
   size_t BatchExistsConsecutive(const std::vector<std::string>& keys) const override;
 

--- a/src/umbp/include/umbp/standalone/standalone_process_client.h
+++ b/src/umbp/include/umbp/standalone/standalone_process_client.h
@@ -87,6 +87,8 @@ class StandaloneProcessClient : public IUMBPClient {
   void MaybeAutoStart();
   std::string ClientId();
   void DeregisterMemoryLocked();
+  bool RegisterDeviceMemory(uintptr_t ptr, size_t size, int device_id);
+  bool RegisterHostShmMemory(uintptr_t ptr, size_t size);
 
   UMBPConfig config_;
   UMBPStandaloneProcessConfig standalone_config_;
@@ -99,14 +101,14 @@ class StandaloneProcessClient : public IUMBPClient {
   std::atomic<bool> closing_{false};
   bool closed_ = false;
 
-  // One registered host shared-memory region. A hybrid HiCache worker (e.g.
-  // DeepSeek-V4) registers several non-contiguous host pools per rank, so the
-  // client tracks N regions and resolves each data op to the one that owns its
-  // pointer. `base` is the worker VA base (== allocation->base), `size` its
-  // mapped size.
+  enum class RegionKind { kHostShm, kGpuIpc };
+
+  // A hybrid worker can register several non-contiguous host or GPU regions.
+  // `base` is the worker VA used as region_base in data requests.
   struct RegisteredRegion {
     uintptr_t base = 0;
     size_t size = 0;
+    RegionKind kind = RegionKind::kHostShm;
   };
 
   mutable std::mutex registration_mu_;

--- a/src/umbp/include/umbp/umbp_client.h
+++ b/src/umbp/include/umbp/umbp_client.h
@@ -43,8 +43,9 @@ enum class UMBPDeploymentMode : int {
 
 /// Abstract interface for UMBP storage clients.
 ///
-/// Two implementations exist behind this interface:
+/// Three implementations exist behind this interface:
 ///   - StandaloneClient: purely local DRAM+SSD storage, no networking.
+///   - StandaloneProcessClient: gRPC forwarding to a standalone server.
 ///   - DistributedClient: master-led global routing + RDMA data plane.
 ///
 /// Use CreateUMBPClient() to obtain the appropriate implementation based on
@@ -83,6 +84,21 @@ class IUMBPClient {
   virtual std::vector<bool> BatchGet(const std::vector<std::string>& keys,
                                      const std::vector<uintptr_t>& dsts,
                                      const std::vector<size_t>& sizes) = 0;
+
+  /// Read byte ranges of stored objects into scattered user buffers. Shape
+  /// errors fail the whole batch; data errors are reported per key.
+  virtual std::vector<bool> BatchGetRanges(const std::vector<std::string>& keys,
+                                           const std::vector<std::vector<uintptr_t>>& dsts,
+                                           const std::vector<std::vector<size_t>>& sizes,
+                                           const std::vector<std::vector<size_t>>& src_offsets) = 0;
+
+  /// Atomically publish objects assembled from scattered buffers. The ranges
+  /// for each key must exactly tile [0, object_sizes[i]).
+  virtual std::vector<bool> BatchPutRanges(const std::vector<std::string>& keys,
+                                           const std::vector<size_t>& object_sizes,
+                                           const std::vector<std::vector<uintptr_t>>& srcs,
+                                           const std::vector<std::vector<size_t>>& sizes,
+                                           const std::vector<std::vector<size_t>>& dst_offsets) = 0;
 
   virtual std::vector<bool> BatchExists(const std::vector<std::string>& keys) const = 0;
 

--- a/src/umbp/include/umbp/umbp_client.h
+++ b/src/umbp/include/umbp/umbp_client.h
@@ -134,6 +134,14 @@ class IUMBPClient {
     return IsDistributed() ? UMBPDeploymentMode::Distributed : UMBPDeploymentMode::Local;
   }
 
+  /// Returns the backend behind a forwarding client. For direct clients this
+  /// equals GetDeploymentMode(); StandaloneProcessClient overrides it with the
+  /// mode reported by the server's Ping response.
+  virtual UMBPDeploymentMode GetBackendMode() const { return GetDeploymentMode(); }
+
+  /// Whether this concrete backend implements ranged multi-buffer I/O.
+  virtual bool SupportsRangedIO() const { return false; }
+
   // ---- Optional zero-copy hooks ----
   //
   // Register a host buffer for zero-copy RDMA transfers.  Standalone

--- a/src/umbp/local/standalone_client.cpp
+++ b/src/umbp/local/standalone_client.cpp
@@ -26,6 +26,7 @@
 #include <string>
 
 #include "mori/utils/mori_log.hpp"
+#include "umbp/common/range_utils.h"
 #include "umbp/local/tiers/dram_tier.h"
 
 namespace mori::umbp {
@@ -184,6 +185,51 @@ std::vector<bool> StandaloneClient::BatchPut(const std::vector<std::string>& key
   return results;
 }
 
+std::vector<bool> StandaloneClient::BatchPutRanges(
+    const std::vector<std::string>& keys, const std::vector<size_t>& object_sizes,
+    const std::vector<std::vector<uintptr_t>>& srcs, const std::vector<std::vector<size_t>>& sizes,
+    const std::vector<std::vector<size_t>>& dst_offsets) {
+  const size_t n = keys.size();
+  std::vector<bool> results(n, false);
+  if (object_sizes.size() != n || !RangeBatchShapeValid(n, srcs, sizes, dst_offsets)) {
+    return results;
+  }
+  if (role_ == UMBPRole::SharedSSDFollower || config_.ssd.enabled) return results;
+
+  std::vector<size_t> write_map;
+  std::vector<std::string> write_keys;
+  std::vector<size_t> write_object_sizes;
+  std::vector<std::vector<uintptr_t>> write_srcs;
+  std::vector<std::vector<size_t>> write_sizes;
+  std::vector<std::vector<size_t>> write_offsets;
+  write_map.reserve(n);
+  for (size_t i = 0; i < n; ++i) {
+    if (!RangesTileObject(object_sizes[i], sizes[i], dst_offsets[i])) continue;
+    if (index_.MayExist(keys[i])) {
+      results[i] = true;
+      continue;
+    }
+    write_map.push_back(i);
+    write_keys.push_back(keys[i]);
+    write_object_sizes.push_back(object_sizes[i]);
+    write_srcs.push_back(srcs[i]);
+    write_sizes.push_back(sizes[i]);
+    write_offsets.push_back(dst_offsets[i]);
+  }
+
+  if (!write_keys.empty()) {
+    auto write_results = storage_.WriteBatchRangesFromPtr(write_keys, write_object_sizes,
+                                                          write_srcs, write_sizes, write_offsets);
+    for (size_t j = 0; j < write_map.size(); ++j) {
+      if (j >= write_results.size() || !write_results[j]) continue;
+      const size_t i = write_map[j];
+      index_.Insert(keys[i], {StorageTier::CPU_DRAM, 0, object_sizes[i]});
+      results[i] = true;
+    }
+  }
+  return results;
+}
+
 std::vector<bool> StandaloneClient::BatchPutWithDepth(const std::vector<std::string>& keys,
                                                       const std::vector<uintptr_t>& srcs,
                                                       const std::vector<size_t>& sizes,
@@ -270,6 +316,45 @@ std::vector<bool> StandaloneClient::BatchGet(const std::vector<std::string>& key
     results[i] = local_hit;
   }
 
+  return results;
+}
+
+std::vector<bool> StandaloneClient::BatchGetRanges(
+    const std::vector<std::string>& keys, const std::vector<std::vector<uintptr_t>>& dsts,
+    const std::vector<std::vector<size_t>>& sizes,
+    const std::vector<std::vector<size_t>>& src_offsets) {
+  const size_t n = keys.size();
+  std::vector<bool> results(n, false);
+  if (!RangeBatchShapeValid(n, dsts, sizes, src_offsets) || config_.ssd.enabled ||
+      role_ == UMBPRole::SharedSSDFollower) {
+    return results;
+  }
+
+  std::vector<size_t> read_map;
+  std::vector<std::string> read_keys;
+  std::vector<std::vector<uintptr_t>> read_dsts;
+  std::vector<std::vector<size_t>> read_sizes;
+  std::vector<std::vector<size_t>> read_offsets;
+  read_map.reserve(n);
+  for (size_t i = 0; i < n; ++i) {
+    if (sizes[i].empty() || !index_.MayExist(keys[i])) continue;
+    read_map.push_back(i);
+    read_keys.push_back(keys[i]);
+    read_dsts.push_back(dsts[i]);
+    read_sizes.push_back(sizes[i]);
+    read_offsets.push_back(src_offsets[i]);
+  }
+
+  if (!read_keys.empty()) {
+    auto read_results =
+        storage_.ReadBatchRangesIntoPtr(read_keys, read_dsts, read_sizes, read_offsets);
+    for (size_t j = 0; j < read_map.size(); ++j) {
+      const size_t i = read_map[j];
+      const bool ok = j < read_results.size() && read_results[j];
+      results[i] = ok;
+      if (!ok && !storage_.Exists(keys[i])) index_.Remove(keys[i]);
+    }
+  }
   return results;
 }
 

--- a/src/umbp/local/tiers/device_copy_run.h
+++ b/src/umbp/local/tiers/device_copy_run.h
@@ -25,7 +25,9 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <limits>
+#include <string>
 #include <vector>
 
 namespace mori::umbp::detail {
@@ -41,6 +43,23 @@ struct DeviceCopyRun {
   size_t dpitch{0};
 };
 
+// Off by default, and it should stay that way. Reading one layer out of
+// page-sized objects gives hipMemcpy2DAsync a pitch/width ratio in the tens,
+// and at that ratio it is bimodal: ~0.35 us per fragment once the source pages
+// have been through it, ~194 us the first time. A live tier recycles slots
+// constantly, so it only ever pays the cold price -- measured 133x slower than
+// per-fragment 1D copies end to end. The gather kernel covers this shape
+// instead. Set UMBP_DRAM_PITCHED_COPY=1 to measure the pitched path again.
+inline bool PitchedCopyEnabled() {
+  static const bool enabled = [] {
+    const char* value = std::getenv("UMBP_DRAM_PITCHED_COPY");
+    if (value == nullptr) return false;
+    const std::string text(value);
+    return text == "1" || text == "on" || text == "true";
+  }();
+  return enabled;
+}
+
 inline uintptr_t PointerAddress(const void* ptr) { return reinterpret_cast<uintptr_t>(ptr); }
 
 inline bool Adjacent(uintptr_t base, size_t size, uintptr_t next) {
@@ -50,8 +69,15 @@ inline bool Adjacent(uintptr_t base, size_t size, uintptr_t next) {
 // Job must expose `src`, `dst`, and `size`. `ordered` must be sorted by source
 // address. Kept as a small pure planner so path selection can be regression-
 // tested without issuing HIP work.
+//
+// `allow_pitched` is false for the gather-kernel path, which wants only the
+// flat merges: a pitched run describes several fragments in one submission,
+// which is the copy engine's vocabulary, not the kernel's. Callers pass
+// PitchedCopyEnabled() rather than having it read here, so the planner stays a
+// pure function of its arguments and can be tested without the environment.
 template <typename Job>
-DeviceCopyRun FindDeviceCopyRun(const std::vector<Job*>& ordered, size_t begin) {
+DeviceCopyRun FindDeviceCopyRun(const std::vector<Job*>& ordered, size_t begin,
+                                bool allow_pitched = true) {
   const Job* first = ordered[begin];
   DeviceCopyRun run{DeviceCopyRunKind::kSingle, begin + 1, first->size, first->size, 0, 0};
 
@@ -77,7 +103,8 @@ DeviceCopyRun FindDeviceCopyRun(const std::vector<Job*>& ordered, size_t begin) 
     return run;
   }
 
-  if (begin + 1 >= ordered.size() || first->size == 0 || ordered[begin + 1]->size != first->size) {
+  if (!allow_pitched || begin + 1 >= ordered.size() || first->size == 0 ||
+      ordered[begin + 1]->size != first->size) {
     return run;
   }
   const uintptr_t src0 = PointerAddress(first->src);

--- a/src/umbp/local/tiers/device_copy_run.h
+++ b/src/umbp/local/tiers/device_copy_run.h
@@ -1,0 +1,118 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+// Source-private run planner shared only by DRAMTier and its unit test.
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+namespace mori::umbp::detail {
+
+enum class DeviceCopyRunKind { kSingle, kLinear, kPitched };
+
+struct DeviceCopyRun {
+  DeviceCopyRunKind kind{DeviceCopyRunKind::kSingle};
+  size_t end{0};  // one past the last job
+  size_t bytes{0};
+  size_t width{0};
+  size_t spitch{0};
+  size_t dpitch{0};
+};
+
+inline uintptr_t PointerAddress(const void* ptr) { return reinterpret_cast<uintptr_t>(ptr); }
+
+inline bool Adjacent(uintptr_t base, size_t size, uintptr_t next) {
+  return size <= std::numeric_limits<uintptr_t>::max() - base && base + size == next;
+}
+
+// Job must expose `src`, `dst`, and `size`. `ordered` must be sorted by source
+// address. Kept as a small pure planner so path selection can be regression-
+// tested without issuing HIP work.
+template <typename Job>
+DeviceCopyRun FindDeviceCopyRun(const std::vector<Job*>& ordered, size_t begin) {
+  const Job* first = ordered[begin];
+  DeviceCopyRun run{DeviceCopyRunKind::kSingle, begin + 1, first->size, first->size, 0, 0};
+
+  // Preserve the existing fast path exactly: adjacent jobs may have different
+  // sizes and still form one flat memcpy.
+  size_t linear_end = begin + 1;
+  size_t linear_bytes = first->size;
+  while (linear_end < ordered.size()) {
+    const Job* prev = ordered[linear_end - 1];
+    const Job* cur = ordered[linear_end];
+    if (!Adjacent(PointerAddress(prev->src), prev->size, PointerAddress(cur->src)) ||
+        !Adjacent(PointerAddress(prev->dst), prev->size, PointerAddress(cur->dst)) ||
+        cur->size > std::numeric_limits<size_t>::max() - linear_bytes) {
+      break;
+    }
+    linear_bytes += cur->size;
+    ++linear_end;
+  }
+  if (linear_end > begin + 1) {
+    run.kind = DeviceCopyRunKind::kLinear;
+    run.end = linear_end;
+    run.bytes = linear_bytes;
+    return run;
+  }
+
+  if (begin + 1 >= ordered.size() || first->size == 0 || ordered[begin + 1]->size != first->size) {
+    return run;
+  }
+  const uintptr_t src0 = PointerAddress(first->src);
+  const uintptr_t src1 = PointerAddress(ordered[begin + 1]->src);
+  const uintptr_t dst0 = PointerAddress(first->dst);
+  const uintptr_t dst1 = PointerAddress(ordered[begin + 1]->dst);
+  if (src1 <= src0 || dst1 <= dst0) return run;
+
+  const size_t spitch = src1 - src0;
+  const size_t dpitch = dst1 - dst0;
+  if (spitch < first->size || dpitch < first->size) return run;
+
+  size_t pitched_end = begin + 2;
+  while (pitched_end < ordered.size()) {
+    const Job* prev = ordered[pitched_end - 1];
+    const Job* cur = ordered[pitched_end];
+    const uintptr_t prev_src = PointerAddress(prev->src);
+    const uintptr_t cur_src = PointerAddress(cur->src);
+    const uintptr_t prev_dst = PointerAddress(prev->dst);
+    const uintptr_t cur_dst = PointerAddress(cur->dst);
+    if (cur->size != first->size || cur_src <= prev_src || cur_dst <= prev_dst ||
+        cur_src - prev_src != spitch || cur_dst - prev_dst != dpitch) {
+      break;
+    }
+    ++pitched_end;
+  }
+
+  const size_t rows = pitched_end - begin;
+  run.kind = DeviceCopyRunKind::kPitched;
+  run.end = pitched_end;
+  run.bytes = first->size <= std::numeric_limits<size_t>::max() / rows ? first->size * rows : 0;
+  run.width = first->size;
+  run.spitch = spitch;
+  run.dpitch = dpitch;
+  return run;
+}
+
+}  // namespace mori::umbp::detail

--- a/src/umbp/local/tiers/device_gather.h
+++ b/src/umbp/local/tiers/device_gather.h
@@ -1,0 +1,69 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+// Source-private to the DRAM tier; not part of the installed API.
+
+#include <hip/hip_runtime_api.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace mori::umbp {
+
+struct DeviceGatherFragment {
+  const void* src;
+  void* dst;
+  size_t bytes;
+};
+
+// Copies `count` independent fragments between a registered host region and
+// device memory in a single kernel launch, in either direction.
+//
+// This exists because the DRAM tier's copy path is scatter-gather by nature:
+// reading one layer out of page-granular objects means dozens of small strided
+// fragments per call, and hipMemcpy has no scatter-gather form. Submitting them
+// one at a time costs ~5.4 us each with 8 ranks active; hipMemcpy2DAsync can
+// express the uniform-stride case but collapses to ~194 us per fragment
+// whenever the source pages are cold, which for a live tier is always.
+// A kernel is insensitive to both: measured ~0.57 us per fragment, and flat
+// across fragment sizes from 8 KiB to 221 KiB.
+//
+// Only worth it below roughly 128 KiB per fragment. Above that the copy engine
+// wins, because one large hipMemcpyAsync already amortizes its submission.
+//
+// The host side must be inside a HostTierRegistration-covered range: a kernel
+// cannot dereference plain mmap memory at all, it faults. Returns false without
+// touching `stream` if the launch could not be issued, so the caller can fall
+// back to hipMemcpy.
+bool LaunchDeviceGather(const DeviceGatherFragment* fragments, size_t count, int device_id,
+                        hipStream_t stream);
+
+// Whether the gather kernel path is compiled in and not disabled via
+// UMBP_DRAM_GATHER_KERNEL=0.
+bool DeviceGatherEnabled();
+
+// Kernels launched since process start. Lets a test assert which path a batch
+// actually took, rather than passing whether or not the kernel ran.
+uint64_t DeviceGatherLaunchCount();
+
+}  // namespace mori::umbp

--- a/src/umbp/local/tiers/device_gather.h
+++ b/src/umbp/local/tiers/device_gather.h
@@ -21,49 +21,6 @@
 // SOFTWARE.
 #pragma once
 
-// Source-private to the DRAM tier; not part of the installed API.
-
-#include <hip/hip_runtime_api.h>
-
-#include <cstddef>
-#include <cstdint>
-
-namespace mori::umbp {
-
-struct DeviceGatherFragment {
-  const void* src;
-  void* dst;
-  size_t bytes;
-};
-
-// Copies `count` independent fragments between a registered host region and
-// device memory in a single kernel launch, in either direction.
-//
-// This exists because the DRAM tier's copy path is scatter-gather by nature:
-// reading one layer out of page-granular objects means dozens of small strided
-// fragments per call, and hipMemcpy has no scatter-gather form. Submitting them
-// one at a time costs ~5.4 us each with 8 ranks active; hipMemcpy2DAsync can
-// express the uniform-stride case but collapses to ~194 us per fragment
-// whenever the source pages are cold, which for a live tier is always.
-// A kernel is insensitive to both: measured ~0.57 us per fragment, and flat
-// across fragment sizes from 8 KiB to 221 KiB.
-//
-// Only worth it below roughly 128 KiB per fragment. Above that the copy engine
-// wins, because one large hipMemcpyAsync already amortizes its submission.
-//
-// The host side must be inside a HostTierRegistration-covered range: a kernel
-// cannot dereference plain mmap memory at all, it faults. Returns false without
-// touching `stream` if the launch could not be issued, so the caller can fall
-// back to hipMemcpy.
-bool LaunchDeviceGather(const DeviceGatherFragment* fragments, size_t count, int device_id,
-                        hipStream_t stream);
-
-// Whether the gather kernel path is compiled in and not disabled via
-// UMBP_DRAM_GATHER_KERNEL=0.
-bool DeviceGatherEnabled();
-
-// Kernels launched since process start. Lets a test assert which path a batch
-// actually took, rather than passing whether or not the kernel ran.
-uint64_t DeviceGatherLaunchCount();
-
-}  // namespace mori::umbp
+// Backward-compatible source-tree include. New shared users include the common
+// header directly.
+#include "umbp/common/device_gather.h"

--- a/src/umbp/local/tiers/device_gather.hip
+++ b/src/umbp/local/tiers/device_gather.hip
@@ -19,8 +19,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-#include "device_gather.h"
-
 #include <hip/hip_runtime.h>
 
 #include <algorithm>
@@ -32,6 +30,7 @@
 #include <string>
 
 #include "mori/utils/mori_log.hpp"
+#include "umbp/common/device_gather.h"
 
 namespace mori::umbp {
 namespace {
@@ -159,9 +158,9 @@ bool LaunchDeviceGather(const DeviceGatherFragment* fragments, size_t count, int
   if (staging == nullptr) return false;
 
   std::memcpy(staging->host, fragments, count * sizeof(DeviceGatherFragment));
-  hipError_t status = hipMemcpyAsync(staging->device, staging->host,
-                                     count * sizeof(DeviceGatherFragment), hipMemcpyHostToDevice,
-                                     stream);
+  hipError_t status =
+      hipMemcpyAsync(staging->device, staging->host, count * sizeof(DeviceGatherFragment),
+                     hipMemcpyHostToDevice, stream);
   if (status != hipSuccess) {
     MORI_UMBP_ERROR("[DRAMTier] gather descriptor upload failed on device {}: {}", device_id,
                     hipGetErrorString(status));

--- a/src/umbp/local/tiers/device_gather.hip
+++ b/src/umbp/local/tiers/device_gather.hip
@@ -1,0 +1,185 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#include "device_gather.h"
+
+#include <hip/hip_runtime.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <map>
+#include <string>
+
+#include "mori/utils/mori_log.hpp"
+
+namespace mori::umbp {
+namespace {
+
+constexpr unsigned kThreadsPerBlock = 256;
+
+// Enough parallelism to keep the link busy on the largest fragment without
+// launching blocks that immediately exit on the smallest. Fragments below one
+// block's worth of work still get one block each.
+constexpr unsigned kMaxBlocksPerFragment = 8;
+
+constexpr size_t kVectorBytes = 16;
+
+// A block copies its slice of one fragment. Fragments are independent, so the
+// grid is flat: blockIdx.x / blocks_per_fragment picks the fragment and the
+// remainder picks the slice.
+__global__ void GatherFragmentsKernel(const DeviceGatherFragment* __restrict__ fragments,
+                                      unsigned blocks_per_fragment) {
+  const DeviceGatherFragment fragment = fragments[blockIdx.x / blocks_per_fragment];
+  const char* __restrict__ src = static_cast<const char*>(fragment.src);
+  char* __restrict__ dst = static_cast<char*>(fragment.dst);
+
+  const size_t slice = blockIdx.x % blocks_per_fragment;
+  const size_t index = slice * blockDim.x + threadIdx.x;
+  const size_t stride = static_cast<size_t>(blocks_per_fragment) * blockDim.x;
+
+  // KV fragments are page-aligned in practice; the byte loop is correctness
+  // insurance for pools whose element size makes them odd.
+  const uintptr_t mask = reinterpret_cast<uintptr_t>(src) | reinterpret_cast<uintptr_t>(dst) |
+                         static_cast<uintptr_t>(fragment.bytes);
+  if ((mask & (kVectorBytes - 1)) == 0) {
+    const uint4* __restrict__ src_vector = reinterpret_cast<const uint4*>(src);
+    uint4* __restrict__ dst_vector = reinterpret_cast<uint4*>(dst);
+    const size_t count = fragment.bytes / kVectorBytes;
+    for (size_t i = index; i < count; i += stride) dst_vector[i] = src_vector[i];
+    return;
+  }
+  for (size_t i = index; i < fragment.bytes; i += stride) dst[i] = src[i];
+}
+
+// Per-thread, per-device descriptor staging.
+//
+// Per-thread because two threads serving the same device share one stream (see
+// DeviceStream), so a shared staging buffer would be a data race even though
+// the stream itself is ordered. Never freed, for the same reason DeviceStream
+// never destroys its streams: releasing HIP resources from a thread or static
+// destructor races with runtime teardown. The count is bounded by the server's
+// worker threads times the devices they touch.
+struct DescriptorStaging {
+  DeviceGatherFragment* host = nullptr;
+  DeviceGatherFragment* device = nullptr;
+  size_t capacity = 0;
+};
+
+DescriptorStaging* StagingFor(int device_id, size_t count) {
+  static thread_local std::map<int, DescriptorStaging>* staging_by_device =
+      new std::map<int, DescriptorStaging>();
+
+  DescriptorStaging& staging = (*staging_by_device)[device_id];
+  if (staging.capacity >= count) return &staging;
+
+  // Grow with headroom so a slowly increasing batch size does not reallocate
+  // on every call.
+  const size_t capacity = std::max<size_t>(count * 2, 256);
+  const size_t bytes = capacity * sizeof(DeviceGatherFragment);
+  DeviceGatherFragment* host = nullptr;
+  DeviceGatherFragment* device = nullptr;
+  hipError_t status = hipHostMalloc(reinterpret_cast<void**>(&host), bytes, hipHostMallocDefault);
+  if (status != hipSuccess) {
+    MORI_UMBP_ERROR("[DRAMTier] hipHostMalloc for {} gather descriptors failed on device {}: {}",
+                    capacity, device_id, hipGetErrorString(status));
+    (void)hipGetLastError();
+    return nullptr;
+  }
+  status = hipMalloc(reinterpret_cast<void**>(&device), bytes);
+  if (status != hipSuccess) {
+    MORI_UMBP_ERROR("[DRAMTier] hipMalloc for {} gather descriptors failed on device {}: {}",
+                    capacity, device_id, hipGetErrorString(status));
+    (void)hipGetLastError();
+    (void)hipHostFree(host);
+    return nullptr;
+  }
+
+  if (staging.host != nullptr) (void)hipHostFree(staging.host);
+  if (staging.device != nullptr) (void)hipFree(staging.device);
+  staging.host = host;
+  staging.device = device;
+  staging.capacity = capacity;
+  return &staging;
+}
+
+std::atomic<uint64_t>& LaunchCounter() {
+  static std::atomic<uint64_t> launches{0};
+  return launches;
+}
+
+}  // namespace
+
+uint64_t DeviceGatherLaunchCount() { return LaunchCounter().load(std::memory_order_relaxed); }
+
+bool DeviceGatherEnabled() {
+  static const bool enabled = [] {
+    const char* value = std::getenv("UMBP_DRAM_GATHER_KERNEL");
+    if (value == nullptr) return true;
+    const std::string text(value);
+    return text != "0" && text != "off" && text != "false";
+  }();
+  return enabled;
+}
+
+bool LaunchDeviceGather(const DeviceGatherFragment* fragments, size_t count, int device_id,
+                        hipStream_t stream) {
+  if (count == 0) return true;
+
+  size_t max_bytes = 0;
+  for (size_t i = 0; i < count; ++i) max_bytes = std::max(max_bytes, fragments[i].bytes);
+  if (max_bytes == 0) return false;
+
+  const size_t chunks = (max_bytes + kVectorBytes - 1) / kVectorBytes;
+  const unsigned blocks_per_fragment = static_cast<unsigned>(std::clamp<size_t>(
+      (chunks + kThreadsPerBlock - 1) / kThreadsPerBlock, 1, kMaxBlocksPerFragment));
+  if (count > std::numeric_limits<unsigned>::max() / blocks_per_fragment) return false;
+
+  DescriptorStaging* staging = StagingFor(device_id, count);
+  if (staging == nullptr) return false;
+
+  std::memcpy(staging->host, fragments, count * sizeof(DeviceGatherFragment));
+  hipError_t status = hipMemcpyAsync(staging->device, staging->host,
+                                     count * sizeof(DeviceGatherFragment), hipMemcpyHostToDevice,
+                                     stream);
+  if (status != hipSuccess) {
+    MORI_UMBP_ERROR("[DRAMTier] gather descriptor upload failed on device {}: {}", device_id,
+                    hipGetErrorString(status));
+    (void)hipGetLastError();
+    return false;
+  }
+
+  hipLaunchKernelGGL(GatherFragmentsKernel,
+                     dim3(static_cast<unsigned>(count) * blocks_per_fragment),
+                     dim3(kThreadsPerBlock), 0, stream, staging->device, blocks_per_fragment);
+  status = hipGetLastError();
+  if (status != hipSuccess) {
+    MORI_UMBP_ERROR("[DRAMTier] gather kernel launch failed on device {} (fragments={}): {}",
+                    device_id, count, hipGetErrorString(status));
+    return false;
+  }
+  LaunchCounter().fetch_add(1, std::memory_order_relaxed);
+  return true;
+}
+
+}  // namespace mori::umbp

--- a/src/umbp/local/tiers/dram_tier.cpp
+++ b/src/umbp/local/tiers/dram_tier.cpp
@@ -43,6 +43,7 @@
 #endif
 
 #include "device_copy_run.h"
+#include "device_gather.h"
 #include "host_registration.h"
 #include "mori/utils/mori_log.hpp"
 #include "umbp/common/device_copy.h"
@@ -123,6 +124,7 @@ struct CopyJob {
 using detail::DeviceCopyRun;
 using detail::DeviceCopyRunKind;
 using detail::FindDeviceCopyRun;
+using detail::PitchedCopyEnabled;
 using detail::PointerAddress;
 
 // ---------------------------------------------------------------------------
@@ -232,6 +234,7 @@ struct MergeStats {
   std::atomic<uint64_t> runs_both{0};  // runs if both sides had to be adjacent
   std::atomic<uint64_t> actual_submissions{0};
   std::atomic<uint64_t> pitched_submissions{0};
+  std::atomic<uint64_t> gather_batches{0};  // batches carried by one kernel launch instead
 };
 
 MergeStats& OffloadMergeStats() {
@@ -287,7 +290,7 @@ void RecordMergeability(const std::vector<CopyJob*>& jobs, hipMemcpyKind kind) {
   uint64_t actual_submissions = 0;
   uint64_t pitched_submissions = 0;
   for (size_t begin = 0; begin < ordered.size();) {
-    const DeviceCopyRun run = FindDeviceCopyRun(ordered, begin);
+    const DeviceCopyRun run = FindDeviceCopyRun(ordered, begin, PitchedCopyEnabled());
     ++actual_submissions;
     if (run.kind == DeviceCopyRunKind::kPitched) ++pitched_submissions;
     begin = run.end;
@@ -303,9 +306,11 @@ void RecordMergeability(const std::vector<CopyJob*>& jobs, hipMemcpyKind kind) {
   };
   MORI_UMBP_INFO(
       "[DRAMTier/profile] mergeability {} batches={} objects={} | submissions kept: "
-      "gpu-side-only={}% dram-side-only={}% adjacent-both={}% actual={}% 2d_runs={}",
+      "gpu-side-only={}% dram-side-only={}% adjacent-both={}% actual={}% 2d_runs={} "
+      "gather_batches={}",
       stats.name, n, objs, pct(stats.runs_gpu), pct(stats.runs_dram), pct(stats.runs_both),
-      pct(stats.actual_submissions), stats.pitched_submissions.load(std::memory_order_relaxed));
+      pct(stats.actual_submissions), stats.pitched_submissions.load(std::memory_order_relaxed),
+      stats.gather_batches.load(std::memory_order_relaxed));
 }
 
 // Times mu_ acquisition and the critical section, then reports periodically.
@@ -376,12 +381,10 @@ void CopyHostJobs(const std::vector<CopyJob*>& jobs, int num_threads) {
 // Creating and destroying a stream around every batch costs ~6.5 ms per pair on
 // MI355X/ROCm 7.2 (measured), which dwarfs the copies themselves: a layer-wise
 // KV load issues 2 * num_layers batches per request, so the churn alone added
-// ~1 s per rank and, because ReadBatchIntoPtr holds mu_ for the whole batch,
-// ~8 s once 8 ranks serialize behind it. Reusing the stream removes that.
+// ~1 s per rank.
 //
 // The streams are intentionally never destroyed: tearing down HIP resources
-// from a static destructor races with runtime teardown. They are a fixed,
-// per-device cost that ends with the process.
+// from a static destructor races with runtime teardown.
 hipStream_t DeviceStream(int device_id) {
   static std::mutex stream_mu;
   static std::map<int, hipStream_t> streams;
@@ -401,7 +404,94 @@ hipStream_t DeviceStream(int device_id) {
   return stream;
 }
 
-void CopyDeviceJobs(const std::vector<CopyJob*>& jobs, int device_id, hipMemcpyKind kind) {
+// Circuit breaker for the gather kernel.
+//
+// Not a general retry policy -- it exists because the caller upstream cannot
+// distinguish a failed copy from a full tier (LocalStorageManager answers both
+// by evicting a victim and retrying), so any systematic data-path failure turns
+// into a tier-wide eviction storm. One latch, never reset: a kernel that has
+// failed once on this host is not something to keep probing on the request
+// path.
+std::atomic<bool>& GatherDisabled() {
+  static std::atomic<bool> disabled{false};
+  return disabled;
+}
+
+bool GatherPathHealthy() { return !GatherDisabled().load(std::memory_order_relaxed); }
+
+void DisableGatherPath() {
+  if (GatherDisabled().exchange(true, std::memory_order_relaxed)) return;
+  MORI_UMBP_ERROR(
+      "[DRAMTier] disabling the GPU gather path after a failed copy; "
+      "falling back to the copy engine for the rest of this process");
+}
+
+// The side of the copy that lives in the tier, and so the only side that
+// HostTierRegistration can vouch for.
+const void* TierSide(const CopyJob* job, hipMemcpyKind kind) {
+  return kind == hipMemcpyDeviceToHost ? job->dst : job->src;
+}
+
+// The copy engine still wins on a handful of large runs: measured break-even
+// with 8 ranks active is around 128 KiB per run, below which per-submission
+// cost dominates and above which one hipMemcpyAsync already amortizes it.
+constexpr size_t kGatherRunBytesThreshold = 128ull << 10;
+
+// Flattens the batch into one fragment per merged run and decides whether a
+// single kernel launch should carry them. Returns false to leave the batch on
+// the copy-engine path -- which is also what happens for any run whose tier
+// side is not registered, since a kernel would fault on it.
+bool PlanGatherFragments(const std::vector<CopyJob*>& ordered, hipMemcpyKind kind,
+                         const HostTierRegistration* registration,
+                         std::vector<DeviceGatherFragment>* fragments) {
+  if (registration == nullptr || !DeviceGatherEnabled()) return false;
+
+  fragments->clear();
+  fragments->reserve(ordered.size());
+  size_t total_bytes = 0;
+  for (size_t begin = 0; begin < ordered.size();) {
+    const DeviceCopyRun run = FindDeviceCopyRun(ordered, begin, /*allow_pitched=*/false);
+    const CopyJob* first = ordered[begin];
+    if (!registration->Covers(TierSide(first, kind), run.bytes)) return false;
+    fragments->push_back({first->src, first->dst, run.bytes});
+    total_bytes += run.bytes;
+    begin = run.end;
+  }
+  return fragments->size() > 1 && total_bytes / fragments->size() < kGatherRunBytesThreshold;
+}
+
+bool SubmitCopyRuns(const std::vector<CopyJob*>& ordered, int device_id, hipMemcpyKind kind,
+                    hipStream_t stream) {
+  for (size_t begin = 0; begin < ordered.size();) {
+    const DeviceCopyRun run = FindDeviceCopyRun(ordered, begin, PitchedCopyEnabled());
+    hipError_t status = hipSuccess;
+    if (run.kind == DeviceCopyRunKind::kPitched) {
+      status = hipMemcpy2DAsync(ordered[begin]->dst, run.dpitch, ordered[begin]->src, run.spitch,
+                                run.width, run.end - begin, kind, stream);
+    } else {
+      status = hipMemcpyAsync(ordered[begin]->dst, ordered[begin]->src, run.bytes, kind, stream);
+    }
+    if (status != hipSuccess) {
+      // Worth logging the tier side explicitly: the caller cannot tell a copy
+      // failure from a full tier, so it responds by evicting and retrying, and
+      // a systematic failure here turns into a tier-wide eviction storm.
+      MORI_UMBP_ERROR(
+          "[DRAMTier] device copy failed on device {} "
+          "(dir={} shape={} width={} rows={} spitch={} dpitch={} bytes={} tier_side={}): {}",
+          device_id, kind == hipMemcpyDeviceToHost ? "d2h" : "h2d",
+          run.kind == DeviceCopyRunKind::kPitched ? "2d" : "1d", run.width, run.end - begin,
+          run.spitch, run.dpitch, run.bytes, TierSide(ordered[begin], kind),
+          hipGetErrorString(status));
+      (void)hipGetLastError();
+      return false;
+    }
+    begin = run.end;
+  }
+  return true;
+}
+
+void CopyDeviceJobs(const std::vector<CopyJob*>& jobs, int device_id, hipMemcpyKind kind,
+                    const HostTierRegistration* registration) {
   if (jobs.empty()) return;
   ScopedHipDevice device_guard(device_id);
   if (!device_guard.IsValid()) {
@@ -414,37 +504,33 @@ void CopyDeviceJobs(const std::vector<CopyJob*>& jobs, int device_id, hipMemcpyK
   if (stream == nullptr) return;
 
   // Coalesce runs whose source AND destination are both adjacent into one
-  // submission. Submission cost (~10us) dominates the DMA itself (~1.5us for a
-  // 72 KiB KV object), so collapsing a run of k objects is close to a k-fold
-  // win on the layer-wise load path. This pays off only because the connector
-  // sends offloads in GPU-address order, which makes the tier's slot layout
-  // mirror the GPU layout -- see UMBP_STANDALONE_PROCESS_DESIGN.md 11.2.
+  // submission, which is worth doing on either path: it is what the copy engine
+  // needs to avoid paying submission cost per object, and it shortens the
+  // descriptor list the kernel walks. How much it finds depends on the object
+  // model -- with page-granular objects the tier side strides by the object
+  // size while reading one layer, so runs stay short and the kernel carries
+  // most batches.
   std::vector<CopyJob*> ordered(jobs.begin(), jobs.end());
   std::sort(ordered.begin(), ordered.end(), [](const CopyJob* a, const CopyJob* b) {
     return PointerAddress(a->src) < PointerAddress(b->src);
   });
 
-  hipError_t status = hipSuccess;
+  // Page-granular objects leave runs that no memcpy shape can merge: one layer
+  // per object means the tier side strides by the object size. One kernel
+  // launch is ~10x the per-fragment submissions and, unlike hipMemcpy2DAsync,
+  // does not collapse when the source pages are cold.
   bool enqueued_all = true;
-  for (size_t begin = 0; begin < ordered.size();) {
-    const DeviceCopyRun run = FindDeviceCopyRun(ordered, begin);
-    if (run.kind == DeviceCopyRunKind::kPitched) {
-      status = hipMemcpy2DAsync(ordered[begin]->dst, run.dpitch, ordered[begin]->src, run.spitch,
-                                run.width, run.end - begin, kind, stream);
-    } else {
-      status = hipMemcpyAsync(ordered[begin]->dst, ordered[begin]->src, run.bytes, kind, stream);
+  std::vector<DeviceGatherFragment> fragments;
+  const bool gathered = GatherPathHealthy() &&
+                        PlanGatherFragments(ordered, kind, registration, &fragments) &&
+                        LaunchDeviceGather(fragments.data(), fragments.size(), device_id, stream);
+  if (gathered) {
+    if (ProfileEnabled()) {
+      MergeStats& stats = kind == hipMemcpyDeviceToHost ? OffloadMergeStats() : LoadMergeStats();
+      stats.gather_batches.fetch_add(1, std::memory_order_relaxed);
     }
-    if (status != hipSuccess) {
-      MORI_UMBP_ERROR(
-          "[DRAMTier] device copy failed on device {} "
-          "(kind={} width={} rows={} spitch={} dpitch={} bytes={}): {}",
-          device_id, run.kind == DeviceCopyRunKind::kPitched ? "2d" : "1d", run.width,
-          run.end - begin, run.spitch, run.dpitch, run.bytes, hipGetErrorString(status));
-      (void)hipGetLastError();
-      enqueued_all = false;
-      break;
-    }
-    begin = run.end;
+  } else {
+    enqueued_all = SubmitCopyRuns(ordered, device_id, kind, stream);
   }
 
   const hipError_t sync_status = hipStreamSynchronize(stream);
@@ -453,6 +539,14 @@ void CopyDeviceJobs(const std::vector<CopyJob*>& jobs, int device_id, hipMemcpyK
                     hipGetErrorString(sync_status));
     (void)hipGetLastError();
     enqueued_all = false;
+    // The caller cannot tell a failed copy from a full tier: it answers both by
+    // evicting a victim and retrying, so a systematic data-path failure drains
+    // the tier one entry at a time. Taking the kernel out of service means the
+    // retry runs on the copy engine, which usually recovers before any eviction
+    // -- but it is a mitigation, not a guarantee: if the fault also left the
+    // context unusable the retry fails too. The complete fix is to distinguish
+    // the failure reasons at the tier/manager boundary.
+    if (gathered) DisableGatherPath();
   }
 
   if (enqueued_all) {
@@ -460,7 +554,8 @@ void CopyDeviceJobs(const std::vector<CopyJob*>& jobs, int device_id, hipMemcpyK
   }
 }
 
-void CopyJobs(std::vector<CopyJob>* jobs, int host_threads, hipMemcpyKind device_copy_kind) {
+void CopyJobs(std::vector<CopyJob>* jobs, int host_threads, hipMemcpyKind device_copy_kind,
+              const HostTierRegistration* registration) {
   if (jobs->empty()) return;
   std::vector<CopyJob*> host_jobs;
   std::map<int, std::vector<CopyJob*>> device_jobs;
@@ -473,11 +568,10 @@ void CopyJobs(std::vector<CopyJob>* jobs, int host_threads, hipMemcpyKind device
       host_jobs.push_back(&job);
     }
   }
-
   CopyHostJobs(host_jobs, host_threads);
   for (auto& [device_id, grouped_jobs] : device_jobs) {
     if (ProfileEnabled()) RecordMergeability(grouped_jobs, device_copy_kind);
-    CopyDeviceJobs(grouped_jobs, device_id, device_copy_kind);
+    CopyDeviceJobs(grouped_jobs, device_id, device_copy_kind, registration);
   }
 }
 
@@ -531,8 +625,9 @@ DRAMTier::DRAMTier(size_t capacity, bool use_shm, const std::string& shm_name, b
   // Initialize free list with entire capacity
   free_list_.push_back({0, capacity_});
 
-  // Must come after base_ptr_ is final. Registering the region takes every
-  // hipMemcpy on this tier off the pageable staging path.
+  // Must come after base_ptr_ is final. Registering the region is what lets the
+  // gather kernel dereference it, and it also moves every hipMemcpy on this
+  // tier off the pageable staging path.
   host_registration_ = std::make_unique<HostTierRegistration>(base_ptr_, mapped_size_);
 
   // Threads for parallel batch-read CopyBlock. Default 8, override via env,
@@ -735,7 +830,7 @@ std::vector<bool> DRAMTier::ReadBatchIntoPtr(const std::vector<std::string>& key
         {dst, static_cast<char*>(base_ptr_) + it->second.offset, dst, sizes[i], i, false});
   }
 
-  CopyJobs(&jobs, read_threads_, hipMemcpyHostToDevice);
+  CopyJobs(&jobs, read_threads_, hipMemcpyHostToDevice, host_registration_.get());
   if (!jobs.empty()) {
     // One acquisition per batch avoids recreating the per-object lock convoy
     // that the server-side range-resolution change removes.
@@ -792,7 +887,7 @@ std::vector<bool> DRAMTier::ReadBatchRangesIntoPtr(
     }
   }
 
-  CopyJobs(&jobs, read_threads_, hipMemcpyHostToDevice);
+  CopyJobs(&jobs, read_threads_, hipMemcpyHostToDevice, host_registration_.get());
   std::vector<size_t> copied(n, 0);
   for (const auto& job : jobs) {
     if (job.copied) ++copied[job.idx];
@@ -862,7 +957,7 @@ std::vector<bool> DRAMTier::BatchWrite(const std::vector<std::string>& keys,
   // device and submitted to one stream with one synchronization per device.
   copy_jobs.reserve(write_jobs.size());
   for (const auto& job : write_jobs) copy_jobs.push_back(job.copy);
-  CopyJobs(&copy_jobs, write_threads_, hipMemcpyDeviceToHost);
+  CopyJobs(&copy_jobs, write_threads_, hipMemcpyDeviceToHost, host_registration_.get());
 
   // Phase 3 (serial): register slots + LRU, mark successes.
   {
@@ -940,7 +1035,7 @@ std::vector<bool> DRAMTier::BatchWriteRanges(const std::vector<std::string>& key
     reservations.push_back({i, offset, object_sizes[i], job_begin, sizes[i].size()});
   }
 
-  CopyJobs(&jobs, write_threads_, hipMemcpyDeviceToHost);
+  CopyJobs(&jobs, write_threads_, hipMemcpyDeviceToHost, host_registration_.get());
 
   std::lock_guard<std::mutex> lru_lock(lru_mu_);
   for (const Reservation& reservation : reservations) {

--- a/src/umbp/local/tiers/dram_tier.cpp
+++ b/src/umbp/local/tiers/dram_tier.cpp
@@ -284,9 +284,11 @@ void RecordMergeability(const std::vector<CopyJob*>& jobs, hipMemcpyKind kind) {
 }
 
 // Times mu_ acquisition and the critical section, then reports periodically.
+template <typename Lock>
 class ProfiledLock {
  public:
-  ProfiledLock(std::mutex& mutex, LockStats& stats, size_t objects)
+  template <typename Mutex>
+  ProfiledLock(Mutex& mutex, LockStats& stats, size_t objects)
       : lock_(mutex, std::defer_lock), stats_(stats), objects_(objects) {
     if (!ProfileEnabled()) {
       lock_.lock();
@@ -307,13 +309,16 @@ class ProfiledLock {
   }
 
  private:
-  std::unique_lock<std::mutex> lock_;
+  Lock lock_;
   LockStats& stats_;
   size_t objects_;
   bool profiling_{false};
   uint64_t wait_us_{0};
   std::chrono::steady_clock::time_point acquired_{};
 };
+
+using ProfiledSharedLock = ProfiledLock<std::shared_lock<std::shared_mutex>>;
+using ProfiledUniqueLock = ProfiledLock<std::unique_lock<std::shared_mutex>>;
 
 void CopyHostJobs(const std::vector<CopyJob*>& jobs, int num_threads) {
   if (jobs.empty()) return;
@@ -390,9 +395,8 @@ void CopyDeviceJobs(const std::vector<CopyJob*>& jobs, int device_id, hipMemcpyK
   // sends offloads in GPU-address order, which makes the tier's slot layout
   // mirror the GPU layout -- see UMBP_STANDALONE_PROCESS_DESIGN.md 11.2.
   std::vector<CopyJob*> ordered(jobs.begin(), jobs.end());
-  std::sort(ordered.begin(), ordered.end(), [](const CopyJob* a, const CopyJob* b) {
-    return a->src < b->src;
-  });
+  std::sort(ordered.begin(), ordered.end(),
+            [](const CopyJob* a, const CopyJob* b) { return a->src < b->src; });
 
   hipError_t status = hipSuccess;
   bool enqueued_all = true;
@@ -589,6 +593,7 @@ void DRAMTier::TouchLRU(const std::string& key) {
 }
 
 void DRAMTier::EvictLRU() {
+  std::lock_guard<std::mutex> lru_lock(lru_mu_);
   if (lru_list_.empty()) return;
 
   const std::string& victim = lru_list_.back();
@@ -603,7 +608,7 @@ void DRAMTier::EvictLRU() {
 }
 
 bool DRAMTier::Write(const std::string& key, const void* data, size_t size) {
-  std::lock_guard<std::mutex> lock(mu_);
+  std::unique_lock<std::shared_mutex> lock(mu_);
 
   // If key already exists, free its old slot first
   auto existing = slots_.find(key);
@@ -611,10 +616,13 @@ bool DRAMTier::Write(const std::string& key, const void* data, size_t size) {
     Deallocate(existing->second.offset, existing->second.size);
     used_ -= existing->second.size;
     slots_.erase(existing);
-    auto lru_it = lru_map_.find(key);
-    if (lru_it != lru_map_.end()) {
-      lru_list_.erase(lru_it->second);
-      lru_map_.erase(lru_it);
+    {
+      std::lock_guard<std::mutex> lru_lock(lru_mu_);
+      auto lru_it = lru_map_.find(key);
+      if (lru_it != lru_map_.end()) {
+        lru_list_.erase(lru_it->second);
+        lru_map_.erase(lru_it);
+      }
     }
   }
 
@@ -638,12 +646,15 @@ bool DRAMTier::Write(const std::string& key, const void* data, size_t size) {
   }
   slots_[key] = {offset, size};
   used_ += size;
-  TouchLRU(key);
+  {
+    std::lock_guard<std::mutex> lru_lock(lru_mu_);
+    TouchLRU(key);
+  }
   return true;
 }
 
 bool DRAMTier::ReadIntoPtr(const std::string& key, uintptr_t dst_ptr, size_t size) {
-  std::lock_guard<std::mutex> lock(mu_);
+  std::shared_lock<std::shared_mutex> lock(mu_);
 
   auto it = slots_.find(key);
   if (it == slots_.end()) return false;
@@ -665,7 +676,10 @@ bool DRAMTier::ReadIntoPtr(const std::string& key, uintptr_t dst_ptr, size_t siz
   } else {
     std::memcpy(dst, static_cast<char*>(base_ptr_) + it->second.offset, size);
   }
-  TouchLRU(key);
+  {
+    std::lock_guard<std::mutex> lru_lock(lru_mu_);
+    TouchLRU(key);
+  }
   return true;
 }
 
@@ -676,16 +690,11 @@ std::vector<bool> DRAMTier::ReadBatchIntoPtr(const std::vector<std::string>& key
   std::vector<bool> results(n, false);
   if (n == 0) return results;
 
-  // Hold mu_ for the whole batch. This tier uses a single mutex (reads and
-  // writes are mutually exclusive), so holding it keeps slot offsets valid
-  // during the parallel copy without a use-after-free against Write/Evict/
-  // Clear. The per-block copies still run in parallel within the batch, which
-  // is what breaks the single-core memcpy ceiling on cold DRAM.
-  //
-  // This whole-batch hold is what serializes concurrent clients; ProfiledLock
-  // quantifies it under UMBP_DRAM_PROFILE=1.
+  // Hold shared ownership for the whole batch so slot offsets remain valid
+  // during CopyJobs. Other readers may proceed concurrently; writers and
+  // eviction wait until every copy has finished.
   ScopedInFlight in_flight;
-  ProfiledLock lock(mu_, ReadLockStats(), n);
+  ProfiledSharedLock lock(mu_, ReadLockStats(), n);
 
   std::vector<CopyJob> jobs;
   jobs.reserve(n);
@@ -699,10 +708,15 @@ std::vector<bool> DRAMTier::ReadBatchIntoPtr(const std::vector<std::string>& key
   }
 
   CopyJobs(&jobs, read_threads_, hipMemcpyHostToDevice);
-  for (const auto& job : jobs) {
-    if (!job.copied) continue;
-    results[job.idx] = true;
-    TouchLRU(keys[job.idx]);
+  if (!jobs.empty()) {
+    // One acquisition per batch avoids recreating the per-object lock convoy
+    // that the server-side range-resolution change removes.
+    std::lock_guard<std::mutex> lru_lock(lru_mu_);
+    for (const auto& job : jobs) {
+      if (!job.copied) continue;
+      results[job.idx] = true;
+      TouchLRU(keys[job.idx]);
+    }
   }
   return results;
 }
@@ -714,16 +728,15 @@ std::vector<bool> DRAMTier::BatchWrite(const std::vector<std::string>& keys,
   std::vector<bool> results(n, false);
   if (n == 0) return results;
 
-  // Hold mu_ for the whole batch (single-mutex model: serializes against other
-  // reads/writes). Slot allocation mutates free_list_/slots_ and must be serial;
-  // only the per-block payload copies run in parallel, which is what breaks the
-  // single-core memcpy ceiling on the backup path.
+  // Hold unique ownership for the whole batch. Slot allocation and payload
+  // publication mutate shared state, and reserved slots must not be reused
+  // while CopyJobs is filling them.
   //
   // Phase 2 could in principle run outside the lock (the reserved-but-
   // unregistered region is unreachable to other threads); ProfiledLock measures
   // what that would be worth. See UMBP_STANDALONE_PROCESS_DESIGN.md 11.1.
   ScopedInFlight in_flight;
-  ProfiledLock lock(mu_, WriteLockStats(), n);
+  ProfiledUniqueLock lock(mu_, WriteLockStats(), n);
 
   struct WriteJob {
     CopyJob copy;
@@ -736,23 +749,26 @@ std::vector<bool> DRAMTier::BatchWrite(const std::vector<std::string>& keys,
   // Phase 1 (serial): free any existing slot for the key, then allocate. Does
   // NOT self-evict — a key that doesn't fit is left false so the upper layer
   // (LocalStorageManager) can demote LRU keys and retry per-key.
-  for (size_t i = 0; i < n; ++i) {
-    auto existing = slots_.find(keys[i]);
-    if (existing != slots_.end()) {
-      Deallocate(existing->second.offset, existing->second.size);
-      used_ -= existing->second.size;
-      slots_.erase(existing);
-      auto lru_it = lru_map_.find(keys[i]);
-      if (lru_it != lru_map_.end()) {
-        lru_list_.erase(lru_it->second);
-        lru_map_.erase(lru_it);
+  {
+    std::lock_guard<std::mutex> lru_lock(lru_mu_);
+    for (size_t i = 0; i < n; ++i) {
+      auto existing = slots_.find(keys[i]);
+      if (existing != slots_.end()) {
+        Deallocate(existing->second.offset, existing->second.size);
+        used_ -= existing->second.size;
+        slots_.erase(existing);
+        auto lru_it = lru_map_.find(keys[i]);
+        if (lru_it != lru_map_.end()) {
+          lru_list_.erase(lru_it->second);
+          lru_map_.erase(lru_it);
+        }
       }
+      size_t offset = Allocate(sizes[i]);
+      if (offset == static_cast<size_t>(-1)) continue;
+      write_jobs.push_back(
+          {{static_cast<char*>(base_ptr_) + offset, data_ptrs[i], data_ptrs[i], sizes[i], i, false},
+           offset});
     }
-    size_t offset = Allocate(sizes[i]);
-    if (offset == static_cast<size_t>(-1)) continue;
-    write_jobs.push_back(
-        {{static_cast<char*>(base_ptr_) + offset, data_ptrs[i], data_ptrs[i], sizes[i], i, false},
-         offset});
   }
 
   // Phase 2: preserve the existing parallel host path; GPU jobs are grouped by
@@ -762,34 +778,40 @@ std::vector<bool> DRAMTier::BatchWrite(const std::vector<std::string>& keys,
   CopyJobs(&copy_jobs, write_threads_, hipMemcpyDeviceToHost);
 
   // Phase 3 (serial): register slots + LRU, mark successes.
-  for (size_t i = 0; i < write_jobs.size(); ++i) {
-    const WriteJob& write_job = write_jobs[i];
-    const CopyJob& copy_job = copy_jobs[i];
-    if (!copy_job.copied) {
-      Deallocate(write_job.offset, copy_job.size);
-      continue;
+  {
+    std::lock_guard<std::mutex> lru_lock(lru_mu_);
+    for (size_t i = 0; i < write_jobs.size(); ++i) {
+      const WriteJob& write_job = write_jobs[i];
+      const CopyJob& copy_job = copy_jobs[i];
+      if (!copy_job.copied) {
+        Deallocate(write_job.offset, copy_job.size);
+        continue;
+      }
+      slots_[keys[copy_job.idx]] = {write_job.offset, copy_job.size};
+      used_ += copy_job.size;
+      TouchLRU(keys[copy_job.idx]);
+      results[copy_job.idx] = true;
     }
-    slots_[keys[copy_job.idx]] = {write_job.offset, copy_job.size};
-    used_ += copy_job.size;
-    TouchLRU(keys[copy_job.idx]);
-    results[copy_job.idx] = true;
   }
   return results;
 }
 
 const void* DRAMTier::ReadPtr(const std::string& key, size_t* out_size) {
-  std::lock_guard<std::mutex> lock(mu_);
+  std::shared_lock<std::shared_mutex> lock(mu_);
 
   auto it = slots_.find(key);
   if (it == slots_.end()) return nullptr;
 
   if (out_size) *out_size = it->second.size;
-  TouchLRU(key);
+  {
+    std::lock_guard<std::mutex> lru_lock(lru_mu_);
+    TouchLRU(key);
+  }
   return static_cast<char*>(base_ptr_) + it->second.offset;
 }
 
 std::vector<char> DRAMTier::Read(const std::string& key) {
-  std::lock_guard<std::mutex> lock(mu_);
+  std::shared_lock<std::shared_mutex> lock(mu_);
 
   auto it = slots_.find(key);
   if (it == slots_.end()) return {};
@@ -797,7 +819,10 @@ std::vector<char> DRAMTier::Read(const std::string& key) {
   size_t sz = it->second.size;
   std::vector<char> buf(sz);
   std::memcpy(buf.data(), static_cast<char*>(base_ptr_) + it->second.offset, sz);
-  TouchLRU(key);
+  {
+    std::lock_guard<std::mutex> lru_lock(lru_mu_);
+    TouchLRU(key);
+  }
   return buf;
 }
 
@@ -810,12 +835,12 @@ TierCapabilities DRAMTier::Capabilities() const {
 }
 
 bool DRAMTier::Exists(const std::string& key) const {
-  std::lock_guard<std::mutex> lock(mu_);
+  std::shared_lock<std::shared_mutex> lock(mu_);
   return slots_.count(key) > 0;
 }
 
 bool DRAMTier::Evict(const std::string& key) {
-  std::lock_guard<std::mutex> lock(mu_);
+  std::unique_lock<std::shared_mutex> lock(mu_);
 
   auto it = slots_.find(key);
   if (it == slots_.end()) return false;
@@ -824,21 +849,25 @@ bool DRAMTier::Evict(const std::string& key) {
   used_ -= it->second.size;
   slots_.erase(it);
 
-  auto lru_it = lru_map_.find(key);
-  if (lru_it != lru_map_.end()) {
-    lru_list_.erase(lru_it->second);
-    lru_map_.erase(lru_it);
+  {
+    std::lock_guard<std::mutex> lru_lock(lru_mu_);
+    auto lru_it = lru_map_.find(key);
+    if (lru_it != lru_map_.end()) {
+      lru_list_.erase(lru_it->second);
+      lru_map_.erase(lru_it);
+    }
   }
   return true;
 }
 
 std::pair<size_t, size_t> DRAMTier::Capacity() const {
-  std::lock_guard<std::mutex> lock(mu_);
+  std::shared_lock<std::shared_mutex> lock(mu_);
   return {used_, capacity_};
 }
 
 void DRAMTier::Clear() {
-  std::lock_guard<std::mutex> lock(mu_);
+  std::unique_lock<std::shared_mutex> lock(mu_);
+  std::lock_guard<std::mutex> lru_lock(lru_mu_);
   slots_.clear();
   lru_list_.clear();
   lru_map_.clear();
@@ -849,7 +878,8 @@ void DRAMTier::Clear() {
 
 std::vector<std::string> DRAMTier::GetLRUCandidates(size_t max_candidates) const {
   if (max_candidates == 0) max_candidates = 1;
-  std::lock_guard<std::mutex> lock(mu_);
+  std::shared_lock<std::shared_mutex> lock(mu_);
+  std::lock_guard<std::mutex> lru_lock(lru_mu_);
   std::vector<std::string> result;
   result.reserve(std::min(max_candidates, lru_list_.size()));
   // Walk from the back (LRU end) up to max_candidates entries.
@@ -861,13 +891,14 @@ std::vector<std::string> DRAMTier::GetLRUCandidates(size_t max_candidates) const
 }
 
 std::string DRAMTier::GetLRUKey() const {
-  std::lock_guard<std::mutex> lock(mu_);
+  std::shared_lock<std::shared_mutex> lock(mu_);
+  std::lock_guard<std::mutex> lru_lock(lru_mu_);
   if (lru_list_.empty()) return "";
   return lru_list_.back();
 }
 
 std::optional<size_t> DRAMTier::GetSlotOffset(const std::string& key) const {
-  std::lock_guard<std::mutex> lock(mu_);
+  std::shared_lock<std::shared_mutex> lock(mu_);
   auto it = slots_.find(key);
   if (it == slots_.end()) return std::nullopt;
   return it->second.offset;

--- a/src/umbp/local/tiers/dram_tier.cpp
+++ b/src/umbp/local/tiers/dram_tier.cpp
@@ -376,19 +376,29 @@ void CopyHostJobs(const std::vector<CopyJob*>& jobs, int num_threads) {
   for (auto& thread : pool) thread.join();
 }
 
-// One reusable stream per device.
+// One reusable stream per (thread, device).
 //
-// Creating and destroying a stream around every batch costs ~6.5 ms per pair on
-// MI355X/ROCm 7.2 (measured), which dwarfs the copies themselves: a layer-wise
-// KV load issues 2 * num_layers batches per request, so the churn alone added
-// ~1 s per rank.
+// Reusing a stream is what makes the batch path affordable: creating and
+// destroying one around every batch costs ~6.5 ms per pair on MI355X/ROCm 7.2
+// (measured), which dwarfs the copies themselves.
+//
+// Per thread, not just per device, because a batch ends with
+// hipStreamSynchronize. Sharing one stream across threads makes every batch
+// wait for every other batch queued on that device -- loads behind loads, and
+// loads behind the offload path, which writes continuously under
+// write_through_threshold=1. That coupling, not the DMA, held the measured copy
+// phase to 1.7 GB/s against 49 GB/s for the same shape in isolation.
 //
 // The streams are intentionally never destroyed: tearing down HIP resources
-// from a static destructor races with runtime teardown.
+// from a thread or static destructor races with runtime teardown. The count is
+// bounded by the server's worker threads times the devices they touch.
+std::map<int, hipStream_t>& DeviceStreamCache() {
+  static thread_local std::map<int, hipStream_t>* streams = new std::map<int, hipStream_t>();
+  return *streams;
+}
+
 hipStream_t DeviceStream(int device_id) {
-  static std::mutex stream_mu;
-  static std::map<int, hipStream_t> streams;
-  std::lock_guard<std::mutex> lock(stream_mu);
+  std::map<int, hipStream_t>& streams = DeviceStreamCache();
   auto it = streams.find(device_id);
   if (it != streams.end()) return it->second;
 
@@ -403,6 +413,12 @@ hipStream_t DeviceStream(int device_id) {
   streams.emplace(device_id, stream);
   return stream;
 }
+
+// Forget a stream that reported a failure so the next batch builds a fresh one.
+// The old handle is intentionally not destroyed, for the same reason the cache
+// never destroys any of them. This does not repair a context that a fault has
+// already made unusable; it only avoids reusing a stream known to have failed.
+void DiscardDeviceStream(int device_id) { DeviceStreamCache().erase(device_id); }
 
 // Circuit breaker for the gather kernel.
 //
@@ -547,6 +563,7 @@ void CopyDeviceJobs(const std::vector<CopyJob*>& jobs, int device_id, hipMemcpyK
     // context unusable the retry fails too. The complete fix is to distinguish
     // the failure reasons at the tier/manager boundary.
     if (gathered) DisableGatherPath();
+    DiscardDeviceStream(device_id);
   }
 
   if (enqueued_all) {

--- a/src/umbp/local/tiers/dram_tier.cpp
+++ b/src/umbp/local/tiers/dram_tier.cpp
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <map>
@@ -114,6 +115,206 @@ struct CopyJob {
   bool copied{false};
 };
 
+// ---------------------------------------------------------------------------
+// Opt-in profiling (UMBP_DRAM_PROFILE=1). Answers the two questions that gate
+// the next round of optimization work:
+//   1. how much of a batch's wall time is spent waiting for mu_ (i.e. how much
+//      the 8 ranks serialize against each other);
+//   2. how many hipMemcpyAsync submissions would survive if adjacent objects
+//      were merged (i.e. whether contiguous merging is worth implementing).
+// Zero cost when disabled: one predictable branch per batch.
+// ---------------------------------------------------------------------------
+
+bool ProfileEnabled() {
+  static const bool enabled = [] {
+    const char* raw = std::getenv("UMBP_DRAM_PROFILE");
+    return raw != nullptr && raw[0] == '1';
+  }();
+  return enabled;
+}
+
+// Report every N batches so a normal E2E run produces a handful of lines.
+constexpr uint64_t kProfileReportEvery = 512;
+
+// How many batches are inside the tier at the same instant. Zero lock wait can
+// mean either "no contention" or "requests never arrive together"; this tells
+// them apart, which decides whether finer locking could buy anything at all.
+struct InFlightStats {
+  std::atomic<int> current{0};
+  std::atomic<int> peak{0};
+  std::atomic<uint64_t> samples{0};
+  std::atomic<uint64_t> sum{0};
+};
+
+InFlightStats& BatchInFlight() {
+  static InFlightStats stats;
+  return stats;
+}
+
+class ScopedInFlight {
+ public:
+  ScopedInFlight() {
+    if (!ProfileEnabled()) return;
+    active_ = true;
+    InFlightStats& stats = BatchInFlight();
+    const int now = stats.current.fetch_add(1, std::memory_order_relaxed) + 1;
+    int observed = stats.peak.load(std::memory_order_relaxed);
+    while (now > observed &&
+           !stats.peak.compare_exchange_weak(observed, now, std::memory_order_relaxed)) {
+    }
+    stats.sum.fetch_add(static_cast<uint64_t>(now), std::memory_order_relaxed);
+    stats.samples.fetch_add(1, std::memory_order_relaxed);
+  }
+  ~ScopedInFlight() {
+    if (!active_) return;
+    BatchInFlight().current.fetch_sub(1, std::memory_order_relaxed);
+  }
+
+ private:
+  bool active_{false};
+};
+
+struct LockStats {
+  const char* name;
+  std::atomic<uint64_t> calls{0};
+  std::atomic<uint64_t> wait_us{0};
+  std::atomic<uint64_t> held_us{0};
+  std::atomic<uint64_t> objects{0};
+};
+
+LockStats& ReadLockStats() {
+  static LockStats stats{"ReadBatchIntoPtr"};
+  return stats;
+}
+
+LockStats& WriteLockStats() {
+  static LockStats stats{"BatchWrite"};
+  return stats;
+}
+
+void RecordLockStats(LockStats& stats, uint64_t wait_us, uint64_t held_us, size_t objects) {
+  stats.wait_us.fetch_add(wait_us, std::memory_order_relaxed);
+  stats.held_us.fetch_add(held_us, std::memory_order_relaxed);
+  stats.objects.fetch_add(objects, std::memory_order_relaxed);
+  const uint64_t n = stats.calls.fetch_add(1, std::memory_order_relaxed) + 1;
+  if (n % kProfileReportEvery != 0) return;
+
+  const uint64_t wait = stats.wait_us.load(std::memory_order_relaxed);
+  const uint64_t held = stats.held_us.load(std::memory_order_relaxed);
+  const uint64_t objs = stats.objects.load(std::memory_order_relaxed);
+  const uint64_t total = wait + held;
+  const InFlightStats& flight = BatchInFlight();
+  const uint64_t samples = flight.samples.load(std::memory_order_relaxed);
+  const uint64_t sum = flight.sum.load(std::memory_order_relaxed);
+  MORI_UMBP_INFO(
+      "[DRAMTier/profile] {} batches={} objects={} avg_lock_wait={}us avg_lock_held={}us "
+      "wait_share={}% | in_flight avg={}.{:02d} peak={}",
+      stats.name, n, objs, wait / n, held / n, total == 0 ? 0 : (wait * 100 / total),
+      samples == 0 ? 0 : sum / samples, samples == 0 ? 0 : (sum * 100 / samples) % 100,
+      flight.peak.load(std::memory_order_relaxed));
+}
+
+struct MergeStats {
+  const char* name;
+  std::atomic<uint64_t> batches{0};
+  std::atomic<uint64_t> objects{0};
+  std::atomic<uint64_t> runs_gpu{0};   // runs if only the GPU side had to be adjacent
+  std::atomic<uint64_t> runs_dram{0};  // runs if only the DRAM side had to be adjacent
+  std::atomic<uint64_t> runs_both{0};  // runs with both adjacent -- the real submission count
+};
+
+MergeStats& OffloadMergeStats() {
+  static MergeStats stats{"offload D2H (src=GPU dst=DRAM)"};
+  return stats;
+}
+
+MergeStats& LoadMergeStats() {
+  static MergeStats stats{"load    H2D (src=DRAM dst=GPU)"};
+  return stats;
+}
+
+// Counts how many contiguous runs the batch would collapse into. A run of k
+// objects becomes one hipMemcpyAsync, so runs_both/objects is exactly the
+// submission-count reduction that merging would buy. runs_gpu / runs_dram show
+// which side is the obstacle: the DRAM side is ours to control (slot placement
+// follows the order objects are sent), the GPU side is the tree allocator's.
+void RecordMergeability(const std::vector<CopyJob*>& jobs, hipMemcpyKind kind) {
+  if (jobs.empty()) return;
+  const bool src_is_gpu = (kind == hipMemcpyDeviceToHost);
+  MergeStats& stats = src_is_gpu ? OffloadMergeStats() : LoadMergeStats();
+
+  auto gpu_of = [src_is_gpu](const CopyJob* j) {
+    return static_cast<const char*>(src_is_gpu ? j->src : static_cast<const void*>(j->dst));
+  };
+  auto dram_of = [src_is_gpu](const CopyJob* j) {
+    return static_cast<const char*>(src_is_gpu ? static_cast<const void*>(j->dst) : j->src);
+  };
+
+  // Sort by the DRAM side: that is the ordering we could actually impose.
+  std::vector<const CopyJob*> sorted(jobs.begin(), jobs.end());
+  std::sort(sorted.begin(), sorted.end(),
+            [&](const CopyJob* a, const CopyJob* b) { return dram_of(a) < dram_of(b); });
+
+  uint64_t runs_gpu = 1, runs_dram = 1, runs_both = 1;
+  for (size_t i = 1; i < sorted.size(); ++i) {
+    const CopyJob* prev = sorted[i - 1];
+    const CopyJob* cur = sorted[i];
+    const bool gpu_adjacent = gpu_of(prev) + prev->size == gpu_of(cur);
+    const bool dram_adjacent = dram_of(prev) + prev->size == dram_of(cur);
+    if (!gpu_adjacent) ++runs_gpu;
+    if (!dram_adjacent) ++runs_dram;
+    if (!gpu_adjacent || !dram_adjacent) ++runs_both;
+  }
+
+  stats.objects.fetch_add(sorted.size(), std::memory_order_relaxed);
+  stats.runs_gpu.fetch_add(runs_gpu, std::memory_order_relaxed);
+  stats.runs_dram.fetch_add(runs_dram, std::memory_order_relaxed);
+  stats.runs_both.fetch_add(runs_both, std::memory_order_relaxed);
+  const uint64_t n = stats.batches.fetch_add(1, std::memory_order_relaxed) + 1;
+  if (n % kProfileReportEvery != 0) return;
+
+  const uint64_t objs = stats.objects.load(std::memory_order_relaxed);
+  auto pct = [objs](const std::atomic<uint64_t>& runs) {
+    return objs == 0 ? 100 : runs.load(std::memory_order_relaxed) * 100 / objs;
+  };
+  MORI_UMBP_INFO(
+      "[DRAMTier/profile] mergeability {} batches={} objects={} | submissions kept: "
+      "gpu-side-only={}% dram-side-only={}% both={}%",
+      stats.name, n, objs, pct(stats.runs_gpu), pct(stats.runs_dram), pct(stats.runs_both));
+}
+
+// Times mu_ acquisition and the critical section, then reports periodically.
+class ProfiledLock {
+ public:
+  ProfiledLock(std::mutex& mutex, LockStats& stats, size_t objects)
+      : lock_(mutex, std::defer_lock), stats_(stats), objects_(objects) {
+    if (!ProfileEnabled()) {
+      lock_.lock();
+      return;
+    }
+    profiling_ = true;
+    const auto before = std::chrono::steady_clock::now();
+    lock_.lock();
+    acquired_ = std::chrono::steady_clock::now();
+    wait_us_ = std::chrono::duration_cast<std::chrono::microseconds>(acquired_ - before).count();
+  }
+
+  ~ProfiledLock() {
+    if (!profiling_) return;
+    const auto held = std::chrono::steady_clock::now() - acquired_;
+    RecordLockStats(stats_, wait_us_,
+                    std::chrono::duration_cast<std::chrono::microseconds>(held).count(), objects_);
+  }
+
+ private:
+  std::unique_lock<std::mutex> lock_;
+  LockStats& stats_;
+  size_t objects_;
+  bool profiling_{false};
+  uint64_t wait_us_{0};
+  std::chrono::steady_clock::time_point acquired_{};
+};
+
 void CopyHostJobs(const std::vector<CopyJob*>& jobs, int num_threads) {
   if (jobs.empty()) return;
   num_threads = std::max(1, std::min(num_threads, static_cast<int>(jobs.size())));
@@ -182,17 +383,43 @@ void CopyDeviceJobs(const std::vector<CopyJob*>& jobs, int device_id, hipMemcpyK
   hipStream_t stream = DeviceStream(device_id);
   if (stream == nullptr) return;
 
+  // Coalesce runs whose source AND destination are both adjacent into one
+  // submission. Submission cost (~10us) dominates the DMA itself (~1.5us for a
+  // 72 KiB KV object), so collapsing a run of k objects is close to a k-fold
+  // win on the layer-wise load path. This pays off only because the connector
+  // sends offloads in GPU-address order, which makes the tier's slot layout
+  // mirror the GPU layout -- see UMBP_STANDALONE_PROCESS_DESIGN.md 11.2.
+  std::vector<CopyJob*> ordered(jobs.begin(), jobs.end());
+  std::sort(ordered.begin(), ordered.end(), [](const CopyJob* a, const CopyJob* b) {
+    return a->src < b->src;
+  });
+
   hipError_t status = hipSuccess;
   bool enqueued_all = true;
-  for (CopyJob* job : jobs) {
-    status = hipMemcpyAsync(job->dst, job->src, job->size, kind, stream);
+  for (size_t begin = 0; begin < ordered.size();) {
+    size_t end = begin + 1;
+    size_t bytes = ordered[begin]->size;
+    while (end < ordered.size()) {
+      const CopyJob* prev = ordered[end - 1];
+      const CopyJob* cur = ordered[end];
+      const bool src_adjacent =
+          static_cast<const char*>(prev->src) + prev->size == static_cast<const char*>(cur->src);
+      const bool dst_adjacent =
+          static_cast<char*>(prev->dst) + prev->size == static_cast<char*>(cur->dst);
+      if (!src_adjacent || !dst_adjacent) break;
+      bytes += cur->size;
+      ++end;
+    }
+
+    status = hipMemcpyAsync(ordered[begin]->dst, ordered[begin]->src, bytes, kind, stream);
     if (status != hipSuccess) {
-      MORI_UMBP_ERROR("[DRAMTier] hipMemcpyAsync failed on device {}: {}", device_id,
-                      hipGetErrorString(status));
+      MORI_UMBP_ERROR("[DRAMTier] hipMemcpyAsync failed on device {} ({} bytes, {} objects): {}",
+                      device_id, bytes, end - begin, hipGetErrorString(status));
       (void)hipGetLastError();
       enqueued_all = false;
       break;
     }
+    begin = end;
   }
 
   const hipError_t sync_status = hipStreamSynchronize(stream);
@@ -224,6 +451,7 @@ void CopyJobs(std::vector<CopyJob>* jobs, int host_threads, hipMemcpyKind device
 
   CopyHostJobs(host_jobs, host_threads);
   for (auto& [device_id, grouped_jobs] : device_jobs) {
+    if (ProfileEnabled()) RecordMergeability(grouped_jobs, device_copy_kind);
     CopyDeviceJobs(grouped_jobs, device_id, device_copy_kind);
   }
 }
@@ -453,7 +681,11 @@ std::vector<bool> DRAMTier::ReadBatchIntoPtr(const std::vector<std::string>& key
   // during the parallel copy without a use-after-free against Write/Evict/
   // Clear. The per-block copies still run in parallel within the batch, which
   // is what breaks the single-core memcpy ceiling on cold DRAM.
-  std::lock_guard<std::mutex> lock(mu_);
+  //
+  // This whole-batch hold is what serializes concurrent clients; ProfiledLock
+  // quantifies it under UMBP_DRAM_PROFILE=1.
+  ScopedInFlight in_flight;
+  ProfiledLock lock(mu_, ReadLockStats(), n);
 
   std::vector<CopyJob> jobs;
   jobs.reserve(n);
@@ -486,7 +718,12 @@ std::vector<bool> DRAMTier::BatchWrite(const std::vector<std::string>& keys,
   // reads/writes). Slot allocation mutates free_list_/slots_ and must be serial;
   // only the per-block payload copies run in parallel, which is what breaks the
   // single-core memcpy ceiling on the backup path.
-  std::lock_guard<std::mutex> lock(mu_);
+  //
+  // Phase 2 could in principle run outside the lock (the reserved-but-
+  // unregistered region is unreachable to other threads); ProfiledLock measures
+  // what that would be worth. See UMBP_STANDALONE_PROCESS_DESIGN.md 11.1.
+  ScopedInFlight in_flight;
+  ProfiledLock lock(mu_, WriteLockStats(), n);
 
   struct WriteJob {
     CopyJob copy;

--- a/src/umbp/local/tiers/dram_tier.cpp
+++ b/src/umbp/local/tiers/dram_tier.cpp
@@ -30,18 +30,22 @@
 #include <chrono>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <map>
 #include <mutex>
 #include <stdexcept>
 #include <thread>
+#include <unordered_set>
 #include <vector>
 
 #if defined(__x86_64__) || defined(__i386__)
 #include <immintrin.h>
 #endif
 
+#include "device_copy_run.h"
 #include "mori/utils/mori_log.hpp"
 #include "umbp/common/device_copy.h"
+#include "umbp/common/range_utils.h"
 
 namespace mori::umbp {
 
@@ -115,13 +119,17 @@ struct CopyJob {
   bool copied{false};
 };
 
+using detail::DeviceCopyRun;
+using detail::DeviceCopyRunKind;
+using detail::FindDeviceCopyRun;
+using detail::PointerAddress;
+
 // ---------------------------------------------------------------------------
 // Opt-in profiling (UMBP_DRAM_PROFILE=1). Answers the two questions that gate
 // the next round of optimization work:
 //   1. how much of a batch's wall time is spent waiting for mu_ (i.e. how much
 //      the 8 ranks serialize against each other);
-//   2. how many hipMemcpyAsync submissions would survive if adjacent objects
-//      were merged (i.e. whether contiguous merging is worth implementing).
+//   2. how many device-copy submissions survive 1D and pitched-2D merging.
 // Zero cost when disabled: one predictable branch per batch.
 // ---------------------------------------------------------------------------
 
@@ -220,7 +228,9 @@ struct MergeStats {
   std::atomic<uint64_t> objects{0};
   std::atomic<uint64_t> runs_gpu{0};   // runs if only the GPU side had to be adjacent
   std::atomic<uint64_t> runs_dram{0};  // runs if only the DRAM side had to be adjacent
-  std::atomic<uint64_t> runs_both{0};  // runs with both adjacent -- the real submission count
+  std::atomic<uint64_t> runs_both{0};  // runs if both sides had to be adjacent
+  std::atomic<uint64_t> actual_submissions{0};
+  std::atomic<uint64_t> pitched_submissions{0};
 };
 
 MergeStats& OffloadMergeStats() {
@@ -233,11 +243,9 @@ MergeStats& LoadMergeStats() {
   return stats;
 }
 
-// Counts how many contiguous runs the batch would collapse into. A run of k
-// objects becomes one hipMemcpyAsync, so runs_both/objects is exactly the
-// submission-count reduction that merging would buy. runs_gpu / runs_dram show
-// which side is the obstacle: the DRAM side is ours to control (slot placement
-// follows the order objects are sent), the GPU side is the tree allocator's.
+// Counts both the legacy adjacency-only view and the actual 1D/2D plan.
+// runs_gpu / runs_dram show which side blocks flat 1D merging; actual_submissions
+// includes pitched runs recognized by the same planner used for execution.
 void RecordMergeability(const std::vector<CopyJob*>& jobs, hipMemcpyKind kind) {
   if (jobs.empty()) return;
   const bool src_is_gpu = (kind == hipMemcpyDeviceToHost);
@@ -270,6 +278,21 @@ void RecordMergeability(const std::vector<CopyJob*>& jobs, hipMemcpyKind kind) {
   stats.runs_gpu.fetch_add(runs_gpu, std::memory_order_relaxed);
   stats.runs_dram.fetch_add(runs_dram, std::memory_order_relaxed);
   stats.runs_both.fetch_add(runs_both, std::memory_order_relaxed);
+
+  std::vector<CopyJob*> ordered(jobs.begin(), jobs.end());
+  std::sort(ordered.begin(), ordered.end(), [](const CopyJob* a, const CopyJob* b) {
+    return PointerAddress(a->src) < PointerAddress(b->src);
+  });
+  uint64_t actual_submissions = 0;
+  uint64_t pitched_submissions = 0;
+  for (size_t begin = 0; begin < ordered.size();) {
+    const DeviceCopyRun run = FindDeviceCopyRun(ordered, begin);
+    ++actual_submissions;
+    if (run.kind == DeviceCopyRunKind::kPitched) ++pitched_submissions;
+    begin = run.end;
+  }
+  stats.actual_submissions.fetch_add(actual_submissions, std::memory_order_relaxed);
+  stats.pitched_submissions.fetch_add(pitched_submissions, std::memory_order_relaxed);
   const uint64_t n = stats.batches.fetch_add(1, std::memory_order_relaxed) + 1;
   if (n % kProfileReportEvery != 0) return;
 
@@ -279,8 +302,9 @@ void RecordMergeability(const std::vector<CopyJob*>& jobs, hipMemcpyKind kind) {
   };
   MORI_UMBP_INFO(
       "[DRAMTier/profile] mergeability {} batches={} objects={} | submissions kept: "
-      "gpu-side-only={}% dram-side-only={}% both={}%",
-      stats.name, n, objs, pct(stats.runs_gpu), pct(stats.runs_dram), pct(stats.runs_both));
+      "gpu-side-only={}% dram-side-only={}% adjacent-both={}% actual={}% 2d_runs={}",
+      stats.name, n, objs, pct(stats.runs_gpu), pct(stats.runs_dram), pct(stats.runs_both),
+      pct(stats.actual_submissions), stats.pitched_submissions.load(std::memory_order_relaxed));
 }
 
 // Times mu_ acquisition and the critical section, then reports periodically.
@@ -395,35 +419,31 @@ void CopyDeviceJobs(const std::vector<CopyJob*>& jobs, int device_id, hipMemcpyK
   // sends offloads in GPU-address order, which makes the tier's slot layout
   // mirror the GPU layout -- see UMBP_STANDALONE_PROCESS_DESIGN.md 11.2.
   std::vector<CopyJob*> ordered(jobs.begin(), jobs.end());
-  std::sort(ordered.begin(), ordered.end(),
-            [](const CopyJob* a, const CopyJob* b) { return a->src < b->src; });
+  std::sort(ordered.begin(), ordered.end(), [](const CopyJob* a, const CopyJob* b) {
+    return PointerAddress(a->src) < PointerAddress(b->src);
+  });
 
   hipError_t status = hipSuccess;
   bool enqueued_all = true;
   for (size_t begin = 0; begin < ordered.size();) {
-    size_t end = begin + 1;
-    size_t bytes = ordered[begin]->size;
-    while (end < ordered.size()) {
-      const CopyJob* prev = ordered[end - 1];
-      const CopyJob* cur = ordered[end];
-      const bool src_adjacent =
-          static_cast<const char*>(prev->src) + prev->size == static_cast<const char*>(cur->src);
-      const bool dst_adjacent =
-          static_cast<char*>(prev->dst) + prev->size == static_cast<char*>(cur->dst);
-      if (!src_adjacent || !dst_adjacent) break;
-      bytes += cur->size;
-      ++end;
+    const DeviceCopyRun run = FindDeviceCopyRun(ordered, begin);
+    if (run.kind == DeviceCopyRunKind::kPitched) {
+      status = hipMemcpy2DAsync(ordered[begin]->dst, run.dpitch, ordered[begin]->src, run.spitch,
+                                run.width, run.end - begin, kind, stream);
+    } else {
+      status = hipMemcpyAsync(ordered[begin]->dst, ordered[begin]->src, run.bytes, kind, stream);
     }
-
-    status = hipMemcpyAsync(ordered[begin]->dst, ordered[begin]->src, bytes, kind, stream);
     if (status != hipSuccess) {
-      MORI_UMBP_ERROR("[DRAMTier] hipMemcpyAsync failed on device {} ({} bytes, {} objects): {}",
-                      device_id, bytes, end - begin, hipGetErrorString(status));
+      MORI_UMBP_ERROR(
+          "[DRAMTier] device copy failed on device {} "
+          "(kind={} width={} rows={} spitch={} dpitch={} bytes={}): {}",
+          device_id, run.kind == DeviceCopyRunKind::kPitched ? "2d" : "1d", run.width,
+          run.end - begin, run.spitch, run.dpitch, run.bytes, hipGetErrorString(status));
       (void)hipGetLastError();
       enqueued_all = false;
       break;
     }
-    begin = end;
+    begin = run.end;
   }
 
   const hipError_t sync_status = hipStreamSynchronize(stream);
@@ -721,6 +741,65 @@ std::vector<bool> DRAMTier::ReadBatchIntoPtr(const std::vector<std::string>& key
   return results;
 }
 
+std::vector<bool> DRAMTier::ReadBatchRangesIntoPtr(
+    const std::vector<std::string>& keys, const std::vector<std::vector<uintptr_t>>& dst_ptrs,
+    const std::vector<std::vector<size_t>>& sizes,
+    const std::vector<std::vector<size_t>>& src_offsets) {
+  const size_t n = keys.size();
+  std::vector<bool> results(n, false);
+  if (!RangeBatchShapeValid(n, dst_ptrs, sizes, src_offsets) || n == 0) return results;
+
+  size_t total_ranges = 0;
+  for (const auto& entry : sizes) {
+    if (entry.size() > std::numeric_limits<size_t>::max() - total_ranges) return results;
+    total_ranges += entry.size();
+  }
+
+  ScopedInFlight in_flight;
+  ProfiledSharedLock lock(mu_, ReadLockStats(), n);
+
+  std::vector<CopyJob> jobs;
+  jobs.reserve(total_ranges);
+  std::vector<size_t> expected(n, 0);
+  for (size_t i = 0; i < n; ++i) {
+    if (sizes[i].empty()) continue;
+    auto it = slots_.find(keys[i]);
+    if (it == slots_.end()) continue;
+
+    bool valid = true;
+    for (size_t j = 0; j < sizes[i].size(); ++j) {
+      if (sizes[i][j] == 0 ||
+          IsObjectRangeOverflow(src_offsets[i][j], sizes[i][j], it->second.size)) {
+        valid = false;
+        break;
+      }
+    }
+    if (!valid) continue;
+
+    expected[i] = sizes[i].size();
+    for (size_t j = 0; j < sizes[i].size(); ++j) {
+      void* dst = reinterpret_cast<void*>(dst_ptrs[i][j]);
+      const void* src = static_cast<const char*>(base_ptr_) + it->second.offset + src_offsets[i][j];
+      jobs.push_back({dst, src, dst, sizes[i][j], i, false});
+    }
+  }
+
+  CopyJobs(&jobs, read_threads_, hipMemcpyHostToDevice);
+  std::vector<size_t> copied(n, 0);
+  for (const auto& job : jobs) {
+    if (job.copied) ++copied[job.idx];
+  }
+
+  std::lock_guard<std::mutex> lru_lock(lru_mu_);
+  for (size_t i = 0; i < n; ++i) {
+    if (expected[i] != 0 && copied[i] == expected[i]) {
+      results[i] = true;
+      TouchLRU(keys[i]);
+    }
+  }
+  return results;
+}
+
 std::vector<bool> DRAMTier::BatchWrite(const std::vector<std::string>& keys,
                                        const std::vector<const void*>& data_ptrs,
                                        const std::vector<size_t>& sizes) {
@@ -792,6 +871,93 @@ std::vector<bool> DRAMTier::BatchWrite(const std::vector<std::string>& keys,
       TouchLRU(keys[copy_job.idx]);
       results[copy_job.idx] = true;
     }
+  }
+  return results;
+}
+
+std::vector<bool> DRAMTier::BatchWriteRanges(const std::vector<std::string>& keys,
+                                             const std::vector<size_t>& object_sizes,
+                                             const std::vector<std::vector<const void*>>& src_ptrs,
+                                             const std::vector<std::vector<size_t>>& sizes,
+                                             const std::vector<std::vector<size_t>>& dst_offsets) {
+  const size_t n = keys.size();
+  std::vector<bool> results(n, false);
+  if (object_sizes.size() != n || !RangeBatchShapeValid(n, src_ptrs, sizes, dst_offsets) ||
+      n == 0) {
+    return results;
+  }
+
+  size_t total_ranges = 0;
+  for (const auto& entry : sizes) {
+    if (entry.size() > std::numeric_limits<size_t>::max() - total_ranges) return results;
+    total_ranges += entry.size();
+  }
+
+  std::unordered_set<std::string> seen;
+  std::unordered_set<std::string> duplicates;
+  for (const auto& key : keys) {
+    if (!seen.insert(key).second) duplicates.insert(key);
+  }
+
+  ScopedInFlight in_flight;
+  ProfiledUniqueLock lock(mu_, WriteLockStats(), n);
+
+  struct Reservation {
+    size_t index;
+    size_t offset;
+    size_t object_size;
+    size_t job_begin;
+    size_t job_count;
+  };
+  std::vector<Reservation> reservations;
+  std::vector<CopyJob> jobs;
+  reservations.reserve(n);
+  jobs.reserve(total_ranges);
+
+  // Reserve new storage while any previous value remains published. This costs
+  // temporary extra space, but it is what makes replacement failure atomic.
+  for (size_t i = 0; i < n; ++i) {
+    if (duplicates.count(keys[i]) != 0 ||
+        !RangesTileObject(object_sizes[i], sizes[i], dst_offsets[i])) {
+      continue;
+    }
+    const size_t offset = Allocate(object_sizes[i]);
+    if (offset == static_cast<size_t>(-1)) continue;
+
+    const size_t job_begin = jobs.size();
+    for (size_t j = 0; j < sizes[i].size(); ++j) {
+      void* dst = static_cast<char*>(base_ptr_) + offset + dst_offsets[i][j];
+      jobs.push_back({dst, src_ptrs[i][j], src_ptrs[i][j], sizes[i][j], i, false});
+    }
+    reservations.push_back({i, offset, object_sizes[i], job_begin, sizes[i].size()});
+  }
+
+  CopyJobs(&jobs, write_threads_, hipMemcpyDeviceToHost);
+
+  std::lock_guard<std::mutex> lru_lock(lru_mu_);
+  for (const Reservation& reservation : reservations) {
+    bool copied = true;
+    for (size_t j = 0; j < reservation.job_count; ++j) {
+      if (!jobs[reservation.job_begin + j].copied) {
+        copied = false;
+        break;
+      }
+    }
+    if (!copied) {
+      Deallocate(reservation.offset, reservation.object_size);
+      continue;
+    }
+
+    const std::string& key = keys[reservation.index];
+    auto existing = slots_.find(key);
+    if (existing != slots_.end()) {
+      Deallocate(existing->second.offset, existing->second.size);
+      used_ -= existing->second.size;
+    }
+    slots_[key] = {reservation.offset, reservation.object_size};
+    used_ += reservation.object_size;
+    TouchLRU(key);
+    results[reservation.index] = true;
   }
   return results;
 }

--- a/src/umbp/local/tiers/dram_tier.cpp
+++ b/src/umbp/local/tiers/dram_tier.cpp
@@ -43,6 +43,7 @@
 #endif
 
 #include "device_copy_run.h"
+#include "host_registration.h"
 #include "mori/utils/mori_log.hpp"
 #include "umbp/common/device_copy.h"
 #include "umbp/common/range_utils.h"
@@ -530,6 +531,10 @@ DRAMTier::DRAMTier(size_t capacity, bool use_shm, const std::string& shm_name, b
   // Initialize free list with entire capacity
   free_list_.push_back({0, capacity_});
 
+  // Must come after base_ptr_ is final. Registering the region takes every
+  // hipMemcpy on this tier off the pageable staging path.
+  host_registration_ = std::make_unique<HostTierRegistration>(base_ptr_, mapped_size_);
+
   // Threads for parallel batch-read CopyBlock. Default 8, override via env,
   // capped to hardware concurrency. >1 breaks the single-core memcpy ceiling.
   if (const char* e = std::getenv("UMBP_DRAM_READ_THREADS")) {
@@ -548,6 +553,9 @@ DRAMTier::DRAMTier(size_t capacity, bool use_shm, const std::string& shm_name, b
 }
 
 DRAMTier::~DRAMTier() {
+  // Unregister before the mapping goes away, and before any in-flight
+  // background registration can touch an unmapped address.
+  host_registration_.reset();
   if (use_shm_) {
     if (base_ptr_ && base_ptr_ != MAP_FAILED) {
       munmap(base_ptr_, mapped_size_);

--- a/src/umbp/local/tiers/dram_tier.cpp
+++ b/src/umbp/local/tiers/dram_tier.cpp
@@ -29,12 +29,18 @@
 #include <atomic>
 #include <cstdlib>
 #include <cstring>
+#include <map>
+#include <mutex>
 #include <stdexcept>
 #include <thread>
+#include <vector>
 
 #if defined(__x86_64__) || defined(__i386__)
 #include <immintrin.h>
 #endif
+
+#include "mori/utils/mori_log.hpp"
+#include "umbp/common/device_copy.h"
 
 namespace mori::umbp {
 
@@ -96,6 +102,129 @@ inline void CopyBlock(void* dst, const void* src, size_t size) {
     NtCopyAvx2(static_cast<char*>(dst), static_cast<const char*>(src), size);
   } else {
     std::memcpy(dst, src, size);
+  }
+}
+
+struct CopyJob {
+  void* dst;
+  const void* src;
+  const void* classified_ptr;
+  size_t size;
+  size_t idx;
+  bool copied{false};
+};
+
+void CopyHostJobs(const std::vector<CopyJob*>& jobs, int num_threads) {
+  if (jobs.empty()) return;
+  num_threads = std::max(1, std::min(num_threads, static_cast<int>(jobs.size())));
+  if (num_threads == 1) {
+    for (CopyJob* job : jobs) {
+      CopyBlock(job->dst, job->src, job->size);
+      job->copied = true;
+    }
+    return;
+  }
+
+  std::atomic<size_t> next{0};
+  auto worker = [&]() {
+    size_t i = 0;
+    while ((i = next.fetch_add(1)) < jobs.size()) {
+      CopyJob* job = jobs[i];
+      CopyBlock(job->dst, job->src, job->size);
+      job->copied = true;
+    }
+  };
+  std::vector<std::thread> pool;
+  pool.reserve(num_threads);
+  for (int i = 0; i < num_threads; ++i) pool.emplace_back(worker);
+  for (auto& thread : pool) thread.join();
+}
+
+// One reusable stream per device.
+//
+// Creating and destroying a stream around every batch costs ~6.5 ms per pair on
+// MI355X/ROCm 7.2 (measured), which dwarfs the copies themselves: a layer-wise
+// KV load issues 2 * num_layers batches per request, so the churn alone added
+// ~1 s per rank and, because ReadBatchIntoPtr holds mu_ for the whole batch,
+// ~8 s once 8 ranks serialize behind it. Reusing the stream removes that.
+//
+// The streams are intentionally never destroyed: tearing down HIP resources
+// from a static destructor races with runtime teardown. They are a fixed,
+// per-device cost that ends with the process.
+hipStream_t DeviceStream(int device_id) {
+  static std::mutex stream_mu;
+  static std::map<int, hipStream_t> streams;
+  std::lock_guard<std::mutex> lock(stream_mu);
+  auto it = streams.find(device_id);
+  if (it != streams.end()) return it->second;
+
+  hipStream_t stream = nullptr;
+  const hipError_t status = hipStreamCreateWithFlags(&stream, hipStreamNonBlocking);
+  if (status != hipSuccess) {
+    MORI_UMBP_ERROR("[DRAMTier] hipStreamCreateWithFlags failed on device {}: {}", device_id,
+                    hipGetErrorString(status));
+    (void)hipGetLastError();
+    return nullptr;
+  }
+  streams.emplace(device_id, stream);
+  return stream;
+}
+
+void CopyDeviceJobs(const std::vector<CopyJob*>& jobs, int device_id, hipMemcpyKind kind) {
+  if (jobs.empty()) return;
+  ScopedHipDevice device_guard(device_id);
+  if (!device_guard.IsValid()) {
+    MORI_UMBP_ERROR("[DRAMTier] failed to select GPU device {}", device_id);
+    return;
+  }
+
+  // Created under the device guard above, so the stream belongs to device_id.
+  hipStream_t stream = DeviceStream(device_id);
+  if (stream == nullptr) return;
+
+  hipError_t status = hipSuccess;
+  bool enqueued_all = true;
+  for (CopyJob* job : jobs) {
+    status = hipMemcpyAsync(job->dst, job->src, job->size, kind, stream);
+    if (status != hipSuccess) {
+      MORI_UMBP_ERROR("[DRAMTier] hipMemcpyAsync failed on device {}: {}", device_id,
+                      hipGetErrorString(status));
+      (void)hipGetLastError();
+      enqueued_all = false;
+      break;
+    }
+  }
+
+  const hipError_t sync_status = hipStreamSynchronize(stream);
+  if (sync_status != hipSuccess) {
+    MORI_UMBP_ERROR("[DRAMTier] hipStreamSynchronize failed on device {}: {}", device_id,
+                    hipGetErrorString(sync_status));
+    (void)hipGetLastError();
+    enqueued_all = false;
+  }
+
+  if (enqueued_all) {
+    for (CopyJob* job : jobs) job->copied = true;
+  }
+}
+
+void CopyJobs(std::vector<CopyJob>* jobs, int host_threads, hipMemcpyKind device_copy_kind) {
+  if (jobs->empty()) return;
+  std::vector<CopyJob*> host_jobs;
+  std::map<int, std::vector<CopyJob*>> device_jobs;
+  host_jobs.reserve(jobs->size());
+  for (CopyJob& job : *jobs) {
+    const PointerLocation location = DetectPointerLocation(job.classified_ptr);
+    if (location.IsDevice()) {
+      device_jobs[location.device_id].push_back(&job);
+    } else {
+      host_jobs.push_back(&job);
+    }
+  }
+
+  CopyHostJobs(host_jobs, host_threads);
+  for (auto& [device_id, grouped_jobs] : device_jobs) {
+    CopyDeviceJobs(grouped_jobs, device_id, device_copy_kind);
   }
 }
 
@@ -268,7 +397,17 @@ bool DRAMTier::Write(const std::string& key, const void* data, size_t size) {
     return false;
   }
 
-  std::memcpy(static_cast<char*>(base_ptr_) + offset, data, size);
+  const PointerLocation source_location = DetectPointerLocation(data);
+  if (source_location.IsDevice()) {
+    ScopedHipDevice device_guard(source_location.device_id);
+    if (!device_guard.IsValid() || !DeviceCopy(static_cast<char*>(base_ptr_) + offset, data, size,
+                                               hipMemcpyDeviceToHost, source_location.device_id)) {
+      Deallocate(offset, size);
+      return false;
+    }
+  } else {
+    std::memcpy(static_cast<char*>(base_ptr_) + offset, data, size);
+  }
   slots_[key] = {offset, size};
   used_ += size;
   TouchLRU(key);
@@ -286,8 +425,18 @@ bool DRAMTier::ReadIntoPtr(const std::string& key, uintptr_t dst_ptr, size_t siz
   // would produce a partially-filled KV block with no error signal.
   if (size != it->second.size) return false;
 
-  std::memcpy(reinterpret_cast<void*>(dst_ptr), static_cast<char*>(base_ptr_) + it->second.offset,
-              size);
+  void* dst = reinterpret_cast<void*>(dst_ptr);
+  const PointerLocation destination_location = DetectPointerLocation(dst);
+  if (destination_location.IsDevice()) {
+    ScopedHipDevice device_guard(destination_location.device_id);
+    if (!device_guard.IsValid() ||
+        !DeviceCopy(dst, static_cast<char*>(base_ptr_) + it->second.offset, size,
+                    hipMemcpyHostToDevice, destination_location.device_id)) {
+      return false;
+    }
+  } else {
+    std::memcpy(dst, static_cast<char*>(base_ptr_) + it->second.offset, size);
+  }
   TouchLRU(key);
   return true;
 }
@@ -306,46 +455,23 @@ std::vector<bool> DRAMTier::ReadBatchIntoPtr(const std::vector<std::string>& key
   // is what breaks the single-core memcpy ceiling on cold DRAM.
   std::lock_guard<std::mutex> lock(mu_);
 
-  struct Job {
-    void* dst;
-    const void* src;
-    size_t size;
-    size_t idx;
-  };
-  std::vector<Job> jobs;
+  std::vector<CopyJob> jobs;
   jobs.reserve(n);
   for (size_t i = 0; i < n; ++i) {
     auto it = slots_.find(keys[i]);
     if (it == slots_.end()) continue;
     if (sizes[i] != it->second.size) continue;
-    jobs.push_back({reinterpret_cast<void*>(dst_ptrs[i]),
-                    static_cast<char*>(base_ptr_) + it->second.offset, sizes[i], i});
+    void* dst = reinterpret_cast<void*>(dst_ptrs[i]);
+    jobs.push_back(
+        {dst, static_cast<char*>(base_ptr_) + it->second.offset, dst, sizes[i], i, false});
   }
 
-  int num_threads = read_threads_;
-  if (num_threads > static_cast<int>(jobs.size())) num_threads = static_cast<int>(jobs.size());
-
-  if (num_threads <= 1) {
-    for (const auto& j : jobs) {
-      CopyBlock(j.dst, j.src, j.size);
-      results[j.idx] = true;
-    }
-  } else {
-    std::atomic<size_t> next{0};
-    auto worker = [&]() {
-      size_t i;
-      while ((i = next.fetch_add(1)) < jobs.size()) {
-        CopyBlock(jobs[i].dst, jobs[i].src, jobs[i].size);
-      }
-    };
-    std::vector<std::thread> pool;
-    pool.reserve(num_threads);
-    for (int t = 0; t < num_threads; ++t) pool.emplace_back(worker);
-    for (auto& th : pool) th.join();
-    for (const auto& j : jobs) results[j.idx] = true;
+  CopyJobs(&jobs, read_threads_, hipMemcpyHostToDevice);
+  for (const auto& job : jobs) {
+    if (!job.copied) continue;
+    results[job.idx] = true;
+    TouchLRU(keys[job.idx]);
   }
-
-  for (const auto& j : jobs) TouchLRU(keys[j.idx]);
   return results;
 }
 
@@ -362,15 +488,13 @@ std::vector<bool> DRAMTier::BatchWrite(const std::vector<std::string>& keys,
   // single-core memcpy ceiling on the backup path.
   std::lock_guard<std::mutex> lock(mu_);
 
-  struct Job {
-    void* dst;
-    const void* src;
-    size_t size;
-    size_t idx;
+  struct WriteJob {
+    CopyJob copy;
     size_t offset;
   };
-  std::vector<Job> jobs;
-  jobs.reserve(n);
+  std::vector<WriteJob> write_jobs;
+  std::vector<CopyJob> copy_jobs;
+  write_jobs.reserve(n);
 
   // Phase 1 (serial): free any existing slot for the key, then allocate. Does
   // NOT self-evict — a key that doesn't fit is left false so the upper layer
@@ -389,35 +513,29 @@ std::vector<bool> DRAMTier::BatchWrite(const std::vector<std::string>& keys,
     }
     size_t offset = Allocate(sizes[i]);
     if (offset == static_cast<size_t>(-1)) continue;
-    jobs.push_back({static_cast<char*>(base_ptr_) + offset, data_ptrs[i], sizes[i], i, offset});
+    write_jobs.push_back(
+        {{static_cast<char*>(base_ptr_) + offset, data_ptrs[i], data_ptrs[i], sizes[i], i, false},
+         offset});
   }
 
-  // Phase 2 (parallel): non-temporal CopyBlock each payload into its slot.
-  int num_threads = write_threads_;
-  if (num_threads > static_cast<int>(jobs.size())) num_threads = static_cast<int>(jobs.size());
-
-  if (num_threads <= 1) {
-    for (const auto& j : jobs) CopyBlock(j.dst, j.src, j.size);
-  } else {
-    std::atomic<size_t> next{0};
-    auto worker = [&]() {
-      size_t i;
-      while ((i = next.fetch_add(1)) < jobs.size()) {
-        CopyBlock(jobs[i].dst, jobs[i].src, jobs[i].size);
-      }
-    };
-    std::vector<std::thread> pool;
-    pool.reserve(num_threads);
-    for (int t = 0; t < num_threads; ++t) pool.emplace_back(worker);
-    for (auto& th : pool) th.join();
-  }
+  // Phase 2: preserve the existing parallel host path; GPU jobs are grouped by
+  // device and submitted to one stream with one synchronization per device.
+  copy_jobs.reserve(write_jobs.size());
+  for (const auto& job : write_jobs) copy_jobs.push_back(job.copy);
+  CopyJobs(&copy_jobs, write_threads_, hipMemcpyDeviceToHost);
 
   // Phase 3 (serial): register slots + LRU, mark successes.
-  for (const auto& j : jobs) {
-    slots_[keys[j.idx]] = {j.offset, j.size};
-    used_ += j.size;
-    TouchLRU(keys[j.idx]);
-    results[j.idx] = true;
+  for (size_t i = 0; i < write_jobs.size(); ++i) {
+    const WriteJob& write_job = write_jobs[i];
+    const CopyJob& copy_job = copy_jobs[i];
+    if (!copy_job.copied) {
+      Deallocate(write_job.offset, copy_job.size);
+      continue;
+    }
+    slots_[keys[copy_job.idx]] = {write_job.offset, copy_job.size};
+    used_ += copy_job.size;
+    TouchLRU(keys[copy_job.idx]);
+    results[copy_job.idx] = true;
   }
   return results;
 }

--- a/src/umbp/local/tiers/dram_tier.cpp
+++ b/src/umbp/local/tiers/dram_tier.cpp
@@ -313,6 +313,79 @@ void RecordMergeability(const std::vector<CopyJob*>& jobs, hipMemcpyKind kind) {
       stats.gather_batches.load(std::memory_order_relaxed));
 }
 
+// Where a batch's time goes once it is inside the tier. Added because the
+// end-to-end loader was running at a small fraction of the copy path's
+// measured ceiling under 8-rank concurrency, and the copy itself was the only
+// part anyone had timed. Classification is called out separately because it
+// costs one hipPointerGetAttributes per range, which scales with objects times
+// layers rather than with bytes.
+struct PhaseStats {
+  const char* name;
+  std::atomic<uint64_t> batches{0};
+  std::atomic<uint64_t> ranges{0};
+  std::atomic<uint64_t> bytes{0};        // measured, not inferred from a mean range size
+  std::atomic<uint64_t> lookup_us{0};    // resolving keys to slots
+  std::atomic<uint64_t> classify_us{0};  // DetectPointerLocation per range
+  std::atomic<uint64_t> copy_us{0};      // the transfer itself
+};
+
+PhaseStats& ReadPhaseStats() {
+  static PhaseStats stats{"read"};
+  return stats;
+}
+
+PhaseStats& WritePhaseStats() {
+  static PhaseStats stats{"write"};
+  return stats;
+}
+
+void RecordPhases(PhaseStats& stats, size_t ranges, size_t bytes, uint64_t lookup_us,
+                  uint64_t classify_us, uint64_t copy_us) {
+  stats.ranges.fetch_add(ranges, std::memory_order_relaxed);
+  stats.bytes.fetch_add(bytes, std::memory_order_relaxed);
+  stats.lookup_us.fetch_add(lookup_us, std::memory_order_relaxed);
+  stats.classify_us.fetch_add(classify_us, std::memory_order_relaxed);
+  stats.copy_us.fetch_add(copy_us, std::memory_order_relaxed);
+  const uint64_t n = stats.batches.fetch_add(1, std::memory_order_relaxed) + 1;
+  if (n % kProfileReportEvery != 0) return;
+
+  const uint64_t lookup = stats.lookup_us.load(std::memory_order_relaxed);
+  const uint64_t classify = stats.classify_us.load(std::memory_order_relaxed);
+  const uint64_t copy = stats.copy_us.load(std::memory_order_relaxed);
+  const uint64_t moved = stats.bytes.load(std::memory_order_relaxed);
+  const uint64_t total = lookup + classify + copy;
+  MORI_UMBP_INFO(
+      "[DRAMTier/profile] phases {} batches={} ranges={} | per batch: KiB={} lookup={}us "
+      "classify={}us copy={}us | share: lookup={}% classify={}% copy={}% | copy_MBps={}",
+      stats.name, n, stats.ranges.load(std::memory_order_relaxed), moved / n / 1024, lookup / n,
+      classify / n, copy / n, total == 0 ? 0 : lookup * 100 / total,
+      total == 0 ? 0 : classify * 100 / total, total == 0 ? 0 : copy * 100 / total,
+      copy == 0 ? 0 : moved / copy);
+}
+
+// Reads the clock only when profiling is on: these sit on the per-batch path,
+// so an unconditional steady_clock::now() in the constructor would be a cost
+// paid by every batch in production to serve a switch that is normally off.
+class PhaseTimer {
+ public:
+  explicit PhaseTimer(bool enabled) : enabled_(enabled) {
+    if (enabled_) started_ = std::chrono::steady_clock::now();
+  }
+
+  uint64_t Lap() {
+    if (!enabled_) return 0;
+    const auto now = std::chrono::steady_clock::now();
+    const uint64_t elapsed =
+        std::chrono::duration_cast<std::chrono::microseconds>(now - started_).count();
+    started_ = now;
+    return elapsed;
+  }
+
+ private:
+  bool enabled_;
+  std::chrono::steady_clock::time_point started_{};
+};
+
 // Times mu_ acquisition and the critical section, then reports periodically.
 template <typename Lock>
 class ProfiledLock {
@@ -386,8 +459,9 @@ void CopyHostJobs(const std::vector<CopyJob*>& jobs, int num_threads) {
 // hipStreamSynchronize. Sharing one stream across threads makes every batch
 // wait for every other batch queued on that device -- loads behind loads, and
 // loads behind the offload path, which writes continuously under
-// write_through_threshold=1. That coupling, not the DMA, held the measured copy
-// phase to 1.7 GB/s against 49 GB/s for the same shape in isolation.
+// write_through_threshold=1. That coupling, not the DMA, was what held the
+// measured copy phase to 1.7 GB/s against 49 GB/s for the same shape in
+// isolation.
 //
 // The streams are intentionally never destroyed: tearing down HIP resources
 // from a thread or static destructor races with runtime teardown. The count is
@@ -572,8 +646,11 @@ void CopyDeviceJobs(const std::vector<CopyJob*>& jobs, int device_id, hipMemcpyK
 }
 
 void CopyJobs(std::vector<CopyJob>* jobs, int host_threads, hipMemcpyKind device_copy_kind,
-              const HostTierRegistration* registration) {
+              const HostTierRegistration* registration, uint64_t* out_classify_us = nullptr,
+              uint64_t* out_copy_us = nullptr) {
   if (jobs->empty()) return;
+  const bool profiling = ProfileEnabled();
+  PhaseTimer timer(profiling);
   std::vector<CopyJob*> host_jobs;
   std::map<int, std::vector<CopyJob*>> device_jobs;
   host_jobs.reserve(jobs->size());
@@ -585,11 +662,23 @@ void CopyJobs(std::vector<CopyJob>* jobs, int host_threads, hipMemcpyKind device
       host_jobs.push_back(&job);
     }
   }
+  if (out_classify_us != nullptr) *out_classify_us = timer.Lap();
+
+  if (profiling) {
+    // Sorting and re-planning every batch is profiling-only work. Do it before
+    // the copy measurement starts rather than inside the loop, where it would
+    // be charged to the copy it is supposed to describe.
+    for (auto& [device_id, grouped_jobs] : device_jobs) {
+      RecordMergeability(grouped_jobs, device_copy_kind);
+    }
+    timer.Lap();
+  }
+
   CopyHostJobs(host_jobs, host_threads);
   for (auto& [device_id, grouped_jobs] : device_jobs) {
-    if (ProfileEnabled()) RecordMergeability(grouped_jobs, device_copy_kind);
     CopyDeviceJobs(grouped_jobs, device_id, device_copy_kind, registration);
   }
+  if (out_copy_us != nullptr) *out_copy_us = timer.Lap();
 }
 
 }  // namespace
@@ -878,6 +967,9 @@ std::vector<bool> DRAMTier::ReadBatchRangesIntoPtr(
   ScopedInFlight in_flight;
   ProfiledSharedLock lock(mu_, ReadLockStats(), n);
 
+  const bool profiling = ProfileEnabled();
+  PhaseTimer phase(profiling);
+  size_t job_bytes = 0;
   std::vector<CopyJob> jobs;
   jobs.reserve(total_ranges);
   std::vector<size_t> expected(n, 0);
@@ -901,10 +993,18 @@ std::vector<bool> DRAMTier::ReadBatchRangesIntoPtr(
       void* dst = reinterpret_cast<void*>(dst_ptrs[i][j]);
       const void* src = static_cast<const char*>(base_ptr_) + it->second.offset + src_offsets[i][j];
       jobs.push_back({dst, src, dst, sizes[i][j], i, false});
+      job_bytes += sizes[i][j];
     }
   }
 
-  CopyJobs(&jobs, read_threads_, hipMemcpyHostToDevice, host_registration_.get());
+  const uint64_t lookup_us = phase.Lap();
+  uint64_t classify_us = 0;
+  uint64_t copy_us = 0;
+  CopyJobs(&jobs, read_threads_, hipMemcpyHostToDevice, host_registration_.get(), &classify_us,
+           &copy_us);
+  if (profiling) {
+    RecordPhases(ReadPhaseStats(), total_ranges, job_bytes, lookup_us, classify_us, copy_us);
+  }
   std::vector<size_t> copied(n, 0);
   for (const auto& job : jobs) {
     if (job.copied) ++copied[job.idx];
@@ -1022,6 +1122,9 @@ std::vector<bool> DRAMTier::BatchWriteRanges(const std::vector<std::string>& key
   ScopedInFlight in_flight;
   ProfiledUniqueLock lock(mu_, WriteLockStats(), n);
 
+  const bool profiling = ProfileEnabled();
+  PhaseTimer phase(profiling);
+  size_t job_bytes = 0;
   struct Reservation {
     size_t index;
     size_t offset;
@@ -1048,11 +1151,19 @@ std::vector<bool> DRAMTier::BatchWriteRanges(const std::vector<std::string>& key
     for (size_t j = 0; j < sizes[i].size(); ++j) {
       void* dst = static_cast<char*>(base_ptr_) + offset + dst_offsets[i][j];
       jobs.push_back({dst, src_ptrs[i][j], src_ptrs[i][j], sizes[i][j], i, false});
+      job_bytes += sizes[i][j];
     }
     reservations.push_back({i, offset, object_sizes[i], job_begin, sizes[i].size()});
   }
 
-  CopyJobs(&jobs, write_threads_, hipMemcpyDeviceToHost, host_registration_.get());
+  const uint64_t lookup_us = phase.Lap();
+  uint64_t classify_us = 0;
+  uint64_t copy_us = 0;
+  CopyJobs(&jobs, write_threads_, hipMemcpyDeviceToHost, host_registration_.get(), &classify_us,
+           &copy_us);
+  if (profiling) {
+    RecordPhases(WritePhaseStats(), total_ranges, job_bytes, lookup_us, classify_us, copy_us);
+  }
 
   std::lock_guard<std::mutex> lru_lock(lru_mu_);
   for (const Reservation& reservation : reservations) {

--- a/src/umbp/local/tiers/host_registration.cpp
+++ b/src/umbp/local/tiers/host_registration.cpp
@@ -1,0 +1,161 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#include "host_registration.h"
+
+#include <hip/hip_runtime_api.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <string>
+
+#include "mori/utils/mori_log.hpp"
+
+namespace mori::umbp {
+namespace {
+
+// Below this, registering inline costs under ~100 ms and keeps behaviour
+// deterministic, which unit tests rely on.
+constexpr size_t kSyncThresholdBytes = 2ull << 30;
+
+bool RegistrationEnabled() {
+  static const bool enabled = [] {
+    const char* value = std::getenv("UMBP_DRAM_HOST_REGISTER");
+    if (value == nullptr) return true;
+    const std::string text(value);
+    return text != "0" && text != "off" && text != "false";
+  }();
+  return enabled;
+}
+
+bool HasDevice() {
+  int count = 0;
+  if (hipGetDeviceCount(&count) != hipSuccess) {
+    (void)hipGetLastError();
+    return false;
+  }
+  return count > 0;
+}
+
+}  // namespace
+
+HostTierRegistration::HostTierRegistration(void* base, size_t bytes)
+    : base_(static_cast<char*>(base)), bytes_(bytes) {
+  if (base_ == nullptr || bytes_ == 0 || !RegistrationEnabled() || !HasDevice()) {
+    bytes_ = 0;
+    return;
+  }
+
+  if (bytes_ <= kSyncThresholdBytes) {
+    Register();
+    return;
+  }
+  worker_ = std::thread([this]() { Register(); });
+}
+
+HostTierRegistration::~HostTierRegistration() {
+  if (worker_.joinable()) worker_.join();
+  if (registered_bytes_.load(std::memory_order_acquire) == 0) return;
+  if (hipHostUnregister(base_) != hipSuccess) (void)hipGetLastError();
+}
+
+void HostTierRegistration::Register() {
+  const auto started = std::chrono::steady_clock::now();
+
+  // One call for the whole region, never several. hipMemcpy rejects any copy
+  // whose host range spans two separate registrations with hipErrorInvalidValue,
+  // so registering in chunks would break every object that happens to straddle
+  // a chunk boundary -- which is most of them once the tier is large.
+  //
+  // hipHostRegisterPortable so every rank's device can reach the tier;
+  // hipHostRegisterMapped so a kernel can dereference it directly.
+  const hipError_t status =
+      hipHostRegister(base_, bytes_, hipHostRegisterMapped | hipHostRegisterPortable);
+  if (status != hipSuccess) {
+    MORI_UMBP_WARN(
+        "[DRAMTier] hipHostRegister of {} MiB failed: {}; the GPU gather path stays off and "
+        "copies fall back to pageable hipMemcpy",
+        bytes_ >> 20, hipGetErrorString(status));
+    (void)hipGetLastError();
+    return;
+  }
+
+  // The gather path hands host addresses straight to the kernel, which is only
+  // valid under unified addressing. Verify rather than assume -- and verify it
+  // on every device, not just whichever one this thread happens to have
+  // current: the standalone server serves all ranks from one process, so a
+  // batch can launch the kernel on any of them.
+  int devices = 0;
+  if (hipGetDeviceCount(&devices) != hipSuccess || devices <= 0) {
+    // Not being able to enumerate the devices is not the same as having
+    // verified them: an empty loop below would silently publish the region as
+    // kernel-addressable on every device.
+    MORI_UMBP_WARN(
+        "[DRAMTier] cannot enumerate devices to verify the host mapping; the GPU gather path "
+        "stays off");
+    (void)hipGetLastError();
+    (void)hipHostUnregister(base_);
+    return;
+  }
+  int previous = 0;
+  const bool have_previous = hipGetDevice(&previous) == hipSuccess;
+  if (!have_previous) (void)hipGetLastError();
+  for (int device = 0; device < devices; ++device) {
+    void* device_alias = nullptr;
+    const bool selected = hipSetDevice(device) == hipSuccess;
+    const bool matches = selected &&
+                         hipHostGetDevicePointer(&device_alias, base_, 0) == hipSuccess &&
+                         device_alias == base_;
+    if (matches) continue;
+
+    MORI_UMBP_WARN(
+        "[DRAMTier] device {} maps the registered host region at a different address than the "
+        "host does; the GPU gather path needs unified addressing and stays off",
+        device);
+    (void)hipGetLastError();
+    if (have_previous) (void)hipSetDevice(previous);
+    (void)hipHostUnregister(base_);
+    return;
+  }
+  if (have_previous) (void)hipSetDevice(previous);
+
+  registered_bytes_.store(bytes_, std::memory_order_release);
+  const double seconds =
+      std::chrono::duration<double>(std::chrono::steady_clock::now() - started).count();
+  MORI_UMBP_INFO("[DRAMTier] host memory registered for GPU access: {} MiB in {:.1f} s",
+                 bytes_ >> 20, seconds);
+}
+
+bool HostTierRegistration::Covers(const void* ptr, size_t size) const {
+  if (ptr == nullptr || bytes_ == 0) return false;
+  // Compared as integers, not pointers: `ptr` may be outside this region, and
+  // relational operators and subtraction on pointers into different objects are
+  // undefined behaviour even when the hardware would do the obvious thing.
+  const uintptr_t address = reinterpret_cast<uintptr_t>(ptr);
+  const uintptr_t base = reinterpret_cast<uintptr_t>(base_);
+  if (address < base) return false;
+  const uintptr_t offset = address - base;
+  const size_t registered = registered_bytes_.load(std::memory_order_acquire);
+  return size <= registered && offset <= registered - size;
+}
+
+}  // namespace mori::umbp

--- a/src/umbp/local/tiers/host_registration.cpp
+++ b/src/umbp/local/tiers/host_registration.cpp
@@ -19,7 +19,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-#include "host_registration.h"
+#include "umbp/common/host_registration.h"
 
 #include <hip/hip_runtime_api.h>
 

--- a/src/umbp/local/tiers/host_registration.h
+++ b/src/umbp/local/tiers/host_registration.h
@@ -1,0 +1,77 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+// Source-private to the DRAM tier; not part of the installed API.
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <thread>
+
+namespace mori::umbp {
+
+// Makes a tier's host region addressable from GPU kernels via hipHostRegister.
+//
+// Two things depend on this. A gather kernel cannot dereference plain mmap
+// memory at all -- it faults the GPU -- so registration is a hard prerequisite
+// for the scatter-gather copy path. Independently, registering takes
+// hipMemcpyAsync off the pageable staging path, which alone is worth ~6x on the
+// per-fragment copies that remain.
+//
+// Registration runs at roughly 13 GiB/s and does not parallelize: splitting it
+// across threads measured slower, because it serializes inside the driver. A
+// 512 GiB tier would therefore add ~40 s to server startup, so anything larger
+// than the synchronous threshold is registered on a background thread and the
+// tier simply behaves as it did before until that finishes. It must be a single
+// registration covering the whole region -- see Register() -- so this is
+// all-or-nothing rather than a progressive watermark.
+class HostTierRegistration {
+ public:
+  // Registers [base, base + bytes). `bytes` must be the mapped (page-aligned)
+  // length, not the usable capacity. Never throws and never fails hard: if
+  // registration is unavailable the object simply reports Covers() == false
+  // forever.
+  HostTierRegistration(void* base, size_t bytes);
+  ~HostTierRegistration();
+
+  HostTierRegistration(const HostTierRegistration&) = delete;
+  HostTierRegistration& operator=(const HostTierRegistration&) = delete;
+
+  // True when [ptr, ptr + size) is registered, and therefore safe to hand to a
+  // kernel. False is always the safe answer.
+  bool Covers(const void* ptr, size_t size) const;
+
+  // Zero until registration succeeds, then the full region. For logging and
+  // tests.
+  size_t RegisteredBytes() const { return registered_bytes_.load(std::memory_order_acquire); }
+
+ private:
+  void Register();
+
+  char* base_{nullptr};
+  size_t bytes_{0};
+  std::atomic<size_t> registered_bytes_{0};
+  std::thread worker_;
+};
+
+}  // namespace mori::umbp

--- a/src/umbp/local/tiers/local_storage_manager.cpp
+++ b/src/umbp/local/tiers/local_storage_manager.cpp
@@ -27,8 +27,10 @@
 #include <cstring>
 #include <stdexcept>
 #include <thread>
+#include <unordered_set>
 
 #include "mori/utils/mori_log.hpp"
+#include "umbp/common/range_utils.h"
 #include "umbp/local/tiers/dram_tier.h"
 #include "umbp/local/tiers/dummy_ssd_tier.h"
 #include "umbp/local/tiers/ssd_tier.h"
@@ -710,6 +712,97 @@ std::vector<bool> LocalStorageManager::WriteBatchFromPtr(const std::vector<std::
   return results;
 }
 
+bool LocalStorageManager::WriteRangesFromPtr(const std::string& key, size_t object_size,
+                                             const std::vector<uintptr_t>& srcs,
+                                             const std::vector<size_t>& sizes,
+                                             const std::vector<size_t>& dst_offsets,
+                                             StorageTier tier) {
+  // Ranged I/O is intentionally DRAM-only in v1.
+  if (tier != StorageTier::CPU_DRAM || !RangesTileObject(object_size, sizes, dst_offsets) ||
+      srcs.size() != sizes.size()) {
+    return false;
+  }
+  TierBackend* target = GetTier(tier);
+  if (!target) return false;
+
+  std::vector<const void*> ptrs;
+  ptrs.reserve(srcs.size());
+  for (uintptr_t src : srcs) ptrs.push_back(reinterpret_cast<const void*>(src));
+
+  auto attempt = [&]() {
+    auto result = target->BatchWriteRanges({key}, {object_size}, {ptrs}, {sizes}, {dst_offsets});
+    return result.size() == 1 && result[0];
+  };
+  if (attempt()) return true;
+
+  while (DemoteLRUForSpace(target)) {
+    if (attempt()) return true;
+  }
+
+  TierBackend* faster_than_target = NextFasterTier(target->tier_id());
+  while (true) {
+    std::string victim = SelectVictim(target);
+    if (victim.empty()) return false;
+    std::vector<std::string> group = GetGroup(victim);
+    for (const auto& k : group) {
+      if (!target->Exists(k)) continue;
+      const bool only_on_target = !faster_than_target || !faster_than_target->Exists(k);
+      target->Evict(k);
+      if (only_on_target) {
+        if (on_tier_change_) {
+          on_tier_change_(k, target->tier_id(), std::nullopt, std::nullopt);
+        }
+        if (index_) index_->Remove(k);
+        RemoveDepthAndGroup(k);
+      }
+    }
+    if (attempt()) return true;
+  }
+}
+
+std::vector<bool> LocalStorageManager::WriteBatchRangesFromPtr(
+    const std::vector<std::string>& keys, const std::vector<size_t>& object_sizes,
+    const std::vector<std::vector<uintptr_t>>& srcs, const std::vector<std::vector<size_t>>& sizes,
+    const std::vector<std::vector<size_t>>& dst_offsets, StorageTier tier) {
+  const size_t n = keys.size();
+  std::vector<bool> results(n, false);
+  if (object_sizes.size() != n || !RangeBatchShapeValid(n, srcs, sizes, dst_offsets) || n == 0 ||
+      tier != StorageTier::CPU_DRAM) {
+    return results;
+  }
+
+  TierBackend* target = GetTier(tier);
+  if (!target) return results;
+
+  std::unordered_set<std::string> seen;
+  std::unordered_set<std::string> duplicates;
+  for (const auto& key : keys) {
+    if (!seen.insert(key).second) duplicates.insert(key);
+  }
+
+  std::vector<std::vector<const void*>> ptrs(n);
+  std::vector<bool> valid(n, false);
+  for (size_t i = 0; i < n; ++i) {
+    valid[i] = duplicates.count(keys[i]) == 0 &&
+               RangesTileObject(object_sizes[i], sizes[i], dst_offsets[i]);
+    ptrs[i].reserve(srcs[i].size());
+    for (uintptr_t src : srcs[i]) ptrs[i].push_back(reinterpret_cast<const void*>(src));
+  }
+  results = target->BatchWriteRanges(keys, object_sizes, ptrs, sizes, dst_offsets);
+  if (results.size() != n) results.assign(n, false);
+  for (size_t i = 0; i < n; ++i) {
+    if (duplicates.count(keys[i]) != 0) results[i] = false;
+  }
+
+  for (size_t i = 0; i < n; ++i) {
+    if (!results[i] && valid[i]) {
+      results[i] =
+          WriteRangesFromPtr(keys[i], object_sizes[i], srcs[i], sizes[i], dst_offsets[i], tier);
+    }
+  }
+  return results;
+}
+
 bool LocalStorageManager::ReadIntoPtr(const std::string& key, uintptr_t dst, size_t size) {
   bool ok = ReadIntoPtrNoPromote(key, dst, size);
   if (ok && config_.eviction.auto_promote_on_read) {
@@ -829,6 +922,21 @@ std::vector<bool> LocalStorageManager::ReadBatchIntoPtr(const std::vector<std::s
     results[idx] = ReadIntoPtr(keys[idx], dst_ptrs[idx], sizes[idx]);
   }
 
+  return results;
+}
+
+std::vector<bool> LocalStorageManager::ReadBatchRangesIntoPtr(
+    const std::vector<std::string>& keys, const std::vector<std::vector<uintptr_t>>& dst_ptrs,
+    const std::vector<std::vector<size_t>>& sizes,
+    const std::vector<std::vector<size_t>>& src_offsets) {
+  const size_t n = keys.size();
+  std::vector<bool> results(n, false);
+  if (!RangeBatchShapeValid(n, dst_ptrs, sizes, src_offsets) || n == 0) return results;
+
+  TierBackend* dram = GetTier(StorageTier::CPU_DRAM);
+  if (!dram) return results;
+  results = dram->ReadBatchRangesIntoPtr(keys, dst_ptrs, sizes, src_offsets);
+  if (results.size() != n) results.assign(n, false);
   return results;
 }
 

--- a/src/umbp/local/tiers/tier_backend.cpp
+++ b/src/umbp/local/tiers/tier_backend.cpp
@@ -49,6 +49,13 @@ std::vector<bool> TierBackend::ReadBatchIntoPtr(const std::vector<std::string>& 
   return results;
 }
 
+std::vector<bool> TierBackend::ReadBatchRangesIntoPtr(
+    const std::vector<std::string>& keys, const std::vector<std::vector<uintptr_t>>& /*dst_ptrs*/,
+    const std::vector<std::vector<size_t>>& /*sizes*/,
+    const std::vector<std::vector<size_t>>& /*src_offsets*/) {
+  return std::vector<bool>(keys.size(), false);
+}
+
 std::vector<bool> TierBackend::BatchWrite(const std::vector<std::string>& keys,
                                           const std::vector<const void*>& data_ptrs,
                                           const std::vector<size_t>& sizes) {
@@ -57,6 +64,14 @@ std::vector<bool> TierBackend::BatchWrite(const std::vector<std::string>& keys,
     results[i] = Write(keys[i], data_ptrs[i], sizes[i]);
   }
   return results;
+}
+
+std::vector<bool> TierBackend::BatchWriteRanges(
+    const std::vector<std::string>& keys, const std::vector<size_t>& /*object_sizes*/,
+    const std::vector<std::vector<const void*>>& /*src_ptrs*/,
+    const std::vector<std::vector<size_t>>& /*sizes*/,
+    const std::vector<std::vector<size_t>>& /*dst_offsets*/) {
+  return std::vector<bool>(keys.size(), false);
 }
 
 std::vector<bool> TierBackend::BatchReadIntoPtr(const std::vector<std::string>& keys,

--- a/src/umbp/standalone/bin/standalone_server_main.cpp
+++ b/src/umbp/standalone/bin/standalone_server_main.cpp
@@ -157,6 +157,12 @@ bool ApplyDistributedBackendConfigFromEnv(mori::umbp::UMBPConfig* config,
   if (!ParseUint16Env("UMBP_PEER_SERVICE_PORT", &dist.peer_service_port, error)) return false;
   if (!ParseSizeEnv("UMBP_DISTRIBUTED_STAGING_BUFFER_SIZE", &dist.staging_buffer_size, error))
     return false;
+  if (!ParseSizeEnv("UMBP_DISTRIBUTED_RANGED_SCRATCH_BYTES", &dist.ranged_scratch_size, error))
+    return false;
+  if (dist.ranged_scratch_size == 0) {
+    *error = "UMBP_DISTRIBUTED_RANGED_SCRATCH_BYTES must be > 0";
+    return false;
+  }
   if (!ParseSizeEnv("UMBP_DISTRIBUTED_SSD_STAGING_BUFFER_SIZE", &dist.ssd_staging_buffer_size,
                     error)) {
     return false;
@@ -174,6 +180,10 @@ bool ApplyDistributedBackendConfigFromEnv(mori::umbp::UMBPConfig* config,
   size_t dram_page_size = static_cast<size_t>(dist.dram_page_size);
   if (!ParseSizeEnv("UMBP_DISTRIBUTED_DRAM_PAGE_SIZE", &dram_page_size, error)) return false;
   dist.dram_page_size = static_cast<uint64_t>(dram_page_size);
+  if (dist.dram_page_size == 0) {
+    *error = "UMBP_DISTRIBUTED_DRAM_PAGE_SIZE must be explicitly set to > 0";
+    return false;
+  }
 
   config->distributed = dist;
   return true;

--- a/src/umbp/standalone/bin/standalone_server_main.cpp
+++ b/src/umbp/standalone/bin/standalone_server_main.cpp
@@ -159,10 +159,6 @@ bool ApplyDistributedBackendConfigFromEnv(mori::umbp::UMBPConfig* config,
     return false;
   if (!ParseSizeEnv("UMBP_DISTRIBUTED_RANGED_SCRATCH_BYTES", &dist.ranged_scratch_size, error))
     return false;
-  if (dist.ranged_scratch_size == 0) {
-    *error = "UMBP_DISTRIBUTED_RANGED_SCRATCH_BYTES must be > 0";
-    return false;
-  }
   if (!ParseSizeEnv("UMBP_DISTRIBUTED_SSD_STAGING_BUFFER_SIZE", &dist.ssd_staging_buffer_size,
                     error)) {
     return false;

--- a/src/umbp/standalone/standalone_process_client.cpp
+++ b/src/umbp/standalone/standalone_process_client.cpp
@@ -77,6 +77,18 @@ TierType TierFromProto(::umbp::TierType tier) {
   }
 }
 
+UMBPDeploymentMode BackendModeFromProto(::umbp::StandaloneBackendMode mode) {
+  switch (mode) {
+    case ::umbp::STANDALONE_BACKEND_LOCAL:
+      return UMBPDeploymentMode::Local;
+    case ::umbp::STANDALONE_BACKEND_DISTRIBUTED:
+      return UMBPDeploymentMode::Distributed;
+    case ::umbp::STANDALONE_BACKEND_UNKNOWN:
+    default:
+      return UMBPDeploymentMode::StandaloneProcess;
+  }
+}
+
 bool IsLocalRankZero() {
   for (const char* name :
        {"LOCAL_RANK", "OMPI_COMM_WORLD_LOCAL_RANK", "SLURM_LOCALID", "MPI_LOCALRANKID"}) {
@@ -207,7 +219,7 @@ std::string StandaloneProcessClient::ClientId() {
   return client_id_;
 }
 
-bool StandaloneProcessClient::WaitReady(int timeout_ms) const {
+bool StandaloneProcessClient::WaitReady(int timeout_ms) {
   const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
   while (std::chrono::steady_clock::now() < deadline) {
     grpc::ClientContext ctx;
@@ -215,7 +227,11 @@ bool StandaloneProcessClient::WaitReady(int timeout_ms) const {
     ::umbp::Empty req;
     ::umbp::PingResponse resp;
     grpc::Status status = stub_->Ping(&ctx, req, &resp);
-    if (status.ok() && resp.ready()) return true;
+    if (status.ok() && resp.ready()) {
+      backend_mode_ = BackendModeFromProto(resp.deployment_mode());
+      supports_ranged_io_ = resp.supports_ranged_io();
+      return true;
+    }
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
   return false;

--- a/src/umbp/standalone/standalone_process_client.cpp
+++ b/src/umbp/standalone/standalone_process_client.cpp
@@ -41,6 +41,7 @@
 #include <thread>
 
 #include "mori/utils/mori_log.hpp"
+#include "umbp/common/device_copy.h"
 #include "umbp/local/host_mem_allocator.h"
 #include "umbp/standalone/ipc.h"
 
@@ -460,7 +461,11 @@ void StandaloneProcessClient::Close() {
   if (closed_) return;
   try {
     DeregisterMemoryLocked();
+  } catch (const std::exception& error) {
+    MORI_UMBP_ERROR("[StandaloneProcessClient] deregistration during close failed: {}",
+                    error.what());
   } catch (...) {
+    MORI_UMBP_ERROR("[StandaloneProcessClient] deregistration during close failed");
   }
   closed_ = true;
   stub_.reset();
@@ -472,6 +477,86 @@ bool StandaloneProcessClient::RegisterMemory(uintptr_t ptr, size_t size) {
   std::unique_lock lk(op_mutex_);
   if (closed_) return false;
 
+  const PointerLocation location = DetectPointerLocation(reinterpret_cast<void*>(ptr));
+  if (location.IsDevice()) return RegisterDeviceMemory(ptr, size, location.device_id);
+  return RegisterHostShmMemory(ptr, size);
+}
+
+bool StandaloneProcessClient::RegisterDeviceMemory(uintptr_t ptr, size_t size, int device_id) {
+  if (ptr == 0 || size == 0) return false;
+  ScopedHipDevice device_guard(device_id);
+  if (!device_guard.IsValid()) {
+    MORI_UMBP_ERROR("[StandaloneProcessClient] failed to select GPU device {}", device_id);
+    return false;
+  }
+
+  void* allocation_base = nullptr;
+  size_t allocation_size = 0;
+  const hipError_t range_status =
+      hipMemGetAddressRange(reinterpret_cast<hipDeviceptr_t*>(&allocation_base), &allocation_size,
+                            reinterpret_cast<hipDeviceptr_t>(ptr));
+  if (range_status != hipSuccess || allocation_base == nullptr) {
+    MORI_UMBP_ERROR("[StandaloneProcessClient] hipMemGetAddressRange failed for ptr=0x{:x}: {}",
+                    ptr, hipGetErrorString(range_status));
+    (void)hipGetLastError();
+    return false;
+  }
+
+  const uintptr_t allocation_address = reinterpret_cast<uintptr_t>(allocation_base);
+  if (ptr < allocation_address) return false;
+  const uint64_t ipc_offset = static_cast<uint64_t>(ptr - allocation_address);
+  if (ipc_offset > allocation_size || size > allocation_size - ipc_offset) {
+    MORI_UMBP_ERROR(
+        "[StandaloneProcessClient] GPU registration range exceeds allocation: ptr=0x{:x} "
+        "size={} alloc_base=0x{:x} alloc_size={}",
+        ptr, size, allocation_address, allocation_size);
+    return false;
+  }
+
+  hipIpcMemHandle_t handle{};
+  const hipError_t handle_status = hipIpcGetMemHandle(&handle, allocation_base);
+  if (handle_status != hipSuccess) {
+    MORI_UMBP_ERROR("[StandaloneProcessClient] hipIpcGetMemHandle failed for ptr=0x{:x}: {}", ptr,
+                    hipGetErrorString(handle_status));
+    (void)hipGetLastError();
+    return false;
+  }
+
+  ::umbp::RegisterMemoryRequest req;
+  req.set_client_id(ClientId());
+  req.set_worker_base(ptr);
+  req.set_size(size);
+  req.set_worker_node_id(standalone_config_.worker_node_id);
+  req.set_worker_node_address(standalone_config_.worker_node_address);
+  for (const auto& tag : standalone_config_.tags) req.add_tags(tag);
+  req.set_kind(::umbp::MEMORY_KIND_GPU_IPC);
+  req.set_device_id(device_id);
+  req.set_ipc_handle(reinterpret_cast<const char*>(&handle), sizeof(handle));
+  req.set_ipc_offset(ipc_offset);
+  req.set_alloc_base(allocation_address);
+
+  grpc::ClientContext ctx;
+  ::umbp::BoolResponse resp;
+  const grpc::Status rpc_status = stub_->RegisterMemory(&ctx, req, &resp);
+  if (!rpc_status.ok() || !resp.ok()) {
+    MORI_UMBP_ERROR("[StandaloneProcessClient] GPU RegisterMemory failed: {}",
+                    rpc_status.ok() ? resp.error() : rpc_status.error_message());
+    return false;
+  }
+
+  std::lock_guard<std::mutex> lock(registration_mu_);
+  auto existing = std::find_if(regions_.begin(), regions_.end(), [&](const RegisteredRegion& r) {
+    return r.base == ptr && r.kind == RegionKind::kGpuIpc;
+  });
+  if (existing != regions_.end()) {
+    existing->size = size;
+  } else {
+    regions_.push_back({ptr, size, RegionKind::kGpuIpc});
+  }
+  return true;
+}
+
+bool StandaloneProcessClient::RegisterHostShmMemory(uintptr_t ptr, size_t size) {
   auto allocation = HostMemAllocator::AcquireShmAllocation(ptr, size);
   if (!allocation.has_value()) {
     throw std::runtime_error(
@@ -514,7 +599,7 @@ bool StandaloneProcessClient::RegisterMemory(uintptr_t ptr, size_t size) {
       existing->size = allocation->mapped_size;
       HostMemAllocator::ReleaseShmAllocation(base);
     } else {
-      regions_.push_back({base, allocation->mapped_size});
+      regions_.push_back({base, allocation->mapped_size, RegionKind::kHostShm});
     }
     acquired_kept = true;
   } catch (...) {
@@ -533,7 +618,7 @@ void StandaloneProcessClient::DeregisterMemoryLocked() {
     std::lock_guard<std::mutex> lock(registration_mu_);
     if (regions_.empty()) return;
     client_id = client_id_;
-    regions.swap(regions_);
+    regions = regions_;
   }
 
   // One RPC tears down all of this client's regions server-side (UnmapClient),
@@ -542,8 +627,21 @@ void StandaloneProcessClient::DeregisterMemoryLocked() {
   ::umbp::DeregisterMemoryRequest req;
   req.set_client_id(client_id);
   ::umbp::Empty resp;
-  if (stub_) stub_->DeregisterMemory(&ctx, req, &resp);
-  for (const auto& region : regions) HostMemAllocator::ReleaseShmAllocation(region.base);
+  if (!stub_) throw std::runtime_error("standalone DeregisterMemory RPC has no active stub");
+  const grpc::Status status = stub_->DeregisterMemory(&ctx, req, &resp);
+  if (!status.ok()) {
+    throw std::runtime_error("standalone DeregisterMemory RPC failed: " + status.error_message());
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(registration_mu_);
+    regions_.clear();
+  }
+  for (const auto& region : regions) {
+    if (region.kind == RegionKind::kHostShm) {
+      HostMemAllocator::ReleaseShmAllocation(region.base);
+    }
+  }
 }
 
 void StandaloneProcessClient::DeregisterMemory(uintptr_t /*ptr*/) {

--- a/src/umbp/standalone/standalone_process_client.cpp
+++ b/src/umbp/standalone/standalone_process_client.cpp
@@ -42,6 +42,7 @@
 
 #include "mori/utils/mori_log.hpp"
 #include "umbp/common/device_copy.h"
+#include "umbp/common/range_utils.h"
 #include "umbp/local/host_mem_allocator.h"
 #include "umbp/standalone/ipc.h"
 
@@ -403,6 +404,76 @@ std::vector<bool> StandaloneProcessClient::BatchGet(const std::vector<std::strin
   if (!status.ok() || resp.ok_size() != static_cast<int>(keys.size())) {
     return std::vector<bool>(keys.size(), false);
   }
+  return std::vector<bool>(resp.ok().begin(), resp.ok().end());
+}
+
+std::vector<bool> StandaloneProcessClient::BatchGetRanges(
+    const std::vector<std::string>& keys, const std::vector<std::vector<uintptr_t>>& dsts,
+    const std::vector<std::vector<size_t>>& sizes,
+    const std::vector<std::vector<size_t>>& src_offsets) {
+  std::vector<bool> failed(keys.size(), false);
+  if (closing_) return failed;
+  std::shared_lock lk(op_mutex_);
+  if (closed_ || !RangeBatchShapeValid(keys.size(), dsts, sizes, src_offsets)) return failed;
+
+  ::umbp::BatchRangeDataRequest req;
+  req.set_client_id(ClientId());
+  for (size_t i = 0; i < keys.size(); ++i) {
+    if (dsts[i].size() > std::numeric_limits<uint32_t>::max()) return failed;
+    req.add_keys(keys[i]);
+    req.add_range_counts(static_cast<uint32_t>(dsts[i].size()));
+    for (size_t j = 0; j < dsts[i].size(); ++j) {
+      uint64_t shm_offset = 0;
+      uint64_t region_base = 0;
+      if (!OffsetFor(dsts[i][j], sizes[i][j], &shm_offset, &region_base)) return failed;
+      req.add_shm_offsets(shm_offset);
+      req.add_region_bases(region_base);
+      req.add_sizes(sizes[i][j]);
+      req.add_object_offsets(src_offsets[i][j]);
+    }
+  }
+
+  grpc::ClientContext ctx;
+  ::umbp::BatchBoolResponse resp;
+  const grpc::Status status = stub_->BatchGetRanges(&ctx, req, &resp);
+  if (!status.ok() || resp.ok_size() != static_cast<int>(keys.size())) return failed;
+  return std::vector<bool>(resp.ok().begin(), resp.ok().end());
+}
+
+std::vector<bool> StandaloneProcessClient::BatchPutRanges(
+    const std::vector<std::string>& keys, const std::vector<size_t>& object_sizes,
+    const std::vector<std::vector<uintptr_t>>& srcs, const std::vector<std::vector<size_t>>& sizes,
+    const std::vector<std::vector<size_t>>& dst_offsets) {
+  std::vector<bool> failed(keys.size(), false);
+  if (closing_) return failed;
+  std::shared_lock lk(op_mutex_);
+  if (closed_ || object_sizes.size() != keys.size() ||
+      !RangeBatchShapeValid(keys.size(), srcs, sizes, dst_offsets)) {
+    return failed;
+  }
+
+  ::umbp::BatchRangeDataRequest req;
+  req.set_client_id(ClientId());
+  for (size_t i = 0; i < keys.size(); ++i) {
+    if (srcs[i].size() > std::numeric_limits<uint32_t>::max()) return failed;
+    req.add_keys(keys[i]);
+    req.add_object_sizes(object_sizes[i]);
+    req.add_range_counts(static_cast<uint32_t>(srcs[i].size()));
+    for (size_t j = 0; j < srcs[i].size(); ++j) {
+      uint64_t shm_offset = 0;
+      uint64_t region_base = 0;
+      if (!OffsetFor(srcs[i][j], sizes[i][j], &shm_offset, &region_base)) return failed;
+      req.add_shm_offsets(shm_offset);
+      req.add_region_bases(region_base);
+      req.add_sizes(sizes[i][j]);
+      req.add_object_offsets(dst_offsets[i][j]);
+    }
+  }
+
+  grpc::ClientContext ctx;
+  ::umbp::BatchBoolResponse resp;
+  const grpc::Status status = stub_->BatchPutRanges(&ctx, req, &resp);
+  if (!status.ok() || resp.ok_size() != static_cast<int>(keys.size())) return failed;
   return std::vector<bool>(resp.ok().begin(), resp.ok().end());
 }
 

--- a/src/umbp/standalone/standalone_server.cpp
+++ b/src/umbp/standalone/standalone_server.cpp
@@ -173,7 +173,8 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
   Impl(const UMBPConfig& config, std::string address)
       : backend_config_(NormalizeBackendConfig(config)),
         client_(CreateUMBPClient(backend_config_)),
-        shared_reads_(client_->GetDeploymentMode() == UMBPDeploymentMode::Local &&
+        shared_reads_((client_->GetDeploymentMode() == UMBPDeploymentMode::Local ||
+                       client_->GetDeploymentMode() == UMBPDeploymentMode::Distributed) &&
                       !backend_config_.ssd.enabled),
         address_(std::move(address)),
         fd_socket_path_(DeriveFdSocketPath(address_)) {}
@@ -218,8 +219,9 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
     chmod(grpc_path.c_str(), 0600);
     MORI_UMBP_INFO("[StandaloneServer] listening grpc={} fd_socket={}", address_, fd_socket_path_);
     if (shared_reads_) {
-      MORI_UMBP_INFO(
-          "[StandaloneServer] data plane: concurrent reads (local backend, SSD disabled)");
+      MORI_UMBP_INFO("[StandaloneServer] data plane: concurrent reads ({} backend, SSD disabled)",
+                     client_->GetDeploymentMode() == UMBPDeploymentMode::Distributed ? "distributed"
+                                                                                     : "local");
     } else if (client_->GetDeploymentMode() != UMBPDeploymentMode::Local) {
       MORI_UMBP_INFO("[StandaloneServer] data plane: serialized reads (non-local backend)");
     } else {
@@ -258,6 +260,7 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
                     ::umbp::PingResponse* response) override {
     response->set_ready(!shutdown_.load());
     response->set_deployment_mode(BackendModeToProto(client_->GetDeploymentMode()));
+    response->set_supports_ranged_io(!backend_config_.ssd.enabled && client_->SupportsRangedIO());
     return grpc::Status::OK;
   }
 
@@ -526,7 +529,14 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
       return grpc::Status::OK;
     }
     if (request->kind() == ::umbp::MEMORY_KIND_GPU_IPC) {
+      std::lock_guard<std::mutex> lifecycle_lock(external_identity_lifecycle_mu_);
       RegisterGpuIpc(*request, response);
+      if (response->ok() && !EnsureExternalIdentity(*request)) {
+        MORI_UMBP_WARN(
+            "[StandaloneServer] external-KV identity registration failed for client_id={} "
+            "worker_node_id={}; continuing with core GPU registration",
+            request->client_id(), request->worker_node_id());
+      }
       return grpc::Status::OK;
     }
     std::lock_guard<std::mutex> lifecycle_lock(external_identity_lifecycle_mu_);
@@ -905,8 +915,9 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
 
   void RegisterGpuIpc(const ::umbp::RegisterMemoryRequest& request,
                       ::umbp::BoolResponse* response) {
-    if (client_->GetDeploymentMode() != UMBPDeploymentMode::Local) {
-      SetBool(response, false, "GPU IPC registration requires a Local inner backend");
+    const UMBPDeploymentMode mode = client_->GetDeploymentMode();
+    if (mode != UMBPDeploymentMode::Local && mode != UMBPDeploymentMode::Distributed) {
+      SetBool(response, false, "GPU IPC registration requires a Local or Distributed backend");
       return;
     }
     if (backend_config_.ssd.enabled) {
@@ -969,7 +980,12 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
     entry.device_id = request.device_id();
     entry.alloc_base = request.alloc_base();
     entry.client_id = request.client_id();
-    if (!RegisterBackendMemory(entry.base, static_cast<size_t>(entry.size))) {
+    // Ranged distributed I/O stages remote objects through a registered host
+    // arena. The imported worker mapping is only a local HIP copy endpoint;
+    // registering it as an RDMA MR is unnecessary and the dmabuf fallback is
+    // unsafe for IPC-imported ROCm mappings.
+    if (mode == UMBPDeploymentMode::Local &&
+        !RegisterBackendMemory(entry.base, static_cast<size_t>(entry.size))) {
       ReleaseIpcMapping(key);
       SetBool(response, false, "inner backend RegisterMemory failed");
       return;

--- a/src/umbp/standalone/standalone_server.cpp
+++ b/src/umbp/standalone/standalone_server.cpp
@@ -173,9 +173,10 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
   Impl(const UMBPConfig& config, std::string address)
       : backend_config_(NormalizeBackendConfig(config)),
         client_(CreateUMBPClient(backend_config_)),
-        shared_reads_((client_->GetDeploymentMode() == UMBPDeploymentMode::Local ||
-                       client_->GetDeploymentMode() == UMBPDeploymentMode::Distributed) &&
-                      !backend_config_.ssd.enabled),
+        shared_reads_(!backend_config_.ssd.enabled &&
+                      (client_->GetDeploymentMode() == UMBPDeploymentMode::Local ||
+                       (client_->GetDeploymentMode() == UMBPDeploymentMode::Distributed &&
+                        client_->SupportsRangedIO()))),
         address_(std::move(address)),
         fd_socket_path_(DeriveFdSocketPath(address_)) {}
 

--- a/src/umbp/standalone/standalone_server.cpp
+++ b/src/umbp/standalone/standalone_server.cpp
@@ -42,6 +42,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <shared_mutex>
 #include <string>
 #include <thread>
 #include <tuple>
@@ -144,6 +145,27 @@ std::chrono::milliseconds FdHandshakeTimeout() {
   return std::chrono::milliseconds(value);
 }
 
+// Keeps the read-handler bodies independent of the deployment-specific lock
+// policy. Exactly one of the two deferred locks owns the mutex.
+class ConditionalReadLock {
+ public:
+  ConditionalReadLock(std::shared_mutex& mutex, bool shared)
+      : shared_(mutex, std::defer_lock), exclusive_(mutex, std::defer_lock) {
+    if (shared) {
+      shared_.lock();
+    } else {
+      exclusive_.lock();
+    }
+  }
+
+  ConditionalReadLock(const ConditionalReadLock&) = delete;
+  ConditionalReadLock& operator=(const ConditionalReadLock&) = delete;
+
+ private:
+  std::shared_lock<std::shared_mutex> shared_;
+  std::unique_lock<std::shared_mutex> exclusive_;
+};
+
 }  // namespace
 
 class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
@@ -151,6 +173,8 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
   Impl(const UMBPConfig& config, std::string address)
       : backend_config_(NormalizeBackendConfig(config)),
         client_(CreateUMBPClient(backend_config_)),
+        shared_reads_(client_->GetDeploymentMode() == UMBPDeploymentMode::Local &&
+                      !backend_config_.ssd.enabled),
         address_(std::move(address)),
         fd_socket_path_(DeriveFdSocketPath(address_)) {}
 
@@ -193,6 +217,14 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
 
     chmod(grpc_path.c_str(), 0600);
     MORI_UMBP_INFO("[StandaloneServer] listening grpc={} fd_socket={}", address_, fd_socket_path_);
+    if (shared_reads_) {
+      MORI_UMBP_INFO(
+          "[StandaloneServer] data plane: concurrent reads (local backend, SSD disabled)");
+    } else if (client_->GetDeploymentMode() != UMBPDeploymentMode::Local) {
+      MORI_UMBP_INFO("[StandaloneServer] data plane: serialized reads (non-local backend)");
+    } else {
+      MORI_UMBP_INFO("[StandaloneServer] data plane: serialized reads (SSD enabled)");
+    }
     return true;
   }
 
@@ -210,12 +242,12 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
     }
     UnregisterAllExternalIdentities();
     {
-      std::lock_guard<std::mutex> lock(client_mu_);
+      std::unique_lock<std::shared_mutex> lock(client_mu_);
       client_->Flush();
     }
     UnmapAll();
     {
-      std::lock_guard<std::mutex> lock(client_mu_);
+      std::unique_lock<std::shared_mutex> lock(client_mu_);
       client_->Close();
     }
     unlink(UnixPathFromGrpcAddress(address_).c_str());
@@ -231,13 +263,13 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
 
   grpc::Status Put(grpc::ServerContext*, const ::umbp::PutRequest* request,
                    ::umbp::BoolResponse* response) override {
+    std::unique_lock<std::shared_mutex> lock(client_mu_);
     uintptr_t ptr = 0;
     if (!ResolveRange(request->client_id(), request->region_base(), request->shm_offset(),
                       request->size(), &ptr)) {
       SetBool(response, false, "unregistered or out-of-range shm buffer");
       return grpc::Status::OK;
     }
-    std::lock_guard<std::mutex> lock(client_mu_);
     if (shutdown_.load()) {
       SetBool(response, false, "server is shutting down");
       return grpc::Status::OK;
@@ -248,13 +280,13 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
 
   grpc::Status Get(grpc::ServerContext*, const ::umbp::GetRequest* request,
                    ::umbp::BoolResponse* response) override {
+    ConditionalReadLock lock(client_mu_, shared_reads_);
     uintptr_t ptr = 0;
     if (!ResolveRange(request->client_id(), request->region_base(), request->shm_offset(),
                       request->size(), &ptr)) {
       SetBool(response, false, "unregistered or out-of-range shm buffer");
       return grpc::Status::OK;
     }
-    std::lock_guard<std::mutex> lock(client_mu_);
     if (shutdown_.load()) {
       SetBool(response, false, "server is shutting down");
       return grpc::Status::OK;
@@ -265,14 +297,14 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
 
   grpc::Status BatchPut(grpc::ServerContext*, const ::umbp::BatchDataRequest* request,
                         ::umbp::BatchBoolResponse* response) override {
+    std::vector<std::string> keys(request->keys().begin(), request->keys().end());
+    std::vector<size_t> sizes = Sizes(*request);
+    std::unique_lock<std::shared_mutex> lock(client_mu_);
     std::vector<uintptr_t> ptrs;
     if (!ResolveBatch(*request, &ptrs)) {
       FillFalse(request->keys_size(), response);
       return grpc::Status::OK;
     }
-    std::vector<std::string> keys(request->keys().begin(), request->keys().end());
-    std::vector<size_t> sizes = Sizes(*request);
-    std::lock_guard<std::mutex> lock(client_mu_);
     if (shutdown_.load()) {
       FillFalse(request->keys_size(), response);
       return grpc::Status::OK;
@@ -285,8 +317,7 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
                                  const ::umbp::BatchDataWithDepthRequest* request,
                                  ::umbp::BatchBoolResponse* response) override {
     // region_bases is optional for legacy single-region callers; when present it
-    // must be parallel to keys (BatchPutWithDepth resolves inline, not through
-    // ResolveBatch).
+    // must be parallel to keys.
     const bool has_region_bases = request->region_bases_size() > 0;
     if (request->keys_size() != request->shm_offsets_size() ||
         request->keys_size() != request->sizes_size() ||
@@ -294,24 +325,24 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
       FillFalse(request->keys_size(), response);
       return grpc::Status::OK;
     }
-    std::vector<uintptr_t> ptrs;
-    ptrs.reserve(request->keys_size());
-    for (int i = 0; i < request->keys_size(); ++i) {
-      uintptr_t ptr = 0;
-      uint64_t region_base = has_region_bases ? request->region_bases(i) : 0;
-      if (!ResolveRange(request->client_id(), region_base, request->shm_offsets(i),
-                        request->sizes(i), &ptr)) {
-        FillFalse(request->keys_size(), response);
-        return grpc::Status::OK;
-      }
-      ptrs.push_back(ptr);
-    }
     std::vector<std::string> keys(request->keys().begin(), request->keys().end());
     std::vector<size_t> sizes;
     sizes.reserve(request->sizes_size());
     for (uint64_t size : request->sizes()) sizes.push_back(static_cast<size_t>(size));
     std::vector<int> depths(request->depths().begin(), request->depths().end());
-    std::lock_guard<std::mutex> lock(client_mu_);
+    std::vector<RangeQuery> queries;
+    queries.reserve(request->keys_size());
+    for (int i = 0; i < request->keys_size(); ++i) {
+      queries.push_back({has_region_bases ? request->region_bases(i) : 0, request->shm_offsets(i),
+                         request->sizes(i)});
+    }
+
+    std::unique_lock<std::shared_mutex> lock(client_mu_);
+    std::vector<uintptr_t> ptrs;
+    if (!ResolveRanges(request->client_id(), queries, &ptrs)) {
+      FillFalse(request->keys_size(), response);
+      return grpc::Status::OK;
+    }
     if (shutdown_.load()) {
       FillFalse(request->keys_size(), response);
       return grpc::Status::OK;
@@ -322,14 +353,14 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
 
   grpc::Status BatchGet(grpc::ServerContext*, const ::umbp::BatchDataRequest* request,
                         ::umbp::BatchBoolResponse* response) override {
+    std::vector<std::string> keys(request->keys().begin(), request->keys().end());
+    std::vector<size_t> sizes = Sizes(*request);
+    ConditionalReadLock lock(client_mu_, shared_reads_);
     std::vector<uintptr_t> ptrs;
     if (!ResolveBatch(*request, &ptrs)) {
       FillFalse(request->keys_size(), response);
       return grpc::Status::OK;
     }
-    std::vector<std::string> keys(request->keys().begin(), request->keys().end());
-    std::vector<size_t> sizes = Sizes(*request);
-    std::lock_guard<std::mutex> lock(client_mu_);
     if (shutdown_.load()) {
       FillFalse(request->keys_size(), response);
       return grpc::Status::OK;
@@ -340,7 +371,7 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
 
   grpc::Status Exists(grpc::ServerContext*, const ::umbp::KeyRequest* request,
                       ::umbp::BoolResponse* response) override {
-    std::lock_guard<std::mutex> lock(client_mu_);
+    ConditionalReadLock lock(client_mu_, shared_reads_);
     if (shutdown_.load()) {
       SetBool(response, false, "server is shutting down");
       return grpc::Status::OK;
@@ -352,7 +383,7 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
   grpc::Status BatchExists(grpc::ServerContext*, const ::umbp::BatchKeysRequest* request,
                            ::umbp::BatchBoolResponse* response) override {
     std::vector<std::string> keys(request->keys().begin(), request->keys().end());
-    std::lock_guard<std::mutex> lock(client_mu_);
+    ConditionalReadLock lock(client_mu_, shared_reads_);
     if (shutdown_.load()) {
       FillFalse(request->keys_size(), response);
       return grpc::Status::OK;
@@ -364,7 +395,7 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
   grpc::Status BatchExistsConsecutive(grpc::ServerContext*, const ::umbp::BatchKeysRequest* request,
                                       ::umbp::CountResponse* response) override {
     std::vector<std::string> keys(request->keys().begin(), request->keys().end());
-    std::lock_guard<std::mutex> lock(client_mu_);
+    ConditionalReadLock lock(client_mu_, shared_reads_);
     if (shutdown_.load()) {
       response->set_count(0);
       return grpc::Status::OK;
@@ -375,7 +406,7 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
 
   grpc::Status Clear(grpc::ServerContext*, const ::umbp::Empty*,
                      ::umbp::BoolResponse* response) override {
-    std::lock_guard<std::mutex> lock(client_mu_);
+    std::unique_lock<std::shared_mutex> lock(client_mu_);
     if (shutdown_.load()) {
       SetBool(response, false, "server is shutting down");
       return grpc::Status::OK;
@@ -386,7 +417,7 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
 
   grpc::Status Flush(grpc::ServerContext*, const ::umbp::Empty*,
                      ::umbp::BoolResponse* response) override {
-    std::lock_guard<std::mutex> lock(client_mu_);
+    std::unique_lock<std::shared_mutex> lock(client_mu_);
     if (shutdown_.load()) {
       SetBool(response, false, "server is shutting down");
       return grpc::Status::OK;
@@ -408,7 +439,7 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
     std::lock_guard<std::mutex> lifecycle_lock(external_identity_lifecycle_mu_);
     bool ok = false;
     {
-      std::lock_guard<std::mutex> lock(memory_mu_);
+      std::shared_lock<std::shared_mutex> lock(memory_mu_);
       auto it = memory_.find(request->client_id());
       if (it != memory_.end()) {
         ok = std::any_of(it->second.begin(), it->second.end(), [&](const RegisteredMemory& mem) {
@@ -499,7 +530,7 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
     if (auto identity = GetExternalIdentity(request->client_id())) {
       matches = identity->MatchExternalKv(hashes, request->count_as_hit());
     } else {
-      std::lock_guard<std::mutex> lock(client_mu_);
+      ConditionalReadLock lock(client_mu_, shared_reads_);
       if (!shutdown_.load()) matches = client_->MatchExternalKv(hashes, request->count_as_hit());
     }
     FillExternalKvMatches(matches, response);
@@ -515,7 +546,7 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
     if (auto identity = GetExternalIdentity(request->client_id())) {
       entries = identity->GetExternalKvHitCounts(hashes);
     } else {
-      std::lock_guard<std::mutex> lock(client_mu_);
+      ConditionalReadLock lock(client_mu_, shared_reads_);
       if (!shutdown_.load()) entries = client_->GetExternalKvHitCounts(hashes);
     }
     FillExternalKvHitCounts(entries, response);
@@ -533,6 +564,12 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
     int device_id = -1;
     uint64_t alloc_base = 0;
     std::string client_id;
+  };
+
+  struct RangeQuery {
+    uint64_t region_base = 0;
+    uint64_t offset = 0;
+    uint64_t size = 0;
   };
 
   struct IpcKey {
@@ -747,7 +784,7 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
   }
 
   bool HasIdenticalGpuRegion(const ::umbp::RegisterMemoryRequest& request) {
-    std::lock_guard<std::mutex> lock(memory_mu_);
+    std::shared_lock<std::shared_mutex> lock(memory_mu_);
     auto it = memory_.find(request.client_id());
     if (it == memory_.end()) return false;
     return std::any_of(it->second.begin(), it->second.end(), [&](const RegisteredMemory& mem) {
@@ -759,7 +796,7 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
 
   std::optional<RegisteredMemory> InsertOrReplaceRegion(const std::string& client_id,
                                                         const RegisteredMemory& entry) {
-    std::lock_guard<std::mutex> lock(memory_mu_);
+    std::unique_lock<std::shared_mutex> lock(memory_mu_);
     auto& regions = memory_[client_id];
     auto existing = std::find_if(regions.begin(), regions.end(), [&](const RegisteredMemory& mem) {
       return mem.worker_base == entry.worker_base;
@@ -887,7 +924,7 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
   void UnmapClient(const std::string& client_id) {
     std::vector<RegisteredMemory> mems;
     {
-      std::lock_guard<std::mutex> lock(memory_mu_);
+      std::unique_lock<std::shared_mutex> lock(memory_mu_);
       auto it = memory_.find(client_id);
       if (it == memory_.end()) return;
       mems.swap(it->second);
@@ -906,7 +943,7 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
   void UnmapAll() {
     std::vector<RegisteredMemory> entries;
     {
-      std::lock_guard<std::mutex> lock(memory_mu_);
+      std::unique_lock<std::shared_mutex> lock(memory_mu_);
       for (auto& kv : memory_) {
         for (const auto& mem : kv.second) entries.push_back(mem);
       }
@@ -916,7 +953,7 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
   }
 
   bool RegisterBackendMemory(void* base, size_t size) {
-    std::lock_guard<std::mutex> lock(client_mu_);
+    std::unique_lock<std::shared_mutex> lock(client_mu_);
     if (shutdown_.load()) return false;
     return client_->RegisterMemory(reinterpret_cast<uintptr_t>(base), size);
   }
@@ -924,7 +961,7 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
   void ReleaseRegisteredMemory(const RegisteredMemory& mem) {
     if (!mem.base) return;
     {
-      std::lock_guard<std::mutex> lock(client_mu_);
+      std::unique_lock<std::shared_mutex> lock(client_mu_);
       client_->DeregisterMemory(reinterpret_cast<uintptr_t>(mem.base));
     }
     if (mem.kind == MemoryKind::kGpuIpc) {
@@ -940,10 +977,17 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
   bool ResolveRange(const std::string& client_id, uint64_t region_base, uint64_t offset,
                     uint64_t size, uintptr_t* out_ptr) {
     if (!out_ptr || size == 0) return false;
-    std::lock_guard<std::mutex> lock(memory_mu_);
+    std::shared_lock<std::shared_mutex> lock(memory_mu_);
     auto it = memory_.find(client_id);
     if (it == memory_.end()) return false;
-    for (const auto& mem : it->second) {
+    return ResolveRangeInRegions(it->second, region_base, offset, size, out_ptr);
+  }
+
+  static bool ResolveRangeInRegions(const std::vector<RegisteredMemory>& regions,
+                                    uint64_t region_base, uint64_t offset, uint64_t size,
+                                    uintptr_t* out_ptr) {
+    if (!out_ptr || size == 0) return false;
+    for (const auto& mem : regions) {
       if (region_base != 0 && mem.worker_base != region_base) continue;
       if (offset > mem.size || size > mem.size - offset) {
         if (region_base != 0) return false;
@@ -955,6 +999,28 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
     return false;
   }
 
+  bool ResolveRanges(const std::string& client_id, const std::vector<RangeQuery>& queries,
+                     std::vector<uintptr_t>* ptrs) {
+    if (!ptrs) return false;
+    ptrs->clear();
+    ptrs->reserve(queries.size());
+    if (queries.empty()) return true;
+
+    std::shared_lock<std::shared_mutex> lock(memory_mu_);
+    auto it = memory_.find(client_id);
+    if (it == memory_.end()) return false;
+
+    for (const auto& query : queries) {
+      uintptr_t ptr = 0;
+      if (!ResolveRangeInRegions(it->second, query.region_base, query.offset, query.size, &ptr)) {
+        ptrs->clear();
+        return false;
+      }
+      ptrs->push_back(ptr);
+    }
+    return true;
+  }
+
   bool ResolveBatch(const ::umbp::BatchDataRequest& request, std::vector<uintptr_t>* ptrs) {
     // region_bases is optional for legacy single-region callers; when present it
     // must be parallel to keys.
@@ -964,18 +1030,13 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
         (has_region_bases && request.keys_size() != request.region_bases_size())) {
       return false;
     }
-    ptrs->clear();
-    ptrs->reserve(request.keys_size());
+    std::vector<RangeQuery> queries;
+    queries.reserve(request.keys_size());
     for (int i = 0; i < request.keys_size(); ++i) {
-      uintptr_t ptr = 0;
       uint64_t region_base = has_region_bases ? request.region_bases(i) : 0;
-      if (!ResolveRange(request.client_id(), region_base, request.shm_offsets(i), request.sizes(i),
-                        &ptr)) {
-        return false;
-      }
-      ptrs->push_back(ptr);
+      queries.push_back({region_base, request.shm_offsets(i), request.sizes(i)});
     }
-    return true;
+    return ResolveRanges(request.client_id(), queries, ptrs);
   }
 
   static std::vector<size_t> Sizes(const ::umbp::BatchDataRequest& request) {
@@ -1021,13 +1082,17 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
 
   UMBPConfig backend_config_;
   std::unique_ptr<IUMBPClient> client_;
+  const bool shared_reads_;
   std::string address_;
   std::string fd_socket_path_;
   std::unique_ptr<grpc::Server> server_;
   std::atomic<bool> shutdown_{false};
 
-  std::mutex client_mu_;
-  std::mutex memory_mu_;
+  // Data operations acquire client_mu_ before memory_mu_ and keep the client
+  // lock through the backend call, making it the lifetime barrier for resolved
+  // host/GPU mappings. Lifecycle paths never hold the two locks at once.
+  std::shared_mutex client_mu_;
+  mutable std::shared_mutex memory_mu_;
   std::mutex ipc_mu_;
   // A worker registers N non-contiguous host regions (e.g. DeepSeek-V4's KV
   // side pools), so each client_id maps to a list of regions, resolved by

--- a/src/umbp/standalone/standalone_server.cpp
+++ b/src/umbp/standalone/standalone_server.cpp
@@ -37,15 +37,18 @@
 #include <chrono>
 #include <climits>
 #include <cstring>
+#include <limits>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
 #include <thread>
+#include <tuple>
 #include <vector>
 
 #include "mori/utils/mori_log.hpp"
+#include "umbp/common/device_copy.h"
 #include "umbp/standalone/external_kv_identity_client.h"
 #include "umbp/standalone/ipc.h"
 #include "umbp/umbp_client.h"
@@ -398,6 +401,10 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
       SetBool(response, false, "server is shutting down");
       return grpc::Status::OK;
     }
+    if (request->kind() == ::umbp::MEMORY_KIND_GPU_IPC) {
+      RegisterGpuIpc(*request, response);
+      return grpc::Status::OK;
+    }
     std::lock_guard<std::mutex> lifecycle_lock(external_identity_lifecycle_mu_);
     bool ok = false;
     {
@@ -516,10 +523,32 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
   }
 
  private:
+  enum class MemoryKind { kHostShm, kGpuIpc };
+
   struct RegisteredMemory {
     void* base = nullptr;
     uint64_t worker_base = 0;
     uint64_t size = 0;
+    MemoryKind kind = MemoryKind::kHostShm;
+    int device_id = -1;
+    uint64_t alloc_base = 0;
+    std::string client_id;
+  };
+
+  struct IpcKey {
+    std::string client_id;
+    int device_id = -1;
+    uint64_t alloc_base = 0;
+
+    bool operator<(const IpcKey& other) const {
+      return std::tie(client_id, device_id, alloc_base) <
+             std::tie(other.client_id, other.device_id, other.alloc_base);
+    }
+  };
+
+  struct IpcMapping {
+    void* base = nullptr;
+    size_t refcount = 0;
   };
 
   bool BackendIsDistributed() const {
@@ -702,22 +731,12 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
     }
 
     std::string client_id(msg.client_id);
-    RegisteredMemory entry{mapped, static_cast<uint64_t>(msg.worker_base), msg.size};
-    std::optional<RegisteredMemory> old_mem;
-    {
-      std::lock_guard<std::mutex> lock(memory_mu_);
-      auto& regions = memory_[client_id];
-      auto existing = std::find_if(
-          regions.begin(), regions.end(),
-          [&](const RegisteredMemory& mem) { return mem.worker_base == entry.worker_base; });
-      if (existing != regions.end()) {
-        // Same region re-registered: replace the mapping, release the old one.
-        old_mem = *existing;
-        *existing = entry;
-      } else {
-        regions.push_back(entry);
-      }
-    }
+    RegisteredMemory entry;
+    entry.base = mapped;
+    entry.worker_base = static_cast<uint64_t>(msg.worker_base);
+    entry.size = msg.size;
+    entry.client_id = client_id;
+    std::optional<RegisteredMemory> old_mem = InsertOrReplaceRegion(client_id, entry);
     // Release outside the lock, and via ReleaseRegisteredMemory so the backend
     // deregisters the region before its mapping is munmap'd (required by the
     // distributed backend; see design-standalone-process-mode.md §5.3/§6.3).
@@ -725,6 +744,144 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
     MORI_UMBP_INFO("[StandaloneServer] registered shm client_id={} worker_base=0x{:x} size={}MB",
                    client_id, msg.worker_base, msg.size / (1024 * 1024));
     return true;
+  }
+
+  bool HasIdenticalGpuRegion(const ::umbp::RegisterMemoryRequest& request) {
+    std::lock_guard<std::mutex> lock(memory_mu_);
+    auto it = memory_.find(request.client_id());
+    if (it == memory_.end()) return false;
+    return std::any_of(it->second.begin(), it->second.end(), [&](const RegisteredMemory& mem) {
+      return mem.kind == MemoryKind::kGpuIpc && mem.worker_base == request.worker_base() &&
+             mem.size == request.size() && mem.device_id == request.device_id() &&
+             mem.alloc_base == request.alloc_base();
+    });
+  }
+
+  std::optional<RegisteredMemory> InsertOrReplaceRegion(const std::string& client_id,
+                                                        const RegisteredMemory& entry) {
+    std::lock_guard<std::mutex> lock(memory_mu_);
+    auto& regions = memory_[client_id];
+    auto existing = std::find_if(regions.begin(), regions.end(), [&](const RegisteredMemory& mem) {
+      return mem.worker_base == entry.worker_base;
+    });
+    if (existing == regions.end()) {
+      regions.push_back(entry);
+      return std::nullopt;
+    }
+    RegisteredMemory old = *existing;
+    *existing = entry;
+    return old;
+  }
+
+  void RegisterGpuIpc(const ::umbp::RegisterMemoryRequest& request,
+                      ::umbp::BoolResponse* response) {
+    if (client_->GetDeploymentMode() != UMBPDeploymentMode::Local) {
+      SetBool(response, false, "GPU IPC registration requires a Local inner backend");
+      return;
+    }
+    if (backend_config_.ssd.enabled) {
+      SetBool(response, false,
+              "GPU IPC registration requires SSD to be disabled "
+              "(start the server with UMBP_SSD_ENABLED=0)");
+      return;
+    }
+    if (request.client_id().empty() || request.worker_base() == 0 || request.size() == 0 ||
+        request.alloc_base() == 0 || request.ipc_handle().size() != sizeof(hipIpcMemHandle_t)) {
+      SetBool(response, false, "invalid GPU IPC registration payload");
+      return;
+    }
+    if (HasIdenticalGpuRegion(request)) {
+      SetBool(response, true);
+      return;
+    }
+
+    const IpcKey key{request.client_id(), request.device_id(), request.alloc_base()};
+    ScopedHipDevice device_guard(request.device_id());
+    if (!device_guard.IsValid()) {
+      SetBool(response, false, "hipSetDevice failed for the requested device_id");
+      return;
+    }
+
+    void* mapped_base = nullptr;
+    {
+      std::lock_guard<std::mutex> lock(ipc_mu_);
+      auto existing = ipc_maps_.find(key);
+      if (existing != ipc_maps_.end()) {
+        ++existing->second.refcount;
+        mapped_base = existing->second.base;
+      } else {
+        hipIpcMemHandle_t handle{};
+        std::memcpy(&handle, request.ipc_handle().data(), sizeof(handle));
+        const hipError_t status =
+            hipIpcOpenMemHandle(&mapped_base, handle, hipIpcMemLazyEnablePeerAccess);
+        if (status != hipSuccess) {
+          const std::string error = hipGetErrorString(status);
+          (void)hipGetLastError();
+          SetBool(response, false, "hipIpcOpenMemHandle failed: " + error);
+          return;
+        }
+        ipc_maps_.emplace(key, IpcMapping{mapped_base, 1});
+      }
+    }
+
+    const uintptr_t mapped_address = reinterpret_cast<uintptr_t>(mapped_base);
+    if (request.ipc_offset() > std::numeric_limits<uintptr_t>::max() - mapped_address) {
+      ReleaseIpcMapping(key);
+      SetBool(response, false, "GPU IPC offset overflows the mapped address");
+      return;
+    }
+
+    RegisteredMemory entry;
+    entry.base = reinterpret_cast<void*>(mapped_address + request.ipc_offset());
+    entry.worker_base = request.worker_base();
+    entry.size = request.size();
+    entry.kind = MemoryKind::kGpuIpc;
+    entry.device_id = request.device_id();
+    entry.alloc_base = request.alloc_base();
+    entry.client_id = request.client_id();
+    if (!RegisterBackendMemory(entry.base, static_cast<size_t>(entry.size))) {
+      ReleaseIpcMapping(key);
+      SetBool(response, false, "inner backend RegisterMemory failed");
+      return;
+    }
+
+    std::optional<RegisteredMemory> old_mem = InsertOrReplaceRegion(request.client_id(), entry);
+    if (old_mem.has_value()) ReleaseRegisteredMemory(*old_mem);
+    MORI_UMBP_INFO(
+        "[StandaloneServer] registered GPU IPC client_id={} worker_base=0x{:x} size={}MB "
+        "device={}",
+        request.client_id(), request.worker_base(), request.size() / (1024 * 1024),
+        request.device_id());
+    SetBool(response, true);
+  }
+
+  void ReleaseIpcMapping(const IpcKey& key) {
+    void* mapped_base = nullptr;
+    {
+      std::lock_guard<std::mutex> lock(ipc_mu_);
+      auto it = ipc_maps_.find(key);
+      if (it == ipc_maps_.end()) return;
+      if (--it->second.refcount != 0) return;
+      mapped_base = it->second.base;
+      ipc_maps_.erase(it);
+    }
+
+    ScopedHipDevice device_guard(key.device_id);
+    if (!device_guard.IsValid()) {
+      MORI_UMBP_WARN("[StandaloneServer] failed to select GPU {} while closing IPC mapping",
+                     key.device_id);
+    }
+    const hipError_t status = hipIpcCloseMemHandle(mapped_base);
+    if (status != hipSuccess) {
+      MORI_UMBP_WARN("[StandaloneServer] hipIpcCloseMemHandle failed for client_id={}: {}",
+                     key.client_id, hipGetErrorString(status));
+      (void)hipGetLastError();
+    }
+  }
+
+  size_t IpcMappingCount() {
+    std::lock_guard<std::mutex> lock(ipc_mu_);
+    return ipc_maps_.size();
   }
 
   void UnmapClient(const std::string& client_id) {
@@ -736,7 +893,14 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
       mems.swap(it->second);
       memory_.erase(it);
     }
+    const size_t mappings_before = IpcMappingCount();
     for (const auto& mem : mems) ReleaseRegisteredMemory(mem);
+    const size_t mappings_after = IpcMappingCount();
+    MORI_UMBP_INFO(
+        "[StandaloneServer] unmapped client_id={} regions={} ipc_allocations_released={} "
+        "ipc_allocations_remaining={}",
+        client_id, mems.size(),
+        mappings_before >= mappings_after ? mappings_before - mappings_after : 0, mappings_after);
   }
 
   void UnmapAll() {
@@ -763,7 +927,11 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
       std::lock_guard<std::mutex> lock(client_mu_);
       client_->DeregisterMemory(reinterpret_cast<uintptr_t>(mem.base));
     }
-    munmap(mem.base, static_cast<size_t>(mem.size));
+    if (mem.kind == MemoryKind::kGpuIpc) {
+      ReleaseIpcMapping(IpcKey{mem.client_id, mem.device_id, mem.alloc_base});
+    } else {
+      munmap(mem.base, static_cast<size_t>(mem.size));
+    }
   }
 
   // Resolves (client_id, region_base, offset) to a server-local pointer.
@@ -860,10 +1028,12 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
 
   std::mutex client_mu_;
   std::mutex memory_mu_;
+  std::mutex ipc_mu_;
   // A worker registers N non-contiguous host regions (e.g. DeepSeek-V4's KV
   // side pools), so each client_id maps to a list of regions, resolved by
   // worker_base at data-op time.
   std::map<std::string, std::vector<RegisteredMemory>> memory_;
+  std::map<IpcKey, IpcMapping> ipc_maps_;
   std::mutex external_identity_lifecycle_mu_;
   std::mutex external_identity_mu_;
   std::map<std::string, std::shared_ptr<ExternalKvIdentityClient>> external_identities_;

--- a/src/umbp/standalone/standalone_server.cpp
+++ b/src/umbp/standalone/standalone_server.cpp
@@ -313,6 +313,54 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
     return grpc::Status::OK;
   }
 
+  grpc::Status BatchPutRanges(grpc::ServerContext*, const ::umbp::BatchRangeDataRequest* request,
+                              ::umbp::BatchBoolResponse* response) override {
+    size_t total_ranges = 0;
+    if (!ValidateRangeRequest(*request, /*put=*/true, &total_ranges)) {
+      FillFalse(request->keys_size(), response);
+      return grpc::Status::OK;
+    }
+
+    std::vector<RangeQuery> queries;
+    queries.reserve(total_ranges);
+    for (size_t i = 0; i < total_ranges; ++i) {
+      queries.push_back({request->region_bases(static_cast<int>(i)),
+                         request->shm_offsets(static_cast<int>(i)),
+                         request->sizes(static_cast<int>(i))});
+    }
+
+    std::unique_lock<std::shared_mutex> lock(client_mu_);
+    std::vector<uintptr_t> flat_ptrs;
+    if (!ResolveRanges(request->client_id(), queries, &flat_ptrs, /*allow_zero=*/true) ||
+        shutdown_.load()) {
+      FillFalse(request->keys_size(), response);
+      return grpc::Status::OK;
+    }
+
+    std::vector<std::string> keys(request->keys().begin(), request->keys().end());
+    std::vector<size_t> object_sizes;
+    object_sizes.reserve(keys.size());
+    for (uint64_t size : request->object_sizes()) object_sizes.push_back(static_cast<size_t>(size));
+    std::vector<std::vector<uintptr_t>> ptrs(keys.size());
+    std::vector<std::vector<size_t>> sizes(keys.size());
+    std::vector<std::vector<size_t>> offsets(keys.size());
+    size_t cursor = 0;
+    for (size_t i = 0; i < keys.size(); ++i) {
+      const size_t count = request->range_counts(static_cast<int>(i));
+      ptrs[i].reserve(count);
+      sizes[i].reserve(count);
+      offsets[i].reserve(count);
+      for (size_t j = 0; j < count; ++j, ++cursor) {
+        ptrs[i].push_back(flat_ptrs[cursor]);
+        sizes[i].push_back(static_cast<size_t>(request->sizes(static_cast<int>(cursor))));
+        offsets[i].push_back(
+            static_cast<size_t>(request->object_offsets(static_cast<int>(cursor))));
+      }
+    }
+    FillResults(client_->BatchPutRanges(keys, object_sizes, ptrs, sizes, offsets), response);
+    return grpc::Status::OK;
+  }
+
   grpc::Status BatchPutWithDepth(grpc::ServerContext*,
                                  const ::umbp::BatchDataWithDepthRequest* request,
                                  ::umbp::BatchBoolResponse* response) override {
@@ -339,7 +387,7 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
 
     std::unique_lock<std::shared_mutex> lock(client_mu_);
     std::vector<uintptr_t> ptrs;
-    if (!ResolveRanges(request->client_id(), queries, &ptrs)) {
+    if (!ResolveRanges(request->client_id(), queries, &ptrs, /*allow_zero=*/false)) {
       FillFalse(request->keys_size(), response);
       return grpc::Status::OK;
     }
@@ -366,6 +414,51 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
       return grpc::Status::OK;
     }
     FillResults(client_->BatchGet(keys, ptrs, sizes), response);
+    return grpc::Status::OK;
+  }
+
+  grpc::Status BatchGetRanges(grpc::ServerContext*, const ::umbp::BatchRangeDataRequest* request,
+                              ::umbp::BatchBoolResponse* response) override {
+    size_t total_ranges = 0;
+    if (!ValidateRangeRequest(*request, /*put=*/false, &total_ranges)) {
+      FillFalse(request->keys_size(), response);
+      return grpc::Status::OK;
+    }
+
+    std::vector<RangeQuery> queries;
+    queries.reserve(total_ranges);
+    for (size_t i = 0; i < total_ranges; ++i) {
+      queries.push_back({request->region_bases(static_cast<int>(i)),
+                         request->shm_offsets(static_cast<int>(i)),
+                         request->sizes(static_cast<int>(i))});
+    }
+
+    ConditionalReadLock lock(client_mu_, shared_reads_);
+    std::vector<uintptr_t> flat_ptrs;
+    if (!ResolveRanges(request->client_id(), queries, &flat_ptrs, /*allow_zero=*/true) ||
+        shutdown_.load()) {
+      FillFalse(request->keys_size(), response);
+      return grpc::Status::OK;
+    }
+
+    std::vector<std::string> keys(request->keys().begin(), request->keys().end());
+    std::vector<std::vector<uintptr_t>> ptrs(keys.size());
+    std::vector<std::vector<size_t>> sizes(keys.size());
+    std::vector<std::vector<size_t>> offsets(keys.size());
+    size_t cursor = 0;
+    for (size_t i = 0; i < keys.size(); ++i) {
+      const size_t count = request->range_counts(static_cast<int>(i));
+      ptrs[i].reserve(count);
+      sizes[i].reserve(count);
+      offsets[i].reserve(count);
+      for (size_t j = 0; j < count; ++j, ++cursor) {
+        ptrs[i].push_back(flat_ptrs[cursor]);
+        sizes[i].push_back(static_cast<size_t>(request->sizes(static_cast<int>(cursor))));
+        offsets[i].push_back(
+            static_cast<size_t>(request->object_offsets(static_cast<int>(cursor))));
+      }
+    }
+    FillResults(client_->BatchGetRanges(keys, ptrs, sizes, offsets), response);
     return grpc::Status::OK;
   }
 
@@ -980,13 +1073,14 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
     std::shared_lock<std::shared_mutex> lock(memory_mu_);
     auto it = memory_.find(client_id);
     if (it == memory_.end()) return false;
-    return ResolveRangeInRegions(it->second, region_base, offset, size, out_ptr);
+    return ResolveRangeInRegions(it->second, region_base, offset, size, out_ptr,
+                                 /*allow_zero=*/false);
   }
 
   static bool ResolveRangeInRegions(const std::vector<RegisteredMemory>& regions,
                                     uint64_t region_base, uint64_t offset, uint64_t size,
-                                    uintptr_t* out_ptr) {
-    if (!out_ptr || size == 0) return false;
+                                    uintptr_t* out_ptr, bool allow_zero) {
+    if (!out_ptr || (!allow_zero && size == 0)) return false;
     for (const auto& mem : regions) {
       if (region_base != 0 && mem.worker_base != region_base) continue;
       if (offset > mem.size || size > mem.size - offset) {
@@ -1000,7 +1094,7 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
   }
 
   bool ResolveRanges(const std::string& client_id, const std::vector<RangeQuery>& queries,
-                     std::vector<uintptr_t>* ptrs) {
+                     std::vector<uintptr_t>* ptrs, bool allow_zero) {
     if (!ptrs) return false;
     ptrs->clear();
     ptrs->reserve(queries.size());
@@ -1012,7 +1106,8 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
 
     for (const auto& query : queries) {
       uintptr_t ptr = 0;
-      if (!ResolveRangeInRegions(it->second, query.region_base, query.offset, query.size, &ptr)) {
+      if (!ResolveRangeInRegions(it->second, query.region_base, query.offset, query.size, &ptr,
+                                 allow_zero)) {
         ptrs->clear();
         return false;
       }
@@ -1036,7 +1131,42 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
       uint64_t region_base = has_region_bases ? request.region_bases(i) : 0;
       queries.push_back({region_base, request.shm_offsets(i), request.sizes(i)});
     }
-    return ResolveRanges(request.client_id(), queries, ptrs);
+    return ResolveRanges(request.client_id(), queries, ptrs, /*allow_zero=*/false);
+  }
+
+  static bool ValidateRangeRequest(const ::umbp::BatchRangeDataRequest& request, bool put,
+                                   size_t* total_ranges) {
+    if (!total_ranges || request.range_counts_size() != request.keys_size()) return false;
+    if ((put && request.object_sizes_size() != request.keys_size()) ||
+        (!put && request.object_sizes_size() != 0)) {
+      return false;
+    }
+
+    size_t total = 0;
+    for (uint32_t count : request.range_counts()) {
+      if (count > std::numeric_limits<size_t>::max() - total) return false;
+      total += count;
+    }
+    if (total != static_cast<size_t>(request.shm_offsets_size()) ||
+        total != static_cast<size_t>(request.region_bases_size()) ||
+        total != static_cast<size_t>(request.sizes_size()) ||
+        total != static_cast<size_t>(request.object_offsets_size())) {
+      return false;
+    }
+
+    if constexpr (sizeof(size_t) < sizeof(uint64_t)) {
+      for (uint64_t value : request.sizes()) {
+        if (value > std::numeric_limits<size_t>::max()) return false;
+      }
+      for (uint64_t value : request.object_offsets()) {
+        if (value > std::numeric_limits<size_t>::max()) return false;
+      }
+      for (uint64_t value : request.object_sizes()) {
+        if (value > std::numeric_limits<size_t>::max()) return false;
+      }
+    }
+    *total_ranges = total;
+    return true;
   }
 
   static std::vector<size_t> Sizes(const ::umbp::BatchDataRequest& request) {

--- a/tests/cpp/umbp/distributed/CMakeLists.txt
+++ b/tests/cpp/umbp/distributed/CMakeLists.txt
@@ -189,8 +189,19 @@ target_link_libraries(
 add_test(NAME umbp_pool_client_batch_put
          COMMAND test_umbp_pool_client_batch_put)
 
+add_executable(test_umbp_pool_client_ranges test_pool_client_ranges.cpp)
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  target_link_options(test_umbp_pool_client_ranges PRIVATE -Wl,--no-as-needed)
+endif()
+target_link_libraries(
+  test_umbp_pool_client_ranges
+  PRIVATE umbp_core umbp_common ${_TEST_PROTOBUF_LIB} ${_TEST_GRPCPP_LIB}
+          gtest_main)
+add_test(NAME umbp_pool_client_ranges COMMAND test_umbp_pool_client_ranges)
+
 set_tests_properties(umbp_peer_service umbp_cross_node_smoke
-                     umbp_pool_client_batch_put PROPERTIES LABELS "integration")
+                     umbp_pool_client_batch_put umbp_pool_client_ranges
+                     PROPERTIES LABELS "integration")
 
 # --------------------------------------------------------------------------
 # Benchmarks (manual; built but NOT registered with add_test).

--- a/tests/cpp/umbp/distributed/test_master_client_flush_heartbeat.cpp
+++ b/tests/cpp/umbp/distributed/test_master_client_flush_heartbeat.cpp
@@ -46,6 +46,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include "umbp.grpc.pb.h"
 #include "umbp/distributed/master/master_client.h"
@@ -77,12 +78,21 @@ class RecordingMasterService final : public ::umbp::UMBPMaster::Service {
     return grpc::Status::OK;
   }
 
-  grpc::Status Heartbeat(grpc::ServerContext* ctx, const ::umbp::HeartbeatRequest*,
+  grpc::Status Heartbeat(grpc::ServerContext* ctx, const ::umbp::HeartbeatRequest* req,
                          ::umbp::HeartbeatResponse* resp) override {
     {
       std::lock_guard<std::mutex> lock(mu_);
       ++count_;
       last_time_ = std::chrono::steady_clock::now();
+      size_t event_count = 0;
+      uint64_t highest_seq = 0;
+      for (const auto& bundle : req->bundles()) {
+        event_count += static_cast<size_t>(bundle.events_size());
+        highest_seq = std::max(highest_seq, bundle.seq());
+      }
+      heartbeat_event_counts_.push_back(event_count);
+      resp->set_acked_seq(highest_seq);
+      resp->set_status(::umbp::CLIENT_STATUS_ALIVE);
       entered_cv_.notify_all();
     }
     if (block_heartbeats_) {
@@ -95,7 +105,6 @@ class RecordingMasterService final : public ::umbp::UMBPMaster::Service {
                              [&] { return released_ || ctx->IsCancelled(); });
       }
     }
-    resp->set_acked_seq(0);
     return grpc::Status::OK;
   }
 
@@ -133,6 +142,11 @@ class RecordingMasterService final : public ::umbp::UMBPMaster::Service {
     return last_time_;
   }
 
+  std::vector<size_t> HeartbeatEventCounts() {
+    std::lock_guard<std::mutex> lock(mu_);
+    return heartbeat_event_counts_;
+  }
+
  private:
   const int interval_ms_;
   const bool block_heartbeats_;
@@ -141,8 +155,30 @@ class RecordingMasterService final : public ::umbp::UMBPMaster::Service {
   std::condition_variable entered_cv_;
   std::condition_variable release_cv_;
   int count_ = 0;
+  std::vector<size_t> heartbeat_event_counts_;
   std::chrono::steady_clock::time_point last_time_;
   bool released_ = false;
+};
+
+class VectorEventSource final : public OwnedLocationSource {
+ public:
+  explicit VectorEventSource(size_t count) {
+    pending_.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+      pending_.push_back(
+          KvEvent{KvEvent::Kind::ADD, "heartbeat-key-" + std::to_string(i), TierType::DRAM, 4096});
+    }
+  }
+
+  std::vector<KvEvent> DrainPendingEvents() override { return std::move(pending_); }
+  std::vector<KvEvent> SnapshotOwnedKeys() const override { return {}; }
+  std::vector<KvEvent> SnapshotOwnedKeysForFullSync() override {
+    pending_.clear();
+    return {};
+  }
+
+ private:
+  std::vector<KvEvent> pending_;
 };
 
 // --------------------------------------------------------------------------
@@ -280,6 +316,26 @@ TEST_F(FlushHeartbeatTest, FlushWhileRPCInFlightFiresNextTickImmediately) {
   EXPECT_LT(gap_ms, kDeadlineMs)
       << "Second heartbeat arrived " << gap_ms << " ms after release (budget " << kDeadlineMs
       << " ms); flush_requested_ may not have been preserved across the in-flight RPC";
+}
+
+TEST_F(FlushHeartbeatTest, LargeEventBacklogIsSplitAcrossBoundedImmediateHeartbeats) {
+  constexpr size_t kEvents = 20'000;
+  constexpr size_t kDefaultMaxEventsPerRpc = 16 * 1024;
+  ASSERT_NO_FATAL_FAILURE(BuildServer(/*interval_ms=*/10'000));
+  auto client = MakeRegisteredClient();
+  VectorEventSource source(kEvents);
+  client->AddOwnedLocationSource(&source);
+  client->StartHeartbeat();
+
+  client->FlushHeartbeat();
+  ASSERT_TRUE(service_->WaitForCount(2, std::chrono::milliseconds(2000)));
+  client->StopHeartbeat();
+
+  const auto counts = service_->HeartbeatEventCounts();
+  ASSERT_GE(counts.size(), 2u);
+  EXPECT_LE(counts[0], kDefaultMaxEventsPerRpc);
+  EXPECT_LE(counts[1], kDefaultMaxEventsPerRpc);
+  EXPECT_EQ(counts[0] + counts[1], kEvents);
 }
 
 }  // namespace

--- a/tests/cpp/umbp/distributed/test_pool_client_batch_put.cpp
+++ b/tests/cpp/umbp/distributed/test_pool_client_batch_put.cpp
@@ -375,5 +375,72 @@ TEST_F(BatchPutWarnTest, ZeroSizeGetEntriesFailOthersSucceed) {
   EXPECT_TRUE(gres[2]) << "key=" << gkeys[2];
 }
 
+// ---------------------------------------------------------------------------
+// Multi-page objects exercise the tier-page run merging in LocalPutPages /
+// LocalGetPages. Every other test here uses exactly one page per key, so the
+// merge path never runs there.
+//
+// A wrong run boundary or a miscomputed run length still returns true, so these
+// assert bytes rather than status. The fill pattern varies per byte so a
+// shifted, duplicated or truncated run is visible.
+// ---------------------------------------------------------------------------
+
+namespace {
+void FillPattern(char* buf, size_t bytes, uint8_t seed) {
+  for (size_t i = 0; i < bytes; ++i) {
+    buf[i] = static_cast<char>((i * 31u + seed) & 0xFFu);
+  }
+}
+}  // namespace
+
+TEST_F(BatchPutWarnTest, MultiPageObjectRoundTripsByteExact) {
+  constexpr size_t kPages = 4;
+  constexpr size_t kSize = kPages * kPageSize;  // whole pages, no partial tail
+
+  std::vector<char> src(kSize);
+  FillPattern(src.data(), kSize, 0x5A);
+  std::vector<std::string> keys = {"mp-full"};
+  std::vector<const void*> srcs = {src.data()};
+  std::vector<size_t> sizes = {kSize};
+  auto pres = target_->BatchPut(keys, srcs, sizes);
+  ASSERT_EQ(pres.size(), 1u);
+  ASSERT_TRUE(pres[0]);
+
+  std::vector<char> dst(kSize, 0);
+  std::vector<void*> dsts = {dst.data()};
+  auto gres = target_->BatchGet(keys, dsts, sizes);
+  ASSERT_EQ(gres.size(), 1u);
+  ASSERT_TRUE(gres[0]);
+  EXPECT_EQ(std::memcmp(src.data(), dst.data(), kSize), 0)
+      << "multi-page object did not round trip byte-exact";
+}
+
+TEST_F(BatchPutWarnTest, MultiPageObjectWithPartialTailRoundTripsByteExact) {
+  // Deliberately not a page multiple: the final page is short, which is the
+  // one place LogicalPageBytes differs and the easiest boundary to get wrong
+  // when accumulating a run length.
+  constexpr size_t kSize = 3 * kPageSize + 1234;
+
+  std::vector<char> src(kSize);
+  FillPattern(src.data(), kSize, 0xA5);
+  std::vector<std::string> keys = {"mp-tail"};
+  std::vector<const void*> srcs = {src.data()};
+  std::vector<size_t> sizes = {kSize};
+  auto pres = target_->BatchPut(keys, srcs, sizes);
+  ASSERT_EQ(pres.size(), 1u);
+  ASSERT_TRUE(pres[0]);
+
+  // One extra byte of guard on each side catches a run that copies too much.
+  std::vector<char> dst(kSize + 2, 0x7E);
+  std::vector<void*> dsts = {dst.data() + 1};
+  auto gres = target_->BatchGet(keys, dsts, sizes);
+  ASSERT_EQ(gres.size(), 1u);
+  ASSERT_TRUE(gres[0]);
+  EXPECT_EQ(std::memcmp(src.data(), dst.data() + 1, kSize), 0)
+      << "partial-tail object did not round trip byte-exact";
+  EXPECT_EQ(dst.front(), static_cast<char>(0x7E)) << "run underran the destination";
+  EXPECT_EQ(dst.back(), static_cast<char>(0x7E)) << "run overran the destination";
+}
+
 }  // namespace
 }  // namespace mori::umbp

--- a/tests/cpp/umbp/distributed/test_pool_client_ranges.cpp
+++ b/tests/cpp/umbp/distributed/test_pool_client_ranges.cpp
@@ -43,6 +43,7 @@
 #include "umbp/distributed/master/master_server.h"
 #include "umbp/distributed/peer/peer_dram_allocator.h"
 #include "umbp/distributed/pool_client.h"
+#include "umbp/umbp_client.h"
 
 namespace mori::umbp {
 namespace {
@@ -80,6 +81,17 @@ bool WaitForExists(PoolClient* client, const std::string& key) {
     std::this_thread::sleep_for(std::chrono::milliseconds(25));
   }
   return client->Exists(key);
+}
+
+bool WaitForExists(IUMBPClient* client, const std::string& key) {
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (std::chrono::steady_clock::now() < deadline) {
+    const auto found = client->BatchExists({key});
+    if (found.size() == 1 && found[0]) return true;
+    std::this_thread::sleep_for(std::chrono::milliseconds(25));
+  }
+  const auto found = client->BatchExists({key});
+  return found.size() == 1 && found[0];
 }
 
 class PoolClientRangesTest : public ::testing::Test {
@@ -139,6 +151,27 @@ class PoolClientRangesTest : public ::testing::Test {
     EXPECT_TRUE(client->Init());
     EXPECT_TRUE(client->RegisterMemory(scratch.data(), scratch.size()));
     return client;
+  }
+
+  UMBPConfig DistributedConfig(const std::string& node_id, size_t ranged_scratch_size) {
+    UMBPConfig config;
+    config.dram.capacity_bytes = 4 * kTargetCapacity;
+    config.dram.use_hugepages = false;
+    config.ssd.enabled = false;
+
+    UMBPDistributedConfig distributed;
+    distributed.master_config.node_id = node_id;
+    distributed.master_config.node_address = "127.0.0.1";
+    distributed.master_config.master_address = master_address_;
+    distributed.io_engine.host = "0.0.0.0";
+    distributed.io_engine.port = 0;
+    distributed.peer_service_port = FreePort();
+    distributed.dram_page_size = kPageSize;
+    distributed.staging_buffer_size = 4 * kObjectSize;
+    distributed.ranged_scratch_size = ranged_scratch_size;
+    distributed.cache_remote_fetches = false;
+    config.distributed = std::move(distributed);
+    return config;
   }
 
   void PutLocalReplica(PoolClient* client, std::vector<char>& dram, const std::string& key,
@@ -261,6 +294,51 @@ TEST_F(PoolClientRangesTest, InvalidRangesFailWithoutPublishing) {
   EXPECT_EQ(result, std::vector<bool>({false, false}));
   EXPECT_FALSE(caller_->Exists(keys[0]));
   EXPECT_FALSE(caller_->Exists(keys[1]));
+}
+
+TEST_F(PoolClientRangesTest, DistributedScratchIsExplicitlyOptedIn) {
+  EXPECT_EQ(UMBPDistributedConfig{}.ranged_scratch_size, 0u);
+
+  auto config = DistributedConfig("ranges-no-scratch", /*ranged_scratch_size=*/0);
+  std::string validation_error;
+  ASSERT_TRUE(config.Validate(&validation_error)) << validation_error;
+  auto client = CreateUMBPClient(config);
+  ASSERT_NE(client, nullptr);
+  EXPECT_EQ(client->GetDeploymentMode(), UMBPDeploymentMode::Distributed);
+  EXPECT_FALSE(client->SupportsRangedIO());
+
+  const std::string key = "ordinary-io-without-ranged-scratch";
+  std::vector<char> source(kObjectSize);
+  for (size_t i = 0; i < source.size(); ++i) {
+    source[i] = static_cast<char>((i * 17 + 3) & 0xff);
+  }
+  auto put = client->BatchPut({key}, {reinterpret_cast<uintptr_t>(source.data())}, {source.size()});
+  ASSERT_EQ(put, std::vector<bool>({true}));
+  ASSERT_TRUE(client->Flush());
+  ASSERT_TRUE(WaitForExists(client.get(), key));
+
+  std::vector<char> restored(source.size(), 0);
+  auto get =
+      client->BatchGet({key}, {reinterpret_cast<uintptr_t>(restored.data())}, {restored.size()});
+  ASSERT_EQ(get, std::vector<bool>({true}));
+  EXPECT_EQ(restored, source);
+
+  // Bypassing the advertised capability remains a safe per-key failure. Use a
+  // missing key so the call reaches the remote-scratch guard after its local probe.
+  std::vector<char> ranged_out(16, 0);
+  auto ranged = client->BatchGetRanges({"missing-without-ranged-scratch"},
+                                       {{reinterpret_cast<uintptr_t>(ranged_out.data())}},
+                                       {{ranged_out.size()}}, {{0}});
+  EXPECT_EQ(ranged, std::vector<bool>({false}));
+  client->Close();
+  client.reset();
+
+  auto opted_in_config = DistributedConfig("ranges-with-scratch", kScratchSize);
+  ASSERT_TRUE(opted_in_config.Validate(&validation_error)) << validation_error;
+  auto opted_in = CreateUMBPClient(opted_in_config);
+  ASSERT_NE(opted_in, nullptr);
+  EXPECT_TRUE(opted_in->SupportsRangedIO());
+  opted_in->Close();
 }
 
 TEST_F(PoolClientRangesTest, StaleSelfLocationIsExcludedBeforeRemoteFetch) {

--- a/tests/cpp/umbp/distributed/test_pool_client_ranges.cpp
+++ b/tests/cpp/umbp/distributed/test_pool_client_ranges.cpp
@@ -1,0 +1,361 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <gtest/gtest.h>
+#include <hip/hip_runtime_api.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
+#include "umbp/common/device_gather.h"
+#include "umbp/distributed/config.h"
+#include "umbp/distributed/master/master_client.h"
+#include "umbp/distributed/master/master_server.h"
+#include "umbp/distributed/peer/peer_dram_allocator.h"
+#include "umbp/distributed/pool_client.h"
+
+namespace mori::umbp {
+namespace {
+
+constexpr size_t kPageSize = 4096;
+constexpr size_t kObjectSize = 2 * kPageSize;
+constexpr size_t kCallerCapacity = 16 * kPageSize;
+constexpr size_t kTargetCapacity = 256 * kPageSize;
+constexpr size_t kScratchSize = kObjectSize;  // Forces one object per sub-batch.
+
+uint16_t FreePort() {
+  int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+  if (fd >= 0) {
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_port = 0;
+    socklen_t len = sizeof(addr);
+    if (::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0 &&
+        ::getsockname(fd, reinterpret_cast<sockaddr*>(&addr), &len) == 0) {
+      const uint16_t port = ntohs(addr.sin_port);
+      ::close(fd);
+      return port;
+    }
+    ::close(fd);
+  }
+  static std::atomic<uint16_t> next{56000};
+  return next.fetch_add(1);
+}
+
+bool WaitForExists(PoolClient* client, const std::string& key) {
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (client->Exists(key)) return true;
+    std::this_thread::sleep_for(std::chrono::milliseconds(25));
+  }
+  return client->Exists(key);
+}
+
+class PoolClientRangesTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    MasterServerConfig master_cfg;
+    master_cfg.listen_address = "0.0.0.0:0";
+    // The registry derives a 2 s client heartbeat from this TTL: short enough
+    // for normal publication tests, while the 12 s expiry window keeps a stopped
+    // caller alive through the stale-self assertion.
+    master_cfg.registry_config.heartbeat_ttl = std::chrono::seconds(4);
+    master_ = std::make_unique<MasterServer>(std::move(master_cfg));
+    master_thread_ = std::thread([this] { master_->Run(); });
+    for (int i = 0; i < 100 && master_->GetBoundPort() == 0; ++i) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_NE(master_->GetBoundPort(), 0);
+    master_address_ = "localhost:" + std::to_string(master_->GetBoundPort());
+
+    caller_dram_.resize(kCallerCapacity);
+    target_dram_.resize(kTargetCapacity);
+    caller_scratch_.resize(kScratchSize);
+    target_scratch_.resize(kScratchSize);
+    caller_ = MakeClient("ranges-caller", caller_dram_, caller_scratch_);
+    target_ = MakeClient("ranges-target", target_dram_, target_scratch_);
+  }
+
+  void TearDown() override {
+    if (caller_) caller_->Shutdown();
+    if (target_) target_->Shutdown();
+    caller_.reset();
+    target_.reset();
+    if (master_) master_->Shutdown();
+    if (master_thread_.joinable()) master_thread_.join();
+    master_.reset();
+  }
+
+  std::unique_ptr<PoolClient> MakeClient(const std::string& node_id, std::vector<char>& dram,
+                                         std::vector<char>& scratch) {
+    PoolClientConfig cfg;
+    cfg.master_config.node_id = node_id;
+    cfg.master_config.node_address = "127.0.0.1";
+    cfg.master_config.master_address = master_address_;
+    cfg.io_engine.host = "0.0.0.0";
+    cfg.io_engine.port = 0;
+    cfg.peer_service_port = FreePort();
+    cfg.dram_page_size = kPageSize;
+    // Smaller than one object: ranged remote I/O can pass only through the
+    // registered arena's zero-copy descriptor, never the legacy staging path.
+    cfg.staging_buffer_size = 1024;
+    cfg.dram_buffers = {{dram.data(), dram.size()}};
+    cfg.tier_capacities = {{TierType::DRAM, {dram.size(), dram.size()}}};
+    cfg.ranged_scratch_buffer = scratch.data();
+    cfg.ranged_scratch_size = scratch.size();
+    cfg.cache_remote_fetches = false;
+    auto client = std::make_unique<PoolClient>(std::move(cfg));
+    EXPECT_TRUE(client->Init());
+    EXPECT_TRUE(client->RegisterMemory(scratch.data(), scratch.size()));
+    return client;
+  }
+
+  void PutLocalReplica(PoolClient* client, std::vector<char>& dram, const std::string& key,
+                       const std::vector<char>& object) {
+    auto* allocator = client->DramAllocator();
+    ASSERT_NE(allocator, nullptr);
+    auto allocated = allocator->Allocate(key, object.size(), TierType::DRAM);
+    ASSERT_EQ(allocated.outcome, PeerDramAllocator::Outcome::kSuccessAllocated);
+    ASSERT_TRUE(allocated.slot.has_value());
+
+    const auto& slot = *allocated.slot;
+    size_t copied = 0;
+    for (const auto& page : slot.pages) {
+      ASSERT_EQ(page.buffer_index, 0u);
+      const size_t bytes = std::min(kPageSize, object.size() - copied);
+      const size_t offset = static_cast<size_t>(page.page_index) * kPageSize;
+      ASSERT_LE(offset + bytes, dram.size());
+      std::memcpy(dram.data() + offset, object.data() + copied, bytes);
+      copied += bytes;
+    }
+    ASSERT_EQ(copied, object.size());
+
+    uint64_t committed = 0;
+    ASSERT_TRUE(allocator->Commit(slot.slot_id, key, committed));
+    ASSERT_EQ(committed, object.size());
+  }
+
+  bool WaitForRoute(PoolClient* client, const std::string& key,
+                    const std::unordered_set<std::string>& excludes,
+                    const std::string& expected_node) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (std::chrono::steady_clock::now() < deadline) {
+      std::vector<std::optional<RouteGetResult>> routes;
+      const auto status = client->Master().BatchRouteGet({key}, excludes, &routes);
+      if (status.ok() && routes.size() == 1 && routes[0].has_value() &&
+          routes[0]->node_id == expected_node) {
+        return true;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    }
+    return false;
+  }
+
+  std::unique_ptr<MasterServer> master_;
+  std::thread master_thread_;
+  std::string master_address_;
+  std::unique_ptr<PoolClient> caller_;
+  std::unique_ptr<PoolClient> target_;
+  std::vector<char> caller_dram_;
+  std::vector<char> target_dram_;
+  std::vector<char> caller_scratch_;
+  std::vector<char> target_scratch_;
+};
+
+TEST_F(PoolClientRangesTest, RemoteRoundTripSubBatchesAndInstallsLocally) {
+  constexpr size_t kKeys = 2;
+  std::vector<std::string> keys = {"range-object-0", "range-object-1"};
+  std::vector<std::vector<char>> objects(kKeys, std::vector<char>(kObjectSize));
+  for (size_t k = 0; k < kKeys; ++k) {
+    for (size_t i = 0; i < kObjectSize; ++i) {
+      objects[k][i] = static_cast<char>((i * 13 + k * 37) & 0xff);
+    }
+  }
+
+  std::vector<size_t> object_sizes(kKeys, kObjectSize);
+  std::vector<std::vector<const void*>> put_ptrs(kKeys);
+  std::vector<std::vector<size_t>> put_sizes(kKeys);
+  std::vector<std::vector<size_t>> put_offsets(kKeys);
+  for (size_t k = 0; k < kKeys; ++k) {
+    put_ptrs[k] = {objects[k].data(), objects[k].data() + 1500, objects[k].data() + 6000};
+    put_sizes[k] = {1500, 4500, kObjectSize - 6000};
+    put_offsets[k] = {0, 1500, 6000};
+  }
+
+  auto put = caller_->BatchPutRanges(keys, object_sizes, put_ptrs, put_sizes, put_offsets);
+  ASSERT_EQ(put.size(), kKeys);
+  EXPECT_TRUE(put[0]);
+  EXPECT_TRUE(put[1]);
+  caller_->Master().FlushHeartbeat();
+  target_->Master().FlushHeartbeat();
+  ASSERT_TRUE(WaitForExists(caller_.get(), keys[0]));
+  ASSERT_TRUE(WaitForExists(caller_.get(), keys[1]));
+
+  std::vector<std::vector<char>> out_a(kKeys, std::vector<char>(900, 0));
+  std::vector<std::vector<char>> out_b(kKeys, std::vector<char>(700, 0));
+  std::vector<std::vector<void*>> get_ptrs(kKeys);
+  std::vector<std::vector<size_t>> get_sizes(kKeys, {900, 700});
+  std::vector<std::vector<size_t>> get_offsets(kKeys, {200, 5000});
+  for (size_t k = 0; k < kKeys; ++k) get_ptrs[k] = {out_a[k].data(), out_b[k].data()};
+
+  auto first_get = caller_->BatchGetRanges(keys, get_ptrs, get_sizes, get_offsets);
+  ASSERT_EQ(first_get.size(), kKeys);
+  for (size_t k = 0; k < kKeys; ++k) {
+    ASSERT_TRUE(first_get[k]) << "key=" << keys[k];
+    EXPECT_EQ(std::memcmp(out_a[k].data(), objects[k].data() + 200, 900), 0);
+    EXPECT_EQ(std::memcmp(out_b[k].data(), objects[k].data() + 5000, 700), 0);
+  }
+
+  // The first remote get synchronously installs both objects in caller DRAM.
+  // A second ranged get must succeed even before the ADD events reach master.
+  for (auto& v : out_a) std::fill(v.begin(), v.end(), 0);
+  for (auto& v : out_b) std::fill(v.begin(), v.end(), 0);
+  auto second_get = caller_->BatchGetRanges(keys, get_ptrs, get_sizes, get_offsets);
+  EXPECT_EQ(second_get, std::vector<bool>({true, true}));
+  for (size_t k = 0; k < kKeys; ++k) {
+    EXPECT_EQ(std::memcmp(out_a[k].data(), objects[k].data() + 200, 900), 0);
+    EXPECT_EQ(std::memcmp(out_b[k].data(), objects[k].data() + 5000, 700), 0);
+  }
+}
+
+TEST_F(PoolClientRangesTest, InvalidRangesFailWithoutPublishing) {
+  std::vector<char> src(kObjectSize, 0x5a);
+  std::vector<std::string> keys = {"range-gap", "range-overlap"};
+  std::vector<size_t> object_sizes = {kObjectSize, kObjectSize};
+  std::vector<std::vector<const void*>> ptrs = {{src.data(), src.data() + 4096},
+                                                {src.data(), src.data() + 2048}};
+  std::vector<std::vector<size_t>> sizes = {{4096, 2048}, {4096, 4096}};
+  std::vector<std::vector<size_t>> offsets = {{0, 6144}, {0, 2048}};
+  auto result = caller_->BatchPutRanges(keys, object_sizes, ptrs, sizes, offsets);
+  EXPECT_EQ(result, std::vector<bool>({false, false}));
+  EXPECT_FALSE(caller_->Exists(keys[0]));
+  EXPECT_FALSE(caller_->Exists(keys[1]));
+}
+
+TEST_F(PoolClientRangesTest, StaleSelfLocationIsExcludedBeforeRemoteFetch) {
+  const std::string key = "range-stale-self";
+  std::vector<char> stale_object(kObjectSize, 0x11);
+  std::vector<char> remote_object(kObjectSize);
+  for (size_t i = 0; i < remote_object.size(); ++i) {
+    remote_object[i] = static_cast<char>((i * 29 + 7) & 0xff);
+  }
+
+  // Publish two replicas without going through RoutePut's de-duplication. The
+  // caller heartbeat is then stopped before local eviction, deliberately
+  // leaving its location stale at master while the target remains readable.
+  PutLocalReplica(caller_.get(), caller_dram_, key, stale_object);
+  PutLocalReplica(target_.get(), target_dram_, key, remote_object);
+  caller_->Master().FlushHeartbeat();
+  target_->Master().FlushHeartbeat();
+  ASSERT_TRUE(WaitForRoute(caller_.get(), key, {"ranges-target"}, "ranges-caller"));
+  ASSERT_TRUE(WaitForRoute(caller_.get(), key, {"ranges-caller"}, "ranges-target"));
+
+  caller_->Master().StopHeartbeat();
+  auto evicted = caller_->DramAllocator()->Evict({key});
+  ASSERT_EQ(evicted.size(), 1u);
+  ASSERT_EQ(evicted[0].bytes_freed, kObjectSize);
+  ASSERT_TRUE(WaitForRoute(caller_.get(), key, {}, "ranges-caller"))
+      << "master must still prefer the caller's deliberately stale location";
+
+  std::vector<char> out_a(777, 0);
+  std::vector<char> out_b(999, 0);
+  auto result =
+      caller_->BatchGetRanges({key}, {{out_a.data(), out_b.data()}}, {{777, 999}}, {{123, 5000}});
+
+  ASSERT_EQ(result, std::vector<bool>({true}));
+  EXPECT_EQ(std::memcmp(out_a.data(), remote_object.data() + 123, out_a.size()), 0);
+  EXPECT_EQ(std::memcmp(out_b.data(), remote_object.data() + 5000, out_b.size()), 0);
+}
+
+TEST_F(PoolClientRangesTest, GpuRangesUseGatherKernel) {
+  struct HipAllocation {
+    void* ptr = nullptr;
+    ~HipAllocation() {
+      if (ptr) (void)hipFree(ptr);
+    }
+  };
+
+  const std::vector<size_t> part_sizes = {1024, 2048, kObjectSize - 3072};
+  std::vector<HipAllocation> gpu_src(part_sizes.size());
+  std::vector<std::vector<char>> host_src(part_sizes.size());
+  std::vector<const void*> src_ptrs;
+  for (size_t i = 0; i < part_sizes.size(); ++i) {
+    host_src[i].resize(part_sizes[i], static_cast<char>(0x31 + i));
+    ASSERT_EQ(hipMalloc(&gpu_src[i].ptr, part_sizes[i]), hipSuccess);
+    ASSERT_EQ(hipMemcpy(gpu_src[i].ptr, host_src[i].data(), part_sizes[i], hipMemcpyHostToDevice),
+              hipSuccess);
+    src_ptrs.push_back(gpu_src[i].ptr);
+  }
+
+  const uint64_t launches_before = DeviceGatherLaunchCount();
+  const std::vector<std::string> gpu_keys = {"gpu-range-object-0", "gpu-range-object-1"};
+  auto put = target_->BatchPutRanges(gpu_keys, {kObjectSize, kObjectSize}, {src_ptrs, src_ptrs},
+                                     {part_sizes, part_sizes}, {{0, 1024, 3072}, {0, 1024, 3072}});
+  ASSERT_EQ(put, std::vector<bool>({true, true}));
+  EXPECT_EQ(DeviceGatherLaunchCount(), launches_before + 1);
+
+  const std::vector<size_t> get_sizes = {600, 700, 800};
+  const std::vector<size_t> get_offsets = {100, 2200, 6500};
+  std::vector<HipAllocation> gpu_dst(2 * get_sizes.size());
+  std::vector<std::vector<void*>> dst_ptrs(2);
+  for (size_t key = 0; key < 2; ++key) {
+    for (size_t i = 0; i < get_sizes.size(); ++i) {
+      auto& allocation = gpu_dst[key * get_sizes.size() + i];
+      ASSERT_EQ(hipMalloc(&allocation.ptr, get_sizes[i]), hipSuccess);
+      ASSERT_EQ(hipMemset(allocation.ptr, 0, get_sizes[i]), hipSuccess);
+      dst_ptrs[key].push_back(allocation.ptr);
+    }
+  }
+  auto get = target_->BatchGetRanges(gpu_keys, dst_ptrs, {get_sizes, get_sizes},
+                                     {get_offsets, get_offsets});
+  ASSERT_EQ(get, std::vector<bool>({true, true}));
+  EXPECT_EQ(DeviceGatherLaunchCount(), launches_before + 2);
+
+  std::vector<char> full(kObjectSize);
+  std::memset(full.data(), 0x31, 1024);
+  std::memset(full.data() + 1024, 0x32, 2048);
+  std::memset(full.data() + 3072, 0x33, kObjectSize - 3072);
+  for (size_t key = 0; key < 2; ++key) {
+    for (size_t i = 0; i < get_sizes.size(); ++i) {
+      std::vector<char> actual(get_sizes[i]);
+      ASSERT_EQ(hipMemcpy(actual.data(), gpu_dst[key * get_sizes.size() + i].ptr, get_sizes[i],
+                          hipMemcpyDeviceToHost),
+                hipSuccess);
+      EXPECT_EQ(std::memcmp(actual.data(), full.data() + get_offsets[i], get_sizes[i]), 0);
+    }
+  }
+}
+
+}  // namespace
+}  // namespace mori::umbp

--- a/tests/cpp/umbp/distributed/test_pool_client_ranges.cpp
+++ b/tests/cpp/umbp/distributed/test_pool_client_ranges.cpp
@@ -55,10 +55,8 @@ constexpr size_t kCallerCapacity = 16 * kPageSize;
 constexpr size_t kTargetCapacity = 256 * kPageSize;
 constexpr size_t kScratchSize = kObjectSize;  // Forces one object per sub-batch.
 
-// The gather kernel dereferences the tier directly, so it can only run where the
-// host region registers for GPU access. That is best-effort by design and the
-// client falls back to the copy engine without it, which leaves the byte
-// expectations valid but the launch counter flat.
+// The kernel dereferences the tier directly, so it needs the host region
+// registered for GPU access; without it the client uses the copy engine.
 bool GatherPathAvailable() {
   static const bool available = [] {
     std::vector<char> probe(64 * 1024);
@@ -409,8 +407,6 @@ TEST_F(PoolClientRangesTest, GpuRangesUseGatherKernel) {
     src_ptrs.push_back(gpu_src[i].ptr);
   }
 
-  // Checked only where the kernel can run at all; the round trip below is the
-  // part that has to hold on every machine.
   const bool gather_available = DeviceGatherEnabled() && GatherPathAvailable();
   const uint64_t launches_before = DeviceGatherLaunchCount();
   const std::vector<std::string> gpu_keys = {"gpu-range-object-0", "gpu-range-object-1"};

--- a/tests/cpp/umbp/distributed/test_pool_client_ranges.cpp
+++ b/tests/cpp/umbp/distributed/test_pool_client_ranges.cpp
@@ -38,6 +38,7 @@
 #include <vector>
 
 #include "umbp/common/device_gather.h"
+#include "umbp/common/host_registration.h"
 #include "umbp/distributed/config.h"
 #include "umbp/distributed/master/master_client.h"
 #include "umbp/distributed/master/master_server.h"
@@ -53,6 +54,18 @@ constexpr size_t kObjectSize = 2 * kPageSize;
 constexpr size_t kCallerCapacity = 16 * kPageSize;
 constexpr size_t kTargetCapacity = 256 * kPageSize;
 constexpr size_t kScratchSize = kObjectSize;  // Forces one object per sub-batch.
+
+// The gather kernel dereferences the tier directly, so it can only run where the
+// host region registers for GPU access. That is best-effort by design and the
+// client falls back to the copy engine without it, which leaves the byte
+// expectations valid but the launch counter flat.
+bool GatherPathAvailable() {
+  static const bool available = [] {
+    std::vector<char> probe(64 * 1024);
+    return HostTierRegistration(probe.data(), probe.size()).RegisteredBytes() != 0;
+  }();
+  return available;
+}
 
 uint16_t FreePort() {
   int fd = ::socket(AF_INET, SOCK_STREAM, 0);
@@ -396,12 +409,15 @@ TEST_F(PoolClientRangesTest, GpuRangesUseGatherKernel) {
     src_ptrs.push_back(gpu_src[i].ptr);
   }
 
+  // Checked only where the kernel can run at all; the round trip below is the
+  // part that has to hold on every machine.
+  const bool gather_available = DeviceGatherEnabled() && GatherPathAvailable();
   const uint64_t launches_before = DeviceGatherLaunchCount();
   const std::vector<std::string> gpu_keys = {"gpu-range-object-0", "gpu-range-object-1"};
   auto put = target_->BatchPutRanges(gpu_keys, {kObjectSize, kObjectSize}, {src_ptrs, src_ptrs},
                                      {part_sizes, part_sizes}, {{0, 1024, 3072}, {0, 1024, 3072}});
   ASSERT_EQ(put, std::vector<bool>({true, true}));
-  EXPECT_EQ(DeviceGatherLaunchCount(), launches_before + 1);
+  if (gather_available) EXPECT_EQ(DeviceGatherLaunchCount(), launches_before + 1);
 
   const std::vector<size_t> get_sizes = {600, 700, 800};
   const std::vector<size_t> get_offsets = {100, 2200, 6500};
@@ -418,7 +434,7 @@ TEST_F(PoolClientRangesTest, GpuRangesUseGatherKernel) {
   auto get = target_->BatchGetRanges(gpu_keys, dst_ptrs, {get_sizes, get_sizes},
                                      {get_offsets, get_offsets});
   ASSERT_EQ(get, std::vector<bool>({true, true}));
-  EXPECT_EQ(DeviceGatherLaunchCount(), launches_before + 2);
+  if (gather_available) EXPECT_EQ(DeviceGatherLaunchCount(), launches_before + 2);
 
   std::vector<char> full(kObjectSize);
   std::memset(full.data(), 0x31, 1024);

--- a/tests/cpp/umbp/distributed/test_standalone_shm_ipc.cpp
+++ b/tests/cpp/umbp/distributed/test_standalone_shm_ipc.cpp
@@ -246,6 +246,8 @@ TEST(StandaloneShmIpcTest, StandaloneClientUsesNonZeroOffsetsAndCanReregister) {
   UMBPConfig client_cfg = server_cfg;
   auto client = CreateUMBPClient(client_cfg);
   ASSERT_EQ(client->GetDeploymentMode(), UMBPDeploymentMode::StandaloneProcess);
+  EXPECT_EQ(client->GetBackendMode(), UMBPDeploymentMode::Local);
+  EXPECT_TRUE(client->SupportsRangedIO());
 
   HostMemAllocator allocator;
   HostBufferOptions opts;

--- a/tests/cpp/umbp/distributed/test_standalone_shm_ipc.cpp
+++ b/tests/cpp/umbp/distributed/test_standalone_shm_ipc.cpp
@@ -359,6 +359,47 @@ TEST(StandaloneShmIpcTest, StandaloneClientResolvesAcrossMultipleRegions) {
   for (int i = 0; i < 8; ++i) EXPECT_EQ(bytes_a[300 + i], static_cast<unsigned char>(0xa0 + i));
   for (int i = 0; i < 8; ++i) EXPECT_EQ(bytes_b[300 + i], static_cast<unsigned char>(0xb0 + i));
 
+  // One object can be assembled from, and read back into, ranges belonging to
+  // different registered regions.
+  for (int i = 0; i < 8; ++i) bytes_a[400 + i] = static_cast<unsigned char>(0xc0 + i);
+  for (int i = 0; i < 8; ++i) bytes_b[400 + i] = static_cast<unsigned char>(0xd0 + i);
+  auto range_put = client->BatchPutRanges(
+      {"range-key"}, {16},
+      {{reinterpret_cast<uintptr_t>(bytes_b + 400), reinterpret_cast<uintptr_t>(bytes_a + 400)}},
+      {{8, 8}}, {{8, 0}});
+  ASSERT_EQ(range_put, std::vector<bool>({true}));
+  EXPECT_TRUE(client->Exists("range-key"));
+
+  std::memset(bytes_a + 500, 0, 8);
+  std::memset(bytes_b + 500, 0, 8);
+  auto range_get = client->BatchGetRanges(
+      {"range-key"},
+      {{reinterpret_cast<uintptr_t>(bytes_a + 500), reinterpret_cast<uintptr_t>(bytes_b + 500)}},
+      {{8, 8}}, {{8, 0}});
+  ASSERT_EQ(range_get, std::vector<bool>({true}));
+  for (int i = 0; i < 8; ++i) {
+    EXPECT_EQ(bytes_a[500 + i], static_cast<unsigned char>(0xd0 + i));
+    EXPECT_EQ(bytes_b[500 + i], static_cast<unsigned char>(0xc0 + i));
+  }
+
+  // Malformed flattened range arrays are rejected before address resolution.
+  auto raw_stub = ::umbp::UMBPStandalone::NewStub(
+      grpc::CreateChannel(address, grpc::InsecureChannelCredentials()));
+  grpc::ClientContext malformed_context;
+  ::umbp::BatchRangeDataRequest malformed_request;
+  malformed_request.add_keys("malformed");
+  malformed_request.add_range_counts(1);
+  malformed_request.add_shm_offsets(0);
+  // region_bases is deliberately missing.
+  malformed_request.add_sizes(8);
+  malformed_request.add_object_offsets(0);
+  malformed_request.add_object_sizes(8);
+  ::umbp::BatchBoolResponse malformed_response;
+  ASSERT_TRUE(
+      raw_stub->BatchPutRanges(&malformed_context, malformed_request, &malformed_response).ok());
+  ASSERT_EQ(malformed_response.ok_size(), 1);
+  EXPECT_FALSE(malformed_response.ok(0));
+
   // A pointer outside every registered region fails cleanly (no crash, no hit).
   HostBufferHandle unregistered = allocator.Alloc(4096, opts);
   ASSERT_TRUE(unregistered.valid());

--- a/tests/cpp/umbp/distributed/test_standalone_shm_ipc.cpp
+++ b/tests/cpp/umbp/distributed/test_standalone_shm_ipc.cpp
@@ -22,6 +22,7 @@
 // Copyright © Advanced Micro Devices, Inc. All rights reserved.
 //
 // MIT License
+#include <grpcpp/grpcpp.h>
 #include <gtest/gtest.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
@@ -32,6 +33,7 @@
 #include <cerrno>
 #include <chrono>
 #include <cstring>
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <thread>
@@ -41,6 +43,7 @@
 #include "umbp/standalone/ipc.h"
 #include "umbp/standalone/standalone_server.h"
 #include "umbp/umbp_client.h"
+#include "umbp_standalone.grpc.pb.h"
 
 namespace mori::umbp {
 namespace {
@@ -177,6 +180,46 @@ TEST(StandaloneShmIpcTest, RawUdsFdRegistrationTransfersFd) {
   allocator.Free(handle);
 
   EXPECT_TRUE(receiver_ok.load());
+}
+
+TEST(StandaloneShmIpcTest, GpuRegistrationRejectsSsdBackedServer) {
+  const std::string suffix = std::to_string(getpid());
+  const std::string address = "unix:///tmp/umbp_standalone_gpu_reject_" + suffix + ".sock";
+  const std::string grpc_path = standalone::UnixPathFromGrpcAddress(address);
+  const std::string fd_path = standalone::DeriveFdSocketPath(address);
+  const std::string ssd_path = "/tmp/umbp_standalone_gpu_reject_ssd_" + suffix;
+  unlink(grpc_path.c_str());
+  unlink(fd_path.c_str());
+  std::filesystem::remove_all(ssd_path);
+
+  UMBPConfig config;
+  config.dram.capacity_bytes = 1 << 20;
+  config.ssd.enabled = true;
+  config.ssd.storage_dir = ssd_path;
+  config.ssd.capacity_bytes = 1 << 20;
+  standalone::StandaloneServer server(config, address);
+  ASSERT_TRUE(server.Start());
+  std::thread server_thread([&]() { server.Run(); });
+
+  auto channel = grpc::CreateChannel(address, grpc::InsecureChannelCredentials());
+  auto stub = ::umbp::UMBPStandalone::NewStub(channel);
+  grpc::ClientContext context;
+  ::umbp::RegisterMemoryRequest request;
+  request.set_kind(::umbp::MEMORY_KIND_GPU_IPC);
+  request.set_client_id("gpu-client");
+  request.set_worker_base(0x1000);
+  request.set_size(4096);
+  ::umbp::BoolResponse response;
+  const grpc::Status status = stub->RegisterMemory(&context, request, &response);
+  ASSERT_TRUE(status.ok());
+  EXPECT_FALSE(response.ok());
+  EXPECT_NE(response.error().find("SSD"), std::string::npos);
+
+  server.Shutdown();
+  server_thread.join();
+  unlink(grpc_path.c_str());
+  unlink(fd_path.c_str());
+  std::filesystem::remove_all(ssd_path);
 }
 
 TEST(StandaloneShmIpcTest, StandaloneClientUsesNonZeroOffsetsAndCanReregister) {

--- a/tests/cpp/umbp/distributed/test_standalone_shm_ipc.cpp
+++ b/tests/cpp/umbp/distributed/test_standalone_shm_ipc.cpp
@@ -37,6 +37,7 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "umbp/local/host_mem_allocator.h"
@@ -369,6 +370,246 @@ TEST(StandaloneShmIpcTest, StandaloneClientResolvesAcrossMultipleRegions) {
   allocator.Free(region_a);
   allocator.Free(region_b);
   allocator.Free(unregistered);
+  server.Shutdown();
+  server_thread.join();
+  unlink(grpc_path.c_str());
+  unlink(fd_path.c_str());
+}
+
+TEST(StandaloneShmIpcTest, DeregistrationCannotUnmapAnInFlightDataOperation) {
+  constexpr size_t kValueSize = 32ULL << 20;
+  const std::string suffix = std::to_string(getpid());
+  const std::string address =
+      "unix:///tmp/umbp_standalone_deregister_race_" + suffix + ".grpc.sock";
+  const std::string grpc_path = standalone::UnixPathFromGrpcAddress(address);
+  const std::string fd_path = standalone::DeriveFdSocketPath(address);
+  unlink(grpc_path.c_str());
+  unlink(fd_path.c_str());
+
+  UMBPConfig config;
+  config.dram.capacity_bytes = 2 * kValueSize;
+  config.ssd.enabled = false;
+  standalone::StandaloneServer server(config, address);
+  ASSERT_TRUE(server.Start());
+  std::thread server_thread([&]() { server.Run(); });
+
+  HostMemAllocator allocator;
+  HostBufferOptions options;
+  options.backing = HostBufferBacking::kAnonymousShm;
+  options.prefault = false;
+  HostBufferHandle handle = allocator.Alloc(2 * kValueSize, options);
+  ASSERT_TRUE(handle.valid());
+  auto* bytes = static_cast<unsigned char*>(handle.ptr);
+  std::memset(bytes, 0x5a, kValueSize);
+  std::memset(bytes + kValueSize, 0, kValueSize);
+
+  auto allocation = HostMemAllocator::LookupShmAllocation(reinterpret_cast<uintptr_t>(handle.ptr),
+                                                          handle.mapped_size);
+  ASSERT_TRUE(allocation.has_value());
+  constexpr char kClientId[] = "deregister-race-client";
+  std::string registration_error;
+  ASSERT_EQ(standalone::SendFdRegistration(fd_path, allocation->fd, kClientId,
+                                           reinterpret_cast<uintptr_t>(handle.ptr),
+                                           allocation->mapped_size, 5000, &registration_error),
+            0)
+      << registration_error;
+
+  auto channel = grpc::CreateChannel(address, grpc::InsecureChannelCredentials());
+  auto stub = ::umbp::UMBPStandalone::NewStub(channel);
+  {
+    grpc::ClientContext context;
+    ::umbp::RegisterMemoryRequest request;
+    request.set_kind(::umbp::MEMORY_KIND_HOST_SHM);
+    request.set_client_id(kClientId);
+    request.set_worker_base(reinterpret_cast<uintptr_t>(handle.ptr));
+    request.set_size(allocation->mapped_size);
+    ::umbp::BoolResponse response;
+    const grpc::Status status = stub->RegisterMemory(&context, request, &response);
+    ASSERT_TRUE(status.ok());
+    ASSERT_TRUE(response.ok()) << response.error();
+  }
+
+  {
+    grpc::ClientContext context;
+    ::umbp::PutRequest request;
+    request.set_key("large-value");
+    request.set_client_id(kClientId);
+    request.set_region_base(reinterpret_cast<uintptr_t>(handle.ptr));
+    request.set_shm_offset(0);
+    request.set_size(kValueSize);
+    ::umbp::BoolResponse response;
+    const grpc::Status status = stub->Put(&context, request, &response);
+    ASSERT_TRUE(status.ok());
+    ASSERT_TRUE(response.ok()) << response.error();
+  }
+
+  std::atomic<bool> get_started{false};
+  grpc::Status get_status;
+  ::umbp::BoolResponse get_response;
+  std::thread getter([&]() {
+    grpc::ClientContext context;
+    ::umbp::GetRequest request;
+    request.set_key("large-value");
+    request.set_client_id(kClientId);
+    request.set_region_base(reinterpret_cast<uintptr_t>(handle.ptr));
+    request.set_shm_offset(kValueSize);
+    request.set_size(kValueSize);
+    get_started.store(true, std::memory_order_release);
+    get_status = stub->Get(&context, request, &get_response);
+  });
+
+  while (!get_started.load(std::memory_order_acquire)) std::this_thread::yield();
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  grpc::Status deregister_status;
+  {
+    grpc::ClientContext context;
+    ::umbp::DeregisterMemoryRequest request;
+    request.set_client_id(kClientId);
+    ::umbp::Empty response;
+    deregister_status = stub->DeregisterMemory(&context, request, &response);
+  }
+  getter.join();
+
+  ASSERT_TRUE(deregister_status.ok());
+  ASSERT_TRUE(get_status.ok());
+  if (get_response.ok()) {
+    EXPECT_EQ(std::memcmp(bytes, bytes + kValueSize, kValueSize), 0);
+  }
+
+  // Once deregistration returns, new operations must fail resolution rather
+  // than reaching a stale server-side mapping.
+  {
+    grpc::ClientContext context;
+    ::umbp::GetRequest request;
+    request.set_key("large-value");
+    request.set_client_id(kClientId);
+    request.set_region_base(reinterpret_cast<uintptr_t>(handle.ptr));
+    request.set_shm_offset(kValueSize);
+    request.set_size(kValueSize);
+    ::umbp::BoolResponse response;
+    const grpc::Status status = stub->Get(&context, request, &response);
+    EXPECT_TRUE(status.ok());
+    EXPECT_FALSE(response.ok());
+  }
+
+  allocator.Free(handle);
+  server.Shutdown();
+  server_thread.join();
+  unlink(grpc_path.c_str());
+  unlink(fd_path.c_str());
+}
+
+TEST(StandaloneShmIpcTest, WritersCompleteUnderContinuousReaderLoad) {
+  constexpr int kReaderCount = 8;
+  constexpr size_t kValueSize = 2ULL << 20;
+  const std::string address =
+      "unix:///tmp/umbp_standalone_writer_liveness_" + std::to_string(getpid()) + ".grpc.sock";
+  const std::string grpc_path = standalone::UnixPathFromGrpcAddress(address);
+  const std::string fd_path = standalone::DeriveFdSocketPath(address);
+  unlink(grpc_path.c_str());
+  unlink(fd_path.c_str());
+
+  UMBPConfig config;
+  config.dram.capacity_bytes = 8 * kValueSize;
+  config.ssd.enabled = false;
+  UMBPStandaloneProcessConfig standalone_config;
+  standalone_config.address = address;
+  standalone_config.startup_timeout_ms = 5000;
+  config.standalone_process = standalone_config;
+
+  standalone::StandaloneServer server(config, address);
+  ASSERT_TRUE(server.Start());
+  std::thread server_thread([&]() { server.Run(); });
+
+  HostMemAllocator allocator;
+  HostBufferOptions options;
+  options.backing = HostBufferBacking::kAnonymousShm;
+  options.prefault = false;
+
+  std::vector<std::unique_ptr<IUMBPClient>> readers;
+  std::vector<HostBufferHandle> reader_buffers;
+  readers.reserve(kReaderCount);
+  reader_buffers.reserve(kReaderCount);
+  for (int i = 0; i < kReaderCount; ++i) {
+    reader_buffers.push_back(allocator.Alloc(kValueSize, options));
+    ASSERT_TRUE(reader_buffers.back().valid());
+    auto client = CreateUMBPClient(config);
+    ASSERT_TRUE(client->RegisterMemory(reinterpret_cast<uintptr_t>(reader_buffers.back().ptr),
+                                       reader_buffers.back().mapped_size));
+    readers.push_back(std::move(client));
+  }
+
+  HostBufferHandle writer_buffer = allocator.Alloc(2 * kValueSize, options);
+  ASSERT_TRUE(writer_buffer.valid());
+  auto writer = CreateUMBPClient(config);
+  ASSERT_TRUE(writer->RegisterMemory(reinterpret_cast<uintptr_t>(writer_buffer.ptr),
+                                     writer_buffer.mapped_size));
+  auto* writer_bytes = static_cast<unsigned char*>(writer_buffer.ptr);
+  std::memset(writer_bytes, 0x31, kValueSize);
+  std::memset(writer_bytes + kValueSize, 0x72, kValueSize);
+  ASSERT_TRUE(writer->Put("read-hot-key", reinterpret_cast<uintptr_t>(writer_bytes), kValueSize));
+
+  std::atomic<bool> stop{false};
+  std::atomic<int> readers_started{0};
+  std::vector<std::thread> reader_threads;
+  reader_threads.reserve(kReaderCount);
+  for (int i = 0; i < kReaderCount; ++i) {
+    reader_threads.emplace_back([&, i]() {
+      readers_started.fetch_add(1, std::memory_order_release);
+      while (!stop.load(std::memory_order_acquire)) {
+        readers[i]->Get("read-hot-key", reinterpret_cast<uintptr_t>(reader_buffers[i].ptr),
+                        kValueSize);
+      }
+    });
+  }
+  while (readers_started.load(std::memory_order_acquire) != kReaderCount) {
+    std::this_thread::yield();
+  }
+  // Let every synchronous reader enter its steady RPC loop before introducing
+  // a writer; otherwise this could accidentally test an uncontended lock.
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+  auto run_with_deadline = [&](auto operation) {
+    std::atomic<bool> done{false};
+    std::atomic<bool> ok{false};
+    std::thread operation_thread([&]() {
+      ok.store(operation(), std::memory_order_relaxed);
+      done.store(true, std::memory_order_release);
+    });
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (!done.load(std::memory_order_acquire) && std::chrono::steady_clock::now() < deadline) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    const bool completed_in_time = done.load(std::memory_order_acquire);
+    if (!completed_in_time) stop.store(true, std::memory_order_release);
+    operation_thread.join();
+    return std::pair{completed_in_time, ok.load(std::memory_order_relaxed)};
+  };
+
+  const auto put_result = run_with_deadline([&]() {
+    return writer->Put("writer-liveness-key",
+                       reinterpret_cast<uintptr_t>(writer_bytes + kValueSize), kValueSize);
+  });
+  EXPECT_TRUE(put_result.first) << "Put starved behind continuous readers";
+  EXPECT_TRUE(put_result.second);
+
+  std::pair<bool, bool> clear_result{false, false};
+  if (put_result.first) clear_result = run_with_deadline([&]() { return writer->Clear(); });
+  EXPECT_TRUE(clear_result.first) << "Clear starved behind continuous readers";
+  EXPECT_TRUE(clear_result.second);
+
+  stop.store(true, std::memory_order_release);
+  for (auto& thread : reader_threads) thread.join();
+
+  for (size_t i = 0; i < readers.size(); ++i) {
+    readers[i]->DeregisterMemory(reinterpret_cast<uintptr_t>(reader_buffers[i].ptr));
+    readers[i]->Close();
+    allocator.Free(reader_buffers[i]);
+  }
+  writer->DeregisterMemory(reinterpret_cast<uintptr_t>(writer_buffer.ptr));
+  writer->Close();
+  allocator.Free(writer_buffer);
+
   server.Shutdown();
   server_thread.join();
   unlink(grpc_path.c_str());

--- a/tests/cpp/umbp/local/CMakeLists.txt
+++ b/tests/cpp/umbp/local/CMakeLists.txt
@@ -23,6 +23,14 @@ target_compile_features(test_umbp_dram_tier_concurrency PRIVATE cxx_std_17)
 add_test(NAME umbp_dram_tier_concurrency
          COMMAND test_umbp_dram_tier_concurrency)
 
+add_executable(test_umbp_dram_tier_ranges test_dram_tier_ranges.cpp)
+target_link_libraries(test_umbp_dram_tier_ranges PRIVATE umbp_core
+                                                         GTest::gtest_main)
+target_include_directories(test_umbp_dram_tier_ranges
+                           PRIVATE ${PROJECT_SOURCE_DIR}/src/umbp/local/tiers)
+target_compile_features(test_umbp_dram_tier_ranges PRIVATE cxx_std_17)
+add_test(NAME umbp_dram_tier_ranges COMMAND test_umbp_dram_tier_ranges)
+
 add_executable(test_umbp_local_follower_mode test_follower_mode.cpp)
 target_link_libraries(test_umbp_local_follower_mode PRIVATE umbp_core)
 add_test(NAME umbp_local_follower_mode COMMAND test_umbp_local_follower_mode)

--- a/tests/cpp/umbp/local/CMakeLists.txt
+++ b/tests/cpp/umbp/local/CMakeLists.txt
@@ -31,6 +31,22 @@ target_include_directories(test_umbp_dram_tier_ranges
 target_compile_features(test_umbp_dram_tier_ranges PRIVATE cxx_std_17)
 add_test(NAME umbp_dram_tier_ranges COMMAND test_umbp_dram_tier_ranges)
 
+# Run the same byte-level expectations against both copy paths, since the
+# kernel and the copy engine must be indistinguishable in their results.
+add_executable(test_umbp_dram_tier_gather test_dram_tier_gather.cpp)
+target_link_libraries(test_umbp_dram_tier_gather PRIVATE umbp_core
+                                                         GTest::gtest_main)
+# The gather and registration headers are source-private to the tier, like the
+# run planner; the test reaches them the same way rather than installing them.
+target_include_directories(test_umbp_dram_tier_gather
+                           PRIVATE ${PROJECT_SOURCE_DIR}/src/umbp/local/tiers)
+target_compile_features(test_umbp_dram_tier_gather PRIVATE cxx_std_17)
+add_test(NAME umbp_dram_tier_gather COMMAND test_umbp_dram_tier_gather)
+add_test(NAME umbp_dram_tier_gather_kernel_off
+         COMMAND test_umbp_dram_tier_gather)
+set_tests_properties(umbp_dram_tier_gather_kernel_off
+                     PROPERTIES ENVIRONMENT "UMBP_DRAM_GATHER_KERNEL=0")
+
 add_executable(test_umbp_local_follower_mode test_follower_mode.cpp)
 target_link_libraries(test_umbp_local_follower_mode PRIVATE umbp_core)
 add_test(NAME umbp_local_follower_mode COMMAND test_umbp_local_follower_mode)

--- a/tests/cpp/umbp/local/CMakeLists.txt
+++ b/tests/cpp/umbp/local/CMakeLists.txt
@@ -16,6 +16,13 @@ add_executable(test_umbp_local_client test_umbp_client.cpp)
 target_link_libraries(test_umbp_local_client PRIVATE umbp_core)
 add_test(NAME umbp_local_client COMMAND test_umbp_local_client)
 
+add_executable(test_umbp_dram_tier_concurrency test_dram_tier_concurrency.cpp)
+target_link_libraries(test_umbp_dram_tier_concurrency PRIVATE umbp_core
+                                                              GTest::gtest_main)
+target_compile_features(test_umbp_dram_tier_concurrency PRIVATE cxx_std_17)
+add_test(NAME umbp_dram_tier_concurrency
+         COMMAND test_umbp_dram_tier_concurrency)
+
 add_executable(test_umbp_local_follower_mode test_follower_mode.cpp)
 target_link_libraries(test_umbp_local_follower_mode PRIVATE umbp_core)
 add_test(NAME umbp_local_follower_mode COMMAND test_umbp_local_follower_mode)

--- a/tests/cpp/umbp/local/CMakeLists.txt
+++ b/tests/cpp/umbp/local/CMakeLists.txt
@@ -34,14 +34,15 @@ add_test(NAME umbp_dram_tier_ranges COMMAND test_umbp_dram_tier_ranges)
 # Run the same byte-level expectations against both copy paths, since the
 # kernel and the copy engine must be indistinguishable in their results.
 add_executable(test_umbp_dram_tier_gather test_dram_tier_gather.cpp)
-target_link_libraries(test_umbp_dram_tier_gather PRIVATE umbp_core
-                                                         GTest::gtest_main)
+# Own main(), to exit with SKIP_RETURN_CODE where the kernel path is unreachable.
+target_link_libraries(test_umbp_dram_tier_gather PRIVATE umbp_core GTest::gtest)
 # The gather and registration headers are source-private to the tier, like the
 # run planner; the test reaches them the same way rather than installing them.
 target_include_directories(test_umbp_dram_tier_gather
                            PRIVATE ${PROJECT_SOURCE_DIR}/src/umbp/local/tiers)
 target_compile_features(test_umbp_dram_tier_gather PRIVATE cxx_std_17)
 add_test(NAME umbp_dram_tier_gather COMMAND test_umbp_dram_tier_gather)
+set_tests_properties(umbp_dram_tier_gather PROPERTIES SKIP_RETURN_CODE 77)
 add_test(NAME umbp_dram_tier_gather_kernel_off
          COMMAND test_umbp_dram_tier_gather)
 set_tests_properties(umbp_dram_tier_gather_kernel_off

--- a/tests/cpp/umbp/local/test_dram_tier_concurrency.cpp
+++ b/tests/cpp/umbp/local/test_dram_tier_concurrency.cpp
@@ -1,0 +1,153 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
+#include "umbp/local/tiers/dram_tier.h"
+
+namespace mori::umbp {
+namespace {
+
+TEST(DRAMTierConcurrencyTest, MixedBatchReadsWritesAndEvictionsNeverTearData) {
+  constexpr size_t kKeyCount = 16;
+  constexpr size_t kValueSize = 4096;
+  constexpr int kReaderCount = 6;
+  constexpr int kIterations = 100;
+
+  // Keep the test's internal worker count modest: concurrency under test is
+  // between tier calls, not the CopyJobs implementation inside one call.
+  setenv("UMBP_DRAM_READ_THREADS", "2", 1);
+  setenv("UMBP_DRAM_WRITE_THREADS", "2", 1);
+
+  DRAMTier tier(2 * kKeyCount * kValueSize);
+  std::vector<std::string> keys;
+  std::vector<size_t> sizes(kKeyCount, kValueSize);
+  keys.reserve(kKeyCount);
+  for (size_t i = 0; i < kKeyCount; ++i) keys.push_back("concurrent-key-" + std::to_string(i));
+
+  std::vector<std::vector<unsigned char>> patterns[2];
+  for (int generation = 0; generation < 2; ++generation) {
+    patterns[generation].reserve(kKeyCount);
+    for (size_t i = 0; i < kKeyCount; ++i) {
+      const auto value = static_cast<unsigned char>(0x20 + generation * 0x40 + i);
+      patterns[generation].emplace_back(kValueSize, value);
+    }
+  }
+
+  auto write_generation = [&](int generation) {
+    std::vector<const void*> sources;
+    sources.reserve(kKeyCount);
+    for (const auto& pattern : patterns[generation]) sources.push_back(pattern.data());
+    return tier.BatchWrite(keys, sources, sizes);
+  };
+
+  const auto initial = write_generation(0);
+  ASSERT_EQ(initial.size(), kKeyCount);
+  for (bool ok : initial) ASSERT_TRUE(ok);
+
+  std::atomic<int> readers_ready{0};
+  std::atomic<bool> start{false};
+  std::atomic<bool> failed{false};
+  std::vector<std::thread> readers;
+  readers.reserve(kReaderCount);
+
+  for (int reader_id = 0; reader_id < kReaderCount; ++reader_id) {
+    readers.emplace_back([&]() {
+      std::vector<std::vector<unsigned char>> buffers(kKeyCount,
+                                                      std::vector<unsigned char>(kValueSize));
+      std::vector<uintptr_t> destinations;
+      destinations.reserve(kKeyCount);
+      for (auto& buffer : buffers) {
+        destinations.push_back(reinterpret_cast<uintptr_t>(buffer.data()));
+      }
+
+      readers_ready.fetch_add(1, std::memory_order_release);
+      while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
+
+      for (int iteration = 0; iteration < kIterations && !failed.load(); ++iteration) {
+        const auto results = tier.ReadBatchIntoPtr(keys, destinations, sizes);
+        if (results.size() != kKeyCount) {
+          failed.store(true);
+          break;
+        }
+        for (size_t i = 0; i < kKeyCount; ++i) {
+          if (!results[i]) continue;  // A concurrent eviction is a clean miss.
+          const unsigned char observed = buffers[i][0];
+          const unsigned char expected0 = patterns[0][i][0];
+          const unsigned char expected1 = patterns[1][i][0];
+          if (observed != expected0 && observed != expected1) {
+            failed.store(true);
+            break;
+          }
+          for (unsigned char byte : buffers[i]) {
+            if (byte != observed) {
+              failed.store(true);
+              break;
+            }
+          }
+        }
+      }
+    });
+  }
+
+  while (readers_ready.load(std::memory_order_acquire) != kReaderCount) {
+    std::this_thread::yield();
+  }
+  start.store(true, std::memory_order_release);
+
+  for (int iteration = 0; iteration < kIterations && !failed.load(); ++iteration) {
+    if (iteration % 7 == 0) tier.Evict(keys[static_cast<size_t>(iteration) % kKeyCount]);
+    const auto results = write_generation(iteration & 1);
+    if (results.size() != kKeyCount) {
+      failed.store(true);
+      break;
+    }
+    for (bool ok : results) {
+      if (!ok) failed.store(true);
+    }
+  }
+
+  for (auto& reader : readers) reader.join();
+  ASSERT_FALSE(failed.load());
+
+  const auto [used, capacity] = tier.Capacity();
+  EXPECT_EQ(used, kKeyCount * kValueSize);
+  EXPECT_EQ(capacity, 2 * kKeyCount * kValueSize);
+
+  const auto candidates = tier.GetLRUCandidates(kKeyCount);
+  EXPECT_EQ(candidates.size(), kKeyCount);
+  EXPECT_EQ(std::unordered_set<std::string>(candidates.begin(), candidates.end()).size(),
+            kKeyCount);
+  for (const auto& key : keys) EXPECT_TRUE(tier.Exists(key));
+}
+
+}  // namespace
+}  // namespace mori::umbp

--- a/tests/cpp/umbp/local/test_dram_tier_gather.cpp
+++ b/tests/cpp/umbp/local/test_dram_tier_gather.cpp
@@ -24,9 +24,7 @@
 // once with UMBP_DRAM_GATHER_KERNEL=0, so the same byte-level expectations are
 // enforced against both the kernel and the copy engine. The launch counter
 // assertions are what stop this from passing when the kernel silently never
-// runs -- on any machine that can register host memory for GPU access, which is
-// the one precondition the kernel path has and the one thing a test cannot
-// assert its way into.
+// runs.
 #include <gtest/gtest.h>
 #include <hip/hip_runtime_api.h>
 
@@ -48,12 +46,9 @@ bool GatherKernelExpected() {
   return value == nullptr || (std::string(value) != "0");
 }
 
-// Whether this machine can make host memory GPU-addressable at all. The tier
-// registers itself exactly this way, and where the registration does not take
-// the tier falls back to the copy engine on purpose -- so the launch counter
-// below would be measuring the machine rather than the planner's decision.
-// Probed once; the reason for a failure is logged by the registration itself at
-// warn level.
+// The tier registers itself the same way. Without it the kernel path cannot
+// engage whatever the batch looks like, so the launch counter would be
+// measuring the machine rather than the planner.
 bool GatherPathAvailable() {
   static const bool available = [] {
     std::vector<char> probe(64 * 1024);
@@ -62,13 +57,11 @@ bool GatherPathAvailable() {
   return available;
 }
 
-// The kernel-off variant asserts the absence of launches and holds anywhere;
-// only the kernel-on variant needs the registration to have taken.
 bool GatherKernelReachable() { return !GatherKernelExpected() || GatherPathAvailable(); }
 
 constexpr const char* kGatherPathUnreachable =
-    "host memory cannot be registered for GPU access on this machine, so the tier stays on the "
-    "copy engine; rerun with MORI_UMBP_LOG_LEVEL=warn for the reason the registration failed";
+    "host memory cannot be registered for GPU access here, so the tier stays on the copy engine; "
+    "rerun with MORI_UMBP_LOG_LEVEL=warn for the reason";
 
 bool HasDevice() {
   int count = 0;
@@ -339,3 +332,12 @@ TEST(HostTierRegistrationTest, CoversOnlyRegisteredBytesAndRejectsOverflow) {
 
 }  // namespace
 }  // namespace mori::umbp
+
+// 77 is SKIP_RETURN_CODE in CMakeLists.txt: gtest exits 0 on a skip, so without
+// this ctest reports a pass.
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  const int status = RUN_ALL_TESTS();
+  if (status != 0) return status;
+  return mori::umbp::GatherKernelReachable() ? 0 : 77;
+}

--- a/tests/cpp/umbp/local/test_dram_tier_gather.cpp
+++ b/tests/cpp/umbp/local/test_dram_tier_gather.cpp
@@ -24,7 +24,9 @@
 // once with UMBP_DRAM_GATHER_KERNEL=0, so the same byte-level expectations are
 // enforced against both the kernel and the copy engine. The launch counter
 // assertions are what stop this from passing when the kernel silently never
-// runs.
+// runs -- on any machine that can register host memory for GPU access, which is
+// the one precondition the kernel path has and the one thing a test cannot
+// assert its way into.
 #include <gtest/gtest.h>
 #include <hip/hip_runtime_api.h>
 
@@ -45,6 +47,28 @@ bool GatherKernelExpected() {
   const char* value = std::getenv("UMBP_DRAM_GATHER_KERNEL");
   return value == nullptr || (std::string(value) != "0");
 }
+
+// Whether this machine can make host memory GPU-addressable at all. The tier
+// registers itself exactly this way, and where the registration does not take
+// the tier falls back to the copy engine on purpose -- so the launch counter
+// below would be measuring the machine rather than the planner's decision.
+// Probed once; the reason for a failure is logged by the registration itself at
+// warn level.
+bool GatherPathAvailable() {
+  static const bool available = [] {
+    std::vector<char> probe(64 * 1024);
+    return HostTierRegistration(probe.data(), probe.size()).RegisteredBytes() != 0;
+  }();
+  return available;
+}
+
+// The kernel-off variant asserts the absence of launches and holds anywhere;
+// only the kernel-on variant needs the registration to have taken.
+bool GatherKernelReachable() { return !GatherKernelExpected() || GatherPathAvailable(); }
+
+constexpr const char* kGatherPathUnreachable =
+    "host memory cannot be registered for GPU access on this machine, so the tier stays on the "
+    "copy engine; rerun with MORI_UMBP_LOG_LEVEL=warn for the reason the registration failed";
 
 bool HasDevice() {
   int count = 0;
@@ -127,6 +151,7 @@ class PageObjectTier {
 
 TEST(DeviceGatherTest, StridedLayerReadIsByteCorrect) {
   if (!HasDevice()) GTEST_SKIP() << "No HIP device available";
+  if (!GatherKernelReachable()) GTEST_SKIP() << kGatherPathUnreachable;
 
   constexpr size_t kObjects = 32;
   constexpr size_t kLayers = 8;
@@ -161,6 +186,7 @@ TEST(DeviceGatherTest, StridedLayerReadIsByteCorrect) {
 
 TEST(DeviceGatherTest, UnalignedFragmentsAreByteCorrect) {
   if (!HasDevice()) GTEST_SKIP() << "No HIP device available";
+  if (!GatherKernelReachable()) GTEST_SKIP() << kGatherPathUnreachable;
 
   // Neither the size nor the resulting offsets are multiples of 16, which sends
   // the kernel down its byte loop instead of the vectorized one.
@@ -186,6 +212,7 @@ TEST(DeviceGatherTest, UnalignedFragmentsAreByteCorrect) {
 
 TEST(DeviceGatherTest, StridedOffloadWriteIsByteCorrect) {
   if (!HasDevice()) GTEST_SKIP() << "No HIP device available";
+  if (!GatherKernelReachable()) GTEST_SKIP() << kGatherPathUnreachable;
 
   // The offload direction: contiguous device source scattered into one layer
   // slot of each page object.

--- a/tests/cpp/umbp/local/test_dram_tier_gather.cpp
+++ b/tests/cpp/umbp/local/test_dram_tier_gather.cpp
@@ -1,0 +1,314 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// The GPU gather path for page-granular objects. Registered twice in ctest,
+// once with UMBP_DRAM_GATHER_KERNEL=0, so the same byte-level expectations are
+// enforced against both the kernel and the copy engine. The launch counter
+// assertions are what stop this from passing when the kernel silently never
+// runs.
+#include <gtest/gtest.h>
+#include <hip/hip_runtime_api.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "device_gather.h"
+#include "host_registration.h"
+#include "umbp/local/tiers/dram_tier.h"
+
+namespace mori::umbp {
+namespace {
+
+bool GatherKernelExpected() {
+  const char* value = std::getenv("UMBP_DRAM_GATHER_KERNEL");
+  return value == nullptr || (std::string(value) != "0");
+}
+
+bool HasDevice() {
+  int count = 0;
+  if (hipGetDeviceCount(&count) != hipSuccess) {
+    (void)hipGetLastError();
+    return false;
+  }
+  return count > 0;
+}
+
+// Distinct per byte so a fragment landing at the wrong offset cannot match.
+char ByteAt(size_t object, size_t offset) {
+  return static_cast<char>((object * 131u + offset * 17u + (offset >> 8)) & 0xff);
+}
+
+// hipMemset on device memory is asynchronous with respect to the host, and the
+// tier copies on a non-blocking stream that the null stream does not order
+// against. Without this the zeroing can land after the copy under test.
+void ZeroDevice(void* device, size_t bytes) {
+  ASSERT_EQ(hipMemset(device, 0, bytes), hipSuccess);
+  ASSERT_EQ(hipDeviceSynchronize(), hipSuccess);
+}
+
+// The production shape: `objects` page objects of `layers` layers each, one
+// layer read out of every object into one contiguous device buffer.
+class PageObjectTier {
+ public:
+  PageObjectTier(size_t objects, size_t layers, size_t layer_bytes)
+      : objects_(objects),
+        layers_(layers),
+        layer_bytes_(layer_bytes),
+        object_bytes_(layers * layer_bytes),
+        tier_(objects * layers * layer_bytes * 4) {
+    for (size_t object = 0; object < objects_; ++object) {
+      std::vector<char> payload(object_bytes_);
+      for (size_t i = 0; i < object_bytes_; ++i) payload[i] = ByteAt(object, i);
+      EXPECT_TRUE(tier_.Write(Key(object), payload.data(), payload.size()));
+    }
+  }
+
+  std::string Key(size_t object) const { return "page_" + std::to_string(object); }
+
+  DRAMTier& tier() { return tier_; }
+  size_t objects() const { return objects_; }
+  size_t layer_bytes() const { return layer_bytes_; }
+  size_t object_bytes() const { return object_bytes_; }
+
+  // Reads layer `layer` of every object into consecutive slots of `device`.
+  std::vector<bool> ReadLayer(size_t layer, char* device) {
+    std::vector<std::string> keys;
+    std::vector<std::vector<uintptr_t>> destinations;
+    std::vector<std::vector<size_t>> sizes;
+    std::vector<std::vector<size_t>> offsets;
+    for (size_t object = 0; object < objects_; ++object) {
+      keys.push_back(Key(object));
+      destinations.push_back({reinterpret_cast<uintptr_t>(device + object * layer_bytes_)});
+      sizes.push_back({layer_bytes_});
+      offsets.push_back({layer * layer_bytes_});
+    }
+    return tier_.ReadBatchRangesIntoPtr(keys, destinations, sizes, offsets);
+  }
+
+  std::vector<char> ExpectedLayer(size_t layer) const {
+    std::vector<char> expected(objects_ * layer_bytes_);
+    for (size_t object = 0; object < objects_; ++object) {
+      for (size_t i = 0; i < layer_bytes_; ++i) {
+        expected[object * layer_bytes_ + i] = ByteAt(object, layer * layer_bytes_ + i);
+      }
+    }
+    return expected;
+  }
+
+ private:
+  size_t objects_;
+  size_t layers_;
+  size_t layer_bytes_;
+  size_t object_bytes_;
+  DRAMTier tier_;
+};
+
+TEST(DeviceGatherTest, StridedLayerReadIsByteCorrect) {
+  if (!HasDevice()) GTEST_SKIP() << "No HIP device available";
+
+  constexpr size_t kObjects = 32;
+  constexpr size_t kLayers = 8;
+  constexpr size_t kLayerBytes = 4096;
+  PageObjectTier fixture(kObjects, kLayers, kLayerBytes);
+
+  char* device = nullptr;
+  ASSERT_EQ(hipMalloc(reinterpret_cast<void**>(&device), kObjects * kLayerBytes), hipSuccess);
+
+  for (size_t layer = 0; layer < kLayers; ++layer) {
+    ZeroDevice(device, kObjects * kLayerBytes);
+    const uint64_t launches_before = DeviceGatherLaunchCount();
+
+    EXPECT_EQ(fixture.ReadLayer(layer, device), std::vector<bool>(kObjects, true));
+
+    // 32 fragments of 4 KiB is well inside the fragmented regime, so the path
+    // is not a matter of tuning: it must be the kernel unless disabled.
+    if (GatherKernelExpected()) {
+      EXPECT_GT(DeviceGatherLaunchCount(), launches_before);
+    } else {
+      EXPECT_EQ(DeviceGatherLaunchCount(), launches_before);
+    }
+
+    std::vector<char> readback(kObjects * kLayerBytes, 0);
+    ASSERT_EQ(hipMemcpy(readback.data(), device, readback.size(), hipMemcpyDeviceToHost),
+              hipSuccess);
+    EXPECT_EQ(readback, fixture.ExpectedLayer(layer)) << "layer " << layer;
+  }
+
+  EXPECT_EQ(hipFree(device), hipSuccess);
+}
+
+TEST(DeviceGatherTest, UnalignedFragmentsAreByteCorrect) {
+  if (!HasDevice()) GTEST_SKIP() << "No HIP device available";
+
+  // Neither the size nor the resulting offsets are multiples of 16, which sends
+  // the kernel down its byte loop instead of the vectorized one.
+  constexpr size_t kObjects = 16;
+  constexpr size_t kLayers = 5;
+  constexpr size_t kLayerBytes = 3001;
+  PageObjectTier fixture(kObjects, kLayers, kLayerBytes);
+
+  char* device = nullptr;
+  ASSERT_EQ(hipMalloc(reinterpret_cast<void**>(&device), kObjects * kLayerBytes), hipSuccess);
+  ZeroDevice(device, kObjects * kLayerBytes);
+
+  const uint64_t launches_before = DeviceGatherLaunchCount();
+  EXPECT_EQ(fixture.ReadLayer(3, device), std::vector<bool>(kObjects, true));
+  if (GatherKernelExpected()) EXPECT_GT(DeviceGatherLaunchCount(), launches_before);
+
+  std::vector<char> readback(kObjects * kLayerBytes, 0);
+  ASSERT_EQ(hipMemcpy(readback.data(), device, readback.size(), hipMemcpyDeviceToHost), hipSuccess);
+  EXPECT_EQ(readback, fixture.ExpectedLayer(3));
+
+  EXPECT_EQ(hipFree(device), hipSuccess);
+}
+
+TEST(DeviceGatherTest, StridedOffloadWriteIsByteCorrect) {
+  if (!HasDevice()) GTEST_SKIP() << "No HIP device available";
+
+  // The offload direction: contiguous device source scattered into one layer
+  // slot of each page object.
+  constexpr size_t kObjects = 24;
+  constexpr size_t kLayers = 6;
+  constexpr size_t kLayerBytes = 2048;
+  constexpr size_t kObjectBytes = kLayers * kLayerBytes;
+
+  DRAMTier tier(kObjects * kObjectBytes * 4);
+
+  // The device pool is layer-major and the tier object is page-major, which is
+  // exactly what makes the offload a scatter: consecutive device fragments land
+  // one object size apart in the tier, so no run merges.
+  auto device_offset = [](size_t object, size_t layer) {
+    return layer * kObjects * kLayerBytes + object * kLayerBytes;
+  };
+  std::vector<char> payload(kObjects * kObjectBytes);
+  for (size_t object = 0; object < kObjects; ++object) {
+    for (size_t layer = 0; layer < kLayers; ++layer) {
+      for (size_t i = 0; i < kLayerBytes; ++i) {
+        payload[device_offset(object, layer) + i] = ByteAt(object, layer * kLayerBytes + i);
+      }
+    }
+  }
+
+  char* device = nullptr;
+  ASSERT_EQ(hipMalloc(reinterpret_cast<void**>(&device), payload.size()), hipSuccess);
+  ASSERT_EQ(hipMemcpy(device, payload.data(), payload.size(), hipMemcpyHostToDevice), hipSuccess);
+
+  std::vector<std::string> keys;
+  std::vector<size_t> object_sizes;
+  std::vector<std::vector<const void*>> sources;
+  std::vector<std::vector<size_t>> sizes;
+  std::vector<std::vector<size_t>> offsets;
+  for (size_t object = 0; object < kObjects; ++object) {
+    keys.push_back("offload_" + std::to_string(object));
+    object_sizes.push_back(kObjectBytes);
+    std::vector<const void*> object_sources;
+    std::vector<size_t> object_sizes_per_layer;
+    std::vector<size_t> object_offsets;
+    for (size_t layer = 0; layer < kLayers; ++layer) {
+      object_sources.push_back(device + device_offset(object, layer));
+      object_sizes_per_layer.push_back(kLayerBytes);
+      object_offsets.push_back(layer * kLayerBytes);
+    }
+    sources.push_back(object_sources);
+    sizes.push_back(object_sizes_per_layer);
+    offsets.push_back(object_offsets);
+  }
+
+  const uint64_t launches_before = DeviceGatherLaunchCount();
+  EXPECT_EQ(tier.BatchWriteRanges(keys, object_sizes, sources, sizes, offsets),
+            std::vector<bool>(kObjects, true));
+  if (GatherKernelExpected()) EXPECT_GT(DeviceGatherLaunchCount(), launches_before);
+
+  for (size_t object = 0; object < kObjects; ++object) {
+    std::vector<char> expected(kObjectBytes);
+    for (size_t i = 0; i < kObjectBytes; ++i) expected[i] = ByteAt(object, i);
+    std::vector<char> readback(kObjectBytes, 0);
+    ASSERT_TRUE(tier.ReadIntoPtr(keys[object], reinterpret_cast<uintptr_t>(readback.data()),
+                                 readback.size()));
+    EXPECT_EQ(readback, expected) << "object " << object;
+  }
+
+  EXPECT_EQ(hipFree(device), hipSuccess);
+}
+
+TEST(DeviceGatherTest, OneLargeContiguousRunStaysOnTheCopyEngine) {
+  if (!HasDevice()) GTEST_SKIP() << "No HIP device available";
+
+  // A single object read whole is one run of 512 KiB, past the point where a
+  // kernel beats hipMemcpyAsync. Guards the threshold from drifting to "always
+  // use the kernel", which measured slower for this shape.
+  constexpr size_t kBytes = 512 * 1024;
+  DRAMTier tier(kBytes * 4);
+  std::vector<char> payload(kBytes);
+  for (size_t i = 0; i < kBytes; ++i) payload[i] = ByteAt(7, i);
+  ASSERT_TRUE(tier.Write("bulk", payload.data(), payload.size()));
+
+  char* device = nullptr;
+  ASSERT_EQ(hipMalloc(reinterpret_cast<void**>(&device), kBytes), hipSuccess);
+  ZeroDevice(device, kBytes);
+
+  const uint64_t launches_before = DeviceGatherLaunchCount();
+  EXPECT_EQ(tier.ReadBatchIntoPtr({"bulk"}, {reinterpret_cast<uintptr_t>(device)}, {kBytes}),
+            std::vector<bool>({true}));
+  EXPECT_EQ(DeviceGatherLaunchCount(), launches_before);
+
+  std::vector<char> readback(kBytes, 0);
+  ASSERT_EQ(hipMemcpy(readback.data(), device, kBytes, hipMemcpyDeviceToHost), hipSuccess);
+  EXPECT_EQ(readback, payload);
+
+  EXPECT_EQ(hipFree(device), hipSuccess);
+}
+
+TEST(HostTierRegistrationTest, CoversOnlyRegisteredBytesAndRejectsOverflow) {
+  std::vector<char> region(64 * 1024);
+  HostTierRegistration registration(region.data(), region.size());
+
+  if (registration.RegisteredBytes() == 0) {
+    // No device, or registration unavailable: the safe answer is always false,
+    // which is exactly what keeps the kernel path off.
+    EXPECT_FALSE(registration.Covers(region.data(), 1));
+    return;
+  }
+
+  // All-or-nothing, never a partial prefix. Registering the region in pieces
+  // makes hipMemcpy reject any copy that straddles two of them, which in the
+  // tier surfaces as a write failure that the storage manager mistakes for a
+  // full tier and answers by evicting everything.
+  ASSERT_EQ(registration.RegisteredBytes(), region.size());
+  EXPECT_TRUE(registration.Covers(region.data(), region.size()));
+  EXPECT_TRUE(registration.Covers(region.data() + region.size() - 1, 1));
+  EXPECT_FALSE(registration.Covers(region.data(), region.size() + 1));
+  EXPECT_FALSE(registration.Covers(region.data() + region.size(), 1));
+  // Built from an integer, not as `region.data() - 1`: forming a pointer before
+  // the start of an array is undefined even without dereferencing it.
+  EXPECT_FALSE(registration.Covers(
+      reinterpret_cast<const void*>(reinterpret_cast<uintptr_t>(region.data()) - 1), 1));
+  EXPECT_FALSE(registration.Covers(nullptr, 1));
+  // A size that would wrap when added to the offset must not read as covered.
+  EXPECT_FALSE(registration.Covers(region.data(), static_cast<size_t>(-1)));
+}
+
+}  // namespace
+}  // namespace mori::umbp

--- a/tests/cpp/umbp/local/test_dram_tier_ranges.cpp
+++ b/tests/cpp/umbp/local/test_dram_tier_ranges.cpp
@@ -1,0 +1,350 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#include <gtest/gtest.h>
+#include <hip/hip_runtime_api.h>
+
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "device_copy_run.h"
+#include "umbp/local/tiers/dram_tier.h"
+#include "umbp/local/tiers/local_storage_manager.h"
+
+namespace mori::umbp {
+namespace {
+
+std::vector<const void*> ConstPtrs(const std::vector<std::vector<char>>& buffers) {
+  std::vector<const void*> ptrs;
+  ptrs.reserve(buffers.size());
+  for (const auto& buffer : buffers) ptrs.push_back(buffer.data());
+  return ptrs;
+}
+
+struct PlannerJob {
+  void* dst;
+  const void* src;
+  size_t size;
+};
+
+TEST(DeviceCopyRunPlannerTest, MixedSizeAdjacentJobsStayOnLinearPath) {
+  char src[64]{};
+  char dst[64]{};
+  std::vector<PlannerJob> jobs{{dst, src, 8}, {dst + 8, src + 8, 16}, {dst + 24, src + 24, 4}};
+  std::vector<PlannerJob*> ordered{&jobs[0], &jobs[1], &jobs[2]};
+
+  const auto run = detail::FindDeviceCopyRun(ordered, 0);
+  EXPECT_EQ(run.kind, detail::DeviceCopyRunKind::kLinear);
+  EXPECT_EQ(run.end, 3u);
+  EXPECT_EQ(run.bytes, 28u);
+}
+
+TEST(DeviceCopyRunPlannerTest, UniformStridedJobsUseOnePitchedRun) {
+  char src[96]{};
+  char dst[144]{};
+  std::vector<PlannerJob> jobs{{dst, src, 16}, {dst + 48, src + 32, 16}, {dst + 96, src + 64, 16}};
+  std::vector<PlannerJob*> ordered{&jobs[0], &jobs[1], &jobs[2]};
+
+  const auto run = detail::FindDeviceCopyRun(ordered, 0);
+  EXPECT_EQ(run.kind, detail::DeviceCopyRunKind::kPitched);
+  EXPECT_EQ(run.end, 3u);
+  EXPECT_EQ(run.bytes, 48u);
+  EXPECT_EQ(run.width, 16u);
+  EXPECT_EQ(run.spitch, 32u);
+  EXPECT_EQ(run.dpitch, 48u);
+}
+
+TEST(DeviceCopyRunPlannerTest, MixedSizeStridedJobsFallBackPerRange) {
+  char src[96]{};
+  char dst[120]{};
+  std::vector<PlannerJob> jobs{{dst, src, 8}, {dst + 40, src + 32, 16}, {dst + 80, src + 64, 8}};
+  std::vector<PlannerJob*> ordered{&jobs[0], &jobs[1], &jobs[2]};
+
+  size_t submissions = 0;
+  for (size_t begin = 0; begin < ordered.size();) {
+    const auto run = detail::FindDeviceCopyRun(ordered, begin);
+    EXPECT_EQ(run.kind, detail::DeviceCopyRunKind::kSingle);
+    ++submissions;
+    begin = run.end;
+  }
+  EXPECT_EQ(submissions, 3u);
+}
+
+TEST(DRAMTierRangesTest, ShuffledPutAndOverlappingGetAreByteCorrect) {
+  DRAMTier tier(4096);
+  std::vector<std::vector<char>> pieces{
+      {'B', 'B', 'B', 'B'}, {'C', 'C', 'C', 'C'}, {'A', 'A', 'A', 'A'}};
+  auto put = tier.BatchWriteRanges({"key"}, {12}, {ConstPtrs(pieces)}, {{4, 4, 4}}, {{4, 8, 0}});
+  ASSERT_EQ(put, std::vector<bool>({true}));
+
+  std::vector<char> suffix(4, 0);
+  std::vector<char> prefix_a(4, 0);
+  std::vector<char> prefix_b(4, 0);
+  auto get = tier.ReadBatchRangesIntoPtr(
+      {"key"},
+      {{reinterpret_cast<uintptr_t>(suffix.data()), reinterpret_cast<uintptr_t>(prefix_a.data()),
+        reinterpret_cast<uintptr_t>(prefix_b.data())}},
+      {{4, 4, 4}}, {{8, 0, 0}});
+  ASSERT_EQ(get, std::vector<bool>({true}));
+  EXPECT_EQ(suffix, std::vector<char>(4, 'C'));
+  EXPECT_EQ(prefix_a, std::vector<char>(4, 'A'));
+  EXPECT_EQ(prefix_b, std::vector<char>(4, 'A'));
+}
+
+TEST(DRAMTierRangesTest, ShapeErrorsFailWholeBatch) {
+  DRAMTier tier(4096);
+  std::vector<char> value(8, 'x');
+  ASSERT_TRUE(tier.Write("a", value.data(), value.size()));
+  ASSERT_TRUE(tier.Write("b", value.data(), value.size()));
+  std::vector<char> out_a(4), out_b(4);
+
+  auto get = tier.ReadBatchRangesIntoPtr(
+      {"a", "b"},
+      {{reinterpret_cast<uintptr_t>(out_a.data())}, {reinterpret_cast<uintptr_t>(out_b.data())}},
+      {{4, 4}, {4}}, {{0}, {0}});
+  EXPECT_EQ(get, std::vector<bool>({false, false}));
+
+  auto put = tier.BatchWriteRanges({"c", "d"}, {8}, {{value.data()}, {value.data()}}, {{8}, {8}},
+                                   {{0}, {0}});
+  EXPECT_EQ(put, std::vector<bool>({false, false}));
+}
+
+TEST(DRAMTierRangesTest, DataErrorsAreIsolatedPerEntry) {
+  DRAMTier tier(4096);
+  std::vector<char> value(8, 'v');
+  ASSERT_TRUE(tier.Write("present", value.data(), value.size()));
+  std::vector<char> good(4, 0), missing(4, 0), overflow(4, 0);
+
+  auto result = tier.ReadBatchRangesIntoPtr({"present", "missing", "present"},
+                                            {{reinterpret_cast<uintptr_t>(good.data())},
+                                             {reinterpret_cast<uintptr_t>(missing.data())},
+                                             {reinterpret_cast<uintptr_t>(overflow.data())}},
+                                            {{4}, {4}, {4}}, {{2}, {0}, {6}});
+  EXPECT_EQ(result, std::vector<bool>({true, false, false}));
+  EXPECT_EQ(good, std::vector<char>(4, 'v'));
+}
+
+TEST(DRAMTierRangesTest, RejectsOverflowZeroAndEmptyEntries) {
+  DRAMTier tier(4096);
+  std::vector<char> value(16, 'z');
+  ASSERT_TRUE(tier.Write("key", value.data(), value.size()));
+  std::vector<char> out(64, 0);
+
+  auto overflow = tier.ReadBatchRangesIntoPtr({"key"}, {{reinterpret_cast<uintptr_t>(out.data())}},
+                                              {{64}}, {{std::numeric_limits<size_t>::max() - 8}});
+  EXPECT_EQ(overflow, std::vector<bool>({false}));
+
+  auto zero = tier.ReadBatchRangesIntoPtr({"key"}, {{reinterpret_cast<uintptr_t>(out.data())}},
+                                          {{0}}, {{0}});
+  EXPECT_EQ(zero, std::vector<bool>({false}));
+
+  auto empty_get = tier.ReadBatchRangesIntoPtr({"key"}, {{}}, {{}}, {{}});
+  EXPECT_EQ(empty_get, std::vector<bool>({false}));
+  auto empty_put = tier.BatchWriteRanges({"empty"}, {0}, {{}}, {{}}, {{}});
+  EXPECT_EQ(empty_put, std::vector<bool>({false}));
+  EXPECT_FALSE(tier.Exists("empty"));
+}
+
+TEST(DRAMTierRangesTest, MissingTrailingRangeNeverReplacesExistingValue) {
+  DRAMTier tier(4096);
+  std::vector<char> original(12, 'o');
+  ASSERT_TRUE(tier.Write("key", original.data(), original.size()));
+  std::vector<std::vector<char>> pieces{{'n', 'n', 'n', 'n'}, {'m', 'm', 'm', 'm'}};
+
+  // Keep object_size independent from emitted ranges; this is the §4.1 guard
+  // against silently publishing [0, 8) as a complete 12-byte object.
+  auto short_put = tier.BatchWriteRanges({"key"}, {12}, {ConstPtrs(pieces)}, {{4, 4}}, {{0, 4}});
+  EXPECT_EQ(short_put, std::vector<bool>({false}));
+
+  std::vector<char> readback(12, 0);
+  ASSERT_TRUE(tier.ReadIntoPtr("key", reinterpret_cast<uintptr_t>(readback.data()), 12));
+  EXPECT_EQ(readback, original);
+}
+
+TEST(DRAMTierRangesTest, AllocationFailureNeverReplacesExistingValue) {
+  DRAMTier tier(12);
+  std::vector<char> original(12, 'o');
+  ASSERT_TRUE(tier.Write("key", original.data(), original.size()));
+  std::vector<std::vector<char>> replacement{{'a', 'a', 'a', 'a', 'a', 'a'},
+                                             {'b', 'b', 'b', 'b', 'b', 'b'}};
+
+  auto put = tier.BatchWriteRanges({"key"}, {12}, {ConstPtrs(replacement)}, {{6, 6}}, {{0, 6}});
+  EXPECT_EQ(put, std::vector<bool>({false}));
+
+  std::vector<char> readback(12, 0);
+  ASSERT_TRUE(tier.ReadIntoPtr("key", reinterpret_cast<uintptr_t>(readback.data()), 12));
+  EXPECT_EQ(readback, original);
+}
+
+TEST(LocalStorageManagerRangesTest, FullTierEvictsAndRetriesWholeEntry) {
+  UMBPConfig config;
+  config.dram.capacity_bytes = 16;
+  config.ssd.enabled = false;
+  LocalStorageManager manager(config);
+  std::vector<char> old_value(8, 'o');
+  ASSERT_TRUE(manager.Write("old", old_value.data(), old_value.size()));
+
+  std::vector<std::vector<char>> pieces{{'a', 'a', 'a', 'a', 'a', 'a'},
+                                        {'b', 'b', 'b', 'b', 'b', 'b'}};
+  std::vector<std::vector<uintptr_t>> ptrs{{reinterpret_cast<uintptr_t>(pieces[0].data()),
+                                            reinterpret_cast<uintptr_t>(pieces[1].data())}};
+  auto put = manager.WriteBatchRangesFromPtr({"new"}, {12}, ptrs, {{6, 6}}, {{0, 6}});
+  ASSERT_EQ(put, std::vector<bool>({true}));
+  EXPECT_FALSE(manager.Exists("old"));
+  EXPECT_TRUE(manager.Exists("new"));
+
+  std::vector<char> out_a(6, 0), out_b(6, 0);
+  auto get = manager.ReadBatchRangesIntoPtr(
+      {"new"},
+      {{reinterpret_cast<uintptr_t>(out_a.data()), reinterpret_cast<uintptr_t>(out_b.data())}},
+      {{6, 6}}, {{0, 6}});
+  ASSERT_EQ(get, std::vector<bool>({true}));
+  EXPECT_EQ(out_a, pieces[0]);
+  EXPECT_EQ(out_b, pieces[1]);
+}
+
+TEST(LocalStorageManagerRangesTest, InvalidEntryDoesNotTriggerEvictionRetry) {
+  UMBPConfig config;
+  config.dram.capacity_bytes = 16;
+  config.ssd.enabled = false;
+  LocalStorageManager manager(config);
+  std::vector<char> old_value(16, 'o');
+  ASSERT_TRUE(manager.Write("old", old_value.data(), old_value.size()));
+
+  std::vector<char> incomplete(8, 'n');
+  auto put = manager.WriteBatchRangesFromPtr(
+      {"invalid"}, {12}, {{reinterpret_cast<uintptr_t>(incomplete.data())}}, {{8}}, {{0}});
+  EXPECT_EQ(put, std::vector<bool>({false}));
+  EXPECT_TRUE(manager.Exists("old"));
+  EXPECT_FALSE(manager.Exists("invalid"));
+}
+
+TEST(DRAMTierRangesTest, DuplicateKeysAreRejectedConsistentlyAcrossLayers) {
+  std::vector<char> first(4, 'a');
+  std::vector<char> second(4, 'b');
+  std::vector<char> unique(4, 'u');
+
+  DRAMTier tier(64);
+  auto tier_result = tier.BatchWriteRanges({"dup", "dup", "unique"}, {4, 4, 4},
+                                           {{first.data()}, {second.data()}, {unique.data()}},
+                                           {{4}, {4}, {4}}, {{0}, {0}, {0}});
+  EXPECT_EQ(tier_result, std::vector<bool>({false, false, true}));
+  EXPECT_FALSE(tier.Exists("dup"));
+  EXPECT_TRUE(tier.Exists("unique"));
+
+  UMBPConfig config;
+  config.dram.capacity_bytes = 64;
+  config.ssd.enabled = false;
+  LocalStorageManager manager(config);
+  auto manager_result =
+      manager.WriteBatchRangesFromPtr({"dup", "dup", "unique"}, {4, 4, 4},
+                                      {{reinterpret_cast<uintptr_t>(first.data())},
+                                       {reinterpret_cast<uintptr_t>(second.data())},
+                                       {reinterpret_cast<uintptr_t>(unique.data())}},
+                                      {{4}, {4}, {4}}, {{0}, {0}, {0}});
+  EXPECT_EQ(manager_result, std::vector<bool>({false, false, true}));
+  EXPECT_FALSE(manager.Exists("dup"));
+  EXPECT_TRUE(manager.Exists("unique"));
+}
+
+TEST(DRAMTierRangesTest, DevicePitchedAndMixedWidthCopiesAreByteCorrect) {
+  int device_count = 0;
+  if (hipGetDeviceCount(&device_count) != hipSuccess || device_count == 0) {
+    (void)hipGetLastError();
+    GTEST_SKIP() << "No HIP device available";
+  }
+
+  constexpr size_t kRows = 3;
+  constexpr size_t kWidth = 16;
+  constexpr size_t kPitch = 32;
+  std::vector<unsigned char> host(kRows * kPitch, 0);
+  std::vector<char> expected(kRows * kWidth, 0);
+  for (size_t row = 0; row < kRows; ++row) {
+    for (size_t col = 0; col < kWidth; ++col) {
+      const unsigned char value = static_cast<unsigned char>(row * 32 + col);
+      host[row * kPitch + col] = value;
+      expected[row * kWidth + col] = static_cast<char>(value);
+    }
+  }
+
+  void* device = nullptr;
+  ASSERT_EQ(hipMalloc(&device, host.size()), hipSuccess);
+  ASSERT_EQ(hipMemcpy(device, host.data(), host.size(), hipMemcpyHostToDevice), hipSuccess);
+
+  DRAMTier tier(4096);
+  std::vector<const void*> sources;
+  for (size_t row = 0; row < kRows; ++row) {
+    sources.push_back(static_cast<const unsigned char*>(device) + row * kPitch);
+  }
+  ASSERT_EQ(tier.BatchWriteRanges({"pitched"}, {expected.size()}, {sources},
+                                  {{kWidth, kWidth, kWidth}}, {{0, kWidth, 2 * kWidth}}),
+            std::vector<bool>({true}));
+  std::vector<char> readback(expected.size(), 0);
+  ASSERT_TRUE(
+      tier.ReadIntoPtr("pitched", reinterpret_cast<uintptr_t>(readback.data()), readback.size()));
+  EXPECT_EQ(readback, expected);
+
+  ASSERT_EQ(hipMemset(device, 0, host.size()), hipSuccess);
+  std::vector<uintptr_t> destinations;
+  for (size_t row = 0; row < kRows; ++row) {
+    destinations.push_back(
+        reinterpret_cast<uintptr_t>(static_cast<unsigned char*>(device) + row * kPitch));
+  }
+  ASSERT_EQ(tier.ReadBatchRangesIntoPtr({"pitched"}, {destinations}, {{kWidth, kWidth, kWidth}},
+                                        {{0, kWidth, 2 * kWidth}}),
+            std::vector<bool>({true}));
+  ASSERT_EQ(hipMemcpy(host.data(), device, host.size(), hipMemcpyDeviceToHost), hipSuccess);
+  for (size_t row = 0; row < kRows; ++row) {
+    EXPECT_EQ(std::memcmp(host.data() + row * kPitch, expected.data() + row * kWidth, kWidth), 0);
+  }
+
+  // Different row widths cannot use the 2D path. Keep the source strided so
+  // they also cannot accidentally form a flat 1D run.
+  const std::vector<size_t> mixed_sizes{8, 16, 8};
+  const std::vector<size_t> mixed_offsets{0, 8, 24};
+  std::vector<char> mixed_expected(32, 0);
+  std::fill(host.begin(), host.end(), 0);
+  size_t cursor = 0;
+  for (size_t row = 0; row < kRows; ++row) {
+    for (size_t col = 0; col < mixed_sizes[row]; ++col) {
+      const unsigned char value = static_cast<unsigned char>(0x80 + cursor + col);
+      host[row * kPitch + col] = value;
+      mixed_expected[cursor + col] = static_cast<char>(value);
+    }
+    cursor += mixed_sizes[row];
+  }
+  ASSERT_EQ(hipMemcpy(device, host.data(), host.size(), hipMemcpyHostToDevice), hipSuccess);
+  ASSERT_EQ(tier.BatchWriteRanges({"mixed"}, {mixed_expected.size()}, {sources}, {mixed_sizes},
+                                  {mixed_offsets}),
+            std::vector<bool>({true}));
+  std::vector<char> mixed_readback(mixed_expected.size(), 0);
+  ASSERT_TRUE(tier.ReadIntoPtr("mixed", reinterpret_cast<uintptr_t>(mixed_readback.data()),
+                               mixed_readback.size()));
+  EXPECT_EQ(mixed_readback, mixed_expected);
+
+  EXPECT_EQ(hipFree(device), hipSuccess);
+}
+
+}  // namespace
+}  // namespace mori::umbp

--- a/tests/cpp/umbp/local/test_umbp_client.cpp
+++ b/tests/cpp/umbp/local/test_umbp_client.cpp
@@ -19,6 +19,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+#include <hip/hip_runtime_api.h>
+
 #include <cassert>
 #include <cstring>
 #include <iostream>
@@ -184,6 +186,64 @@ void test_put_from_ptr_get_into_ptr() {
   std::cout << "PASSED" << std::endl;
 }
 
+void test_gpu_put_get() {
+  std::cout << "test_gpu_put_get... ";
+  int device_count = 0;
+  if (hipGetDeviceCount(&device_count) != hipSuccess || device_count == 0) {
+    (void)hipGetLastError();
+    std::cout << "SKIPPED (no GPU)" << std::endl;
+    return;
+  }
+
+  UMBPConfig config;
+  config.dram.capacity_bytes = 1 * 1024 * 1024;
+  config.ssd.enabled = false;
+  StandaloneClient client(config);
+
+  constexpr size_t kSize = 4096;
+  std::vector<unsigned char> host_a(kSize, 0x2a);
+  std::vector<unsigned char> host_b(kSize, 0x7c);
+  void* device_buffer = nullptr;
+  assert(hipMalloc(&device_buffer, 2 * kSize) == hipSuccess);
+  assert(hipMemcpy(device_buffer, host_a.data(), kSize, hipMemcpyHostToDevice) == hipSuccess);
+  assert(hipMemcpy(static_cast<char*>(device_buffer) + kSize, host_b.data(), kSize,
+                   hipMemcpyHostToDevice) == hipSuccess);
+
+  // Exercise the single-item Write/ReadIntoPtr paths.
+  assert(client.Put("gpu-single", reinterpret_cast<uintptr_t>(device_buffer), kSize));
+  assert(hipMemset(device_buffer, 0, kSize) == hipSuccess);
+  assert(client.Get("gpu-single", reinterpret_cast<uintptr_t>(device_buffer), kSize));
+  std::vector<unsigned char> single_result(kSize);
+  assert(hipMemcpy(single_result.data(), device_buffer, kSize, hipMemcpyDeviceToHost) ==
+         hipSuccess);
+  assert(single_result == host_a);
+
+  // Exercise the batched stream path in both directions.
+  assert(hipMemcpy(device_buffer, host_a.data(), kSize, hipMemcpyHostToDevice) == hipSuccess);
+  assert(hipMemcpy(static_cast<char*>(device_buffer) + kSize, host_b.data(), kSize,
+                   hipMemcpyHostToDevice) == hipSuccess);
+  const std::vector<std::string> keys{"gpu-batch-a", "gpu-batch-b"};
+  const std::vector<uintptr_t> ptrs{reinterpret_cast<uintptr_t>(device_buffer),
+                                    reinterpret_cast<uintptr_t>(device_buffer) + kSize};
+  const std::vector<size_t> sizes{kSize, kSize};
+  const auto put_results = client.BatchPut(keys, ptrs, sizes);
+  assert(put_results.size() == 2 && put_results[0] && put_results[1]);
+
+  assert(hipMemset(device_buffer, 0, 2 * kSize) == hipSuccess);
+  const auto get_results = client.BatchGet(keys, ptrs, sizes);
+  assert(get_results.size() == 2 && get_results[0] && get_results[1]);
+  std::vector<unsigned char> batch_a(kSize);
+  std::vector<unsigned char> batch_b(kSize);
+  assert(hipMemcpy(batch_a.data(), device_buffer, kSize, hipMemcpyDeviceToHost) == hipSuccess);
+  assert(hipMemcpy(batch_b.data(), static_cast<char*>(device_buffer) + kSize, kSize,
+                   hipMemcpyDeviceToHost) == hipSuccess);
+  assert(batch_a == host_a);
+  assert(batch_b == host_b);
+
+  assert(hipFree(device_buffer) == hipSuccess);
+  std::cout << "PASSED" << std::endl;
+}
+
 void test_dram_full_demote_with_index() {
   std::cout << "test_dram_full_demote_with_index... ";
 
@@ -332,6 +392,7 @@ int main() {
   test_batch_put_get();
   test_clear();
   test_put_from_ptr_get_into_ptr();
+  test_gpu_put_get();
   test_dram_full_demote_with_index();
   test_batch_get_ssd_tier();
   test_batch_get_follower();

--- a/tests/python/umbp/test_umbp_client_ptr.py
+++ b/tests/python/umbp/test_umbp_client_ptr.py
@@ -99,6 +99,42 @@ def test_put_from_ptr_get_into_ptr_round_trip():
     assert client.clear()
 
 
+def test_batch_put_get_ranges_round_trip_and_shape_failure():
+    client = _make_client()
+    a = (ctypes.c_ubyte * 4)(*b"AAAA")
+    b = (ctypes.c_ubyte * 4)(*b"BBBB")
+    c = (ctypes.c_ubyte * 4)(*b"CCCC")
+
+    assert client.batch_put_ranges_from_ptr(
+        ["range_key"],
+        [12],
+        [[ctypes.addressof(b), ctypes.addressof(c), ctypes.addressof(a)]],
+        [[4, 4, 4]],
+        [[4, 8, 0]],
+    ) == [True]
+    assert client.exists("range_key")
+
+    prefix = (ctypes.c_ubyte * 4)()
+    suffix = (ctypes.c_ubyte * 4)()
+    assert client.batch_get_ranges_into_ptr(
+        ["range_key"],
+        [[ctypes.addressof(suffix), ctypes.addressof(prefix)]],
+        [[4, 4]],
+        [[8, 0]],
+    ) == [True]
+    assert bytes(prefix) == b"AAAA"
+    assert bytes(suffix) == b"CCCC"
+
+    # A ragged inner vector is a whole-call shape error.
+    assert client.batch_get_ranges_into_ptr(
+        ["range_key", "missing"],
+        [[ctypes.addressof(prefix)], [ctypes.addressof(suffix)]],
+        [[4, 4], [4]],
+        [[0], [0]],
+    ) == [False, False]
+    assert client.clear()
+
+
 def test_batch_put_get_multiple_page_components():
     client = _make_client()
     mem_pool = MockPageFirstKVCache(num_pages=4, page_size=1, element_size=256)


### PR DESCRIPTION
## Summary

Lets the SGLang UMBP tree connector run against a **Distributed inner backend**, so a node's KV
cache becomes visible to the whole master-led pool instead of only to the node that produced it.

The enabling piece is ranged multi-buffer I/O in `DistributedClient`: `BatchGetRanges` /
`BatchPutRanges` were stubs returning all-false.

## Why

The tree connector stores one object per KV page and reads a single layer as a byte range inside
that object, so it can only run where the ranged entry points work. That restricted it to the
Local inner backend, i.e. to a single machine.

## What is in here

Grouped by theme rather than by commit order:

| Theme | Commits |
|---|---|
| GPU pointer support and the ranged API surface | `11123d60`, `e3c81dcc`, `619f1a35` |
| DRAM-tier local data plane (coalescing, host registration, gather kernel, per-thread streams, profiling) | `d63b785f`, `7996e266`, `2d548ba1`, `ab4fe0fa`, `362cd22c` |
| Concurrent reads in the standalone server | `6be2c85d` |
| Share host registration and gather across backends — pure move, old headers forward | `93f2998a` |
| Bound heartbeat event batches — independent fix, benefits every distributed user | `1d3c859e` |
| Ranged I/O in the distributed backend, GPU IPC with a distributed inner backend, capability reporting | `875d4ac3` |
| Make the ranged scratch arena opt-in | `c0044f87` |

A remote ranged read fetches the whole object into a registered host scratch arena, installs it
into the local tier, and then serves the ranges through the same code path as a local hit. True
ranged RDMA is deliberately left out: it would have to widen `RemoteGetEntry`'s local side to a
descriptor list inside the descriptor-cache window, and the measured saving does not justify that
yet.

## Impact on deployments that do not use ranged I/O

- **The scratch arena is opt-in.** `ranged_scratch_size` defaults to 0 and
  `UMBP_DISTRIBUTED_RANGED_SCRATCH_BYTES` may be unset or 0: nothing is allocated, nothing is
  registered, and `SupportsRangedIO()` reports false.
- The standalone server enables concurrent reads for a Distributed inner backend **only when
  ranged I/O is available**. Local-backend behaviour is unchanged.
- `IUMBPClient::SupportsRangedIO()` has a default implementation returning false, so out-of-tree
  implementations are unaffected.
- `supports_ranged_io` is a new Ping field number, so old and new peers interoperate.
- Non-ranged `BatchGet` / `BatchPut` and the local page paths are untouched.

Checked on DeepSeek-V4-Flash / TP8 / MI355X with HiCache using UMBP as its L3 backend and the
scratch left unset, in both shapes:

- one `DistributedClient` per rank: 8 clients start, hugepage consumption matches the tiers
  exactly with no scratch, and L3 restores 7936 tokens after a device-cache flush;
- standalone server with a Distributed inner backend: 48 host shm regions register, the server
  reports serialized reads, same L3 restore.

## Testing

```bash
cmake -S . -B build -GNinja -DBUILD_TESTS=ON -DBUILD_UMBP=ON -DCMAKE_BUILD_TYPE=Release
cmake --build build
HIP_VISIBLE_DEVICES=0 ctest --test-dir build -R "umbp|dram|ssd_tier|prefix|host_mem|storage"
```

30/30 pass. `-DBUILD_UMBP=ON` is required; without it the UMBP tests are not registered and the
filter matches nothing.

Real hardware, DeepSeek-V4-Flash / TP8 / MI355X, tree connector:

- single node: multi-length cache restore passes at 2K/4K/8K/16K with the control prompt at zero;
  restore latency within 1.04x of the Local inner backend; KV survives an SGLang restart.
- two physical nodes: objects spread across both, cross-node restore passes, remote traffic
  1.18 GB put and 103 MB get.
- paired GSM8K 200-question smoke, n=1: cold run 0.900, restored run 0.900, no observed
  regression. Token-level equivalence stayed inconclusive because the device reference itself is
  nondeterministic at these lengths.

## Known limitations

- **Cross-node deployments must use hugepages for the DRAM tier.** Registering a multi-GiB region
  with 4 KiB pages exhausts the NIC's MTT table (`ibv_reg_mr` fails with `ENOMEM`). Single-node
  deployments never trigger the RDMA registration and are unaffected, so a single-node run does
  not tell you whether the cross-node path will register.
- Key visibility to `BatchExists` follows the owning peer's master heartbeat, so a freshly
  offloaded page is not discoverable for up to two heartbeat intervals. Deployments that need
  prompt visibility should shorten the interval.
