### PR TITLE
Io cpp bench default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -661,6 +661,16 @@ jobs:
           ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST \
             "$CT exec $CONTAINER bash -c 'cd $GITHUB_WORKSPACE && BUILD_EXAMPLES=ON pip install . && pip install prettytable && (command -v numactl >/dev/null || (apt-get update && apt-get install -y numactl))'"
 
+      # The IO benchmark runner defaults to the native C++ engine
+      # (tools/run_internode_io_benchmark.sh --engine cpp), which needs the
+      # bench_engine binary built on BOTH nodes. pip install above does not
+      # produce it, so build it explicitly into build/tests/cpp/bench_engine.
+      - name: Build MORI-IO C++ bench_engine (both nodes)
+        run: |
+          BUILD_CMD="cd $GITHUB_WORKSPACE && cmake -B build -DBUILD_IO=ON -DBUILD_TESTS=ON -DBUILD_EXAMPLES=OFF && cmake --build build --target bench_engine -j && ls -la build/tests/cpp/bench_engine"
+          $CT exec $CONTAINER bash -c "$BUILD_CMD"
+          ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "$CT exec $CONTAINER bash -c \"$BUILD_CMD\""
+
       - name: MORI-IO internode write sweep
         run: |
           SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_io_benchmark.sh"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -612,6 +612,7 @@ jobs:
             -e MORI_SOCKET_IFNAME=$MORI_SOCKET_IFNAME \
             -e GLOO_SOCKET_IFNAME=$NODE1_IFNAME \
             -e NCCL_SOCKET_IFNAME=$NODE1_IFNAME \
+            -e MORI_IO_BENCH_ENGINE_BIN=$GITHUB_WORKSPACE/build_bench/tests/cpp/bench_engine \
             -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
             -w $GITHUB_WORKSPACE \
             $IMAGE sleep infinity
@@ -644,6 +645,7 @@ jobs:
               -e MORI_SOCKET_IFNAME=$MORI_SOCKET_IFNAME \
               -e GLOO_SOCKET_IFNAME=$NODE2_IFNAME \
               -e NCCL_SOCKET_IFNAME=$NODE2_IFNAME \
+              -e MORI_IO_BENCH_ENGINE_BIN=$GITHUB_WORKSPACE/build_bench/tests/cpp/bench_engine \
               -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
               -w $GITHUB_WORKSPACE \
               $IMAGE sleep infinity &&
@@ -664,10 +666,15 @@ jobs:
       # The IO benchmark runner defaults to the native C++ engine
       # (tools/run_internode_io_benchmark.sh --engine cpp), which needs the
       # bench_engine binary built on BOTH nodes. pip install above does not
-      # produce it, so build it explicitly into build/tests/cpp/bench_engine.
+      # produce it. Build into a SEPARATE build_bench/ dir, not the build/ that
+      # `pip install .` created: that cache was configured inside pip's
+      # build-isolation env (ephemeral ninja + pybind11 that no longer exist), so
+      # reconfiguring it here fails. The runner picks up the binary via
+      # MORI_IO_BENCH_ENGINE_BIN (set on both containers at start) and derives the
+      # matching LD_LIBRARY_PATH from it.
       - name: Build MORI-IO C++ bench_engine (both nodes)
         run: |
-          BUILD_CMD="cd $GITHUB_WORKSPACE && cmake -B build -DBUILD_IO=ON -DBUILD_TESTS=ON -DBUILD_EXAMPLES=OFF && cmake --build build --target bench_engine -j && ls -la build/tests/cpp/bench_engine"
+          BUILD_CMD="cd $GITHUB_WORKSPACE && cmake -B build_bench -DBUILD_IO=ON -DBUILD_TESTS=ON -DBUILD_EXAMPLES=OFF -DBUILD_PYBINDS=OFF -DBUILD_OPS=OFF -DBUILD_SHMEM=OFF -DBUILD_CCO=OFF -DBUILD_COLLECTIVE=OFF -DBUILD_METRICS=OFF && cmake --build build_bench --target bench_engine -j && ls -la build_bench/tests/cpp/bench_engine"
           $CT exec $CONTAINER bash -c "$BUILD_CMD"
           ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "$CT exec $CONTAINER bash -c \"$BUILD_CMD\""
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -647,6 +647,37 @@ jobs:
             --num-initiator-dev 8 --num-target-dev 8
           wait
 
+      # Read counterpart of the write sweep above: same geometry (full 1K-16M
+      # sweep, 8 QP, 8 threads, batch-contiguous), so read bandwidth lands on the
+      # perf dashboard alongside write. Unlike the 4KB smoke read below it does
+      # NOT use --poll_cq_mode event, so the batch-into-one-WR hang that gates
+      # that step does not apply here.
+      - name: MORI-IO internode read sweep
+        run: |
+          SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_io_benchmark.sh"
+          PORT=29122
+          echo "=== MORI-IO internode benchmark: wide-read-sweep port=$PORT ==="
+          NODE2_CMD=(
+            $CT exec $CONTAINER bash $SCRIPT
+            --rank 1 --master-addr $NODE1_HOST --master-port $PORT
+            --ifname $NODE2_IFNAME
+            -- --op-type read --buffer-size 65536 --transfer-batch-size 256 --all
+            --sweep-start-size 1024 --sweep-max-size 16777216 --iters 128
+            --batch-contiguous --enable-sess --enable-batch-transfer
+            --num-qp-per-transfer 8 --num-worker-threads 8
+            --num-initiator-dev 8 --num-target-dev 8
+          )
+          ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
+          $CT exec $CONTAINER bash $SCRIPT \
+            --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
+            --ifname $NODE1_IFNAME \
+            -- --op-type read --buffer-size 65536 --transfer-batch-size 256 --all \
+            --sweep-start-size 1024 --sweep-max-size 16777216 --iters 128 \
+            --batch-contiguous --enable-sess --enable-batch-transfer \
+            --num-qp-per-transfer 8 --num-worker-threads 8 \
+            --num-initiator-dev 8 --num-target-dev 8
+          wait
+
       # Correctness/smoke check only: a fixed 4KB single-point read, not a sweep.
       # The numbers are far below what the write sweep reports, so this step runs
       # with MORI_PERF_OUT cleared and contributes nothing to the perf report.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -539,6 +539,7 @@ jobs:
             -e MORI_PERF_PLATFORM=$MORI_PERF_PLATFORM \
             -e MORI_PERF_PYTHON=$MORI_PERF_PYTHON \
             -e MORI_PERF_DATE=$(date -u +%Y-%m-%d) \
+            -e MORI_IO_BENCH_ENGINE_BIN=$GITHUB_WORKSPACE/build_bench/tests/cpp/bench_engine \
             -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
             -w $GITHUB_WORKSPACE \
             $IMAGE sleep infinity
@@ -575,6 +576,7 @@ jobs:
               -e MORI_SOCKET_IFNAME=$MORI_SOCKET_IFNAME \
               -e GLOO_SOCKET_IFNAME=$NODE2_IFNAME \
               -e NCCL_SOCKET_IFNAME=$NODE2_IFNAME \
+              -e MORI_IO_BENCH_ENGINE_BIN=$GITHUB_WORKSPACE/build_bench/tests/cpp/bench_engine \
               -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
               -w $GITHUB_WORKSPACE \
               $IMAGE sleep infinity &&
@@ -609,10 +611,13 @@ jobs:
       # The IO benchmark runner defaults to the native C++ engine
       # (tools/run_internode_io_benchmark.sh --engine cpp), which needs the
       # bench_engine binary built on BOTH nodes. The wheel install above does not
-      # produce it, so build it explicitly into build/tests/cpp/bench_engine.
+      # produce it. Build into a SEPARATE build_bench/ dir, not the build/ that
+      # the wheel build created inside pip's build-isolation env (ephemeral ninja
+      # + pybind11 that no longer exist), which would fail to reconfigure. The
+      # runner picks up the binary via MORI_IO_BENCH_ENGINE_BIN.
       - name: Build MORI-IO C++ bench_engine (both nodes)
         run: |
-          BUILD_CMD="cd $GITHUB_WORKSPACE && cmake -B build -DBUILD_IO=ON -DBUILD_TESTS=ON -DBUILD_EXAMPLES=OFF && cmake --build build --target bench_engine -j && ls -la build/tests/cpp/bench_engine"
+          BUILD_CMD="cd $GITHUB_WORKSPACE && cmake -B build_bench -DBUILD_IO=ON -DBUILD_TESTS=ON -DBUILD_EXAMPLES=OFF -DBUILD_PYBINDS=OFF -DBUILD_OPS=OFF -DBUILD_SHMEM=OFF -DBUILD_CCO=OFF -DBUILD_COLLECTIVE=OFF -DBUILD_METRICS=OFF && cmake --build build_bench --target bench_engine -j && ls -la build_bench/tests/cpp/bench_engine"
           $CT exec $CONTAINER bash -c "$BUILD_CMD"
           ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "$CT exec $CONTAINER bash -c \"$BUILD_CMD\""
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -606,6 +606,16 @@ jobs:
               python3 -c \"import mori; print(\\\"mori \\\" + mori.__version__ + \\\" imported OK\\\")\"
             '"
 
+      # The IO benchmark runner defaults to the native C++ engine
+      # (tools/run_internode_io_benchmark.sh --engine cpp), which needs the
+      # bench_engine binary built on BOTH nodes. The wheel install above does not
+      # produce it, so build it explicitly into build/tests/cpp/bench_engine.
+      - name: Build MORI-IO C++ bench_engine (both nodes)
+        run: |
+          BUILD_CMD="cd $GITHUB_WORKSPACE && cmake -B build -DBUILD_IO=ON -DBUILD_TESTS=ON -DBUILD_EXAMPLES=OFF && cmake --build build --target bench_engine -j && ls -la build/tests/cpp/bench_engine"
+          $CT exec $CONTAINER bash -c "$BUILD_CMD"
+          ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "$CT exec $CONTAINER bash -c \"$BUILD_CMD\""
+
       - name: MORI-IO internode write sweep
         run: |
           SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_io_benchmark.sh"
@@ -661,35 +671,6 @@ jobs:
             --num-qp-per-transfer 2 --num-worker-threads 2 \
             --num-initiator-dev 8 --num-target-dev 8
           wait
-
-      - name: Build MORI-IO C++ bench_engine (both nodes)
-        run: |
-          # Dedicated build dir, wiped each run. The runner workspace is shared with
-          # ci.yml, whose pip build leaves a build/CMakeCache.txt whose
-          # CMAKE_MAKE_PROGRAM points into an ephemeral /tmp/pip-build-env-*/overlay
-          # that pip has already removed, so configuring into "build" fails with
-          # "Running '<...>/ninja' '--version' failed with: No such file or
-          # directory". A private dir also keeps this configure from inheriting a
-          # cache written by a different cmake or base image.
-          BUILD_CMD="cd $GITHUB_WORKSPACE && rm -rf build-cpp && cmake -B build-cpp -DBUILD_IO=ON -DBUILD_TESTS=ON -DBUILD_EXAMPLES=OFF -DBUILD_PYBINDS=OFF && cmake --build build-cpp --target bench_engine -j && ls -la build-cpp/tests/cpp/bench_engine"
-          $CT exec $CONTAINER bash -c "$BUILD_CMD"
-          ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "$CT exec $CONTAINER bash -c \"$BUILD_CMD\""
-
-      - name: MORI-IO C++ bench_engine write sweep (batch 1 and 64)
-        run: |
-          BIN=$GITHUB_WORKSPACE/build-cpp/tests/cpp/bench_engine
-          LDP="LD_LIBRARY_PATH=$GITHUB_WORKSPACE/build-cpp/src/io:$GITHUB_WORKSPACE/build-cpp/src/application"
-          PORT=29130
-          for BATCH in 1 64; do
-            echo "=== C++ bench_engine GPU write sweep, batch=$BATCH, port=$PORT ==="
-            ARGS="--op write --mem-type gpu --all --sweep-start 1048576 --sweep-max 33554432 --sweep-step 1048576 --transfer-batch-size $BATCH --enable-sess --enable-batch-transfer --num-initiator-dev 1 --num-target-dev 1 --num-qp-per-transfer 8 --iters 200 --warmup-iters 5"
-            R1="cd $GITHUB_WORKSPACE && $LDP $BIN --rank 1 --master-ip $NODE1_HOST --self-ip $NODE2_HOST --port $PORT $ARGS"
-            R0="cd $GITHUB_WORKSPACE && $LDP $BIN --rank 0 --master-ip $NODE1_HOST --self-ip $NODE1_HOST --port $PORT $ARGS"
-            ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "$CT exec $CONTAINER bash -c \"$R1\"" &
-            $CT exec $CONTAINER bash -c "$R0"
-            wait
-            PORT=$((PORT + 1))
-          done
 
       - name: MORI-EP internode normal kernel bench
         run: |

--- a/README.md
+++ b/README.md
@@ -295,11 +295,14 @@ export PYTHONPATH=/path/to/mori:$PYTHONPATH
 # Correctness tests
 pytest tests/python/io/
 
-# Benchmark performance (two nodes)
-export GLOO_SOCKET_IFNAME=ens14np0
-torchrun --nnodes=2 --node_rank=0 --nproc_per_node=1 --master_addr="10.194.129.65" --master_port=1234 \
-  tests/python/io/benchmark.py --host="10.194.129.65" --enable-batch-transfer --enable-sess --buffer-size 32768 --transfer-batch-size 128
+# Benchmark performance (two nodes). The runner defaults to the native C++
+# benchmark (tests/cpp/io/bench_engine); pass --engine python for the torchrun path.
+tools/run_internode_io_benchmark.sh --rank 0 --master-addr "10.194.129.65" --ifname ens14np0 \
+  -- --op write --enable-batch-transfer --enable-sess --buffer-size 32768 --transfer-batch-size 128
+# (run the same command on the second node with --rank 1)
 ```
+
+See [docs/MORI-IO-BENCHMARK.md](docs/MORI-IO-BENCHMARK.md) for both engines and tuning.
 
 ### Test MORI-IR (Triton + shmem integration, [guide](python/mori/ir/README.md))
 

--- a/docs/MORI-IO-BENCHMARK.md
+++ b/docs/MORI-IO-BENCHMARK.md
@@ -2,13 +2,14 @@
 
 ## Table of Contents
 
-- [Benchmark Commands](#benchmark-commands)
-  - [Fabric (cross-node scale-up UALink super-node)](#fabric-cross-node-scale-up-ualink-super-node)
-- [C++ Benchmark (nixlbench-matching)](#c-benchmark-nixlbench-matching)
+- [Which benchmark to use](#which-benchmark-to-use)
+- [C++ Benchmark (default, nixlbench-matching)](#c-benchmark-default-nixlbench-matching)
   - [Build](#build)
   - [Run (two nodes)](#run-two-nodes)
   - [Sweep modes](#sweep-modes)
   - [Differences from the Python flags](#differences-from-the-python-flags)
+- [Python Benchmark](#python-benchmark)
+  - [Fabric (cross-node scale-up UALink super-node)](#fabric-cross-node-scale-up-ualink-super-node)
 - [Benchmark Arguments](#benchmark-arguments)
 - [Results: Thor2 RDMA Read](#results-thor2-rdma-read)
 - [Results: Thor2 RDMA Write](#results-thor2-rdma-write)
@@ -24,46 +25,38 @@
   - [Parameters that usually do not help (or can hurt)](#parameters-that-usually-do-not-help-or-can-hurt)
   - [Host (CPU) vs GPU memory](#host-cpu-vs-gpu-memory)
 
-## Benchmark Commands
+## Which benchmark to use
+
+MORI-IO ships two benchmarks that measure the same transfer paths:
+
+- **C++ (`tests/cpp/io/bench_engine`) — the default.** No Python interpreter in
+  the measurement loop, and its timing matches
+  [nixlbench](https://github.com/ai-dynamo/nixl) so MORI-IO and NIXL numbers are
+  directly comparable. This is what `tools/run_internode_io_benchmark.sh` runs by
+  default and what CI reports. Start here.
+- **Python (`tests/python/io/benchmark.py`) — kept for parity.** Uses `torchrun`
+  for rendezvous; convenient when you are already in a torch/torchrun workflow.
+  Select it with `run_internode_io_benchmark.sh --engine python`.
+
+Both accept the same workload flags (op, sweep, batch, QP, session); the C++ tool
+also accepts the Python spellings as aliases. See
+[Differences from the Python flags](#differences-from-the-python-flags).
+
+The two-node runner picks the engine with `--engine`:
 
 ```bash
-cd /path/to/mori
-export PYTHONPATH=/path/to/mori:$PYTHONPATH
-export GLOO_SOCKET_IFNAME=ens14np0  # Set to your NIC interface
+# C++ engine (default)
+tools/run_internode_io_benchmark.sh --rank 0 --master-addr <ip> --ifname <nic> \
+    -- --op write --all --enable-sess --enable-batch-transfer
 
-# Run on two nodes (replace node_rank and master_addr)
-torchrun --nnodes=2 --node_rank=0 --nproc_per_node=1 \
-    --master_addr="10.194.129.65" --master_port=1234 \
-    tests/python/io/benchmark.py --host="10.194.129.65"
+# Python engine
+tools/run_internode_io_benchmark.sh --engine python --rank 0 --master-addr <ip> \
+    --ifname <nic> -- --op-type write --all --enable-sess --enable-batch-transfer
 ```
 
-### Fabric (cross-node scale-up UALink super-node)
+## C++ Benchmark (default, nixlbench-matching)
 
-The `fabric` backend transfers between two nodes that share the same scale-up
-fabric domain (**same vPOD** — verify with `amd-smi fabric` that `PPOD_ID` and
-`VPOD_ID` match and `ACCEL_STATE` is `READY` on both). Buffers are allocated as
-fabric-exportable VMM memory internally, so no `--host`/QP options are needed;
-OOB metadata is still exchanged over gloo (torchrun).
-
-```bash
-# node A (initiator)
-torchrun --nnodes=2 --node_rank=0 --nproc_per_node=1 \
-    --master_addr="<nodeA_ip>" --master_port=1234 \
-    tests/python/io/benchmark.py --backend fabric \
-    --all --enable-sess --enable-batch-transfer --transfer-batch-size 1 \
-    --sweep-start-size 1048576 --sweep-max-size 268435456 --op-type read
-
-# node B (target): same command with --node_rank=1
-```
-
-> Requires ROCm ≥ 7.15 (HIP fabric VMM APIs). Only GPU memory is supported
-> (`--mem-type gpu`). If the two nodes are not in the same vPOD, session creation
-> fails fast with a clear error.
-
-## C++ Benchmark (nixlbench-matching)
-
-The commands above use the **Python** benchmark (`tests/python/io/benchmark.py`).
-There is also a native **C++** benchmark, `tests/cpp/io/bench_engine.cpp`, whose
+The **C++** benchmark, `tests/cpp/io/bench_engine.cpp`, is the default. Its
 measurement loop is written to **match [nixlbench](https://github.com/ai-dynamo/nixl)**
 (NVIDIA NIXL's `xferbench`) exactly, so MORI-IO and NIXL RDMA numbers are
 apples-to-apples on the same fabric. Use it when you want a head-to-head
@@ -217,6 +210,46 @@ Most flags share names with the Python benchmark (`--op-type`/`--op`,
 > `P+1 … P+2N` for the engines — leave that range free. Each side forks `N-1`
 > children before touching HIP, so a failure in one pair still reaps the others
 > rather than leaving them holding ports.
+
+## Python Benchmark
+
+Kept for parity with the C++ default (select it in the runner with
+`--engine python`). It uses `torchrun` for the out-of-band rendezvous instead of
+MORI's socket bootstrap.
+
+```bash
+cd /path/to/mori
+export PYTHONPATH=/path/to/mori:$PYTHONPATH
+export GLOO_SOCKET_IFNAME=ens14np0  # Set to your NIC interface
+
+# Run on two nodes (replace node_rank and master_addr)
+torchrun --nnodes=2 --node_rank=0 --nproc_per_node=1 \
+    --master_addr="10.194.129.65" --master_port=1234 \
+    tests/python/io/benchmark.py --host="10.194.129.65"
+```
+
+### Fabric (cross-node scale-up UALink super-node)
+
+The `fabric` backend transfers between two nodes that share the same scale-up
+fabric domain (**same vPOD** — verify with `amd-smi fabric` that `PPOD_ID` and
+`VPOD_ID` match and `ACCEL_STATE` is `READY` on both). Buffers are allocated as
+fabric-exportable VMM memory internally, so no `--host`/QP options are needed;
+OOB metadata is still exchanged over gloo (torchrun).
+
+```bash
+# node A (initiator)
+torchrun --nnodes=2 --node_rank=0 --nproc_per_node=1 \
+    --master_addr="<nodeA_ip>" --master_port=1234 \
+    tests/python/io/benchmark.py --backend fabric \
+    --all --enable-sess --enable-batch-transfer --transfer-batch-size 1 \
+    --sweep-start-size 1048576 --sweep-max-size 268435456 --op-type read
+
+# node B (target): same command with --node_rank=1
+```
+
+> Requires ROCm ≥ 7.15 (HIP fabric VMM APIs). Only GPU memory is supported
+> (`--mem-type gpu`). If the two nodes are not in the same vPOD, session creation
+> fails fast with a clear error. The C++ benchmark also supports `--backend fabric`.
 
 ## Benchmark Arguments
 
@@ -456,13 +489,16 @@ or single-transfer workloads may prefer different settings.
 
 ### Recommended starting config
 
+These workload flags apply to both engines (the C++ default and Python); only the
+launch wrapper differs. Shown against the C++ binary:
+
 ```bash
-tests/python/io/benchmark.py \
-    --op-type write \
+tests/cpp/io/bench_engine --op write \
     --enable-sess --enable-batch-transfer --batch-contiguous \
     --disable-chunking \
     --num-qp-per-transfer 8 --num-worker-threads 8 \
     --transfer-batch-size 128 --num-initiator-dev 1 --num-target-dev 1
+    # (plus --rank/--master-ip/--self-ip/--port for the two-node rendezvous)
 ```
 
 On a 400G-class NIC this typically reaches ~95%+ of link rate across the

--- a/docs/MORI-IO-GUIDE.md
+++ b/docs/MORI-IO-GUIDE.md
@@ -225,5 +225,6 @@ Either variable can be enabled alone. Enabled values include `1`, `on`, and
 | `src/pybind/mori.cpp` | IO binding registration (`RegisterMoriIo`) |
 | `examples/io/example.py` | Complete usage examples (read, write, batch, session) |
 | `tests/python/io/test_engine.py` | Comprehensive test suite |
-| `tests/python/io/benchmark.py` | Performance benchmark |
+| `tests/cpp/io/bench_engine.cpp` | Performance benchmark (default, nixlbench-matching) |
+| `tests/python/io/benchmark.py` | Performance benchmark (Python, kept for parity) |
 | `docs/MORI-IO-BENCHMARK.md` | Benchmark commands and results |

--- a/tests/cpp/io/bench_engine.cpp
+++ b/tests/cpp/io/bench_engine.cpp
@@ -62,6 +62,7 @@
 
 #include <hip/hip_runtime.h>
 #include <signal.h>
+#include <sys/file.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -72,10 +73,14 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <ctime>
 #include <exception>
+#include <fstream>
 #include <iostream>
+#include <limits>
 #include <msgpack.hpp>
 #include <optional>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -784,8 +789,119 @@ struct SweepResult {
   double bw;   // GB/s, GB=10^9
   double lat;  // us per single transfer
   double dur;  // us, whole timed loop
-  MSGPACK_DEFINE(msg, batch, bw, lat, dur);
+  // Python-benchmark-format metrics for the perf report (tests/python/perf_report.py).
+  // Python times each iteration separately and reports bandwidth/latency PER
+  // ITERATION (whole batch), deriving max_bw/min_lat from the FASTEST iteration.
+  // The nixl fields above (bw/lat) are per-single-transfer over one whole-loop
+  // timer, so they are NOT interchangeable -- these mirror what benchmark.py emits.
+  double avg_bw_gbps;  // total_mem_mb/1e3 / avg_iter_duration_s
+  double max_bw_gbps;  // total_mem_mb/1e3 / min_iter_duration_s
+  double avg_lat_us;   // mean per-iteration duration
+  double min_lat_us;   // fastest per-iteration duration
+  double total_mb;     // msg * batch / 1e6
+  MSGPACK_DEFINE(msg, batch, bw, lat, dur, avg_bw_gbps, max_bw_gbps, avg_lat_us, min_lat_us,
+                 total_mb);
 };
+
+// Minimal JSON string escaper for the perf record. Only the characters that can
+// appear in our values (backslash, quote, control chars) need handling.
+std::string JsonEscape(const std::string& s) {
+  std::string out;
+  out.reserve(s.size() + 2);
+  for (char c : s) {
+    switch (c) {
+      case '"':
+        out += "\\\"";
+        break;
+      case '\\':
+        out += "\\\\";
+        break;
+      case '\n':
+        out += "\\n";
+        break;
+      case '\r':
+        out += "\\r";
+        break;
+      case '\t':
+        out += "\\t";
+        break;
+      default:
+        out += c;
+    }
+  }
+  return out;
+}
+
+std::string EnvOr(const char* name, const std::string& dflt = "") {
+  const char* v = std::getenv(name);
+  return v ? std::string(v) : dflt;
+}
+
+// Append perf records for the whole sweep to $MORI_PERF_OUT as JSON lines,
+// matching tests/python/perf_report.py::record_perf exactly so the C++ bench
+// and the Python bench feed one report pipeline (tools/perf/build_report.py).
+// No-op unless MORI_PERF_OUT is set. Call from the initiator root only, so a
+// record is not written once per rank. Any error is swallowed -- perf reporting
+// must never fail a benchmark run.
+void WritePerfRecords(const Args& a, const std::vector<SweepResult>& rows) {
+  const std::string out = EnvOr("MORI_PERF_OUT");
+  if (out.empty() || rows.empty()) return;
+
+  const std::string run_id = EnvOr("MORI_PERF_RUN_ID");
+  const std::string commit = EnvOr("MORI_PERF_COMMIT");
+  const std::string platform = EnvOr("MORI_PERF_PLATFORM");
+  const std::string python = EnvOr("MORI_PERF_PYTHON");
+  const std::string date = EnvOr("MORI_PERF_DATE");
+  const double ts = static_cast<double>(std::time(nullptr));
+
+  // Build the whole payload first, then take the lock once and write it, so a
+  // concurrent writer never sees a half-written record. Keys are emitted in
+  // sorted order to match Python's json.dumps(sort_keys=True).
+  std::ostringstream payload;
+  for (const auto& r : rows) {
+    std::ostringstream line;
+    line.setf(std::ios::fixed);
+    line.precision(6);
+    line << '{' << "\"category\": \"io\", "
+         << "\"commit\": \"" << JsonEscape(commit) << "\", "
+         << "\"date\": \"" << JsonEscape(date) << "\", "
+         << "\"metrics\": {"
+         << "\"avg_bw_gbps\": " << r.avg_bw_gbps << ", "
+         << "\"avg_lat_us\": " << r.avg_lat_us << ", "
+         << "\"max_bw_gbps\": " << r.max_bw_gbps << ", "
+         << "\"min_lat_us\": " << r.min_lat_us << ", "
+         << "\"total_mb\": " << r.total_mb << "}, "
+         << "\"params\": {"
+         << "\"backend\": \"" << JsonEscape(a.backend) << "\", "
+         << "\"batch_size\": " << r.batch << ", "
+         << "\"enable_batch_transfer\": " << (a.enable_batch_transfer ? "true" : "false") << ", "
+         << "\"enable_sess\": " << (a.enable_sess ? "true" : "false") << ", "
+         << "\"msg_size\": " << r.msg << ", "
+         << "\"num_initiator_dev\": " << a.num_initiator_dev << ", "
+         << "\"num_qp_per_transfer\": " << a.qp_per_transfer << ", "
+         << "\"num_target_dev\": " << a.num_target_dev << ", "
+         << "\"num_worker_threads\": " << a.worker_threads << ", "
+         << "\"op_type\": \"" << JsonEscape(a.op) << "\", "
+         << "\"transfer_batch_size\": " << a.batch << "}, "
+         << "\"platform\": \"" << JsonEscape(platform) << "\", "
+         << "\"python\": \"" << JsonEscape(python) << "\", "
+         << "\"run_id\": \"" << JsonEscape(run_id) << "\", "
+         << "\"ts\": " << ts << "}\n";
+    payload << line.str();
+  }
+
+  std::FILE* fh = std::fopen(out.c_str(), "a");
+  if (fh == nullptr) {
+    std::fprintf(stderr, "[perf_report] failed to open %s: %s\n", out.c_str(),
+                 std::strerror(errno));
+    return;
+  }
+  int fd = fileno(fh);
+  if (fd >= 0) flock(fd, LOCK_EX);
+  std::fputs(payload.str().c_str(), fh);
+  if (fd >= 0) flock(fd, LOCK_UN);
+  std::fclose(fh);
+}
 
 // Drive every point in `plan` from localMem into peerMem and print one row each.
 // `label` prefixes every row, so N initiator processes writing to the same
@@ -917,9 +1033,14 @@ std::vector<SweepResult> RunSweep(const Args& a, IOEngine& engine, const MemoryD
     // ---- timed region: ONE whole-loop timer, nixl-style ----
     // Strict stop-and-wait (nixl --pipeline_depth 1): post one request, spin
     // until it completes, then post the next.
+    // A per-iteration clock read is also taken so we can emit the Python
+    // benchmark's per-iteration metrics (min/avg) to the perf report without
+    // disturbing the whole-loop nixl figure (t1-t0 stays authoritative).
+    double min_iter_us = std::numeric_limits<double>::max();
     auto t0 = Clock::now();
 
     for (int completed = 0; completed < a.iters; ++completed) {
+      auto it0 = Clock::now();
       post();
       // spin-poll, mirroring nixl's "check status, if IN_PROG continue" scan
       // (status flags stored by MORI's CQ worker thread)
@@ -928,6 +1049,10 @@ std::vector<SweepResult> RunSweep(const Args& a, IOEngine& engine, const MemoryD
       if (TransferStatus* f = reqFailed()) {
         throw std::runtime_error("transfer failed: " + f->Message());
       }
+      double iter_us =
+          std::chrono::duration_cast<std::chrono::duration<double, std::micro>>(Clock::now() - it0)
+              .count();
+      if (iter_us < min_iter_us) min_iter_us = iter_us;
     }
     auto t1 = Clock::now();
 
@@ -948,7 +1073,18 @@ std::vector<SweepResult> RunSweep(const Args& a, IOEngine& engine, const MemoryD
     std::printf("%s%-11zu %-6d %-6d %-12.2f %-11.2f %-.1f\n", label.c_str(), msg, curBatch, a.iters,
                 avg_bw, avg_lat, total_us);
     std::fflush(stdout);
-    results.push_back(SweepResult{msg, curBatch, avg_bw, avg_lat, total_us});
+
+    // Python-benchmark-format metrics (tests/python/io/benchmark.py _run_and_compute):
+    // per-iteration timing, bandwidth/latency PER ITERATION (whole batch), with
+    // max_bw/min_lat taken from the fastest iteration. avg iteration duration is
+    // the whole-loop time / iters (identical to averaging the per-iter samples,
+    // minus the negligible gap between the loop timer and the first/last sample).
+    const double total_mb = static_cast<double>(msg) * curBatch / 1e6;
+    const double avg_iter_us = total_us / a.iters;
+    const double avg_bw_gbps = (total_mb / 1e3) / (avg_iter_us / 1e6);
+    const double max_bw_gbps = (total_mb / 1e3) / (min_iter_us / 1e6);
+    results.push_back(SweepResult{msg, curBatch, avg_bw, avg_lat, total_us, avg_bw_gbps,
+                                  max_bw_gbps, avg_iter_us, min_iter_us, total_mb});
   }
 
   return results;
@@ -1083,6 +1219,11 @@ int RunDistributed(const Args& a, int localRank) {
     }
     std::fflush(stdout);
   }
+
+  // Perf report: each initiator appends its own rows (matches the Python bench's
+  // per-rank _emit_io_perf; build_report.py dedups by op/backend/msg/batch).
+  // No-op unless MORI_PERF_OUT is set.
+  if (isInitiator) WritePerfRecords(a, mine);
 
   // Correctness check on the last sweep point, matching the Python benchmark's
   // always-on validation. Runs after the timed region so it cannot perturb the

--- a/tests/cpp/io/bench_engine.cpp
+++ b/tests/cpp/io/bench_engine.cpp
@@ -63,6 +63,7 @@
 #include <hip/hip_runtime.h>
 #include <signal.h>
 #include <sys/file.h>
+#include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -890,6 +891,27 @@ void WritePerfRecords(const Args& a, const std::vector<SweepResult>& rows) {
     payload << line.str();
   }
 
+  // Create the parent directory if it does not exist, matching Python's
+  // record_perf (os.makedirs(parent, exist_ok=True)). On a clean nightly
+  // workspace MORI_PERF_OUT points at $WORKSPACE/_perf/perf.jsonl and no earlier
+  // step creates _perf, so without this fopen fails and every IO row is silently
+  // dropped from the uploaded perf data. mkdir each path component in turn.
+  const auto slash = out.find_last_of('/');
+  if (slash != std::string::npos && slash > 0) {
+    const std::string dir = out.substr(0, slash);
+    std::string partial;
+    for (size_t i = 0; i < dir.size(); ++i) {
+      partial += dir[i];
+      if (dir[i] == '/' || i + 1 == dir.size()) {
+        if (partial != "/" && ::mkdir(partial.c_str(), 0755) != 0 && errno != EEXIST) {
+          std::fprintf(stderr, "[perf_report] failed to create %s: %s\n", partial.c_str(),
+                       std::strerror(errno));
+          break;
+        }
+      }
+    }
+  }
+
   std::FILE* fh = std::fopen(out.c_str(), "a");
   if (fh == nullptr) {
     std::fprintf(stderr, "[perf_report] failed to open %s: %s\n", out.c_str(),
@@ -1285,7 +1307,11 @@ int RunXgmiSingleProcess(const Args& a) {
 
   std::cout << "XGMI single-process: GPU" << src << " -> GPU" << dst << std::endl;
   std::cout << "MsgSize(B)  Batch  Iters  AvgBW(GB/s)  AvgLat(us)  TotalDur(us)" << std::endl;
-  RunSweep(a, engine, srcBuf.Desc(), dstBuf.Desc(), plan, "");
+  const auto results = RunSweep(a, engine, srcBuf.Desc(), dstBuf.Desc(), plan, "");
+  // Emit perf records here too: this path returns before the distributed writer,
+  // and the equivalent Python XGMI mode records perf. No-op unless MORI_PERF_OUT
+  // is set.
+  WritePerfRecords(a, results);
 
   // Both buffers are local, so the checksums compare directly -- no exchange.
   const auto& last = plan.back();

--- a/tests/cpp/io/bench_engine.cpp
+++ b/tests/cpp/io/bench_engine.cpp
@@ -921,6 +921,11 @@ void WritePerfRecords(const Args& a, const std::vector<SweepResult>& rows) {
   int fd = fileno(fh);
   if (fd >= 0) flock(fd, LOCK_EX);
   std::fputs(payload.str().c_str(), fh);
+  // Flush the FILE* buffer to the fd while the lock is still held. fputs only
+  // fills the stdio buffer; the actual write() can otherwise be deferred to
+  // fclose() below, after the unlock, letting another initiator's payload
+  // interleave mid-line. build_report.py then silently drops the mangled line.
+  std::fflush(fh);
   if (fd >= 0) flock(fd, LOCK_UN);
   std::fclose(fh);
 }
@@ -1242,11 +1247,6 @@ int RunDistributed(const Args& a, int localRank) {
     std::fflush(stdout);
   }
 
-  // Perf report: each initiator appends its own rows (matches the Python bench's
-  // per-rank _emit_io_perf; build_report.py dedups by op/backend/msg/batch).
-  // No-op unless MORI_PERF_OUT is set.
-  if (isInitiator) WritePerfRecords(a, mine);
-
   // Correctness check on the last sweep point, matching the Python benchmark's
   // always-on validation. Runs after the timed region so it cannot perturb the
   // reported numbers.
@@ -1254,6 +1254,24 @@ int RunDistributed(const Args& a, int localRank) {
   const bool valid = ValidateTransfer(rdv, buf, last.first, last.second,
                                       a.enable_batch_transfer && last.second > 1,
                                       a.batch_contiguous, isInitiator, !a.skip_validate, label);
+
+  // Aggregate every rank's validity before publishing perf: allgather the flag
+  // (a world-wide collective, so all ranks call it in the same order) and let
+  // only rank 0 write. Two reasons this is gated on globalRank == 0 AND allValid:
+  //  - one deterministic writer: isInitiator is true in all initiator processes,
+  //    so writing per-initiator appends identical-key rows that build_report.py
+  //    dedups by scheduling order rather than by policy.
+  //  - never publish a failed run: the nightly workflow uploads the JSONL with
+  //    if: always(), so a corrupt-but-completed transfer must not land a row.
+  const char myFlag = valid ? 1 : 0;
+  const auto flags = rdv.AllgatherBlobs(std::string(1, myFlag));
+  bool allValid = true;
+  for (const auto& f : flags)
+    if (f.size() == 1 && f[0] == 0) allValid = false;
+
+  // No-op unless MORI_PERF_OUT is set.
+  if (globalRank == 0 && allValid) WritePerfRecords(a, mine);
+
   return valid ? 0 : 1;
 }
 
@@ -1308,10 +1326,6 @@ int RunXgmiSingleProcess(const Args& a) {
   std::cout << "XGMI single-process: GPU" << src << " -> GPU" << dst << std::endl;
   std::cout << "MsgSize(B)  Batch  Iters  AvgBW(GB/s)  AvgLat(us)  TotalDur(us)" << std::endl;
   const auto results = RunSweep(a, engine, srcBuf.Desc(), dstBuf.Desc(), plan, "");
-  // Emit perf records here too: this path returns before the distributed writer,
-  // and the equivalent Python XGMI mode records perf. No-op unless MORI_PERF_OUT
-  // is set.
-  WritePerfRecords(a, results);
 
   // Both buffers are local, so the checksums compare directly -- no exchange.
   const auto& last = plan.back();
@@ -1321,7 +1335,15 @@ int RunXgmiSingleProcess(const Args& a) {
                                       a.batch_contiguous, wanted);
   const auto peer = TransferChecksums(dstBuf.Data(), last.first, last.second, batched,
                                       a.batch_contiguous, wanted);
-  return CompareChecksums(mine, peer, last.first, last.second, "") ? 0 : 1;
+  const bool valid = CompareChecksums(mine, peer, last.first, last.second, "");
+
+  // Publish perf only after validation succeeds, matching the distributed path:
+  // the nightly workflow uploads the JSONL with if: always(), so a
+  // corrupt-but-completed transfer must not land a row. No-op unless
+  // MORI_PERF_OUT is set.
+  if (valid) WritePerfRecords(a, results);
+
+  return valid ? 0 : 1;
 }
 
 // ------------------------------ main ---------------------------------------

--- a/tools/run_internode_io_benchmark.sh
+++ b/tools/run_internode_io_benchmark.sh
@@ -1,18 +1,30 @@
 #!/bin/bash
-# Run one node of the two-node MORI-IO RDMA benchmark via torchrun.
+# Run one node of the two-node MORI-IO RDMA benchmark.
 #
 # Usage:
 #   run_internode_io_benchmark.sh \
 #     --rank <0|1> \
 #     --master-addr <ip-or-hostname> \
 #     --ifname <nic> \
+#     [--engine <cpp|python>] \
 #     [--master-port <port>] \
 #     [--host <io-engine-host>] \
-#     -- [benchmark.py args...]
+#     -- [benchmark args...]
 #
-# The benchmark args after `--` are forwarded to tests/python/io/benchmark.py.
-# The script always runs the RDMA backend in 2-node mode with nproc_per_node=1.
+# Two benchmark engines are selectable with --engine (default: cpp):
+#   cpp     the native tests/cpp/io/bench_engine binary (default). No Python
+#           interpreter in the measurement loop, so numbers are cleaner and it
+#           is the nixlbench-matching path. Requires the binary to be built
+#           (see MORI_IO_BENCH_ENGINE_BIN below); brought up over MORI's own
+#           socket bootstrap rather than torchrun.
+#   python  the tests/python/io/benchmark.py torchrun path (kept for parity).
+#
+# The benchmark args after `--` are forwarded to the selected engine. Most flag
+# names are shared; the C++ engine additionally accepts the Python spellings as
+# aliases (see docs/MORI-IO-BENCHMARK.md "Differences from the Python flags").
+# The script always runs the RDMA backend in 2-node mode.
 # Timeout can be overridden via MORI_IO_BENCH_TIMEOUT_SEC.
+# The C++ binary path can be overridden via MORI_IO_BENCH_ENGINE_BIN.
 
 set -euo pipefail
 
@@ -22,6 +34,7 @@ MASTER_PORT=1234
 IFNAME=""
 HOST=""
 NUMA_NODE=""
+ENGINE="cpp"
 EXTRA_ARGS=()
 
 while [[ $# -gt 0 ]]; do
@@ -32,10 +45,16 @@ while [[ $# -gt 0 ]]; do
     --ifname)       IFNAME="$2";      shift 2 ;;
     --host)         HOST="$2";        shift 2 ;;
     --numa)         NUMA_NODE="$2";   shift 2 ;;
+    --engine)       ENGINE="$2";      shift 2 ;;
     --)             shift; EXTRA_ARGS=("$@"); break ;;
     *) echo "Unknown option: $1"; exit 1 ;;
   esac
 done
+
+case "$ENGINE" in
+  cpp|python) ;;
+  *) echo "Invalid --engine '$ENGINE' (expected cpp or python)"; exit 1 ;;
+esac
 
 for var in RANK MASTER_ADDR IFNAME; do
   [[ -z "${!var}" ]] && { echo "Missing required argument for --${var,,}"; exit 1; }
@@ -93,13 +112,41 @@ if [[ -n "$NUMA_NODE" ]]; then
   fi
 fi
 
-exec "${NUMACTL[@]}" timeout "$BENCH_TIMEOUT_SEC" torchrun \
-  --nnodes=2 \
-  --node_rank="$RANK" \
-  --nproc_per_node=1 \
-  --master_addr="$MASTER_ADDR" \
-  --master_port="$MASTER_PORT" \
-  -m tests.python.io.benchmark \
+if [[ "$ENGINE" == "python" ]]; then
+  exec "${NUMACTL[@]}" timeout "$BENCH_TIMEOUT_SEC" torchrun \
+    --nnodes=2 \
+    --node_rank="$RANK" \
+    --nproc_per_node=1 \
+    --master_addr="$MASTER_ADDR" \
+    --master_port="$MASTER_PORT" \
+    -m tests.python.io.benchmark \
+    --backend rdma \
+    --host "$HOST" \
+    "${EXTRA_ARGS[@]}"
+fi
+
+# --- C++ engine (default) ---------------------------------------------------
+# The C++ bench brings the two ranks together over MORI's own socket bootstrap
+# (rank 0 is the rendezvous root) instead of torchrun, so the rendezvous args
+# translate: --master-addr -> --master-ip (rank 0's IP, identical on both ranks)
+# and this node's own reachable IP -> --self-ip (advertised in EngineDesc). The
+# base --port is the bootstrap; the engine control planes take --port+1+rank.
+BENCH_BIN="${MORI_IO_BENCH_ENGINE_BIN:-$REPO_ROOT/build/tests/cpp/bench_engine}"
+if [[ ! -x "$BENCH_BIN" ]]; then
+  echo "[run_internode_io_benchmark] ERROR: C++ bench_engine not found at $BENCH_BIN" >&2
+  echo "  build it with: cmake -B build -DBUILD_IO=ON -DBUILD_TESTS=ON &&" \
+       "cmake --build build --target bench_engine -j" >&2
+  echo "  or set MORI_IO_BENCH_ENGINE_BIN, or pass --engine python" >&2
+  exit 1
+fi
+
+# The engine's shared libraries must be discoverable at runtime.
+export LD_LIBRARY_PATH="$REPO_ROOT/build/src/io:$REPO_ROOT/build/src/application${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+exec "${NUMACTL[@]}" timeout "$BENCH_TIMEOUT_SEC" "$BENCH_BIN" \
+  --rank "$RANK" \
+  --master-ip "$MASTER_ADDR" \
+  --self-ip "$HOST" \
+  --port "$MASTER_PORT" \
   --backend rdma \
-  --host "$HOST" \
   "${EXTRA_ARGS[@]}"

--- a/tools/run_internode_io_benchmark.sh
+++ b/tools/run_internode_io_benchmark.sh
@@ -134,14 +134,17 @@ fi
 BENCH_BIN="${MORI_IO_BENCH_ENGINE_BIN:-$REPO_ROOT/build/tests/cpp/bench_engine}"
 if [[ ! -x "$BENCH_BIN" ]]; then
   echo "[run_internode_io_benchmark] ERROR: C++ bench_engine not found at $BENCH_BIN" >&2
-  echo "  build it with: cmake -B build -DBUILD_IO=ON -DBUILD_TESTS=ON &&" \
-       "cmake --build build --target bench_engine -j" >&2
+  echo "  build it with: cmake -B build_bench -DBUILD_IO=ON -DBUILD_TESTS=ON &&" \
+       "cmake --build build_bench --target bench_engine -j" >&2
   echo "  or set MORI_IO_BENCH_ENGINE_BIN, or pass --engine python" >&2
   exit 1
 fi
 
-# The engine's shared libraries must be discoverable at runtime.
-export LD_LIBRARY_PATH="$REPO_ROOT/build/src/io:$REPO_ROOT/build/src/application${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+# The engine's shared libraries must be discoverable at runtime. Derive the build
+# tree from the binary path (tests/cpp/bench_engine -> <build>/src/io etc.) so a
+# custom MORI_IO_BENCH_ENGINE_BIN in a non-default build dir still finds its libs.
+BENCH_BUILD_DIR="$(cd "$(dirname "$BENCH_BIN")/../.." && pwd)"
+export LD_LIBRARY_PATH="$BENCH_BUILD_DIR/src/io:$BENCH_BUILD_DIR/src/application${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
 exec "${NUMACTL[@]}" timeout "$BENCH_TIMEOUT_SEC" "$BENCH_BIN" \
   --rank "$RANK" \


### PR DESCRIPTION
  ## Summary

  Makes the native C++ benchmark (`tests/cpp/io/bench_engine`) the default
  MORI-IO benchmark across the runner, CI, and docs, while keeping the Python
  benchmark (`tests/python/io/benchmark.py`) available for parity. The C++ path
  has no Python interpreter in the measurement loop and matches nixlbench timing,
  so numbers are cleaner and directly comparable to NIXL.

  ## What changed

  ### Engine (code)
  - **bench_engine emits perf records.** `bench_engine` now appends one JSON line
    per sweep point to `$MORI_PERF_OUT`, in the exact schema
    `tests/python/perf_report.py` writes, so the C++ and Python benches feed the
    one report pipeline (`tools/perf/build_report.py`). It captures per-iteration
    timing to report the Python bench's per-iteration metrics (avg/max bandwidth,
    avg/min latency) alongside the nixl whole-loop figure. No-op unless
    `MORI_PERF_OUT` is set; initiator-only; `flock`-appended.
  - **Runner engine switch.** `tools/run_internode_io_benchmark.sh` takes
    `--engine cpp|python` (default `cpp`). The cpp path locates the built binary,
    sets `LD_LIBRARY_PATH`, and translates the torchrun rendezvous args
    (`--master-addr`/`--host`) to the C++ socket-bootstrap args
    (`--master-ip`/`--self-ip`). The python torchrun path is unchanged.

  ### CI
  - **ci.yml**: builds `bench_engine` on both nodes before the internode IO steps.
    The IO steps already call the runner with no `--engine`, so they switch to C++
    automatically.
  - **nightly.yml**: same build step; drops the now-redundant standalone C++ bench
    step -- the write-sweep step covers it via the runner and emits perf records
    through the existing `MORI_PERF_OUT` wiring. The read smoke step keeps
    `MORI_PERF_OUT` cleared.
  ### Docs
  - `docs/MORI-IO-BENCHMARK.md` now leads with the C++ benchmark and keeps Python
    as the parity alternative; adds a "Which benchmark to use" section. The Fabric
    (UALink super-node) section is preserved and noted as also supported by C++.
  - `README.md` and `docs/MORI-IO-GUIDE.md` point at the C++ default.

  ## Validation
  
  Verified on a two-node MI308X / ionic (AINIC) cluster:
  - C++ and Python benches produce matching bandwidth across a 1--8 MiB GPU write
    sweep; C++ ~10-20% faster; byte-exact validation on both.
  - The emitted C++ perf JSONL renders correctly through `build_report.py`.
  - Both runner paths (`--engine cpp` default and `--engine python`) run two-node.
