### PR TITLE
(feat) Enable MLX5 + MI300X CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
         include:
           - platform: MI355X_AINIC
             runner: [self-hosted, MI355X-AINIC-TW]
+          - platform: MI300X_MLX
+            runner: [self-hosted, 300_mlx_p19_29]
           # Runner 325_bnxt_108 is decommissioned.
           # - platform: MI325X_BNXT
           #   runner: [self-hosted, 325_bnxt_108]
@@ -464,6 +466,21 @@ jobs:
             rdma_sl: 3
             rdma_tc: 104
             ct: podman
+            timeout_minutes: 45
+          # 8x ConnectX-7 NDR on InfiniBand, so no rdma_sl/rdma_tc: mlx5 applies
+          # both only on the RoCE path. mlx5_8 is deliberately not in
+          # rdma_devices -- it is the 100GbE port behind ens14np0 (the TCP
+          # rendezvous interface), not one of the 8 rails.
+          - platform: MI300X_MLX
+            runner: [self-hosted, 300_mlx_p19_29]
+            node1_host: 10.194.132.110
+            node2_host: 10.194.132.59
+            node2_port: 22
+            node1_ifname: ens14np0
+            node2_ifname: ens14np0
+            rdma_devices: mlx5_0,mlx5_1,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_7
+            ct: docker
+            timeout_minutes: 90
           # Runner 325_bnxt_108 is decommissioned.
           # - platform: MI325X_BNXT
           #   runner: [self-hosted, 325_bnxt_108]
@@ -476,6 +493,7 @@ jobs:
           #   rdma_sl: 3
           #   rdma_tc: 104
           #   ct: docker
+          #   timeout_minutes: 45
     env:
       CT: ${{ matrix.ct }}
       SSH_OPTS: -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
@@ -488,7 +506,7 @@ jobs:
       MORI_RDMA_SL: ${{ matrix.rdma_sl }}
       MORI_RDMA_TC: ${{ matrix.rdma_tc }}
       MORI_SOCKET_IFNAME: ${{ matrix.node1_ifname }}
-    timeout-minutes: 45
+    timeout-minutes: ${{ matrix.timeout_minutes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -507,8 +525,8 @@ jobs:
           $CT rm -f $CONTAINER 2>/dev/null || true
           CONTAINER_RUNTIME=$CT ./docker/ci_run.sh --name $CONTAINER \
             -e MORI_RDMA_DEVICES=$MORI_RDMA_DEVICES \
-            -e MORI_RDMA_SL=$MORI_RDMA_SL \
-            -e MORI_RDMA_TC=$MORI_RDMA_TC \
+            ${MORI_RDMA_SL:+-e MORI_RDMA_SL=$MORI_RDMA_SL} \
+            ${MORI_RDMA_TC:+-e MORI_RDMA_TC=$MORI_RDMA_TC} \
             -e MORI_SOCKET_IFNAME=$MORI_SOCKET_IFNAME \
             -e GLOO_SOCKET_IFNAME=$NODE1_IFNAME \
             -e NCCL_SOCKET_IFNAME=$NODE1_IFNAME \
@@ -533,8 +551,8 @@ jobs:
             $CT build --network=host --build-arg BASE_IMAGE=$BASE_IMAGE -t $IMAGE -f docker/Dockerfile.dev . &&
             CONTAINER_RUNTIME=$CT ./docker/ci_run.sh --name $CONTAINER \
               -e MORI_RDMA_DEVICES=$MORI_RDMA_DEVICES \
-              -e MORI_RDMA_SL=$MORI_RDMA_SL \
-              -e MORI_RDMA_TC=$MORI_RDMA_TC \
+              ${MORI_RDMA_SL:+-e MORI_RDMA_SL=$MORI_RDMA_SL} \
+              ${MORI_RDMA_TC:+-e MORI_RDMA_TC=$MORI_RDMA_TC} \
               -e MORI_SOCKET_IFNAME=$MORI_SOCKET_IFNAME \
               -e GLOO_SOCKET_IFNAME=$NODE2_IFNAME \
               -e NCCL_SOCKET_IFNAME=$NODE2_IFNAME \
@@ -817,7 +835,8 @@ jobs:
               $CT exec
               -e MORI_ENABLE_SDMA=1 -e MORI_INTERNODE_TIMEOUT=300
               -e MORI_RDMA_DEVICES=$MORI_RDMA_DEVICES
-              -e MORI_RDMA_SL=$MORI_RDMA_SL -e MORI_RDMA_TC=$MORI_RDMA_TC
+              ${MORI_RDMA_SL:+-e MORI_RDMA_SL=$MORI_RDMA_SL}
+              ${MORI_RDMA_TC:+-e MORI_RDMA_TC=$MORI_RDMA_TC}
               $CONTAINER bash $SCRIPT
               --rank 1 --master-addr $NODE1_HOST --master-port $PORT
               --ifname $NODE2_IFNAME --handle $HANDLE --sizes-mb 8,64
@@ -827,7 +846,8 @@ jobs:
               -e MORI_ENABLE_SDMA=1 \
               -e MORI_INTERNODE_TIMEOUT=300 \
               -e MORI_RDMA_DEVICES=$MORI_RDMA_DEVICES \
-              -e MORI_RDMA_SL=$MORI_RDMA_SL -e MORI_RDMA_TC=$MORI_RDMA_TC \
+              ${MORI_RDMA_SL:+-e MORI_RDMA_SL=$MORI_RDMA_SL} \
+              ${MORI_RDMA_TC:+-e MORI_RDMA_TC=$MORI_RDMA_TC} \
               $CONTAINER bash $SCRIPT \
               --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
               --ifname $NODE1_IFNAME --handle $HANDLE --sizes-mb 8,64

--- a/include/mori/application/transport/rdma/providers/dv_loader.hpp
+++ b/include/mori/application/transport/rdma/providers/dv_loader.hpp
@@ -43,6 +43,8 @@ struct Mlx5DvApi {
   using devx_general_cmd_t = int (*)(struct ibv_context*, const void*, size_t, void*, size_t);
   using devx_umem_reg_t = struct mlx5dv_devx_umem* (*)(struct ibv_context*, void*, size_t,
                                                        uint32_t);
+  using devx_umem_reg_ex_t = struct mlx5dv_devx_umem* (*)(struct ibv_context*,
+                                                          struct mlx5dv_devx_umem_in*);
   using devx_umem_dereg_t = int (*)(struct mlx5dv_devx_umem*);
   using devx_alloc_uar_t = struct mlx5dv_devx_uar* (*)(struct ibv_context*, uint32_t);
   using devx_free_uar_t = void (*)(struct mlx5dv_devx_uar*);
@@ -55,6 +57,7 @@ struct Mlx5DvApi {
 
   devx_general_cmd_t devx_general_cmd = nullptr;
   devx_umem_reg_t devx_umem_reg = nullptr;
+  devx_umem_reg_ex_t devx_umem_reg_ex = nullptr;
   devx_umem_dereg_t devx_umem_dereg = nullptr;
   devx_alloc_uar_t devx_alloc_uar = nullptr;
   devx_free_uar_t devx_free_uar = nullptr;
@@ -72,6 +75,7 @@ struct Mlx5DvApi {
 
     devx_general_cmd = (devx_general_cmd_t)DvLoadSymbol(handle, "mlx5dv_devx_general_cmd");
     devx_umem_reg = (devx_umem_reg_t)DvLoadSymbol(handle, "mlx5dv_devx_umem_reg");
+    devx_umem_reg_ex = (devx_umem_reg_ex_t)DvLoadSymbol(handle, "mlx5dv_devx_umem_reg_ex");
     devx_umem_dereg = (devx_umem_dereg_t)DvLoadSymbol(handle, "mlx5dv_devx_umem_dereg");
     devx_alloc_uar = (devx_alloc_uar_t)DvLoadSymbol(handle, "mlx5dv_devx_alloc_uar");
     devx_free_uar = (devx_free_uar_t)DvLoadSymbol(handle, "mlx5dv_devx_free_uar");

--- a/include/mori/application/transport/rdma/providers/dv_loader.hpp
+++ b/include/mori/application/transport/rdma/providers/dv_loader.hpp
@@ -44,7 +44,7 @@ struct Mlx5DvApi {
   using devx_umem_reg_t = struct mlx5dv_devx_umem* (*)(struct ibv_context*, void*, size_t,
                                                        uint32_t);
   using devx_umem_reg_ex_t = struct mlx5dv_devx_umem* (*)(struct ibv_context*,
-                                                          struct mlx5dv_devx_umem_in*);
+                                                          struct Mlx5DevxUmemIn*);
   using devx_umem_dereg_t = int (*)(struct mlx5dv_devx_umem*);
   using devx_alloc_uar_t = struct mlx5dv_devx_uar* (*)(struct ibv_context*, uint32_t);
   using devx_free_uar_t = void (*)(struct mlx5dv_devx_uar*);

--- a/include/mori/application/transport/rdma/providers/mlx5/mlx5_dv.h
+++ b/include/mori/application/transport/rdma/providers/mlx5/mlx5_dv.h
@@ -85,6 +85,15 @@ struct mlx5dv_devx_umem {
   uint32_t umem_id;
 };
 
+struct mlx5dv_devx_umem_in {
+  void* addr;
+  size_t size;
+  uint32_t access;
+  uint64_t pgsz_bitmap;
+  uint64_t comp_mask;
+  int dmabuf_fd;
+};
+
 struct mlx5dv_devx_uar {
   void* reg_addr;
   void* base_addr;
@@ -111,5 +120,10 @@ enum mlx5dv_obj_type {
 #ifndef MLX5DV_UAR_ALLOC_TYPE_NC
 #define MLX5DV_UAR_ALLOC_TYPE_NC 0x1
 #endif
+
+// mlx5dv_devx_umem_in::comp_mask flags
+enum mlx5dv_devx_umem_mask {
+  MLX5DV_UMEM_MASK_DMABUF = 1 << 0,
+};
 
 #endif  // __has_include(<infiniband/mlx5dv.h>)

--- a/include/mori/application/transport/rdma/providers/mlx5/mlx5_dv.h
+++ b/include/mori/application/transport/rdma/providers/mlx5/mlx5_dv.h
@@ -85,15 +85,6 @@ struct mlx5dv_devx_umem {
   uint32_t umem_id;
 };
 
-struct mlx5dv_devx_umem_in {
-  void* addr;
-  size_t size;
-  uint32_t access;
-  uint64_t pgsz_bitmap;
-  uint64_t comp_mask;
-  int dmabuf_fd;
-};
-
 struct mlx5dv_devx_uar {
   void* reg_addr;
   void* base_addr;
@@ -121,9 +112,29 @@ enum mlx5dv_obj_type {
 #define MLX5DV_UAR_ALLOC_TYPE_NC 0x1
 #endif
 
-// mlx5dv_devx_umem_in::comp_mask flags
-enum mlx5dv_devx_umem_mask {
-  MLX5DV_UMEM_MASK_DMABUF = 1 << 0,
+#endif  // __has_include(<infiniband/mlx5dv.h>)
+
+/* -------------------------------------------------------------------------- */
+/*  DEVX umem registration input (dmabuf capable)                             */
+/* -------------------------------------------------------------------------- */
+
+// rdma-core only grew dmabuf support for DEVX umem in v43, but mori still has to
+// build against older system headers: Ubuntu 22.04 ships v39, whose
+// mlx5dv_devx_umem_in has neither dmabuf_fd nor MLX5DV_UMEM_MASK_DMABUF. Carry our
+// own copy of the current layout under a distinct name and hand it across the
+// dlopen boundary, so what we can compile no longer depends on the installed
+// rdma-core version. Whether the *runtime* libmlx5 honours the dmabuf mask is a
+// separate matter: older ones reject the unknown comp_mask bit with EOPNOTSUPP, so
+// callers must be prepared to fall back to registration by address.
+struct Mlx5DevxUmemIn {
+  void* addr;
+  size_t size;
+  uint32_t access;
+  uint64_t pgsz_bitmap;
+  uint64_t comp_mask;
+  int dmabuf_fd;
 };
 
-#endif  // __has_include(<infiniband/mlx5dv.h>)
+enum mori_mlx5_devx_umem_mask {
+  MORI_MLX5_UMEM_MASK_DMABUF = 1 << 0,
+};

--- a/include/mori/application/transport/rdma/rdma.hpp
+++ b/include/mori/application/transport/rdma/rdma.hpp
@@ -201,6 +201,11 @@ bool ReadIoTrafficClassDisableEnv();
 bool ReadIbEnableRelaxedOrderingEnv();
 int MaybeAddRelaxedOrderingFlag(int accessFlag);
 
+// Export a dmabuf fd for the GPU buffer at `ptr`, and report the offset of `ptr`
+// within the exported dmabuf via `*offset`. Returns -1 if unsupported; the caller
+// owns the fd and should close it once the kernel holds its own reference.
+int TryExportDmabufFd(void* ptr, size_t size, uint64_t* offset);
+
 /* -------------------------------------------------------------------------- */
 /*                              RdmaDeviceContext                             */
 /* -------------------------------------------------------------------------- */

--- a/src/application/transport/rdma/providers/mlx5/mlx5.cpp
+++ b/src/application/transport/rdma/providers/mlx5/mlx5.cpp
@@ -23,7 +23,9 @@
 
 #include <hip/hip_runtime_api.h>
 #include <infiniband/verbs.h>
+#include <unistd.h>
 
+#include <cstdint>
 #include <iostream>
 
 #include "mori/application/transport/rdma/providers/mlx5/mlx5_ifc.hpp"
@@ -69,6 +71,78 @@ HcaCapability QueryHcaCap(ibv_context* context) {
 }
 
 /* ---------------------------------------------------------------------------------------------- */
+/*                                     Device Memory Registration                                 */
+/* ---------------------------------------------------------------------------------------------- */
+// Registering device memory by virtual address needs the kernel peer-memory API,
+// which is absent on inbox ib_uverbs and unusable even with MLNX_OFED on kernels
+// >= 6.3: OFED exports ib_register_peer_memory_client as a non-GPL symbol, and
+// symbol_get() refuses those, so amdgpu's peer-direct bridge never registers.
+// Without a peer-memory client the CQ/QP/DBR umems and the atomic ibuf MR all fail
+// with EFAULT. Exporting the allocation as a dmabuf instead routes the pinning
+// through ib_umem_dmabuf_get_pinned, which needs no peer-memory client at all.
+//
+// Both helpers fall back to the by-address call so hosts that do have a working
+// peer-memory client (or lack dmabuf export) keep their previous behaviour.
+
+// Granularity rdma-core's own mlx5dv_devx_umem_reg wrapper asks the adapter for.
+static constexpr uint64_t kMlx5AdapterPageSize = 4096;
+
+static mlx5dv_devx_umem* RegisterUmem(ibv_context* context, void* addr, size_t size,
+                                      uint32_t access, bool onGpu) {
+  auto& api = Mlx5DvApi::Instance();
+  if (onGpu && api.devx_umem_reg_ex) {
+    uint64_t dmabufOffset = 0;
+    int dmabufFd = TryExportDmabufFd(addr, size, &dmabufOffset);
+    if (dmabufFd >= 0) {
+      // With MLX5DV_UMEM_MASK_DMABUF the kernel reads `addr` as an offset into the
+      // dmabuf, not as a virtual address.
+      mlx5dv_devx_umem_in in = {};
+      in.addr = reinterpret_cast<void*>(dmabufOffset);
+      in.size = size;
+      in.access = access;
+      in.pgsz_bitmap = UINT64_MAX & ~(kMlx5AdapterPageSize - 1);
+      in.comp_mask = MLX5DV_UMEM_MASK_DMABUF;
+      in.dmabuf_fd = dmabufFd;
+
+      mlx5dv_devx_umem* umem = api.devx_umem_reg_ex(context, &in);
+      close(dmabufFd);
+      if (umem) {
+        MORI_APP_TRACE("MLX5 umem registered via dmabuf: addr=0x{:x}, size={}, offset={}",
+                       reinterpret_cast<uintptr_t>(addr), size, dmabufOffset);
+        return umem;
+      }
+      MORI_APP_WARN(
+          "MLX5 dmabuf umem registration failed, falling back to registration by address: "
+          "addr=0x{:x}, size={}, offset={}, errno={} ({})",
+          reinterpret_cast<uintptr_t>(addr), size, dmabufOffset, errno, strerror(errno));
+    }
+  }
+  return api.devx_umem_reg(context, addr, size, access);
+}
+
+static ibv_mr* RegisterMr(ibv_pd* pd, void* addr, size_t size, int access, bool onGpu) {
+  if (onGpu) {
+    uint64_t dmabufOffset = 0;
+    int dmabufFd = TryExportDmabufFd(addr, size, &dmabufOffset);
+    if (dmabufFd >= 0) {
+      ibv_mr* mr = ibv_reg_dmabuf_mr(pd, dmabufOffset, size, reinterpret_cast<uint64_t>(addr),
+                                     dmabufFd, access);
+      close(dmabufFd);
+      if (mr) {
+        MORI_APP_TRACE("MLX5 MR registered via dmabuf: addr=0x{:x}, size={}, offset={}",
+                       reinterpret_cast<uintptr_t>(addr), size, dmabufOffset);
+        return mr;
+      }
+      MORI_APP_WARN(
+          "MLX5 dmabuf MR registration failed, falling back to registration by address: "
+          "addr=0x{:x}, size={}, offset={}, errno={} ({})",
+          reinterpret_cast<uintptr_t>(addr), size, dmabufOffset, errno, strerror(errno));
+    }
+  }
+  return ibv_reg_mr(pd, addr, size, access);
+}
+
+/* ---------------------------------------------------------------------------------------------- */
 /*                                          Mlx5CqContainer */
 /* ---------------------------------------------------------------------------------------------- */
 Mlx5CqContainer::Mlx5CqContainer(ibv_context* context, const RdmaEndpointConfig& config)
@@ -99,7 +173,7 @@ Mlx5CqContainer::Mlx5CqContainer(ibv_context* context, const RdmaEndpointConfig&
     assert(!status);
   }
 
-  cqUmem = Mlx5DvApi::Instance().devx_umem_reg(context, cqUmemAddr, cqSize, IBV_ACCESS_LOCAL_WRITE);
+  cqUmem = RegisterUmem(context, cqUmemAddr, cqSize, IBV_ACCESS_LOCAL_WRITE, config.onGpu);
   assert(cqUmem);
 
   // Allocate user memory for CQ DBR (doorbell?)
@@ -112,8 +186,7 @@ Mlx5CqContainer::Mlx5CqContainer(ibv_context* context, const RdmaEndpointConfig&
     assert(!status);
   }
 
-  cqDbrUmem =
-      Mlx5DvApi::Instance().devx_umem_reg(context, cqDbrUmemAddr, 8, IBV_ACCESS_LOCAL_WRITE);
+  cqDbrUmem = RegisterUmem(context, cqDbrUmemAddr, 8, IBV_ACCESS_LOCAL_WRITE, config.onGpu);
   assert(cqDbrUmem);
 
   // Allocate user access region
@@ -241,8 +314,7 @@ void Mlx5QpContainer::CreateQueuePair(uint32_t cqn, uint32_t pdn) {
     assert(!status);
   }
 
-  qpUmem =
-      Mlx5DvApi::Instance().devx_umem_reg(context, qpUmemAddr, qpTotalSize, IBV_ACCESS_LOCAL_WRITE);
+  qpUmem = RegisterUmem(context, qpUmemAddr, qpTotalSize, IBV_ACCESS_LOCAL_WRITE, config.onGpu);
   assert(qpUmem);
 
   // Allocate user memory for DBR (doorbell?)
@@ -255,8 +327,7 @@ void Mlx5QpContainer::CreateQueuePair(uint32_t cqn, uint32_t pdn) {
     assert(!status);
   }
 
-  qpDbrUmem =
-      Mlx5DvApi::Instance().devx_umem_reg(context, qpDbrUmemAddr, 8, IBV_ACCESS_LOCAL_WRITE);
+  qpDbrUmem = RegisterUmem(context, qpDbrUmemAddr, 8, IBV_ACCESS_LOCAL_WRITE, config.onGpu);
   assert(qpDbrUmem);
 
   // Allocate and register atomic internal buffer (ibuf)
@@ -275,8 +346,8 @@ void Mlx5QpContainer::CreateQueuePair(uint32_t cqn, uint32_t pdn) {
   int atomicIbufAccessFlag =
       MaybeAddRelaxedOrderingFlag(IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
                                   IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC);
-  atomicIbufMr =
-      ibv_reg_mr(device_context->GetIbvPd(), atomicIbufAddr, atomicIbufSize, atomicIbufAccessFlag);
+  atomicIbufMr = RegisterMr(device_context->GetIbvPd(), atomicIbufAddr, atomicIbufSize,
+                            atomicIbufAccessFlag, config.onGpu);
   assert(atomicIbufMr);
 
   MORI_APP_TRACE(
@@ -290,8 +361,16 @@ void Mlx5QpContainer::CreateQueuePair(uint32_t cqn, uint32_t pdn) {
   assert(qpUar->page_id != 0);
 
   if (config.onGpu) {
+    // Multiple qp may share the same uar address, and hipHostRegister maps at page
+    // granularity, so a sibling qp may have mapped this page already. Mirrors the
+    // unregister-once handling in DestroyQueuePair.
     uint32_t flag = hipHostRegisterPortable | hipHostRegisterMapped;
-    HIP_RUNTIME_CHECK(hipHostRegister(qpUar->reg_addr, QueryHcaCap(context).dbrRegSize, flag));
+    hipError_t err = hipHostRegister(qpUar->reg_addr, QueryHcaCap(context).dbrRegSize, flag);
+    if (err == hipErrorHostMemoryAlreadyRegistered) {
+      (void)hipGetLastError();
+    } else {
+      HIP_RUNTIME_CHECK(err);
+    }
     HIP_RUNTIME_CHECK(hipHostGetDevicePointer(&qpUarPtr, qpUar->reg_addr, 0));
   } else {
     qpUarPtr = qpUar->reg_addr;

--- a/src/application/transport/rdma/providers/mlx5/mlx5.cpp
+++ b/src/application/transport/rdma/providers/mlx5/mlx5.cpp
@@ -94,14 +94,14 @@ static mlx5dv_devx_umem* RegisterUmem(ibv_context* context, void* addr, size_t s
     uint64_t dmabufOffset = 0;
     int dmabufFd = TryExportDmabufFd(addr, size, &dmabufOffset);
     if (dmabufFd >= 0) {
-      // With MLX5DV_UMEM_MASK_DMABUF the kernel reads `addr` as an offset into the
+      // With the dmabuf mask set the kernel reads `addr` as an offset into the
       // dmabuf, not as a virtual address.
-      mlx5dv_devx_umem_in in = {};
+      Mlx5DevxUmemIn in = {};
       in.addr = reinterpret_cast<void*>(dmabufOffset);
       in.size = size;
       in.access = access;
       in.pgsz_bitmap = UINT64_MAX & ~(kMlx5AdapterPageSize - 1);
-      in.comp_mask = MLX5DV_UMEM_MASK_DMABUF;
+      in.comp_mask = MORI_MLX5_UMEM_MASK_DMABUF;
       in.dmabuf_fd = dmabufFd;
 
       mlx5dv_devx_umem* umem = api.devx_umem_reg_ex(context, &in);

--- a/src/application/transport/rdma/rdma.cpp
+++ b/src/application/transport/rdma/rdma.cpp
@@ -440,9 +440,6 @@ application::RdmaMemoryRegion RdmaDeviceContext::RegisterRdmaMemoryRegionDmabufI
   return handle;
 }
 
-// Export a dmabuf fd for the GPU buffer at `ptr`, and report the offset of `ptr`
-// within the exported dmabuf via `*offset`. Returns -1 if unsupported.
-//
 // hipMemGetHandleForAddressRange exports an fd for the *backing* allocation but
 // does not report where `ptr` sits inside it; callers previously assumed offset
 // 0. That is wrong when `ptr` is a sub-region of a larger allocation (e.g. a
@@ -452,7 +449,7 @@ application::RdmaMemoryRegion RdmaDeviceContext::RegisterRdmaMemoryRegionDmabufI
 // silent writes to the wrong address). hsa_amd_portable_export_dmabuf reports the
 // true byte offset, so prefer it and fall back to the hip path (offset 0, correct
 // only for whole-allocation exports) when HSA export is unavailable.
-static int TryExportDmabufFd(void* ptr, size_t size, uint64_t* offset) {
+int TryExportDmabufFd(void* ptr, size_t size, uint64_t* offset) {
   int fd = -1;
   uint64_t off = 0;
   hsa_status_t hs = hsa_amd_portable_export_dmabuf(ptr, size, &fd, &off);


### PR DESCRIPTION
## Motivation

On mlx5 hosts without a working peer-memory bridge, DEVX registration of GPU
memory fails with EFAULT and MORI aborts at `assert(cqUmem)`. Peer-memory is
missing from inbox `ib_uverbs`, and OFED cannot supply it on kernels >= 6.3:
`ib_register_peer_memory_client` is exported non-GPL, so `symbol_get()` rejects
it and amdgpu's peer-direct bridge never registers.

## Technical Details

Register the GPU CQ/QP/DBR umems and the atomic ibuf through dmabuf
(`mlx5dv_devx_umem_reg_ex`, `ibv_reg_dmabuf_mr`), which pins via
`ib_umem_dmabuf_get_pinned` and needs no peer-memory client. Both helpers fall
back to by-address registration, so hosts that already work are unaffected. The
symbol is resolved optionally and its descriptor vendored, keeping the build
green on rdma-core v39. Also tolerates `hipErrorHostMemoryAlreadyRegistered`
when sibling QPs share a UAR page.

CI gains an `MI300X_MLX` platform (2x MI300X, 8x CX-7 NDR InfiniBand). SL/TC are
omitted -- mlx5 applies them only on the RoCE path.

## Test Result

Two-node EP dispatch/combine (v1, v1_ll, async_ll), bit-exact hierarchical
AllGather, and MORI-IO all pass on the new runner.