### PR TITLE
Support graph replays for SDMA AllReduce

### DIFF
--- a/examples/collective/sdma_allreduce_sync_example.cpp
+++ b/examples/collective/sdma_allreduce_sync_example.cpp
@@ -93,7 +93,7 @@ static void printStats(const std::vector<double>& times, size_t bytesPerPe, int 
 }
 
 // =========================================================================
-// Test 1: Out-of-place (copy_output_to_user=False, read from transit buffer)
+// Test 1: Out-of-place (legacy copy_output_to_user=False compatibility)
 // =========================================================================
 static bool testOutplace(int myPe, int npes, int elemsPerPe, size_t bytesPerPe,
                          size_t outputBufSize, uint32_t fillValue, hipStream_t stream,
@@ -130,17 +130,9 @@ static bool testOutplace(int myPe, int npes, int elemsPerPe, size_t bytesPerPe,
       printf("  Warmup %d/%d: %.3f ms\n", i + 1, warmup, (t1 - t0) * 1000);
   }
 
-  // Verify from transit buffer (outBuf should remain zeros)
-  void* transitPtr = ar->getOutputTransitBuffer();
-  std::vector<uint32_t> transitData(elemsPerPe);
-  CHECK_HIP(hipMemcpy(transitData.data(), transitPtr, bytesPerPe, hipMemcpyDeviceToHost));
-  bool ok = verifyResult(transitData.data(), elemsPerPe, computeExpected(npes), myPe);
-
   std::vector<uint32_t> outData(elemsPerPe);
   CHECK_HIP(hipMemcpy(outData.data(), outBuf, bytesPerPe, hipMemcpyDeviceToHost));
-  bool allZero = std::all_of(outData.begin(), outData.end(), [](uint32_t v) { return v == 0; });
-  if (allZero && myPe == 0)
-    printf("  PE %d: output_tensor correctly untouched (all zeros)\n", myPe);
+  bool ok = verifyResult(outData.data(), elemsPerPe, computeExpected(npes), myPe);
 
   MPI_Barrier(MPI_COMM_WORLD);
   if (myPe == 0) printf("\n--- Out-of-place Performance ---\n");

--- a/include/mori/collective/allreduce/sdma_allreduce.hpp
+++ b/include/mori/collective/allreduce/sdma_allreduce.hpp
@@ -96,8 +96,9 @@ double Allreduce_sdma(T* input, T* output, size_t total_count, hipStream_t strea
   double start = CollectiveWallTime();
   ReduceScatterKernel<T><<<blocks, threads, 0, stream>>>(myPe, npes, inPutBuffObj, transitObj,
                                                          barrierObj, total_count);
-  AllGatherSdmaKernel<T>
-      <<<1, 512, 0, stream>>>(myPe, npes, transitObj, flagsObj, agBarrier, total_count);
+  const size_t slotStrideElements = static_cast<size_t>(partSize) * pack_size;
+  AllGatherSdmaKernel<T><<<1, 512, 0, stream>>>(myPe, npes, transitObj, transitObj, flagsObj,
+                                                agBarrier, total_count, slotStrideElements, 0);
 
   // Synchronize GPU to ensure kernel completion
   hipError_t sync_err;

--- a/include/mori/collective/allreduce/twoshot_allreduce_sdma_class.hpp
+++ b/include/mori/collective/allreduce/twoshot_allreduce_sdma_class.hpp
@@ -71,6 +71,8 @@ class AllreduceSdma {
   T* async_output_;
   size_t async_total_count_;
   hipStream_t async_stream_;
+  // Marks completion of work enqueued by start_async for cross-stream waits.
+  hipEvent_t async_start_event_;
   double async_start_time_;
 
   // Kept for source compatibility. Results are always materialized in the

--- a/include/mori/collective/allreduce/twoshot_allreduce_sdma_class.hpp
+++ b/include/mori/collective/allreduce/twoshot_allreduce_sdma_class.hpp
@@ -31,6 +31,7 @@
 #include <tuple>
 
 #include "mori/application/application.hpp"
+#include "mori/collective/allreduce/twoshot_sdma_common.hpp"
 #include "mori/collective/ccl_kernel_args.hpp"
 #include "mori/collective/collective_pub.hpp"
 #include "mori/collective/core/wall_time.hpp"
@@ -38,18 +39,6 @@
 
 namespace mori {
 namespace collective {
-
-struct alignas(128) CrossPeBarrier {
-  alignas(128) uint32_t flag;
-};
-
-inline int getDeviceMaxBlocks() {
-  int dev = 0;
-  (void)hipGetDevice(&dev);
-  hipDeviceProp_t prop;
-  (void)hipGetDeviceProperties(&prop, dev);
-  return (prop.multiProcessorCount > 0) ? prop.multiProcessorCount : 80;
-}
 
 template <typename T>
 class AllreduceSdma {
@@ -64,25 +53,17 @@ class AllreduceSdma {
   application::SymmMemObjPtr flagsObj_;
   std::unique_ptr<uint64_t[], ShmemDeleter> flags_;
 
-  // Device-scope barrier for block-0-to-all broadcast inside
-  // SdmaReduceScatterKernel (generation counter, ~128 bytes).
+  // Device-side generation and per-block rendezvous state.
   CrossPeBarrier* barrierPtr_;
   std::unique_ptr<void, ShmemDeleter> barrierMem_;
 
-  // Input transit buffer (symmetric memory for P2P reads)
+  // Fixed-stride symmetric scratch for SDMA scatter + local reduce. Rank slots
+  // keep stable offsets across graph replays with different message sizes.
   void* input_transit_buffer_;
   size_t input_transit_buffer_size_;
+  size_t slot_stride_elements_;
   application::SymmMemObjPtr input_transit_buffer_obj_;
   std::unique_ptr<void, ShmemDeleter> input_transit_buffer_ptr_;
-
-  // Output transit buffer — serves as:
-  //   1. SDMA scatter destination (gather buffer, npes * chunkSize)
-  //   2. Local reduce output (myPe's slot)
-  //   3. AllGather source / final result
-  void* output_transit_buffer_;
-  size_t output_transit_buffer_size_;
-  application::SymmMemObjPtr output_transit_buffer_obj_;
-  std::unique_ptr<void, ShmemDeleter> output_transit_buffer_ptr_;
 
   // Async state variables
   std::atomic<bool> async_in_progress_;
@@ -92,19 +73,14 @@ class AllreduceSdma {
   hipStream_t async_stream_;
   double async_start_time_;
 
-  // Copy mode flag: if true, copy output_transit_buffer to user output buffer
-  // if false, user should directly use output_transit_buffer
+  // Kept for source compatibility. Results are always materialized in the
+  // caller output; two-shot operations copy from compact symmetric scratch.
   bool copy_output_to_user_;
 
   AllreduceSdma(const AllreduceSdma&) = delete;
   AllreduceSdma& operator=(const AllreduceSdma&) = delete;
 
-  bool ensure_buffer_size(void*& buffer, std::unique_ptr<void, ShmemDeleter>& buffer_ptr,
-                          size_t& current_size, application::SymmMemObjPtr& buffer_obj,
-                          size_t required_size, const char* buffer_name);
-
   void copy_input_to_transit(T* input, size_t total_count, hipStream_t stream);
-  void copy_output_to_user(T* output, size_t total_count, hipStream_t stream);
   void fill_jit_args_(const T* input, size_t total_count);
 
  public:
@@ -113,7 +89,7 @@ class AllreduceSdma {
    * @param myPe Current PE ID
    * @param npes Total number of PEs
    * @param transit_buffer_size Output transit buffer size in bytes (default 512MB)
-   * @param copy_output_to_user If true, copy result to user output buffer
+   * @param copy_output_to_user Kept for compatibility; caller output is always populated.
    * @param use_graph_mode Kept for API compat — ignored (SDMA always reads
    *        input directly, no IPC registration needed).
    */
@@ -167,11 +143,6 @@ class AllreduceSdma {
   bool allreduce_inplace(T* data, size_t total_count, hipStream_t stream = nullptr);
 
   application::SymmMemObjPtr getFlagsObj() const { return flagsObj_; }
-  void* getOutputTransitBuffer() const { return output_transit_buffer_; }
-  size_t getOutputTransitBufferSize() const { return output_transit_buffer_size_; }
-  application::SymmMemObjPtr getOutputTransitBufferObj() const {
-    return output_transit_buffer_obj_;
-  }
 
   void resetFlags();
 
@@ -184,15 +155,15 @@ class AllreduceSdma {
   std::tuple<int, int> get_reduce_scatter_grid(size_t total_count) const;
   int64_t prepare_allgather(size_t total_count, hipStream_t stream);
   double finish_sync(T* output, size_t total_count, hipStream_t stream,
-                     bool force_copy_output_to_user = false);
+                     bool force_copy_output_to_user = false, bool direct_output = false);
 
   int64_t prepare_async_reduce_scatter(const T* input, T* output, size_t total_count,
                                        hipStream_t stream);
   int64_t prepare_async_allgather_put(size_t total_count, hipStream_t stream);
-  void after_async_start();
+  void after_async_start(bool capturing = false);
 
   int64_t prepare_async_wait(hipStream_t stream);
-  double finish_async_wait(hipStream_t stream);
+  double finish_async_wait(hipStream_t stream, bool capturing = false, bool direct_output = false);
 
   int max_blocks() const { return max_blocks_; }
   int npes() const { return npes_; }

--- a/include/mori/collective/allreduce/twoshot_sdma_async_kernel.hpp
+++ b/include/mori/collective/allreduce/twoshot_sdma_async_kernel.hpp
@@ -115,8 +115,8 @@ __device__ void AllGatherAsyncPutKernel_body(int myPe, int npes,
   // Generation counter — matches AllGatherSdmaKernel's protocol
   __shared__ uint64_t ag_token;
   if (threadIdx.x == 0) {
-    ag_token = static_cast<uint64_t>(barrier->flag) + 1ULL;
-    barrier->flag = static_cast<uint32_t>(ag_token);
+    ag_token = barrier->flag + 1ULL;
+    barrier->flag = ag_token;
   }
   __syncthreads();
   uint64_t flag_val = ag_token;
@@ -174,7 +174,7 @@ __device__ void AllGatherAsyncWaitKernel_body(int myPe, int npes,
   uint64_t* __restrict__ flags = reinterpret_cast<uint64_t*>(flagsMemObj->localPtr);
 
   // Read the generation token set by AllGatherAsyncPutKernel
-  uint64_t flag_val = static_cast<uint64_t>(barrier->flag);
+  uint64_t flag_val = barrier->flag;
 
   for (int sender = 0; sender < npes; ++sender) {
     if (sender == myPe) continue;
@@ -192,10 +192,9 @@ __device__ void AllGatherAsyncWaitKernel_body(int myPe, int npes,
   }
 
   // Ensure SDMA-written data is visible to subsequent CU reads.
-  // SDMA AllGather writes bypass L2/L1, so flush caches to force re-fetch.
   __threadfence_system();
   if (threadIdx.x == 0) {
-    // asm volatile("buffer_wbinvl1_vol" ::: "memory");
+    SdmaDirectOutputCacheInvalidate();
   }
   __syncthreads();
 }
@@ -255,12 +254,10 @@ __device__ void ReduceScatterLocalReduceKernel_body(T* gathered, const T* input,
 
   // Flush L2 dirty lines to HBM so AllGather SDMA reads see fresh data.
   // CU reduce writes land in L2 (write-back); SDMA reads bypass L2.
-#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
   __syncthreads();
   if (threadIdx.x == 0) {
-    asm volatile("buffer_wbl2" ::: "memory");
+    SdmaTransitCacheWriteback();
   }
-#endif
 }
 
 template <typename T>
@@ -321,12 +318,10 @@ __device__ void ReduceScatterP2pKernel_body(int myPe, int npes,
   }
 
   // Flush L2 dirty lines to HBM so AllGather SDMA reads see fresh data.
-#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
   __syncthreads();
   if (threadIdx.x == 0) {
-    asm volatile("buffer_wbl2" ::: "memory");
+    SdmaTransitCacheWriteback();
   }
-#endif
 }
 
 template <typename T>
@@ -418,9 +413,9 @@ __device__ void ReduceScatterAllGatherFusedKernel_body(int myPe, int npes,
   if (elementCountPerRank == 0) return;
 
   // --- generation counter for device-scope broadcast -------------------------
-  __shared__ uint32_t s_next;
+  __shared__ uint64_t s_next;
   if (threadIdx.x == 0) {
-    s_next = barrier->flag + 1;
+    s_next = barrier->flag + 1ULL;
   }
   __syncthreads();
 
@@ -431,7 +426,7 @@ __device__ void ReduceScatterAllGatherFusedKernel_body(int myPe, int npes,
   // =========================================================================
   if (blockIdx.x == 0) {
     uint64_t* __restrict__ flags = reinterpret_cast<uint64_t*>(flagsMemObj->localPtr);
-    uint64_t flag_val = static_cast<uint64_t>(s_next);
+    uint64_t flag_val = s_next;
 
     const int warpId = static_cast<int>(threadIdx.x) / warpSize;
     const int laneId = static_cast<int>(threadIdx.x) % warpSize;
@@ -522,12 +517,10 @@ __device__ void ReduceScatterAllGatherFusedKernel_body(int myPe, int npes,
   }
 
   // Flush dirty L2 lines to HBM so SDMA-based AllGather reads fresh data.
-#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
   __syncthreads();
   if (threadIdx.x == 0) {
-    asm volatile("buffer_wbl2" ::: "memory");
+    SdmaTransitCacheWriteback();
   }
-#endif
 }
 
 template <typename T>

--- a/include/mori/collective/allreduce/twoshot_sdma_common.hpp
+++ b/include/mori/collective/allreduce/twoshot_sdma_common.hpp
@@ -1,0 +1,56 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#ifndef MORI_TWOSHOT_SDMA_COMMON_HPP
+#define MORI_TWOSHOT_SDMA_COMMON_HPP
+
+#include <hip/hip_runtime.h>
+
+#include <cstdint>
+
+namespace mori {
+namespace collective {
+
+constexpr int kSdmaMaxBlocks = 512;
+
+struct alignas(128) CrossPeBarrier {
+  alignas(128) uint64_t flag;
+  alignas(128) uint64_t reuseGeneration;
+  alignas(128) uint32_t needsReuseHandshake;
+  alignas(128) uint64_t reuseSafeChunkBytes;
+  alignas(128) uint64_t blockDone[kSdmaMaxBlocks];
+};
+
+inline int getDeviceMaxBlocks() {
+  int dev = 0;
+  (void)hipGetDevice(&dev);
+  hipDeviceProp_t prop;
+  (void)hipGetDeviceProperties(&prop, dev);
+  return (prop.multiProcessorCount > 0) ? prop.multiProcessorCount : 80;
+}
+
+}  // namespace collective
+}  // namespace mori
+
+#endif

--- a/include/mori/collective/allreduce/twoshot_sdma_kernel.hpp
+++ b/include/mori/collective/allreduce/twoshot_sdma_kernel.hpp
@@ -243,8 +243,7 @@ __device__ void SdmaReduceScatterKernel_body(int myPe, int npes, const T* __rest
           dstMemObj->deviceHandles_d + destPe * dstMemObj->sdmaNumQueue;
       HSAuint64* sig = dstMemObj->signalPtrs + destPe * dstMemObj->sdmaNumQueue;
       HSAuint64* esig = dstMemObj->expectSignalsPtr + destPe * dstMemObj->sdmaNumQueue;
-      core::SdmaPutThread(srcPtr, remoteDst, chunkBytes, dh, sig, esig,
-                          dstMemObj->sdmaNumQueue, 0);
+      core::SdmaPutThread(srcPtr, remoteDst, chunkBytes, dh, sig, esig, dstMemObj->sdmaNumQueue, 0);
     }
 
     // Notify remote PEs that our data has landed
@@ -505,9 +504,8 @@ __device__ void AllGatherSdmaKernel_body(int myPe, int npes,
     // enter the collective reuse rendezvous.
     const size_t slotStrideBytes = slotStrideElements * bytesPerElement;
     barrier->reuseSafeChunkBytes =
-        outputBaseOffsetBytes == 0
-            ? 0
-            : slotStrideBytes - static_cast<size_t>(npes - 1) * agSendBytes;
+        outputBaseOffsetBytes == 0 ? 0
+                                   : slotStrideBytes - static_cast<size_t>(npes - 1) * agSendBytes;
   }
 
   // Flags are monotonic generation tokens (AMO_SET), so no reset is needed.

--- a/include/mori/collective/allreduce/twoshot_sdma_kernel.hpp
+++ b/include/mori/collective/allreduce/twoshot_sdma_kernel.hpp
@@ -25,6 +25,7 @@
 
 #include <cstddef>
 
+#include "mori/collective/allreduce/twoshot_sdma_common.hpp"
 #include "mori/collective/intra_node/kernels/vec_type.cuh"
 #include "mori/core/transport/rdma/device_primitives.hpp"
 #include "mori/core/transport/sdma/device_primitives.hpp"
@@ -35,26 +36,43 @@ namespace collective {
 
 constexpr int kRSMaxBlocks = 80;
 
+__device__ __forceinline__ void SdmaTransitCacheWriteback() {
+#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
+  asm volatile("buffer_wbl2\n\ts_waitcnt 0" ::: "memory");
+#elif defined(__gfx950__)
+  asm volatile("buffer_inv\n\ts_waitcnt 0" ::: "memory");
+#endif
+}
+
+__device__ __forceinline__ void SdmaDirectOutputCacheInvalidate() {
+#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__) || defined(__gfx950__)
+  asm volatile("buffer_inv\n\ts_waitcnt 0" ::: "memory");
+#endif
+}
+
+template <typename P>
+__device__ __forceinline__ void SdmaVisibleStore(P* destination, const P& value) {
+  using Uint4 = uint32_t __attribute__((ext_vector_type(4)));
+  static_assert(sizeof(P) == sizeof(Uint4));
+  const Uint4 bits = *reinterpret_cast<const Uint4*>(&value);
+  __builtin_nontemporal_store(bits, reinterpret_cast<Uint4*>(destination));
+}
+
+__device__ __forceinline__ void PublishControlFlag(const application::SymmMemObjPtr flagsMemObj,
+                                                   size_t flagIndex, uint64_t value, int remotePe) {
+  auto* remoteFlags = reinterpret_cast<uint64_t*>(flagsMemObj->peerPtrs[remotePe]);
+  __scoped_atomic_store_n(remoteFlags + flagIndex, value, __ATOMIC_RELAXED, __MEMORY_SCOPE_SYSTEM);
+}
+
+__device__ __forceinline__ uint64_t LoadControlFlag(const uint64_t* flag) {
+  return __scoped_atomic_load_n(flag, __ATOMIC_RELAXED, __MEMORY_SCOPE_SYSTEM);
+}
+
 // Legacy per-block barrier for ReduceScatterKernel / standalone Allreduce_sdma.
 struct alignas(128) RSBarrierSignal {
   uint32_t sync[kRSMaxBlocks][8];
   alignas(128) uint32_t flag[kRSMaxBlocks];
 };
-
-// Lightweight barrier for SdmaReduceScatterKernel.
-// Block 0 does the SDMA scatter + wait, then device-scope broadcasts to
-// all other blocks.  Device-side generation counter → graph-safe.
-struct alignas(128) CrossPeBarrier {
-  alignas(128) uint32_t flag;
-};
-
-inline int getDeviceMaxBlocks() {
-  int dev = 0;
-  (void)hipGetDevice(&dev);
-  hipDeviceProp_t prop;
-  (void)hipGetDeviceProperties(&prop, dev);
-  return (prop.multiProcessorCount > 0) ? prop.multiProcessorCount : 80;
-}
 
 // ============================================================================
 // ReduceScatterKernel (LEGACY) — IPC reads with per-block start_sync barrier
@@ -161,7 +179,8 @@ __device__ void SdmaReduceScatterKernel_body(int myPe, int npes, const T* __rest
                                              const application::SymmMemObjPtr dstMemObj,
                                              const application::SymmMemObjPtr flagsMemObj,
                                              CrossPeBarrier* __restrict__ barrier,
-                                             size_t elementCount) {
+                                             size_t elementCount, size_t slotStrideElements,
+                                             T* output = nullptr) {
   if (elementCount == 0 || npes <= 0) return;
 
   using P = typename packed_t<T>::P;
@@ -173,65 +192,82 @@ __device__ void SdmaReduceScatterKernel_body(int myPe, int npes, const T* __rest
   const size_t bytesPerElement = sizeof(T);
   const size_t chunkBytes = elementCountPerRank * bytesPerElement;
   const size_t packedPerRank = elementCountPerRank / pack_size;
+  const size_t slotStrideBytes = slotStrideElements * bytesPerElement;
+  const size_t slotStridePacked = slotStrideElements / pack_size;
   if (elementCountPerRank == 0) return;
 
   // --- generation counter for device-scope broadcast -------------------------
-  __shared__ uint32_t s_next;
+  __shared__ uint64_t s_next;
+  __shared__ uint64_t s_reuse;
+  __shared__ uint32_t s_needs_reuse;
   if (threadIdx.x == 0) {
-    s_next = barrier->flag + 1;
+    s_next = barrier->flag + 1ULL;
+    s_reuse = barrier->reuseGeneration + 1ULL;
+    s_needs_reuse = barrier->needsReuseHandshake && chunkBytes > barrier->reuseSafeChunkBytes;
   }
   __syncthreads();
 
   if (blockIdx.x == 0) {
-    // === Phase 1: SDMA scatter ===============================================
-    // Each warp handles one destination PE.
     uint64_t* __restrict__ flags = reinterpret_cast<uint64_t*>(flagsMemObj->localPtr);
-    uint64_t flag_val = static_cast<uint64_t>(s_next);
+    uint64_t flag_val = s_next;
+    uint64_t reuse_val = s_reuse;
 
     const int warpId = static_cast<int>(threadIdx.x) / warpSize;
     const int laneId = static_cast<int>(threadIdx.x) % warpSize;
 
-    if (warpId < npes && laneId == 0) {
+    // Protect scratch reuse without a separate stream-barrier launch. Reaching
+    // this point proves that the prior operation's local copy-out has finished.
+    if (s_needs_reuse && warpId < npes && laneId == 0 && warpId != myPe) {
+      PublishControlFlag(flagsMemObj, npes + myPe, reuse_val, warpId);
+    }
+    if (s_needs_reuse) {
+      if (warpId < npes && laneId == 0 && warpId != myPe) {
+        while (LoadControlFlag(flags + npes + warpId) < reuse_val);
+      }
+      __syncthreads();
+      if (threadIdx.x == 0) barrier->reuseGeneration = s_reuse;
+    }
+
+    // === Phase 1: SDMA scatter ===============================================
+    // Each warp handles one destination PE.
+    if (warpId < npes && laneId == 0 && warpId != myPe) {
       int destPe = warpId;
 
       uint8_t* srcPtr = reinterpret_cast<uint8_t*>(const_cast<T*>(input)) +
                         static_cast<size_t>(destPe) * chunkBytes;
 
       uint8_t* remoteDst = reinterpret_cast<uint8_t*>(dstMemObj->peerPtrs[destPe]) +
-                           static_cast<size_t>(myPe) * chunkBytes;
+                           static_cast<size_t>(myPe) * slotStrideBytes;
 
       anvil::SdmaQueueDeviceHandle** dh =
           dstMemObj->deviceHandles_d + destPe * dstMemObj->sdmaNumQueue;
       HSAuint64* sig = dstMemObj->signalPtrs + destPe * dstMemObj->sdmaNumQueue;
       HSAuint64* esig = dstMemObj->expectSignalsPtr + destPe * dstMemObj->sdmaNumQueue;
-      core::SdmaPutThread(srcPtr, remoteDst, chunkBytes, dh, sig, esig, dstMemObj->sdmaNumQueue, 0);
+      core::SdmaPutThread(srcPtr, remoteDst, chunkBytes, dh, sig, esig,
+                          dstMemObj->sdmaNumQueue, 0);
     }
 
     // Notify remote PEs that our data has landed
-    if (warpId < npes && laneId == 0) {
+    if (warpId < npes && laneId == 0 && warpId != myPe) {
       int destPe = warpId;
       shmem::ShmemQuietThread(destPe, dstMemObj);
-      shmem::ShmemAtomicSizeNonFetchThreadKernel<application::TransportType::SDMA>(
-          flagsMemObj, static_cast<size_t>(myPe) * sizeof(uint64_t), &flag_val, 8,
-          core::atomicType::AMO_SET, destPe, 0);
+      PublishControlFlag(flagsMemObj, myPe, flag_val, destPe);
     }
     __syncthreads();
 
     // === Phase 2: Wait for all peers' scatter ================================
-    for (int sender = 0; sender < npes; ++sender) {
-      if (sender == myPe) continue;
-      if (threadIdx.x == 0) {
-        int spin = 0;
-        bool warned = false;
-        while (core::AtomicLoadRelaxed(flags + sender) < flag_val) {
-          if (++spin > 100000000 && !warned) {
-            printf("PE %d: SdmaScatter timeout waiting for peer %d\n", myPe, sender);
-            warned = true;
-          }
+    if (warpId < npes && laneId == 0 && warpId != myPe) {
+      const int sender = warpId;
+      int spin = 0;
+      bool warned = false;
+      while (LoadControlFlag(flags + sender) < flag_val) {
+        if (++spin > 100000000 && !warned) {
+          printf("PE %d: SdmaScatter timeout waiting for peer %d\n", myPe, sender);
+          warned = true;
         }
       }
-      __syncthreads();
     }
+    __syncthreads();
 
     // === Broadcast to all local blocks: scatter done =========================
     if (threadIdx.x == 0) {
@@ -246,59 +282,107 @@ __device__ void SdmaReduceScatterKernel_body(int myPe, int npes, const T* __rest
     __syncthreads();
   }
 
-  // === Phase 2.5: CU copy of slot[myPe] — L2 coherence fix =================
-  // SDMA scatter writes bypass L2 and land in HBM directly.  However, the
-  // previous reduce wrote slot[myPe] via CU stores, which left a dirty L2
-  // line holding the *old reduce result*.  When the CU reduce below reads
-  // slot[myPe], it hits L2 and sees stale data instead of the fresh scatter
-  // data in HBM.  Overwriting slot[myPe] with the current input via CU
-  // stores forces L2 to match.  Other slots are only *read* (never written
-  // by the reduce), so their L2 entries remain correct.
-  //
-  // Uses the same tid/stride as the reduce, so each thread fixes exactly the
-  // elements it will read — no inter-block barrier required.
+  // The local contribution is read directly from input. This avoids a
+  // redundant self-SDMA transfer and never gives a receive slot a CU-written
+  // role, which also removes the old local-slot L2 alias hazard.
   P* __restrict__ buf = reinterpret_cast<P*>(dstMemObj->localPtr);
-  P* __restrict__ myDst = buf + static_cast<size_t>(myPe) * packedPerRank;
+  P* __restrict__ reduced = buf + static_cast<size_t>(npes) * slotStridePacked;
+  P* __restrict__ directOutput =
+      output == nullptr || chunkBytes < (64U << 10)
+          ? nullptr
+          : reinterpret_cast<P*>(output) + static_cast<size_t>(myPe) * packedPerRank;
+  const P* __restrict__ inputSlot =
+      reinterpret_cast<const P*>(input) + static_cast<size_t>(myPe) * packedPerRank;
 
   const size_t tid =
       static_cast<size_t>(blockIdx.x) * static_cast<size_t>(blockDim.x) + threadIdx.x;
   const size_t stride = static_cast<size_t>(blockDim.x) * static_cast<size_t>(gridDim.x);
 
-  {
-    const P* __restrict__ inputSlot =
-        reinterpret_cast<const P*>(input) + static_cast<size_t>(myPe) * packedPerRank;
-    for (size_t k = tid; k < packedPerRank; k += stride) {
-      myDst[k] = inputSlot[k];
-    }
-  }
-
   // === Phase 3: Local reduce (all blocks) ==================================
   for (size_t k = tid; k < packedPerRank; k += stride) {
-    A acc = upcast_v<typename P::type, pack_size>(buf[k]);
+    A acc = upcast_v<typename P::type, pack_size>(myPe == 0 ? inputSlot[k] : buf[k]);
     for (int pe = 1; pe < npes; ++pe) {
-      packed_assign_add(acc, upcast_v<typename P::type, pack_size>(
-                                 buf[static_cast<size_t>(pe) * packedPerRank + k]));
+      const P value =
+          pe == myPe ? inputSlot[k] : buf[static_cast<size_t>(pe) * slotStridePacked + k];
+      packed_assign_add(acc, upcast_v<typename P::type, pack_size>(value));
     }
-    myDst[k] = downcast_v<typename P::type, pack_size>(acc);
+    const P value = downcast_v<typename P::type, pack_size>(acc);
+    SdmaVisibleStore(reduced + k, value);
+    if (directOutput != nullptr) SdmaVisibleStore(directOutput + k, value);
   }
 
-  // Flush dirty L2 lines to HBM so the SDMA-based AllGather reads fresh data.
-  // CU stores land in L2 (write-back); SDMA reads bypass L2 and hit HBM.
-  // buffer_wbl2 (CDNA3 / MI300, gfx94x) writes back ALL dirty L2 lines.
-#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
+  if (output == nullptr) return;
+
   __syncthreads();
   if (threadIdx.x == 0) {
-    asm volatile("buffer_wbl2" ::: "memory");
+    __scoped_atomic_store_n(&barrier->blockDone[blockIdx.x], s_next, __ATOMIC_RELEASE,
+                            __MEMORY_SCOPE_DEVICE);
   }
-#endif
+  if (blockIdx.x != 0) return;
+  __syncthreads();
+
+  if (threadIdx.x < gridDim.x) {
+    while (__scoped_atomic_load_n(&barrier->blockDone[threadIdx.x], __ATOMIC_ACQUIRE,
+                                  __MEMORY_SCOPE_DEVICE) < s_next);
+  }
+  __syncthreads();
+
+  uint64_t* __restrict__ flags = reinterpret_cast<uint64_t*>(flagsMemObj->localPtr);
+  const int warpId = static_cast<int>(threadIdx.x) / warpSize;
+  const int laneId = static_cast<int>(threadIdx.x) % warpSize;
+  uint64_t ready_val = static_cast<uint64_t>(s_next) + 1ULL;
+
+  if (warpId < npes && laneId == 0 && warpId != myPe) {
+    int remotePe = warpId;
+    PublishControlFlag(flagsMemObj, myPe, ready_val, remotePe);
+  }
+  __syncthreads();
+  if (warpId < npes && laneId == 0 && warpId != myPe) {
+    while (LoadControlFlag(flags + warpId) < ready_val);
+  }
+  __syncthreads();
+
+  if (warpId < npes && laneId == 0 && (warpId != myPe || directOutput == nullptr)) {
+    int sourcePe = warpId;
+    uint8_t* source = reinterpret_cast<uint8_t*>(dstMemObj->peerPtrs[sourcePe]) +
+                      static_cast<size_t>(npes) * slotStrideBytes;
+    uint8_t* destination =
+        reinterpret_cast<uint8_t*>(output) + static_cast<size_t>(sourcePe) * chunkBytes;
+    anvil::SdmaQueueDeviceHandle** handles =
+        dstMemObj->deviceHandles_d + sourcePe * dstMemObj->sdmaNumQueue;
+    HSAuint64* signals = dstMemObj->signalPtrs + sourcePe * dstMemObj->sdmaNumQueue;
+    HSAuint64* expectedSignals = dstMemObj->expectSignalsPtr + sourcePe * dstMemObj->sdmaNumQueue;
+    core::SdmaPutThread(source, destination, chunkBytes, handles, signals, expectedSignals,
+                        dstMemObj->sdmaNumQueue, 0);
+    shmem::ShmemQuietThread(sourcePe, dstMemObj);
+  }
+  __syncthreads();
+  if (threadIdx.x == 0) SdmaDirectOutputCacheInvalidate();
+
+  uint64_t done_val = ready_val + 1ULL;
+  if (warpId < npes && laneId == 0 && warpId != myPe) {
+    int remotePe = warpId;
+    PublishControlFlag(flagsMemObj, myPe, done_val, remotePe);
+  }
+  __syncthreads();
+  if (warpId < npes && laneId == 0 && warpId != myPe) {
+    while (LoadControlFlag(flags + warpId) < done_val);
+  }
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    barrier->flag = done_val;
+    barrier->needsReuseHandshake = 0;
+  }
 }
 
 template <typename T>
 __global__ void SdmaReduceScatterKernel(int myPe, int npes, const T* __restrict__ input,
                                         const application::SymmMemObjPtr dstMemObj,
                                         const application::SymmMemObjPtr flagsMemObj,
-                                        CrossPeBarrier* __restrict__ barrier, size_t elementCount) {
-  SdmaReduceScatterKernel_body<T>(myPe, npes, input, dstMemObj, flagsMemObj, barrier, elementCount);
+                                        CrossPeBarrier* __restrict__ barrier, size_t elementCount,
+                                        size_t slotStrideElements) {
+  SdmaReduceScatterKernel_body<T>(myPe, npes, input, dstMemObj, flagsMemObj, barrier, elementCount,
+                                  slotStrideElements);
 }
 
 // ============================================================================
@@ -309,10 +393,12 @@ __global__ void SdmaReduceScatterKernel(int myPe, int npes, const T* __restrict_
 // ============================================================================
 template <typename T>
 __device__ void AllGatherSdmaKernel_body(int myPe, int npes,
+                                         const application::SymmMemObjPtr srcMemObj,
                                          const application::SymmMemObjPtr dstMemObj,
                                          const application::SymmMemObjPtr flagsMemObj,
-                                         CrossPeBarrier* __restrict__ barrier,
-                                         size_t elementCount) {
+                                         CrossPeBarrier* __restrict__ barrier, size_t elementCount,
+                                         size_t slotStrideElements, size_t outputBaseOffsetBytes,
+                                         size_t sourceOffsetElements = SIZE_MAX) {
   if (elementCount == 0 || npes <= 0) {
     return;
   }
@@ -332,26 +418,49 @@ __device__ void AllGatherSdmaKernel_body(int myPe, int npes,
   __shared__ uint64_t ag_token;
   if (threadIdx.x == 0) {
     ag_token = static_cast<uint64_t>(barrier->flag) + 1ULL;
-    barrier->flag = static_cast<uint32_t>(ag_token);
   }
   __syncthreads();
-  uint64_t flag_val = ag_token;
+  uint64_t ready_val = ag_token;
+  uint64_t done_val = ag_token + 1ULL;
 
   const size_t threadLinearId =
       static_cast<size_t>(blockIdx.x) * static_cast<size_t>(blockDim.x) + threadIdx.x;
   int warpId = threadLinearId / warpSize;
   const int laneId = threadIdx.x % warpSize;
 
+  // A nonzero output base lies wholly in slot-0 padding and cannot overwrite
+  // receive data. Compact output at base zero still needs the cross-rank ready
+  // rendezvous before any peer writes into another rank's receive slots.
+  if (outputBaseOffsetBytes == 0) {
+    if (warpId < npes && laneId == 0 && warpId != myPe) {
+      PublishControlFlag(flagsMemObj, myPe, ready_val, warpId);
+    }
+    __syncthreads();
+    if (warpId < npes && laneId == 0 && warpId != myPe) {
+      while (LoadControlFlag(flags + warpId) < ready_val);
+    }
+    __syncthreads();
+  }
+
   // --- SDMA put: send my reduced shard to every rank -------------------------
-  uint8_t* agSrcPtr = reinterpret_cast<uint8_t*>(dstMemObj->localPtr) +
-                      static_cast<size_t>(myPe) * elementCountPerRank * bytesPerElement;
+  if (sourceOffsetElements == SIZE_MAX) {
+    sourceOffsetElements = static_cast<size_t>(myPe) * slotStrideElements;
+  }
+  uint8_t* agSrcPtr =
+      reinterpret_cast<uint8_t*>(srcMemObj->localPtr) + sourceOffsetElements * bytesPerElement;
   size_t agSendBytes = elementCountPerRank * bytesPerElement;
 
-  if (warpId < npes && laneId == 0) {
+  if (warpId < npes && laneId == 0 && (outputBaseOffsetBytes == 0 || warpId != myPe)) {
     int remotePe = warpId;
     application::SymmMemObjPtr dest = dstMemObj;
 
-    uint8_t* agDstPtr = reinterpret_cast<uint8_t*>(dest->peerPtrs[remotePe]) +
+    const size_t remoteOutputBase =
+        outputBaseOffsetBytes == 0
+            ? 0
+            : static_cast<size_t>(static_cast<ptrdiff_t>(outputBaseOffsetBytes) +
+                                  static_cast<ptrdiff_t>(myPe - remotePe) *
+                                      static_cast<ptrdiff_t>(agSendBytes));
+    uint8_t* agDstPtr = reinterpret_cast<uint8_t*>(dest->peerPtrs[remotePe]) + remoteOutputBase +
                         static_cast<size_t>(myPe) * elementCountPerRank * bytesPerElement;
 
     anvil::SdmaQueueDeviceHandle** devicehandles =
@@ -363,42 +472,55 @@ __device__ void AllGatherSdmaKernel_body(int myPe, int npes,
   }
 
   // --- Notify remote PEs that our data is in place ---------------------------
-  if (warpId < npes && laneId == 0) {
+  if (warpId < npes && laneId == 0 && (outputBaseOffsetBytes == 0 || warpId != myPe)) {
     int remotePe = warpId;
     shmem::ShmemQuietThread(remotePe, dstMemObj);
-    shmem::ShmemAtomicSizeNonFetchThreadKernel<application::TransportType::SDMA>(
-        flagsMemObj, static_cast<size_t>(myPe) * sizeof(uint64_t), &flag_val, 8,
-        core::atomicType::AMO_SET, remotePe, 0);
+    if (remotePe != myPe) {
+      PublishControlFlag(flagsMemObj, myPe, done_val, remotePe);
+    }
   }
   __syncthreads();
 
   // --- Wait for all peers to finish AllGather --------------------------------
-  for (int sender = 0; sender < npes; ++sender) {
-    if (sender == myPe) {
-      continue;
-    }
-    if (threadLinearId == 0) {
-      int spinCount = 0;
-      bool warned = false;
-      while (core::AtomicLoadRelaxed(flags + sender) < flag_val) {
-        ++spinCount;
-        if (spinCount > 10000000 && !warned) {
-          printf("PE %d: AllGather timeout waiting for peer %d\n", myPe, sender);
-          warned = true;
-        }
+  if (warpId < npes && laneId == 0 && warpId != myPe) {
+    const int sender = warpId;
+    int spinCount = 0;
+    bool warned = false;
+    while (LoadControlFlag(flags + sender) < done_val) {
+      ++spinCount;
+      if (spinCount > 10000000 && !warned) {
+        printf("PE %d: AllGather timeout waiting for peer %d\n", myPe, sender);
+        warned = true;
       }
     }
-    __syncthreads();
+  }
+  __syncthreads();
+
+  if (threadLinearId == 0) {
+    barrier->flag = done_val;
+    barrier->needsReuseHandshake = 1;
+    // The next scatter writes the prefix of every fixed receive slot. Use the
+    // most restrictive rank's padding so every rank makes the same handshake
+    // decision; a rank-local threshold would deadlock when only some ranks
+    // enter the collective reuse rendezvous.
+    const size_t slotStrideBytes = slotStrideElements * bytesPerElement;
+    barrier->reuseSafeChunkBytes =
+        outputBaseOffsetBytes == 0
+            ? 0
+            : slotStrideBytes - static_cast<size_t>(npes - 1) * agSendBytes;
   }
 
   // Flags are monotonic generation tokens (AMO_SET), so no reset is needed.
 }
 
 template <typename T>
-__global__ void AllGatherSdmaKernel(int myPe, int npes, const application::SymmMemObjPtr dstMemObj,
+__global__ void AllGatherSdmaKernel(int myPe, int npes, const application::SymmMemObjPtr srcMemObj,
+                                    const application::SymmMemObjPtr dstMemObj,
                                     const application::SymmMemObjPtr flagsMemObj,
-                                    CrossPeBarrier* __restrict__ barrier, size_t elementCount) {
-  AllGatherSdmaKernel_body<T>(myPe, npes, dstMemObj, flagsMemObj, barrier, elementCount);
+                                    CrossPeBarrier* __restrict__ barrier, size_t elementCount,
+                                    size_t slotStrideElements, size_t outputBaseOffsetBytes) {
+  AllGatherSdmaKernel_body<T>(myPe, npes, srcMemObj, dstMemObj, flagsMemObj, barrier, elementCount,
+                              slotStrideElements, outputBaseOffsetBytes);
 }
 
 }  // namespace collective

--- a/include/mori/collective/ccl_kernel_args.hpp
+++ b/include/mori/collective/ccl_kernel_args.hpp
@@ -159,10 +159,14 @@ struct CclAllreduceArgs {
   int myPe;
   int npes;
   const T* input;
+  T* output;
   application::SymmMemObjPtr dstMemObj;
+  application::SymmMemObjPtr outputMemObj;
   application::SymmMemObjPtr flagsMemObj;
   CrossPeBarrier* barrier;
   size_t elementCount;
+  size_t slotStrideElements;
+  size_t outputBaseOffsetBytes;
 };
 
 // Inter-node RDMA ring AllGather. Ring buffer memObj holds ringSize contiguous chunks of

--- a/python/mori/ccl/collective.py
+++ b/python/mori/ccl/collective.py
@@ -1030,6 +1030,8 @@ _HANDLE_MAP = {
 
 
 class AllreduceSdma:
+    _ONESHOT_MAX_BYTES = 1 << 20
+
     def __init__(
         self,
         my_pe: int,
@@ -1046,6 +1048,8 @@ class AllreduceSdma:
         self.my_pe = my_pe
         self.npes = npes
         self.dtype = dtype
+        self._element_size = torch.empty((), dtype=dtype).element_size()
+        self._async_oneshot = False
         self.mode = mode
         self._type_suffix = _DTYPE_TO_SUFFIX.get(dtype)
         if self._type_suffix is None:
@@ -1086,15 +1090,21 @@ class AllreduceSdma:
             input_data.data_ptr(), output_data.data_ptr(), count, s
         )
         blocks, threads = self._handle.get_reduce_scatter_grid(count)
-        _get_ccl_func(f"SdmaReduceScatterKernel_{sfx}").launch_struct(
+        oneshot = count * self._element_size <= self._ONESHOT_MAX_BYTES
+        kernel = "SdmaOneShotAllreduceKernel" if oneshot else "SdmaReduceScatterKernel"
+        _get_ccl_func(f"{kernel}_{sfx}").launch_struct(
             (blocks,), (threads,), 0, s, args
         )
+        if oneshot:
+            self._handle.finish_sync(
+                output_data.data_ptr(), count, s, force_copy_output, True
+            )
+            return True
         # Step 2: AllGather
         args = self._handle.prepare_allgather(count, s)
-        _get_ccl_func(f"AllGatherSdmaKernel_{sfx}").launch_struct(
+        _get_ccl_func(f"AllGatherSdmaFromProtectedKernel_{sfx}").launch_struct(
             (1,), (512,), 0, s, args
         )
-        # Sync + copy output
         self._handle.finish_sync(output_data.data_ptr(), count, s, force_copy_output)
         return True
 
@@ -1112,25 +1122,30 @@ class AllreduceSdma:
             input_data.data_ptr(), output_data.data_ptr(), count, s
         )
         blocks, threads = self._handle.get_reduce_scatter_grid(count)
-        _get_ccl_func(f"SdmaReduceScatterKernel_{sfx}").launch_struct(
+        self._async_oneshot = count * self._element_size <= self._ONESHOT_MAX_BYTES
+        kernel = (
+            "SdmaOneShotAllreduceKernel"
+            if self._async_oneshot
+            else "SdmaReduceScatterKernel"
+        )
+        _get_ccl_func(f"{kernel}_{sfx}").launch_struct(
             (blocks,), (threads,), 0, s, args
         )
-        # AllGather PUT
-        args = self._handle.prepare_async_allgather_put(count, s)
-        _get_ccl_func(f"AllGatherAsyncPutKernel_{sfx}").launch_struct(
-            (1,), (512,), 0, s, args
-        )
-        self._handle.after_async_start()
+        if not self._async_oneshot:
+            args = self._handle.prepare_async_allgather_put(count, s)
+            _get_ccl_func(
+                f"AllGatherSdmaFromProtectedKernel_{sfx}"
+            ).launch_struct((1,), (512,), 0, s, args)
+        capturing = torch.cuda.is_current_stream_capturing()
+        self._handle.after_async_start(capturing)
         return True
 
     def wait_async(self, stream=None) -> float:
         s = _stream_to_int(stream)
-        sfx = self._type_suffix
-        args = self._handle.prepare_async_wait(s)
-        _get_ccl_func(f"AllGatherAsyncWaitKernel_{sfx}").launch_struct(
-            (1,), (64,), 0, s, args
-        )
-        return self._handle.finish_async_wait(s)
+        capturing = torch.cuda.is_current_stream_capturing()
+        if self._async_oneshot:
+            return self._handle.finish_async_wait(s, capturing, True)
+        return self._handle.finish_async_wait(s, capturing)
 
     def is_async_in_progress(self) -> bool:
         return self._handle.is_async_in_progress()
@@ -1140,8 +1155,3 @@ class AllreduceSdma:
 
     def reset_flags(self):
         self._handle.reset_flags()
-
-    def get_output_transit_buffer(self, dtype=None, device=None):
-        dtype, device = _resolve_transit_view_args(dtype, device, self.dtype)
-        ptr, size_bytes = self._handle.get_output_transit_buffer()
-        return _ptr_to_tensor(ptr, size_bytes, dtype, device)

--- a/python/mori/ccl/collective.py
+++ b/python/mori/ccl/collective.py
@@ -1133,9 +1133,9 @@ class AllreduceSdma:
         )
         if not self._async_oneshot:
             args = self._handle.prepare_async_allgather_put(count, s)
-            _get_ccl_func(
-                f"AllGatherSdmaFromProtectedKernel_{sfx}"
-            ).launch_struct((1,), (512,), 0, s, args)
+            _get_ccl_func(f"AllGatherSdmaFromProtectedKernel_{sfx}").launch_struct(
+                (1,), (512,), 0, s, args
+            )
         capturing = torch.cuda.is_current_stream_capturing()
         self._handle.after_async_start(capturing)
         return True

--- a/src/collective/core/twoshot_allreduce_sdma_class.cpp
+++ b/src/collective/core/twoshot_allreduce_sdma_class.cpp
@@ -92,6 +92,7 @@ AllreduceSdma<T>::AllreduceSdma(int myPe, int npes, size_t input_buffer_size,
       async_output_(nullptr),
       async_total_count_(0),
       async_stream_(nullptr),
+      async_start_event_(nullptr),
       async_start_time_(0.0),
       copy_output_to_user_(copy_output_to_user) {
   (void)output_buffer_size;
@@ -127,6 +128,10 @@ AllreduceSdma<T>::AllreduceSdma(int myPe, int npes, size_t input_buffer_size,
   if (!input_transit_buffer_obj_.IsValid())
     throw std::runtime_error("Failed to register input transit buffer");
 
+  hipError_t event_err = hipEventCreateWithFlags(&async_start_event_, hipEventDisableTiming);
+  if (event_err != hipSuccess)
+    throw std::runtime_error("Failed to create async stream-ordering event");
+
   printf("AllreduceSdma(SDMA) initialized: PE %d of %d, max_blocks=%d\n", myPe_, npes_,
          max_blocks_);
   printf("  Flags: %zu bytes at %p\n", flagsSize, flags_.get());
@@ -140,6 +145,9 @@ template <typename T>
 AllreduceSdma<T>::~AllreduceSdma() {
   if (async_in_progress_) {
     cancel_async();
+  }
+  if (async_start_event_ != nullptr) {
+    (void)hipEventDestroy(async_start_event_);
   }
   if (flags_) {
     printf("AllreduceSdma destroyed: PE %d\n", myPe_);
@@ -366,11 +374,17 @@ int64_t AllreduceSdma<T>::prepare_async_allgather_put(size_t total_count, hipStr
 
 template <typename T>
 void AllreduceSdma<T>::after_async_start(bool capturing) {
-  if (capturing) return;
-  hipError_t err = hipGetLastError();
+  if (!capturing) {
+    hipError_t err = hipGetLastError();
+    if (err != hipSuccess) {
+      async_in_progress_ = false;
+      throw std::runtime_error("Async kernel launch failed");
+    }
+  }
+  hipError_t err = hipEventRecord(async_start_event_, async_stream_);
   if (err != hipSuccess) {
     async_in_progress_ = false;
-    throw std::runtime_error("Async kernel launch failed");
+    throw std::runtime_error("Failed to record async start event");
   }
 }
 
@@ -392,6 +406,10 @@ int64_t AllreduceSdma<T>::prepare_async_wait(hipStream_t stream) {
 template <typename T>
 double AllreduceSdma<T>::finish_async_wait(hipStream_t stream, bool capturing, bool direct_output) {
   hipStream_t ws = (stream != nullptr) ? stream : async_stream_;
+  if (ws != async_stream_) {
+    hipError_t err = hipStreamWaitEvent(ws, async_start_event_, 0);
+    if (err != hipSuccess) throw std::runtime_error("Failed to order async wait stream");
+  }
   if (!direct_output) {
     auto* source = static_cast<uint8_t*>(input_transit_buffer_) + jit_args_.outputBaseOffsetBytes;
     hipError_t err = hipMemcpyAsync(async_output_, source, async_total_count_ * dtype_size_,

--- a/src/collective/core/twoshot_allreduce_sdma_class.cpp
+++ b/src/collective/core/twoshot_allreduce_sdma_class.cpp
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstring>
+#include <limits>
 #include <stdexcept>
 
 #include "mori/shmem/shmem.hpp"
@@ -35,19 +36,44 @@
 namespace mori {
 namespace collective {
 
+namespace {
+template <typename T>
+size_t FixedSlotElements(size_t input_buffer_size, int npes) {
+  if (npes <= 0) throw std::invalid_argument("npes must be positive");
+  if (input_buffer_size == 0 || input_buffer_size % sizeof(T) != 0)
+    throw std::invalid_argument("input_buffer_size must be a positive whole number of elements");
+  constexpr size_t pack_size = 16 / sizeof(T);
+  const size_t elements = input_buffer_size / sizeof(T);
+  const size_t shard = (elements + static_cast<size_t>(npes) - 1) / static_cast<size_t>(npes);
+  const size_t rounded = ((shard + pack_size - 1) / pack_size) * pack_size;
+  if (rounded > std::numeric_limits<size_t>::max() - 64)
+    throw std::overflow_error("AllReduce scratch size overflow");
+  return rounded + 64;
+}
+
+template <typename T>
+size_t FixedScratchBytes(size_t input_buffer_size, int npes) {
+  const size_t slot = FixedSlotElements<T>(input_buffer_size, npes);
+  if (slot > std::numeric_limits<size_t>::max() / (static_cast<size_t>(npes) + 1) / sizeof(T))
+    throw std::overflow_error("AllReduce scratch size overflow");
+  return (static_cast<size_t>(npes) + 1) * slot * sizeof(T);
+}
+}  // namespace
+
 // ---------------------------------------------------------------------------
 // Delegating constructor
 // ---------------------------------------------------------------------------
 template <typename T>
 AllreduceSdma<T>::AllreduceSdma(int myPe, int npes, size_t transit_buffer_size,
                                 bool copy_output_to_user, bool /*use_graph_mode*/)
-    : AllreduceSdma(myPe, npes, 0, transit_buffer_size, copy_output_to_user, false) {}
+    : AllreduceSdma(myPe, npes, transit_buffer_size, transit_buffer_size, copy_output_to_user,
+                    false) {}
 
 // ---------------------------------------------------------------------------
 // Main constructor
 // ---------------------------------------------------------------------------
 template <typename T>
-AllreduceSdma<T>::AllreduceSdma(int myPe, int npes, size_t /*input_buffer_size*/,
+AllreduceSdma<T>::AllreduceSdma(int myPe, int npes, size_t input_buffer_size,
                                 size_t output_buffer_size, bool copy_output_to_user,
                                 bool /*use_graph_mode*/)
     : myPe_(myPe),
@@ -58,11 +84,9 @@ AllreduceSdma<T>::AllreduceSdma(int myPe, int npes, size_t /*input_buffer_size*/
       barrierPtr_(nullptr),
       barrierMem_(nullptr, ShmemDeleter()),
       input_transit_buffer_(nullptr),
-      input_transit_buffer_size_(0),
+      input_transit_buffer_size_(FixedScratchBytes<T>(input_buffer_size, npes)),
+      slot_stride_elements_(FixedSlotElements<T>(input_buffer_size, npes)),
       input_transit_buffer_ptr_(nullptr, ShmemDeleter()),
-      output_transit_buffer_(nullptr),
-      output_transit_buffer_size_(output_buffer_size),
-      output_transit_buffer_ptr_(nullptr, ShmemDeleter()),
       async_in_progress_(false),
       async_input_(nullptr),
       async_output_(nullptr),
@@ -70,8 +94,12 @@ AllreduceSdma<T>::AllreduceSdma(int myPe, int npes, size_t /*input_buffer_size*/
       async_stream_(nullptr),
       async_start_time_(0.0),
       copy_output_to_user_(copy_output_to_user) {
+  (void)output_buffer_size;
+  if (myPe_ < 0 || myPe_ >= npes_) throw std::invalid_argument("myPe must be in [0, npes)");
+  if (max_blocks_ > kSdmaMaxBlocks)
+    throw std::runtime_error("GPU block count exceeds one-shot barrier capacity");
   // 1. Allocate SDMA completion flags
-  size_t flagsSize = npes_ * sizeof(uint64_t);
+  size_t flagsSize = 2 * npes_ * sizeof(uint64_t);
   void* flags = shmem::ShmemMalloc(flagsSize);
   if (!flags) throw std::runtime_error("Failed to allocate flags memory");
   flags_.reset(static_cast<uint64_t*>(flags));
@@ -88,22 +116,23 @@ AllreduceSdma<T>::AllreduceSdma(int myPe, int npes, size_t /*input_buffer_size*/
   hipError_t me = hipMemset(bMem, 0, barrierSize);
   if (me != hipSuccess) throw std::runtime_error("Failed to zero-init barrier memory");
 
-  // 3. Allocate output transit buffer (gather + reduce + allgather)
-  output_transit_buffer_ = shmem::ShmemMalloc(output_transit_buffer_size_);
-  if (!output_transit_buffer_) throw std::runtime_error("Failed to allocate output transit buffer");
-  output_transit_buffer_ptr_.reset(output_transit_buffer_);
-
-  output_transit_buffer_obj_ =
-      shmem::ShmemSymmetricRegister(output_transit_buffer_, output_transit_buffer_size_);
-  if (!output_transit_buffer_obj_.IsValid())
-    throw std::runtime_error("Failed to register output transit buffer");
+  // 3. Allocate a fixed-stride reduce-scatter scratch buffer. Keeping rank
+  // slots at stable offsets prevents a region written by a prior CU reduce
+  // from becoming an SDMA-written peer slot when graph message sizes change.
+  input_transit_buffer_ = shmem::ShmemMalloc(input_transit_buffer_size_);
+  if (!input_transit_buffer_) throw std::runtime_error("Failed to allocate input transit buffer");
+  input_transit_buffer_ptr_.reset(input_transit_buffer_);
+  input_transit_buffer_obj_ =
+      shmem::ShmemSymmetricRegister(input_transit_buffer_, input_transit_buffer_size_);
+  if (!input_transit_buffer_obj_.IsValid())
+    throw std::runtime_error("Failed to register input transit buffer");
 
   printf("AllreduceSdma(SDMA) initialized: PE %d of %d, max_blocks=%d\n", myPe_, npes_,
          max_blocks_);
   printf("  Flags: %zu bytes at %p\n", flagsSize, flags_.get());
   printf("  Barrier: %zu bytes at %p\n", barrierSize, bMem);
-  printf("  Output transit buffer: %.2f MB at %p\n",
-         output_transit_buffer_size_ / (1024.0 * 1024.0), output_transit_buffer_);
+  printf("  Reduce scratch buffer: %.2f MB at %p\n", input_transit_buffer_size_ / (1024.0 * 1024.0),
+         input_transit_buffer_);
 }
 
 // ---------------------------------------------------------------------------
@@ -115,46 +144,6 @@ AllreduceSdma<T>::~AllreduceSdma() {
   if (flags_) {
     printf("AllreduceSdma destroyed: PE %d\n", myPe_);
   }
-}
-
-// ---------------------------------------------------------------------------
-template <typename T>
-bool AllreduceSdma<T>::ensure_buffer_size(void*& buffer,
-                                          std::unique_ptr<void, ShmemDeleter>& buffer_ptr,
-                                          size_t& current_size,
-                                          application::SymmMemObjPtr& buffer_obj,
-                                          size_t required_size, const char* buffer_name) {
-  if (required_size <= current_size) {
-    return true;
-  }
-
-  // If buffer is not large enough, reallocate
-  printf("PE %d: %s too small: required %.2f MB, current %.2f MB\n", myPe_, buffer_name,
-         required_size / (1024.0 * 1024.0), current_size / (1024.0 * 1024.0));
-
-  // First release the old one
-  buffer_ptr.reset();
-
-  // Allocate new one
-  current_size = required_size;
-  buffer = shmem::ShmemMalloc(current_size);
-  if (buffer == nullptr) {
-    fprintf(stderr, "PE %d: Failed to reallocate %s of size %.2f MB\n", myPe_, buffer_name,
-            current_size / (1024.0 * 1024.0));
-    return false;
-  }
-  buffer_ptr.reset(buffer);
-
-  // Re-register
-  buffer_obj = shmem::ShmemSymmetricRegister(buffer, current_size);
-  if (!buffer_obj.IsValid()) {
-    fprintf(stderr, "PE %d: Failed to re-register %s\n", myPe_, buffer_name);
-    return false;
-  }
-
-  printf("PE %d: %s reallocated to %.2f MB\n", myPe_, buffer_name,
-         current_size / (1024.0 * 1024.0));
-  return true;
 }
 
 // copy_input_to_transit implementation
@@ -187,24 +176,6 @@ void AllreduceSdma<T>::copy_input_to_transit(T* input, size_t total_count, hipSt
     fprintf(stderr, "PE %d: Failed to copy input to transit buffer: %s\n", myPe_,
             hipGetErrorString(err));
     throw std::runtime_error("Input copy failed");
-  }
-}
-
-// copy_output_to_user implementation
-// For AllReduce: output is total_count elements (same size as input, NOT npes * total_count)
-template <typename T>
-void AllreduceSdma<T>::copy_output_to_user(T* output, size_t total_count, hipStream_t stream) {
-  size_t bytes = total_count * dtype_size_;
-  if (!output) throw std::runtime_error("Output pointer is null");
-  if (!output_transit_buffer_) throw std::runtime_error("Output transit buffer is null");
-
-  hipError_t err =
-      stream
-          ? hipMemcpyAsync(output, output_transit_buffer_, bytes, hipMemcpyDeviceToDevice, stream)
-          : hipMemcpy(output, output_transit_buffer_, bytes, hipMemcpyDeviceToDevice);
-  if (err != hipSuccess) {
-    fprintf(stderr, "PE %d: copy_output_to_user failed: %s\n", myPe_, hipGetErrorString(err));
-    throw std::runtime_error("Output copy failed");
   }
 }
 
@@ -264,7 +235,7 @@ bool AllreduceSdma<T>::allreduce_inplace(T* /*data*/, size_t /*total_count*/,
 template <typename T>
 void AllreduceSdma<T>::resetFlags() {
   if (flags_) {
-    memset(flags_.get(), 0, npes_ * sizeof(uint64_t));
+    memset(flags_.get(), 0, 2 * npes_ * sizeof(uint64_t));
   }
 }
 
@@ -276,19 +247,33 @@ void AllreduceSdma<T>::fill_jit_args_(const T* input, size_t total_count) {
   jit_args_.myPe = myPe_;
   jit_args_.npes = npes_;
   jit_args_.input = input;
-  jit_args_.dstMemObj = output_transit_buffer_obj_;
+  jit_args_.output = nullptr;
+  jit_args_.dstMemObj = input_transit_buffer_obj_;
+  jit_args_.outputMemObj = input_transit_buffer_obj_;
   jit_args_.flagsMemObj = flagsObj_;
   jit_args_.barrier = barrierPtr_;
   jit_args_.elementCount = total_count;
+  jit_args_.slotStrideElements = slot_stride_elements_;
+  jit_args_.outputBaseOffsetBytes = 0;
 }
 
 template <typename T>
 int64_t AllreduceSdma<T>::prepare_reduce_scatter(const T* input, T* output, size_t total_count,
                                                  hipStream_t stream) {
   if (async_in_progress_) throw std::runtime_error("Async operation in progress");
-  (void)output;
   (void)stream;
+  constexpr size_t pack_size = 16 / sizeof(T);
+  const size_t collective_pack = static_cast<size_t>(npes_) * pack_size;
+  if (input == nullptr || output == nullptr) throw std::invalid_argument("input/output is null");
+  if (total_count == 0 || total_count % collective_pack != 0)
+    throw std::invalid_argument("AllReduce count must be divisible by npes * pack_size");
+  if (total_count > std::numeric_limits<size_t>::max() / dtype_size_)
+    throw std::overflow_error("AllReduce byte count overflow");
+  const size_t required_slot = total_count / npes_;
+  if (required_slot > slot_stride_elements_)
+    throw std::runtime_error("AllReduce input exceeds fixed reduce scratch capacity");
   fill_jit_args_(input, total_count);
+  jit_args_.output = output;
   return reinterpret_cast<int64_t>(&jit_args_);
 }
 
@@ -296,24 +281,38 @@ template <typename T>
 std::tuple<int, int> AllreduceSdma<T>::get_reduce_scatter_grid(size_t total_count) const {
   constexpr size_t pack_size = 16 / sizeof(T);
   size_t packedPerRank = (total_count / npes_ + pack_size - 1) / pack_size;
-  int threads = 512;
+  const size_t total_bytes = total_count * dtype_size_;
+  int threads = total_bytes <= (1U << 20) || total_bytes > (16U << 20)
+                    ? (packedPerRank >= 1024 ? 1024 : 512)
+                    : 512;
   int blocks = std::min(max_blocks_, static_cast<int>((packedPerRank + threads - 1) / threads));
   if (blocks < 1) blocks = 1;
   return {blocks, threads};
 }
 
 template <typename T>
-int64_t AllreduceSdma<T>::prepare_allgather(size_t total_count, hipStream_t /*stream*/) {
+int64_t AllreduceSdma<T>::prepare_allgather(size_t total_count, hipStream_t stream) {
   jit_args_.input = nullptr;
   jit_args_.elementCount = total_count;
+  const size_t shard_bytes = total_count / npes_ * dtype_size_;
+  const size_t output_bytes = total_count * dtype_size_;
+  const size_t slot_bytes = slot_stride_elements_ * dtype_size_;
+  jit_args_.outputBaseOffsetBytes =
+      output_bytes <= slot_bytes
+          ? static_cast<size_t>(npes_) * slot_bytes - static_cast<size_t>(myPe_) * shard_bytes
+          : 0;
   return reinterpret_cast<int64_t>(&jit_args_);
 }
 
 template <typename T>
 double AllreduceSdma<T>::finish_sync(T* output, size_t total_count, hipStream_t stream,
-                                     bool force_copy_output_to_user) {
-  if (copy_output_to_user_ || force_copy_output_to_user) {
-    copy_output_to_user(output, total_count, stream);
+                                     bool force_copy_output_to_user, bool direct_output) {
+  (void)force_copy_output_to_user;
+  if (!direct_output) {
+    auto* source = static_cast<uint8_t*>(input_transit_buffer_) + jit_args_.outputBaseOffsetBytes;
+    hipError_t err =
+        hipMemcpyAsync(output, source, total_count * dtype_size_, hipMemcpyDeviceToDevice, stream);
+    if (err != hipSuccess) throw std::runtime_error("Failed to copy AllReduce output");
   }
   return 0.0;
 }
@@ -331,15 +330,23 @@ int64_t AllreduceSdma<T>::prepare_async_reduce_scatter(const T* input, T* output
   async_stream_ = stream;
   async_start_time_ = CollectiveWallTime();
 
-  size_t required = (total_count / npes_) * npes_ * dtype_size_;
-  if (!ensure_buffer_size(output_transit_buffer_, output_transit_buffer_ptr_,
-                          output_transit_buffer_size_, output_transit_buffer_obj_, required,
-                          "output transit buffer")) {
+  try {
+    constexpr size_t pack_size = 16 / sizeof(T);
+    const size_t collective_pack = static_cast<size_t>(npes_) * pack_size;
+    if (input == nullptr || output == nullptr) throw std::invalid_argument("input/output is null");
+    if (total_count == 0 || total_count % collective_pack != 0)
+      throw std::invalid_argument("AllReduce count must be divisible by npes * pack_size");
+    if (total_count > std::numeric_limits<size_t>::max() / dtype_size_)
+      throw std::overflow_error("AllReduce byte count overflow");
+    const size_t required_slot = total_count / npes_;
+    if (required_slot > slot_stride_elements_)
+      throw std::runtime_error("AllReduce input exceeds fixed reduce scratch capacity");
+    fill_jit_args_(input, total_count);
+    jit_args_.output = output;
+  } catch (...) {
     async_in_progress_ = false;
-    throw std::runtime_error("Buffer allocation failed");
+    throw;
   }
-
-  fill_jit_args_(input, total_count);
   return reinterpret_cast<int64_t>(&jit_args_);
 }
 
@@ -347,11 +354,19 @@ template <typename T>
 int64_t AllreduceSdma<T>::prepare_async_allgather_put(size_t total_count, hipStream_t /*stream*/) {
   jit_args_.input = nullptr;
   jit_args_.elementCount = total_count;
+  const size_t shard_bytes = total_count / npes_ * dtype_size_;
+  const size_t output_bytes = total_count * dtype_size_;
+  const size_t slot_bytes = slot_stride_elements_ * dtype_size_;
+  jit_args_.outputBaseOffsetBytes =
+      output_bytes <= slot_bytes
+          ? static_cast<size_t>(npes_) * slot_bytes - static_cast<size_t>(myPe_) * shard_bytes
+          : 0;
   return reinterpret_cast<int64_t>(&jit_args_);
 }
 
 template <typename T>
-void AllreduceSdma<T>::after_async_start() {
+void AllreduceSdma<T>::after_async_start(bool capturing) {
+  if (capturing) return;
   hipError_t err = hipGetLastError();
   if (err != hipSuccess) {
     async_in_progress_ = false;
@@ -362,20 +377,30 @@ void AllreduceSdma<T>::after_async_start() {
 template <typename T>
 int64_t AllreduceSdma<T>::prepare_async_wait(hipStream_t stream) {
   if (!async_in_progress_) throw std::runtime_error("No async operation in progress");
-  (void)stream;
   jit_args_.input = nullptr;
   jit_args_.elementCount = async_total_count_;
+  const size_t shard_bytes = async_total_count_ / npes_ * dtype_size_;
+  const size_t output_bytes = async_total_count_ * dtype_size_;
+  const size_t slot_bytes = slot_stride_elements_ * dtype_size_;
+  jit_args_.outputBaseOffsetBytes =
+      output_bytes <= slot_bytes
+          ? static_cast<size_t>(npes_) * slot_bytes - static_cast<size_t>(myPe_) * shard_bytes
+          : 0;
   return reinterpret_cast<int64_t>(&jit_args_);
 }
 
 template <typename T>
-double AllreduceSdma<T>::finish_async_wait(hipStream_t stream) {
+double AllreduceSdma<T>::finish_async_wait(hipStream_t stream, bool capturing, bool direct_output) {
   hipStream_t ws = (stream != nullptr) ? stream : async_stream_;
-  hipError_t err = ws ? hipStreamSynchronize(ws) : hipDeviceSynchronize();
-  if (err != hipSuccess) throw std::runtime_error("Synchronization failed");
-
-  if (copy_output_to_user_) {
-    copy_output_to_user(async_output_, async_total_count_, ws);
+  if (!direct_output) {
+    auto* source = static_cast<uint8_t*>(input_transit_buffer_) + jit_args_.outputBaseOffsetBytes;
+    hipError_t err = hipMemcpyAsync(async_output_, source, async_total_count_ * dtype_size_,
+                                    hipMemcpyDeviceToDevice, ws);
+    if (err != hipSuccess) throw std::runtime_error("Failed to copy async AllReduce output");
+  }
+  if (!capturing) {
+    hipError_t err = ws ? hipStreamSynchronize(ws) : hipDeviceSynchronize();
+    if (err != hipSuccess) throw std::runtime_error("Synchronization failed");
   }
 
   double duration = CollectiveWallTime() - async_start_time_;

--- a/src/collective/kernels/ccl_kernels.hip
+++ b/src/collective/kernels/ccl_kernels.hip
@@ -97,23 +97,32 @@ using namespace mori::collective;
 #define CCL_WRAP_ALLREDUCE_RS(kernel, suffix, T)                              \
   extern "C" __global__ void kernel##_##suffix(CclAllreduceArgs<T> args) {   \
     kernel##_body<T>(args.myPe, args.npes, args.input, args.dstMemObj,       \
-                     args.flagsMemObj, args.barrier, args.elementCount);     \
+                     args.flagsMemObj, args.barrier, args.elementCount,      \
+                     args.slotStrideElements);                               \
   }
 
-// AllReduce allgather / async-put: (myPe, npes, dstMemObj, flagsMemObj,
-//                                   barrier, elementCount)
+#define CCL_WRAP_ALLREDUCE_ONESHOT(kernel, suffix, T)                         \
+  extern "C" __global__ void kernel##_##suffix(CclAllreduceArgs<T> args) {   \
+    SdmaReduceScatterKernel_body<T>(                                          \
+        args.myPe, args.npes, args.input, args.dstMemObj, args.flagsMemObj,   \
+        args.barrier, args.elementCount, args.slotStrideElements, args.output); \
+  }
+
+// AllReduce allgather: fixed-stride reduce scratch -> compact output transit.
 #define CCL_WRAP_ALLREDUCE_AG(kernel, suffix, T)                              \
   extern "C" __global__ void kernel##_##suffix(CclAllreduceArgs<T> args) {   \
-    kernel##_body<T>(args.myPe, args.npes, args.dstMemObj, args.flagsMemObj, \
-                     args.barrier, args.elementCount);                       \
+    kernel##_body<T>(args.myPe, args.npes, args.dstMemObj, args.outputMemObj, \
+                     args.flagsMemObj, args.barrier, args.elementCount,      \
+                     args.slotStrideElements, args.outputBaseOffsetBytes);   \
   }
 
-// AllReduce async wait (non-template): (myPe, npes, flagsMemObj, barrier,
-//                                       elementCount)
-#define CCL_WRAP_ALLREDUCE_AG_WAIT(kernel, suffix, T)                         \
+#define CCL_WRAP_ALLREDUCE_PROTECTED_AG(kernel, suffix, T)                    \
   extern "C" __global__ void kernel##_##suffix(CclAllreduceArgs<T> args) {   \
-    kernel##_body(args.myPe, args.npes, args.flagsMemObj, args.barrier,      \
-                  args.elementCount);                                        \
+    AllGatherSdmaKernel_body<T>(                                              \
+        args.myPe, args.npes, args.dstMemObj, args.dstMemObj,                 \
+        args.flagsMemObj, args.barrier, args.elementCount,                    \
+        args.slotStrideElements, args.outputBaseOffsetBytes,                  \
+        static_cast<size_t>(args.npes) * args.slotStrideElements);            \
   }
 
 // Async RS SDMA put: (myPe, npes, input, dstMemObj, elementCount)
@@ -209,6 +218,9 @@ extern "C" __global__ void OneShotBroadcastSdmaSubGroupKernel_u32(
 // --- SdmaReduceScatterKernel ---
 CCL_ALLREDUCE_ALL_TYPES(CCL_WRAP_ALLREDUCE_RS, SdmaReduceScatterKernel)
 
+// --- Fused SDMA reduce-scatter + pull AllGather for small messages ---
+CCL_ALLREDUCE_ALL_TYPES(CCL_WRAP_ALLREDUCE_ONESHOT, SdmaOneShotAllreduceKernel)
+
 // --- AllGatherSdmaKernel ---
 CCL_ALLREDUCE_ALL_TYPES(CCL_WRAP_ALLREDUCE_AG, AllGatherSdmaKernel)
 
@@ -221,11 +233,9 @@ CCL_ALLREDUCE_ALL_TYPES(CCL_WRAP_ALLREDUCE_LOCAL_REDUCE, ReduceScatterLocalReduc
 // --- AllGatherReducedSdmaPutKernel (SDMA put of reduced shard) ---
 CCL_ALLREDUCE_ALL_TYPES(CCL_WRAP_ALLREDUCE_AG_REDUCED_PUT, AllGatherReducedSdmaPutKernel)
 
-// --- AllGatherAsyncPutKernel ---
-CCL_ALLREDUCE_ALL_TYPES(CCL_WRAP_ALLREDUCE_AG, AllGatherAsyncPutKernel)
-
-// --- AllGatherAsyncWaitKernel (non-template) ---
-CCL_ALLREDUCE_ALL_TYPES(CCL_WRAP_ALLREDUCE_AG_WAIT, AllGatherAsyncWaitKernel)
+// --- SDMA gather from protected reduced shard into compact scratch output ---
+CCL_ALLREDUCE_ALL_TYPES(CCL_WRAP_ALLREDUCE_PROTECTED_AG,
+                        AllGatherSdmaFromProtectedKernel)
 
 // ============================================================================
 // Inter-node RDMA ring AllGather

--- a/src/pybind/pybind_ccl.cpp
+++ b/src/pybind/pybind_ccl.cpp
@@ -75,13 +75,13 @@ void BindAllreduceHandle(py::module_& m, const char* python_name) {
       .def(
           "finish_sync",
           [](Handle& self, uintptr_t output, size_t count, int64_t stream,
-             bool force_copy_output_to_user) -> double {
+             bool force_copy_output_to_user, bool direct_output) -> double {
             return self.finish_sync(reinterpret_cast<T*>(output), count,
                                     reinterpret_cast<hipStream_t>(stream),
-                                    force_copy_output_to_user);
+                                    force_copy_output_to_user, direct_output);
           },
           py::arg("output_ptr"), py::arg("count"), py::arg("stream"),
-          py::arg("force_copy_output_to_user") = false)
+          py::arg("force_copy_output_to_user") = false, py::arg("direct_output") = false)
       // JIT async path
       .def(
           "prepare_async_reduce_scatter",
@@ -98,7 +98,7 @@ void BindAllreduceHandle(py::module_& m, const char* python_name) {
             return self.prepare_async_allgather_put(count, reinterpret_cast<hipStream_t>(stream));
           },
           py::arg("count"), py::arg("stream"))
-      .def("after_async_start", &Handle::after_async_start)
+      .def("after_async_start", &Handle::after_async_start, py::arg("capturing") = false)
       .def(
           "prepare_async_wait",
           [](Handle& self, int64_t stream) -> int64_t {
@@ -107,22 +107,14 @@ void BindAllreduceHandle(py::module_& m, const char* python_name) {
           py::arg("stream"))
       .def(
           "finish_async_wait",
-          [](Handle& self, int64_t stream) -> double {
-            return self.finish_async_wait(reinterpret_cast<hipStream_t>(stream));
+          [](Handle& self, int64_t stream, bool capturing, bool direct_output) -> double {
+            return self.finish_async_wait(reinterpret_cast<hipStream_t>(stream), capturing,
+                                          direct_output);
           },
-          py::arg("stream"))
+          py::arg("stream"), py::arg("capturing") = false, py::arg("direct_output") = false)
       .def("is_async_in_progress", &Handle::is_async_in_progress)
       .def("cancel_async", &Handle::cancel_async)
       .def("reset_flags", &Handle::resetFlags)
-      .def(
-          "get_output_transit_buffer",
-          [](Handle& self) -> py::tuple {
-            void* ptr = self.getOutputTransitBuffer();
-            size_t size = self.getOutputTransitBufferSize();
-            if (ptr == nullptr) throw std::runtime_error("Output transit buffer is null");
-            return py::make_tuple(reinterpret_cast<uintptr_t>(ptr), size);
-          },
-          "Return (ptr, size_bytes) of the output transit buffer")
       .def("max_blocks", &Handle::max_blocks)
       .def("npes", &Handle::npes);
 }

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -9,6 +9,19 @@ FetchContent_Declare(
   GIT_SHALLOW TRUE)
 FetchContent_MakeAvailable(googletest)
 
+add_library(test_sdma_allreduce_public_header_compile OBJECT
+            collective/test_sdma_allreduce_public_header.hip)
+set_source_files_properties(
+  collective/test_sdma_allreduce_public_header.hip PROPERTIES LANGUAGE HIP)
+target_include_directories(test_sdma_allreduce_public_header_compile
+                           PRIVATE ${CMAKE_SOURCE_DIR}/include
+                                   ${CMAKE_SOURCE_DIR})
+if(DEFINED GPU_TARGETS)
+  set_target_properties(
+    test_sdma_allreduce_public_header_compile
+    PROPERTIES HIP_ARCHITECTURES "${GPU_TARGETS}")
+endif()
+
 add_executable(test_transport_tcp application/test_transport_tcp.cpp)
 
 target_include_directories(test_transport_tcp

--- a/tests/cpp/collective/test_sdma_allreduce_public_header.hip
+++ b/tests/cpp/collective/test_sdma_allreduce_public_header.hip
@@ -1,0 +1,9 @@
+// Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include <cstdint>
+
+#include "mori/collective/collective.hpp"
+
+template double mori::collective::Allreduce_sdma<uint32_t>(uint32_t*, uint32_t*, size_t,
+                                                            hipStream_t);

--- a/tests/python/ccl/test_allreduce.py
+++ b/tests/python/ccl/test_allreduce.py
@@ -24,7 +24,7 @@
 AllReduce SDMA Test using torch.distributed and multiprocessing.
 
 Tests four modes:
-  1. SDMA out-of-place (copy_output_to_user=False, read from transit buffer)
+  1. SDMA out-of-place (legacy copy_output_to_user=False compatibility)
   2. SDMA in-place     (allreduce_inplace)
   3. RCCL out-of-place (torch.distributed.all_reduce, copy + reduce)
   4. RCCL in-place     (torch.distributed.all_reduce, refill + reduce)
@@ -177,9 +177,9 @@ def _test_outplace(
     iterations,
     warmup,
 ):
-    """Test 1: out-of-place (copy_output_to_user=False)."""
+    """Test 1: direct caller-output out-of-place."""
     if rank == 0:
-        print(f"\n>>> Test 1: Out-of-place (copy_output_to_user=False, {dtype_name})")
+        print(f"\n>>> Test 1: Direct caller-output out-of-place ({dtype_name})")
 
     ar = AllreduceSdma(
         my_pe,
@@ -209,20 +209,10 @@ def _test_outplace(
         rank,
     )
 
-    transit_buf = ar.get_output_transit_buffer(dtype=input_tensor.dtype)
-    transit_cpu = _to_numpy(transit_buf.cpu())
+    output_cpu = _to_numpy(output_tensor.cpu())
     ok = _verify_allreduce_result(
-        transit_cpu, elems, my_pe, npes, f"outplace/{dtype_name}", dtype=dtype
+        output_cpu, elems, my_pe, npes, f"outplace/{dtype_name}", dtype=dtype
     )
-
-    out_cpu = _to_numpy(output_tensor.cpu())
-    zero_check = (
-        np.allclose(out_cpu, 0)
-        if dtype not in (torch.uint32, torch.int32)
-        else np.all(out_cpu == 0)
-    )
-    if zero_check and rank == 0:
-        print(f"  PE {rank}: output_tensor correctly untouched (all zeros)")
 
     dist.barrier()
     _print_stats(times, data_bytes, npes, rank, f"Out-of-place ({dtype_name})")

--- a/tests/python/ccl/test_allreduce_async.py
+++ b/tests/python/ccl/test_allreduce_async.py
@@ -128,11 +128,7 @@ def _test_allreduce_async(
 
         expected_value = sum((pe + 1) * 1000 for pe in range(npes))
 
-        if copy_output:
-            verify_tensor = output_tensor.cpu()
-        else:
-            transit_buf = allreduce.get_output_transit_buffer(device=input_tensor)
-            verify_tensor = transit_buf.cpu()[:elems]
+        verify_tensor = output_tensor.cpu()
 
         if dtype in (torch.float16, torch.bfloat16):
             verify_cpu = verify_tensor.float().numpy()
@@ -142,7 +138,7 @@ def _test_allreduce_async(
             match = np.all(verify_cpu == expected_value)
 
         success = True
-        src = "output_tensor" if copy_output else "transit_buffer"
+        src = "caller_output"
         if match:
             print(
                 f"PE {rank}: PASSED ({src}, {dtype_name}), all {elems} elements = {expected_value}"

--- a/tests/python/ccl/test_allreduce_sdma_async_graph.py
+++ b/tests/python/ccl/test_allreduce_sdma_async_graph.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Regression test for graph-captured asynchronous SDMA AllReduce."""
+
+import argparse
+import os
+
+import torch
+import torch.distributed as dist
+
+import mori.shmem as shmem
+from mori.ccl import AllreduceSdma
+from tests.python.utils import TorchDistContext, get_free_port
+
+
+def _parse_size(value: str) -> int:
+    value = value.strip().upper()
+    scale = 1
+    if value.endswith("K"):
+        scale, value = 1024, value[:-1]
+    elif value.endswith("M"):
+        scale, value = 1024**2, value[:-1]
+    return int(value) * scale
+
+
+def _run_rank(
+    rank: int,
+    world_size: int,
+    port: int,
+    sizes: list[int],
+    replays: int,
+    expect_baseline_failure: bool,
+) -> None:
+    with TorchDistContext(rank=rank, world_size=world_size, master_port=port):
+        shmem.shmem_torch_process_group_init("default")
+        device = torch.device(f"cuda:{rank}")
+        torch.cuda.set_device(device)
+        dtype = torch.bfloat16
+        element_size = torch.empty((), dtype=dtype).element_size()
+        allreduce = AllreduceSdma(
+            rank,
+            world_size,
+            input_buffer_size=max(sizes),
+            output_buffer_size=max(sizes) + world_size * 128,
+            copy_output_to_user=True,
+            dtype=dtype,
+        )
+
+        captures = []
+        capture_error = None
+        try:
+            for size_bytes in sizes:
+                elems = size_bytes // element_size
+                inp = torch.empty(elems, dtype=dtype, device=device)
+                out = torch.empty_like(inp)
+                graph = torch.cuda.CUDAGraph()
+                torch.cuda.synchronize(device)
+                dist.barrier()
+                with torch.cuda.graph(graph):
+                    stream = torch.cuda.current_stream(device)
+                    allreduce.start_async(inp, out, elems, stream)
+                    allreduce.wait_async(stream)
+                captures.append((size_bytes, inp, out, graph))
+        except RuntimeError as exc:
+            capture_error = str(exc)
+
+        failed = torch.tensor(
+            [int(capture_error is not None)], dtype=torch.int32, device="cpu"
+        )
+        dist.all_reduce(failed, op=dist.ReduceOp.MAX)
+        if expect_baseline_failure:
+            if not failed.item():
+                raise AssertionError("baseline unexpectedly captured async start+wait")
+            if rank == 0:
+                print(f"EXPECTED_BASELINE_CAPTURE_FAILURE: {capture_error}", flush=True)
+            os._exit(0)
+        if failed.item():
+            raise AssertionError(capture_error or "another rank failed graph capture")
+
+        for replay in range(replays):
+            capture_index = replay % len(captures)
+            size_bytes, inp, out, graph = captures[capture_index]
+            value = rank + replay + 2
+            inp.fill_(value)
+            expected_value = sum(pe + replay + 2 for pe in range(world_size))
+            dist.barrier()
+            graph.replay()
+            torch.cuda.synchronize(device)
+            mismatch_count = int(torch.count_nonzero(out != expected_value).item())
+            local_failed = torch.tensor(
+                [int(mismatch_count != 0)], dtype=torch.int32, device="cpu"
+            )
+            dist.all_reduce(local_failed, op=dist.ReduceOp.MAX)
+            if local_failed.item():
+                raise AssertionError(
+                    f"rank={rank}, bytes={size_bytes}, replay={replay}, "
+                    f"mismatches={mismatch_count}/{out.numel()}"
+                )
+
+        torch.cuda.synchronize(device)
+        dist.barrier()
+        del captures
+        del allreduce
+        shmem.shmem_finalize()
+        if rank == 0:
+            print(
+                "PASSED: MORI async graph replay "
+                f"TP={world_size}, sizes={sizes}, replays={replays}",
+                flush=True,
+            )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-t", "--world-size", type=int, default=4)
+    parser.add_argument("--sizes", default="128M,32M,128M,1M,16K,16M,64M")
+    parser.add_argument("--replays", type=int, default=20)
+    parser.add_argument("--expect-baseline-failure", action="store_true")
+    args = parser.parse_args()
+    os.environ.setdefault("MORI_ENABLE_SDMA", "1")
+    sizes = [_parse_size(value) for value in args.sizes.split(",")]
+    torch.multiprocessing.spawn(
+        _run_rank,
+        args=(
+            args.world_size,
+            get_free_port(),
+            sizes,
+            args.replays,
+            args.expect_baseline_failure,
+        ),
+        nprocs=args.world_size,
+        join=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/ccl/test_allreduce_sdma_async_graph.py
+++ b/tests/python/ccl/test_allreduce_sdma_async_graph.py
@@ -20,7 +20,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""Regression test for graph-captured asynchronous SDMA AllReduce."""
+"""Regression tests for graph-captured and cross-stream asynchronous SDMA AllReduce."""
 
 import argparse
 import os
@@ -50,6 +50,7 @@ def _run_rank(
     sizes: list[int],
     replays: int,
     expect_baseline_failure: bool,
+    cross_stream: bool,
 ) -> None:
     with TorchDistContext(rank=rank, world_size=world_size, master_port=port):
         shmem.shmem_torch_process_group_init("default")
@@ -67,6 +68,7 @@ def _run_rank(
         )
 
         captures = []
+        start_stream = torch.cuda.Stream(device=device) if cross_stream else None
         capture_error = None
         try:
             for size_bytes in sizes:
@@ -77,9 +79,13 @@ def _run_rank(
                 torch.cuda.synchronize(device)
                 dist.barrier()
                 with torch.cuda.graph(graph):
-                    stream = torch.cuda.current_stream(device)
-                    allreduce.start_async(inp, out, elems, stream)
-                    allreduce.wait_async(stream)
+                    wait_stream = torch.cuda.current_stream(device)
+                    if start_stream is not None:
+                        start_stream.wait_stream(wait_stream)
+                        allreduce.start_async(inp, out, elems, start_stream)
+                    else:
+                        allreduce.start_async(inp, out, elems, wait_stream)
+                    allreduce.wait_async(wait_stream)
                 captures.append((size_bytes, inp, out, graph))
         except RuntimeError as exc:
             capture_error = str(exc)
@@ -125,7 +131,8 @@ def _run_rank(
         if rank == 0:
             print(
                 "PASSED: MORI async graph replay "
-                f"TP={world_size}, sizes={sizes}, replays={replays}",
+                f"TP={world_size}, sizes={sizes}, replays={replays}, "
+                f"cross_stream={cross_stream}",
                 flush=True,
             )
 
@@ -136,6 +143,11 @@ def main() -> None:
     parser.add_argument("--sizes", default="128M,32M,128M,1M,16K,16M,64M")
     parser.add_argument("--replays", type=int, default=20)
     parser.add_argument("--expect-baseline-failure", action="store_true")
+    parser.add_argument(
+        "--cross-stream",
+        action="store_true",
+        help="Launch start_async on a side stream and wait_async on the capture stream.",
+    )
     args = parser.parse_args()
     os.environ.setdefault("MORI_ENABLE_SDMA", "1")
     sizes = [_parse_size(value) for value in args.sizes.split(",")]
@@ -147,6 +159,7 @@ def main() -> None:
             sizes,
             args.replays,
             args.expect_baseline_failure,
+            args.cross_stream,
         ),
         nprocs=args.world_size,
         join=True,

--- a/tests/python/ccl/test_allreduce_sdma_graph.py
+++ b/tests/python/ccl/test_allreduce_sdma_graph.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Reproduce MORI SDMA AllReduce corruption under HIP graph replay."""
+
+import argparse
+import os
+
+import torch
+import torch.distributed as dist
+
+import mori.shmem as shmem
+from mori.ccl import AllreduceSdma
+from tests.python.utils import TorchDistContext, get_free_port
+
+
+def _parse_size(value: str) -> int:
+    suffixes = {"K": 1 << 10, "M": 1 << 20}
+    suffix = value[-1].upper()
+    if suffix in suffixes:
+        return int(value[:-1]) * suffixes[suffix]
+    return int(value)
+
+
+def _run_rank(
+    rank: int,
+    world_size: int,
+    port: int,
+    sizes: list[int],
+    replays: int,
+    external_reuse_barrier: bool,
+) -> None:
+    with TorchDistContext(rank=rank, world_size=world_size, master_port=port):
+        shmem.shmem_torch_process_group_init("default")
+        device = torch.device(f"cuda:{rank}")
+        torch.cuda.set_device(device)
+        element_size = torch.tensor([], dtype=torch.bfloat16).element_size()
+        max_bytes = max(sizes)
+        max_elems = max_bytes // element_size
+        output_buffer_size = world_size * (max_elems // world_size + 64) * element_size
+        allreduce = AllreduceSdma(
+            rank,
+            world_size,
+            input_buffer_size=max_bytes,
+            output_buffer_size=output_buffer_size,
+            copy_output_to_user=True,
+            dtype=torch.bfloat16,
+        )
+
+        failure = None
+        global_failure = False
+        captures = []
+        for size_bytes in sizes:
+            elems = size_bytes // element_size
+            inp = torch.empty(elems, dtype=torch.bfloat16, device=device)
+            out = torch.empty_like(inp)
+            graph = torch.cuda.CUDAGraph()
+
+            torch.cuda.synchronize(device)
+            dist.barrier()
+            with torch.cuda.graph(graph):
+                capture_stream = torch.cuda.current_stream(device)
+                allreduce(inp, out, elems, capture_stream)
+                if external_reuse_barrier:
+                    shmem.shmem_barrier_on_stream(capture_stream.cuda_stream)
+            torch.cuda.synchronize(device)
+            dist.barrier()
+            captures.append((size_bytes, elems, inp, out, graph))
+
+        for replay in range(replays):
+            for capture_index, (size_bytes, elems, inp, out, graph) in enumerate(
+                captures
+            ):
+                operation = replay * len(captures) + capture_index
+                value_offset = operation % 32
+                inp.fill_(rank + 2 + value_offset)
+                expected_value = sum(
+                    pe + 2 + value_offset for pe in range(world_size)
+                )
+                dist.barrier()
+                graph.replay()
+                torch.cuda.synchronize(device)
+
+                mismatch_count = int(
+                    torch.count_nonzero(out != expected_value).item()
+                )
+                if mismatch_count:
+                    shard_elems = elems // world_size
+                    shard_mismatches = [
+                        int(
+                            torch.count_nonzero(
+                                out[pe * shard_elems : (pe + 1) * shard_elems]
+                                != expected_value
+                            ).item()
+                        )
+                        for pe in range(world_size)
+                    ]
+                    shard_first = [
+                        float(out[pe * shard_elems].float().item())
+                        for pe in range(world_size)
+                    ]
+                    max_abs = float(
+                        (out.float() - expected_value).abs().max().item()
+                    )
+                    failure = (
+                        f"rank={rank}, bytes={size_bytes}, replay={replay}, "
+                        f"capture_index={capture_index}, "
+                        f"mismatches={mismatch_count}/{elems}, max_abs={max_abs}, "
+                        f"shard_mismatches={shard_mismatches}, "
+                        f"shard_first={shard_first}, expected={expected_value}"
+                    )
+                failed = torch.tensor(
+                    [int(failure is not None)], dtype=torch.int32, device="cpu"
+                )
+                dist.all_reduce(failed, op=dist.ReduceOp.MAX)
+                if failed.item():
+                    global_failure = True
+                    if failure is not None:
+                        print(f"GRAPH_REPLAY_CORRUPTION: {failure}", flush=True)
+                    break
+            if global_failure:
+                break
+
+        torch.cuda.synchronize(device)
+        dist.barrier()
+        del captures
+        del allreduce
+        shmem.shmem_finalize()
+        if global_failure:
+            raise AssertionError(failure or "another rank detected graph corruption")
+        if rank == 0:
+            print(
+                "PASSED: MORI SDMA graph replay "
+                f"TP={world_size}, sizes={sizes}, replays={replays}",
+                flush=True,
+            )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-t", "--world-size", type=int, default=4)
+    parser.add_argument("--sizes", default="128M,32M,128M,1M,16K,16M,64M")
+    parser.add_argument("--replays", type=int, default=100)
+    parser.add_argument(
+        "--external-reuse-barrier",
+        action="store_true",
+        help="Append an additional cross-PE barrier after the MORI call.",
+    )
+    args = parser.parse_args()
+
+    os.environ.setdefault("MORI_ENABLE_SDMA", "1")
+    sizes = [_parse_size(value) for value in args.sizes.split(",")]
+    torch.multiprocessing.spawn(
+        _run_rank,
+        args=(
+            args.world_size,
+            get_free_port(),
+            sizes,
+            args.replays,
+            args.external_reuse_barrier,
+        ),
+        nprocs=args.world_size,
+        join=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/ccl/test_allreduce_sdma_graph.py
+++ b/tests/python/ccl/test_allreduce_sdma_graph.py
@@ -94,16 +94,12 @@ def _run_rank(
                 operation = replay * len(captures) + capture_index
                 value_offset = operation % 32
                 inp.fill_(rank + 2 + value_offset)
-                expected_value = sum(
-                    pe + 2 + value_offset for pe in range(world_size)
-                )
+                expected_value = sum(pe + 2 + value_offset for pe in range(world_size))
                 dist.barrier()
                 graph.replay()
                 torch.cuda.synchronize(device)
 
-                mismatch_count = int(
-                    torch.count_nonzero(out != expected_value).item()
-                )
+                mismatch_count = int(torch.count_nonzero(out != expected_value).item())
                 if mismatch_count:
                     shard_elems = elems // world_size
                     shard_mismatches = [
@@ -119,9 +115,7 @@ def _run_rank(
                         float(out[pe * shard_elems].float().item())
                         for pe in range(world_size)
                     ]
-                    max_abs = float(
-                        (out.float() - expected_value).abs().max().item()
-                    )
+                    max_abs = float((out.float() - expected_value).abs().max().item())
                     failure = (
                         f"rank={rank}, bytes={size_bytes}, replay={replay}, "
                         f"capture_index={capture_index}, "


### PR DESCRIPTION
## Motivation

`AllreduceSdma` could return stale data when one communicator replayed graphs with different message sizes. The reduce-scatter layout used message-dependent rank offsets, so an address written by a CU reduction in one graph could become an SDMA receive slot in another. On gfx950, that role change could expose stale cache lines and corrupt an entire rank shard.

This matters for inference runtimes that capture several batch-size or token-count buckets and reuse the same communicator across them.

## Changes

- Use fixed, pack-aligned receive slots derived from the configured maximum message size.
- Reserve a protected reduced-shard slot so AllGather output cannot overwrite data still being read by another rank.
- Track scratch reuse with a rank-uniform overlap threshold and cross-rank handshake.
- Use 64-bit device-side generations for scatter, gather, reuse, and block completion.
- Match peer-published system-scope stores with system-scope polling loads.
- Use a one-shot SDMA path for messages up to 1 MiB and the protected two-shot path for larger messages.
- Make async graph capture enqueue both ReduceScatter and AllGather in `start_async`; `wait_async` only performs copy-out and completion.
- Order a different `wait_async` stream after the `start_async` stream with a graph-capturable HIP event.
- Preserve the legacy `copy_output_to_user=False` argument while always returning results through the caller-provided output.
- Add sync and async changing-size graph-replay tests and a public-header compile test.

## Validation

All tests below passed on gfx950.

| TP | Sync graph replay | Async graph replay | Message sequence |
| ---: | --- | --- | --- |
| 2 | 10 replays per captured graph | 20 alternating replays | 128 MiB, 64 MiB, 128 MiB, 1 MiB, 16 KiB, 16 MiB |
| 4 | 5 replays per captured graph | 14 alternating replays | 128 MiB, 32 MiB, 128 MiB, 1 MiB, 16 KiB, 16 MiB, 64 MiB |
| 8 | 5 replays per captured graph | 14 alternating replays | 128 MiB, 32 MiB, 128 MiB, 1 MiB, 16 KiB, 16 MiB, 64 MiB |

The graph tests capture every size before replay, change input values on each operation, and cover one-shot/two-shot transitions plus compact-output reuse.

Additional checks:

- TP=4 eager out-of-place and in-place AllReduce at 1 MiB with BF16, FP16, and `uint32`.
- TP=4 async BF16 at 16 MiB with `copy_output_to_user=False`.
- TP=8 async BF16 at 16 MiB with normal copy-out.
- TP=4 async graph replay with `start_async` on a side stream and `wait_async` on the capture stream.
- Mixed eager/graph and sync/async correctness at 16 KiB, 1 MiB, 16 MiB, 64 MiB, and 128 MiB.
- Public umbrella-header compilation for gfx950.
- Editable package rebuild.

## Reproduction

Run the following commands from the repository root after installing the package:

```bash
# Changing-size graph replay
HIP_VISIBLE_DEVICES=4,5 python -m tests.python.ccl.test_allreduce_sdma_graph --world-size 2 --sizes 128M,64M,128M,1M,16K,16M --replays 10
HIP_VISIBLE_DEVICES=4,5 python -m tests.python.ccl.test_allreduce_sdma_async_graph --world-size 2 --sizes 128M,64M,128M,1M,16K,16M --replays 20
HIP_VISIBLE_DEVICES=4,5,6,7 python -m tests.python.ccl.test_allreduce_sdma_graph --world-size 4 --sizes 128M,32M,128M,1M,16K,16M,64M --replays 5
HIP_VISIBLE_DEVICES=4,5,6,7 python -m tests.python.ccl.test_allreduce_sdma_async_graph --world-size 4 --sizes 128M,32M,128M,1M,16K,16M,64M --replays 14
HIP_VISIBLE_DEVICES=4,5,6,7 python -m tests.python.ccl.test_allreduce_sdma_async_graph --world-size 4 --sizes 128M,32M,128M,1M,16K,16M,64M --replays 14 --cross-stream
HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python -m tests.python.ccl.test_allreduce_sdma_graph --world-size 8 --sizes 128M,32M,128M,1M,16K,16M,64M --replays 5
HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python -m tests.python.ccl.test_allreduce_sdma_async_graph --world-size 8 --sizes 128M,32M,128M,1M,16K,16M,64M --replays 14

# Eager compatibility
HIP_VISIBLE_DEVICES=4,5,6,7 python tests/python/ccl/test_allreduce.py --world-size 4 --elems 524288 --iterations 3 --warmup 3 --dtype bf16
HIP_VISIBLE_DEVICES=4,5,6,7 python tests/python/ccl/test_allreduce.py --world-size 4 --elems 524288 --iterations 3 --warmup 3 --dtype fp16
HIP_VISIBLE_DEVICES=4,5,6,7 python tests/python/ccl/test_allreduce.py --world-size 4 --elems 262144 --iterations 3 --warmup 3 --dtype uint32
HIP_VISIBLE_DEVICES=4,5,6,7 python tests/python/ccl/test_allreduce_async.py --world-size 4 --elems 8388608 --iterations 3 --warmup 3 --dtype bf16 --no-copy
HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python tests/python/ccl/test_allreduce_async.py --world-size 8 --elems 8388608 --iterations 3 --warmup 3 --dtype bf16

# Public-header compile check
/opt/rocm/bin/hipcc -std=c++17 --offload-arch=gfx950 -Iinclude -I. -fsyntax-only tests/cpp/collective/test_sdma_allreduce_public_header.hip
```

## Performance

Measurements use BF16, 20 warmups, 100 measured iterations, five repetitions, and rank-averaged device-event timing. The baseline always uses separate ReduceScatter and AllGather kernels. The PR uses the new one-shot kernel through 1 MiB and the protected two-shot path for larger messages. Negative changes are improvements. PR measurements were refreshed after adding cross-stream event ordering. The 1 MiB graph and 64 MiB eager rows use isolated reruns because the full sweeps contained scheduler outliers.

### TP=2

| Size | Baseline path | PR path | Graph baseline | Graph PR | Change | Eager baseline | Eager PR | Change |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 16 KiB | two-shot | one-shot | 30.62 us | 31.21 us | +1.9% | 25.25 us | 25.08 us | -0.7% |
| 1 MiB | two-shot | one-shot | 50.84 us | 51.15 us | +0.6% | 45.60 us | 45.97 us | +0.8% |
| 16 MiB | two-shot | two-shot | 333.81 us | 336.72 us | +0.9% | 327.94 us | 330.46 us | +0.8% |
| 64 MiB | two-shot | two-shot | 1.239 ms | 1.222 ms | -1.3% | 1.232 ms | 1.218 ms | -1.1% |
| 128 MiB | two-shot | two-shot | 2.457 ms | 2.414 ms | -1.7% | 2.444 ms | 2.408 ms | -1.5% |

### TP=4

| Size | Baseline path | PR path | Graph baseline | Graph PR | Change | Eager baseline | Eager PR | Change |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 16 KiB | two-shot | one-shot | 34.29 us | 32.15 us | -6.2% | 28.35 us | 26.06 us | -8.1% |
| 1 MiB | two-shot | one-shot | 46.74 us | 45.16 us | -3.4% | 41.08 us | 39.63 us | -3.5% |
| 16 MiB | two-shot | two-shot | 191.89 us | 194.77 us | +1.5% | 186.73 us | 189.50 us | +1.5% |
| 64 MiB | two-shot | two-shot | 661.10 us | 654.05 us | -1.1% | 655.19 us | 645.81 us | -1.4% |
| 128 MiB | two-shot | two-shot | 1.295 ms | 1.266 ms | -2.3% | 1.281 ms | 1.260 ms | -1.6% |

### TP=8

| Size | Baseline path | PR path | Graph baseline | Graph PR | Change | Eager baseline | Eager PR | Change |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 16 KiB | two-shot | one-shot | 39.83 us | 36.05 us | -9.5% | 36.73 us | 30.28 us | -17.6% |
| 1 MiB | two-shot | one-shot | 48.30 us | 45.26 us | -6.3% | 45.20 us | 40.53 us | -10.3% |
| 16 MiB | two-shot | two-shot | 123.41 us | 126.20 us | +2.3% | 119.21 us | 119.80 us | +0.5% |
| 64 MiB | two-shot | two-shot | 376.16 us | 371.31 us | -1.3% | 369.68 us | 363.50 us | -1.7% |
| 128 MiB | two-shot | two-shot | 715.91 us | 695.11 us | -2.9% | 704.51 us | 690.91 us | -1.9% |

### Cross-stream event overhead

The TP=4 async modes were also compared against the saved pre-event PR run using the same benchmark protocol. Graph replay shows no meaningful regression. Eager async adds approximately 3–5 us at 16 MiB and above, consistent with recording the completion event before the host-side wait.

| Size | Async eager before | Async eager after | Change | Async graph before | Async graph after | Change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 16 KiB | 40.12 us | 39.96 us | -0.4% | 33.88 us | 33.02 us | -2.6% |
| 1 MiB | 55.42 us | 54.90 us | -0.9% | 48.51 us | 47.63 us | -1.8% |
| 16 MiB | 201.39 us | 205.44 us | +2.0% | 195.10 us | 194.75 us | -0.2% |
| 64 MiB | 661.37 us | 664.71 us | +0.5% | 654.29 us | 654.03 us | 0.0% |
| 128 MiB | 1.272 ms | 1.277 ms | +0.4% | 1.264 ms | 1.266 ms | +0.1% |

## Trade-offs

- Symmetric scratch grows from the maximum message size to approximately `(TP + 1) / TP` times that size: 192 MiB at TP=2, 160 MiB at TP=4, and 144 MiB at TP=8 for a 128 MiB maximum.
- `copy_output_to_user=False` remains source-compatible but no longer suppresses copy-out.
- Sync-graph latency improves at 10 of 15 measured points. The largest regression is TP=8 at 16 MiB: +2.79 us (+2.3%).
- Sync-eager latency improves at 11 of 15 measured points. The largest regression is TP=4 at 16 MiB: +2.77 us (+1.5%).
- Cross-stream safety has no material graph-replay cost in the measured TP=4 sweep. Async eager has a small fixed overhead at larger sizes, peaking at +5.06 us (+0.4%) for 128 MiB.
