### PR TITLE
chore(EPv2): initialize the routing dest_map once within the op construct

### DIFF
--- a/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
+++ b/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
@@ -795,6 +795,7 @@ class EpDispatchCombineOp:
         half, so one rank resetting alone would leave the two disagreeing."""
         self.arena.zero()
         self.token_dest_map.fill_(-1)
+        self.routing_dest_map.fill_(self._null_flat)
         self.dest_pe_counter.zero_()
         self.dispatch_barrier.zero_()
         self.combine_barrier.zero_()

--- a/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
+++ b/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
@@ -695,13 +695,10 @@ class EpDispatchCombineOp:
             kern, dest_map = table[disp_spec], routing.disp_dest_tok_id_map
         else:
             kern = self._kernels.dispatch[disp_spec]
-            # return_routing hands the handle its own dest_map (filled -1 so unset
-            # (tok,k) slots read as null); a plain dispatch reuses the scratch one.
-            dest_map = (
-                torch.full_like(self.token_dest_map, -1)
-                if return_routing
-                else self.token_dest_map
-            )
+            if return_routing:
+                dest_map = self.routing_dest_map
+            else:
+                dest_map = self.token_dest_map
 
         kern(
             input=input,

--- a/python/mori/ops/dispatch_combine_v2/flydsl_backend.py
+++ b/python/mori/ops/dispatch_combine_v2/flydsl_backend.py
@@ -118,7 +118,8 @@ class EpDispatchCombineOpFlyDSL(EpDispatchCombineOp, backend="flydsl"):
         self.token_dest_map = torch.full(
             (max_tok_per_rank * topk,), -1, dtype=torch.int32, device=device
         )
-        self.routing_dest_map = torch.full_like(self.token_dest_map, -1)
+        self._null_flat = cfg.world_size * cfg.effective_max_recv
+        self.routing_dest_map = torch.full_like(self.token_dest_map, self._null_flat)
         self.dest_pe_counter = torch.zeros(
             cfg.world_size, dtype=torch.int32, device=device
         )

--- a/python/mori/ops/dispatch_combine_v2/flydsl_backend.py
+++ b/python/mori/ops/dispatch_combine_v2/flydsl_backend.py
@@ -118,6 +118,7 @@ class EpDispatchCombineOpFlyDSL(EpDispatchCombineOp, backend="flydsl"):
         self.token_dest_map = torch.full(
             (max_tok_per_rank * topk,), -1, dtype=torch.int32, device=device
         )
+        self.routing_dest_map = torch.full_like(self.token_dest_map, -1)
         self.dest_pe_counter = torch.zeros(
             cfg.world_size, dtype=torch.int32, device=device
         )

--- a/python/mori/ops/dispatch_combine_v2/hip_backend.py
+++ b/python/mori/ops/dispatch_combine_v2/hip_backend.py
@@ -105,6 +105,7 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
         max_tok = cfg.max_num_inp_token_per_rank
         i32 = dict(dtype=torch.int32, device=dev)
         self.token_dest_map = torch.zeros(max_tok * topk, **i32)
+        self.routing_dest_map = torch.full_like(self.token_dest_map, -1)
         self.dest_pe_counter = torch.zeros(cfg.world_size, **i32)
         self.total_recv = torch.zeros(1, **i32)
         self.dispatch_barrier = torch.zeros(1, dtype=torch.uint32, device=dev)

--- a/python/mori/ops/dispatch_combine_v2/hip_backend.py
+++ b/python/mori/ops/dispatch_combine_v2/hip_backend.py
@@ -105,7 +105,8 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
         max_tok = cfg.max_num_inp_token_per_rank
         i32 = dict(dtype=torch.int32, device=dev)
         self.token_dest_map = torch.zeros(max_tok * topk, **i32)
-        self.routing_dest_map = torch.full_like(self.token_dest_map, -1)
+        self._null_flat = cfg.world_size * cfg.effective_max_recv
+        self.routing_dest_map = torch.full_like(self.token_dest_map, self._null_flat)
         self.dest_pe_counter = torch.zeros(cfg.world_size, **i32)
         self.total_recv = torch.zeros(1, **i32)
         self.dispatch_barrier = torch.zeros(1, dtype=torch.uint32, device=dev)


### PR DESCRIPTION
##  Summary

  - Pre-allocate routing_dest_map in __init__ (both flydsl and hip backends) instead of calling torch.full_like(self.token_dest_map, -1) on every dispatch(return_routing=True) call.
  - The dispatch kernel writes every (tok, k) slot below num_tokens, and no consumer reads past that bound, so the -1 sentinel only matters for the initial state — a single fill at init time is sufficient.
  - routing_dest_map is kept separate from token_dest_map because return_routing=True passes the buffer into EpDispatchRoutingHandle for combine replay; sharing one buffer would let the next dispatch overwrite data that combine still needs.

 ##  Why the original code was wasteful

  - torch.full_like both allocates a new tensor and fills it on every call. In the bench loop this added a per-iteration alloc+fill whose cost was silently folded into the dispatch CUDA-event timing. In e2e serving the allocation only ran once per forward (dispatch → experts → combine), but the fill was still unnecessary.

##  Safety
  - The handle from call N is aliased by call N+1 — acceptable because the serving path never holds a handle across steps (dispatch → experts → combine within one forward).
