### PR TITLE
MORI IO improvements 2nd try

### DIFF
--- a/src/io/rdma/backend_impl.cpp
+++ b/src/io/rdma/backend_impl.cpp
@@ -591,6 +591,7 @@ EndpointId RdmaManager::ConnectEndpoint(EngineKey remoteKey, int devId,
   EndpointId id = nextEndpointId_.fetch_add(1);
   auto rt = std::make_shared<EndpointRuntime>(id, ep);
   endpointsById_[id] = rt;
+  endpointsEpoch_.fetch_add(1, std::memory_order_release);
   return id;
 }
 
@@ -617,14 +618,13 @@ bool RdmaManager::HasIonicDevice() const {
   return false;
 }
 
-std::vector<std::shared_ptr<EndpointRuntime>> RdmaManager::SnapshotEndpointRuntimes() {
+void RdmaManager::SnapshotEndpointRuntimes(SnapshotVector& result) {
   std::shared_lock<std::shared_mutex> lock(mu);
-  std::vector<std::shared_ptr<EndpointRuntime>> result;
-  result.reserve(endpointsById_.size());
-  for (auto& [_, rt] : endpointsById_) {
-    result.push_back(rt);
+  result.resize(endpointsById_.size());
+  size_t i = 0;
+  for (const auto& [_, rt] : endpointsById_) {
+    result[i++] = rt;
   }
-  return result;
 }
 
 application::RdmaDeviceContext* RdmaManager::GetOrCreateDeviceContext(int devId) {
@@ -676,7 +676,10 @@ void NotifManager::RegisterEndpoint(const std::shared_ptr<EndpointRuntime>& rt) 
   application::RdmaMemoryRegion mr =
       devCtx->RegisterRdmaMemoryRegionAuto(buf, config.notifPerQp * sizeof(NotifMessage));
 
-  notifCtxById_.insert({rt->id, {mr, buf}});
+  auto notifIt = notifCtxById_.insert({rt->id, {mr, buf}}).first;
+  // Publish the (rehash-stable, node-based map) context pointer so the poll loop
+  // can read it locklessly. release pairs with the acquire load in ProcessOneCqe.
+  rt->notifCtx.store(&notifIt->second, std::memory_order_release);
 
   struct ibv_qp* qp = rt->ep.local.ibvHandle.qp;
   assert(qp);
@@ -703,13 +706,13 @@ NotifManager::FlushDrainStats NotifManager::ProcessOneCqe(
   ibv_cq* cq = ep.local.ibvHandle.cq;
   FlushDrainStats flushDrain;
 
-  // Resolve notif context once before the CQ drain loop.
-  QpNotifContext* notifCtxPtr = nullptr;
-  if (config.enableNotification) {
-    std::lock_guard<std::mutex> lock(mu);
-    auto nit = notifCtxById_.find(rt->id);
-    if (nit != notifCtxById_.end()) notifCtxPtr = &nit->second;
-  }
+  // Resolve notif context locklessly: it is published once at registration and
+  // the containing map is node-based, so the cached pointer stays valid. acquire
+  // pairs with the release store in RegisterEndpoint.
+  QpNotifContext* notifCtxPtr =
+      config.enableNotification
+          ? static_cast<QpNotifContext*>(rt->notifCtx.load(std::memory_order_acquire))
+          : nullptr;
 
   const int batchSize = 32;
   struct ibv_wc wc[batchSize];
@@ -956,8 +959,18 @@ void NotifManager::MainLoop() {
       }
     }
   } else {
+    // The endpoint set is effectively append-only and changes rarely, but this
+    // is a tight busy-poll loop. Rebuilding the snapshot every iteration would
+    // take a shared_lock and heap-allocate on every spin (a large fraction of
+    // this thread's CPU). Instead cache it and only rebuild when the epoch moves.
+    RdmaManager::SnapshotVector snapshot;
+    uint64_t snapshotEpoch = rdma->EndpointsEpoch() - 1;
     while (running.load()) {
-      auto snapshot = rdma->SnapshotEndpointRuntimes();
+      uint64_t curEpoch = rdma->EndpointsEpoch();
+      if (curEpoch != snapshotEpoch) {
+        rdma->SnapshotEndpointRuntimes(snapshot);
+        snapshotEpoch = curEpoch;
+      }
       if (snapshot.empty()) {
         EmitFlushSummaryIfNeeded(FlushRoundStats{});
         std::this_thread::yield();

--- a/src/io/rdma/backend_impl.hpp
+++ b/src/io/rdma/backend_impl.hpp
@@ -68,6 +68,8 @@ EpPairVec InterleaveEndpointsByLocalDevice(const EpPairVec& eps,
 /* ---------------------------------------------------------------------------------------------- */
 class RdmaManager {
  public:
+  using SnapshotVector = std::vector<std::shared_ptr<EndpointRuntime>>;
+
   RdmaManager(const RdmaBackendConfig cfg, application::RdmaContext* ctx);
   ~RdmaManager();
 
@@ -98,7 +100,12 @@ class RdmaManager {
                              int rdevId, application::RdmaEndpointHandle remote, TopoKeyPair key,
                              int weight);
   std::shared_ptr<EndpointRuntime> GetEndpointRuntime(EndpointId id);
-  std::vector<std::shared_ptr<EndpointRuntime>> SnapshotEndpointRuntimes();
+  void SnapshotEndpointRuntimes(SnapshotVector& result);
+  // Monotonic generation counter bumped whenever the endpoint set changes.
+  // Lets hot pollers skip the locked snapshot rebuild when nothing changed.
+  uint64_t EndpointsEpoch() const noexcept {
+    return endpointsEpoch_.load(std::memory_order_acquire);
+  }
 
   application::RdmaDeviceContext* GetRdmaDeviceContext(int devId);
   size_t NumAvailDevices() const { return availDevices.size(); }
@@ -119,6 +126,7 @@ class RdmaManager {
   std::unordered_map<EngineKey, RemoteEngineMeta> remotes;
   std::atomic<EndpointId> nextEndpointId_{1};
   std::unordered_map<EndpointId, std::shared_ptr<EndpointRuntime>> endpointsById_;
+  std::atomic<uint64_t> endpointsEpoch_{0};
 
   std::unique_ptr<application::TopoSystem> topo{nullptr};
   std::atomic<uint32_t> roundRobinCounter{0};

--- a/src/io/rdma/common.hpp
+++ b/src/io/rdma/common.hpp
@@ -240,6 +240,11 @@ struct EndpointRuntime {
 
   EndpointId id{0};
   EpPair ep;
+  // Cached pointer to this endpoint's NotifManager::QpNotifContext, published once
+  // at registration. Lets the hot CQ poller resolve the notif context without
+  // locking NotifManager::mu on every poll. Type-erased (void*) to avoid a header
+  // dependency on the NotifManager-private struct; nullptr until registered.
+  std::atomic<void*> notifCtx{nullptr};
 };
 
 using EpPairVec = std::vector<EpPair>;


### PR DESCRIPTION
Extracted the most obvious IO improvements from the original PR: https://github.com/ROCm/mori/pull/518

Epoch-gated snapshot caching. `NotifManager::MainLoop` busy-poll loop was calling `rdma->SnapshotEndpointRuntimes()` every single spin iteration, which took a shared_lock and heap-allocated a fresh `vector<shared_ptr<EndpointRuntime>>`
Profiled across 3 different presets (listed in the main PR above). 

I have left the risky `SubmissionLedger` improvements alone, anyway, the profiling suggests that this part needs to be changed too. See the comment: https://github.com/ROCm/mori/pull/518#issuecomment-5294464381 

Improvements from this PR eliminate the following hot-path function calls (the complete profiling graphs (OLD vs NEW) are attatched):
```
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes 114512615
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;operator!= 111658322
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;shared_lock<shared_mutex>::shared_lock;shared_mutex::lock_shared;__shared_mutex_pthread::lock_shared;__glibcxx_rwlock_rdlock 40515037
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;shared_lock<shared_mutex>::shared_lock;shared_mutex::lock_shared;__shared_mutex_pthread::lock_shared;__glibcxx_rwlock_rdlock;[libmori_io.so] 31490844
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;shared_lock<shared_mutex>::shared_lock;shared_mutex::lock_shared;__shared_mutex_pthread::lock_shared;__glibcxx_rwlock_rdlock;__pthread_rwlock_rdlock@GLIBC_2.2.5;__pthread_rwlock_rdlock_full64 683062131
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;shared_lock<shared_mutex>::shared_lock;shared_mutex::lock_shared;__shared_mutex_pthread::lock_shared;__glibcxx_rwlock_rdlock;__pthread_rwlock_rdlock@GLIBC_2.2.5;__pthread_rwlock_rdlock_full64;asm_sysvec_apic_timer_interrupt;sysvec_apic_timer_interrupt;irq_exit_rcu;handle_softirqs;run_rebalance_domains;rebalance_domains;_raw_spin_trylock 953832
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;shared_lock<shared_mutex>::~shared_lock;shared_mutex::unlock_shared;__shared_mutex_pthread::unlock_shared;__shared_mutex_pthread::unlock;__glibcxx_rwlock_unlock 23864280
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;shared_lock<shared_mutex>::~shared_lock;shared_mutex::unlock_shared;__shared_mutex_pthread::unlock_shared;__shared_mutex_pthread::unlock;__glibcxx_rwlock_unlock;[libmori_io.so] 27654880
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;shared_lock<shared_mutex>::~shared_lock;shared_mutex::unlock_shared;__shared_mutex_pthread::unlock_shared;__shared_mutex_pthread::unlock;__glibcxx_rwlock_unlock;__pthread_rwlock_unlock@GLIBC_2.2.5 26748895
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;shared_lock<shared_mutex>::~shared_lock;shared_mutex::unlock_shared;__shared_mutex_pthread::unlock_shared;__shared_mutex_pthread::unlock;__glibcxx_rwlock_unlock;__pthread_rwlock_unlock@GLIBC_2.2.5;__pthread_rwlock_rdunlock 596099856
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;shared_lock<shared_mutex>::~shared_lock;shared_mutex::unlock_shared;__shared_mutex_pthread::unlock_shared;__shared_mutex_pthread::unlock;__glibcxx_rwlock_unlock;__pthread_rwlock_unlock@GLIBC_2.2.5;__pthread_rwlock_rdunlock;__pthread_rwlock_get_private 62062530
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;vector<shared_ptr<mori::io::EndpointRuntime>,  >::push_back 72632305
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;vector<shared_ptr<mori::io::EndpointRuntime>,  >::push_back;asm_sysvec_apic_timer_interrupt;sysvec_apic_timer_interrupt;__sysvec_apic_timer_interrupt;hrtimer_interrupt;__hrtimer_run_queues;tick_sched_timer;tick_sched_handle;update_process_times 954217
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;vector<shared_ptr<mori::io::EndpointRuntime>,  >::push_back;asm_sysvec_apic_timer_interrupt;sysvec_apic_timer_interrupt;__sysvec_apic_timer_interrupt;hrtimer_interrupt;__hrtimer_run_queues;tick_sched_timer;tick_sched_handle;update_process_times;scheduler_tick;_raw_spin_lock 954919
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;vector<shared_ptr<mori::io::EndpointRuntime>,  >::push_back;asm_sysvec_call_function_single;sysvec_call_function_single;__sysvec_call_function_single;generic_smp_call_function_single_interrupt;flush_smp_call_function_queue 953771
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;vector<shared_ptr<mori::io::EndpointRuntime>,  >::push_back;allocator_traits< >::construct<shared_ptr<mori::io::EndpointRuntime>, shared_ptr<mori::io::EndpointRuntime> const&>;__new_allocator<shared_ptr<mori::io::EndpointRuntime> >::construct<shared_ptr<mori::io::EndpointRuntime>, shared_ptr<mori::io::EndpointRuntime> const&>;shared_ptr<mori::io::EndpointRuntime>::shared_ptr;__shared_ptr<mori::io::EndpointRuntime,  60443041
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;vector<shared_ptr<mori::io::EndpointRuntime>,  >::push_back;allocator_traits< >::construct<shared_ptr<mori::io::EndpointRuntime>, shared_ptr<mori::io::EndpointRuntime> const&>;__new_allocator<shared_ptr<mori::io::EndpointRuntime> >::construct<shared_ptr<mori::io::EndpointRuntime>, shared_ptr<mori::io::EndpointRuntime> const&>;shared_ptr<mori::io::EndpointRuntime>::shared_ptr;__shared_ptr<mori::io::EndpointRuntime, ;__shared_count<;_Sp_counted_base<;__gnu_cxx::__atomic_add_dispatch 98459061
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;vector<shared_ptr<mori::io::EndpointRuntime>,  >::push_back;allocator_traits< >::construct<shared_ptr<mori::io::EndpointRuntime>, shared_ptr<mori::io::EndpointRuntime> const&>;__new_allocator<shared_ptr<mori::io::EndpointRuntime> >::construct<shared_ptr<mori::io::EndpointRuntime>, shared_ptr<mori::io::EndpointRuntime> const&>;shared_ptr<mori::io::EndpointRuntime>::shared_ptr;__shared_ptr<mori::io::EndpointRuntime, ;__shared_count<;_Sp_counted_base<;__gnu_cxx::__atomic_add_dispatch;__gnu_cxx::__atomic_add 1828898986
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;vector<shared_ptr<mori::io::EndpointRuntime>,  >::reserve 75344962
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;vector<shared_ptr<mori::io::EndpointRuntime>,  >::reserve;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::_M_allocate;allocator_traits< >::allocate;__new_allocator<shared_ptr<mori::io::EndpointRuntime> >::allocate 58185955
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;vector<shared_ptr<mori::io::EndpointRuntime>,  >::reserve;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::_M_allocate;allocator_traits< >::allocate;__new_allocator<shared_ptr<mori::io::EndpointRuntime> >::allocate;[libmori_io.so] 33431372
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;vector<shared_ptr<mori::io::EndpointRuntime>,  >::reserve;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::_M_allocate;allocator_traits< >::allocate;__new_allocator<shared_ptr<mori::io::EndpointRuntime> >::allocate;operator new;[libstdc++.so.6.0.30] 40085527
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;vector<shared_ptr<mori::io::EndpointRuntime>,  >::reserve;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::_M_allocate;allocator_traits< >::allocate;__new_allocator<shared_ptr<mori::io::EndpointRuntime> >::allocate;operator new;malloc 193893150
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;vector<shared_ptr<mori::io::EndpointRuntime>,  >::reserve;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::_M_allocate;allocator_traits< >::allocate;__new_allocator<shared_ptr<mori::io::EndpointRuntime> >::allocate;operator new;malloc;checked_request2size 59199734
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;vector<shared_ptr<mori::io::EndpointRuntime>,  >::reserve;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::_M_allocate;allocator_traits< >::allocate;__new_allocator<shared_ptr<mori::io::EndpointRuntime> >::allocate;operator new;malloc;tcache_get 96478953
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;mori::io::RdmaManager::SnapshotEndpointRuntimes;vector<shared_ptr<mori::io::EndpointRuntime>,  >::vector;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::_Vector_base;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::_Vector_impl::_Vector_impl;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::_Vector_impl_data::_Vector_impl_data 34376215
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;vector<shared_ptr<mori::io::EndpointRuntime>,  >::~vector;_Destroy<shared_ptr<mori::io::EndpointRuntime>*, shared_ptr<mori::io::EndpointRuntime> >;_Destroy<shared_ptr<mori::io::EndpointRuntime>*>;_Destroy_aux<false>::__destroy<shared_ptr<mori::io::EndpointRuntime>*> 68723674
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;vector<shared_ptr<mori::io::EndpointRuntime>,  >::~vector;_Destroy<shared_ptr<mori::io::EndpointRuntime>*, shared_ptr<mori::io::EndpointRuntime> >;_Destroy<shared_ptr<mori::io::EndpointRuntime>*>;_Destroy_aux<false>::__destroy<shared_ptr<mori::io::EndpointRuntime>*>;_Destroy<shared_ptr<mori::io::EndpointRuntime> >;__shared_ptr<mori::io::EndpointRuntime, ;__shared_count< 53581628
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;vector<shared_ptr<mori::io::EndpointRuntime>,  >::~vector;_Destroy<shared_ptr<mori::io::EndpointRuntime>*, shared_ptr<mori::io::EndpointRuntime> >;_Destroy<shared_ptr<mori::io::EndpointRuntime>*>;_Destroy_aux<false>::__destroy<shared_ptr<mori::io::EndpointRuntime>*>;_Destroy<shared_ptr<mori::io::EndpointRuntime> >;__shared_ptr<mori::io::EndpointRuntime, ;__shared_count<;_Sp_counted_base< 131683372
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;vector<shared_ptr<mori::io::EndpointRuntime>,  >::~vector;_Destroy<shared_ptr<mori::io::EndpointRuntime>*, shared_ptr<mori::io::EndpointRuntime> >;_Destroy<shared_ptr<mori::io::EndpointRuntime>*>;_Destroy_aux<false>::__destroy<shared_ptr<mori::io::EndpointRuntime>*>;_Destroy<shared_ptr<mori::io::EndpointRuntime> >;__shared_ptr<mori::io::EndpointRuntime, ;__shared_count<;_Sp_counted_base<;__gnu_cxx::__exchange_and_add_dispatch 93837917
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;vector<shared_ptr<mori::io::EndpointRuntime>,  >::~vector;_Destroy<shared_ptr<mori::io::EndpointRuntime>*, shared_ptr<mori::io::EndpointRuntime> >;_Destroy<shared_ptr<mori::io::EndpointRuntime>*>;_Destroy_aux<false>::__destroy<shared_ptr<mori::io::EndpointRuntime>*>;_Destroy<shared_ptr<mori::io::EndpointRuntime> >;__shared_ptr<mori::io::EndpointRuntime, ;__shared_count<;_Sp_counted_base<;__gnu_cxx::__exchange_and_add_dispatch;__gnu_cxx::__exchange_and_add 1767436526
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;vector<shared_ptr<mori::io::EndpointRuntime>,  >::~vector;_Destroy<shared_ptr<mori::io::EndpointRuntime>*, shared_ptr<mori::io::EndpointRuntime> >;_Destroy<shared_ptr<mori::io::EndpointRuntime>*>;_Destroy_aux<false>::__destroy<shared_ptr<mori::io::EndpointRuntime>*>;_Destroy<shared_ptr<mori::io::EndpointRuntime> >;__shared_ptr<mori::io::EndpointRuntime, ;__shared_count<;_Sp_counted_base<;__gnu_cxx::__exchange_and_add_dispatch;__gnu_cxx::__is_single_threaded 85921638
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;vector<shared_ptr<mori::io::EndpointRuntime>,  >::~vector;_Destroy<shared_ptr<mori::io::EndpointRuntime>*, shared_ptr<mori::io::EndpointRuntime> >;_Destroy<shared_ptr<mori::io::EndpointRuntime>*>;_Destroy_aux<false>::__destroy<shared_ptr<mori::io::EndpointRuntime>*>;_Destroy<shared_ptr<mori::io::EndpointRuntime> >;__shared_ptr<mori::io::EndpointRuntime, ;__shared_count<;_Sp_counted_base<;asm_sysvec_apic_timer_interrupt;sysvec_apic_timer_interrupt;irqentry_exit;irqentry_exit_to_user_mode;exit_to_user_mode_loop;schedule;__schedule;pick_next_task;pick_next_task_fair;put_prev_entity;update_load_avg;__update_load_avg_se 953650
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;vector<shared_ptr<mori::io::EndpointRuntime>,  >::~vector;_Destroy<shared_ptr<mori::io::EndpointRuntime>*, shared_ptr<mori::io::EndpointRuntime> >;_Destroy<shared_ptr<mori::io::EndpointRuntime>*>;_Destroy_aux<false>::__destroy<shared_ptr<mori::io::EndpointRuntime>*>;_Destroy<shared_ptr<mori::io::EndpointRuntime> >;__shared_ptr<mori::io::EndpointRuntime, ;__shared_count<;_Sp_counted_base<;sync_regs 954021
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;vector<shared_ptr<mori::io::EndpointRuntime>,  >::~vector;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::~_Vector_base 47765544
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;vector<shared_ptr<mori::io::EndpointRuntime>,  >::~vector;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::~_Vector_base;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::_M_deallocate;allocator_traits< >::deallocate;__new_allocator<shared_ptr<mori::io::EndpointRuntime> >::deallocate 21930807
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;vector<shared_ptr<mori::io::EndpointRuntime>,  >::~vector;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::~_Vector_base;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::_M_deallocate;allocator_traits< >::deallocate;__new_allocator<shared_ptr<mori::io::EndpointRuntime> >::deallocate;[libmori_io.so] 38176858
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;vector<shared_ptr<mori::io::EndpointRuntime>,  >::~vector;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::~_Vector_base;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::_M_deallocate;allocator_traits< >::deallocate;__new_allocator<shared_ptr<mori::io::EndpointRuntime> >::deallocate;[libstdc++.so.6.0.30] 61075161
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;vector<shared_ptr<mori::io::EndpointRuntime>,  >::~vector;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::~_Vector_base;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::_M_deallocate;allocator_traits< >::deallocate;__new_allocator<shared_ptr<mori::io::EndpointRuntime> >::deallocate;asm_sysvec_apic_timer_interrupt;sysvec_apic_timer_interrupt;native_apic_msr_eoi_write 954112
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;vector<shared_ptr<mori::io::EndpointRuntime>,  >::~vector;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::~_Vector_base;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::_M_deallocate;allocator_traits< >::deallocate;__new_allocator<shared_ptr<mori::io::EndpointRuntime> >::deallocate;cfree@GLIBC_2.2.5 94542400
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;vector<shared_ptr<mori::io::EndpointRuntime>,  >::~vector;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::~_Vector_base;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::_M_deallocate;allocator_traits< >::deallocate;__new_allocator<shared_ptr<mori::io::EndpointRuntime> >::deallocate;cfree@GLIBC_2.2.5;_int_free 135500242
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;vector<shared_ptr<mori::io::EndpointRuntime>,  >::~vector;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::~_Vector_base;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::_M_deallocate;allocator_traits< >::deallocate;__new_allocator<shared_ptr<mori::io::EndpointRuntime> >::deallocate;cfree@GLIBC_2.2.5;_int_free;asm_sysvec_apic_timer_interrupt;sysvec_apic_timer_interrupt;__sysvec_apic_timer_interrupt;hrtimer_interrupt;__hrtimer_run_queues;tick_sched_timer;tick_sched_handle;update_process_times;scheduler_tick;trigger_load_balance;nohz_balancer_kick 953786
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;vector<shared_ptr<mori::io::EndpointRuntime>,  >::~vector;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::~_Vector_base;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::_M_deallocate;allocator_traits< >::deallocate;__new_allocator<shared_ptr<mori::io::EndpointRuntime> >::deallocate;cfree@GLIBC_2.2.5;_int_free;tcache_put 21999006
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;vector<shared_ptr<mori::io::EndpointRuntime>,  >::~vector;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::~_Vector_base;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::_M_deallocate;allocator_traits< >::deallocate;__new_allocator<shared_ptr<mori::io::EndpointRuntime> >::deallocate;cfree@GLIBC_2.2.5;arena_for_chunk;arena_for_chunk;heap_for_ptr 38180995
python;[unknown];[libstdc++.so.6.0.30];mori::io::NotifManager::MainLoop;vector<shared_ptr<mori::io::EndpointRuntime>,  >::~vector;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::~_Vector_base;_Vector_base<shared_ptr<mori::io::EndpointRuntime>,  >::_M_deallocate;allocator_traits< >::deallocate;__new_allocator<shared_ptr<mori::io::EndpointRuntime> >::deallocate;operator delete 60186407
```

