### PR TITLE
Logger and timer macros improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,10 +220,23 @@ add_subdirectory(3rdparty/spdlog)
 # MORI's .so files.
 set_target_properties(spdlog PROPERTIES CXX_VISIBILITY_PRESET hidden
                                         VISIBILITY_INLINES_HIDDEN ON)
+# Silence the deprecated `operator"" _a` warning from the bundled fmt while
+# compiling spdlog's own sources (see mori_logging below for consumers).
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag("-Wno-deprecated-literal-operator"
+                        HAVE_WNO_DEPRECATED_LITERAL_OPERATOR)
+if(HAVE_WNO_DEPRECATED_LITERAL_OPERATOR)
+  target_compile_options(spdlog PRIVATE -Wno-deprecated-literal-operator)
+endif()
 
 add_library(mori_logging INTERFACE)
 target_include_directories(mori_logging INTERFACE include)
 target_link_libraries(mori_logging INTERFACE spdlog::spdlog)
+
+if(HAVE_WNO_DEPRECATED_LITERAL_OPERATOR)
+  target_compile_options(mori_logging
+                         INTERFACE -Wno-deprecated-literal-operator)
+endif()
 
 if(ENABLE_PROFILER)
   find_package(

--- a/include/mori/core/utils/utils.hpp
+++ b/include/mori/core/utils/utils.hpp
@@ -29,14 +29,23 @@
 // host (non-hipcc) parse working for the __device__/__host__-tagged helpers.
 #if defined(__HIPCC__) || defined(__CUDACC__)
 #include <hip/hip_runtime.h>
-#endif
-
+// `warpSize` is only used by the __device__ helpers below. Define it as a macro
+// solely under device compilation.
 #ifndef warpSize
 #if defined(__GFX8__) || defined(__GFX9__)
 #define warpSize 64
 #else
 #define warpSize 32
 #endif
+#endif
+#endif   // __HIPCC__ || __CUDACC__
+
+#if defined(__GNUC__) || defined(__clang__)
+#define MORI_LIKELY(expr) __builtin_expect(!!(expr), 1)
+#define MORI_UNLIKELY(expr) __builtin_expect(!!(expr), 0)
+#else
+#define MORI_LIKELY(expr) (!!(expr))
+#define MORI_UNLIKELY(expr) (!!(expr))
 #endif
 
 /* ---------------------------------------------------------------------------------------------- */

--- a/include/mori/core/utils/utils.hpp
+++ b/include/mori/core/utils/utils.hpp
@@ -38,7 +38,7 @@
 #define warpSize 32
 #endif
 #endif
-#endif   // __HIPCC__ || __CUDACC__
+#endif  // __HIPCC__ || __CUDACC__
 
 #if defined(__GNUC__) || defined(__clang__)
 #define MORI_LIKELY(expr) __builtin_expect(!!(expr), 1)

--- a/include/mori/utils/mori_log.hpp
+++ b/include/mori/utils/mori_log.hpp
@@ -302,19 +302,20 @@ constexpr const char* METRICS = "metrics";
 
 // General MORI logging macros.
 //
-// Hot-path note: MORI_GET_LOGGER() resolves the logger by a string-hashed
+// Hot-path note: GetLogger() resolves the logger by a string-hashed
 // unordered_map lookup. Doing that on every call — even when the level is
-// disabled and spdlog drops the message — shows up on hot paths (e.g. a
-// per-batch MORI_IO_TRACE). We cache the resolved logger pointer in a
-// function-local static so the map lookup happens once per call-site, ever.
-// spdlog's own logger->level(...) already checks the level and skips
-// formatting when disabled, and it reads the level on each call, so runtime
-// level changes are still honored.
-#define MORI_LOG(module, level, ...)                                 \
-  do {                                                               \
-    static ::spdlog::logger* _mori_log_logger =                      \
-        ::mori::ModuleLogger::GetInstance().GetLogger(module).get(); \
-    _mori_log_logger->level(__VA_ARGS__);                            \
+// disabled and spdlog drops the message — shows up on hot paths. 
+// We cache the resolved logger shared_ptr in a  function-local static so the 
+// map lookup happens once per call-site, ever. spdlog's own logger->level(...) 
+// already checks the level and skips formatting when disabled, and it reads the 
+// level on each call, so runtime level changes are still honored. 
+// Matches MORI_TIMER and avoids a dangling pointer if a logger is 
+// spdlog::drop()-ed or torn down during static destruction.
+#define MORI_LOG(module, level, ...)                            \
+  do {                                                          \
+    static const auto _mori_log_logger =                        \
+        ::mori::ModuleLogger::GetInstance().GetLogger(module);  \
+    _mori_log_logger->level(__VA_ARGS__);                       \
   } while (0)
 
 #define MORI_TRACE(module, ...) MORI_LOG(module, trace, __VA_ARGS__)
@@ -388,12 +389,10 @@ class ScopedTimer {
 
   // Fast path used by the MORI_TIMER / MORI_FUNCTION_TIMER macros: the logger
   // is pre-resolved and cached by the call-site, so nothing is allocated or
-  // sampled unless DEBUG logging is actually enabled for this module. The name
-  // is copied into an owned string only on the enabled path, so string_view
-  // callers may pass temporaries safely.
-  ScopedTimer(std::string_view name, spdlog::logger* logger) {
-    if (MORI_UNLIKELY(logger != nullptr && logger->should_log(spdlog::level::debug))) {
-      logger_ = logger;
+  // sampled unless DEBUG logging is actually enabled for this module. 
+  ScopedTimer(std::string_view name, spdlog::logger& logger) {
+    if (MORI_UNLIKELY(logger.should_log(spdlog::level::debug))) {
+      logger_ = &logger;
       name_.assign(name.data(), name.size());
       start_ = Clock::now();
     }
@@ -402,14 +401,8 @@ class ScopedTimer {
   // Legacy path: resolves the logger by module name. Still early-outs when the
   // level is disabled so it never copies strings or reads the clock needlessly.
   explicit ScopedTimer(const std::string& name,
-                       const std::string& module = mori::modules::APPLICATION) {
-    auto logger = ModuleLogger::GetInstance().GetLogger(module).get();
-    if (MORI_UNLIKELY(logger != nullptr && logger->should_log(spdlog::level::debug))) {
-      logger_ = logger;
-      name_ = name;
-      start_ = Clock::now();
-    }
-  }
+                       const std::string& module = mori::modules::APPLICATION) 
+    : ScopedTimer(name, *ModuleLogger::GetInstance().GetLogger(module)) {}
 
   ~ScopedTimer() {
     if (MORI_UNLIKELY(logger_ != nullptr)) {
@@ -429,22 +422,18 @@ class ScopedTimer {
  private:
   spdlog::logger* logger_ = nullptr;
   std::string name_;
-  Clock::time_point start_{};
+  Clock::time_point start_;
 };
 
 // Cache the (module -> logger) resolution in a function-local static so the
 // unordered_map<string, logger> lookup runs once per call-site instead of on
 // every invocation of the timed function.
 #define MORI_TIMER(name, module)                                                       \
-  ::mori::ScopedTimer timer_instance((name), [] {                                      \
+  ::mori::ScopedTimer timer_instance((name), []() -> ::spdlog::logger& {               \
     static const auto _logger = ::mori::ModuleLogger::GetInstance().GetLogger(module); \
-    return _logger.get();                                                              \
+    return *_logger;                                                                   \
   }())
-#define MORI_FUNCTION_TIMER(module)                                                    \
-  ::mori::ScopedTimer timer_instance(__PRETTY_FUNCTION__, [] {                         \
-    static const auto _logger = ::mori::ModuleLogger::GetInstance().GetLogger(module); \
-    return _logger.get();                                                              \
-  }())
+#define MORI_FUNCTION_TIMER(module) MORI_TIMER(__PRETTY_FUNCTION__, module)
 
 // Initialization helper functions
 inline void InitializeLogging() {

--- a/include/mori/utils/mori_log.hpp
+++ b/include/mori/utils/mori_log.hpp
@@ -24,13 +24,15 @@
 #include <algorithm>
 #include <cctype>
 #include <chrono>
+#include <cstdio>
 #include <cstdlib>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <unordered_map>
-#include <unordered_set>
 
+#include "mori/core/utils/utils.hpp"
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include "spdlog/spdlog.h"
@@ -54,12 +56,26 @@ class ModuleLogger {
       globalLevel_ = LevelFromString(std::string(globalEnvLevel));
       globalLevelSet_ = true;
     }
+    // Eagerly create every known module logger while we are still single
+    // threaded: the Meyers singleton guarantees this ctor runs exactly once and
+    // blocks other threads until it returns, so loggers_ is fully populated
+    // before any GetLogger() call can touch the map.
+    for (const char* moduleName : kKnownModules) {
+      InitModuleLocked(moduleName);
+    }
   }
 
  public:
-  // Initialize a module-specific logger
+  // Initialize a module-specific logger.
   void InitModule(const std::string& moduleName, Level level = Level::ERROR) {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
+    InitModuleLocked(moduleName, level);
+  }
+
+ private:
+  // Body of InitModule; callers must hold mutex_ (or be the constructor, which
+  // runs before the instance is observable).
+  void InitModuleLocked(const std::string& moduleName, Level level = Level::ERROR) {
     // Check if logger already exists
     auto existing_logger = spdlog::get(moduleName);
     std::shared_ptr<spdlog::logger> logger;
@@ -95,7 +111,6 @@ class ModuleLogger {
       std::transform(envVar.begin(), envVar.end(), envVar.begin(), ::toupper);
     }
     const char* envLevel = std::getenv(envVar.c_str());
-
     if (envLevel) {
       finalLevel = LevelFromString(std::string(envLevel));
       envOverrides_[moduleName] = finalLevel;
@@ -103,54 +118,47 @@ class ModuleLogger {
       // Use global setting if no env var and global level is set
       finalLevel = globalLevel_;
     }
-
     logger->set_level(ConvertLevel(finalLevel));
     loggers_[moduleName] = logger;
   }
 
-  // Get logger for a specific module
+ public:
+  // Get logger for a specific module. Never returns null: unknown modules are
+  // created on demand, and if creation ever fails we log a fatal message and
+  // abort(), rather than returning null and letting callers silently drop logs.
   std::shared_ptr<spdlog::logger> GetLogger(const std::string& moduleName) {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
-    auto it = loggers_.find(moduleName);
-    if (it != loggers_.end()) {
-      return it->second;
-    }
-    // If not found, create with default settings
-    InitModule(moduleName);
-    return loggers_[moduleName];
+    std::lock_guard<std::mutex> lock(mutex_);
+    return GetLoggerLocked(moduleName);
   }
 
   // Set log level for a specific module
   void SetModuleLevel(const std::string& moduleName, Level level) {
-    std::shared_ptr<spdlog::logger> appLogger;
-    {
-      std::lock_guard<std::recursive_mutex> lock(mutex_);
-      // Check if this module is protected by environment variable
-      if (HasEnvOverride(moduleName)) {
-        appLogger = GetLogger("application");  // Use application logger for warnings
-      } else {
-        auto logger = GetLogger(moduleName);
-        logger->set_level(ConvertLevel(level));
-        return;
-      }
+    std::lock_guard<std::mutex> lock(mutex_);
+    // Check if this module is protected by environment variable
+    if (HasEnvOverrideLocked(moduleName)) {
+      // Log a warning but don't change the level
+      auto logger = GetLoggerLocked("application");  // Use application logger for warnings
+      logger->warn(
+          "Attempted to change log level for module '{}' which is controlled by environment "
+          "variable. Use ForceSetModuleLevel() to override.",
+          moduleName);
+      return;
     }
-    // Warn outside the lock: this is I/O, not map access.
-    appLogger->warn(
-        "Attempted to change log level for module '{}' which is controlled by environment "
-        "variable. Use ForceSetModuleLevel() to override.",
-        moduleName);
+
+    auto logger = GetLoggerLocked(moduleName);
+    logger->set_level(ConvertLevel(level));
   }
 
   // Set log level for all modules (global control)
   void SetGlobalLevel(Level level) {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     globalLevel_ = level;
     globalLevelSet_ = true;
 
     // Apply to all existing loggers
     for (auto& [name, logger] : loggers_) {
       // Skip modules controlled by environment variables
-      if (!HasEnvOverride(name)) {
+      if (!HasEnvOverrideLocked(name)) {
         logger->set_level(ConvertLevel(level));
       }
     }
@@ -158,8 +166,8 @@ class ModuleLogger {
 
   // Set log level with priority check (used internally for env vars)
   void SetModuleLevelInternal(const std::string& moduleName, Level level, bool fromEnv = false) {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
-    auto logger = GetLogger(moduleName);
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto logger = GetLoggerLocked(moduleName);
     logger->set_level(ConvertLevel(level));
     if (fromEnv) {
       envOverrides_[moduleName] = level;
@@ -168,38 +176,38 @@ class ModuleLogger {
 
   // Check if a module has environment override
   bool HasEnvOverride(const std::string& moduleName) const {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
-    return envOverrides_.find(moduleName) != envOverrides_.end();
+    std::lock_guard<std::mutex> lock(mutex_);
+    return HasEnvOverrideLocked(moduleName);
   }
 
   // Clear environment overrides for a module
   void ClearEnvOverride(const std::string& moduleName) {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     envOverrides_.erase(moduleName);
   }
 
   // Force set log level (ignores env protection)
   void ForceSetModuleLevel(const std::string& moduleName, Level level) {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
-    auto logger = GetLogger(moduleName);
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto logger = GetLoggerLocked(moduleName);
     logger->set_level(ConvertLevel(level));
   }
 
   // Get current global level
   Level GetGlobalLevel() const {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     return globalLevel_;
   }
 
   // Check if global level is set
   bool IsGlobalLevelSet() const {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     return globalLevelSet_;
   }
 
   // Clear global level setting (revert to individual module control)
   void ClearGlobalLevel() {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     globalLevelSet_ = false;
   }
 
@@ -221,18 +229,43 @@ class ModuleLogger {
   // rehash mid-iteration.
   template <typename F>
   void ForEachLogger(F&& fn) {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     for (auto& [name, lg] : loggers_) fn(name, lg);
   }
 
  private:
+  // Body of GetLogger; callers must hold mutex_. Never returns null.
+  std::shared_ptr<spdlog::logger> GetLoggerLocked(const std::string& moduleName) {
+    for (int i = 0; i < 2; i++) {
+      auto it = loggers_.find(moduleName);
+      if (it != loggers_.end() && it->second) {
+        return it->second;
+      }
+      InitModuleLocked(moduleName);  // Create on demand
+    }
+    // The logging system is fundamentally broken, so we abort loudly.
+    std::fprintf(stderr,
+                 "FATAL: ModuleLogger failed to resolve or create a logger for module '%s' "
+                 "after retrying; aborting.\n",
+                 moduleName.c_str());
+    std::abort();
+  }
+
+  // Body of HasEnvOverride; callers must hold mutex_.
+  bool HasEnvOverrideLocked(const std::string& moduleName) const {
+    return envOverrides_.find(moduleName) != envOverrides_.end();
+  }
+
+  // Known modules created eagerly by the constructor. Kept in sync with the
+  // mori::modules namespace below (this class is defined before it).
+  static constexpr const char* kKnownModules[] = {"application", "io",   "shmem",  "core",
+                                                  "ops",         "umbp", "metrics"};
+
   std::unordered_map<std::string, std::shared_ptr<spdlog::logger>> loggers_;
   std::unordered_map<std::string, Level> envOverrides_;  // Track env variable overrides
   Level globalLevel_ = Level::ERROR;
   bool globalLevelSet_ = false;
-  // Guards loggers_, envOverrides_, globalLevel_, globalLevelSet_. Recursive
-  // since methods call each other while holding it (e.g. GetLogger -> InitModule).
-  mutable std::recursive_mutex mutex_;
+  mutable std::mutex mutex_;
 
   spdlog::level::level_enum ConvertLevel(Level level) {
     switch (level) {
@@ -267,8 +300,22 @@ constexpr const char* METRICS = "metrics";
 // Macro helpers
 #define MORI_GET_LOGGER(module) mori::ModuleLogger::GetInstance().GetLogger(module)
 
-// General MORI logging macros
-#define MORI_LOG(module, level, ...) MORI_GET_LOGGER(module)->level(__VA_ARGS__)
+// General MORI logging macros.
+//
+// Hot-path note: MORI_GET_LOGGER() resolves the logger by a string-hashed
+// unordered_map lookup. Doing that on every call — even when the level is
+// disabled and spdlog drops the message — shows up on hot paths (e.g. a
+// per-batch MORI_IO_TRACE). We cache the resolved logger pointer in a
+// function-local static so the map lookup happens once per call-site, ever.
+// spdlog's own logger->level(...) already checks the level and skips
+// formatting when disabled, and it reads the level on each call, so runtime
+// level changes are still honored.
+#define MORI_LOG(module, level, ...)                                 \
+  do {                                                               \
+    static ::spdlog::logger* _mori_log_logger =                      \
+        ::mori::ModuleLogger::GetInstance().GetLogger(module).get(); \
+    _mori_log_logger->level(__VA_ARGS__);                            \
+  } while (0)
 
 #define MORI_TRACE(module, ...) MORI_LOG(module, trace, __VA_ARGS__)
 #define MORI_DEBUG(module, ...) MORI_LOG(module, debug, __VA_ARGS__)
@@ -327,19 +374,49 @@ constexpr const char* METRICS = "metrics";
 #define MORI_METRICS_ERROR(...) MORI_ERROR(mori::modules::METRICS, __VA_ARGS__)
 #define MORI_METRICS_CRITICAL(...) MORI_CRITICAL(mori::modules::METRICS, __VA_ARGS__)
 
-// Scoped Timer class
+// Scoped Timer class.
+//
+// Hot-path note: the timer only logs at DEBUG level, so on any normal run
+// (INFO/WARN/ERROR) it must be a true no-op. We resolve the logger once and
+// check the level in the constructor; when disabled we skip the string copy,
+// both clock reads, the per-call GetLogger() hashtable lookup, and the log
+// call entirely. The macros cache the (module -> logger) lookup in a
+// function-local static so the hashtable probe happens once per call-site.
 class ScopedTimer {
  public:
   using Clock = std::chrono::steady_clock;
 
+  // Fast path used by the MORI_TIMER / MORI_FUNCTION_TIMER macros: the logger
+  // is pre-resolved and cached by the call-site, so nothing is allocated or
+  // sampled unless DEBUG logging is actually enabled for this module. The name
+  // is copied into an owned string only on the enabled path, so string_view
+  // callers may pass temporaries safely.
+  ScopedTimer(std::string_view name, spdlog::logger* logger) {
+    if (MORI_UNLIKELY(logger != nullptr && logger->should_log(spdlog::level::debug))) {
+      logger_ = logger;
+      name_.assign(name.data(), name.size());
+      start_ = Clock::now();
+    }
+  }
+
+  // Legacy path: resolves the logger by module name. Still early-outs when the
+  // level is disabled so it never copies strings or reads the clock needlessly.
   explicit ScopedTimer(const std::string& name,
-                       const std::string& module = mori::modules::APPLICATION)
-      : name_(name), module_(module), start_(Clock::now()) {}
+                       const std::string& module = mori::modules::APPLICATION) {
+    auto logger = ModuleLogger::GetInstance().GetLogger(module).get();
+    if (MORI_UNLIKELY(logger != nullptr && logger->should_log(spdlog::level::debug))) {
+      logger_ = logger;
+      name_ = name;
+      start_ = Clock::now();
+    }
+  }
 
   ~ScopedTimer() {
-    auto end = Clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start_).count();
-    MORI_DEBUG(module_, "ScopedTimer [{}] took {} ns", name_, duration);
+    if (MORI_UNLIKELY(logger_ != nullptr)) {
+      auto end = Clock::now();
+      auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start_).count();
+      logger_->debug("ScopedTimer [{}] took {} ns", name_, duration);
+    }
   }
 
   double ElapsedSeconds() const {
@@ -350,13 +427,22 @@ class ScopedTimer {
   ScopedTimer& operator=(const ScopedTimer&) = delete;
 
  private:
+  spdlog::logger* logger_ = nullptr;
   std::string name_;
-  std::string module_;
-  Clock::time_point start_;
+  Clock::time_point start_{};
 };
 
-#define MORI_TIMER(name, module) ScopedTimer timer_instance(name, module)
-#define MORI_FUNCTION_TIMER(module) ScopedTimer timer_instance(__PRETTY_FUNCTION__, module)
+// Cache the (module -> logger) resolution in a function-local static so the
+// unordered_map<string, logger> lookup runs once per call-site instead of on
+// every invocation of the timed function.
+#define MORI_TIMER(name, module)                                    \
+  static const std::shared_ptr<spdlog::logger> _mori_timer_logger = \
+      ::mori::ModuleLogger::GetInstance().GetLogger(module);        \
+  ::mori::ScopedTimer timer_instance(name, _mori_timer_logger.get())
+#define MORI_FUNCTION_TIMER(module)                                 \
+  static const std::shared_ptr<spdlog::logger> _mori_timer_logger = \
+      ::mori::ModuleLogger::GetInstance().GetLogger(module);        \
+  ::mori::ScopedTimer timer_instance(__PRETTY_FUNCTION__, _mori_timer_logger.get())
 
 // Initialization helper functions
 inline void InitializeLogging() {

--- a/include/mori/utils/mori_log.hpp
+++ b/include/mori/utils/mori_log.hpp
@@ -304,18 +304,17 @@ constexpr const char* METRICS = "metrics";
 //
 // Hot-path note: GetLogger() resolves the logger by a string-hashed
 // unordered_map lookup. Doing that on every call — even when the level is
-// disabled and spdlog drops the message — shows up on hot paths. 
-// We cache the resolved logger shared_ptr in a  function-local static so the 
-// map lookup happens once per call-site, ever. spdlog's own logger->level(...) 
-// already checks the level and skips formatting when disabled, and it reads the 
-// level on each call, so runtime level changes are still honored. 
-// Matches MORI_TIMER and avoids a dangling pointer if a logger is 
+// disabled and spdlog drops the message — shows up on hot paths.
+// We cache the resolved logger shared_ptr in a  function-local static so the
+// map lookup happens once per call-site, ever. spdlog's own logger->level(...)
+// already checks the level and skips formatting when disabled, and it reads the
+// level on each call, so runtime level changes are still honored.
+// Matches MORI_TIMER and avoids a dangling pointer if a logger is
 // spdlog::drop()-ed or torn down during static destruction.
-#define MORI_LOG(module, level, ...)                            \
-  do {                                                          \
-    static const auto _mori_log_logger =                        \
-        ::mori::ModuleLogger::GetInstance().GetLogger(module);  \
-    _mori_log_logger->level(__VA_ARGS__);                       \
+#define MORI_LOG(module, level, ...)                                                            \
+  do {                                                                                          \
+    static const auto _mori_log_logger = ::mori::ModuleLogger::GetInstance().GetLogger(module); \
+    _mori_log_logger->level(__VA_ARGS__);                                                       \
   } while (0)
 
 #define MORI_TRACE(module, ...) MORI_LOG(module, trace, __VA_ARGS__)
@@ -389,7 +388,7 @@ class ScopedTimer {
 
   // Fast path used by the MORI_TIMER / MORI_FUNCTION_TIMER macros: the logger
   // is pre-resolved and cached by the call-site, so nothing is allocated or
-  // sampled unless DEBUG logging is actually enabled for this module. 
+  // sampled unless DEBUG logging is actually enabled for this module.
   ScopedTimer(std::string_view name, spdlog::logger& logger) {
     if (MORI_UNLIKELY(logger.should_log(spdlog::level::debug))) {
       logger_ = &logger;
@@ -401,8 +400,8 @@ class ScopedTimer {
   // Legacy path: resolves the logger by module name. Still early-outs when the
   // level is disabled so it never copies strings or reads the clock needlessly.
   explicit ScopedTimer(const std::string& name,
-                       const std::string& module = mori::modules::APPLICATION) 
-    : ScopedTimer(name, *ModuleLogger::GetInstance().GetLogger(module)) {}
+                       const std::string& module = mori::modules::APPLICATION)
+      : ScopedTimer(name, *ModuleLogger::GetInstance().GetLogger(module)) {}
 
   ~ScopedTimer() {
     if (MORI_UNLIKELY(logger_ != nullptr)) {

--- a/include/mori/utils/mori_log.hpp
+++ b/include/mori/utils/mori_log.hpp
@@ -435,14 +435,16 @@ class ScopedTimer {
 // Cache the (module -> logger) resolution in a function-local static so the
 // unordered_map<string, logger> lookup runs once per call-site instead of on
 // every invocation of the timed function.
-#define MORI_TIMER(name, module)                                    \
-  static const std::shared_ptr<spdlog::logger> _mori_timer_logger = \
-      ::mori::ModuleLogger::GetInstance().GetLogger(module);        \
-  ::mori::ScopedTimer timer_instance(name, _mori_timer_logger.get())
-#define MORI_FUNCTION_TIMER(module)                                 \
-  static const std::shared_ptr<spdlog::logger> _mori_timer_logger = \
-      ::mori::ModuleLogger::GetInstance().GetLogger(module);        \
-  ::mori::ScopedTimer timer_instance(__PRETTY_FUNCTION__, _mori_timer_logger.get())
+#define MORI_TIMER(name, module)                                                       \
+  ::mori::ScopedTimer timer_instance((name), [] {                                      \
+    static const auto _logger = ::mori::ModuleLogger::GetInstance().GetLogger(module); \
+    return _logger.get();                                                              \
+  }())
+#define MORI_FUNCTION_TIMER(module)                                                    \
+  ::mori::ScopedTimer timer_instance(__PRETTY_FUNCTION__, [] {                         \
+    static const auto _logger = ::mori::ModuleLogger::GetInstance().GetLogger(module); \
+    return _logger.get();                                                              \
+  }())
 
 // Initialization helper functions
 inline void InitializeLogging() {

--- a/src/io/xgmi/backend_impl.cpp
+++ b/src/io/xgmi/backend_impl.cpp
@@ -498,7 +498,7 @@ XgmiBackend::~XgmiBackend() {
 
   for (auto& mod : scatterGatherModules_) {
     if (mod != nullptr) {
-      hipModuleUnload(mod);
+      (void)hipModuleUnload(mod);
     }
   }
   scatterGatherModules_.clear();
@@ -535,7 +535,7 @@ hipFunction_t XgmiBackend::GetScatterGatherFunc(int deviceId) {
   if (err != hipSuccess) {
     MORI_IO_WARN("XGMI: Failed to get scatterGatherCopyKernel on device {}: {}", deviceId,
                  hipGetErrorString(err));
-    hipModuleUnload(scatterGatherModules_[deviceId]);
+    (void)hipModuleUnload(scatterGatherModules_[deviceId]);
     scatterGatherModules_[deviceId] = nullptr;
     return nullptr;
   }

--- a/src/shmem/init.cpp
+++ b/src/shmem/init.cpp
@@ -38,6 +38,7 @@
 #include "mori/application/utils/cpu_affinity.hpp"
 #include "mori/shmem/internal.hpp"
 #include "mori/shmem/shmem_api.hpp"
+#include "mori/core/utils/utils.hpp"
 #include "mori/utils/mori_log.hpp"
 
 namespace mori {
@@ -62,7 +63,7 @@ ShmemStates* ShmemStatesSingleton::GetInstance() {
   static ShmemStatesSingleton s_inst;
   int id = -1;
   HIP_RUNTIME_CHECK(hipGetDevice(&id));
-  if (__builtin_expect(id < 0 || id >= mori::kMaxGpusPerNode, 0)) {
+  if (MORI_UNLIKELY(id < 0 || id >= mori::kMaxGpusPerNode)) {
     MORI_SHMEM_ERROR("hipGetDevice() returned out-of-range id {}, max supported is {}", id,
                      mori::kMaxGpusPerNode - 1);
     assert(false);
@@ -704,7 +705,7 @@ bool ShmemIsInitialized() {
 /* ---------------------------------------------------------------------------------------------- */
 
 static void FinalizeGpuStates(ShmemStates* states) {
-  hipDeviceSynchronize();
+  (void)hipDeviceSynchronize();
   (void)hipGetLastError();
   HIP_RUNTIME_CHECK(hipFree(states->gpuStates.transportTypes));
   HIP_RUNTIME_CHECK(hipFree(states->gpuStates.rdmaEndpoints));

--- a/src/shmem/init.cpp
+++ b/src/shmem/init.cpp
@@ -36,9 +36,9 @@
 #include "mori/application/application.hpp"
 #include "mori/application/bootstrap/socket_bootstrap.hpp"
 #include "mori/application/utils/cpu_affinity.hpp"
+#include "mori/core/utils/utils.hpp"
 #include "mori/shmem/internal.hpp"
 #include "mori/shmem/shmem_api.hpp"
-#include "mori/core/utils/utils.hpp"
 #include "mori/utils/mori_log.hpp"
 
 namespace mori {

--- a/src/shmem/runtime.cpp
+++ b/src/shmem/runtime.cpp
@@ -116,7 +116,7 @@ void CopyGpuStatesToDevice(ShmemStates* states) {
 void FinalizeRuntime(ShmemStates* states) {
   ModuleStates& ms = states->moduleStates;
   if (ms.module != nullptr) {
-    hipModuleUnload(ms.module);
+    (void)hipModuleUnload(ms.module);
     ms.module = nullptr;
     ms.gpuStatesPtr = nullptr;
     ms.barrierFunc = nullptr;

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -22,6 +22,14 @@ if(DEFINED GPU_TARGETS)
     PROPERTIES HIP_ARCHITECTURES "${GPU_TARGETS}")
 endif()
 
+# Core logging is header-only (spdlog); test its thread-safety independently of
+# BUILD_IO. Run under ThreadSanitizer to actually prove the maps are safe.
+add_executable(test_logging utils/test_logging.cpp)
+target_include_directories(test_logging PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(test_logging PUBLIC ${CMAKE_SOURCE_DIR})
+target_link_libraries(test_logging PRIVATE mori_logging gtest_main)
+add_test(NAME logging_concurrency COMMAND test_logging)
+
 add_executable(test_transport_tcp application/test_transport_tcp.cpp)
 
 target_include_directories(test_transport_tcp

--- a/tests/cpp/utils/test_logging.cpp
+++ b/tests/cpp/utils/test_logging.cpp
@@ -1,0 +1,153 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Multi-threaded stress tests for the ModuleLogger wrapper in
+// include/mori/utils/mori_log.hpp.
+//
+// These guard against the previously-present data race on ModuleLogger's
+// internal std::unordered_maps (loggers_/envOverrides_), which under the
+// multithreaded RDMA workload could hand back an empty shared_ptr that callers
+// then cached forever. The functional asserts here catch null/crash
+// regressions; running this binary under ThreadSanitizer is what actually
+// proves the map access is synchronized (build with -fsanitize=thread; if the
+// container aborts with "unexpected memory mapping", run via
+// `setarch $(uname -m) -R ./test_logging`).
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "mori/utils/mori_log.hpp"
+
+namespace {
+
+// Spin barrier so all threads hit the racy window together.
+struct StartGate {
+  std::atomic<bool> go{false};
+  void wait() const {
+    while (!go.load(std::memory_order_acquire)) {
+    }
+  }
+  void open() { go.store(true, std::memory_order_release); }
+};
+
+const char* kKnown[] = {mori::modules::APPLICATION, mori::modules::IO,  mori::modules::SHMEM,
+                        mori::modules::CORE,        mori::modules::OPS, mori::modules::UMBP,
+                        mori::modules::METRICS};
+
+}  // namespace
+
+// Concurrent resolution of known + many distinct unknown modules. Unknown names
+// force on-demand InitModuleLocked() inserts, i.e. writes racing reads.
+TEST(ModuleLoggerConcurrency, ResolveNeverReturnsNull) {
+  constexpr int kThreads = 32;
+  constexpr int kIters = 5000;
+  StartGate gate;
+  std::atomic<int> nulls{0};
+
+  std::vector<std::thread> ts;
+  ts.reserve(kThreads);
+  for (int t = 0; t < kThreads; ++t) {
+    ts.emplace_back([&, t] {
+      gate.wait();
+      for (int i = 0; i < kIters; ++i) {
+        const char* known = kKnown[(t + i) % 7];
+        if (!mori::ModuleLogger::GetInstance().GetLogger(known)) nulls.fetch_add(1);
+        // Distinct (but bounded) unknown module -> exercises the insert path.
+        std::string unknown = "utmod_" + std::to_string((t * kIters + i) % 128);
+        if (!mori::ModuleLogger::GetInstance().GetLogger(unknown)) nulls.fetch_add(1);
+      }
+    });
+  }
+  gate.open();
+  for (auto& th : ts) th.join();
+  EXPECT_EQ(nulls.load(), 0);
+}
+
+// Many threads resolve the SAME brand-new module at once: the create-once path
+// (spdlog registry race handling) must yield one stable, non-null logger.
+TEST(ModuleLoggerConcurrency, ConcurrentFirstTouchSameModule) {
+  constexpr int kThreads = 64;
+  StartGate gate;
+  std::vector<spdlog::logger*> got(kThreads, nullptr);
+
+  std::vector<std::thread> ts;
+  ts.reserve(kThreads);
+  for (int t = 0; t < kThreads; ++t) {
+    ts.emplace_back([&, t] {
+      gate.wait();
+      got[t] = mori::ModuleLogger::GetInstance().GetLogger("ut_first_touch").get();
+    });
+  }
+  gate.open();
+  for (auto& th : ts) th.join();
+
+  ASSERT_NE(got[0], nullptr);
+  for (int t = 1; t < kThreads; ++t) {
+    EXPECT_NE(got[t], nullptr);
+    EXPECT_EQ(got[t], got[0]);  // all observe the same registered instance
+  }
+}
+
+// Logging while levels are reconfigured. Primarily a TSAN target; the functional
+// assert is just "no crash/hang". Kept quiet at 'critical' to avoid stdout spam.
+TEST(ModuleLoggerConcurrency, LogWhileReconfiguring) {
+  constexpr int kLoggers = 24;
+  constexpr int kIters = 5000;
+  StartGate gate;
+
+  const std::string savedGlobal = mori::GetGlobalLogLevel();
+  mori::SetGlobalLogLevel("critical");
+
+  std::vector<std::thread> ts;
+  ts.reserve(kLoggers + 4);
+  for (int t = 0; t < kLoggers; ++t) {
+    ts.emplace_back([&, t] {
+      gate.wait();
+      for (int i = 0; i < kIters; ++i) {
+        MORI_IO_TRACE("io {} {}", t, i);
+        MORI_APP_DEBUG("app {} {}", t, i);
+        MORI_CORE_INFO("core {} {}", t, i);
+      }
+    });
+  }
+  // Reconfigurer threads racing the loggers above.
+  for (int r = 0; r < 4; ++r) {
+    ts.emplace_back([&] {
+      gate.wait();
+      for (int i = 0; i < kIters; ++i) {
+        mori::SetGlobalLogLevel((i & 1) ? "trace" : "critical");
+        mori::SetModuleLogLevel(mori::modules::IO, (i & 2) ? "debug" : "warn");
+        mori::ForceSetModuleLogLevel(mori::modules::CORE, "info");
+        (void)mori::GetGlobalLogLevel();
+      }
+    });
+  }
+  gate.open();
+  for (auto& th : ts) th.join();
+
+  mori::SetGlobalLogLevel(savedGlobal);
+  SUCCEED();
+}


### PR DESCRIPTION
## Summary

This PR hardens the logging subsystem (`include/mori/utils/mori_log.hpp`) on two fronts:

1. **Fixes a data race** in `ModuleLogger`'s internal maps that, under the
   multithreaded RDMA workload, could hand back an empty `shared_ptr` that
   callers then cached forever.
2. **Removes `ScopedTimer` overhead on the hot path** so timers compile down to
   a true no-op unless DEBUG logging is actually enabled for the module.

It also adds a dedicated, TSAN-friendly concurrency test and silences a
deprecated-literal warning coming from the bundled `fmt`/`spdlog`.

## Motivation

`ModuleLogger` guarded its `loggers_` / `envOverrides_` maps inconsistently and
relied on a `recursive_mutex`, while several methods called each other and
re-locked. Concurrent first-touch of a module (or resolution of an unknown
module) raced the on-demand insert, occasionally returning a null logger that a
call-site cached permanently. Separately, `ScopedTimer` always copied strings,
read the clock twice, and did a per-call `GetLogger()` hashtable lookup even when
DEBUG was off — measurable on hot paths such as a per-batch `MORI_IO_TRACE`.

## Changes

### `ModuleLogger` thread-safety
- Eagerly create every known module logger in the singleton constructor, while
  still single-threaded, so `loggers_` is fully populated before any
  `GetLogger()` can touch the map.
- Split the public API from `*Locked` helpers (`GetLoggerLocked`,
  `InitModuleLocked`, `HasEnvOverrideLocked`) so methods no longer re-lock via
  each other.
- Replace the `recursive_mutex` with a plain `std::mutex`.
- `GetLogger()` never returns null: unknown modules are created on demand, and a
  hard failure logs a fatal message and `abort()`s instead of silently dropping
  logs.
- `SetModuleLevel()` now emits the env-override warning via the pre-resolved
  logger while holding the lock (no re-entrant `GetLogger`).

### `ScopedTimer` hot-path optimization
- Resolve and cache the `(module -> logger)` lookup once per call-site in a
  function-local static (`MORI_TIMER` / `MORI_FUNCTION_TIMER`).
- Constructors early-out when the level is disabled: no string copy, no clock
  read, no allocation. The enabled path is marked `MORI_UNLIKELY`.
- Unified name handling under `std::string_view`, copying into an owned string
  only on the enabled path (safe for temporaries).
- Dropped the redundant `enabled_`/`module_` members; `logger_ != nullptr` now
  serves as the "enabled" sentinel.

### Supporting changes
- `include/mori/core/utils/utils.hpp`: add `MORI_LIKELY` / `MORI_UNLIKELY`
  branch-hint macros and scope the `warpSize` macro to device compilation.
- `CMakeLists.txt`: silence `-Wdeprecated-literal-operator` from bundled `fmt`
  for both the `spdlog` build and `mori_logging` consumers (guarded by a
  compiler-flag check).

## Tests
- New `tests/cpp/utils/test_logging.cpp` with multi-threaded stress tests:
  - `ResolveNeverReturnsNull` — concurrent resolution of known + unknown modules.
  - `ConcurrentFirstTouchSameModule` — 64 threads first-touch the same new
    module; all must observe one stable, non-null instance.
  - `LogWhileReconfiguring` — logging while levels are reconfigured concurrently.
- Wired into `tests/cpp/CMakeLists.txt` as `test_logging` (builds independently
  of `BUILD_IO` since core logging is header-only). Intended to be run under
  ThreadSanitizer to prove map access is synchronized.
