### PR TITLE
Don't merge: AI NIC perf collection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,39 +118,32 @@ jobs:
           SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_io_benchmark.sh"
           chmod +x "$SCRIPT"
 
-          # Sweep: 128 MiB .. 512 MiB by 32 MiB (134217728, step 33554432).
-          COMMON_BATCH1="--op-type write --mem-type gpu --all \
-            --sweep-start-size 134217728 --sweep-max-size 536870912 --sweep-step 33554432 \
-            --num-qp-per-transfer 8 --num-worker-threads 8 --enable-sess --poll_cq_mode polling \
+          # Sweep: 1 MiB .. 32 MiB by 1 MiB; 4 QP, chunking off, 4 workers, batch-contiguous.
+          SWEEP="--all --sweep-start-size 1048576 --sweep-max-size 33554432 --sweep-step 1048576 \
+            --disable-chunking --batch-contiguous \
+            --num-qp-per-transfer 4 --num-worker-threads 4 --enable-sess --poll_cq_mode polling \
             --num-initiator-dev 1 --num-target-dev 1 --target-dev-offset 0 \
             --log-level info"
 
-          BATCH64_CPP="--op write --mem-type gpu --gpu 0 --target-dev-offset 0 \
-            --all --sweep-start-size 134217728 --sweep-max-size 536870912 --sweep-step 33554432 \
-            --transfer-batch-size 64 --enable-batch-transfer --batch-contiguous \
-            --enable-sess \
-            --num-qp-per-transfer 8 --num-worker-threads 8 \
-            --num-initiator-dev 1 --num-target-dev 1 \
-            --poll_cq_mode polling --iters 128 --warmup-iters 10 \
-            --log-level info"
+          BATCH1_CPP="--op write --mem-type gpu --gpu 0 $SWEEP \
+            --transfer-batch-size 1 --iters 512 --warmup-iters 10"
 
-          BATCH64_PY="--op-type write --mem-type gpu --target-dev-offset 0 \
-            --all --sweep-start-size 134217728 --sweep-max-size 536870912 --sweep-step 33554432 \
-            --transfer-batch-size 64 --enable-batch-transfer --batch-contiguous \
-            --enable-sess \
-            --num-qp-per-transfer 8 --num-worker-threads 8 \
-            --num-initiator-dev 1 --num-target-dev 1 \
-            --poll_cq_mode polling --iters 128 --warmup-iters 10 \
-            --log-level info"
+          BATCH1_PY="--op-type write --mem-type gpu $SWEEP \
+            --transfer-batch-size 1 --enable-batch-transfer --iters 512 --warmup-iters 10"
+
+          BATCH64_CPP="--op write --mem-type gpu --gpu 0 $SWEEP \
+            --transfer-batch-size 64 --enable-batch-transfer --iters 128 --warmup-iters 10"
+
+          BATCH64_PY="--op-type write --mem-type gpu $SWEEP \
+            --transfer-batch-size 64 --enable-batch-transfer --iters 128 --warmup-iters 10"
 
           CPP_PORT=29130
           PY_PORT=29230
           for BATCH in 1 64; do
             if [ "$BATCH" -eq 1 ]; then
-              ITERS=512
-              CPP_ARGS="$COMMON_BATCH1 --transfer-batch-size 1 --iters $ITERS"
-              CPP_RENDEZ="--target-dev-offset 0 --warmup-iters 10"
-              PY_ARGS="$CPP_ARGS --enable-batch-transfer"
+              CPP_ARGS="$BATCH1_CPP"
+              CPP_RENDEZ=""
+              PY_ARGS="$BATCH1_PY"
             else
               CPP_ARGS="$BATCH64_CPP"
               CPP_RENDEZ=""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,16 +118,15 @@ jobs:
           SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_io_benchmark.sh"
           chmod +x "$SCRIPT"
 
-          # batch=1: 512 iters (chunking ON by default; no --batch-contiguous).
-          # batch=64: tuned write sweep (batch-contiguous, disable-chunking, 8 workers).
+          # Sweep: 256 MiB .. 512 MiB by 64 MiB (268435456, step 67108864).
           COMMON_BATCH1="--op-type write --mem-type gpu --all \
-            --sweep-start-size 1048576 --sweep-max-size 33554432 --sweep-step 1048576 \
+            --sweep-start-size 268435456 --sweep-max-size 536870912 --sweep-step 67108864 \
             --num-qp-per-transfer 8 --enable-sess --poll_cq_mode polling \
             --num-initiator-dev 1 --num-target-dev 1 --target-dev-offset 0 \
             --log-level info"
 
           BATCH64_CPP="--op write --mem-type gpu --gpu 0 --target-dev-offset 0 \
-            --all --sweep-start-size 1048576 --sweep-max-size 33554432 --sweep-step 1048576 \
+            --all --sweep-start-size 268435456 --sweep-max-size 536870912 --sweep-step 67108864 \
             --transfer-batch-size 64 --enable-batch-transfer --batch-contiguous \
             --enable-sess --disable-chunking \
             --num-qp-per-transfer 8 --num-worker-threads 8 \
@@ -136,7 +135,7 @@ jobs:
             --log-level info"
 
           BATCH64_PY="--op-type write --mem-type gpu --target-dev-offset 0 \
-            --all --sweep-start-size 1048576 --sweep-max-size 33554432 --sweep-step 1048576 \
+            --all --sweep-start-size 268435456 --sweep-max-size 536870912 --sweep-step 67108864 \
             --transfer-batch-size 64 --enable-batch-transfer --batch-contiguous \
             --enable-sess --disable-chunking \
             --num-qp-per-transfer 8 --num-worker-threads 8 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
             --sweep-start-size 1048576 --sweep-max-size 33554432 --sweep-step 1048576 \
             --num-qp-per-transfer 4 --batch-contiguous \
             --num-initiator-dev 1 --num-target-dev 1 \
-            --warmup-iters 10 --log-level info"
+            --warmup-iters 128 --log-level info"
           for BATCH in 1 64; do
             ITERS=128
             if [ "$BATCH" -eq 1 ]; then ITERS=512; fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       MORI_RDMA_SL: ${{ matrix.rdma_sl }}
       MORI_RDMA_TC: ${{ matrix.rdma_tc }}
       MORI_SOCKET_IFNAME: ${{ matrix.node1_ifname }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -127,18 +127,20 @@ jobs:
           COMMON="--op-type write --mem-type gpu --all \
             --sweep-start-size 1048576 --sweep-max-size 33554432 --sweep-step 1048576 \
             --num-qp-per-transfer 4 --batch-contiguous \
-            --num-initiator-dev 8 --num-target-dev 8 \
+            --num-initiator-dev 1 --num-target-dev 1 \
             --warmup-iters 128 --log-level info"
           {
             echo "=== MORI-IO bench_engine CI commands ==="
             echo "COMMON=${COMMON}"
+            echo "GPU sweep: 0 1 2 3 4 5 6 7 (one GPU pair per run)"
             echo "NODE1_HOST=${NODE1_HOST} NODE2_HOST=${NODE2_HOST}"
             echo ""
           } | tee "$RESULTS"
+          for GPU in 0 1 2 3 4 5 6 7; do
           for BATCH in 1 64; do
             ITERS=128
             if [ "$BATCH" -eq 1 ]; then ITERS=512; fi
-            ARGS="$COMMON --transfer-batch-size $BATCH --iters $ITERS"
+            ARGS="$COMMON --gpu $GPU --transfer-batch-size $BATCH --iters $ITERS"
             R1="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \
               --rank 1 --master-ip $NODE1_HOST --self-ip $NODE2_HOST --port $PORT \
               --target-dev-offset 0 $ARGS"
@@ -146,7 +148,7 @@ jobs:
               --rank 0 --master-ip $NODE1_HOST --self-ip $NODE1_HOST --port $PORT \
               --target-dev-offset 0 $ARGS"
             {
-              echo "=== C++ bench_engine GPU write sweep, batch=$BATCH, iters=$ITERS, port=$PORT ==="
+              echo "=== C++ bench_engine GPU write sweep, gpu=$GPU, batch=$BATCH, iters=$ITERS, port=$PORT ==="
               echo "rank 0 (initiator, node1):"
               echo "$R0"
               echo "rank 1 (target, node2):"
@@ -158,6 +160,7 @@ jobs:
             $CT exec $CONTAINER bash -c "$R0" | tee -a "$RESULTS"
             wait
             PORT=$((PORT + 1))
+          done
           done
 
       - name: Upload bench_engine results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,78 +108,36 @@ jobs:
           ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST \
             "$CT exec $CONTAINER bash -c \"$INSTALL_CMD\""
 
-      - name: MORI-IO C++ and Python write sweeps (batch 1 and 64)
+      - name: MORI-IO C++ bench_engine write sweep (batch 1)
         run: |
+          set -euo pipefail
           mkdir -p $GITHUB_WORKSPACE/_perf
           CPP_RESULTS=$GITHUB_WORKSPACE/_perf/bench_engine_results.txt
-          PY_RESULTS=$GITHUB_WORKSPACE/_perf/python_benchmark_results.txt
           BIN=$GITHUB_WORKSPACE/build/tests/cpp/bench_engine
           LDP="LD_LIBRARY_PATH=$GITHUB_WORKSPACE/build/src/io:$GITHUB_WORKSPACE/build/src/application"
-          SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_io_benchmark.sh"
-          chmod +x "$SCRIPT"
-
-          # Sweep: 1 MiB .. 32 MiB by 1 MiB; 4 QP, chunking off, 4 workers, batch-contiguous.
-          SWEEP="--all --sweep-start-size 1048576 --sweep-max-size 33554432 --sweep-step 1048576 \
-            --disable-chunking --batch-contiguous \
-            --num-qp-per-transfer 4 --num-worker-threads 4 --enable-sess --poll_cq_mode polling \
+          PORT=29130
+          ARGS="--op-type write --mem-type gpu --all \
+            --sweep-start-size 1048576 --sweep-max-size 33554432 --sweep-step 1048576 \
+            --disable-chunking --num-qp-per-transfer 8 --enable-sess --poll_cq_mode polling \
             --num-initiator-dev 1 --num-target-dev 1 --target-dev-offset 0 \
-            --log-level info"
+            --transfer-batch-size 1 --iters 512 --log-level info"
 
-          BATCH1_CPP="--op write --mem-type gpu --gpu 0 $SWEEP \
-            --transfer-batch-size 1 --iters 512 --warmup-iters 10"
-
-          BATCH1_PY="--op-type write --mem-type gpu $SWEEP \
-            --transfer-batch-size 1 --enable-batch-transfer --iters 512 --warmup-iters 10"
-
-          BATCH64_CPP="--op write --mem-type gpu --gpu 0 $SWEEP \
-            --transfer-batch-size 64 --enable-batch-transfer --iters 128 --warmup-iters 10"
-
-          BATCH64_PY="--op-type write --mem-type gpu $SWEEP \
-            --transfer-batch-size 64 --enable-batch-transfer --iters 128 --warmup-iters 10"
-
-          CPP_PORT=29130
-          PY_PORT=29230
-          for BATCH in 1 64; do
-            if [ "$BATCH" -eq 1 ]; then
-              CPP_ARGS="$BATCH1_CPP"
-              CPP_RENDEZ=""
-              PY_ARGS="$BATCH1_PY"
-            else
-              CPP_ARGS="$BATCH64_CPP"
-              CPP_RENDEZ=""
-              PY_ARGS="$BATCH64_PY"
-            fi
-
-            echo "=== C++ bench_engine GPU write sweep, batch=$BATCH, port=$CPP_PORT ===" \
-              | tee -a "$CPP_RESULTS"
-            R1="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \
-              --rank 1 --master-ip $NODE1_HOST --self-ip $NODE2_HOST --port $CPP_PORT \
-              $CPP_RENDEZ $CPP_ARGS"
-            R0="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \
-              --rank 0 --master-ip $NODE1_HOST --self-ip $NODE1_HOST --port $CPP_PORT \
-              $CPP_RENDEZ $CPP_ARGS"
-            ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST \
-              "$CT exec $CONTAINER bash -c \"$R1\"" >> "$CPP_RESULTS" 2>&1 &
-            $CT exec $CONTAINER bash -c "$R0" | tee -a "$CPP_RESULTS"
-            wait
-            CPP_PORT=$((CPP_PORT + 1))
-
-            echo "=== Python benchmark.py GPU write sweep, batch=$BATCH, port=$PY_PORT ===" \
-              | tee -a "$PY_RESULTS"
-            NODE2_CMD=(
-              $CT exec -e MORI_DISABLE_AUTO_XGMI=1 $CONTAINER bash $SCRIPT
-              --rank 1 --master-addr $NODE1_HOST --master-port $PY_PORT
-              --ifname $NODE2_IFNAME
-              -- $PY_ARGS
-            )
-            ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" >> "$PY_RESULTS" 2>&1 &
-            $CT exec -e MORI_DISABLE_AUTO_XGMI=1 $CONTAINER bash $SCRIPT \
-              --rank 0 --master-addr $NODE1_HOST --master-port $PY_PORT \
-              --ifname $NODE1_IFNAME \
-              -- $PY_ARGS | tee -a "$PY_RESULTS"
-            wait
-            PY_PORT=$((PY_PORT + 1))
-          done
+          echo "=== C++ bench_engine GPU write sweep, batch=1, iters=512, port=$PORT ===" \
+            | tee "$CPP_RESULTS"
+          R1="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \
+            --rank 1 --master-ip $NODE1_HOST --self-ip $NODE2_HOST --port $PORT \
+            --target-dev-offset 0 --warmup-iters 128 $ARGS"
+          R0="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \
+            --rank 0 --master-ip $NODE1_HOST --self-ip $NODE1_HOST --port $PORT \
+            --target-dev-offset 0 --warmup-iters 128 $ARGS"
+          ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST \
+            "$CT exec $CONTAINER bash -c \"$R1\"" >> "$CPP_RESULTS" 2>&1 &
+          pid=$!
+          if ! $CT exec $CONTAINER bash -c "$R0" | tee -a "$CPP_RESULTS"; then
+            wait "$pid" || true
+            exit 1
+          fi
+          wait "$pid"
 
       - name: Upload perf results
         if: always()
@@ -188,7 +146,6 @@ jobs:
           name: mori-io-perf-${{ github.run_id }}
           path: |
             ${{ github.workspace }}/_perf/bench_engine_results.txt
-            ${{ github.workspace }}/_perf/python_benchmark_results.txt
           if-no-files-found: warn
 
       - name: Cleanup node1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   io-bench-engine-internode:
-    name: bench_engine internode (${{ matrix.platform }})
+    name: MORI-IO internode perf (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -45,7 +45,7 @@ jobs:
       MORI_RDMA_SL: ${{ matrix.rdma_sl }}
       MORI_RDMA_TC: ${{ matrix.rdma_tc }}
       MORI_SOCKET_IFNAME: ${{ matrix.node1_ifname }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -98,61 +98,82 @@ jobs:
               git config --global --add safe.directory $GITHUB_WORKSPACE
           "
 
-      - name: Build bench_engine (both nodes)
+      - name: Install mori and build bench_engine (both nodes)
         run: |
-          BUILD_CMD="cd $GITHUB_WORKSPACE && cmake -B build \
-            -DBUILD_IO=ON \
-            -DBUILD_TESTS=ON \
-            -DBUILD_EXAMPLES=OFF \
-            -DBUILD_PYBINDS=OFF \
-            -DBUILD_OPS=OFF \
-            -DBUILD_SHMEM=OFF \
-            -DBUILD_CCO=OFF \
-            -DBUILD_COLLECTIVE=OFF \
-            -DBUILD_METRICS=OFF \
-            -DBUILD_UMBP=OFF \
-            && cmake --build build --target bench_engine -j \
-            && ls -la build/tests/cpp/bench_engine"
-          $CT exec $CONTAINER bash -c "$BUILD_CMD"
+          INSTALL_CMD="cd $GITHUB_WORKSPACE && \
+            BUILD_TESTS=ON BUILD_EXAMPLES=OFF BUILD_OPS=OFF BUILD_SHMEM=OFF \
+            BUILD_CCO=OFF BUILD_COLLECTIVE=OFF BUILD_UMBP=OFF BUILD_METRICS=OFF \
+            pip install . && ls -la build/tests/cpp/bench_engine"
+          $CT exec $CONTAINER bash -c "$INSTALL_CMD"
           ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST \
-            "$CT exec $CONTAINER bash -c \"$BUILD_CMD\""
+            "$CT exec $CONTAINER bash -c \"$INSTALL_CMD\""
 
-      - name: MORI-IO C++ bench_engine write sweep (batch 1 and 64)
+      - name: MORI-IO C++ and Python write sweeps (batch 1 and 64)
         run: |
           mkdir -p $GITHUB_WORKSPACE/_perf
-          RESULTS=$GITHUB_WORKSPACE/_perf/bench_engine_results.txt
+          CPP_RESULTS=$GITHUB_WORKSPACE/_perf/bench_engine_results.txt
+          PY_RESULTS=$GITHUB_WORKSPACE/_perf/python_benchmark_results.txt
           BIN=$GITHUB_WORKSPACE/build/tests/cpp/bench_engine
           LDP="LD_LIBRARY_PATH=$GITHUB_WORKSPACE/build/src/io:$GITHUB_WORKSPACE/build/src/application"
-          PORT=29130
+          SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_io_benchmark.sh"
+          chmod +x "$SCRIPT"
+
+          # Shared workload for C++ bench_engine and Python benchmark.py.
+          # batch=1: 512 iters (chunking ON by default; no --batch-contiguous).
+          # batch=64: 128 iters.
           COMMON="--op-type write --mem-type gpu --all \
             --sweep-start-size 1048576 --sweep-max-size 33554432 --sweep-step 1048576 \
-            --num-qp-per-transfer 4 --batch-contiguous \
-            --num-initiator-dev 1 --num-target-dev 1 \
-            --warmup-iters 10 --log-level info"
+            --num-qp-per-transfer 8 --enable-sess --poll_cq_mode polling \
+            --num-initiator-dev 1 --num-target-dev 1 --target-dev-offset 0 \
+            --log-level info"
+
+          CPP_PORT=29130
+          PY_PORT=29230
           for BATCH in 1 64; do
             ITERS=128
             if [ "$BATCH" -eq 1 ]; then ITERS=512; fi
-            echo "=== C++ bench_engine GPU write sweep, batch=$BATCH, iters=$ITERS, port=$PORT ===" | tee -a "$RESULTS"
             ARGS="$COMMON --transfer-batch-size $BATCH --iters $ITERS"
+
+            echo "=== C++ bench_engine GPU write sweep, batch=$BATCH, iters=$ITERS, port=$CPP_PORT ===" \
+              | tee -a "$CPP_RESULTS"
             R1="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \
-              --rank 1 --master-ip $NODE1_HOST --self-ip $NODE2_HOST --port $PORT \
-              --target-dev-offset 0 $ARGS"
+              --rank 1 --master-ip $NODE1_HOST --self-ip $NODE2_HOST --port $CPP_PORT \
+              --target-dev-offset 0 --warmup-iters 10 $ARGS"
             R0="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \
-              --rank 0 --master-ip $NODE1_HOST --self-ip $NODE1_HOST --port $PORT \
-              --target-dev-offset 0 $ARGS"
+              --rank 0 --master-ip $NODE1_HOST --self-ip $NODE1_HOST --port $CPP_PORT \
+              --target-dev-offset 0 --warmup-iters 10 $ARGS"
             ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST \
-              "$CT exec $CONTAINER bash -c \"$R1\"" >> "$RESULTS" 2>&1 &
-            $CT exec $CONTAINER bash -c "$R0" | tee -a "$RESULTS"
+              "$CT exec $CONTAINER bash -c \"$R1\"" >> "$CPP_RESULTS" 2>&1 &
+            $CT exec $CONTAINER bash -c "$R0" | tee -a "$CPP_RESULTS"
             wait
-            PORT=$((PORT + 1))
+            CPP_PORT=$((CPP_PORT + 1))
+
+            echo "=== Python benchmark.py GPU write sweep, batch=$BATCH, iters=$ITERS, port=$PY_PORT ===" \
+              | tee -a "$PY_RESULTS"
+            PY_ARGS="$ARGS --enable-batch-transfer"
+            NODE2_CMD=(
+              $CT exec -e MORI_DISABLE_AUTO_XGMI=1 $CONTAINER bash $SCRIPT
+              --rank 1 --master-addr $NODE1_HOST --master-port $PY_PORT
+              --ifname $NODE2_IFNAME
+              -- $PY_ARGS
+            )
+            ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" >> "$PY_RESULTS" 2>&1 &
+            $CT exec -e MORI_DISABLE_AUTO_XGMI=1 $CONTAINER bash $SCRIPT \
+              --rank 0 --master-addr $NODE1_HOST --master-port $PY_PORT \
+              --ifname $NODE1_IFNAME \
+              -- $PY_ARGS | tee -a "$PY_RESULTS"
+            wait
+            PY_PORT=$((PY_PORT + 1))
           done
 
-      - name: Upload bench_engine results
+      - name: Upload perf results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: bench-engine-perf-${{ github.run_id }}
-          path: ${{ github.workspace }}/_perf/bench_engine_results.txt
+          name: mori-io-perf-${{ github.run_id }}
+          path: |
+            ${{ github.workspace }}/_perf/bench_engine_results.txt
+            ${{ github.workspace }}/_perf/python_benchmark_results.txt
           if-no-files-found: warn
 
       - name: Cleanup node1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,27 +1,11 @@
-name: MoRI CI test
+name: MORI-IO bench_engine perf
+
 on:
   push:
-    branches: [main]
+    branches: [main, ci/io-bench-engine-perf]
   pull_request:
-    branches: [main]
   workflow_dispatch:
-    inputs:
-      run_umbp_single_node_hicache:
-        type: boolean
-        default: false
-        description: Run UMBP single-node hicache smoke test
-      sglang_repo:
-        type: string
-        default: "sgl-team/sglang"
-        description: owner/repo to checkout for SGLang
-      sglang_ref:
-        type: string
-        default: "main"
-        description: branch, tag, or SHA for SGLang checkout
-      enable_dp:
-        type: boolean
-        default: false
-        description: Enable DP/EP modes when launching the hicache test
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -29,425 +13,12 @@ concurrency:
 env:
   IMAGE: rocm/mori:ci
   BASE_IMAGE: rocm/pytorch:rocm7.14_ubuntu24.04_py3.12_pytorch_release_2.12.0
-  CONTAINER: mori_ci_${{ github.run_id }}
-  CT: docker
+  CONTAINER: mori_bench_ci_${{ github.run_id }}
+  CT: podman
 
 jobs:
-  build:
-    name: mori build (${{ matrix.platform }})
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: MI355X_AINIC
-            runner: [self-hosted, MI355X-AINIC-TW]
-          # Runner 325_bnxt_108 is decommissioned.
-          # - platform: MI325X_BNXT
-          #   runner: [self-hosted, 325_bnxt_108]
-    timeout-minutes: 15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Build CI image
-        run: $CT build --network=host --build-arg BASE_IMAGE=$BASE_IMAGE -t $IMAGE -f docker/Dockerfile.dev .
-
-      - name: Start container
-        run: |
-          $CT rm -f $CONTAINER 2>/dev/null || true
-          CONTAINER_RUNTIME=$CT ./docker/ci_run.sh --name $CONTAINER \
-            -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
-            -w $GITHUB_WORKSPACE \
-            $IMAGE sleep infinity
-          $CT exec $CONTAINER \
-            git config --global --add safe.directory $GITHUB_WORKSPACE
-
-      - name: Build and install mori
-        run: $CT exec $CONTAINER pip install .
-
-      - name: Build and install mori (with examples)
-        run: $CT exec $CONTAINER bash -c "BUILD_EXAMPLES=ON pip install ."
-
-      - name: Verify installation
-        run: $CT exec $CONTAINER python -c "import mori; print('mori ' + mori.__version__ + ' OK')"
-
-      - name: Cleanup
-        if: always()
-        run: |
-          $CT rm -f $CONTAINER || true
-          $CT run --rm -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE $BASE_IMAGE \
-              chown -R $(id -u):$(id -g) $GITHUB_WORKSPACE 2>/dev/null || true
-
-  intranode-test:
-    name: mori intranode test (${{ matrix.platform }})
-    needs: build
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: MI355X_AINIC
-            runner: [self-hosted, MI355X-AINIC-TW]
-            rdma_devices: rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7
-            rdma_sl: 3
-            rdma_tc: 104
-          # Runner 325_bnxt_108 is decommissioned.
-          # - platform: MI325X_BNXT
-          #   runner: [self-hosted, 325_bnxt_108]
-          #   rdma_devices: bnxt_re0,bnxt_re1,bnxt_re2,bnxt_re3,bnxt_re4,bnxt_re5,bnxt_re7,bnxt_re8
-          #   rdma_sl: 3
-          #   rdma_tc: 104
-          #   socket_ifname: enp49s0f1np1
-    env:
-      MORI_RDMA_DEVICES: ${{ matrix.rdma_devices }}
-      MORI_RDMA_SL: ${{ matrix.rdma_sl }}
-      MORI_RDMA_TC: ${{ matrix.rdma_tc }}
-      MORI_SOCKET_IFNAME: ${{ matrix.socket_ifname }}
-      NCCL_SOCKET_IFNAME: ${{ matrix.socket_ifname }}
-    timeout-minutes: 45
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Build CI image
-        run: $CT build --network=host --build-arg BASE_IMAGE=$BASE_IMAGE -t $IMAGE -f docker/Dockerfile.dev .
-
-      - name: Start container
-        run: |
-          $CT rm -f $CONTAINER 2>/dev/null || true
-          CONTAINER_RUNTIME=$CT ./docker/ci_run.sh --name $CONTAINER \
-            -e MORI_RDMA_DEVICES=$MORI_RDMA_DEVICES \
-            -e MORI_RDMA_SL=$MORI_RDMA_SL \
-            -e MORI_RDMA_TC=$MORI_RDMA_TC \
-            ${MORI_SOCKET_IFNAME:+-e MORI_SOCKET_IFNAME=$MORI_SOCKET_IFNAME} \
-            ${NCCL_SOCKET_IFNAME:+-e NCCL_SOCKET_IFNAME=$NCCL_SOCKET_IFNAME} \
-            -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
-            -w $GITHUB_WORKSPACE \
-            $IMAGE sleep infinity
-          $CT exec $CONTAINER \
-            git config --global --add safe.directory $GITHUB_WORKSPACE
-
-      - name: Install mori
-        run: |
-          $CT exec $CONTAINER bash -c \
-            "cd $GITHUB_WORKSPACE && BUILD_BENCHMARK=ON BUILD_CCO_SDMA=ON BUILD_EXAMPLES=ON pip install . && pip install prettytable"
-
-      - name: MORI-EP (intranode)
-        run: |
-          $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE && timeout 360 pytest tests/python/ops/test_dispatch_combine_intranode.py -v
-          "
-
-      - name: MORI-EP (internode_v1)
-        run: |
-          $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE && timeout 300 pytest tests/python/ops/test_dispatch_combine_internode_v1.py -v
-          "
-
-      - name: MORI-EP (routing handle)
-        run: |
-          $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE && timeout 300 pytest tests/python/ops/test_dispatch_combine_routing_handle.py -v
-          "
-
-      - name: MORI-EP (async_ll SDMA)
-        run: |
-          $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE && MORI_ENABLE_SDMA=1 timeout 300 pytest tests/python/ops/test_dispatch_combine_async_ll.py -v
-          "
-
-      - name: MORI-CCL (param-contiguous allgather SDMA)
-        run: |
-          $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE && MORI_ENABLE_SDMA=1 timeout 300 pytest tests/python/ccl/test_allgather_param_contiguous.py -v
-          "
-
-      - name: MORI-CCL (hier allgather offset spec, CPU)
-        run: |
-          $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE && timeout 120 pytest tests/python/ccl/test_hier_allgather_cpu.py -v
-          "
-
-      - name: MORI-CCL (hier allgather bit-exact, single-node)
-        run: |
-          # Splits the local 8 GPUs into simulated nodes to drive the hierarchical
-          # pipeline (ranks_per_node < world), bit-exact vs all_gather_into_tensor.
-          # CUDA_GRAPH=0: the launch-collapse HIP-graph fallback is not yet
-          # bit-exact-safe on all archs -- exercise the eager path here.
-          $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE && MORI_ENABLE_SDMA=1 MORI_HIER_CUDA_GRAPH=0 timeout 400 pytest tests/python/ccl/test_hier_allgather.py -v
-          "
-
-      - name: MORI-EP (async_ll IBGDA)
-        run: |
-          $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE && MORI_DISABLE_P2P=1 MORI_ENABLE_SDMA=0 timeout 300 pytest tests/python/ops/test_dispatch_combine_async_ll.py -v
-          "
-
-      - name: MORI-EP bench
-        run: |
-          $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE
-            timeout 120 python3 tests/python/ops/bench_dispatch_combine.py
-            timeout 120 python3 tests/python/ops/bench_dispatch_combine.py \
-              --cmd bench --dtype bf16 --quant-type fp8_blockwise \
-              --zero-copy 0 --max-tokens 128 \
-              --force-scale-active 1 --report-scale-stats 1
-          "
-
-      - name: MORI-IO
-        run: |
-          $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE
-            timeout 60 pytest tests/python/io/ -v
-            MORI_IO_XGMI_SCATTER_GATHER_THRESHOLD=4 \
-              timeout 120 pytest tests/python/io/test_discrete_buffer.py -v -k 'not performance'
-          "
-
-      - name: MORI-IR
-        run: |
-          $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE -e HOME=/tmp $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE
-            timeout 60 torchrun --nproc_per_node=2 examples/shmem/ir/test_triton_shmem.py
-            timeout 60 torchrun --nproc_per_node=8 examples/shmem/ir/test_triton_allreduce.py
-            MORI_DISABLE_P2P=ON timeout 60 torchrun --nproc_per_node=8 examples/shmem/ir/test_triton_allreduce.py
-          "
-
-      - name: MORI-CPP shmem_benchmark (P2P)
-        run: |
-          $CT exec $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE
-            timeout 60 mpirun --allow-run-as-root  -np 2 ./build/benchmark/p2p_put_bw
-            timeout 60 mpirun --allow-run-as-root  -np 2 ./build/benchmark/p2p_get_bw
-            timeout 60 mpirun --allow-run-as-root  -np 2 ./build/benchmark/p2p_put_latency
-            timeout 60 mpirun --allow-run-as-root  -np 2 ./build/benchmark/p2p_get_latency
-            timeout 60 mpirun --allow-run-as-root  -np 2 ./build/benchmark/p2p_put_bw -s warp
-            timeout 60 mpirun --allow-run-as-root  -np 2 ./build/benchmark/p2p_get_bw -s warp
-            timeout 60 mpirun --allow-run-as-root  -np 2 ./build/benchmark/p2p_put_latency -s warp
-            timeout 60 mpirun --allow-run-as-root  -np 2 ./build/benchmark/p2p_get_latency -s warp
-            timeout 60 mpirun --allow-run-as-root  -np 2 ./build/benchmark/p2p_put_bw -s thread
-            timeout 60 mpirun --allow-run-as-root  -np 2 ./build/benchmark/p2p_get_bw -s thread
-            timeout 60 mpirun --allow-run-as-root  -np 2 ./build/benchmark/p2p_put_latency -s thread
-            timeout 60 mpirun --allow-run-as-root  -np 2 ./build/benchmark/p2p_get_latency -s thread
-          "
-
-      - name: MORI-CPP shmem_benchmark (RDMA)
-        run: |
-          $CT exec $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE
-            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/benchmark/p2p_put_bw
-            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/benchmark/p2p_get_bw
-            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/benchmark/p2p_put_latency
-            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/benchmark/p2p_get_latency
-            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/benchmark/p2p_put_bw -s warp
-            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/benchmark/p2p_get_bw -s warp
-            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/benchmark/p2p_put_latency -s warp
-            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/benchmark/p2p_get_latency -s warp
-            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/benchmark/p2p_put_bw -s thread
-            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/benchmark/p2p_get_bw -s thread
-            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/benchmark/p2p_put_latency -s thread
-            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/benchmark/p2p_get_latency -s thread
-          "
-
-      - name: MORI-CPP shmem (P2P)
-        run: |
-          $CT exec $CONTAINER bash -c "
-            set -e
-            cd $GITHUB_WORKSPACE
-            timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/concurrent_put_thread
-            timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/concurrent_get_thread
-            timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/concurrent_put_imm_thread
-            timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/concurrent_put_signal_thread
-            timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/atomic_nonfetch_thread
-            timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/atomic_fetch_thread
-          "
-
-      - name: MORI-CPP shmem (IBGDA)
-        run: |
-          $CT exec $CONTAINER bash -c "
-            set -e
-            cd $GITHUB_WORKSPACE
-            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/concurrent_put_thread
-            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/concurrent_get_thread
-            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/concurrent_put_imm_thread
-            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/concurrent_put_signal_thread
-            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/atomic_nonfetch_thread
-            MORI_DISABLE_P2P=ON timeout 60 mpirun --allow-run-as-root -np 2 ./build/examples/atomic_fetch_thread
-          "
-
-      - name: MORI-CCL/shmem
-        run: |
-          $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE
-            timeout 600 pytest tests/python/shmem/test_api.py -v
-          "
-
-      - name: MORI-CCL collectives
-        run: |
-          $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE
-            MORI_ENABLE_SDMA=1 timeout 300 python -m tests.python.ccl.test_allgather --world-size 8 --elems 1024 --iterations 1 --warmup 0
-            MORI_ENABLE_SDMA=1 timeout 300 python -m tests.python.ccl.test_all2all --world-size 8 --elems 1024 --iterations 1 --warmup 0
-          "
-
-      - name: MORI-EP async kernel bench (intranode)
-        run: |
-          $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE
-            PORT=12390
-            for TOKENS in 64 128; do
-              echo \"=== async_ll bench max-tokens=\$TOKENS port=\$PORT ===\"
-              MORI_ENABLE_SDMA=1 GPU_PER_NODE=8 \
-              timeout 120 torchrun \
-                --nnodes=1 --node_rank=0 --nproc_per_node=1 \
-                --master_addr=127.0.0.1 --master_port=\$PORT \
-                examples/ops/dispatch_combine/test_dispatch_combine_internode.py \
-                --kernel-type async_ll --num-qp 2 --cmd bench \
-                --dtype bf16 --max-tokens \$TOKENS
-              PORT=\$((PORT + 1))
-            done
-          "
-
-      - name: Cleanup
-        if: always()
-        run: |
-          $CT rm -f $CONTAINER || true
-          if $CT image inspect $IMAGE &>/dev/null; then
-            $CT run --rm -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE $IMAGE \
-                chown -R $(id -u):$(id -g) $GITHUB_WORKSPACE 2>/dev/null || true
-          fi
-
-  jax-intranode-test:
-    name: mori JAX intranode test (${{ matrix.platform }})
-    needs: build
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: MI355X_AINIC
-            runner: [self-hosted, MI355X-AINIC-TW]
-            rdma_devices: rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7
-            gpu_arch: gfx950
-          # Runner 325_bnxt_108 is decommissioned.
-          # - platform: MI325X_BNXT
-          #   runner: [self-hosted, 325_bnxt_108]
-          #   rdma_devices: bnxt_re0,bnxt_re1,bnxt_re2,bnxt_re3,bnxt_re4,bnxt_re5,bnxt_re7,bnxt_re8
-          #   gpu_arch: gfx942
-    timeout-minutes: 90
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Build JAX CI image
-        run: |
-          BUILD_ARGS="--network=host --build-arg GPU_TARGET=${{ matrix.gpu_arch }}"
-          if [ "$CT" = "podman" ]; then
-            BUILD_ARGS="$BUILD_ARGS --isolation=chroot"
-          fi
-          $CT build $BUILD_ARGS \
-            -t rocm/mori:jax-ci \
-            -f docker/Dockerfile.jax091-rocm711 .
-
-      - name: Start container
-        run: |
-          $CT rm -f ${CONTAINER}_jax 2>/dev/null || true
-          CONTAINER_RUNTIME=$CT ./docker/ci_run.sh --name ${CONTAINER}_jax \
-            -e MORI_RDMA_DEVICES=${{ matrix.rdma_devices }} \
-            -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
-            -w $GITHUB_WORKSPACE \
-            rocm/mori:jax-ci sleep infinity
-          $CT exec ${CONTAINER}_jax \
-            git config --global --add safe.directory $GITHUB_WORKSPACE
-
-      - name: Install mori (XLA FFI)
-        run: |
-          $CT exec ${CONTAINER}_jax bash -c \
-            "cd $GITHUB_WORKSPACE && BUILD_UMBP=OFF BUILD_XLA_FFI_OPS=ON pip install --break-system-packages ."
-
-      - name: MORI-EP JAX test
-        run: |
-          $CT exec ${CONTAINER}_jax bash -c "
-            cd $GITHUB_WORKSPACE
-            MORI_KERNEL_DIR=\$(ls -d $GITHUB_WORKSPACE/build/lib/gfx* | head -1) \
-            timeout 300 pytest tests/python/ops/test_dispatch_combine_jax.py -s -v
-          "
-
-      - name: Cleanup
-        if: always()
-        run: |
-          $CT rm -f ${CONTAINER}_jax || true
-          if $CT image inspect rocm/mori:jax-ci &>/dev/null; then
-            $CT run --rm -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE rocm/mori:jax-ci \
-                chown -R $(id -u):$(id -g) $GITHUB_WORKSPACE 2>/dev/null || true
-          fi
-
-  umbp-unit-test:
-    name: mori umbp unit test (${{ matrix.platform }})
-    needs: build
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: MI355X_AINIC
-            runner: [self-hosted, MI355X-AINIC-TW]
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Build CI image
-        run: $CT build --network=host --build-arg BASE_IMAGE=$BASE_IMAGE -t $IMAGE -f docker/Dockerfile.dev .
-
-      - name: Start container
-        run: |
-          $CT rm -f $CONTAINER 2>/dev/null || true
-          CONTAINER_RUNTIME=$CT ./docker/ci_run.sh --name $CONTAINER \
-            -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
-            -w $GITHUB_WORKSPACE \
-            $IMAGE sleep infinity
-          $CT exec $CONTAINER \
-            git config --global --add safe.directory $GITHUB_WORKSPACE
-
-      - name: Build mori with UMBP
-        run: |
-          $CT exec $CONTAINER bash -c \
-            "cd $GITHUB_WORKSPACE && BUILD_UMBP=ON BUILD_TESTS=ON pip install -e ."
-
-      - name: UMBP Python packaging tests
-        run: |
-          $CT exec $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE
-            timeout 60 pytest tests/python/umbp/ -v
-          "
-
-      - name: UMBP C++ unit tests (local + distributed)
-        run: |
-          $CT exec $CONTAINER bash -c "
-            cd $GITHUB_WORKSPACE/build
-            timeout 300 ctest --output-on-failure \
-              -R '^(umbp_|test_dummy_ssd_tier|test_prefix_aware_eviction|test_ssd_tier)'
-          "
-
-      - name: Cleanup
-        if: always()
-        run: |
-          $CT exec $CONTAINER chown -R $(id -u):$(id -g) $GITHUB_WORKSPACE 2>/dev/null || true
-          $CT rm -f $CONTAINER || true
-
-  internode-test:
-    name: mori internode test (${{ matrix.platform }})
-    needs: build
+  io-bench-engine-internode:
+    name: bench_engine internode (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -463,21 +34,7 @@ jobs:
             rdma_devices: rocep105s0,rocep121s0,rocep137s0,rocep153s0,rocep233s0,rocep249s0,rocep25s0,rocep9s0
             rdma_sl: 3
             rdma_tc: 104
-            ct: podman
-          # Runner 325_bnxt_108 is decommissioned.
-          # - platform: MI325X_BNXT
-          #   runner: [self-hosted, 325_bnxt_108]
-          #   node1_host: 10.162.224.131
-          #   node2_host: 10.162.224.162
-          #   node2_port: 22
-          #   node1_ifname: enp49s0f1np1
-          #   node2_ifname: enp49s0f1np1
-          #   rdma_devices: bnxt_re0,bnxt_re1,bnxt_re2,bnxt_re3,bnxt_re4,bnxt_re5,bnxt_re7,bnxt_re8
-          #   rdma_sl: 3
-          #   rdma_tc: 104
-          #   ct: docker
     env:
-      CT: ${{ matrix.ct }}
       SSH_OPTS: -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
       NODE1_HOST: ${{ matrix.node1_host }}
       NODE2_HOST: ${{ matrix.node2_host }}
@@ -488,28 +45,12 @@ jobs:
       MORI_RDMA_SL: ${{ matrix.rdma_sl }}
       MORI_RDMA_TC: ${{ matrix.rdma_tc }}
       MORI_SOCKET_IFNAME: ${{ matrix.node1_ifname }}
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           submodules: true
-
-      - name: Recover podman if needed
-        run: |
-          build() {
-            $CT build --network=host --build-arg BASE_IMAGE=$BASE_IMAGE -t $IMAGE -f docker/Dockerfile.dev .
-          }
-          build && exit 0
-          if [ "$CT" = podman ]; then
-            # 'system migrate' stops every container owned by this user, not just
-            # this job's, so keep it on the failure path only.
-            echo "::warning::podman build failed; retrying after 'system migrate'"
-            podman ps --format 'will be stopped: {{.Names}}' || true
-            podman system migrate || true
-          fi
-          build
-
 
       - name: Build CI image
         run: $CT build --network=host --build-arg BASE_IMAGE=$BASE_IMAGE -t $IMAGE -f docker/Dockerfile.dev .
@@ -557,296 +98,58 @@ jobs:
               git config --global --add safe.directory $GITHUB_WORKSPACE
           "
 
-      - name: Install mori (node1)
+      - name: Build bench_engine (both nodes)
         run: |
-          $CT exec $CONTAINER bash -c \
-            "cd $GITHUB_WORKSPACE && BUILD_EXAMPLES=ON pip install . && pip install prettytable && (command -v numactl >/dev/null || (apt-get update && apt-get install -y numactl))"
-
-      - name: Install mori (node2)
-        run: |
+          BUILD_CMD="cd $GITHUB_WORKSPACE && cmake -B build \
+            -DBUILD_IO=ON \
+            -DBUILD_TESTS=ON \
+            -DBUILD_EXAMPLES=OFF \
+            -DBUILD_PYBINDS=OFF \
+            -DBUILD_OPS=OFF \
+            -DBUILD_SHMEM=OFF \
+            -DBUILD_CCO=OFF \
+            -DBUILD_COLLECTIVE=OFF \
+            -DBUILD_METRICS=OFF \
+            -DBUILD_UMBP=OFF \
+            && cmake --build build --target bench_engine -j \
+            && ls -la build/tests/cpp/bench_engine"
+          $CT exec $CONTAINER bash -c "$BUILD_CMD"
           ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST \
-            "$CT exec $CONTAINER bash -c 'cd $GITHUB_WORKSPACE && BUILD_EXAMPLES=ON pip install . && pip install prettytable && (command -v numactl >/dev/null || (apt-get update && apt-get install -y numactl))'"
+            "$CT exec $CONTAINER bash -c \"$BUILD_CMD\""
 
-      - name: MORI-IO internode write sweep
+      - name: MORI-IO C++ bench_engine write sweep (batch 1 and 64)
         run: |
-          SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_io_benchmark.sh"
-          PORT=29120
-          echo "=== MORI-IO internode benchmark: wide-write-sweep port=$PORT ==="
-          NODE2_CMD=(
-            $CT exec $CONTAINER bash $SCRIPT
-            --rank 1 --master-addr $NODE1_HOST --master-port $PORT
-            --ifname $NODE2_IFNAME
-            -- --op-type write --transfer-batch-size 128 --all
-            --sweep-start-size 1024 --sweep-max-size 16777216 --iters 4
-            --enable-sess --enable-batch-transfer
-            --num-qp-per-transfer 2
-            --num-initiator-dev 8 --num-target-dev 8
-          )
-          ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
-          $CT exec $CONTAINER bash $SCRIPT \
-            --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
-            --ifname $NODE1_IFNAME \
-            -- --op-type write --transfer-batch-size 128 --all \
-            --sweep-start-size 1024 --sweep-max-size 16777216 --iters 4 \
-            --enable-sess --enable-batch-transfer \
-            --num-qp-per-transfer 2 \
-            --num-initiator-dev 8 --num-target-dev 8
-          wait
-
-      - name: MORI-IO internode read
-        run: |
-          SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_io_benchmark.sh"
-          PORT=29121
-          echo "=== MORI-IO internode benchmark: batch-session-read port=$PORT ==="
-          NODE2_CMD=(
-            $CT exec $CONTAINER bash $SCRIPT
-            --rank 1 --master-addr $NODE1_HOST --master-port $PORT
-            --ifname $NODE2_IFNAME
-            -- --op-type read --buffer-size 4096 --transfer-batch-size 128 --iters 8
-            --enable-batch-transfer --enable-sess --poll_cq_mode event
-            --num-qp-per-transfer 2
-            --num-initiator-dev 8 --num-target-dev 8
-          )
-          ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
-          $CT exec $CONTAINER bash $SCRIPT \
-            --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
-            --ifname $NODE1_IFNAME \
-            -- --op-type read --buffer-size 4096 --transfer-batch-size 128 --iters 8 \
-            --enable-batch-transfer --enable-sess --poll_cq_mode event \
-            --num-qp-per-transfer 2 \
-            --num-initiator-dev 8 --num-target-dev 8
-          wait
-
-      - name: MORI-IO internode CPU memory sweep (chunking + 4 NIC x 4 QP)
-        run: |
-          SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_io_benchmark.sh"
-          # CPU host memory, chunking on (default), striped across 4 NUMA-local NICs
-          # with 16 QPs total (= 4 QP per NIC). Single posting thread (inline).
-          PORT=29122
-          for OP in write read; do
-            echo "=== MORI-IO internode benchmark: cpu-mem $OP sweep (chunking, 4 NIC x 4 QP) port=$PORT ==="
-            NODE2_CMD=(
-              $CT exec -e MORI_IO_NUM_NICS_PER_TRANSFER=4 $CONTAINER bash $SCRIPT
-              --rank 1 --master-addr $NODE1_HOST --master-port $PORT
-              --ifname $NODE2_IFNAME --numa 0
-              -- --mem-type cpu --op-type $OP --transfer-batch-size 64 --all
-              --sweep-start-size 1024 --sweep-max-size 1048576 --iters 4
-              --enable-sess --enable-batch-transfer
-              --num-qp-per-transfer 16 --num-initiator-dev 1 --num-target-dev 1
-            )
-            ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
-            $CT exec -e MORI_IO_NUM_NICS_PER_TRANSFER=4 $CONTAINER bash $SCRIPT \
-              --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
-              --ifname $NODE1_IFNAME --numa 0 \
-              -- --mem-type cpu --op-type $OP --transfer-batch-size 64 --all \
-              --sweep-start-size 1024 --sweep-max-size 1048576 --iters 4 \
-              --enable-sess --enable-batch-transfer \
-              --num-qp-per-transfer 16 --num-initiator-dev 1 --num-target-dev 1
-          wait
-            PORT=$((PORT + 1))
-          done
-
-      - name: MORI-IO internode multi-worker executor correctness (chunking off)
-        run: |
-          SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_io_benchmark.sh"
-          PORT=29124
-          # Legacy multi-worker executor path: only active when chunking is off and
-          # single NIC. Small write run to guard byte-for-byte correctness of that path.
-          echo "=== MORI-IO internode benchmark: multi-worker executor (chunking off) port=$PORT ==="
-          NODE2_CMD=(
-            $CT exec $CONTAINER bash $SCRIPT
-            --rank 1 --master-addr $NODE1_HOST --master-port $PORT
-            --ifname $NODE2_IFNAME
-            -- --op-type write --disable-chunking --transfer-batch-size 64 --all
-            --sweep-start-size 1024 --sweep-max-size 1048576 --iters 4
-            --enable-sess --enable-batch-transfer
-            --num-qp-per-transfer 4 --num-worker-threads 2
-            --num-initiator-dev 8 --num-target-dev 8
-          )
-          ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
-          $CT exec $CONTAINER bash $SCRIPT \
-            --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
-            --ifname $NODE1_IFNAME \
-            -- --op-type write --disable-chunking --transfer-batch-size 64 --all \
-            --sweep-start-size 1024 --sweep-max-size 1048576 --iters 4 \
-            --enable-sess --enable-batch-transfer \
-            --num-qp-per-transfer 4 --num-worker-threads 2 \
-            --num-initiator-dev 8 --num-target-dev 8
-          wait
-
-      - name: MORI-IO internode multi-worker executor correctness (chunking on)
-        run: |
-          SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_io_benchmark.sh"
-          PORT=29125
-          # Phase-1 worker+chunking path: GPU memory, single NIC, batch API,
-          # numWorkerThreads>1. Sweep crosses the default 64 KiB chunk size,
-          # covering both unsplit and actually chunk-expanded requests.
-          for OP in write read; do
-            echo "=== MORI-IO internode benchmark: multi-worker executor (chunking on, $OP sweep) port=$PORT ==="
-            NODE2_CMD=(
-              $CT exec $CONTAINER bash $SCRIPT
-              --rank 1 --master-addr $NODE1_HOST --master-port $PORT
-              --ifname $NODE2_IFNAME
-              -- --op-type $OP --transfer-batch-size 64 --all
-              --sweep-start-size 1024 --sweep-max-size 1048576 --iters 4
-              --enable-sess --enable-batch-transfer
-              --num-qp-per-transfer 4 --num-worker-threads 4
-              --num-initiator-dev 8 --num-target-dev 8
-            )
-            ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
-            $CT exec $CONTAINER bash $SCRIPT \
-              --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
-              --ifname $NODE1_IFNAME \
-              -- --op-type $OP --transfer-batch-size 64 --all \
-              --sweep-start-size 1024 --sweep-max-size 1048576 --iters 4 \
-              --enable-sess --enable-batch-transfer \
-              --num-qp-per-transfer 4 --num-worker-threads 4 \
-              --num-initiator-dev 8 --num-target-dev 8
+          mkdir -p $GITHUB_WORKSPACE/_perf
+          RESULTS=$GITHUB_WORKSPACE/_perf/bench_engine_results.txt
+          BIN=$GITHUB_WORKSPACE/build/tests/cpp/bench_engine
+          LDP="LD_LIBRARY_PATH=$GITHUB_WORKSPACE/build/src/io:$GITHUB_WORKSPACE/build/src/application"
+          PORT=29130
+          COMMON="--op-type write --mem-type gpu --all \
+            --sweep-start-size 1048576 --sweep-max-size 33554432 --sweep-step 1048576 \
+            --num-qp-per-transfer 4 --batch-contiguous --target-dev-offset 0 \
+            --num-initiator-dev 1 --num-target-dev 1 \
+            --iters 128 --warmup-iters 10 --log-level info"
+          for BATCH in 1 64; do
+            echo "=== C++ bench_engine GPU write sweep, batch=$BATCH, port=$PORT ===" | tee -a "$RESULTS"
+            ARGS="$COMMON --transfer-batch-size $BATCH"
+            R1="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \
+              --rank 1 --master-ip $NODE1_HOST --self-ip $NODE2_HOST --port $PORT $ARGS"
+            R0="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \
+              --rank 0 --master-ip $NODE1_HOST --self-ip $NODE1_HOST --port $PORT $ARGS"
+            ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST \
+              "$CT exec $CONTAINER bash -c \"$R1\"" >> "$RESULTS" 2>&1 &
+            $CT exec $CONTAINER bash -c "$R0" | tee -a "$RESULTS"
             wait
             PORT=$((PORT + 1))
           done
 
-      - name: MORI-IO internode cross-rail write (rail affinity)
-        run: |
-          SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_io_benchmark.sh"
-          PORT=29127
-          # Cross-rail validation: --target-dev-offset 5 makes GPU-0 pair with GPU-5
-          # (different NUMA → different NIC preference). With MORI_IO_RAIL_AFFINITY=1
-          # the receiver must follow the sender's railId, keeping traffic on-rail.
-          # On a rail-isolated fabric this would fail without rail affinity.
-          echo "=== MORI-IO internode: cross-rail GPU write (offset=5, rail affinity ON) ==="
-          NODE2_CMD=(
-            $CT exec -e MORI_IO_RAIL_AFFINITY=1 $CONTAINER bash $SCRIPT
-            --rank 1 --master-addr $NODE1_HOST --master-port $PORT
-            --ifname $NODE2_IFNAME
-            -- --op-type write --buffer-size 4096 --transfer-batch-size 64
-            --iters 4 --enable-sess --enable-batch-transfer
-            --num-qp-per-transfer 2
-            --num-initiator-dev 8 --num-target-dev 8
-            --target-dev-offset 5
-          )
-          ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
-          $CT exec -e MORI_IO_RAIL_AFFINITY=1 $CONTAINER bash $SCRIPT \
-            --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
-            --ifname $NODE1_IFNAME \
-            -- --op-type write --buffer-size 4096 --transfer-batch-size 64 \
-            --iters 4 --enable-sess --enable-batch-transfer \
-            --num-qp-per-transfer 2 \
-            --num-initiator-dev 8 --num-target-dev 8 \
-            --target-dev-offset 5
-          wait
-
-      - name: MORI-EP internode normal kernel bench
-        run: |
-          SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_test.sh"
-          PORT=29140
-          for KERNEL in v1 v1_ll; do
-            for TOKENS in 64 128 1024 2048 4096; do
-              echo "=== bench kernel=$KERNEL max-tokens=$TOKENS port=$PORT ==="
-              NODE2_CMD=(
-                $CT exec -e MORI_INTERNODE_TIMEOUT=600 $CONTAINER bash $SCRIPT
-                --rank 1 --master-addr $NODE1_HOST --master-port $PORT
-                --ifname $NODE2_IFNAME
-                --cmd bench --kernel-type $KERNEL --max-tokens $TOKENS
-              )
-              ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
-              $CT exec -e MORI_INTERNODE_TIMEOUT=600 $CONTAINER bash $SCRIPT \
-                --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
-                --ifname $NODE1_IFNAME \
-                --cmd bench --kernel-type $KERNEL --max-tokens $TOKENS
-              wait
-              sleep 1
-              PORT=$((PORT + 1))
-            done
-          done
-
-      - name: MORI-EP internode normal kernel stress
-        run: |
-          SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_test.sh"
-          PORT=29160
-          for KERNEL in v1 v1_ll; do
-            for TOKENS in 64 128 1024 2048 4096; do
-              echo "=== stress kernel=$KERNEL max-tokens=$TOKENS port=$PORT ==="
-              NODE2_CMD=(
-                $CT exec -e MORI_INTERNODE_TIMEOUT=600 $CONTAINER bash $SCRIPT
-                --rank 1 --master-addr $NODE1_HOST --master-port $PORT
-                --ifname $NODE2_IFNAME
-                --cmd stress --kernel-type $KERNEL --max-tokens $TOKENS
-              )
-              ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
-              $CT exec -e MORI_INTERNODE_TIMEOUT=600 $CONTAINER bash $SCRIPT \
-                --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
-                --ifname $NODE1_IFNAME \
-                --cmd stress --kernel-type $KERNEL --max-tokens $TOKENS
-              wait
-              sleep 1
-              PORT=$((PORT + 1))
-            done
-          done
-
-      - name: MORI-EP internode async kernel test
-        run: |
-          SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_test.sh"
-          PORT=29180
-          for TOKENS in 64 128; do
-            echo "=== async_ll test max-tokens=$TOKENS port=$PORT ==="
-            NODE2_CMD=(
-              $CT exec
-              -e GPU_PER_NODE=8 -e MORI_ENABLE_SDMA=1 -e MORI_INTERNODE_TIMEOUT=600
-              $CONTAINER bash $SCRIPT
-              --rank 1 --master-addr $NODE1_HOST --master-port $PORT
-              --ifname $NODE2_IFNAME
-              --cmd test --kernel-type async_ll
-              --quant-type none --dtype bf16 --max-tokens $TOKENS
-            )
-            ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
-            $CT exec \
-              -e GPU_PER_NODE=8 \
-              -e MORI_ENABLE_SDMA=1 \
-              -e MORI_INTERNODE_TIMEOUT=600 \
-              $CONTAINER bash $SCRIPT \
-              --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
-              --ifname $NODE1_IFNAME \
-              --cmd test --kernel-type async_ll \
-              --quant-type none --dtype bf16 --max-tokens $TOKENS
-            wait
-            sleep 1
-            PORT=$((PORT + 1))
-          done
-
-      - name: MORI-CCL internode hier allgather bit-exact smoke
-        run: |
-          # world=16 (2 node x 8 GPU) hierarchical AllGather: intra-node SDMA +
-          # inter-node RDMA, asserted byte-for-byte against a locally-computed
-          # reference (no RCCL collective -> no dependency on RCCL's cross-node
-          # RoCE bring-up). Both inter-node legs: device = IBGDA (GPU-posted),
-          # hostproxy = CPU-posted.
-          SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_ccl_ag.sh"
-          PORT=29200
-          for HANDLE in device hostproxy; do
-            echo "=== hier allgather smoke handle=$HANDLE port=$PORT ==="
-            NODE2_CMD=(
-              $CT exec
-              -e MORI_ENABLE_SDMA=1 -e MORI_INTERNODE_TIMEOUT=300
-              -e MORI_RDMA_DEVICES=$MORI_RDMA_DEVICES
-              -e MORI_RDMA_SL=$MORI_RDMA_SL -e MORI_RDMA_TC=$MORI_RDMA_TC
-              $CONTAINER bash $SCRIPT
-              --rank 1 --master-addr $NODE1_HOST --master-port $PORT
-              --ifname $NODE2_IFNAME --handle $HANDLE --sizes-mb 8,64
-            )
-            ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
-            $CT exec \
-              -e MORI_ENABLE_SDMA=1 \
-              -e MORI_INTERNODE_TIMEOUT=300 \
-              -e MORI_RDMA_DEVICES=$MORI_RDMA_DEVICES \
-              -e MORI_RDMA_SL=$MORI_RDMA_SL -e MORI_RDMA_TC=$MORI_RDMA_TC \
-              $CONTAINER bash $SCRIPT \
-              --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
-              --ifname $NODE1_IFNAME --handle $HANDLE --sizes-mb 8,64
-            wait
-            sleep 1
-            PORT=$((PORT + 1))
-          done
+      - name: Upload bench_engine results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-engine-perf-${{ github.run_id }}
+          path: ${{ github.workspace }}/_perf/bench_engine_results.txt
+          if-no-files-found: warn
 
       - name: Cleanup node1
         if: always()
@@ -863,54 +166,3 @@ jobs:
           ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
             -p $NODE2_PORT $(whoami)@$NODE2_HOST \
             "$CT rm -f $CONTAINER || true"
-
-  umbp-single-node-hicache:
-    name: mori umbp single-node hicache smoke test
-    needs: build
-    if: github.event_name == 'workflow_dispatch' && inputs.run_umbp_single_node_hicache == 'true'
-    runs-on: [self-hosted, MI355X-AINIC-TW]
-    timeout-minutes: 180
-    steps:
-      - name: Checkout MoRI
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Checkout SGLang
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ inputs.sglang_repo }}
-          ref: ${{ inputs.sglang_ref }}
-          path: sglang
-          fetch-depth: 1
-
-      - name: Ensure hicache script is executable
-        run: chmod +x src/umbp/scripts/run_umbp_single_node_hicache.sh
-
-      - name: Run hicache smoke test
-        env:
-          SGLANG_REPO: ${{ github.workspace }}/sglang
-          MORI_REPO: ${{ github.workspace }}
-          RESULTS_DIR: ${{ github.workspace }}/umbp_single_node_results
-          USE_DUMMY_WEIGHTS: "true"
-          RUN_GSM8K: "false"
-          MODEL_PATH: ${{ github.workspace }}/umbp_dummy_model
-          ENABLE_DP: ${{ inputs.enable_dp }}
-          START_UMBP_MASTER: "false"
-        run: |
-          set -euo pipefail
-          mkdir -p "$RESULTS_DIR"
-          ./src/umbp/scripts/run_umbp_single_node_hicache.sh
-
-      - name: Upload hicache artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: umbp-single-node-hicache-${{ github.run_id }}
-          path: |
-            ${{ github.workspace }}/umbp_single_node_results
-          if-no-files-found: warn
-
-      - name: Cleanup hicache container
-        if: always()
-        run: docker rm -f umbp-single-node >/dev/null 2>&1 || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
           PORT=29130
           COMMON="--op-type write --mem-type gpu --all \
             --sweep-start-size 1048576 --sweep-max-size 33554432 --sweep-step 1048576 \
-            --num-qp-per-transfer 4 --batch-contiguous --target-dev-offset 0 \
+            --num-qp-per-transfer 4 --batch-contiguous \
             --num-initiator-dev 1 --num-target-dev 1 \
             --warmup-iters 10 --log-level info"
           for BATCH in 1 64; do
@@ -135,9 +135,11 @@ jobs:
             echo "=== C++ bench_engine GPU write sweep, batch=$BATCH, iters=$ITERS, port=$PORT ===" | tee -a "$RESULTS"
             ARGS="$COMMON --transfer-batch-size $BATCH --iters $ITERS"
             R1="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \
-              --rank 1 --master-ip $NODE1_HOST --self-ip $NODE2_HOST --port $PORT $ARGS"
+              --rank 1 --master-ip $NODE1_HOST --self-ip $NODE2_HOST --port $PORT \
+              --target-dev-offset 0 $ARGS"
             R0="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \
-              --rank 0 --master-ip $NODE1_HOST --self-ip $NODE1_HOST --port $PORT $ARGS"
+              --rank 0 --master-ip $NODE1_HOST --self-ip $NODE1_HOST --port $PORT \
+              --target-dev-offset 0 $ARGS"
             ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST \
               "$CT exec $CONTAINER bash -c \"$R1\"" >> "$RESULTS" 2>&1 &
             $CT exec $CONTAINER bash -c "$R0" | tee -a "$RESULTS"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   io-bench-engine-internode:
-    name: MORI-IO internode perf (${{ matrix.platform }})
+    name: bench_engine internode (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -45,7 +45,7 @@ jobs:
       MORI_RDMA_SL: ${{ matrix.rdma_sl }}
       MORI_RDMA_TC: ${{ matrix.rdma_tc }}
       MORI_SOCKET_IFNAME: ${{ matrix.node1_ifname }}
-    timeout-minutes: 90
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -98,54 +98,61 @@ jobs:
               git config --global --add safe.directory $GITHUB_WORKSPACE
           "
 
-      - name: Install mori and build bench_engine (both nodes)
+      - name: Build bench_engine (both nodes)
         run: |
-          INSTALL_CMD="cd $GITHUB_WORKSPACE && \
-            BUILD_TESTS=ON BUILD_EXAMPLES=OFF BUILD_OPS=OFF BUILD_SHMEM=OFF \
-            BUILD_CCO=OFF BUILD_COLLECTIVE=OFF BUILD_UMBP=OFF BUILD_METRICS=OFF \
-            pip install . && ls -la build/tests/cpp/bench_engine"
-          $CT exec $CONTAINER bash -c "$INSTALL_CMD"
+          BUILD_CMD="cd $GITHUB_WORKSPACE && cmake -B build \
+            -DBUILD_IO=ON \
+            -DBUILD_TESTS=ON \
+            -DBUILD_EXAMPLES=OFF \
+            -DBUILD_PYBINDS=OFF \
+            -DBUILD_OPS=OFF \
+            -DBUILD_SHMEM=OFF \
+            -DBUILD_CCO=OFF \
+            -DBUILD_COLLECTIVE=OFF \
+            -DBUILD_METRICS=OFF \
+            -DBUILD_UMBP=OFF \
+            && cmake --build build --target bench_engine -j \
+            && ls -la build/tests/cpp/bench_engine"
+          $CT exec $CONTAINER bash -c "$BUILD_CMD"
           ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST \
-            "$CT exec $CONTAINER bash -c \"$INSTALL_CMD\""
+            "$CT exec $CONTAINER bash -c \"$BUILD_CMD\""
 
-      - name: MORI-IO C++ bench_engine write sweep (batch 1)
+      - name: MORI-IO C++ bench_engine write sweep (batch 1 and 64)
         run: |
-          set -euo pipefail
           mkdir -p $GITHUB_WORKSPACE/_perf
-          CPP_RESULTS=$GITHUB_WORKSPACE/_perf/bench_engine_results.txt
+          RESULTS=$GITHUB_WORKSPACE/_perf/bench_engine_results.txt
           BIN=$GITHUB_WORKSPACE/build/tests/cpp/bench_engine
           LDP="LD_LIBRARY_PATH=$GITHUB_WORKSPACE/build/src/io:$GITHUB_WORKSPACE/build/src/application"
           PORT=29130
-          ARGS="--op-type write --mem-type gpu --all \
+          COMMON="--op-type write --mem-type gpu --all \
             --sweep-start-size 1048576 --sweep-max-size 33554432 --sweep-step 1048576 \
-            --disable-chunking --num-qp-per-transfer 8 --enable-sess --poll_cq_mode polling \
-            --num-initiator-dev 1 --num-target-dev 1 --target-dev-offset 0 \
-            --transfer-batch-size 1 --iters 512 --log-level info"
+            --num-qp-per-transfer 4 --batch-contiguous \
+            --num-initiator-dev 1 --num-target-dev 1 \
+            --warmup-iters 10 --log-level info"
+          for BATCH in 1 64; do
+            ITERS=128
+            if [ "$BATCH" -eq 1 ]; then ITERS=512; fi
+            echo "=== C++ bench_engine GPU write sweep, batch=$BATCH, iters=$ITERS, port=$PORT ===" | tee -a "$RESULTS"
+            ARGS="$COMMON --transfer-batch-size $BATCH --iters $ITERS"
+            R1="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \
+              --rank 1 --master-ip $NODE1_HOST --self-ip $NODE2_HOST --port $PORT \
+              --target-dev-offset 0 $ARGS"
+            R0="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \
+              --rank 0 --master-ip $NODE1_HOST --self-ip $NODE1_HOST --port $PORT \
+              --target-dev-offset 0 $ARGS"
+            ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST \
+              "$CT exec $CONTAINER bash -c \"$R1\"" >> "$RESULTS" 2>&1 &
+            $CT exec $CONTAINER bash -c "$R0" | tee -a "$RESULTS"
+            wait
+            PORT=$((PORT + 1))
+          done
 
-          echo "=== C++ bench_engine GPU write sweep, batch=1, iters=512, port=$PORT ===" \
-            | tee "$CPP_RESULTS"
-          R1="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \
-            --rank 1 --master-ip $NODE1_HOST --self-ip $NODE2_HOST --port $PORT \
-            --target-dev-offset 0 --warmup-iters 128 $ARGS"
-          R0="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \
-            --rank 0 --master-ip $NODE1_HOST --self-ip $NODE1_HOST --port $PORT \
-            --target-dev-offset 0 --warmup-iters 128 $ARGS"
-          ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST \
-            "$CT exec $CONTAINER bash -c \"$R1\"" >> "$CPP_RESULTS" 2>&1 &
-          pid=$!
-          if ! $CT exec $CONTAINER bash -c "$R0" | tee -a "$CPP_RESULTS"; then
-            wait "$pid" || true
-            exit 1
-          fi
-          wait "$pid"
-
-      - name: Upload perf results
+      - name: Upload bench_engine results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: mori-io-perf-${{ github.run_id }}
-          path: |
-            ${{ github.workspace }}/_perf/bench_engine_results.txt
+          name: bench-engine-perf-${{ github.run_id }}
+          path: ${{ github.workspace }}/_perf/bench_engine_results.txt
           if-no-files-found: warn
 
       - name: Cleanup node1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
           # Sweep: 256 MiB .. 512 MiB by 64 MiB (268435456, step 67108864).
           COMMON_BATCH1="--op-type write --mem-type gpu --all \
             --sweep-start-size 268435456 --sweep-max-size 536870912 --sweep-step 67108864 \
-            --num-qp-per-transfer 8 --enable-sess --poll_cq_mode polling \
+            --num-qp-per-transfer 8 --num-worker-threads 8 --enable-sess --poll_cq_mode polling \
             --num-initiator-dev 1 --num-target-dev 1 --target-dev-offset 0 \
             --log-level info"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
           BATCH64_CPP="--op write --mem-type gpu --gpu 0 --target-dev-offset 0 \
             --all --sweep-start-size 268435456 --sweep-max-size 536870912 --sweep-step 67108864 \
             --transfer-batch-size 64 --enable-batch-transfer --batch-contiguous \
-            --enable-sess --disable-chunking \
+            --enable-sess \
             --num-qp-per-transfer 8 --num-worker-threads 8 \
             --num-initiator-dev 1 --num-target-dev 1 \
             --poll_cq_mode polling --iters 128 --warmup-iters 10 \
@@ -137,7 +137,7 @@ jobs:
           BATCH64_PY="--op-type write --mem-type gpu --target-dev-offset 0 \
             --all --sweep-start-size 268435456 --sweep-max-size 536870912 --sweep-step 67108864 \
             --transfer-batch-size 64 --enable-batch-transfer --batch-contiguous \
-            --enable-sess --disable-chunking \
+            --enable-sess \
             --num-qp-per-transfer 8 --num-worker-threads 8 \
             --num-initiator-dev 1 --num-target-dev 1 \
             --poll_cq_mode polling --iters 128 --warmup-iters 10 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,10 +128,12 @@ jobs:
             --sweep-start-size 1048576 --sweep-max-size 33554432 --sweep-step 1048576 \
             --num-qp-per-transfer 4 --batch-contiguous --target-dev-offset 0 \
             --num-initiator-dev 1 --num-target-dev 1 \
-            --iters 128 --warmup-iters 10 --log-level info"
+            --warmup-iters 10 --log-level info"
           for BATCH in 1 64; do
-            echo "=== C++ bench_engine GPU write sweep, batch=$BATCH, port=$PORT ===" | tee -a "$RESULTS"
-            ARGS="$COMMON --transfer-batch-size $BATCH"
+            ITERS=128
+            if [ "$BATCH" -eq 1 ]; then ITERS=512; fi
+            echo "=== C++ bench_engine GPU write sweep, batch=$BATCH, iters=$ITERS, port=$PORT ===" | tee -a "$RESULTS"
+            ARGS="$COMMON --transfer-batch-size $BATCH --iters $ITERS"
             R1="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \
               --rank 1 --master-ip $NODE1_HOST --self-ip $NODE2_HOST --port $PORT $ARGS"
             R0="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,15 +118,15 @@ jobs:
           SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_io_benchmark.sh"
           chmod +x "$SCRIPT"
 
-          # Sweep: 256 MiB .. 512 MiB by 64 MiB (268435456, step 67108864).
+          # Sweep: 128 MiB .. 512 MiB by 32 MiB (134217728, step 33554432).
           COMMON_BATCH1="--op-type write --mem-type gpu --all \
-            --sweep-start-size 268435456 --sweep-max-size 536870912 --sweep-step 67108864 \
+            --sweep-start-size 134217728 --sweep-max-size 536870912 --sweep-step 33554432 \
             --num-qp-per-transfer 8 --num-worker-threads 8 --enable-sess --poll_cq_mode polling \
             --num-initiator-dev 1 --num-target-dev 1 --target-dev-offset 0 \
             --log-level info"
 
           BATCH64_CPP="--op write --mem-type gpu --gpu 0 --target-dev-offset 0 \
-            --all --sweep-start-size 268435456 --sweep-max-size 536870912 --sweep-step 67108864 \
+            --all --sweep-start-size 134217728 --sweep-max-size 536870912 --sweep-step 33554432 \
             --transfer-batch-size 64 --enable-batch-transfer --batch-contiguous \
             --enable-sess \
             --num-qp-per-transfer 8 --num-worker-threads 8 \
@@ -135,7 +135,7 @@ jobs:
             --log-level info"
 
           BATCH64_PY="--op-type write --mem-type gpu --target-dev-offset 0 \
-            --all --sweep-start-size 268435456 --sweep-max-size 536870912 --sweep-step 67108864 \
+            --all --sweep-start-size 134217728 --sweep-max-size 536870912 --sweep-step 33554432 \
             --transfer-batch-size 64 --enable-batch-transfer --batch-contiguous \
             --enable-sess \
             --num-qp-per-transfer 8 --num-worker-threads 8 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       MORI_RDMA_SL: ${{ matrix.rdma_sl }}
       MORI_RDMA_TC: ${{ matrix.rdma_tc }}
       MORI_SOCKET_IFNAME: ${{ matrix.node1_ifname }}
+      # Force GPU RDMA registration via dma-buf (ibv_reg_dmabuf_mr) instead of
+      # ibv_reg_mr-first fallback — matches production AINIC GPU IO path.
+      MORI_ENABLE_DMABUF_REG: "1"
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -63,6 +66,7 @@ jobs:
             -e MORI_RDMA_SL=$MORI_RDMA_SL \
             -e MORI_RDMA_TC=$MORI_RDMA_TC \
             -e MORI_SOCKET_IFNAME=$MORI_SOCKET_IFNAME \
+            -e MORI_ENABLE_DMABUF_REG=$MORI_ENABLE_DMABUF_REG \
             -e GLOO_SOCKET_IFNAME=$NODE1_IFNAME \
             -e NCCL_SOCKET_IFNAME=$NODE1_IFNAME \
             -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
@@ -89,6 +93,7 @@ jobs:
               -e MORI_RDMA_SL=$MORI_RDMA_SL \
               -e MORI_RDMA_TC=$MORI_RDMA_TC \
               -e MORI_SOCKET_IFNAME=$MORI_SOCKET_IFNAME \
+              -e MORI_ENABLE_DMABUF_REG=$MORI_ENABLE_DMABUF_REG \
               -e GLOO_SOCKET_IFNAME=$NODE2_IFNAME \
               -e NCCL_SOCKET_IFNAME=$NODE2_IFNAME \
               -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
@@ -132,6 +137,7 @@ jobs:
           {
             echo "=== MORI-IO bench_engine CI commands ==="
             echo "COMMON=${COMMON}"
+            echo "MORI_ENABLE_DMABUF_REG=${MORI_ENABLE_DMABUF_REG}"
             echo "GPU sweep: 0 1 2 3 4 5 6 7 (one GPU pair per run)"
             echo "NODE1_HOST=${NODE1_HOST} NODE2_HOST=${NODE2_HOST}"
             echo ""
@@ -141,10 +147,10 @@ jobs:
             ITERS=128
             if [ "$BATCH" -eq 1 ]; then ITERS=512; fi
             ARGS="$COMMON --gpu $GPU --transfer-batch-size $BATCH --iters $ITERS"
-            R1="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \
+            R1="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 MORI_ENABLE_DMABUF_REG=1 $LDP $BIN \
               --rank 1 --master-ip $NODE1_HOST --self-ip $NODE2_HOST --port $PORT \
               --target-dev-offset 0 $ARGS"
-            R0="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \
+            R0="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 MORI_ENABLE_DMABUF_REG=1 $LDP $BIN \
               --rank 0 --master-ip $NODE1_HOST --self-ip $NODE1_HOST --port $PORT \
               --target-dev-offset 0 $ARGS"
             {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,10 +129,15 @@ jobs:
             --num-qp-per-transfer 4 --batch-contiguous \
             --num-initiator-dev 1 --num-target-dev 1 \
             --warmup-iters 128 --log-level info"
+          {
+            echo "=== MORI-IO bench_engine CI commands ==="
+            echo "COMMON=${COMMON}"
+            echo "NODE1_HOST=${NODE1_HOST} NODE2_HOST=${NODE2_HOST}"
+            echo ""
+          } | tee "$RESULTS"
           for BATCH in 1 64; do
             ITERS=128
             if [ "$BATCH" -eq 1 ]; then ITERS=512; fi
-            echo "=== C++ bench_engine GPU write sweep, batch=$BATCH, iters=$ITERS, port=$PORT ===" | tee -a "$RESULTS"
             ARGS="$COMMON --transfer-batch-size $BATCH --iters $ITERS"
             R1="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \
               --rank 1 --master-ip $NODE1_HOST --self-ip $NODE2_HOST --port $PORT \
@@ -140,6 +145,14 @@ jobs:
             R0="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \
               --rank 0 --master-ip $NODE1_HOST --self-ip $NODE1_HOST --port $PORT \
               --target-dev-offset 0 $ARGS"
+            {
+              echo "=== C++ bench_engine GPU write sweep, batch=$BATCH, iters=$ITERS, port=$PORT ==="
+              echo "rank 0 (initiator, node1):"
+              echo "$R0"
+              echo "rank 1 (target, node2):"
+              echo "$R1"
+              echo ""
+            } | tee -a "$RESULTS"
             ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST \
               "$CT exec $CONTAINER bash -c \"$R1\"" >> "$RESULTS" 2>&1 &
             $CT exec $CONTAINER bash -c "$R0" | tee -a "$RESULTS"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,39 +118,62 @@ jobs:
           SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_io_benchmark.sh"
           chmod +x "$SCRIPT"
 
-          # Shared workload for C++ bench_engine and Python benchmark.py.
           # batch=1: 512 iters (chunking ON by default; no --batch-contiguous).
-          # batch=64: 128 iters.
-          COMMON="--op-type write --mem-type gpu --all \
+          # batch=64: tuned write sweep (batch-contiguous, disable-chunking, 8 workers).
+          COMMON_BATCH1="--op-type write --mem-type gpu --all \
             --sweep-start-size 1048576 --sweep-max-size 33554432 --sweep-step 1048576 \
             --num-qp-per-transfer 8 --enable-sess --poll_cq_mode polling \
             --num-initiator-dev 1 --num-target-dev 1 --target-dev-offset 0 \
             --log-level info"
 
+          BATCH64_CPP="--op write --mem-type gpu --gpu 0 --target-dev-offset 0 \
+            --all --sweep-start-size 1048576 --sweep-max-size 33554432 --sweep-step 1048576 \
+            --transfer-batch-size 64 --enable-batch-transfer --batch-contiguous \
+            --enable-sess --disable-chunking \
+            --num-qp-per-transfer 8 --num-worker-threads 8 \
+            --num-initiator-dev 1 --num-target-dev 1 \
+            --poll_cq_mode polling --iters 128 --warmup-iters 10 \
+            --log-level info"
+
+          BATCH64_PY="--op-type write --mem-type gpu --target-dev-offset 0 \
+            --all --sweep-start-size 1048576 --sweep-max-size 33554432 --sweep-step 1048576 \
+            --transfer-batch-size 64 --enable-batch-transfer --batch-contiguous \
+            --enable-sess --disable-chunking \
+            --num-qp-per-transfer 8 --num-worker-threads 8 \
+            --num-initiator-dev 1 --num-target-dev 1 \
+            --poll_cq_mode polling --iters 128 --warmup-iters 10 \
+            --log-level info"
+
           CPP_PORT=29130
           PY_PORT=29230
           for BATCH in 1 64; do
-            ITERS=128
-            if [ "$BATCH" -eq 1 ]; then ITERS=512; fi
-            ARGS="$COMMON --transfer-batch-size $BATCH --iters $ITERS"
+            if [ "$BATCH" -eq 1 ]; then
+              ITERS=512
+              CPP_ARGS="$COMMON_BATCH1 --transfer-batch-size 1 --iters $ITERS"
+              CPP_RENDEZ="--target-dev-offset 0 --warmup-iters 10"
+              PY_ARGS="$CPP_ARGS --enable-batch-transfer"
+            else
+              CPP_ARGS="$BATCH64_CPP"
+              CPP_RENDEZ=""
+              PY_ARGS="$BATCH64_PY"
+            fi
 
-            echo "=== C++ bench_engine GPU write sweep, batch=$BATCH, iters=$ITERS, port=$CPP_PORT ===" \
+            echo "=== C++ bench_engine GPU write sweep, batch=$BATCH, port=$CPP_PORT ===" \
               | tee -a "$CPP_RESULTS"
             R1="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \
               --rank 1 --master-ip $NODE1_HOST --self-ip $NODE2_HOST --port $CPP_PORT \
-              --target-dev-offset 0 --warmup-iters 10 $ARGS"
+              $CPP_RENDEZ $CPP_ARGS"
             R0="cd $GITHUB_WORKSPACE && MORI_DISABLE_AUTO_XGMI=1 $LDP $BIN \
               --rank 0 --master-ip $NODE1_HOST --self-ip $NODE1_HOST --port $CPP_PORT \
-              --target-dev-offset 0 --warmup-iters 10 $ARGS"
+              $CPP_RENDEZ $CPP_ARGS"
             ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST \
               "$CT exec $CONTAINER bash -c \"$R1\"" >> "$CPP_RESULTS" 2>&1 &
             $CT exec $CONTAINER bash -c "$R0" | tee -a "$CPP_RESULTS"
             wait
             CPP_PORT=$((CPP_PORT + 1))
 
-            echo "=== Python benchmark.py GPU write sweep, batch=$BATCH, iters=$ITERS, port=$PY_PORT ===" \
+            echo "=== Python benchmark.py GPU write sweep, batch=$BATCH, port=$PY_PORT ===" \
               | tee -a "$PY_RESULTS"
-            PY_ARGS="$ARGS --enable-batch-transfer"
             NODE2_CMD=(
               $CT exec -e MORI_DISABLE_AUTO_XGMI=1 $CONTAINER bash $SCRIPT
               --rank 1 --master-addr $NODE1_HOST --master-port $PY_PORT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
           COMMON="--op-type write --mem-type gpu --all \
             --sweep-start-size 1048576 --sweep-max-size 33554432 --sweep-step 1048576 \
             --num-qp-per-transfer 4 --batch-contiguous \
-            --num-initiator-dev 1 --num-target-dev 1 \
+            --num-initiator-dev 8 --num-target-dev 8 \
             --warmup-iters 128 --log-level info"
           {
             echo "=== MORI-IO bench_engine CI commands ==="

--- a/.github/workflows/ci_cco.yml
+++ b/.github/workflows/ci_cco.yml
@@ -1,10 +1,11 @@
 name: CCO CI test
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
+  # Disabled on the bench_engine perf CI branch.
+  # push:
+  #   branches: [main]
+  # pull_request:
+  #   branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,8 +1,10 @@
 name: pre-commit
 
 on:
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
+  # Disabled on the bench_engine perf CI branch; re-enable when merging back to upstream main.
+  # pull_request:
+  #   branches: [main]
 
 jobs:
   pre-commit:


### PR DESCRIPTION
Replace the full MoRI test matrix with a single two-node job that builds bench_engine and runs a 1-32 MiB GPU write sweep at batch sizes 1 and 64. Disable pre-commit and CCO workflows on this branch so dummy PRs only trigger the perf benchmark.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
