### PR TITLE
build: recognise gfx1250 and let anvil_device.hpp compile for it

### DIFF
--- a/include/mori/core/transport/sdma/anvil_device.hpp
+++ b/include/mori/core/transport/sdma/anvil_device.hpp
@@ -52,6 +52,17 @@ constexpr long long MAX_RETRIES = 1LL << 34;
 
 #if defined(__HIPCC__) || defined(__CUDACC__)
 
+// gfx12 dropped the s_waitcnt intrinsic. This gate only makes the header build
+// for gfx1250 -- the packets below are still the gfx9 layout, with no npd/scope
+// fields, so this path is not ported to gfx12.5 (see cco.hpp for one that is).
+__device__ __forceinline__ void PublishStores() {
+#if defined(__gfx1250__)
+  __builtin_amdgcn_fence(__ATOMIC_RELEASE, "agent");
+#else
+  __builtin_amdgcn_s_waitcnt(0);
+#endif
+}
+
 // SDMA_PKT_COPY_LINEAR DW2 (PARAMETER_UNION) stays 0: peak D2D/XGMI copy BW.
 __device__ __forceinline__ SDMA_PKT_COPY_LINEAR CreateCopyPacket(void* srcBuf, void* dstBuf,
                                                                  long long int packetSize) {
@@ -196,24 +207,24 @@ struct SdmaQueueDeviceHandle {
       // Ringing the doorbell out of order would publish a partial packet.
       if (++retries > MAX_RETRIES) __builtin_trap();
     }
-    __builtin_amdgcn_s_waitcnt(0);
+    PublishStores();
     __builtin_amdgcn_wave_barrier();
     __atomic_signal_fence(__ATOMIC_SEQ_CST);
 
     __hip_atomic_store(wptr, pendingWptr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
 
-    __builtin_amdgcn_s_waitcnt(0);
+    PublishStores();
     __builtin_amdgcn_wave_barrier();
     __atomic_signal_fence(__ATOMIC_SEQ_CST);
 
     __hip_atomic_store(doorbell, pendingWptr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
 
-    __builtin_amdgcn_s_waitcnt(0);
+    PublishStores();
     __builtin_amdgcn_wave_barrier();
     __atomic_signal_fence(__ATOMIC_SEQ_CST);
     __hip_atomic_store(committedWptr, pendingWptr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
 
-    __builtin_amdgcn_s_waitcnt(0);
+    PublishStores();
     __builtin_amdgcn_wave_barrier();
     __atomic_signal_fence(__ATOMIC_SEQ_CST);
   }

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ try:
 except ImportError:
     _HAVE_CYTHON = False
 
-_supported_arch_list = ["gfx942", "gfx950"]
+_supported_arch_list = ["gfx942", "gfx950", "gfx1250"]
 
 _REQUIRED_SYSTEM_DEPS: list = []
 


### PR DESCRIPTION
`setup.py` filters every arch source -- local detection, `PYTORCH_ROCM_ARCH`, `GPU_ARCHS` -- against `_supported_arch_list`, which held only `gfx942` and `gfx950`. On a gfx1250 box `_detect_local_gpu_arch()` therefore returned nothing and the build fell back to a `gfx942;gfx950` fat binary that cannot run there. `MORI_GPU_ARCHS` was the only way through, because it is the one input that bypasses the filter.

Adding gfx1250 to the list also puts it in the fat-binary fallback, which requires `anvil_device.hpp` to build for gfx1250. It did not: gfx12 dropped the `s_waitcnt` intrinsic, and `submitPacket` used it in four places, so any kernel reaching `put`/`signal` failed with `Cannot select: intrinsic llvm.amdgcn.s.waitcnt`. Those four now go through `PublishStores()` -- a release fence on gfx1250, `s_waitcnt` elsewhere, the same split `cco.hpp` already uses.

**This is a compile fix only.** The packets in this header are still the gfx9 layout with no `npd`/scope fields, so the path is not ported to gfx12.5; the comment on `PublishStores()` says so and points at `cco.hpp` for one that is.

## Validation

Compiled on f01-2 (gfx1250, ROCm 7.15) with a kernel that actually calls `put`, `signal` and `putWithSignal`, so the backend runs instruction selection over `submitPacket` -- compiling the header alone is not enough, since its `__device__` functions never reach codegen on their own.

- gfx1250: **compiles** (previously `Cannot select: intrinsic llvm.amdgcn.s.waitcnt`)
- gfx950: **instruction stream byte-identical**, 735 instructions before and after, register use unchanged (44 SGPR, 14 VGPR). Only the `__hip_cuid_*` symbol differs, which is a hash of the translation unit.

## Effect

A gfx1250 box can now use the same install line as everyone else:

```
BUILD_BENCHMARK=ON BUILD_CCO_SDMA=ON BUILD_UMBP=OFF pip install .
```

instead of needing `MORI_GPU_ARCHS=gfx1250 ... BUILD_EXAMPLES=OFF`.
