### PR TITLE
(bugfix): intranode bw check in mixed-vendor environment

### DIFF
--- a/tools/env_check.sh
+++ b/tools/env_check.sh
@@ -403,9 +403,8 @@ check_bnxt_version_recommendation() {
 }
 
 # dominant_group <out_array_name> <dev...>
-#   sets the named array to the largest same-vendor-prefix subset of the inputs.
-#   Fallback for when the PCI vendor id isn't known (see devs_of_vendor below) —
-#   guesses vendor grouping from device-name prefixes instead.
+#   sets the named array to the largest same-vendor-prefix subset of the inputs
+#   (prefix = name minus trailing digits: ionic_, mlx5_, bnxt_re_bond).
 dominant_group() {
     local -n _out="$1"; shift
     local -A _pref=(); local d p best="" bc=0
@@ -415,18 +414,6 @@ dominant_group() {
         (( ${#g[@]} > bc )) && { bc=${#g[@]}; best="$p"; }
     done
     read -ra _out <<< "${_pref[$best]}"
-}
-
-# devs_of_vendor <out_array_name> <pci_vendor_id> <dev...>
-#   sets the named array to the subset of the given IB device names whose PCI
-#   vendor id (/sys/class/infiniband/<dev>/device/vendor) matches.
-devs_of_vendor() {
-    local -n _out="$1"; local vid="$2"; shift 2
-    _out=()
-    local d
-    for d in "$@"; do
-        [[ "$(cat "/sys/class/infiniband/$d/device/vendor" 2>/dev/null)" == "$vid" ]] && _out+=("$d")
-    done
 }
 
 # ======================== check functions =======================
@@ -602,14 +589,10 @@ check_intra_node_bw() {
     [[ ${#all_devs[@]} -gt 0 ]] || { log_fail "no local RDMA devices found (check ibv_devices)"; return 1; }
     log_ok "local RDMA devices (${#all_devs[@]}): ${all_devs[*]}"
 
-    # Use the same dominant-vendor NICs that got firmware/QoS-checked above
-    # (falls back to name-prefix guessing if no known vendor was detected).
+    # Group by name prefix, like the remote side: the sysfs vendor id is empty for
+    # auxiliary-bus RDMA devices, which dropped 8x ionic in favour of 1x mlx5.
     # Exported via LOCAL_DEVS for inter-node tests.
-    if [[ -n "${_dominant_vid:-}" ]]; then
-        devs_of_vendor LOCAL_DEVS "$_dominant_vid" "${all_devs[@]}"
-    else
-        dominant_group LOCAL_DEVS "${all_devs[@]}"
-    fi
+    dominant_group LOCAL_DEVS "${all_devs[@]}"
     if (( ${#all_devs[@]} != ${#LOCAL_DEVS[@]} )); then
         log_warn "mixed NIC vendors detected; using ${#LOCAL_DEVS[@]} devices for tests: ${LOCAL_DEVS[*]}"
     fi

--- a/tools/env_check.sh
+++ b/tools/env_check.sh
@@ -589,8 +589,7 @@ check_intra_node_bw() {
     [[ ${#all_devs[@]} -gt 0 ]] || { log_fail "no local RDMA devices found (check ibv_devices)"; return 1; }
     log_ok "local RDMA devices (${#all_devs[@]}): ${all_devs[*]}"
 
-    # Group by name prefix, like the remote side: the sysfs vendor id is empty for
-    # auxiliary-bus RDMA devices, which dropped 8x ionic in favour of 1x mlx5.
+    # Group by name prefix, like the remote side below.
     # Exported via LOCAL_DEVS for inter-node tests.
     dominant_group LOCAL_DEVS "${all_devs[@]}"
     if (( ${#all_devs[@]} != ${#LOCAL_DEVS[@]} )); then
@@ -1264,10 +1263,22 @@ LOCAL_DEVS=()
 # bnxt_re management NIC can't steal the checks away from 8x mlx5 GPU NICs.
 _VENDOR_IDS=(ionic:0x1dd8 bnxt:0x14e4 mlx:0x15b3)
 
+# <dev sysfs dir> -> its PCI vendor id. "device" can be an auxiliary device
+# (.../0000:c1:00.0/ionic.rdma.0) with no "vendor" node, so walk up to the PCI one.
+ib_pci_vendor() {
+    local p; p=$(readlink -f "$1/device" 2>/dev/null) || return
+    local i
+    for (( i = 0; i < 6; i++ )); do
+        [[ "$p" == /sys/devices/* ]] || return
+        [[ -r "$p/vendor" ]] && { cat "$p/vendor"; return; }
+        p=$(dirname "$p")
+    done
+}
+
 ib_count_vendor() {   # <pci_vendor_id> -> number of matching IB devices
     local vid="$1" d n=0
     for d in /sys/class/infiniband/*; do
-        [[ "$(cat "$d/device/vendor" 2>/dev/null)" == "$vid" ]] && (( n++ ))
+        [[ "$(ib_pci_vendor "$d")" == "$vid" ]] && (( n++ ))
     done
     echo "$n"
 }


### PR DESCRIPTION
On a 1x mlx5 + 8x ionic host the intra-node bandwidth check tested the lone mlx5. It filtered devices by the sysfs PCI vendor id, which is empty for auxiliary-bus RDMA devices, so all 8 ionic NICs dropped out. Now groups by name prefix, matching the remote side. Removes devs_of_vendor().