### PR TITLE
fix(ionic): enable MoRI-EP inter-node on gfx942 + AINIC/ionic

### DIFF
--- a/include/mori/application/transport/rdma/providers/dv_loader.hpp
+++ b/include/mori/application/transport/rdma/providers/dv_loader.hpp
@@ -183,6 +183,7 @@ struct IonicDvApi {
   using pd_set_udma_mask_t = int (*)(struct ibv_pd*, uint32_t);
   using create_cq_ex_t = struct ibv_cq_ex* (*)(struct ibv_context*, struct ibv_cq_init_attr_ex*,
                                                struct ionic_cq_init_attr_ex*);
+  using qp_set_gda_t = int (*)(struct ibv_qp*, bool, bool);
 
   get_ctx_t get_ctx = nullptr;
   qp_get_udma_idx_t qp_get_udma_idx = nullptr;
@@ -192,6 +193,7 @@ struct IonicDvApi {
   pd_set_rqcmb_t pd_set_rqcmb = nullptr;
   pd_set_udma_mask_t pd_set_udma_mask = nullptr;
   create_cq_ex_t create_cq_ex = nullptr;
+  qp_set_gda_t qp_set_gda = nullptr;
 
   void* handle = nullptr;
 
@@ -207,8 +209,10 @@ struct IonicDvApi {
     pd_set_rqcmb = (pd_set_rqcmb_t)DvLoadSymbol(handle, "ionic_dv_pd_set_rqcmb");
     pd_set_udma_mask = (pd_set_udma_mask_t)DvLoadSymbol(handle, "ionic_dv_pd_set_udma_mask");
     create_cq_ex = (create_cq_ex_t)DvLoadSymbol(handle, "ionic_dv_create_cq_ex");
+    qp_set_gda = (qp_set_gda_t)DvLoadSymbol(handle, "ionic_dv_qp_set_gda");
 
-    // create_cq_ex is optional: nullptr means CCQE not supported by this driver version
+    // create_cq_ex (CCQE) and qp_set_gda (GPU-Direct Async) are optional: nullptr means the
+    // running driver version doesn't support them.
     return get_ctx && qp_get_udma_idx && get_cq && get_qp && pd_set_sqcmb && pd_set_rqcmb &&
            pd_set_udma_mask;
   }

--- a/include/mori/shmem/shmem_ibgda_kernels.hpp
+++ b/include/mori/shmem/shmem_ibgda_kernels.hpp
@@ -1059,10 +1059,13 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelImpl(
                 qpn, ibuf->addr, ibuf->lkey, signalRaddr, signalRkey, &signalValue, &signalValue,
                 sizeof(signalValue), core::atomicType::AMO_ADD);
           } else if constexpr (PrvdType == core::ProviderType::PSD) {
-            dbr_val = core::PostAtomic<PrvdType>(
+            // gfx942+ionic: GPU-issued RDMA atomic-add does NOT transmit at all (confirmed on driver
+            // 26.03.27.002: tx counter stays 0 when PostAtomic is used). Use a plain remote WRITE of
+            // the accumulated value instead. Single-writer-per-slot signal slots make write ==
+            // add-from-zero semantically.
+            dbr_val = core::PostWriteInline<PrvdType>(
                 *wq, my_sq_counter + 1, my_sq_counter + 1, my_sq_counter + 1, is_leader, qpn,
-                ibuf->addr, ibuf->lkey, signalRaddr, signalRkey, &signalValue, &signalValue,
-                sizeof(signalValue), core::atomicType::AMO_ADD);
+                &signalValue, signalRaddr, signalRkey, sizeof(signalValue));
           }
         }
       } else {
@@ -1302,9 +1305,11 @@ inline __device__ void ShmemAtomicSizeNonFetchThreadKernelImpl(
         core::PostAtomic<PrvdType>(*wq, my_sq_counter, my_msntbl_counter, my_psn_counter, is_leader,
                                    qpn, laddr, lkey, raddr, rkey, val, val, bytes, amoType);
   } else if constexpr (PrvdType == core::ProviderType::PSD) {
-    dbr_val =
-        core::PostAtomic<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter, is_leader, qpn,
-                                   laddr, lkey, raddr, rkey, val, val, bytes, amoType);
+    // gfx942+ionic: GPU-issued RDMA atomics don't land at the remote target (post OK, never applied).
+    // MoRI-EP uses this non-fetch atomic only for single-writer signal counters, so a remote WRITE of
+    // the value is equivalent and uses the working write path. (AMO_ADD-from-zero == write of value.)
+    dbr_val = core::PostWriteInline<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter,
+                                              is_leader, qpn, val, raddr, rkey, bytes);
   }
 
   __threadfence_system();
@@ -2157,10 +2162,13 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelAddrImpl(
                 qpn, ibuf->addr, ibuf->lkey, signalRaddr, signalRkey, &signalValue, &signalValue,
                 sizeof(signalValue), core::atomicType::AMO_ADD);
           } else if constexpr (PrvdType == core::ProviderType::PSD) {
-            dbr_val = core::PostAtomic<PrvdType>(
+            // gfx942+ionic: GPU-issued RDMA atomic-add does NOT transmit at all (confirmed on driver
+            // 26.03.27.002: tx counter stays 0 when PostAtomic is used). Use a plain remote WRITE of
+            // the accumulated value instead. Single-writer-per-slot signal slots make write ==
+            // add-from-zero semantically.
+            dbr_val = core::PostWriteInline<PrvdType>(
                 *wq, my_sq_counter + 1, my_sq_counter + 1, my_sq_counter + 1, is_leader, qpn,
-                ibuf->addr, ibuf->lkey, signalRaddr, signalRkey, &signalValue, &signalValue,
-                sizeof(signalValue), core::atomicType::AMO_ADD);
+                &signalValue, signalRaddr, signalRkey, sizeof(signalValue));
           }
         }
       } else {
@@ -2377,9 +2385,11 @@ inline __device__ void ShmemAtomicSizeNonFetchThreadKernelAddrImpl(const void* d
         core::PostAtomic<PrvdType>(*wq, my_sq_counter, my_msntbl_counter, my_psn_counter, is_leader,
                                    qpn, laddr, lkey, raddr, rkey, val, val, bytes, amoType);
   } else if constexpr (PrvdType == core::ProviderType::PSD) {
-    dbr_val =
-        core::PostAtomic<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter, is_leader, qpn,
-                                   laddr, lkey, raddr, rkey, val, val, bytes, amoType);
+    // gfx942+ionic: GPU-issued RDMA atomics don't land at the remote target (post OK, never applied).
+    // MoRI-EP uses this non-fetch atomic only for single-writer signal counters, so a remote WRITE of
+    // the value is equivalent and uses the working write path. (AMO_ADD-from-zero == write of value.)
+    dbr_val = core::PostWriteInline<PrvdType>(*wq, my_sq_counter, my_sq_counter, my_sq_counter,
+                                              is_leader, qpn, val, raddr, rkey, bytes);
   }
 
   __threadfence_system();

--- a/src/application/transport/rdma/providers/ionic/ionic.cpp
+++ b/src/application/transport/rdma/providers/ionic/ionic.cpp
@@ -276,6 +276,22 @@ IonicQpContainer::IonicQpContainer(ibv_context* context, const RdmaEndpointConfi
   MORI_APP_TRACE("cq ptr:0x{:x}, cq size:{}, cq mask:0x{:x}",
                  reinterpret_cast<uintptr_t>(dvcq.q.ptr), dvcq.q.size, dvcq.q.mask);
 
+  // Enable GPU-Direct Async (GDA) mode on the QP: the provider writes WQEs into the SQ/RQ ring
+  // without ringing the doorbell, so the GPU kernel can ring the mapped doorbell register itself
+  // (this is exactly what the device-side IonicPostSend/RingDoorbell path does). Without this the
+  // QP stays in normal mode and the GPU-issued doorbell has no effect -> internode EP dispatch hangs.
+  // Required on gfx942+ionic; optional symbol (older drivers may lack it).
+  if (IonicDvApi::Instance().qp_set_gda != nullptr && !std::getenv("MORI_DISABLE_IONIC_GDA")) {
+    int gdaRc = IonicDvApi::Instance().qp_set_gda(qp, /*enable_send=*/true, /*enable_recv=*/true);
+    if (gdaRc != 0) {
+      MORI_APP_WARN("ionic_dv_qp_set_gda failed rc={} (GPU-direct doorbell may not work)", gdaRc);
+    } else {
+      MORI_APP_TRACE("ionic_dv_qp_set_gda enabled (GDA mode) for GPU doorbell");
+    }
+  } else {
+    MORI_APP_WARN("ionic_dv_qp_set_gda unavailable in libionic; GPU-direct doorbell may not work");
+  }
+
   ionic_dv_qp dvqp;
   IonicDvApi::Instance().get_qp(&dvqp, qp);
 
@@ -316,7 +332,29 @@ IonicQpContainer::IonicQpContainer(ibv_context* context, const RdmaEndpointConfi
   int atomicIbufAccessFlag =
       MaybeAddRelaxedOrderingFlag(IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
                                   IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC);
-  atomicIbufMr = ibv_reg_mr(pd_uxdma, atomicIbufAddr, atomicIbufSize, atomicIbufAccessFlag);
+  // gfx942+ionic: plain ibv_reg_mr on GPU memory needs amdgpu_peermem (absent on this stack).
+  // Register the GPU atomic ibuf via dmabuf first (matches the symmetric-heap dmabuf path that works
+  // for MoRI-IO here); fall back to plain ibv_reg_mr for host memory / when dmabuf is unavailable.
+  atomicIbufMr = nullptr;
+  if (config.onGpu) {
+    int atomicIbufDmabufFd = -1;
+    hipError_t dmabufErr = hipMemGetHandleForAddressRange(
+        &atomicIbufDmabufFd, reinterpret_cast<hipDeviceptr_t>(atomicIbufAddr), atomicIbufSize,
+        hipMemRangeHandleTypeDmaBufFd, 0);
+    if (dmabufErr == hipSuccess && atomicIbufDmabufFd >= 0) {
+      atomicIbufMr = ibv_reg_dmabuf_mr(pd_uxdma, 0, atomicIbufSize,
+                                       reinterpret_cast<uint64_t>(atomicIbufAddr),
+                                       atomicIbufDmabufFd, atomicIbufAccessFlag);
+      close(atomicIbufDmabufFd);
+      if (atomicIbufMr) {
+        MORI_APP_TRACE("IONIC Atomic ibuf registered via dmabuf, addr=0x{:x}",
+                       reinterpret_cast<uintptr_t>(atomicIbufAddr));
+      }
+    }
+  }
+  if (!atomicIbufMr) {
+    atomicIbufMr = ibv_reg_mr(pd_uxdma, atomicIbufAddr, atomicIbufSize, atomicIbufAccessFlag);
+  }
   assert(atomicIbufMr);
 
   MORI_APP_TRACE(
@@ -389,7 +427,10 @@ void IonicQpContainer::ModifyInit2Rtr(const RdmaEndpointHandle& local_handle,
   attr.ah_attr.grh.sgid_index = local_handle.eth.gidIdx;
   attr.ah_attr.port_num = config.portId;
   attr.ah_attr.is_global = 1;
-  attr.ah_attr.grh.hop_limit = 1;
+  // hop_limit=1 only survives a single switch hop -> works for same-leaf/loopback but DROPS packets
+  // that cross a routed leaf-spine fabric (multi-hop) -> cross-physical-node RDMA never lands and the
+  // receiver hangs. Use 255 like the bnxt provider (mlx5 uses 64) so cross-node traffic is routed.
+  attr.ah_attr.grh.hop_limit = 255;
   attr.ah_attr.sl = ReadRdmaServiceLevelEnv().value_or(0);
   std::optional<uint8_t> tc = ReadRdmaTrafficClassEnv();
   if (tc.has_value()) {

--- a/src/ops/dispatch_combine/internode_v1.cpp
+++ b/src/ops/dispatch_combine/internode_v1.cpp
@@ -1017,11 +1017,19 @@ __forceinline__ __device__ void CombineInterNodeTyped(EpDispatchCombineArgs<T>& 
     if ((laneId < nNodes) &&
         (laneId != myNode)) {  // avoid setting myNode, it will be set in intra node branch
       int proxyPe = laneId * config.gpuPerNode + (config.rank % config.gpuPerNode);
+#ifdef MORI_DEVICE_NIC_IONIC
+      // gfx942+ionic: RDMA atomic-add is emulated as an overwriting WRITE (real atomics don't
+      // transmit). numQpPerPe add-1s can't accumulate, so write the absolute expected value once.
+      shmem::ShmemAtomicTypeNonFetchThread<uint64_t>(
+          args.crossDeviceBarrierMemObj, args.config.rank * sizeof(uint64_t),
+          barrierFlag * config.numQpPerPe, core::AMO_ADD, proxyPe, 0);
+#else
       for (int i = 0; i < config.numQpPerPe; i++) {
         shmem::ShmemAtomicTypeNonFetchThread<uint64_t>(args.crossDeviceBarrierMemObj,
                                                        args.config.rank * sizeof(uint64_t), 1,
                                                        core::AMO_ADD, proxyPe, i);
       }
+#endif
     }
     if (laneId == 0) args.interNodeBlocksBarrier[0] = 0;
 
@@ -1152,11 +1160,18 @@ __forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs<T>
     if ((laneId < nNodes) &&
         (laneId != myNode)) {  // avoid setting myNode, it will be set in intra node branch
       int proxyPe = laneId * config.gpuPerNode + (config.rank % config.gpuPerNode);
+#ifdef MORI_DEVICE_NIC_IONIC
+      // gfx942+ionic: RDMA atomic-add is emulated as an overwriting WRITE; write absolute value once.
+      shmem::ShmemAtomicTypeNonFetchThread<uint64_t>(
+          args.crossDeviceBarrierMemObj, args.config.rank * sizeof(uint64_t),
+          barrierFlag * config.numQpPerPe, core::AMO_ADD, proxyPe, 0);
+#else
       for (int i = 0; i < config.numQpPerPe; i++) {
         shmem::ShmemAtomicTypeNonFetchThread<uint64_t>(args.crossDeviceBarrierMemObj,
                                                        args.config.rank * sizeof(uint64_t), 1,
                                                        core::AMO_ADD, proxyPe, i);
       }
+#endif
       __threadfence_system();
     }
     if (laneId == 0) args.interNodeBlocksBarrier[0] = 0;


### PR DESCRIPTION
## Summary

Inter-node **MoRI-EP** (dispatch/combine over RDMA/IBGDA) hung on **MI308X (gfx942) + AINIC (ionic/PSD)**. Intra-node EP and MoRI-IO already worked; only cross-physical-node EP hung, entering the first dispatch and later spinning in `EpCombineInterNodeV1Kernel`. This PR fixes four ionic/PSD-specific issues so 2-node EP16 dispatch+combine pass.

This `gfx942 + ionic` combination is not currently covered by CI (CI runs gfx950+ionic and gfx942+bnxt), which is why these slipped through.

## Root causes & fixes

1. **QP never put in GDA mode** — `ionic_dv_qp_set_gda()` was never called, so the GPU-issued doorbell had no effect and dispatch never transmitted. We now enable GDA (GPU-Direct Async) at QP creation. Optional symbol (older `libionic` lacks it); `MORI_DISABLE_IONIC_GDA` opts out. (`ionic.cpp`, `dv_loader.hpp`)

2. **GRH `hop_limit = 1`** — dropped every packet crossing a routed leaf-spine fabric (OK for same-leaf/loopback, fatal cross-node). Set to `255` (bnxt uses 255, mlx5 uses 64). (`ionic.cpp`)

3. **Atomic ibuf registered with plain `ibv_reg_mr`** — needs `amdgpu_peermem` for GPU memory (absent on this stack). Register via **dmabuf** first (matching the working symmetric-heap dmabuf path), fall back to `ibv_reg_mr` for host memory. (`ionic.cpp`)

4. **GPU-issued RDMA atomic-add does not transmit on ionic** — with `PostAtomic` the NIC tx counter stays 0 (host-posted atomics via `ib_atomic_bw` do work; GPU-posted do not). MoRI-EP uses non-fetch atomics only for **single-writer signal counters**, so we emulate them with a plain remote **write** of the accumulated value (`AMO_ADD`-from-zero == write of value). The cross-device combine barrier accordingly writes the absolute expected value `barrierFlag * numQpPerPe` once instead of `numQpPerPe` add-1s. (`shmem_ibgda_kernels.hpp`, `internode_v1.cpp`)

All PSD-specific changes are gated to the ionic path (`ProviderType::PSD` / `MORI_DEVICE_NIC_IONIC`); mlx5 and bnxt paths are untouched.

## Validation

- Hardware: 2 physical nodes × 8× MI308X (gfx942) + AINIC/ionic, EP16 inter-node.
- `run_internode_test.sh --cmd test --kernel-type v1`: **"Node 0 Dispatch Pass" + "Node 0 Combine Pass" across many rounds, 0 failures** (previously hung on round 1).
- Prereqicites in the environment: ionic driver with working GPU doorbell, and lossless RoCE (PFC) on the fabric.

## Known limitation / discussion

- Currently requires **`MORI_NUM_QP_PER_PE=1`**. With multiple QPs the emulated atomic **writes** can be reordered/lost across queues (combine receiver observes a stale `nodeRecvTokenNum` and spins). Single QP serializes the signals. Making the emulated-atomic signal path safe under multi-QP is left as follow-up — feedback welcome on the preferred approach (e.g. per-generation counters vs. ordering fences), or whether a proper GPU-atomic path is planned for ionic.

## Test plan

- [ ] Maintainer review of the PSD-gated changes
- [ ] CI coverage for gfx942 + ionic if feasible
- [ ] Multi-QP follow-up for the emulated-atomic signal path