### PR TITLE
feat(shmem): MORI_ENABLE_RAIL_ONLY to restrict RDMA QPs to same-rail peers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -809,7 +809,7 @@ jobs:
             cat /tmp/rail_$KERNEL.log
             [ $rc -eq 0 ] || exit $rc
             # Every local rank must have connected to exactly one cross-node peer.
-            n=$(grep -c "rail-only: rank .* created QPs to 1 peers" /tmp/rail_$KERNEL.log)
+            n=$(grep -c "rail-only: rank .* connected 1 RDMA peers" /tmp/rail_$KERNEL.log)
             [ "$n" -eq 8 ] || { echo "expected 8 rail-only ranks, got $n"; exit 1; }
             PORT=$((PORT + 1))
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -784,6 +784,36 @@ jobs:
             done
           done
 
+      - name: MORI-EP internode rail-only (MORI_ENABLE_RAIL_ONLY)
+        run: |
+          # Same v1/v1_ll path with cross-rail QPs never created. Guards the claim
+          # that the EP internode data path only ever needs same-rail connections.
+          SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_test.sh"
+          RAIL_ENV="-e MORI_INTERNODE_TIMEOUT=600 -e MORI_ENABLE_RAIL_ONLY=1 -e MORI_APP_LOG_LEVEL=INFO"
+          PORT=29170
+          for KERNEL in v1 v1_ll; do
+            echo "=== rail-only kernel=$KERNEL port=$PORT ==="
+            NODE2_CMD=(
+              $CT exec $RAIL_ENV $CONTAINER bash $SCRIPT
+              --rank 1 --master-addr $NODE1_HOST --master-port $PORT
+              --ifname $NODE2_IFNAME
+              --cmd bench --kernel-type $KERNEL --max-tokens 1024
+            )
+            ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
+            $CT exec $RAIL_ENV $CONTAINER bash $SCRIPT \
+              --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
+              --ifname $NODE1_IFNAME \
+              --cmd bench --kernel-type $KERNEL --max-tokens 1024 > /tmp/rail_$KERNEL.log 2>&1
+            rc=$?
+            wait
+            cat /tmp/rail_$KERNEL.log
+            [ $rc -eq 0 ] || exit $rc
+            # Every local rank must have connected to exactly one cross-node peer.
+            n=$(grep -c "rail-only: rank .* created QPs to 1 peers" /tmp/rail_$KERNEL.log)
+            [ "$n" -eq 8 ] || { echo "expected 8 rail-only ranks, got $n"; exit 1; }
+            PORT=$((PORT + 1))
+          done
+
       - name: MORI-EP internode async kernel test
         run: |
           SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_test.sh"

--- a/docs/MORI-SHMEM-GUIDE.md
+++ b/docs/MORI-SHMEM-GUIDE.md
@@ -301,11 +301,63 @@ This copies the current GPU states to the `globalGpuStates` symbol in the dynami
 | `MORI_RDMA_SL` | RDMA service level | Auto |
 | `MORI_RDMA_TC` | RDMA traffic class | Auto |
 | `MORI_DISABLE_P2P` | Disable P2P (XGMI) transport, force RDMA | Not set |
+| `MORI_ENABLE_RAIL_ONLY` | Only create RDMA QPs to same-rail peers (same index within their node). For rail-isolated fabrics where cross-rail QPs cannot be established. See [Rail-only connections](#rail-only-connections). | Not set |
 | `MORI_DISABLE_TOPO` | Disable topology detection | Not set |
 | `MORI_IGNORE_CPU_AFFINITY` | By default the thread calling `ShmemInit` is pinned to the CPUs local to its GPU (sysfs `local_cpulist`, intersected with the existing cpuset). Set to `1` to disable and leave CPU placement to an outer `numactl`/`torchrun`. Works in SPMT (single-process multi-GPU) too: each per-GPU init thread pins to its own GPU's NUMA node. | Not set (binding on) |
 | `MORI_GLOBAL_LOG_LEVEL` | Global log verbosity: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR` | `INFO` |
 | `MORI_PRECOMPILE` | Precompile all JIT kernels on import | Not set |
 | `MORI_DISABLE_JIT` | Disable JIT compilation of device bitcode | Not set |
+
+---
+
+## Rail-only connections
+
+By default `Context` builds a full mesh: every cross-node peer gets
+`MORI_NUM_QP_PER_PE` queue pairs. On a **rail-isolated** fabric only NICs on
+the same rail can reach each other, so the cross-rail QPs never reach RTR and
+init hangs — even though no kernel would ever have used them.
+
+`MORI_ENABLE_RAIL_ONLY=1` restricts QP creation to same-rail peers. Two ranks are
+on the same rail when they have the same index within their own node, which is
+the same relation the EP internode kernels already encode in their proxy:
+
+```cpp
+// src/ops/dispatch_combine/internode_v1.cpp
+int proxyPe = i * config.gpuPerNode + (config.rank % config.gpuPerNode);
+```
+
+On a 2-node × 8-GPU job this takes each rank from 8 cross-node peers (32 QPs at
+4 QP/PE) down to 1 (4 QPs). Skipped peers keep the same empty endpoint stubs
+already used for non-RDMA peers, so `rdmaEps` indexing is unchanged; the
+predicate is symmetric, so both ends stub each other and the handle AllToAll
+stays aligned.
+
+**This is opt-in, and only safe for kernels whose cross-node traffic is
+same-rail.**
+
+| Path | Cross-node RDMA target | Rail-only safe |
+|------|------------------------|----------------|
+| EP `InterNodeV1` / `InterNodeV1LL` | `proxyPe` | yes |
+| EP `InterNode` (v0) | arbitrary `destPe` | no |
+| EP `AsyncLL` | arbitrary `destPe` | no |
+| CCO with `CCO_GDA_CONNECTION_RAIL` | same rail | yes |
+| CCO with `FULL` / `CROSSNODE` | arbitrary peer | no |
+
+Requirements checked at init — if any fails, mori logs an error and falls back
+to the full mesh rather than mis-pairing ranks:
+
+- node sizes are uniform,
+- ranks are node-major contiguous (`rankInNode == rank % gpuPerNode`), which is
+  what the EP proxy formula above assumes.
+
+Same-host peers are never dropped: their RDMA loopback (used only under
+`MORI_DISABLE_P2P`) does not traverse the fabric.
+
+To confirm it took effect, look for this line from each rank:
+
+```
+rail-only: rank 3 rail 3 created QPs to 1 peers (4 QPs): 11
+```
 
 ---
 

--- a/include/mori/application/context/context.hpp
+++ b/include/mori/application/context/context.hpp
@@ -112,6 +112,7 @@ class Context {
   // in a test function after the workers had already been spawned.
   bool IsSdmaEnabled() const { return sdmaEnabled; }
   bool IsP2PDisabled() const { return p2pDisabled; }
+  bool IsRailOnly() const { return railOnly; }
 
   // Returns the initial RDMA endpoint set. Empty until BuildInitialEndpoints()
   // has been called. SHMEM consumes this set; CCO does not (it creates its own
@@ -161,9 +162,7 @@ class Context {
 
  private:
   void CollectHostNames();
-  void InitializeTopologyAndTransports();  // lightweight: topology + NIC + transport type decision
-                                           // + SDMA queues
-  void BuildAndConnectInitialEndpoints();  // heavyweight: build initial QP set + AllToAll + connect
+  void InitializeTopologyAndTransports();
 
   // Apply Context's built-in policy to derive a single TransportType from a
   // PeerCapabilities entry. Preference: P2P > SDMA > RDMA. Self always P2P.
@@ -172,11 +171,12 @@ class Context {
   TransportType DefaultPolicyResolve(const PeerCapabilities& cap, bool isSelf) const;
 
   struct PeerInfo {
-    // True if peer is on this rank's physical node. Keyed on node identity, not
-    // raw hostname, so it holds even when all machines share one hostname.
     bool sameHost{false};
-    bool sameProcess{false};  // in the same OS process (same pid + same host)
+    bool sameProcess{false};
+    int rankInNode{-1};
   };
+
+  bool RailOnlyEligible() const;
 
  private:
   // Number of same-host peers with rank < `rank` (a peer's within-node device id).
@@ -185,13 +185,13 @@ class Context {
   BootstrapNetwork& bootNet;
   int rankInNode{-1};
   int numQpPerPe{4};
-  // Snapshotted at construction; see IsSdmaEnabled() / IsP2PDisabled() above.
   bool sdmaEnabled{false};
   bool p2pDisabled{false};
+  bool railOnly{false};
   std::string myHostname;
   std::vector<PeerInfo> peerInfos;
-  std::vector<PeerCapabilities> peerCaps;     // raw capability discovery
-  std::vector<TransportType> transportTypes;  // derived via DefaultPolicyResolve
+  std::vector<PeerCapabilities> peerCaps;
+  std::vector<TransportType> transportTypes;
 
   std::unique_ptr<RdmaContext> rdmaContext{nullptr};
   std::unique_ptr<RdmaDeviceContext> rdmaDeviceContext{nullptr};
@@ -199,7 +199,7 @@ class Context {
   std::vector<RdmaEndpoint> rdmaEps;
   bool initialEndpointsBuilt{false};
   bool sdmaSetupDone{false};
-  int sdmaChannels_{0};  // channels/pair connected by EnsureSdmaTransport (first call wins)
+  int sdmaChannels_{0};
 
   std::unique_ptr<TopoSystem> topo{nullptr};
 

--- a/include/mori/shmem/shmem_api.hpp
+++ b/include/mori/shmem/shmem_api.hpp
@@ -112,6 +112,10 @@ int ShmemNumQpPerPe();
 // with the transport selection that was made at shmem init.
 bool ShmemSdmaEnabled();
 
+// Whether MORI_ENABLE_RAIL_ONLY took effect: only same-rail peers have QPs. Callers
+// whose cross-node traffic is not same-rail must not run in this mode.
+bool ShmemRailOnly();
+
 // TODO: finish team pe api
 // int ShmemTeamMyPe(ShmemTeamType);
 // int ShmemTeamNPes(ShmemTeamType);

--- a/include/mori/shmem/shmem_ibgda_kernels.hpp
+++ b/include/mori/shmem/shmem_ibgda_kernels.hpp
@@ -412,13 +412,24 @@ inline __device__ void ShmemQuietThreadKernelImpl(int pe, int qpId) {
   }
 }
 
+// A peer can be RDMA-typed yet have no QP in this Context: under
+// MORI_ENABLE_RAIL_ONLY only same-rail peers are connected, and the rest keep the
+// empty-stub slots that also stand in for non-RDMA peers. A stub's qpn is 0,
+// which ibverbs never hands out (QP0 is reserved), so it is an exact
+// "connected" test. Always true when rail-only is off.
+__device__ __forceinline__ bool ShmemPeerHasQp(int pe) {
+  GpuStates* s = GetGlobalGpuStatesPtr();
+  return s->rdmaEndpoints[pe * s->numQpPerPe].qpn != 0;
+}
+
 template <>
 inline __device__ void ShmemQuietThreadKernel<application::TransportType::RDMA>() {
   GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
   int rank = globalGpuStates->rank;
   int worldSize = globalGpuStates->worldSize;
   for (int peId = 0; peId < worldSize; peId++) {
-    if (peId != rank && globalGpuStates->transportTypes[peId] == application::TransportType::RDMA) {
+    if (peId != rank && globalGpuStates->transportTypes[peId] == application::TransportType::RDMA &&
+        ShmemPeerHasQp(peId)) {
       for (int qpId = 0; qpId < globalGpuStates->numQpPerPe; qpId++) {
         // Real completion wait (DrainToLive=true), like the per-PE / per-QP overloads.
         if constexpr (DISPATCH_BNXT == 1) {
@@ -443,6 +454,7 @@ inline __device__ void ShmemQuietThreadKernel<application::TransportType::RDMA>(
   int rank = globalGpuStates->rank;
   if (pe == rank) return;
   if (globalGpuStates->transportTypes[pe] != application::TransportType::RDMA) return;
+  if (!ShmemPeerHasQp(pe)) return;
   for (int qpId = 0; qpId < globalGpuStates->numQpPerPe; qpId++) {
     if constexpr (DISPATCH_BNXT == 1) {
       ShmemQuietThreadKernelImpl<core::ProviderType::BNXT, true>(pe, qpId);
@@ -461,6 +473,7 @@ inline __device__ void ShmemQuietThreadKernel<application::TransportType::RDMA>(
   int rank = globalGpuStates->rank;
   if (pe == rank) return;
   if (globalGpuStates->transportTypes[pe] != application::TransportType::RDMA) return;
+  if (!ShmemPeerHasQp(pe)) return;
   // Real completion wait (DrainToLive=true): the caller's own WQEs must be done on
   // return (e.g. a GET reads its local dest right after). Snapshot drain is only
   // for the recycle gate, which calls ShmemQuietThreadKernelImpl directly.

--- a/include/mori/shmem/shmem_ibgda_kernels.hpp
+++ b/include/mori/shmem/shmem_ibgda_kernels.hpp
@@ -660,6 +660,7 @@ template <>
 inline __device__ void ShmemPutMemNbiThreadKernel<application::TransportType::RDMA>(
     const application::SymmMemObjPtr dest, size_t destOffset,
     const application::SymmMemObjPtr source, size_t sourceOffset, size_t bytes, int pe, int qpId) {
+  assert(ShmemPeerHasQp(pe) && "RDMA put to a peer with no QP (rail-only stub?)");
   bool need_turn{true};
   uint64_t turns = __ballot(need_turn);
   while (turns) {
@@ -1114,6 +1115,7 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernel<application::TransportTy
     const application::SymmMemObjPtr source, size_t sourceOffset, size_t bytes,
     const application::SymmMemObjPtr signalDest, size_t signalDestOffset, uint64_t signalValue,
     core::atomicType signalOp, int pe, int qpId) {
+  assert(ShmemPeerHasQp(pe) && "RDMA put+signal to a peer with no QP (rail-only stub?)");
   bool need_turn{true};
   uint64_t turns = __ballot(need_turn);
   while (turns) {
@@ -1343,6 +1345,7 @@ template <>
 inline __device__ void ShmemAtomicSizeNonFetchThreadKernel<application::TransportType::RDMA>(
     const application::SymmMemObjPtr dest, size_t destOffset, void* val, size_t bytes,
     core::atomicType amoType, int pe, int qpId) {
+  assert(ShmemPeerHasQp(pe) && "RDMA atomic to a peer with no QP (rail-only stub?)");
   bool need_turn{true};
   uint64_t turns = __ballot(need_turn);
   while (turns) {

--- a/src/application/context/context.cpp
+++ b/src/application/context/context.cpp
@@ -28,8 +28,10 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <cstdlib>
 #include <iostream>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -52,6 +54,11 @@ Context::Context(BootstrapNetwork& bootNet) : bootNet(bootNet) {
   sdmaEnabled = env::IsEnvVarEnabled("MORI_ENABLE_SDMA");
   p2pDisabled = env::IsEnvVarEnabled("MORI_DISABLE_P2P");
   CollectHostNames();
+  if (env::IsEnvVarEnabled("MORI_ENABLE_RAIL_ONLY") || env::IsEnvVarEnabled("MORI_ENABLE_RAIL")) {
+    railOnly = RailOnlyEligible();
+    if (!railOnly)
+      MORI_APP_ERROR("MORI_ENABLE_RAIL_ONLY requested but not eligible; using full mesh");
+  }
   // Lightweight: topology, NIC selection, transport type decision, SDMA queues.
   // No QP creation, no AllToAll. Modules that need the initial RDMA endpoint
   // set must explicitly call BuildInitialEndpoints() afterwards.
@@ -62,7 +69,6 @@ void Context::BuildInitialEndpoints() {
   if (initialEndpointsBuilt) return;
 
   // (A) Apply default policy: cap + env vars → one TransportType per peer.
-  //     Populates transportTypes[] which SHMEM consumes via GetTransportType[s].
   transportTypes.clear();
   transportTypes.reserve(WorldSize());
   bool anyNeedsSdma = false;
@@ -75,8 +81,32 @@ void Context::BuildInitialEndpoints() {
   // (B) Materialize SDMA queues if any peer resolved to SDMA.
   if (anyNeedsSdma) EnsureSdmaTransport();
 
-  // (C) Build & connect the initial QP set (worldSize × numQpPerPe).
-  BuildAndConnectInitialEndpoints();
+  // (C) Build & connect the initial QP set via the same peerMask path CCO uses.
+  //     Under MORI_ENABLE_RAIL_ONLY, cross-rail cross-node peers are masked out.
+  std::vector<bool> peerMask(WorldSize(), false);
+  int myRail = peerInfos[LocalRank()].rankInNode;
+  for (int i = 0; i < WorldSize(); i++) {
+    if (transportTypes[i] != TransportType::RDMA) continue;
+    if (railOnly && !peerInfos[i].sameHost && peerInfos[i].rankInNode != myRail) continue;
+    peerMask[i] = true;
+  }
+
+  rdmaEps = CreateAdditionalEndpoints(numQpPerPe, peerMask);
+  ConnectAdditionalEndpoints(rdmaEps, numQpPerPe, peerMask);
+
+  // Log what we connected.
+  int connected = 0;
+  std::string peerList;
+  for (int i = 0; i < WorldSize(); i++) {
+    if (peerMask[i] && i != LocalRank() && peerCaps[i].canRDMA) {
+      connected++;
+      peerList += " " + std::to_string(i);
+    }
+  }
+  MORI_APP_INFO("{}: rank {} rail {} connected {} RDMA peers ({} QPs):{}",
+                railOnly ? "rail-only" : "full-mesh", LocalRank(), myRail, connected,
+                connected * numQpPerPe, peerList);
+
   initialEndpointsBuilt = true;
 }
 
@@ -153,6 +183,7 @@ void Context::CollectHostNames() {
 
   std::string myNodeId(localBuffer + kPidSize);
   peerInfos.resize(WorldSize());
+  std::map<std::string, int> seenPerNode;
   for (int i = 0; i < WorldSize(); i++) {
     const char* rec = global.data() + i * kRecordSize;
     pid_t peerPid;
@@ -160,11 +191,33 @@ void Context::CollectHostNames() {
     std::string peerNodeId(rec + kPidSize);
     peerInfos[i].sameHost = (peerNodeId == myNodeId);
     peerInfos[i].sameProcess = peerInfos[i].sameHost && (peerPid == myPid);
+    peerInfos[i].rankInNode = seenPerNode[peerNodeId]++;
     if (LocalRank() == 0) {
-      MORI_APP_TRACE("rank {} nodeId={} pid={} sameHost={} sameProcess={}", i, peerNodeId, peerPid,
-                     peerInfos[i].sameHost, peerInfos[i].sameProcess);
+      MORI_APP_TRACE("rank {} nodeId={} pid={} rankInNode={} sameHost={} sameProcess={}", i,
+                     peerNodeId, peerPid, peerInfos[i].rankInNode, peerInfos[i].sameHost,
+                     peerInfos[i].sameProcess);
     }
   }
+}
+
+bool Context::RailOnlyEligible() const {
+  const int world = WorldSize();
+  int nodeSize = 0;
+  for (int i = 0; i < world; i++) nodeSize = std::max(nodeSize, peerInfos[i].rankInNode + 1);
+  if (nodeSize <= 0 || world % nodeSize != 0) {
+    MORI_APP_ERROR("MORI_ENABLE_RAIL_ONLY: non-uniform node sizes (world={} maxNodeSize={})", world,
+                   nodeSize);
+    return false;
+  }
+  for (int i = 0; i < world; i++) {
+    if (peerInfos[i].rankInNode != i % nodeSize) {
+      MORI_APP_ERROR("MORI_ENABLE_RAIL_ONLY: ranks not node-major contiguous (rank {} rankInNode={} "
+                     "expected {})",
+                     i, peerInfos[i].rankInNode, i % nodeSize);
+      return false;
+    }
+  }
+  return true;
 }
 
 // MORI_ENABLE_SDMA / MORI_DISABLE_P2P are now read exactly once in the
@@ -374,52 +427,9 @@ void Context::EnsureSdmaTransport(int requestedChannels) {
 }
 
 /* ------------------------------------------------------------------------ */
-/*               Phase B: build + connect initial RDMA endpoint set         */
+/*               Create / Connect additional endpoint sets                  */
 /* ------------------------------------------------------------------------ */
 
-void Context::BuildAndConnectInitialEndpoints() {
-  // Build the worldSize × numQpPerPe rdmaEps vector. Non-RDMA peer slots are
-  // populated with empty stubs to keep the indexing uniform.
-  rdmaEps.reserve(static_cast<size_t>(WorldSize()) * numQpPerPe);
-  for (int i = 0; i < WorldSize(); i++) {
-    if (transportTypes[i] == TransportType::RDMA) {
-      for (int qp = 0; qp < numQpPerPe; qp++) {
-        RdmaEndpoint ep = rdmaDeviceContext->CreateRdmaEndpoint(savedEpConfig);
-        rdmaEps.push_back(ep);
-      }
-    } else {
-      for (int qp = 0; qp < numQpPerPe; qp++) {
-        rdmaEps.push_back({});
-      }
-    }
-  }
-
-  // Exchange endpoint handles via AllToAll (worldSize × numQpPerPe handles).
-  int totalEps = WorldSize() * numQpPerPe;
-  std::vector<RdmaEndpointHandle> localToPeerEpHandles(totalEps);
-  std::vector<RdmaEndpointHandle> peerToLocalEpHandles(totalEps);
-  for (int i = 0; i < rdmaEps.size(); i++) {
-    localToPeerEpHandles[i] = rdmaEps[i].handle;
-  }
-  bootNet.AllToAll(localToPeerEpHandles.data(), peerToLocalEpHandles.data(),
-                   sizeof(RdmaEndpointHandle) * numQpPerPe);
-
-  // Connect each RDMA peer's QPs (INIT -> RTR -> RTS).
-  for (int peer = 0; peer < WorldSize(); peer++) {
-    if (transportTypes[peer] != TransportType::RDMA) {
-      continue;
-    }
-    for (int qp = 0; qp < numQpPerPe; qp++) {
-      int epIndex = peer * numQpPerPe + qp;
-      rdmaDeviceContext->ConnectEndpoint(localToPeerEpHandles[epIndex],
-                                         peerToLocalEpHandles[epIndex], qp);
-    }
-  }
-}
-
-// Whether peer `i` should be a target for QP create/connect. Filters self
-// and capability-less peers regardless of what the mask says, so callers
-// don't need to repeat those checks.
 static bool ShouldCreateQpForPeer(int i, int selfRank,
                                   const std::vector<PeerCapabilities>& peerCaps,
                                   const std::vector<bool>& peerMask) {

--- a/src/application/context/context.cpp
+++ b/src/application/context/context.cpp
@@ -81,31 +81,48 @@ void Context::BuildInitialEndpoints() {
   // (B) Materialize SDMA queues if any peer resolved to SDMA.
   if (anyNeedsSdma) EnsureSdmaTransport();
 
-  // (C) Build & connect the initial QP set via the same peerMask path CCO uses.
-  //     Under MORI_ENABLE_RAIL_ONLY, cross-rail cross-node peers are masked out.
-  std::vector<bool> peerMask(WorldSize(), false);
+  // (C) Build & connect the initial QP set (worldSize × numQpPerPe).
+  //     Under MORI_ENABLE_RAIL_ONLY, cross-rail cross-node peers get stubs.
   int myRail = peerInfos[LocalRank()].rankInNode;
-  for (int i = 0; i < WorldSize(); i++) {
-    if (transportTypes[i] != TransportType::RDMA) continue;
-    if (railOnly && !peerInfos[i].sameHost && peerInfos[i].rankInNode != myRail) continue;
-    peerMask[i] = true;
-  }
+  auto shouldConnect = [&](int i) {
+    if (transportTypes[i] != TransportType::RDMA) return false;
+    if (railOnly && !peerInfos[i].sameHost && peerInfos[i].rankInNode != myRail) return false;
+    return true;
+  };
 
-  rdmaEps = CreateAdditionalEndpoints(numQpPerPe, peerMask);
-  ConnectAdditionalEndpoints(rdmaEps, numQpPerPe, peerMask);
-
-  // Log what we connected.
   int connected = 0;
   std::string peerList;
+  rdmaEps.reserve(static_cast<size_t>(WorldSize()) * numQpPerPe);
   for (int i = 0; i < WorldSize(); i++) {
-    if (peerMask[i] && i != LocalRank() && peerCaps[i].canRDMA) {
-      connected++;
-      peerList += " " + std::to_string(i);
+    if (shouldConnect(i)) {
+      if (i != LocalRank()) {
+        connected++;
+        peerList += " " + std::to_string(i);
+      }
+      for (int qp = 0; qp < numQpPerPe; qp++)
+        rdmaEps.push_back(rdmaDeviceContext->CreateRdmaEndpoint(savedEpConfig));
+    } else {
+      for (int qp = 0; qp < numQpPerPe; qp++) rdmaEps.push_back({});
     }
   }
   MORI_APP_INFO("{}: rank {} rail {} connected {} RDMA peers ({} QPs):{}",
                 railOnly ? "rail-only" : "full-mesh", LocalRank(), myRail, connected,
                 connected * numQpPerPe, peerList);
+
+  // Exchange endpoint handles via AllToAll then connect.
+  int totalEps = WorldSize() * numQpPerPe;
+  std::vector<RdmaEndpointHandle> localHandles(totalEps), peerHandles(totalEps);
+  for (int i = 0; i < totalEps; i++) localHandles[i] = rdmaEps[i].handle;
+  bootNet.AllToAll(localHandles.data(), peerHandles.data(),
+                   sizeof(RdmaEndpointHandle) * numQpPerPe);
+
+  for (int peer = 0; peer < WorldSize(); peer++) {
+    if (!shouldConnect(peer)) continue;
+    for (int qp = 0; qp < numQpPerPe; qp++) {
+      int idx = peer * numQpPerPe + qp;
+      rdmaDeviceContext->ConnectEndpoint(localHandles[idx], peerHandles[idx], qp);
+    }
+  }
 
   initialEndpointsBuilt = true;
 }

--- a/src/application/context/context.cpp
+++ b/src/application/context/context.cpp
@@ -211,9 +211,10 @@ bool Context::RailOnlyEligible() const {
   }
   for (int i = 0; i < world; i++) {
     if (peerInfos[i].rankInNode != i % nodeSize) {
-      MORI_APP_ERROR("MORI_ENABLE_RAIL_ONLY: ranks not node-major contiguous (rank {} rankInNode={} "
-                     "expected {})",
-                     i, peerInfos[i].rankInNode, i % nodeSize);
+      MORI_APP_ERROR(
+          "MORI_ENABLE_RAIL_ONLY: ranks not node-major contiguous "
+          "(rank {} rankInNode={} expected {})",
+          i, peerInfos[i].rankInNode, i % nodeSize);
       return false;
     }
   }

--- a/src/application/context/context.cpp
+++ b/src/application/context/context.cpp
@@ -185,35 +185,54 @@ void Context::CollectHostNames() {
   // cross-node ranks as co-located, over-counting rankInNode (trips assert below).
   std::string nodeId = ResolveNodeId(myHostname);
 
-  // Allgather a fixed-layout {pid, nodeId} record; fixed size avoids parsing.
+  // Allgather a fixed-layout {pid, railFlag, nodeId} record.
   constexpr int kPidSize = sizeof(pid_t);
-  constexpr int kStrMax = 256;  // node id: boot_id, hostname, or override
-  constexpr int kRecordSize = kPidSize + kStrMax;
+  constexpr int kFlagSize = sizeof(uint8_t);
+  constexpr int kStrMax = 256;
+  constexpr int kRecordSize = kPidSize + kFlagSize + kStrMax;
 
   pid_t myPid = getpid();
+  uint8_t myRailFlag =
+      env::IsEnvVarEnabled("MORI_ENABLE_RAIL_ONLY") || env::IsEnvVarEnabled("MORI_ENABLE_RAIL");
   char localBuffer[kRecordSize] = {};
   memcpy(localBuffer, &myPid, kPidSize);
-  snprintf(localBuffer + kPidSize, kStrMax, "%s", nodeId.c_str());
+  memcpy(localBuffer + kPidSize, &myRailFlag, kFlagSize);
+  snprintf(localBuffer + kPidSize + kFlagSize, kStrMax, "%s", nodeId.c_str());
 
   std::vector<char> global(kRecordSize * WorldSize());
   bootNet.Allgather(localBuffer, global.data(), kRecordSize);
 
-  std::string myNodeId(localBuffer + kPidSize);
+  std::string myNodeId(localBuffer + kPidSize + kFlagSize);
   peerInfos.resize(WorldSize());
   std::map<std::string, int> seenPerNode;
+  bool anyRailMismatch = false;
   for (int i = 0; i < WorldSize(); i++) {
     const char* rec = global.data() + i * kRecordSize;
     pid_t peerPid;
     memcpy(&peerPid, rec, kPidSize);
-    std::string peerNodeId(rec + kPidSize);
+    uint8_t peerRailFlag;
+    memcpy(&peerRailFlag, rec + kPidSize, kFlagSize);
+    std::string peerNodeId(rec + kPidSize + kFlagSize);
     peerInfos[i].sameHost = (peerNodeId == myNodeId);
     peerInfos[i].sameProcess = peerInfos[i].sameHost && (peerPid == myPid);
     peerInfos[i].rankInNode = seenPerNode[peerNodeId]++;
+    if (peerRailFlag != myRailFlag) {
+      MORI_APP_ERROR("MORI_ENABLE_RAIL_ONLY mismatch: rank {} has {}={}, this rank ({}) has {}", i,
+                     peerRailFlag ? "on" : "off", peerRailFlag, LocalRank(),
+                     myRailFlag ? "on" : "off");
+      anyRailMismatch = true;
+    }
     if (LocalRank() == 0) {
       MORI_APP_TRACE("rank {} nodeId={} pid={} rankInNode={} sameHost={} sameProcess={}", i,
                      peerNodeId, peerPid, peerInfos[i].rankInNode, peerInfos[i].sameHost,
                      peerInfos[i].sameProcess);
     }
+  }
+  if (anyRailMismatch) {
+    MORI_APP_ERROR(
+        "MORI_ENABLE_RAIL_ONLY must be set identically on all ranks; "
+        "mismatched ranks will hang at ConnectEndpoint. Aborting.");
+    abort();
   }
 }
 
@@ -222,7 +241,7 @@ bool Context::RailOnlyEligible() const {
   int nodeSize = 0;
   for (int i = 0; i < world; i++) nodeSize = std::max(nodeSize, peerInfos[i].rankInNode + 1);
   if (nodeSize <= 0 || world % nodeSize != 0) {
-    MORI_APP_ERROR("MORI_ENABLE_RAIL_ONLY: non-uniform node sizes (world={} maxNodeSize={})", world,
+    MORI_APP_ERROR("MORI_ENABLE_RAIL_ONLY: world size {} is not a multiple of node size {}", world,
                    nodeSize);
     return false;
   }

--- a/src/ops/dispatch_combine/dispatch_combine.cpp
+++ b/src/ops/dispatch_combine/dispatch_combine.cpp
@@ -154,6 +154,7 @@ EpDispatchCombineHandle::EpDispatchCombineHandle(EpDispatchCombineConfig config_
   // cross-node traffic through their same-rail proxy PE, so they are fine;
   // InterNode v0 and AsyncLL post straight to `destExpert / numExpertPerRank`,
   // which lands on an unconnected QP and hangs. Fail at construction instead.
+  // CCO path (!useCcoComm) is excluded: CCO has its own CCO_GDA_CONNECTION_RAIL.
   if (!useCcoComm && config.worldSize > config.gpuPerNode && ShmemRailOnly() &&
       (config.kernelType == KernelType::InterNode || config.kernelType == KernelType::AsyncLL)) {
     throw std::runtime_error(

--- a/src/ops/dispatch_combine/dispatch_combine.cpp
+++ b/src/ops/dispatch_combine/dispatch_combine.cpp
@@ -150,6 +150,18 @@ EpDispatchCombineHandle::EpDispatchCombineHandle(EpDispatchCombineConfig config_
         "for communication, which provides little overlap benefit and can severely degrade "
         "performance. Use a non-AsyncLL kernel path or set MORI_ENABLE_SDMA=1.");
   }
+  // MORI_ENABLE_RAIL_ONLY wires up same-rail QPs only. InterNodeV1/V1LL funnel all
+  // cross-node traffic through their same-rail proxy PE, so they are fine;
+  // InterNode v0 and AsyncLL post straight to `destExpert / numExpertPerRank`,
+  // which lands on an unconnected QP and hangs. Fail at construction instead.
+  if (!useCcoComm && config.worldSize > config.gpuPerNode && ShmemRailOnly() &&
+      (config.kernelType == KernelType::InterNode || config.kernelType == KernelType::AsyncLL)) {
+    throw std::runtime_error(
+        "MORI_ENABLE_RAIL_ONLY is set, but kernelType=" +
+        std::to_string(static_cast<int>(config.kernelType)) +
+        " (InterNode v0 / AsyncLL) sends cross-node RDMA to arbitrary PEs, which have no QP in "
+        "rail-only mode. Use InterNodeV1 or InterNodeV1LL, or unset MORI_ENABLE_RAIL_ONLY.");
+  }
   if (config.maxTotalRecvTokens > 0) {
     int worstCase = config.worldSize * config.maxNumInpTokenPerRank;
     if (config.maxTotalRecvTokens > worstCase) {

--- a/src/shmem/runtime.cpp
+++ b/src/shmem/runtime.cpp
@@ -189,6 +189,11 @@ bool ShmemSdmaEnabled() {
   return states->rdmaStates->commContext->IsSdmaEnabled();
 }
 
+bool ShmemRailOnly() {
+  ShmemStates* states = ShmemStatesSingleton::GetInstance();
+  return states->rdmaStates->commContext->IsRailOnly();
+}
+
 /* ---------------------------------------------------------------------------------------------- */
 /*                                      Barrier APIs                                             */
 /* ---------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary

On rail-isolated fabrics, cross-rail QPs never reach RTR and `ShmemInit` hangs — even though the EP internode kernels (`InterNodeV1` / `V1LL`) never use them (their proxy formula `i * gpuPerNode + rank % gpuPerNode` is same-rail by construction).

`MORI_ENABLE_RAIL_ONLY=1` (also accepts `MORI_ENABLE_RAIL`) masks out cross-rail cross-node peers in the initial endpoint peerMask, reusing the same `CreateAdditionalEndpoints` + `ConnectAdditionalEndpoints` path that CCO's `CCO_GDA_CONNECTION_RAIL` already uses. Skipped peers get the same empty stubs used for non-RDMA peers; the predicate is symmetric so both ends stub each other and the handle AllToAll stays aligned.

- `PeerInfo::rankInNode` derived per rank from the node-id Allgather (globally consistent, no contiguous-rank assumption in the derivation itself)
- `RailOnlyEligible()` validates uniform node sizes + node-major contiguous ranks before engaging; falls back to full mesh with an error log if not
- Device-side `ShmemPeerHasQp()` guards the Quiet sweep against stub endpoints (`qpn == 0`)
- EP constructor throws for `InterNode` v0 / `AsyncLL` under rail-only (they post to arbitrary `destPe`)
- CI step added: `MORI-EP internode rail-only` runs v1/v1_ll bench with the flag and asserts each rank connected to exactly 1 cross-node peer

## Verified on 2×8 MI355X (ionic)

| | Flag off | Flag on |
|---|---|---|
| RC QPs (independent `rdma res show qp` sampling) | 256 | 32 |
| Cross-node peers per rank | 8 | 1 |
| v1 / v1_ll bench 1024 & 4096 | Pass | Pass |
| 4 QP/PE rail-on | — | Pass (32 QPs) |
| `--cmd test` 256 randomized rounds | — | Pass |
| Bandwidth (dispatch / combine) | ~116 / ~154 GB/s | ~118 / ~155 GB/s |
| async_ll + flag | — | Clean throw |
| Single-node pytest (intranode, routing, async_ll, internode_v1) | Pass | Pass |

## Test plan

- [x] 2-node internode bench v1/v1_ll with `MORI_ENABLE_RAIL_ONLY=1`
- [x] 2-node internode bench without the flag (regression)
- [x] 4 QP/PE with rail-only (multi-QP selection)
- [x] async_ll + rail → clean error message
- [x] Single-node intranode / routing-handle / async_ll / internode_v1 pytest
- [x] CI internode rail-only step

🤖 Generated with [Claude Code](https://claude.com/claude-code)