### PR TITLE
perf(ep): [WIP] optimize intranode dispatch with load-once-write-many

### DIFF
--- a/python/mori/ops/dispatch_combine.py
+++ b/python/mori/ops/dispatch_combine.py
@@ -423,12 +423,15 @@ class EpDispatchCombineOp:
         return self._hip_module.get_function(name)
 
     def _dispatch_shared_mem(self, warp_per_block):
-        """Shared memory for dispatch kernels (worldSize + numExpertPerRank per warp + numExpertPerRank) * sizeof(index_t)."""
-        return (
+        """Shared memory for dispatch kernels."""
+        routing_bytes = (
             self.config.world_size * warp_per_block
             + self.config.num_experts_per_rank * warp_per_block
             + self.config.num_experts_per_rank
         ) * 4  # sizeof(index_t)
+        # dest pointer array for load-once-write-many: 8 pointers per warp
+        dest_ptr_bytes = warp_per_block * 8 * 8  # kMaxGpusPerNode * sizeof(T*)
+        return max(routing_bytes, dest_ptr_bytes)
 
     def _combine_shared_mem(self, warp_per_block, use_weights=True):
         """Shared memory for combine kernels."""

--- a/src/ops/dispatch_combine/intranode.hpp
+++ b/src/ops/dispatch_combine/intranode.hpp
@@ -97,6 +97,7 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   int myPe = config.rank;
   int npes = config.worldSize;
   size_t hiddenDim = config.HiddenDimSz();
+  const int topK = config.numExpertPerToken;
 
   IF_ENABLE_PROFILER(
       INTRANODE_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
@@ -104,107 +105,134 @@ __device__ void EpDispatchIntraNodeKernel_body(EpDispatchCombineArgs<T> args) {
   MORI_TRACE_NEXT(seq, Slot::DispatchSendTokens);
 
   if (args.tokenIndices && args.inpTokenBuf) {
-    // Phase1: send token
-    // Each warp compute token offset on destinition PE
-    for (int i = globalWarpId; i < args.curRankNumToken * config.numExpertPerToken;
-         i += globalWarpNum) {
-      index_t srcTokId = i / config.numExpertPerToken;
-      index_t destPe;
-      index_t destTokId = 0;
+    // Iterate per source token (not per token×expert) to enable load-once-write-many.
+    // For each token, collect all unique destination PEs via lane-based dedup,
+    // write metadata, then load the token payload from HBM once and broadcast
+    // to all destinations via XGMI.
+    extern __shared__ char sharedMem[];
+    T** warpDestPtrs = reinterpret_cast<T**>(sharedMem) + warpId * kMaxGpusPerNode;
+
+    for (int srcTokId = globalWarpId; srcTokId < args.curRankNumToken; srcTokId += globalWarpNum) {
+      int numDests = 0;
+      T* dstPtrReg = nullptr;
 
       if (!args.replayMode) {
-        // Cache routing: decide where this (token, top-k) pair goes via
-        // atomicAdd-based slot assignment. Records the routing into dispDestTokIdMap
-        // (and the symmetric local view via dispTokIdToSrcTokIdMemObj on the
-        // destination PE) so a later replay-routing dispatch / combine can reuse
-        // the same layout deterministically.
-        index_t destExpert = args.tokenIndices[i];
-        // Routing sentinel: a negative expert id means "drop this top-k slot".
-        // Skip the dispatch entirely and write the existing combine-side null sentinel
-        // (PE == worldSize) into dispDestTokIdMap so combine treats this slot as nullptr.
-        if (destExpert < 0) {
-          if (laneId == 0) args.dispDestTokIdMap[i] = FlatTokenIndex(config, config.worldSize, 0);
-          continue;
-        }
-        destPe = destExpert / config.numExpertPerRank;
-        // Out-of-range expert id guard: destPe is warp-uniform here (one
-        // token-expert per warp) and indexes GetAs(destPe) / destPeTokenCounter
-        // below. An out-of-range id (e.g. an EPLB physical id
-        // >= worldSize*numExpertPerRank) would index those out of bounds (the
-        // assert at dispatch is stripped under NDEBUG) -> HSA page fault. Drop it
-        // via the same overflow sentinel the dedup path uses; the whole warp
-        // skips coherently.
-        if (destPe < 0 || destPe >= config.worldSize) {
-          if (laneId == 0) args.dispDestTokIdMap[i] = FlatTokenIndex(config, config.worldSize, 0);
-          continue;
+        // Expert-slot lanes compute target PE
+        int warpTargetPe = -1;
+        if (laneId < topK) {
+          index_t expertId = args.tokenIndices[srcTokId * topK + laneId];
+          if (expertId >= 0) {
+            int pe = expertId / config.numExpertPerRank;
+            if (pe >= 0 && pe < npes) warpTargetPe = pe;
+          }
         }
 
-        // Deduplicate
-        assert(config.numExpertPerToken < warpSize);
-        int condition = 0;
-        if (laneId < (i % config.numExpertPerToken)) {
-          index_t otherExpert = args.tokenIndices[srcTokId * config.numExpertPerToken + laneId];
-          condition = (otherExpert >= 0) && (destPe == (otherExpert / config.numExpertPerRank));
-        }
-        if (__any(condition)) {
-          // Indicate that this token is already sent to the destination PE by setting an overflow
-          // token index
-          if (laneId == 0) args.dispDestTokIdMap[i] = FlatTokenIndex(config, config.worldSize, 0);
-          continue;
+        // PE-indexed dedup via readlane: each PE lane scans all expert slots
+        int expertSlotForMe = -1;
+        if (laneId < npes) {
+#pragma unroll
+          for (int k = 0; k < kMaxGpusPerNode; ++k) {
+            if (k < topK) {
+              int pe_k = __builtin_amdgcn_readlane(warpTargetPe, k);
+              if (pe_k == laneId) expertSlotForMe = k;
+            }
+          }
         }
 
-        if (laneId == 0) {
-          // decide token id in dest pe
-          destTokId = atomicAdd(args.dispTokOffsetMemObj->template GetAs<index_t*>(destPe), 1);
-          assert(destTokId < config.MaxNumTokensToRecv() &&
+        // PE lanes that matched allocate recv slots
+        int didAlloc = (laneId < npes && expertSlotForMe >= 0) ? 1 : 0;
+        index_t warpDestTokId = 0;
+        if (didAlloc) {
+          warpDestTokId = atomicAdd(
+              args.dispTokOffsetMemObj->template GetAs<index_t*>(laneId), 1);
+          assert(warpDestTokId < config.MaxNumTokensToRecv() &&
                  "Total recv token overflow: increase maxTotalRecvTokens");
-          atomicAdd(args.destPeTokenCounter + destPe, 1);
-          // In dispDestTokIdMap, record the destination slot for this token-expert pair (flat index
-          // into the dest PE's recv buffer) In dispTokIdToSrcTokIdMemObj on the dest PE, record
-          // which global source token occupies this slot (for combine-phase routing)
-          args.dispDestTokIdMap[i] = FlatTokenIndex(config, destPe, destTokId);
-          args.dispTokIdToSrcTokIdMemObj->template GetAs<index_t*>(destPe)[destTokId] =
+          atomicAdd(args.destPeTokenCounter + laneId, 1);
+          args.dispTokIdToSrcTokIdMemObj->template GetAs<index_t*>(laneId)[warpDestTokId] =
               FlatTokenIndex(config, myPe, srcTokId);
         }
-        destTokId = __shfl(destTokId, 0);
-      } else {
-        // Replay routing: caller already supplied a populated dispDestTokIdMap
-        // from a matching cache-routing dispatch. Recover (destPe, destTokId) directly
-        // and skip CAS / dedup / cross-rank src-id writes. The sentinel slot
-        // (destPe == worldSize) means the original cache-routing dispatch dropped or deduped
-        // this top-k slot, so we skip transmitting payload as well.
-        index_t flat = args.dispDestTokIdMap[i];
-        destPe = PeFromFlatTokenIndex(config, flat);
-        if (destPe >= config.worldSize) continue;
-        destTokId = LocalTokIdFromFlatTokenIndex(config, flat);
-      }
 
-      // Write weights and indices
-      if (laneId < config.numExpertPerToken) {
-        if (args.weightsBuf) {
-          args.shmemDispatchOutWeightsMemObj->template GetAs<float*>(
-              destPe)[destTokId * config.numExpertPerToken + laneId] =
-              args.weightsBuf[srcTokId * config.numExpertPerToken + laneId];
+        // Write dispDestTokIdMap: null sentinel for all, then valid entries
+        if (laneId < topK) {
+          args.dispDestTokIdMap[srcTokId * topK + laneId] =
+              FlatTokenIndex(config, npes, 0);
         }
-        args.shmemOutIndicesMemObj->template GetAs<index_t*>(
-            destPe)[destTokId * config.numExpertPerToken + laneId] =
-            args.tokenIndices[srcTokId * config.numExpertPerToken + laneId];
+        if (didAlloc) {
+          args.dispDestTokIdMap[srcTokId * topK + expertSlotForMe] =
+              FlatTokenIndex(config, laneId, warpDestTokId);
+        }
+
+        // Compact dest pointers via shared memory
+        unsigned long long activeMask = __ballot(didAlloc);
+        numDests = __popcll(activeMask);
+
+        if (didAlloc) {
+          int compactPos = __popcll(activeMask & ((1ULL << laneId) - 1));
+          warpDestPtrs[compactPos] =
+              args.intraNodeTokBufs.dispatchOut->template GetAs<T*>(laneId) +
+              warpDestTokId * hiddenDim;
+
+          // Write metadata: weights + indices per destination
+          index_t* indicesOut = args.shmemOutIndicesMemObj->template GetAs<index_t*>(laneId);
+          for (int k = 0; k < topK; ++k) {
+            indicesOut[warpDestTokId * topK + k] = args.tokenIndices[srcTokId * topK + k];
+          }
+          if (args.weightsBuf) {
+            float* weightsOut =
+                args.shmemDispatchOutWeightsMemObj->template GetAs<float*>(laneId);
+            for (int k = 0; k < topK; ++k) {
+              weightsOut[warpDestTokId * topK + k] = args.weightsBuf[srcTokId * topK + k];
+            }
+          }
+          // Write scales
+          if (args.scalesBuf && (config.scaleDim > 0) && (config.scaleTypeSize > 0)) {
+            size_t destScaleOffset =
+                (size_t)warpDestTokId * config.scaleDim * config.scaleTypeSize;
+            size_t srcScaleOffset =
+                (size_t)srcTokId * config.scaleDim * config.scaleTypeSize;
+            // Per-lane scale copy (only active PE lanes participate, not full warp)
+            uint8_t* dstScale =
+                args.shmemOutScalesMemObj->template GetAs<uint8_t*>(laneId) + destScaleOffset;
+            const uint8_t* srcScale = args.scalesBuf + srcScaleOffset;
+            size_t scaleSize = config.scaleDim * config.scaleTypeSize;
+            for (size_t s = 0; s < scaleSize; ++s) {
+              dstScale[s] = srcScale[s];
+            }
+          }
+        }
+        __syncwarp();
+
+        if (laneId < numDests) dstPtrReg = warpDestPtrs[laneId];
+
+      } else {
+        // Replay mode: recover routing from dispDestTokIdMap
+        int destPe = npes;
+        index_t destTokId = 0;
+        if (laneId < topK) {
+          index_t flat = args.dispDestTokIdMap[srcTokId * topK + laneId];
+          destPe = PeFromFlatTokenIndex(config, flat);
+          destTokId = LocalTokIdFromFlatTokenIndex(config, flat);
+        }
+        int isValid = (laneId < topK && destPe >= 0 && destPe < npes) ? 1 : 0;
+        unsigned long long validMask = __ballot(isValid);
+        numDests = __popcll(validMask);
+
+        if (isValid) {
+          int compactPos = __popcll(validMask & ((1ULL << laneId) - 1));
+          warpDestPtrs[compactPos] =
+              args.intraNodeTokBufs.dispatchOut->template GetAs<T*>(destPe) +
+              destTokId * hiddenDim;
+        }
+        __syncwarp();
+
+        if (laneId < numDests) dstPtrReg = warpDestPtrs[laneId];
       }
 
-      // Write scales
-      if (args.scalesBuf && (config.scaleDim > 0) && (config.scaleTypeSize > 0)) {
-        size_t destScaleOffset = (size_t)destTokId * config.scaleDim * config.scaleTypeSize;
-        size_t srcScaleOffset = (size_t)srcTokId * config.scaleDim * config.scaleTypeSize;
-        core::WarpCopy(
-            args.shmemOutScalesMemObj->template GetAs<uint8_t*>(destPe) + destScaleOffset,
-            args.scalesBuf + srcScaleOffset, config.scaleDim * config.scaleTypeSize);
+      // Load token payload from HBM ONCE, write to all destinations via XGMI
+      if (numDests > 0) {
+        WarpLoadBroadcastStore<T>(dstPtrReg, numDests,
+                                  args.inpTokenBuf + srcTokId * hiddenDim, hiddenDim);
       }
-
-      size_t srcTokOffset = srcTokId * hiddenDim;
-      size_t destTokOffset = destTokId * hiddenDim;
-
-      core::WarpCopy(args.intraNodeTokBufs.dispatchOut->template GetAs<T*>(destPe) + destTokOffset,
-                     args.inpTokenBuf + srcTokOffset, hiddenDim);
     }
   }
   __syncthreads();

--- a/src/ops/kernels/ep_common.hip
+++ b/src/ops/kernels/ep_common.hip
@@ -17,8 +17,8 @@
 #include "src/ops/dispatch_combine/common.hpp"
 #include "src/ops/dispatch_combine/convert.hpp"
 #include "src/ops/dispatch_combine/internode.hpp"
-#include "src/ops/dispatch_combine/intranode.hpp"
 #include "src/ops/dispatch_combine/intranode_ll.hpp"
+#include "src/ops/dispatch_combine/intranode.hpp"
 
 #define MORI_JIT_GENCO
 #include "src/ops/dispatch_combine/internode_v1.cpp"


### PR DESCRIPTION
## Motivation

The IntraNode V1 dispatch kernel (`EpDispatchIntraNodeKernel`) has a ~20-30% bandwidth gap with the combine kernel on MI350X. The root cause is HBM read amplification: when a token is routed to N destination PEs, the kernel reads the token payload from HBM N times (once per `core::WarpCopy` to each destination). The combine kernel reads once and accumulates, avoiding this overhead.

The IntraNodeLL kernel already solves this with a load-once-write-many pattern (`WarpLoadBroadcastStore`), but production workloads (ATOM) use the V1 IntraNode kernel.

## Changes

Restructure `EpDispatchIntraNodeKernel_body` in `intranode.hpp`:

- **Per-token iteration** instead of per-(token,expert): each warp now handles one source token and collects all unique destination PEs before copying
- **Lane-based PE dedup** via `readlane` scan (same approach as the LL kernel): expert-slot lanes compute target PE, PE-indexed lanes check for matches and allocate recv slots
- **Load-once-write-many** for token payload: uses `WarpLoadBroadcastStore` from the LL kernel — loads `hiddenDim` elements from HBM into registers once, then writes to all destination PEs via XGMI
- **Shared memory** for dest pointer compaction: each warp uses 64 bytes of shared memory (8 pointers) to compact sparse PE destinations into contiguous lanes

Supporting changes:
- `ep_common.hip`: reorder includes so `intranode_ll.hpp` precedes `intranode.hpp` (V1 kernel now uses LL helper functions)
- `dispatch_combine.py`: update `_dispatch_shared_mem` to allocate space for per-warp dest pointer array

## Validation

Correctness: `test_dispatch_combine_intranode.py` — 317 passed, 528 skipped (fp8_fnuz unsupported on gfx950), 0 failed.

Performance (MI350X gfx950, 256 CUs, bf16, EP8, hdim=7168, DeepSeek V3 config):

| Tokens | Before (GB/s) | After (GB/s) | Dispatch Gain | Gap vs Combine |
|--------|---------------|--------------|---------------|----------------|
| 1 | 2.10 | 3.88 | +84.8% | +0.3% (parity) |
| 4 | 9.05 | 14.82 | +63.8% | -17.5% |
| 16 | 35.88 | 49.78 | +38.7% | -17.9% |
| 64 | 117.88 | 143.67 | +21.9% | -0.4% (parity) |
| 256 | 219.41 | 238.69 | +8.8% | -0.5% (parity) |
| 1024 | 294.86 | 286.14 | -3.0% | -0.0% (parity) |
| 4096 | 337.16 | 364.45 | +8.1% | +0.1% (parity) |

Dispatch-combine bandwidth gap closed from 20-85% to 0-18% across all token counts. Largest gains at small token counts (decode regime): +85% at 1 token, +64% at 4 tokens.