### PR TITLE
feat(umbp): GPU Direct Storage (hipfile) SSD-to-GPU read path

### DIFF
--- a/src/umbp/CMakeLists.txt
+++ b/src/umbp/CMakeLists.txt
@@ -431,6 +431,20 @@ target_link_libraries(
 
 target_compile_features(umbp_common PUBLIC cxx_std_17)
 
+# ---------- Optional hipfile GDS transfer engine -----------------------------
+# GdsEngine reads an SSD segment's byte range straight into GPU memory via
+# hipFileRead (no host bounce). Auto-enabled when hipfile is installed; a build
+# without it keeps only the memory engines and the host-staged SSD path.
+find_package(hipfile QUIET CONFIG GLOBAL)
+if(TARGET hip::hipfile)
+  message(STATUS "[UMBP] hipfile found — GDS transfer engine ENABLED")
+  target_sources(umbp_common PRIVATE distributed/transfer/gds_engine.cpp)
+  target_link_libraries(umbp_common PUBLIC hip::hipfile)
+  target_compile_definitions(umbp_common PUBLIC UMBP_ENABLE_GDS)
+else()
+  message(STATUS "[UMBP] hipfile not found — GDS transfer engine disabled")
+endif()
+
 # ---------- Optional Redis / RESP master metadata backend --------------------
 # Makes the master stateless by storing all metadata in an external RESP store
 # (Redis / Dragonfly / Valkey). OFF by default so existing builds are

--- a/src/umbp/distributed/peer/backend/instrumented_backend.cpp
+++ b/src/umbp/distributed/peer/backend/instrumented_backend.cpp
@@ -158,12 +158,13 @@ std::vector<bool> InstrumentedBackend::BatchAbort(const std::vector<uint64_t>& s
 }
 
 std::vector<ResolvedEntry> InstrumentedBackend::BatchResolve(const std::vector<std::string>& keys,
-                                                             bool include_descs) {
+                                                             bool include_descs,
+                                                             bool allow_file_refs) {
   ops_[kResolve].batches.fetch_add(1, std::memory_order_relaxed);
   std::vector<ResolvedEntry> out;
   {
     ScopedNanos timer(ops_[kResolve].nanos);
-    out = inner_->BatchResolve(keys, include_descs);
+    out = inner_->BatchResolve(keys, include_descs, allow_file_refs);
   }
   uint64_t bytes = 0;
   for (const ResolvedEntry& r : out) {

--- a/src/umbp/distributed/peer/backend/page_backend.cpp
+++ b/src/umbp/distributed/peer/backend/page_backend.cpp
@@ -489,7 +489,8 @@ ResolvedEntry PageBackend::Resolve(const std::string& key) {
 }
 
 std::vector<ResolvedEntry> PageBackend::BatchResolve(const std::vector<std::string>& keys,
-                                                     bool include_descs) {
+                                                     bool include_descs, bool allow_file_refs) {
+  (void)allow_file_refs;  // pages are this medium's storage; there is no file to name
   std::vector<ResolvedEntry> out(keys.size());
   if (keys.empty()) return out;
   std::lock_guard<std::mutex> lock(mutex_);

--- a/src/umbp/distributed/peer/backend/ssd_backend.cpp
+++ b/src/umbp/distributed/peer/backend/ssd_backend.cpp
@@ -138,6 +138,17 @@ void SsdBackend::Shutdown() {
   buffer_ref_ = TransferRef{};
   buffer_desc_.clear();
 
+  // Release the GDS file handles obtained lazily during resolves.
+  {
+    std::lock_guard<std::mutex> lock(gds_mutex_);
+    if (registrar_ != nullptr) {
+      for (auto& [fd, handle] : gds_handles_) {
+        if (handle != nullptr) registrar_->Deregister(TransferRef::File(fd, 0, 0, handle));
+      }
+    }
+    gds_handles_.clear();
+  }
+
   // Deregister before release, same ordering rule as PageBackend::Shutdown.
   if (staging_source_ != nullptr) staging_source_->Release();
   staging_source_.reset();
@@ -252,6 +263,18 @@ void SsdBackend::ClearLocal() {
     unshipped_events_ = 0;
   }
   for (const auto& key : migration_keys) ssd_->UnpinForMigration(key);
+  // The SSD wipe below can close and reopen segment fds, so drop the cached GDS
+  // handles (they are re-registered lazily on the next resolve) rather than risk
+  // a stale handle if an fd number is later reused.
+  {
+    std::lock_guard<std::mutex> lock(gds_mutex_);
+    if (registrar_ != nullptr) {
+      for (auto& [fd, handle] : gds_handles_) {
+        if (handle != nullptr) registrar_->Deregister(TransferRef::File(fd, 0, 0, handle));
+      }
+    }
+    gds_handles_.clear();
+  }
   clear_full_sync_pending_.store(true, std::memory_order_release);
   ssd_->ClearLocal();
 }
@@ -484,6 +507,21 @@ std::vector<ResolvedEntry> SsdBackend::BatchResolve(const std::vector<std::strin
         continue;
       }
 
+      // Zero-copy GDS: when a file engine is configured and the record sits on
+      // an O_DIRECT fd, publish a FileRef and skip the staging arena entirely —
+      // the reader (GdsEngine) DMAs the range straight into device memory.
+      if (auto loc = ssd_->LocateRecord(keys[i]); loc && loc->direct_io && loc->fd >= 0) {
+        if (void* handle = GdsHandleForFd(loc->fd)) {
+          results[i].outcome = ResolveOutcome::kFound;
+          results[i].found = true;
+          results[i].size = loc->value_size;
+          results[i].page_size = cfg_.page_size;
+          results[i].file_ref =
+              TransferRef::File(loc->fd, loc->value_offset, loc->readable_size, handle);
+          continue;
+        }
+      }
+
       const uint64_t size = ssd_->SizeOf(keys[i]);
       const uint32_t page_count = SizeToPages(size, cfg_.page_size);
       if (size == 0) continue;
@@ -675,6 +713,22 @@ std::vector<BufferMemoryDescBytes> SsdBackend::AllBufferDescs() const {
 TransferRef SsdBackend::BufferRef(uint32_t buffer_index) const {
   if (buffer_index != kStagingBufferIndex) return TransferRef{};
   return buffer_ref_;
+}
+
+void* SsdBackend::GdsHandleForFd(int fd) {
+  std::lock_guard<std::mutex> lock(gds_mutex_);
+  auto it = gds_handles_.find(fd);
+  if (it != gds_handles_.end()) return it->second;  // cached, possibly nullptr
+  // A zero-length RegisterFile just obtains (and ref-counts) the fd's handle;
+  // the per-key ranges are built by BatchResolve.  An invalid ref means no file
+  // engine is configured — cache nullptr so the fd is not probed again.
+  void* handle = nullptr;
+  if (registrar_ != nullptr) {
+    TransferRef ref = registrar_->RegisterFile(fd, 0, 0);
+    if (ref.IsFile()) handle = ref.gds_handle;
+  }
+  gds_handles_[fd] = handle;
+  return handle;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/umbp/distributed/peer/backend/ssd_backend.cpp
+++ b/src/umbp/distributed/peer/backend/ssd_backend.cpp
@@ -74,6 +74,14 @@ bool SsdBackend::Init(MemoryRegistrar* registrar) {
 
   registrar_ = registrar;
 
+  // Runtime kill-switch for the file->GPU (GDS) read path.  On by default when
+  // the build has hipfile; UMBP_ENABLE_GDS=0 forces every SSD read back onto the
+  // staging arena without a rebuild (for A/B against GDS, or as a safety valve).
+  if (const char* env = std::getenv("UMBP_ENABLE_GDS")) {
+    const std::string v(env);
+    gds_enabled_ = !(v == "0" || v == "false" || v == "FALSE");
+  }
+
   // ONE buffer covering every staging page, so each page is contiguous and a
   // single registration serves the arena.  Host memory deliberately: this is
   // what the backend publishes, and publishing ordinary registered DRAM is the
@@ -507,10 +515,11 @@ std::vector<ResolvedEntry> SsdBackend::BatchResolve(const std::vector<std::strin
         continue;
       }
 
-      // Zero-copy GDS: when a file engine is configured and the record sits on
-      // an O_DIRECT fd, publish a FileRef and skip the staging arena entirely —
-      // the reader (GdsEngine) DMAs the range straight into device memory.
-      if (auto loc = ssd_->LocateRecord(keys[i]); loc && loc->direct_io && loc->fd >= 0) {
+      // Zero-copy GDS (UMBP_ENABLE_GDS): when enabled, a file engine is present,
+      // and the record is on an O_DIRECT fd, publish a FileRef and skip the
+      // staging arena — the reader (GdsEngine) DMAs the range into device memory.
+      std::optional<RecordLocation> loc;
+      if (gds_enabled_ && (loc = ssd_->LocateRecord(keys[i])) && loc->direct_io && loc->fd >= 0) {
         if (void* handle = GdsHandleForFd(loc->fd)) {
           results[i].outcome = ResolveOutcome::kFound;
           results[i].found = true;

--- a/src/umbp/distributed/peer/backend/ssd_backend.cpp
+++ b/src/umbp/distributed/peer/backend/ssd_backend.cpp
@@ -74,12 +74,12 @@ bool SsdBackend::Init(MemoryRegistrar* registrar) {
 
   registrar_ = registrar;
 
-  // Runtime kill-switch for the file->GPU (GDS) read path.  On by default when
-  // the build has hipfile; UMBP_ENABLE_GDS=0 forces every SSD read back onto the
-  // staging arena without a rebuild (for A/B against GDS, or as a safety valve).
+  // Opt-in switch for the file->GPU (GDS) read path.  Off by default even when
+  // the build has hipfile; set UMBP_ENABLE_GDS=1 to route O_DIRECT SSD reads
+  // through the GdsEngine instead of the staging arena (no rebuild needed).
   if (const char* env = std::getenv("UMBP_ENABLE_GDS")) {
     const std::string v(env);
-    gds_enabled_ = !(v == "0" || v == "false" || v == "FALSE");
+    gds_enabled_ = (v == "1" || v == "true" || v == "TRUE" || v == "on" || v == "ON");
   }
 
   // ONE buffer covering every staging page, so each page is contiguous and a

--- a/src/umbp/distributed/peer/backend/ssd_backend.cpp
+++ b/src/umbp/distributed/peer/backend/ssd_backend.cpp
@@ -461,7 +461,7 @@ std::vector<bool> SsdBackend::BatchAbort(const std::vector<uint64_t>& slot_ids) 
 }
 
 std::vector<ResolvedEntry> SsdBackend::BatchResolve(const std::vector<std::string>& keys,
-                                                    bool include_descs) {
+                                                    bool include_descs, bool allow_file_refs) {
   std::vector<ResolvedEntry> results(keys.size());
   if (keys.empty()) return results;
   const auto now = std::chrono::steady_clock::now();
@@ -515,11 +515,19 @@ std::vector<ResolvedEntry> SsdBackend::BatchResolve(const std::vector<std::strin
         continue;
       }
 
-      // Zero-copy GDS (UMBP_ENABLE_GDS): when enabled, a file engine is present,
-      // and the record is on an O_DIRECT fd, publish a FileRef and skip the
-      // staging arena — the reader (GdsEngine) DMAs the range into device memory.
+      // Zero-copy GDS (UMBP_ENABLE_GDS): when the caller can read a file ref,
+      // the switch is on, a file engine is present, and the record is on an
+      // O_DIRECT fd, publish a FileRef and skip the staging arena — the reader
+      // (GdsEngine) DMAs the range into device memory.
+      //
+      // allow_file_refs is tested FIRST on purpose.  A caller that cannot use a
+      // file ref — a peer serving the wire, or an existence check reading only
+      // `found` — must fall through to the staging path and get real pages, and
+      // testing it first also spares it LocateRecord and the hipFile
+      // registration GdsHandleForFd performs as a side effect.
       std::optional<RecordLocation> loc;
-      if (gds_enabled_ && (loc = ssd_->LocateRecord(keys[i])) && loc->direct_io && loc->fd >= 0) {
+      if (allow_file_refs && gds_enabled_ && (loc = ssd_->LocateRecord(keys[i])) &&
+          loc->direct_io && loc->fd >= 0) {
         if (void* handle = GdsHandleForFd(loc->fd)) {
           results[i].outcome = ResolveOutcome::kFound;
           results[i].found = true;

--- a/src/umbp/distributed/peer/ssd/peer_ssd_manager.cpp
+++ b/src/umbp/distributed/peer/ssd/peer_ssd_manager.cpp
@@ -151,6 +151,15 @@ void PeerSsdManager::UnpinForMigration(const std::string& key) {
   if (inflight_reads_.empty()) reads_drained_cv_.notify_all();
 }
 
+std::optional<RecordLocation> PeerSsdManager::LocateRecord(const std::string& key) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (backend_ == nullptr) return std::nullopt;
+  // A key mid-eviction is a miss, exactly as PrepareRead treats it.
+  if (evicting_.count(key) != 0) return std::nullopt;
+  if (owned_.find(key) == owned_.end()) return std::nullopt;
+  return backend_->LocateRecord(key);
+}
+
 void PeerSsdManager::TouchLocked(const std::string& key) {
   auto it = owned_.find(key);
   if (it == owned_.end()) return;

--- a/src/umbp/distributed/pool/peer_pool.cpp
+++ b/src/umbp/distributed/pool/peer_pool.cpp
@@ -563,7 +563,7 @@ std::vector<bool> PeerPool::BatchAbort(const std::vector<PoolSlotRef>& slots) {
 }
 
 std::vector<PoolResolvedEntry> PeerPool::BatchResolve(const std::vector<std::string>& keys,
-                                                      bool include_descs) {
+                                                      bool include_descs, bool allow_file_refs) {
   std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
   std::vector<PoolResolvedEntry> out(keys.size());
   if (keys.empty()) return out;
@@ -599,7 +599,7 @@ std::vector<PoolResolvedEntry> PeerPool::BatchResolve(const std::vector<std::str
     }
   }
   if (direct_backend != nullptr) {
-    auto resolved = direct_backend->BatchResolve(keys, include_descs);
+    auto resolved = direct_backend->BatchResolve(keys, include_descs, allow_file_refs);
     bool batch_busy = false;
     bool all_found = resolved.size() == keys.size();
     std::vector<bool> failed_but_owned(keys.size(), false);
@@ -661,7 +661,8 @@ std::vector<PoolResolvedEntry> PeerPool::BatchResolve(const std::vector<std::str
       attempted[index] |= static_cast<uint16_t>(1u << backend_id);
       if (!identity) backend_keys.push_back(keys[index]);
     }
-    auto results = backend->BatchResolve(identity ? keys : backend_keys, include_descs);
+    auto results =
+        backend->BatchResolve(identity ? keys : backend_keys, include_descs, allow_file_refs);
     for (size_t i = 0; i < indices.size() && i < results.size(); ++i) {
       const size_t index = indices[i];
       const ResolveOutcome outcome = EffectiveResolveOutcome(results[i]);

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -1429,8 +1429,17 @@ PoolClient::GetAttemptOutcome PoolClient::ExecuteLocalGet(const std::string& key
       return GetAttemptOutcome::kRetry;
     }
     std::vector<TransferItem> items;
-    if (!BuildLocalPageTransfers(backend, resolved.pages, resolved.page_size, dst, size,
-                                 /*to_backend=*/false, &items)) {
+    if (resolved.file_ref.IsFile()) {
+      // Zero-copy GDS path: the backend published a file range, not a staged
+      // host page.  Read it straight into the caller's (device) buffer; the
+      // planner routes the (file, GPU) pair to GdsEngine.
+      TransferItem item;
+      item.src = resolved.file_ref;
+      item.dst = ClassifiedUserBytes(dst, size);
+      item.size = size;
+      items.push_back(std::move(item));
+    } else if (!BuildLocalPageTransfers(backend, resolved.pages, resolved.page_size, dst, size,
+                                        /*to_backend=*/false, &items)) {
       // This medium holds the key but cannot be read in-process (no published
       // endpoint for its buffers).  Route elsewhere rather than reporting a
       // miss, which would make the client exclude a node that does hold it.

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -63,6 +63,9 @@
 #include "umbp/distributed/transfer/hbm_copy_engine.h"
 #include "umbp/distributed/transfer/local_copy_engine.h"
 #include "umbp/distributed/transfer/mori_io_engine.h"
+#ifdef UMBP_ENABLE_GDS
+#include "umbp/distributed/transfer/gds_engine.h"
+#endif
 #include "umbp_peer.grpc.pb.h"
 
 namespace mori::umbp {
@@ -845,6 +848,12 @@ bool PoolClient::Init() {
   // call: everything that moves bytes still goes through transfer_engine_.
   hbm_engine_ = hbm.get();
   composite->AddEngine(std::move(hbm));
+#ifdef UMBP_ENABLE_GDS
+  // The file->GPU engine for SsdBackend's FileRefs.  It claims only (file,
+  // device) pairs, which no memory engine touches, so registration order is
+  // documentation.  Present only when the build found hipfile.
+  composite->AddEngine(std::make_unique<GdsEngine>());
+#endif
   if (!config_.io_engine.host.empty()) {
     mori::io::IOEngineConfig io_cfg;
     io_cfg.host = config_.io_engine.host;

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -520,13 +520,14 @@ inline std::chrono::milliseconds ResolveBusyRetryTimeout() {
 
 std::vector<PoolResolvedEntry> ResolveLocalBatchWithBusyRetry(PeerPool* pool,
                                                               const std::vector<std::string>& keys,
-                                                              bool include_descs) {
+                                                              bool include_descs,
+                                                              bool allow_file_refs) {
   if (pool == nullptr) return std::vector<PoolResolvedEntry>(keys.size());
   const auto deadline = std::chrono::steady_clock::now() + ResolveBusyRetryTimeout();
   std::chrono::milliseconds backoff{1};
   size_t attempts = 0;
   while (true) {
-    auto resolved = pool->BatchResolve(keys, include_descs);
+    auto resolved = pool->BatchResolve(keys, include_descs, allow_file_refs);
     const bool busy = std::any_of(resolved.begin(), resolved.end(), [](const auto& entry) {
       return EffectiveResolveOutcome(entry.resolved) == ResolveOutcome::kBusy;
     });
@@ -557,6 +558,13 @@ TransferRef ClassifiedUserBytes(void* ptr, uint64_t size) {
   const PointerLocation location = DetectPointerLocation(ptr);
   if (!location.IsDevice()) return TransferRef::HostBytes(ptr, size);
   return TransferRef::HostBytes(ptr, size, mori::io::MemoryLocationType::GPU, location.device_id);
+}
+
+// A file ref can only be READ into device memory: GdsEngine claims the
+// (file, GPU) pair and no engine claims (file, host).  Callers use this to
+// decide whether asking a medium for a file ref is even useful.
+bool DestinationIsDevice(void* ptr, uint64_t size) {
+  return ClassifiedUserBytes(ptr, size).loc == mori::io::MemoryLocationType::GPU;
 }
 
 // Read-side range validity: inside the object and non-overlapping.  Weaker than
@@ -1424,7 +1432,9 @@ PoolClient::GetAttemptOutcome PoolClient::ExecuteLocalGet(const std::string& key
     return GetAttemptOutcome::kFatal;
   }
   auto pool_resolved =
-      ResolveLocalBatchWithBusyRetry(default_pool_.get(), {key}, /*include_descs=*/false).front();
+      ResolveLocalBatchWithBusyRetry(default_pool_.get(), {key}, /*include_descs=*/false,
+                                     /*allow_file_refs=*/true)
+          .front();
   auto* backend = registry_.Get(pool_resolved.backend_id);
   bool served = pool_resolved.resolved.found && backend != nullptr;
   if (served) {
@@ -1472,7 +1482,8 @@ PoolClient::GetAttemptOutcome PoolClient::ExecuteLocalGet(const std::string& key
 void PoolClient::ResolveLocalBatch(const std::vector<std::string>& keys,
                                    const std::vector<size_t>& candidates,
                                    std::vector<MediumBackend*>* holders,
-                                   std::vector<ResolvedEntry>* resolutions) {
+                                   std::vector<ResolvedEntry>* resolutions,
+                                   const std::function<bool(size_t)>& dst_is_device) {
   holders->assign(keys.size(), nullptr);
   if (resolutions != nullptr) resolutions->assign(keys.size(), ResolvedEntry{});
   if (candidates.empty() || default_pool_ == nullptr || registry_.Empty()) return;
@@ -1481,7 +1492,39 @@ void PoolClient::ResolveLocalBatch(const std::vector<std::string>& keys,
   batch.reserve(candidates.size());
   for (size_t i : candidates) batch.push_back(keys[i]);
 
-  auto found = ResolveLocalBatchWithBusyRetry(default_pool_.get(), batch, /*include_descs=*/false);
+  // Both readers fed from here — ServeLocalGets and BatchGetRanges — can
+  // consume a file ref, and this resolve never leaves the process, so ask for
+  // one whenever the caller can say where the bytes land.
+  const bool want_file_refs = static_cast<bool>(dst_is_device);
+  auto found = ResolveLocalBatchWithBusyRetry(default_pool_.get(), batch,
+                                              /*include_descs=*/false,
+                                              /*allow_file_refs=*/want_file_refs);
+
+  // A file ref is unreadable into HOST memory, and the medium cannot know the
+  // destination at resolve time.  Re-resolve those keys with file refs off so
+  // they come back on staged pages -- correct, just not zero-copy.
+  //
+  // Deliberately a second pass rather than classifying every destination up
+  // front: with GDS off nothing publishes a file ref, this loop finds nothing,
+  // and the ordinary local read pays no extra HIP call at all.
+  if (want_file_refs) {
+    std::vector<std::string> restage;
+    std::vector<size_t> restage_at;
+    for (size_t j = 0; j < candidates.size() && j < found.size(); ++j) {
+      if (!found[j].resolved.file_ref.IsFile()) continue;
+      if (dst_is_device(candidates[j])) continue;
+      restage.push_back(batch[j]);
+      restage_at.push_back(j);
+    }
+    if (!restage.empty()) {
+      auto staged = ResolveLocalBatchWithBusyRetry(default_pool_.get(), restage,
+                                                   /*include_descs=*/false,
+                                                   /*allow_file_refs=*/false);
+      for (size_t k = 0; k < restage_at.size() && k < staged.size(); ++k) {
+        found[restage_at[k]] = std::move(staged[k]);
+      }
+    }
+  }
   for (size_t j = 0; j < candidates.size() && j < found.size(); ++j) {
     if (!found[j].resolved.found) continue;
     auto* backend = registry_.Get(found[j].backend_id);
@@ -1496,6 +1539,38 @@ void PoolClient::ResolveLocalBatch(const std::vector<std::string>& keys,
 // ---------------------------------------------------------------------------
 //  Ranged I/O — object ranges onto tier pages
 // ---------------------------------------------------------------------------
+
+// The file-ref counterpart of BuildLocalRangeTransfers: the medium published a
+// range of its own storage instead of staged pages, so each caller range is one
+// read at (value start + range offset) -- GdsEngine adds src_offset to the
+// ref's file_offset.  No page walk, because there are no pages to walk.
+//
+// The ranges a layer-wise reader asks for are not 4 KiB aligned in general,
+// while the file ref's own start and length are.  That is not a correctness
+// problem: hipFile serves an unaligned range through its compat path, which
+// gives up the DMA fastpath for that read but returns the right bytes.
+bool PoolClient::BuildLocalFileRangeTransfers(const TransferRef& file_ref,
+                                              const std::vector<ObjectRange>& ranges, size_t tag,
+                                              std::vector<TransferItem>* items) {
+  if (!file_ref.IsFile() || ranges.empty()) return false;
+  items->reserve(items->size() + ranges.size());
+  for (const ObjectRange& r : ranges) {
+    if (r.size == 0) continue;
+    // Same reason BuildLocalRangeTransfers prefers the registration table: a
+    // registered ref names the region BASE, so every range landing in one
+    // caller buffer shares a (src, dst) pair and folds into a single plan.
+    const auto [dst_ref, dst_base_offset] = UserBufferRef(r.user, r.size);
+    TransferItem item;
+    item.src = file_ref;
+    item.src_offset = r.object_offset;
+    item.dst = dst_ref;
+    item.dst_offset = dst_base_offset;
+    item.size = r.size;
+    item.tag = tag;
+    items->push_back(std::move(item));
+  }
+  return true;
+}
 
 bool PoolClient::BuildLocalRangeTransfers(MediumBackend* backend,
                                           const std::vector<PageLocation>& pages,
@@ -2644,7 +2719,8 @@ void PoolClient::ServeLocalGets(const std::vector<std::string>& keys,
 
   std::vector<MediumBackend*> holders;
   std::vector<ResolvedEntry> resolutions;
-  ResolveLocalBatch(keys, indices, &holders, &resolutions);
+  ResolveLocalBatch(keys, indices, &holders, &resolutions,
+                    [&](size_t i) { return DestinationIsDevice(dsts[i], sizes[i]); });
 
   const auto t0 = std::chrono::steady_clock::now();
   std::vector<TransferItem> items;
@@ -2667,8 +2743,17 @@ void PoolClient::ServeLocalGets(const std::vector<std::string>& keys,
       continue;
     }
     const size_t before = items.size();
-    if (!BuildLocalPageTransfers(holder, resolved.pages, resolved.page_size, dsts[i], sizes[i],
-                                 /*to_backend=*/false, &items)) {
+    if (resolved.file_ref.IsFile()) {
+      // Zero-copy GDS path, the same one ExecuteLocalGet takes: the backend
+      // published a file range rather than staged pages, so read it straight
+      // into the caller's device buffer and let the planner pick GdsEngine.
+      TransferItem item;
+      item.src = resolved.file_ref;
+      item.dst = ClassifiedUserBytes(dsts[i], sizes[i]);
+      item.size = sizes[i];
+      items.push_back(std::move(item));
+    } else if (!BuildLocalPageTransfers(holder, resolved.pages, resolved.page_size, dsts[i],
+                                        sizes[i], /*to_backend=*/false, &items)) {
       // This medium holds the key but publishes no in-process endpoint for its
       // buffers.  Drop what was appended for it -- a half-built key must not
       // ride along in the batch -- and route it instead.
@@ -3018,7 +3103,16 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
   std::vector<ResolvedEntry> resolutions;
   {
     PhaseTimer resolve_timer(dbg ? &dbg->resolve : nullptr);
-    ResolveLocalBatch(keys, candidates, &holders, &resolutions);
+    ResolveLocalBatch(keys, candidates, &holders, &resolutions, [&](size_t i) {
+      // One key's ranges normally share a caller allocation, but nothing
+      // guarantees it; a single host range makes the whole key unservable
+      // from a file ref, so require all of them.
+      const std::vector<void*>& key_dsts = dsts[i];
+      for (size_t r = 0; r < key_dsts.size(); ++r) {
+        if (!DestinationIsDevice(key_dsts[r], sizes[i][r])) return false;
+      }
+      return !key_dsts.empty();
+    });
   }
 
   for (size_t i = 0; i < n; ++i) {
@@ -3048,9 +3142,12 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
       // Refilled per key rather than returned fresh: one allocation for the
       // call instead of one per key.
       FillReadRanges(dsts[i], sizes[i], src_offsets[i], &key_ranges);
-      built = BuildLocalRangeTransfers(
-          holder, resolved.pages, resolved.page_size, resolved.size, key_ranges,
-          /*to_backend=*/false, /*tag=*/i, &local_items, dbg ? &dbg->classify : nullptr);
+      built =
+          resolved.file_ref.IsFile()
+              ? BuildLocalFileRangeTransfers(resolved.file_ref, key_ranges, /*tag=*/i, &local_items)
+              : BuildLocalRangeTransfers(holder, resolved.pages, resolved.page_size, resolved.size,
+                                         key_ranges, /*to_backend=*/false,
+                                         /*tag=*/i, &local_items, dbg ? &dbg->classify : nullptr);
     }
     if (!built) {
       // The medium holds the key but cannot be read in-process.  Same call as

--- a/src/umbp/distributed/transfer/composite_transfer_engine.cpp
+++ b/src/umbp/distributed/transfer/composite_transfer_engine.cpp
@@ -165,6 +165,18 @@ TransferRef CompositeTransferEngine::RegisterMemory(void* base, size_t size,
   return merged;
 }
 
+TransferRef CompositeTransferEngine::RegisterFile(int fd, uint64_t offset, uint64_t size) {
+  // Unlike RegisterMemory, a file range fans out to exactly one taker: only a
+  // file-capable engine (GdsEngine) claims it, and it owns the fd registration
+  // outright.  First match wins; an invalid ref means no file engine is
+  // configured and the caller must fall back to a memory path.
+  for (auto& engine : engines_) {
+    TransferRef part = engine->RegisterFile(fd, offset, size);
+    if (part.IsFile()) return part;
+  }
+  return TransferRef{};
+}
+
 void CompositeTransferEngine::Deregister(const TransferRef& ref) {
   for (auto& engine : engines_) engine->Deregister(ref);
 }

--- a/src/umbp/distributed/transfer/gds_engine.cpp
+++ b/src/umbp/distributed/transfer/gds_engine.cpp
@@ -1,0 +1,180 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#include "umbp/distributed/transfer/gds_engine.h"
+
+#include <hipfile.h>
+
+#include <cerrno>
+#include <string>
+#include <utility>
+
+#include "mori/utils/mori_log.hpp"
+
+namespace mori::umbp {
+namespace {
+
+inline bool IsGpu(const TransferRef& r) { return r.loc == mori::io::MemoryLocationType::GPU; }
+
+// Inline-completion handle, same shape as the copy engines': every read runs
+// before Submit returns, so the handle only replays the outcome.
+class SettledHandle final : public TransferHandle {
+ public:
+  explicit SettledHandle(std::vector<TransferFailure> failures) : failures_(std::move(failures)) {}
+
+  void Wait(std::vector<TransferFailure>* failures) override {
+    if (reported_) return;
+    reported_ = true;
+    if (failures != nullptr) {
+      for (auto& f : failures_) failures->push_back(std::move(f));
+    }
+    failures_.clear();
+  }
+
+ private:
+  std::vector<TransferFailure> failures_;
+  bool reported_ = false;
+};
+
+// Turn a hipFileRead return code into a human-readable reason.  >= 0 is a byte
+// count (a short read here); -1 is a POSIX errno; any other negative is the
+// negated hipFileOpError_t.
+std::string ReadFailureReason(ssize_t n, size_t want) {
+  if (n == -1) return std::string("errno=") + std::to_string(errno);
+  if (n < 0) return hipFileGetOpErrorString(static_cast<hipFileOpError_t>(-n));
+  return std::string("short read ") + std::to_string(n) + "/" + std::to_string(want);
+}
+
+}  // namespace
+
+GdsEngine::~GdsEngine() {
+  std::lock_guard<std::mutex> lock(handles_mutex_);
+  for (auto& [fd, entry] : handles_) {
+    if (entry.handle != nullptr) {
+      hipFileHandleDeregister(static_cast<hipFileHandle_t>(entry.handle));
+    }
+  }
+  handles_.clear();
+}
+
+TransferRef GdsEngine::RegisterFile(int fd, uint64_t offset, uint64_t size) {
+  if (fd < 0) return TransferRef{};
+  std::lock_guard<std::mutex> lock(handles_mutex_);
+
+  auto it = handles_.find(fd);
+  if (it != handles_.end()) {
+    ++it->second.refcount;
+    return TransferRef::File(fd, offset, size, it->second.handle);
+  }
+
+  hipFileDescr_t descr{};
+  descr.type = hipFileHandleTypeOpaqueFD;
+  descr.handle.fd = fd;
+  hipFileHandle_t handle = nullptr;
+  hipFileError_t err = hipFileHandleRegister(&handle, &descr);
+  if (err.err != hipFileSuccess || handle == nullptr) {
+    MORI_UMBP_ERROR("[GdsEngine] hipFileHandleRegister(fd={}) failed: {}", fd,
+                    hipFileGetOpErrorString(err.err));
+    return TransferRef{};
+  }
+  handles_.emplace(fd, HandleEntry{static_cast<void*>(handle), 1});
+  return TransferRef::File(fd, offset, size, static_cast<void*>(handle));
+}
+
+void GdsEngine::Deregister(const TransferRef& ref) {
+  if (!ref.IsFile()) return;
+  std::lock_guard<std::mutex> lock(handles_mutex_);
+  auto it = handles_.find(ref.file_fd);
+  if (it == handles_.end()) return;
+  if (--it->second.refcount <= 0) {
+    if (it->second.handle != nullptr) {
+      hipFileHandleDeregister(static_cast<hipFileHandle_t>(it->second.handle));
+    }
+    handles_.erase(it);
+  }
+}
+
+bool GdsEngine::CanHandle(const TransferRef& src, const TransferRef& dst) const {
+  // Read path only: a file source into a device buffer.  A file destination or
+  // a host destination is not ours.
+  return src.IsFile() && !dst.IsFile() && dst.HasHostPtr() && IsGpu(dst);
+}
+
+TransferPlanSet GdsEngine::Plan(const std::vector<TransferItem>& items) const {
+  TransferPlanSet out;
+  out.plans.reserve(items.size());
+  for (const auto& item : items) {
+    if (item.size == 0) continue;
+    if (!CanHandle(item.src, item.dst)) {
+      out.rejected_tags.push_back(item.tag);
+      continue;
+    }
+    // Bound the read to the destination buffer: an overrun into a device pool
+    // is silent corruption, not a segfault, so reject it here rather than let
+    // hipFileRead scribble past the slot.
+    if (item.size > item.dst.size || item.dst_offset > item.dst.size - item.size) {
+      out.rejected_tags.push_back(item.tag);
+      continue;
+    }
+    TransferPlan plan;
+    plan.src = item.src;
+    plan.dst = item.dst;
+    plan.dir = TransferDirection::kLocal;
+    plan.src_offsets.push_back(static_cast<size_t>(item.src_offset));
+    plan.dst_offsets.push_back(static_cast<size_t>(item.dst_offset));
+    plan.sizes.push_back(static_cast<size_t>(item.size));
+    plan.tags.push_back(item.tag);
+    out.plans.push_back(std::move(plan));
+  }
+  return out;
+}
+
+std::unique_ptr<TransferHandle> GdsEngine::Submit(std::vector<TransferPlan> plans) {
+  if (plans.empty()) return nullptr;
+  std::vector<TransferFailure> failures;
+
+  for (const auto& plan : plans) {
+    auto fh = static_cast<hipFileHandle_t>(plan.src.gds_handle);
+    if (fh == nullptr) {
+      failures.push_back(
+          TransferFailure{plan.tags, 0, "GdsEngine: file ref has no hipFile handle", "gds"});
+      continue;
+    }
+    // buffer_base is the GPU allocation base; buffer_offset selects the slot
+    // inside it, and file_offset is the range's absolute position on disk.
+    void* dst_base = plan.dst.host_ptr;
+    for (size_t i = 0; i < plan.sizes.size(); ++i) {
+      const uint64_t file_off = plan.src.file_offset + plan.src_offsets[i];
+      const ssize_t n = hipFileRead(fh, dst_base, plan.sizes[i], static_cast<hoff_t>(file_off),
+                                    static_cast<hoff_t>(plan.dst_offsets[i]));
+      if (n < 0 || static_cast<size_t>(n) != plan.sizes[i]) {
+        const std::string why = ReadFailureReason(n, plan.sizes[i]);
+        MORI_UMBP_ERROR("[GdsEngine] hipFileRead file_off={} size={} failed: {}", file_off,
+                        plan.sizes[i], why);
+        failures.push_back(TransferFailure{plan.tags, 0, "GdsEngine: hipFileRead: " + why, "gds"});
+        break;  // one failure per plan; a partially-read key is failed wholesale
+      }
+    }
+  }
+  return std::make_unique<SettledHandle>(std::move(failures));
+}
+
+}  // namespace mori::umbp

--- a/src/umbp/include/umbp/distributed/peer/backend/instrumented_backend.h
+++ b/src/umbp/include/umbp/distributed/peer/backend/instrumented_backend.h
@@ -110,8 +110,8 @@ class InstrumentedBackend final : public MediumBackend {
   std::vector<AllocateResult> BatchAllocate(const std::vector<AllocateRequest>& reqs) override;
   std::vector<CommitResult> BatchCommit(const std::vector<CommitRequest>& reqs) override;
   std::vector<bool> BatchAbort(const std::vector<uint64_t>& slot_ids) override;
-  std::vector<ResolvedEntry> BatchResolve(const std::vector<std::string>& keys,
-                                          bool include_descs) override;
+  std::vector<ResolvedEntry> BatchResolve(const std::vector<std::string>& keys, bool include_descs,
+                                          bool allow_file_refs = false) override;
   std::vector<EvictResult> Evict(const std::vector<std::string>& keys) override;
 
   // ---- bootstrap / local endpoints: pass-through ----

--- a/src/umbp/include/umbp/distributed/peer/backend/medium_backend.h
+++ b/src/umbp/include/umbp/distributed/peer/backend/medium_backend.h
@@ -175,6 +175,12 @@ struct ResolvedEntry {
   // Empty when the caller passed include_descs=false (it already hydrated them
   // from GetPeerInfo), or when found=false.
   std::vector<BufferMemoryDescBytes> descs;
+
+  // Set instead of `pages` when the backend serves this key by a zero-copy file
+  // range (SsdBackend + GdsEngine): a File TransferRef the reader DMAs straight
+  // into device memory, with `pages` left empty.  A memory-backed medium leaves
+  // this invalid and publishes pages as before.
+  TransferRef file_ref{};
 };
 
 inline ResolveOutcome EffectiveResolveOutcome(const ResolvedEntry& entry) {

--- a/src/umbp/include/umbp/distributed/peer/backend/medium_backend.h
+++ b/src/umbp/include/umbp/distributed/peer/backend/medium_backend.h
@@ -322,8 +322,19 @@ class MediumBackend : public MetricSource {
   // not registerable publishes a descriptor naming its storage (a file/object
   // ref) rather than a memory one — the engine decides how to reach it, and
   // supplies a bounce buffer if the chosen path needs one.
+  //
+  // `allow_file_refs` says the caller can consume a TransferRef::File -- it
+  // will read the medium's own storage directly (GdsEngine DMAs the range into
+  // the destination) instead of a staged page.  It defaults to FALSE because a
+  // file ref only means something IN THIS PROCESS: an fd plus a locally
+  // registered hipFile handle is meaningless to a peer, and a resolve that put
+  // one on the wire would ship a slot carrying no pages at all.  Callers that
+  // serve a remote reader, and callers that only test `found`, leave it off.
+  // Every declaration of this method repeats the same default deliberately --
+  // a default argument on a virtual binds statically, so they must not drift.
   virtual std::vector<ResolvedEntry> BatchResolve(const std::vector<std::string>& keys,
-                                                  bool include_descs) = 0;
+                                                  bool include_descs,
+                                                  bool allow_file_refs = false) = 0;
 
   // Acquire a peer-local migration pin and resolve the key without changing or
   // cancelling normal RPC read leases. The caller must release a successful

--- a/src/umbp/include/umbp/distributed/peer/backend/mock_backend.h
+++ b/src/umbp/include/umbp/distributed/peer/backend/mock_backend.h
@@ -156,8 +156,9 @@ class MockBackend : public MediumBackend {
     return out;
   }
 
-  std::vector<ResolvedEntry> BatchResolve(const std::vector<std::string>& keys,
-                                          bool include_descs) override {
+  std::vector<ResolvedEntry> BatchResolve(const std::vector<std::string>& keys, bool include_descs,
+                                          bool allow_file_refs = false) override {
+    (void)allow_file_refs;  // this mock stages everything; it publishes no file refs
     std::vector<ResolvedEntry> out(keys.size());
     std::lock_guard<std::mutex> lock(mutex_);
     for (size_t i = 0; i < keys.size(); ++i) {

--- a/src/umbp/include/umbp/distributed/peer/backend/page_backend.h
+++ b/src/umbp/include/umbp/distributed/peer/backend/page_backend.h
@@ -254,8 +254,8 @@ class PageBackend : public MediumBackend {
   std::vector<AllocateResult> BatchAllocate(const std::vector<AllocateRequest>& entries) override;
   std::vector<CommitResult> BatchCommit(const std::vector<CommitRequest>& entries) override;
   std::vector<bool> BatchAbort(const std::vector<uint64_t>& slot_ids) override;
-  std::vector<ResolvedEntry> BatchResolve(const std::vector<std::string>& keys,
-                                          bool include_descs) override;
+  std::vector<ResolvedEntry> BatchResolve(const std::vector<std::string>& keys, bool include_descs,
+                                          bool allow_file_refs = false) override;
   bool AcquireMigrationRead(const std::string& key, ResolvedEntry* resolved) override;
   void ReleaseMigrationRead(const std::string& key) override;
   bool Contains(const std::string& key) const override;

--- a/src/umbp/include/umbp/distributed/peer/backend/ssd_backend.h
+++ b/src/umbp/include/umbp/distributed/peer/backend/ssd_backend.h
@@ -250,6 +250,12 @@ class SsdBackend : public MediumBackend {
   std::unordered_map<std::string, ReadLease> read_leases_;
   std::unordered_map<std::string, ReadLease> migration_reads_;
 
+  // Runtime kill-switch (UMBP_ENABLE_GDS=0): keep every SSD read on the staging
+  // arena even when the build has hipfile and a GdsEngine is registered.  Read
+  // once at Init; correctness never depends on it (hipfile's own compat mode
+  // already covers fastpath misses), so this is for A/B and operational safety.
+  bool gds_enabled_ = true;
+
   // GDS file handles by segment fd (see GdsHandleForFd).  On its own lock, off
   // mutex_, so a resolve holding mutex_ can register a handle without widening
   // what mutex_ guards.

--- a/src/umbp/include/umbp/distributed/peer/backend/ssd_backend.h
+++ b/src/umbp/include/umbp/distributed/peer/backend/ssd_backend.h
@@ -215,6 +215,12 @@ class SsdBackend : public MediumBackend {
   // Local address of a staging page.  Valid after Init.
   void* StagingPagePtr(uint32_t page_index) const;
 
+  // hipFile handle for a segment fd, obtained lazily from the registrar's file
+  // engine (GdsEngine) and shared by every key on that segment.  Returns nullptr
+  // when no file engine is configured; that result is cached so a fd is probed
+  // at most once.  Deregistered in Shutdown.
+  void* GdsHandleForFd(int fd);
+
   // Caller MUST hold mutex_.  Bumps the unshipped-event count and fires the
   // auto-flush hook once it crosses the threshold.
   void NoteEventQueuedLocked();
@@ -243,6 +249,12 @@ class SsdBackend : public MediumBackend {
   std::unordered_map<uint64_t, PendingSlot> pending_;
   std::unordered_map<std::string, ReadLease> read_leases_;
   std::unordered_map<std::string, ReadLease> migration_reads_;
+
+  // GDS file handles by segment fd (see GdsHandleForFd).  On its own lock, off
+  // mutex_, so a resolve holding mutex_ can register a handle without widening
+  // what mutex_ guards.
+  std::mutex gds_mutex_;
+  std::unordered_map<int, void*> gds_handles_;
 
   size_t unshipped_events_ = 0;
   size_t auto_flush_threshold_ = SIZE_MAX;

--- a/src/umbp/include/umbp/distributed/peer/backend/ssd_backend.h
+++ b/src/umbp/include/umbp/distributed/peer/backend/ssd_backend.h
@@ -250,11 +250,13 @@ class SsdBackend : public MediumBackend {
   std::unordered_map<std::string, ReadLease> read_leases_;
   std::unordered_map<std::string, ReadLease> migration_reads_;
 
-  // Runtime kill-switch (UMBP_ENABLE_GDS=0): keep every SSD read on the staging
-  // arena even when the build has hipfile and a GdsEngine is registered.  Read
-  // once at Init; correctness never depends on it (hipfile's own compat mode
-  // already covers fastpath misses), so this is for A/B and operational safety.
-  bool gds_enabled_ = true;
+  // Opt-in switch (UMBP_ENABLE_GDS=1): route SSD reads of O_DIRECT records
+  // through the file->GPU GdsEngine instead of the staging arena.  Off by
+  // default even when the build has hipfile and a GdsEngine is registered;
+  // correctness never depends on it (hipfile's own compat mode already covers
+  // fastpath misses), so an unset switch keeps every read on the staging path.
+  // A conservative default; read once at Init.
+  bool gds_enabled_ = false;
 
   // GDS file handles by segment fd (see GdsHandleForFd).  On its own lock, off
   // mutex_, so a resolve holding mutex_ can register a handle without widening

--- a/src/umbp/include/umbp/distributed/peer/backend/ssd_backend.h
+++ b/src/umbp/include/umbp/distributed/peer/backend/ssd_backend.h
@@ -161,8 +161,8 @@ class SsdBackend : public MediumBackend {
   std::vector<AllocateResult> BatchAllocate(const std::vector<AllocateRequest>& entries) override;
   std::vector<CommitResult> BatchCommit(const std::vector<CommitRequest>& entries) override;
   std::vector<bool> BatchAbort(const std::vector<uint64_t>& slot_ids) override;
-  std::vector<ResolvedEntry> BatchResolve(const std::vector<std::string>& keys,
-                                          bool include_descs) override;
+  std::vector<ResolvedEntry> BatchResolve(const std::vector<std::string>& keys, bool include_descs,
+                                          bool allow_file_refs = false) override;
   bool AcquireMigrationRead(const std::string& key, ResolvedEntry* resolved) override;
   void ReleaseMigrationRead(const std::string& key) override;
   bool Contains(const std::string& key) const override;

--- a/src/umbp/include/umbp/distributed/peer/ssd/peer_ssd_manager.h
+++ b/src/umbp/include/umbp/distributed/peer/ssd/peer_ssd_manager.h
@@ -28,6 +28,7 @@
 #include <list>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -36,10 +37,13 @@
 
 #include "umbp/distributed/config.h"  // PeerSsdConfig
 #include "umbp/distributed/types.h"
+// RecordLocation is returned by value from LocateRecord, so the tier interface
+// is included here rather than forward-declared. peer/ssd is the SSD adapter
+// that already builds on the local tier (Phase 5 lint exempts this directory),
+// so this crosses no new boundary.
+#include "umbp/local/tiers/tier_backend.h"
 
 namespace mori::umbp {
-
-class TierBackend;  // umbp/local/tiers/tier_backend.h — kept out of this header.
 
 enum class SsdReadStatus { kOk, kNotFound, kSizeTooLarge, kError };
 struct SsdReadOutcome {
@@ -86,6 +90,11 @@ class PeerSsdManager {
   // Uses the same refcount as active reads so eviction has one protection rule.
   bool PinForMigration(const std::string& key);
   void UnpinForMigration(const std::string& key);
+
+  // Physical location of |key|'s value for a zero-copy GDS read, or nullopt when
+  // the key is unknown or being evicted (mirroring PrepareRead's kNotFound).
+  // Forwards to the SSD tier; does no device IO.
+  std::optional<RecordLocation> LocateRecord(const std::string& key) const;
 
   // Write the key's bytes (assembled from possibly non-contiguous DRAM source
   // segments) to the SSD backend.  On success records the SSD location and

--- a/src/umbp/include/umbp/distributed/pool/peer_pool.h
+++ b/src/umbp/include/umbp/distributed/pool/peer_pool.h
@@ -101,7 +101,7 @@ class PeerPool {
   std::vector<PoolCommitResult> BatchCommit(const std::vector<PoolCommitRequest>& requests);
   std::vector<bool> BatchAbort(const std::vector<PoolSlotRef>& slots);
   std::vector<PoolResolvedEntry> BatchResolve(const std::vector<std::string>& keys,
-                                              bool include_descs);
+                                              bool include_descs, bool allow_file_refs = false);
   std::vector<EvictResult> Evict(const std::vector<std::string>& keys, PoolEvictMode mode);
   void ClearLocal();
   std::vector<KvEvent> DrainPendingEvents();

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -378,10 +378,15 @@ class PoolClient {
   //
   // One pool batch preserves placement/read-order, tier touches, and promotion
   // semantics while avoiding one resolve call per key.
+  // `dst_is_device` answers, for an ORIGINAL key index, whether that key's
+  // destination is device memory -- the only place a file ref can be read.
+  // Empty (the default) means the caller cannot consume a file ref at all, so
+  // none is requested and every key resolves onto staged pages.
   void ResolveLocalBatch(const std::vector<std::string>& keys,
                          const std::vector<size_t>& candidates,
                          std::vector<MediumBackend*>* holders,
-                         std::vector<ResolvedEntry>* resolutions);
+                         std::vector<ResolvedEntry>* resolutions,
+                         const std::function<bool(size_t)>& dst_is_device = {});
 
   // One TransferItem per page between a caller buffer and `backend`'s own
   // buffers.  `to_backend` is Put (user -> pages), false is Get (pages -> user).
@@ -426,6 +431,12 @@ class PoolClient {
                                 uint64_t page_size, uint64_t stored_size,
                                 const std::vector<ObjectRange>& ranges, bool to_backend, size_t tag,
                                 std::vector<TransferItem>* items, double* classify_sink = nullptr);
+
+  // The file-ref counterpart of BuildLocalRangeTransfers, for a medium that
+  // published a range of its own storage instead of staged pages.
+  bool BuildLocalFileRangeTransfers(const TransferRef& file_ref,
+                                    const std::vector<ObjectRange>& ranges, size_t tag,
+                                    std::vector<TransferItem>* items);
 
   // Copy between one contiguous host object and a set of caller ranges, through
   // the transfer engine so a device-resident caller buffer is handled by

--- a/src/umbp/include/umbp/distributed/transfer/composite_transfer_engine.h
+++ b/src/umbp/include/umbp/distributed/transfer/composite_transfer_engine.h
@@ -68,6 +68,10 @@ class CompositeTransferEngine final : public TransferEngine {
   // merged.  Returns an invalid ref only when no engine claimed the memory.
   TransferRef RegisterMemory(void* base, size_t size, mori::io::MemoryLocationType loc,
                              int device) override;
+  // Fan out to the first file-capable sub-engine (GdsEngine): it owns the fd
+  // registration outright and returns a File ref carrying its handle.  Invalid
+  // when no file engine is configured.
+  TransferRef RegisterFile(int fd, uint64_t offset, uint64_t size) override;
   void Deregister(const TransferRef& ref) override;
 
   bool CanHandle(const TransferRef& src, const TransferRef& dst) const override;

--- a/src/umbp/include/umbp/distributed/transfer/gds_engine.h
+++ b/src/umbp/include/umbp/distributed/transfer/gds_engine.h
@@ -1,0 +1,95 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+#include "umbp/distributed/transfer/transfer_engine.h"
+
+namespace mori::umbp {
+
+// The SSD-file-to-GPU implementation of TransferEngine, over AMD hipFile (GDS).
+//
+// WHY THIS EXISTS.  SsdBackend publishes a File TransferRef (an O_DIRECT fd + a
+// byte range) instead of staging its bytes through host DRAM.  No memory engine
+// can move a file endpoint — their CanHandle keys on HasHostPtr() /
+// HasMemoryDesc(), both false for a file ref — so a (file, GPU) pair was
+// unservable until this engine.  It reads the range straight into device memory
+// with hipFileRead, which DMAs drive -> GPU with no host bounce (design §4/§6).
+//
+// READ ONLY, FOR NOW.  CanHandle claims exactly (file source, device
+// destination): the prefill KV-load path.  The reverse (GPU -> file, via
+// hipFileWrite) is a later change, and a host destination is left to the staged
+// path, so this engine never widens what the memory engines already serve.
+//
+// The fd handle is registered once per fd and shared by every range on that
+// segment (a segment file holds many keys): RegisterFile ref-counts, Deregister
+// releases at zero.  hipFileHandle_t is kept as an opaque void* so this header
+// carries no hipfile dependency; only the .cpp includes <hipfile.h>.
+class GdsEngine final : public TransferEngine {
+ public:
+  GdsEngine() = default;
+  ~GdsEngine() override;
+
+  const char* Name() const override { return "GdsEngine"; }
+
+  // Not a memory engine: an invalid ref tells the composite's memory fan-out to
+  // skip it.
+  TransferRef RegisterMemory(void*, size_t, mori::io::MemoryLocationType, int) override {
+    return TransferRef{};
+  }
+
+  // Register an O_DIRECT fd as a hipFile handle (once per fd, ref-counted) and
+  // return a File ref carrying it.  Invalid ref if registration fails.
+  TransferRef RegisterFile(int fd, uint64_t offset, uint64_t size) override;
+  void Deregister(const TransferRef& ref) override;
+
+  // A file source into a device destination — the read path — and nothing else.
+  bool CanHandle(const TransferRef& src, const TransferRef& dst) const override;
+
+  // One plan per (file range -> device buffer).  Grouping/coalescing is left
+  // out deliberately: hipFileRead already moves a contiguous range in one DMA,
+  // and a batch's ranges land in disjoint GPU buffers.
+  TransferPlanSet Plan(const std::vector<TransferItem>& items) const override;
+
+  // Performs the reads inline with hipFileRead; the returned handle is already
+  // settled (same contract as the copy engines).
+  std::unique_ptr<TransferHandle> Submit(std::vector<TransferPlan> plans) override;
+
+ private:
+  // One registered fd: its opaque hipFileHandle_t and a ref count so a segment
+  // shared by many keys registers once and releases once.
+  struct HandleEntry {
+    void* handle = nullptr;  // hipFileHandle_t
+    int refcount = 0;
+  };
+
+  mutable std::mutex handles_mutex_;
+  std::unordered_map<int, HandleEntry> handles_;
+};
+
+}  // namespace mori::umbp

--- a/src/umbp/include/umbp/distributed/transfer/transfer_engine.h
+++ b/src/umbp/include/umbp/distributed/transfer/transfer_engine.h
@@ -71,15 +71,22 @@ namespace mori::umbp {
 //                             or a node with no RDMA configured)
 // An endpoint with neither is invalid and no engine will accept it.
 //
-// DELIBERATELY ABSENT: a file / object endpoint, and MemoryRegistrar::
-// RegisterFile.  §4 specified both, but no engine in tree consumes one yet, and
-// this plan has already refused to land an abstraction nothing exercises once
-// (§3: BackendProperties was proposed and then NOT adopted, because "an
-// advertised order would have been scaffolding nothing exercises").  The same
-// test applies here: SsdBackend is what needs a FileRef, so SsdBackend brings
-// it — adding a `kind` tag and a second handle set is a one-file change to this
-// header, and CanHandle already exists to route it.
+// FILE ENDPOINT (kind == File): the "one-file change" the note below predicted.
+// A `kind` tag plus a second handle set — an O_DIRECT fd, a file offset, and an
+// opaque engine handle — lets a backend publish a byte range of a file that a
+// file engine (GdsEngine) moves straight between the drive and device memory,
+// with no host bounce.  The memory-only engines ignore it for free: their
+// CanHandle keys on HasHostPtr()/HasMemoryDesc(), both false for a file ref, so
+// the existing per-pair selection already routes it to the only engine that
+// claims it.  SsdBackend is the backend that needed it (design doc §4/§6).
 struct TransferRef {
+  enum class Kind : uint8_t { Memory, File };
+
+  // Which handle set below is authoritative.  Memory refs (the default) carry a
+  // process-local pointer and/or a mori-io descriptor; File refs carry an
+  // O_DIRECT fd and offset.
+  Kind kind = Kind::Memory;
+
   // Process-local view.  Set for anything this node allocated or a caller
   // handed us; null for a peer's memory.
   void* host_ptr = nullptr;
@@ -91,9 +98,18 @@ struct TransferRef {
   // (local), or they were hydrated from a peer's published descriptor (remote).
   mori::io::MemoryDesc mem{};
 
+  // File view (kind == File).  A byte range [file_offset, file_offset + size) of
+  // an O_DIRECT file.  gds_handle is a file engine's opaque registration of the
+  // fd (a hipFileHandle_t), left null until RegisterFile fills it; `size` above
+  // is reused for the range length.
+  int file_fd = -1;
+  uint64_t file_offset = 0;
+  void* gds_handle = nullptr;
+
   bool HasHostPtr() const { return host_ptr != nullptr && size > 0; }
   bool HasMemoryDesc() const { return mem.size > 0; }
-  bool Valid() const { return HasHostPtr() || HasMemoryDesc(); }
+  bool IsFile() const { return kind == Kind::File && file_fd >= 0; }
+  bool Valid() const { return HasHostPtr() || HasMemoryDesc() || IsFile(); }
 
   // Unregistered, directly-addressable bytes: a caller's Put src / Get dst that
   // was never passed to RegisterMemory.
@@ -115,6 +131,18 @@ struct TransferRef {
     r.loc = desc.loc;
     r.device = desc.deviceId;
     r.mem = std::move(desc);
+    return r;
+  }
+
+  // A byte range of an O_DIRECT file, addressable only by a file engine.
+  // `handle` is the engine's registration of `fd`, filled in by RegisterFile.
+  static TransferRef File(int fd, uint64_t offset, uint64_t n, void* handle = nullptr) {
+    TransferRef r;
+    r.kind = Kind::File;
+    r.file_fd = fd;
+    r.file_offset = offset;
+    r.size = n;
+    r.gds_handle = handle;
     return r;
   }
 };
@@ -146,6 +174,19 @@ class MemoryRegistrar {
   // still gets a usable local-only endpoint rather than a failure.
   virtual TransferRef RegisterMemory(void* base, size_t size, mori::io::MemoryLocationType loc,
                                      int device) = 0;
+
+  // Register an O_DIRECT file range so a file engine can move it directly
+  // between the drive and device memory, returning a File TransferRef with the
+  // engine's handle filled in.  Default: no file-capable engine, so the range
+  // is unservable and an invalid ref comes back.  Only GdsEngine (and the
+  // composite that fans out to it) overrides this — the memory-only engines
+  // never touch a file.
+  virtual TransferRef RegisterFile(int fd, uint64_t offset, uint64_t size) {
+    (void)fd;
+    (void)offset;
+    (void)size;
+    return TransferRef{};
+  }
 
   // Release every registration held in `ref`.  Tolerates an invalid ref.
   virtual void Deregister(const TransferRef& ref) = 0;

--- a/src/umbp/include/umbp/local/tiers/sharded_ssd_tier.h
+++ b/src/umbp/include/umbp/local/tiers/sharded_ssd_tier.h
@@ -79,6 +79,7 @@ class ShardedSsdTier : public TierBackend {
   std::string GetLRUKey() const override;
   std::vector<std::string> GetLRUCandidates(size_t max_candidates) const override;
   std::optional<std::string> GetLocationId(const std::string& key) const override;
+  std::optional<RecordLocation> LocateRecord(const std::string& key) const override;
   bool Flush() override;
   void SetColdRead(bool enable) override;
 

--- a/src/umbp/include/umbp/local/tiers/ssd_tier.h
+++ b/src/umbp/include/umbp/local/tiers/ssd_tier.h
@@ -90,6 +90,7 @@ class SSDTier : public TierBackend {
   std::vector<std::string> GetLRUCandidates(size_t max_candidates) const override;
   const IoStatus& LastIoStatus() const { return last_io_status_; }
   std::optional<std::string> GetLocationId(const std::string& key) const override;
+  std::optional<RecordLocation> LocateRecord(const std::string& key) const override;
   // Enables O_DIRECT for segments opened from here on.  Takes effect for
   // segments opened after the call; existing fds keep their current mode, so
   // the intended use is at construction (ssd.direct_io) rather than mid-run.

--- a/src/umbp/include/umbp/local/tiers/tier_backend.h
+++ b/src/umbp/include/umbp/local/tiers/tier_backend.h
@@ -43,6 +43,18 @@ struct TierCapabilities {
   bool ranged_read = false;
 };
 
+// Physical location of a value inside a segment file, for a zero-copy reader
+// (GdsEngine) that DMAs the bytes itself with hipFileRead instead of asking the
+// tier to copy them.  Only the segment-file SSD tiers can answer; every other
+// tier reports "no stable file location".
+struct RecordLocation {
+  int fd = -1;                 // O_DIRECT segment descriptor
+  uint64_t value_offset = 0;   // 4 KiB-aligned start of the value in the file
+  uint64_t readable_size = 0;  // 4 KiB-aligned padded length safe to read
+  uint64_t value_size = 0;     // logical value length (<= readable_size)
+  bool direct_io = false;      // fd is O_DIRECT — a hipFile fastpath precondition
+};
+
 // Abstract base class for storage tier backends (SSD, SPDK, ...).
 // All tiers share a common interface for write/read/evict; tier-specific
 // extensions (e.g. SSDTier::direct_io_active) live in the concrete subclass.
@@ -131,6 +143,15 @@ class TierBackend {
   // Return an opaque location identifier for a previously written key.
   // Callers prepend the store index before publishing to the Master.
   virtual std::optional<std::string> GetLocationId(const std::string& key) const;
+
+  // Physical location of |key|'s value for a zero-copy reader that DMAs it
+  // itself (GdsEngine).  Default: no stable file location — only the
+  // segment-file SSD tiers override it.  Read-only: acquires no lock the caller
+  // must hold and does not touch LRU, so a Resolve can call it without
+  // perturbing recency.
+  virtual std::optional<RecordLocation> LocateRecord(const std::string& /*key*/) const {
+    return std::nullopt;
+  }
 
   // Which StorageTier does this backend represent?
   StorageTier tier_id() const { return tier_id_; }

--- a/src/umbp/local/tiers/sharded_ssd_tier.cpp
+++ b/src/umbp/local/tiers/sharded_ssd_tier.cpp
@@ -294,6 +294,12 @@ std::optional<std::string> ShardedSsdTier::GetLocationId(const std::string& key)
   return "s" + std::to_string(shard) + ":" + *inner;
 }
 
+std::optional<RecordLocation> ShardedSsdTier::LocateRecord(const std::string& key) const {
+  const int shard = ShardOf(key);
+  if (shard < 0) return std::nullopt;
+  return shards_[shard]->LocateRecord(key);
+}
+
 bool ShardedSsdTier::Flush() {
   bool ok = true;
   for (auto& s : shards_) ok = s->Flush() && ok;

--- a/src/umbp/local/tiers/ssd_tier.cpp
+++ b/src/umbp/local/tiers/ssd_tier.cpp
@@ -1059,4 +1059,25 @@ std::optional<std::string> SSDTier::GetLocationId(const std::string& key) const 
   return "seg" + std::to_string(meta->segment_id) + ":" + std::to_string(meta->value_offset);
 }
 
+std::optional<RecordLocation> SSDTier::LocateRecord(const std::string& key) const {
+  std::lock_guard<std::mutex> lock(mu_);
+  const auto* meta = index_.FindKey(key);
+  if (!meta && IsReadOnlyShared()) {
+    const_cast<SSDTier*>(this)->RefreshFromDiskLocked(false);
+    meta = index_.FindKey(key);
+  }
+  if (!meta) return std::nullopt;
+  const auto* seg = GetSegmentLocked(meta->segment_id);
+  if (!seg || seg->fd < 0) return std::nullopt;
+  RecordLocation loc;
+  loc.fd = seg->fd;
+  loc.value_offset = meta->value_offset;
+  // v3 pads every value to kRecordAlign, so the padded length is what a GDS read
+  // must move; the reader trims to value_size afterwards.
+  loc.readable_size = segment::AlignUp(meta->size);
+  loc.value_size = meta->size;
+  loc.direct_io = direct_io_;
+  return loc;
+}
+
 }  // namespace mori::umbp

--- a/tests/cpp/umbp/distributed/CMakeLists.txt
+++ b/tests/cpp/umbp/distributed/CMakeLists.txt
@@ -629,3 +629,14 @@ if(USE_REDIS_BACKEND)
   target_compile_features(test_sharded_read PRIVATE cxx_std_17)
   add_test(NAME test_sharded_read COMMAND test_sharded_read)
 endif()
+
+# GDS-vs-staging A/B for SSD reads into device memory.  Run twice, once with
+# UMBP_ENABLE_GDS=1, and diff the CSV.  Standalone executable; not a CTest
+# target, because it needs a real block-backed --dir to measure anything.
+add_executable(bench_umbp_gds_ssd_get bench_gds_ssd_get.cpp)
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  target_link_options(bench_umbp_gds_ssd_get PRIVATE -Wl,--no-as-needed)
+endif()
+target_link_libraries(
+  bench_umbp_gds_ssd_get
+  PRIVATE umbp_core umbp_common hip::host ${_TEST_PROTOBUF_LIB} ${_TEST_GRPCPP_LIB})

--- a/tests/cpp/umbp/distributed/CMakeLists.txt
+++ b/tests/cpp/umbp/distributed/CMakeLists.txt
@@ -466,6 +466,17 @@ target_link_libraries(test_component_metrics PRIVATE umbp_common
 target_compile_features(test_component_metrics PRIVATE cxx_std_17)
 add_test(NAME test_component_metrics COMMAND test_component_metrics)
 
+# test_gds_engine — GdsEngine routing/planning (no GPU) plus a GPU + hipFile
+# read round trip (skipped without a device, or on a filesystem that rejects
+# O_DIRECT). Built only when hipfile is available; umbp_common already carries
+# hip::hipfile and the UMBP_ENABLE_GDS definition in that case.
+if(TARGET hip::hipfile)
+  add_executable(test_gds_engine test_gds_engine.cpp)
+  target_link_libraries(test_gds_engine PRIVATE umbp_common hip::host GTest::gtest_main)
+  target_compile_features(test_gds_engine PRIVATE cxx_std_17)
+  add_test(NAME test_gds_engine COMMAND test_gds_engine)
+endif()
+
 # test_hbm_backend — the HBM medium and the engine that had to exist for it:
 # HbmCopyEngine's selection/planner (no GPU needed) plus real H2D/D2H/D2D bytes
 # and a Put/Get round trip against an hipMalloc'd pool (skipped without a GPU).

--- a/tests/cpp/umbp/distributed/bench_gds_ssd_get.cpp
+++ b/tests/cpp/umbp/distributed/bench_gds_ssd_get.cpp
@@ -1,0 +1,326 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// GDS-vs-staging A/B for SSD reads.  Drives IUMBPClient::BatchGet against an
+// SSD-only node and reports the two passes that actually differ:
+//
+//   cold  -- first touch of each key.  The staging path must do a device read
+//            into the arena and then a second copy out to the caller; the GDS
+//            path DMAs the range straight into the destination.  This is the
+//            only pass where zero-copy can win.
+//   warm  -- the same keys again, now holding a read lease.  BatchResolve
+//            serves a lease before it ever considers a file ref, so BOTH modes
+//            are an arena copy here and the numbers should converge.  Reported
+//            because "GDS made no difference" is the expected answer for hot
+//            data, and it is worth being able to show that rather than assert
+//            it.
+//
+// The mode is not a flag: run the binary twice, once with UMBP_ENABLE_GDS=1
+// and once without, and diff the CSV.  That keeps the two arms honest -- same
+// binary, same node, same data, one environment variable apart.
+//
+// Usage:
+//   bench_gds_ssd_get [--dir PATH] [--value-bytes N] [--batch N] [--keys N]
+//                     [--capacity-mb N] [--page-bytes N] [--slots N]
+//                     [--host-dst] [--io-backend posix|uring] [--no-header]
+//
+// --dir must name a real block-backed filesystem.  The SSD tier probes for
+// O_DIRECT and silently falls back to buffered I/O when the probe fails, and
+// a buffered fd is never eligible for the GDS fastpath (RecordLocation::
+// direct_io gates it), so pointing this at tmpfs measures nothing.
+//
+// CSV (stdout):
+//   mode,pass,dst,value_bytes,batch,keys,slots,wall_ms,gibps,us_per_key
+
+#include <hip/hip_runtime.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "umbp/common/config.h"
+#include "umbp/distributed/master/master_server.h"
+#include "umbp/umbp_client.h"
+
+namespace fs = std::filesystem;
+
+using mori::umbp::CreateUMBPClient;
+using mori::umbp::IUMBPClient;
+using mori::umbp::MasterServer;
+using mori::umbp::MasterServerConfig;
+using mori::umbp::UMBPConfig;
+using mori::umbp::UMBPDistributedConfig;
+using mori::umbp::UMBPIoBackend;
+using mori::umbp::UMBPMedium;
+
+namespace {
+
+struct Options {
+  std::string dir;
+  size_t value_bytes = 1ULL << 20;  // 1 MiB
+  size_t batch = 32;
+  size_t keys = 512;
+  size_t capacity_mb = 8192;
+  size_t page_bytes = 64ULL * 1024;
+  // Staging pages the SSD backend may hold in flight.  0 = size it from the
+  // batch.  The arena is the staging arm's hard concurrency limit: an object of
+  // N pages holds N entries until its read lease expires, and a batch that does
+  // not fit resolves kBusy and backs off (up to 50 ms a try).  Undersizing it
+  // measures the backoff, not the copy -- so size it, and expose the knob so
+  // arena pressure can be studied deliberately rather than stumbled into.
+  size_t slots = 0;
+  bool host_dst = false;
+  bool header = true;
+  UMBPIoBackend io_backend = UMBPIoBackend::Posix;
+};
+
+[[noreturn]] void Die(const std::string& why) {
+  std::fprintf(stderr, "bench_gds_ssd_get: %s\n", why.c_str());
+  std::exit(2);
+}
+
+#define HIP_OK(expr)                                                              \
+  do {                                                                            \
+    hipError_t _e = (expr);                                                       \
+    if (_e != hipSuccess) Die(std::string(#expr) + ": " + hipGetErrorString(_e)); \
+  } while (0)
+
+// A device buffer, or a host one when --host-dst asks for the comparison arm.
+// Host is worth measuring precisely because it CANNOT use GDS: the file engine
+// claims only (file, GPU), so a host destination re-resolves onto staged pages.
+class Destination {
+ public:
+  Destination(size_t bytes, bool host) : bytes_(bytes), host_(host) {
+    if (host_) {
+      ptr_ = std::malloc(bytes_);
+      if (ptr_ == nullptr) Die("malloc failed");
+    } else {
+      HIP_OK(hipMalloc(&ptr_, bytes_));
+    }
+  }
+  ~Destination() {
+    if (ptr_ == nullptr) return;
+    if (host_) {
+      std::free(ptr_);
+    } else {
+      (void)hipFree(ptr_);
+    }
+  }
+  Destination(const Destination&) = delete;
+  Destination& operator=(const Destination&) = delete;
+
+  void* get() const { return ptr_; }
+  bool host() const { return host_; }
+
+ private:
+  size_t bytes_ = 0;
+  bool host_ = false;
+  void* ptr_ = nullptr;
+};
+
+double Seconds(std::chrono::steady_clock::time_point a, std::chrono::steady_clock::time_point b) {
+  return std::chrono::duration_cast<std::chrono::duration<double>>(b - a).count();
+}
+
+// One pass over every key, in batches.  Returns wall seconds; fails loudly,
+// because a benchmark that silently measures misses is worse than no number.
+double RunPass(IUMBPClient* client, const std::vector<std::string>& keys, const Destination& dst,
+               const Options& opt) {
+  auto* base = static_cast<char*>(dst.get());
+  const auto t0 = std::chrono::steady_clock::now();
+  for (size_t start = 0; start < keys.size(); start += opt.batch) {
+    const size_t n = std::min(opt.batch, keys.size() - start);
+    std::vector<std::string> batch_keys(keys.begin() + start, keys.begin() + start + n);
+    std::vector<uintptr_t> dsts(n);
+    std::vector<size_t> sizes(n, opt.value_bytes);
+    for (size_t i = 0; i < n; ++i) {
+      dsts[i] = reinterpret_cast<uintptr_t>(base + i * opt.value_bytes);
+    }
+    auto ok = client->BatchGet(batch_keys, dsts, sizes);
+    for (size_t i = 0; i < n; ++i) {
+      if (i >= ok.size() || !ok[i]) Die("BatchGet miss for key " + batch_keys[i]);
+    }
+  }
+  return Seconds(t0, std::chrono::steady_clock::now());
+}
+
+void Report(const Options& opt, const char* pass, double sec) {
+  const double bytes = static_cast<double>(opt.keys) * static_cast<double>(opt.value_bytes);
+  const double gibps = bytes / (sec > 0 ? sec : 1e-12) / (1024.0 * 1024.0 * 1024.0);
+  const double us_per_key = sec * 1e6 / static_cast<double>(opt.keys);
+  const char* mode = std::getenv("UMBP_ENABLE_GDS");
+  const bool on = mode != nullptr && (std::string(mode) == "1" || std::string(mode) == "true" ||
+                                      std::string(mode) == "on");
+  std::printf("%s,%s,%s,%zu,%zu,%zu,%zu,%.3f,%.3f,%.2f\n", on ? "gds" : "staging", pass,
+              opt.host_dst ? "host" : "device", opt.value_bytes, opt.batch, opt.keys, opt.slots,
+              sec * 1000.0, gibps, us_per_key);
+  std::fflush(stdout);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  Options opt;
+  for (int i = 1; i < argc; ++i) {
+    const std::string a = argv[i];
+    auto next = [&]() -> std::string {
+      if (i + 1 >= argc) Die("missing value for " + a);
+      return argv[++i];
+    };
+    if (a == "--dir")
+      opt.dir = next();
+    else if (a == "--value-bytes")
+      opt.value_bytes = std::stoull(next());
+    else if (a == "--batch")
+      opt.batch = std::stoull(next());
+    else if (a == "--keys")
+      opt.keys = std::stoull(next());
+    else if (a == "--capacity-mb")
+      opt.capacity_mb = std::stoull(next());
+    else if (a == "--page-bytes")
+      opt.page_bytes = std::stoull(next());
+    else if (a == "--slots")
+      opt.slots = std::stoull(next());
+    else if (a == "--host-dst")
+      opt.host_dst = true;
+    else if (a == "--no-header")
+      opt.header = false;
+    else if (a == "--io-backend") {
+      const std::string b = next();
+      if (b == "uring" || b == "io_uring")
+        opt.io_backend = UMBPIoBackend::IoUring;
+      else if (b == "posix")
+        opt.io_backend = UMBPIoBackend::Posix;
+      else
+        Die("--io-backend must be posix or uring");
+    } else {
+      Die("unknown flag: " + a);
+    }
+  }
+  if (opt.dir.empty()) Die("--dir is required and must be on a real block device");
+  if (opt.batch == 0 || opt.keys == 0 || opt.value_bytes == 0) Die("sizes must be non-zero");
+  if (opt.page_bytes == 0) Die("--page-bytes must be non-zero");
+  const size_t pages_per_value = (opt.value_bytes + opt.page_bytes - 1) / opt.page_bytes;
+  // Default: the whole working set.  A staged page is held until its read
+  // lease expires, not until the copy finishes, so an arena sized to one batch
+  // fills after a couple of batches and every later resolve returns kBusy and
+  // sleeps -- which measures the backoff, not the data path.  Pass --slots
+  // explicitly to study that regime on purpose; it is a real one, and it is
+  // where zero-copy helps most, because a file ref occupies no arena at all.
+  if (opt.slots == 0) opt.slots = opt.keys * pages_per_value;
+
+  const fs::path store = fs::path(opt.dir) / ("bench_gds_" + std::to_string(::getpid()));
+  fs::remove_all(store);
+  fs::create_directories(store);
+
+  MasterServerConfig master_cfg;
+  master_cfg.listen_address = "0.0.0.0:0";
+  master_cfg.registry_config.heartbeat_ttl = std::chrono::seconds(4);
+  auto master = std::make_unique<MasterServer>(std::move(master_cfg));
+  std::thread master_thread([&] { master->Run(); });
+  for (int i = 0; i < 200 && master->GetBoundPort() == 0; ++i) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  if (master->GetBoundPort() == 0) Die("master failed to start");
+
+  UMBPConfig config;
+  config.dram.use_hugepages = false;
+  config.dram.capacity_bytes = 8 << 20;  // ignored on an SSD node; see medium selection
+  config.ssd.storage_dir = store.string();
+  config.ssd.capacity_bytes = opt.capacity_mb * 1024ULL * 1024ULL;
+  config.ssd.io.backend = opt.io_backend;
+
+  UMBPDistributedConfig distributed;
+  distributed.master_config.node_id = "bench-gds-ssd";
+  distributed.master_config.node_address = "127.0.0.1";
+  distributed.master_config.master_address = "localhost:" + std::to_string(master->GetBoundPort());
+  distributed.io_engine.host = "0.0.0.0";
+  distributed.io_engine.port = 0;
+  distributed.peer_service_port = 0;
+  distributed.medium = UMBPMedium::SSD;
+  distributed.dram_page_size = opt.page_bytes;
+  // ssd_staging_buffer_slots is what PoolClient hands SsdBackend as
+  // Config::staging_pages -- the LOCAL arena, in pages, not the remote one.
+  distributed.ssd_staging_buffer_slots = static_cast<int>(opt.slots);
+  distributed.ssd_staging_buffer_size =
+      std::max<size_t>(256ULL << 20, opt.batch * opt.value_bytes * 4);
+  config.distributed = std::move(distributed);
+
+  std::string err;
+  if (!config.Validate(&err)) Die("config invalid: " + err);
+  auto client = CreateUMBPClient(config);
+  if (client == nullptr) Die("CreateUMBPClient returned null");
+
+  // ---- populate -------------------------------------------------------------
+  std::vector<char> payload(opt.value_bytes, 0x5A);
+  std::vector<std::string> keys;
+  keys.reserve(opt.keys);
+  for (size_t i = 0; i < opt.keys; ++i) keys.push_back("gdsbench/" + std::to_string(i));
+  for (size_t i = 0; i < opt.keys; ++i) {
+    if (!client->Put(keys[i], reinterpret_cast<uintptr_t>(payload.data()), opt.value_bytes)) {
+      Die("Put failed for " + keys[i]);
+    }
+  }
+
+  Destination dst(opt.batch * opt.value_bytes, opt.host_dst);
+  if (!opt.host_dst) {
+    client->RegisterMemory(reinterpret_cast<uintptr_t>(dst.get()), opt.batch * opt.value_bytes,
+                           mori::io::MemoryLocationType::GPU, 0);
+  }
+
+  if (opt.header) {
+    std::printf("mode,pass,dst,value_bytes,batch,keys,slots,wall_ms,gibps,us_per_key\n");
+  }
+  Report(opt, "cold", RunPass(client.get(), keys, dst, opt));
+  Report(opt, "warm", RunPass(client.get(), keys, dst, opt));
+
+  // Correctness, after the timed passes so it costs them nothing.  The device
+  // arm is the one that matters: it is the only path that can have come from a
+  // hipFileRead, and nothing else in the tree checks those bytes end to end
+  // through the public client API.
+  {
+    std::vector<char> back(opt.value_bytes, 0);
+    if (opt.host_dst) {
+      std::memcpy(back.data(), dst.get(), opt.value_bytes);
+    } else {
+      HIP_OK(hipMemcpy(back.data(), dst.get(), opt.value_bytes, hipMemcpyDeviceToHost));
+    }
+    if (std::memcmp(back.data(), payload.data(), opt.value_bytes) != 0) {
+      Die("VERIFY FAILED: bytes read back do not match what was written");
+    }
+    std::fprintf(stderr, "verify ok (%zu bytes)\n", opt.value_bytes);
+  }
+
+  client->Close();
+  master->Shutdown();
+  if (master_thread.joinable()) master_thread.join();
+  std::error_code ec;
+  fs::remove_all(store, ec);
+  return 0;
+}

--- a/tests/cpp/umbp/distributed/test_gds_engine.cpp
+++ b/tests/cpp/umbp/distributed/test_gds_engine.cpp
@@ -1,0 +1,155 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// GdsEngine: routing/planning are pure and run anywhere; the read round trip
+// needs a GPU and the hipFile driver and skips without them.  Point TMPDIR at
+// an ext4/xfs mount (e.g. TMPDIR=/mnt/gds) so the O_DIRECT open succeeds and the
+// fastpath is actually exercised; on other filesystems it skips or falls back.
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "umbp/distributed/transfer/gds_engine.h"
+
+namespace mori::umbp {
+namespace {
+
+TransferRef GpuBuf(void* p, uint64_t n, int dev = 0) {
+  return TransferRef::HostBytes(p, n, mori::io::MemoryLocationType::GPU, dev);
+}
+
+TransferItem MakeItem(const TransferRef& src, uint64_t src_off, const TransferRef& dst,
+                      uint64_t dst_off, uint64_t size, size_t tag) {
+  TransferItem it;
+  it.src = src;
+  it.src_offset = src_off;
+  it.dst = dst;
+  it.dst_offset = dst_off;
+  it.size = size;
+  it.tag = tag;
+  return it;
+}
+
+// ---------------------------------------------------------------------------
+//  Routing / planning — no GPU, no hipFile driver
+// ---------------------------------------------------------------------------
+
+TEST(GdsEngine, ClaimsFileToGpuOnly) {
+  GdsEngine engine;
+  TransferRef file = TransferRef::File(/*fd=*/7, /*offset=*/0, /*n=*/4096, reinterpret_cast<void*>(0x1));
+  std::vector<char> stub(4096);
+  TransferRef gpu = GpuBuf(stub.data(), stub.size());
+  TransferRef host = TransferRef::HostBytes(stub.data(), stub.size());  // CPU
+
+  EXPECT_TRUE(engine.CanHandle(file, gpu));    // the read path
+  EXPECT_FALSE(engine.CanHandle(file, host));  // host dst -> staged path
+  EXPECT_FALSE(engine.CanHandle(gpu, file));   // write path, a later change
+  EXPECT_FALSE(engine.CanHandle(gpu, gpu));    // no file endpoint at all
+}
+
+TEST(GdsEngine, PlansOneRangePerItemAndBoundsToBuffer) {
+  GdsEngine engine;
+  TransferRef file =
+      TransferRef::File(/*fd=*/7, /*offset=*/8192, /*n=*/1 << 20, reinterpret_cast<void*>(0x1));
+  std::vector<char> stub(4096);
+  TransferRef gpu = GpuBuf(stub.data(), stub.size());
+
+  std::vector<TransferItem> items{
+      MakeItem(file, 0, gpu, 0, 2048, 0),
+      MakeItem(file, 2048, gpu, 2048, 2048, 1),
+      MakeItem(file, 0, gpu, 0, 8192, 2),  // overruns the 4096-byte buffer
+  };
+  TransferPlanSet planned = engine.Plan(items);
+  EXPECT_EQ(std::vector<size_t>({2}), planned.rejected_tags);
+  ASSERT_EQ(2u, planned.plans.size());
+  for (const auto& p : planned.plans) EXPECT_EQ(1u, p.sizes.size());
+}
+
+// ---------------------------------------------------------------------------
+//  End to end — needs a GPU and the hipFile driver
+// ---------------------------------------------------------------------------
+
+bool HaveGpu() {
+  int n = 0;
+  return hipGetDeviceCount(&n) == hipSuccess && n > 0;
+}
+
+TEST(GdsEngine, ReadsFileRangeIntoDeviceMemory) {
+  if (!HaveGpu()) GTEST_SKIP() << "no HIP device";
+
+  const size_t kSize = 8192;  // 4 KiB-aligned so the fastpath can accept it
+  const std::string path = std::string(::testing::TempDir()) + "/gds_engine_rt.bin";
+  std::vector<uint8_t> payload(kSize);
+  for (size_t i = 0; i < kSize; ++i) payload[i] = static_cast<uint8_t>(i * 131 + 7);
+
+  {
+    int wfd = ::open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    ASSERT_GE(wfd, 0);
+    ASSERT_EQ(static_cast<ssize_t>(kSize), ::write(wfd, payload.data(), kSize));
+    ::close(wfd);
+  }
+
+  int fd = ::open(path.c_str(), O_RDONLY | O_DIRECT);
+  if (fd < 0) {
+    ::unlink(path.c_str());
+    GTEST_SKIP() << "filesystem rejects O_DIRECT (errno=" << errno << "); point TMPDIR at ext4/xfs";
+  }
+
+  GdsEngine engine;
+  TransferRef file = engine.RegisterFile(fd, /*offset=*/0, kSize);
+  if (!file.IsFile()) {
+    ::close(fd);
+    ::unlink(path.c_str());
+    GTEST_SKIP() << "hipFileHandleRegister unavailable on this host";
+  }
+
+  void* dbuf = nullptr;
+  ASSERT_EQ(hipSuccess, hipMalloc(&dbuf, kSize));
+  ASSERT_EQ(hipSuccess, hipMemset(dbuf, 0, kSize));
+  TransferRef gpu = GpuBuf(dbuf, kSize);
+
+  std::vector<size_t> failed;
+  ASSERT_TRUE(engine.Transfer({MakeItem(file, 0, gpu, 0, kSize, 0)}, &failed));
+  EXPECT_TRUE(failed.empty());
+
+  std::vector<uint8_t> got(kSize, 0);
+  ASSERT_EQ(hipSuccess, hipMemcpy(got.data(), dbuf, kSize, hipMemcpyDeviceToHost));
+  EXPECT_EQ(payload, got);
+
+  hipFree(dbuf);
+  engine.Deregister(file);
+  ::close(fd);
+  ::unlink(path.c_str());
+}
+
+}  // namespace
+}  // namespace mori::umbp

--- a/tests/cpp/umbp/distributed/test_peer_pool.cpp
+++ b/tests/cpp/umbp/distributed/test_peer_pool.cpp
@@ -126,9 +126,9 @@ class BusyResolveBackend final : public MockBackend {
  public:
   explicit BusyResolveBackend(TierType tier) : MockBackend(tier) {}
 
-  std::vector<ResolvedEntry> BatchResolve(const std::vector<std::string>& keys,
-                                          bool include_descs) override {
-    if (!busy_) return MockBackend::BatchResolve(keys, include_descs);
+  std::vector<ResolvedEntry> BatchResolve(const std::vector<std::string>& keys, bool include_descs,
+                                          bool allow_file_refs = false) override {
+    if (!busy_) return MockBackend::BatchResolve(keys, include_descs, allow_file_refs);
     std::vector<ResolvedEntry> results(keys.size());
     for (size_t i = 0; i < keys.size(); ++i) {
       if (Contains(keys[i])) results[i].outcome = ResolveOutcome::kBusy;
@@ -189,8 +189,8 @@ class BlockingResolveBackend final : public MockBackend {
  public:
   explicit BlockingResolveBackend(TierType tier) : MockBackend(tier) {}
 
-  std::vector<ResolvedEntry> BatchResolve(const std::vector<std::string>& keys,
-                                          bool include_descs) override {
+  std::vector<ResolvedEntry> BatchResolve(const std::vector<std::string>& keys, bool include_descs,
+                                          bool allow_file_refs = false) override {
     {
       std::lock_guard<std::mutex> lock(mutex_);
       entered_ = true;
@@ -200,7 +200,7 @@ class BlockingResolveBackend final : public MockBackend {
       std::unique_lock<std::mutex> lock(mutex_);
       cv_.wait_for(lock, std::chrono::seconds(5), [this] { return released_; });
     }
-    return MockBackend::BatchResolve(keys, include_descs);
+    return MockBackend::BatchResolve(keys, include_descs, allow_file_refs);
   }
 
   bool WaitUntilEntered() {

--- a/tests/cpp/umbp/distributed/test_ssd_backend.cpp
+++ b/tests/cpp/umbp/distributed/test_ssd_backend.cpp
@@ -33,6 +33,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <limits>
@@ -559,6 +560,14 @@ TEST_F(SsdBackendTest, ShutdownDeregistersTheArena) {
 // reads the segment range straight into GPU memory. Point TMPDIR at ext4/xfs
 // (e.g. /mnt/gds); skips without a GPU or where the filesystem rejects O_DIRECT.
 TEST(SsdBackendGds, ResolvePublishesFileRefAndReadsIntoDeviceMemory) {
+  // GDS is opt-in at runtime (default off).  Enable it for this test only and
+  // restore on every exit path (including GTEST_SKIP), so sibling staging tests
+  // in this binary keep their default-off behaviour.
+  struct GdsEnvGuard {
+    GdsEnvGuard() { ::setenv("UMBP_ENABLE_GDS", "1", /*overwrite=*/1); }
+    ~GdsEnvGuard() { ::unsetenv("UMBP_ENABLE_GDS"); }
+  } gds_env_guard;
+
   int ndev = 0;
   if (hipGetDeviceCount(&ndev) != hipSuccess || ndev == 0) GTEST_SKIP() << "no HIP device";
 

--- a/tests/cpp/umbp/distributed/test_ssd_backend.cpp
+++ b/tests/cpp/umbp/distributed/test_ssd_backend.cpp
@@ -45,6 +45,12 @@
 #include "umbp/distributed/peer/backend/ssd_backend.h"
 #include "umbp/distributed/transfer/composite_transfer_engine.h"
 #include "umbp/distributed/transfer/local_copy_engine.h"
+#ifdef UMBP_ENABLE_GDS
+#include <hip/hip_runtime.h>
+
+#include "umbp/distributed/transfer/gds_engine.h"
+#include "umbp/distributed/transfer/hbm_copy_engine.h"
+#endif
 
 namespace mori::umbp {
 namespace {
@@ -546,6 +552,87 @@ TEST_F(SsdBackendTest, ShutdownDeregistersTheArena) {
   backend->Shutdown();  // idempotent
   EXPECT_EQ(registrar_.deregistrations, 1);
 }
+
+#ifdef UMBP_ENABLE_GDS
+// End to end: with a GdsEngine in the transfer stack and an O_DIRECT-capable
+// filesystem, Resolve publishes a FileRef (not a staging page) and the engine
+// reads the segment range straight into GPU memory. Point TMPDIR at ext4/xfs
+// (e.g. /mnt/gds); skips without a GPU or where the filesystem rejects O_DIRECT.
+TEST(SsdBackendGds, ResolvePublishesFileRefAndReadsIntoDeviceMemory) {
+  int ndev = 0;
+  if (hipGetDeviceCount(&ndev) != hipSuccess || ndev == 0) GTEST_SKIP() << "no HIP device";
+
+  const auto dir = fs::temp_directory_path() / ("umbp_ssd_gds_" + std::to_string(::getpid()));
+  fs::remove_all(dir);
+
+  // A transfer stack that can move a file into GPU memory: the memory engines
+  // for the Put, the GdsEngine for the zero-copy Get.
+  CompositeTransferEngine composite;
+  composite.AddEngine(std::make_unique<LocalCopyEngine>());
+  composite.AddEngine(std::make_unique<HbmCopyEngine>());
+  composite.AddEngine(std::make_unique<GdsEngine>());
+
+  SsdBackend::Config cfg;
+  cfg.page_size = kPageSize;
+  cfg.staging_pages = 8;
+  cfg.ssd.enabled = true;
+  cfg.ssd.ssd.enabled = true;
+  cfg.ssd.ssd.storage_dir = dir.string();
+  cfg.ssd.ssd.capacity_bytes = 64ULL * 1024 * 1024;
+  cfg.ssd.ssd.io.backend = UMBPIoBackend::Posix;
+  SsdBackend backend(std::move(cfg));
+  ASSERT_TRUE(backend.Init(&composite));
+
+  // Put: allocate a staging page, move the payload in, commit (spills to SSD).
+  std::vector<char> payload(8192);
+  std::iota(payload.begin(), payload.end(), 3);
+  auto alloc = backend.BatchAllocate({AllocateRequest{"k/gds", payload.size()}});
+  ASSERT_EQ(1u, alloc.size());
+  ASSERT_EQ(AllocateOutcome::kSuccessAllocated, alloc[0].outcome);
+  {
+    TransferRef pool = backend.BufferRef(alloc[0].pages[0].buffer_index);
+    TransferItem in;
+    in.src = TransferRef::HostBytes(payload.data(), payload.size());
+    in.dst = pool;
+    in.dst_offset = static_cast<uint64_t>(alloc[0].pages[0].page_index) * kPageSize;
+    in.size = payload.size();
+    ASSERT_TRUE(composite.Transfer({in}, nullptr));
+  }
+  auto commit = backend.BatchCommit({CommitRequest{alloc[0].slot_id, "k/gds"}});
+  ASSERT_EQ(1u, commit.size());
+  ASSERT_TRUE(commit[0].success);
+
+  auto resolved = backend.BatchResolve({"k/gds"}, /*include_descs=*/false);
+  ASSERT_EQ(1u, resolved.size());
+  ASSERT_TRUE(resolved[0].found);
+  if (!resolved[0].file_ref.IsFile()) {
+    backend.Shutdown();
+    fs::remove_all(dir);
+    GTEST_SKIP() << "GDS branch inactive (filesystem rejects O_DIRECT?)";
+  }
+  EXPECT_EQ(resolved[0].size, payload.size());
+
+  // Read the file range straight into device memory through GdsEngine.
+  void* dbuf = nullptr;
+  ASSERT_EQ(hipSuccess, hipMalloc(&dbuf, payload.size()));
+  ASSERT_EQ(hipSuccess, hipMemset(dbuf, 0, payload.size()));
+  TransferItem out;
+  out.src = resolved[0].file_ref;
+  out.dst = TransferRef::HostBytes(dbuf, payload.size(), mori::io::MemoryLocationType::GPU, 0);
+  out.size = resolved[0].size;
+  std::vector<size_t> failed;
+  ASSERT_TRUE(composite.Transfer({out}, &failed));
+  EXPECT_TRUE(failed.empty());
+
+  std::vector<char> got(payload.size(), 0);
+  ASSERT_EQ(hipSuccess, hipMemcpy(got.data(), dbuf, payload.size(), hipMemcpyDeviceToHost));
+  EXPECT_EQ(payload, got);
+
+  (void)hipFree(dbuf);
+  backend.Shutdown();
+  fs::remove_all(dir);
+}
+#endif  // UMBP_ENABLE_GDS
 
 }  // namespace
 }  // namespace mori::umbp

--- a/tests/cpp/umbp/distributed/test_transfer_engine.cpp
+++ b/tests/cpp/umbp/distributed/test_transfer_engine.cpp
@@ -309,5 +309,93 @@ TEST(CompositeTransferEngine, FailsTagsWhenASubEngineSubmitsNothing) {
   EXPECT_EQ(std::vector<size_t>({5}), failed);
 }
 
+// ---------------------------------------------------------------------------
+//  File endpoints (GdsEngine's shape, without HIP)
+// ---------------------------------------------------------------------------
+
+// Stands in for GdsEngine: the only engine that registers and claims files.
+class FakeFileEngine final : public TransferEngine {
+ public:
+  const char* Name() const override { return "FakeFileEngine"; }
+  TransferRef RegisterMemory(void*, size_t, mori::io::MemoryLocationType, int) override {
+    return TransferRef{};  // not a memory engine
+  }
+  TransferRef RegisterFile(int fd, uint64_t offset, uint64_t size) override {
+    ++file_registrations;
+    return TransferRef::File(fd, offset, size, reinterpret_cast<void*>(0xF11E));
+  }
+  void Deregister(const TransferRef& ref) override {
+    if (ref.IsFile()) ++file_deregistrations;
+  }
+  bool CanHandle(const TransferRef& src, const TransferRef& dst) const override {
+    return src.IsFile() && dst.loc == mori::io::MemoryLocationType::GPU;
+  }
+  TransferPlanSet Plan(const std::vector<TransferItem>&) const override { return {}; }
+  std::unique_ptr<TransferHandle> Submit(std::vector<TransferPlan>) override { return nullptr; }
+
+  int file_registrations = 0;
+  int file_deregistrations = 0;
+};
+
+TEST(TransferRef, FileEndpointIsValidAndIgnoredByMemoryEngines) {
+  TransferRef f = TransferRef::File(/*fd=*/7, /*offset=*/4096, /*n=*/65536);
+  EXPECT_TRUE(f.IsFile());
+  EXPECT_TRUE(f.Valid());
+  EXPECT_FALSE(f.HasHostPtr());
+  EXPECT_FALSE(f.HasMemoryDesc());
+  EXPECT_EQ(7, f.file_fd);
+  EXPECT_EQ(4096u, f.file_offset);
+  EXPECT_EQ(65536u, f.size);
+
+  // A memory engine never claims a file endpoint, so per-pair selection leaves
+  // it for the file engine.
+  LocalCopyEngine mem;
+  std::vector<char> stub(64);
+  TransferRef gpu =
+      TransferRef::HostBytes(stub.data(), stub.size(), mori::io::MemoryLocationType::GPU, 0);
+  EXPECT_FALSE(mem.CanHandle(f, gpu));
+}
+
+TEST(CompositeTransferEngine, RegisterFileFansOutToTheFileEngine) {
+  auto composite = std::make_unique<CompositeTransferEngine>();
+  composite->AddEngine(std::make_unique<LocalCopyEngine>());
+  auto file_owned = std::make_unique<FakeFileEngine>();
+  FakeFileEngine* file = file_owned.get();
+  composite->AddEngine(std::move(file_owned));
+
+  TransferRef ref = composite->RegisterFile(/*fd=*/9, /*offset=*/8192, /*size=*/4096);
+  EXPECT_EQ(1, file->file_registrations);
+  ASSERT_TRUE(ref.IsFile());
+  EXPECT_EQ(9, ref.file_fd);
+  EXPECT_EQ(8192u, ref.file_offset);
+  EXPECT_EQ(reinterpret_cast<void*>(0xF11E), ref.gds_handle);
+
+  composite->Deregister(ref);
+  EXPECT_EQ(1, file->file_deregistrations);
+}
+
+TEST(CompositeTransferEngine, RegisterFileIsInvalidWithoutAFileEngine) {
+  auto composite = std::make_unique<CompositeTransferEngine>();
+  composite->AddEngine(std::make_unique<LocalCopyEngine>());
+  TransferRef ref = composite->RegisterFile(/*fd=*/3, /*offset=*/0, /*size=*/4096);
+  EXPECT_FALSE(ref.IsFile());
+  EXPECT_FALSE(ref.Valid());
+}
+
+TEST(CompositeTransferEngine, SelectsTheFileEngineForAFileToGpuPair) {
+  auto composite = std::make_unique<CompositeTransferEngine>();
+  composite->AddEngine(std::make_unique<LocalCopyEngine>());
+  composite->AddEngine(std::make_unique<FakeFileEngine>());
+
+  TransferRef src =
+      TransferRef::File(/*fd=*/5, /*offset=*/0, /*n=*/4096, reinterpret_cast<void*>(0x1));
+  std::vector<char> gpu(4096);
+  TransferRef dst =
+      TransferRef::HostBytes(gpu.data(), gpu.size(), mori::io::MemoryLocationType::GPU, 0);
+  TransferEngine* sel = composite->SelectEngine(src, dst);
+  ASSERT_NE(nullptr, sel);
+  EXPECT_STREQ("FakeFileEngine", sel->Name());
+}
+
 }  // namespace
 }  // namespace mori::umbp

--- a/tests/cpp/umbp/local/test_ssd_direct_io.cpp
+++ b/tests/cpp/umbp/local/test_ssd_direct_io.cpp
@@ -27,6 +27,8 @@
 // it is meaningless.  These tests pin the correctness properties that make the
 // unbuffered path usable, not its speed.
 
+#include <unistd.h>
+
 #include <cstring>
 #include <filesystem>
 #include <iostream>
@@ -190,6 +192,41 @@ void test_round_trip(bool direct_io) {
   std::cout << "OK\n";
 }
 
+// LocateRecord must hand back an fd and offset that, pread'd directly, yield the
+// stored value — the contract GdsEngine relies on to hipFileRead a segment range
+// straight into GPU memory.
+void test_locate_record() {
+  std::cout << "test_locate_record... ";
+  const std::string dir = MakeDir("locate");
+  auto cfg = BaseConfig(dir, /*direct_io=*/false, /*verify_crc=*/true);
+  SSDTier tier(dir, cfg.capacity_bytes, cfg);
+
+  const std::string key = "k/locate";
+  const auto value = AlignedValue('L', 3);
+  CHECK(tier.Write(key, value.data(), value.size()));
+
+  auto loc = tier.LocateRecord(key);
+  CHECK(loc.has_value());
+  CHECK(loc->fd >= 0);
+  CHECK(loc->value_size == value.size());
+  CHECK(loc->readable_size == PaddedValueBytes(value.size()));
+  CHECK(loc->value_offset % kRecordAlign == 0);
+  CHECK(loc->direct_io == tier.direct_io_active());
+
+  // The offset/size must point at the real bytes: pread the fd ourselves and
+  // compare — exactly what a GDS read does, but on the CPU.
+  std::vector<char> got(loc->value_size, 0);
+  const ssize_t n = ::pread(loc->fd, got.data(), got.size(), static_cast<off_t>(loc->value_offset));
+  CHECK(n == static_cast<ssize_t>(got.size()));
+  CHECK(std::memcmp(got.data(), value.data(), value.size()) == 0);
+
+  // An unknown key has no location.
+  CHECK(!tier.LocateRecord("k/missing").has_value());
+
+  fs::remove_all(dir);
+  std::cout << "OK\n";
+}
+
 // verify_crc=0 must round-trip, and — the part that is easy to get wrong — a
 // store written with checksums off must stay readable by a tier with checksums
 // on.  Without the kFlagNoCrc marker every such key would read back as corrupt.
@@ -297,6 +334,7 @@ int main() {
   test_aligned_buffer();
   test_round_trip(/*direct_io=*/false);
   test_round_trip(/*direct_io=*/true);
+  test_locate_record();
   test_crc_disabled_round_trip();
   test_tier_threads_are_result_invariant();
   test_capacity_charges_padded_bytes();


### PR DESCRIPTION
## Summary
- Add a `File` transfer endpoint (`FileRef`: fd / offset / padded_size / gds_handle) plus `MemoryRegistrar::RegisterFile`, and a hipFile-backed `GdsEngine` that DMAs SSD segment ranges straight into GPU memory with no host bounce.
- Read-only `LocateRecord` on `SsdTier` / `ShardedSsdTier` / `PeerSsdManager` exposes the physical O_DIRECT location of a record; `SsdBackend::BatchResolve` publishes a `FileRef` for O_DIRECT records; `PoolClient` registers `GdsEngine` and routes `(File -> GPU)` items to it.
- Fully gated and backward compatible:
  - compile-time: only built/linked when `hipfile` is found (`UMBP_ENABLE_GDS`);
  - runtime kill-switch: `UMBP_ENABLE_GDS=0` falls back to the existing staging path;
  - no change to Put/write, remote, ranged, or non-SSD transfer/backend paths.
- `SsdBackend::ClearLocal` / `Shutdown` deregister cached hipFile handles to avoid stale fd reuse after segment rotation.

## Test plan
- [x] `test_transfer_engine`: File endpoint + Composite `RegisterFile` fan-out + File->GPU routing
- [x] `test_gds_engine`: CanHandle / Plan bounds + end-to-end `hipFileRead` into device memory
- [x] `test_ssd_direct_io`: `LocateRecord` pread contract (known + unknown key)
- [x] `test_ssd_backend`: end-to-end SSD->GPU via GDS; 21 existing staging tests unchanged
- [x] `UMBP_ENABLE_GDS=0` verified to fall back to staging
- Env: MI300X + hipfile, O_DIRECT ext4 (`TMPDIR=/mnt/gds`)
