### PR TITLE
ops-v2: drop the redundant host counter resets in the hip path

### DIFF
--- a/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
+++ b/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
@@ -682,12 +682,9 @@ class EpDispatchCombineOp:
         disp_spec, _ = self._pick(n)
 
         if not self._kernels.self_resets_counters:
-            # Local scratch only. The arena's tok_off and recv_num are NOT reset:
-            # peers write them, and an unsynchronised host memset would wipe a
-            # signal that already arrived and hang both ranks.
+            # Only this one: the kernels self-clear dest_pe_counter and the grid
+            # barrier, but total_recv is cleared in COMBINE, not in dispatch.
             self.total_recv.zero_()
-            self.dest_pe_counter.zero_()
-            self.dispatch_barrier.zero_()
 
         if routing is not None:
             table = self._kernels.dispatch_replay
@@ -762,8 +759,7 @@ class EpDispatchCombineOp:
             if input.data_ptr() != out_tok_ptr:
                 dst = self.combine_in_view().view(-1)[: input.numel()]
                 dst.copy_(input.reshape(-1))
-        if not self._kernels.self_resets_counters:
-            self.combine_barrier.zero_()
+        # No combine_barrier.zero_(): the cross-device barrier clears it itself.
         # No combine_out.zero_(): the kernel reduce-then-stores every token in
         # [0, ct), so the prior contents of the returned slice never leak.
 


### PR DESCRIPTION
hip_backend sets self_resets_counters=False, so the op memsets total_recv,
dest_pe_counter and dispatch_barrier before every dispatch and combine_barrier
before every combine. Only the first of those does anything.

Both kernel bodies already clear the other three on their way out:
dest_pe_counter at ep_intranode_1250x.hpp:548 / ep_intranode_kernel.hpp:256
(the loop covers the same [0, npes) the accumulate wrote), and the grid barrier
at :532 / :238, plus :573 / :286 for the combine one -- race-free because the
reset follows a wait-for-all-blocks, so no late arrival can land after it.

total_recv stays: dispatch only accumulates into it and it is cleared in
COMBINE, so a dispatch not followed by one -- a bench loop, a dispatch-only
test -- would keep adding to the last count.

Saves three memsets per layer per step, which under cudagraph capture is three
graph nodes per layer.

Tested on 8x MI355X (gfx950, EP8, the portable body): test_op hip topk8 ct=128
and 512 PASS, backend parity flydsl == hip bitwise at ct=8/64/512, graph capture
PASS, and bench_ep 60 consecutive dispatches per point with no hang and stable
recv -- which is what would break first if either counter were left dirty.
Not run on gfx1250.
