### PR TITLE
docs(skills): add known-issues skill for the VMM/XGMI kernel-config trap

### DIFF
--- a/.claude/skills/deploy-mori/SKILL.md
+++ b/.claude/skills/deploy-mori/SKILL.md
@@ -578,6 +578,27 @@ only `4: Warm Reboot` supported — a host reboot is the only recovery path.
 
 ---
 
+## Known environment issues
+
+Some machines are configured in ways that make MORI slow without anything being wrong
+with MORI. The **`known-issues`** skill collects them, with detection commands and fixes.
+
+Worth a look on any newly deployed box, and mandatory reading before debugging a
+performance problem that only shows up on one machine. The most common one:
+
+- **HIP VMM peer traffic silently falls off XGMI** on kernels built without
+  `CONFIG_DMABUF_MOVE_NOTIFY` / `CONFIG_PCI_P2PDMA` (stock Ubuntu 22.04 GA 5.15).
+  Hits `mori-cco` (EPv2) but not `mori-shmem` (EPv1); costs ~9x a2a bandwidth and
+  reports no error. One-line check:
+
+  ```bash
+  grep -E 'CONFIG_(PCI_P2PDMA|DMABUF_MOVE_NOTIFY)=' /boot/config-$(uname -r)
+  ```
+
+  Both must print `=y`. See `.claude/skills/known-issues/SKILL.md`.
+
+---
+
 ## Done — Report Back
 
 - Base image and OS
@@ -586,6 +607,8 @@ only `4: Warm Reboot` supported — a host reboot is the only recovery path.
 - GPU arch and NIC type as reported by MORI
 - Kernels: JIT on first use (`~/.mori/jit/`)
 - `mori check` result — include full output, highlight any `[WARN]` or `[FAIL]`
+- Kernel `CONFIG_PCI_P2PDMA` / `CONFIG_DMABUF_MOVE_NOTIFY` — flag it if either is
+  missing (see Known environment issues above)
 - Attach command (working directory set to the MORI source tree):
 
 ```bash

--- a/.claude/skills/known-issues/SKILL.md
+++ b/.claude/skills/known-issues/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: known-issues
+description: >-
+  Known environment issues that make MORI slow or behave oddly without being MORI bugs —
+  currently: HIP VMM peer traffic silently falling off XGMI onto PCIe/host memory on Linux
+  kernels built without CONFIG_DMABUF_MOVE_NOTIFY / CONFIG_PCI_P2PDMA, which hits mori-cco
+  (EPv2) but not mori-shmem (EPv1). Use when EPv2 / dispatch_combine_v2 / cco is much slower
+  than expected, when EPv2 is far slower than EPv1 on the same box, when a2a bandwidth does
+  not scale with the number of peers, or when the user asks whether a perf problem is a
+  MORI bug or an environment problem.
+---
+
+# MORI Known Issues
+
+Environment-level problems that look like MORI bugs but are not. Check here **before**
+debugging MORI itself when performance is unexpectedly bad on a specific machine.
+
+---
+
+## Issue 1 — VMM peer traffic falls off XGMI onto PCIe / host memory
+
+**Affects:** `mori-cco` (EPv2, `dispatch_combine_v2`) and anything else built on the
+HIP VMM API. **Does not affect** `mori-shmem` (EPv1), which uses IPC handles.
+
+**Root cause:** the Linux kernel was compiled **without**
+`CONFIG_DMABUF_MOVE_NOTIFY=y` (and usually also without `CONFIG_PCI_P2PDMA=y`).
+This is the case for the stock Ubuntu 22.04 GA **5.15** kernel. It is a *kernel build
+configuration* problem, not a kernel version bug and not an amdgpu regression — a 5.15
+rebuilt with those options works fine, and the Ubuntu **6.8 HWE** kernel already has them.
+
+**Impact is silent.** Nothing errors, correctness still passes; the a2a path is just
+~9x slower.
+
+### Symptoms
+
+- EPv2 dispatch/combine bandwidth is a fraction of EPv1's on the same machine.
+- Per-rank bandwidth plateaus at roughly a **single** XGMI link (~55 GB/s on MI355X),
+  or below it — even though the box has 7 peers.
+- Aggregate bandwidth **does not increase with the number of peers**: 1 peer and 7 peers
+  give the same total.
+- `rocm-smi --showtopotype` shows XGMI everywhere and TransferBench reports full
+  aggregate bandwidth — because those use the non-VMM path and are unaffected.
+
+Measured on an 8x MI355X box (`HIDDEN=7168 TOPK=8 EPR=32`, bf16, 4096 tok/rank, 8 ranks):
+
+| | dispatch | combine |
+|---|---|---|
+| EPv1 (shmem / IPC handle) | 345 GB/s | 377 GB/s |
+| EPv2 (cco / VMM) — **affected kernel** | **36 GB/s** | **54 GB/s** |
+| EPv2 (cco / VMM) — after fixing the kernel | **340 GB/s** | **390 GB/s** |
+
+### Detection (30 seconds, no GPU needed)
+
+```bash
+grep -E 'CONFIG_(PCI_P2PDMA|DMABUF_MOVE_NOTIFY)=' /boot/config-$(uname -r)
+```
+
+Both must print `=y`. If either is missing (`# CONFIG_... is not set` or no output),
+the machine is affected.
+
+Also useful:
+
+```bash
+uname -r                                    # 5.15.0-*-generic (Ubuntu GA) is the usual offender
+grep -E 'CONFIG_IOMMU_DEFAULT' /boot/config-$(uname -r)
+```
+
+### Runtime confirmation
+
+`vmm_peer_probe.cpp` in this skill directory gives a direct verdict — it allocates VMM
+memory on one GPU, grants peer access from another, and checks whether the memory stayed
+in VRAM:
+
+```bash
+hipcc -O3 --offload-arch=$(rocminfo | grep -m1 -o 'gfx[0-9a-f]*') \
+      vmm_peer_probe.cpp -o vmm_peer_probe
+./vmm_peer_probe            # defaults: owner=1 peer=0 size=8GB
+```
+
+- `VERDICT: OK` — memory stayed in VRAM, the machine is fine.
+- `VERDICT: AFFECTED` — granting peer access evicted the buffer out of VRAM.
+
+### Mechanism (what actually happens)
+
+1. `hipMemSetAccess()` → ROCr `hsa_amd_vmem_set_access()` imports the allocation into
+   **each peer** as a **dma-buf** (`ImportMemoryHandle(DMABUF_FD)` → `hsaKmtHandleImport`
+   → KFD `import_obj_create()` → `amdgpu_gem_prime_import()` →
+   `dma_buf_dynamic_attach()`).
+2. The dma-buf core then pins the exporter's buffer, calling `amdgpu_dma_buf_pin()`
+   (`amd/amdgpu/amdgpu_dma_buf.c`):
+
+   ```c
+   u32 domains = bo->allowed_domains;              /* VRAM | GTT */
+   if (!IS_ENABLED(CONFIG_DMABUF_MOVE_NOTIFY)) {
+           domains &= ~AMDGPU_GEM_DOMAIN_VRAM;     /* <-- VRAM stripped */
+   } else {
+           list_for_each_entry(attach, &dmabuf->attachments, node)
+                   if (!attach->peer2peer)
+                           domains &= ~AMDGPU_GEM_DOMAIN_VRAM;
+   }
+   return amdgpu_bo_pin(bo, domains);              /* GTT = host system memory */
+   ```
+
+   `IS_ENABLED()` is a **compile-time** constant taken from the kernel's own
+   `autoconf.h`. Without move-notify support the kernel cannot ask an importer to drop
+   its mapping when a buffer must move, so amdgpu conservatively refuses to pin in VRAM.
+
+3. The buffer is therefore **pinned into host system memory**. Note this is stronger than
+   "peer access falls back to PCIe": the data is not in peer VRAM at all. Every subsequent
+   "peer" store is a write to host DRAM across the *writing* GPU's own PCIe link, which is
+   why aggregate bandwidth is capped at ~one PCIe link no matter how many peers there are.
+
+4. `amdgpu_dma_buf_map()` contains a `peer2peer`/VRAM placement check, but it is guarded
+   by `if (!bo->tbo.pin_count)` and the pin already happened — that code never runs.
+
+**Why EPv1 is immune:** `hsa_amd_agents_allow_access()` maps the *same* BO into every
+GPU's page tables in one `hsaKmtMapMemoryToGPUNodes()` call. No dma-buf, no attach, no pin.
+
+**Why there is no application-level workaround:** MORI runs one process per rank, so peer
+memory must cross process boundaries, which requires exportable handles — and ROCr
+unconditionally does the per-peer dma-buf import (it even lazily exports a dma-buf fd for
+locally created handles). cco also cannot fall back to IPC handles because it needs a flat
+symmetric VA at computed addresses, which only
+`hipMemAddressReserve()` + `hipMemMap()` can provide.
+
+### Fix
+
+**Preferred — install a kernel that already has the options** (Ubuntu 22.04):
+
+```bash
+sudo apt install linux-generic-hwe-22.04       # 6.8; amdgpu DKMS rebuilds automatically
+sudo reboot
+```
+
+**If the machine must stay on 5.15 — rebuild it with two options.** All their Kconfig
+dependencies (`ZONE_DEVICE`, `MEMORY_HOTPLUG`, `SPARSEMEM_VMEMMAP`, `GENERIC_ALLOCATOR`,
+`DMA_SHARED_BUFFER`, …) are already satisfied in the stock config:
+
+```bash
+sudo apt build-dep linux-image-unsigned-$(uname -r)
+apt-get source linux-image-unsigned-$(uname -r)
+cd linux-5.15.0-*/
+cp /boot/config-$(uname -r) .config
+scripts/config -e DMABUF_MOVE_NOTIFY -e PCI_P2PDMA
+scripts/config -d DEBUG_INFO -d DEBUG_INFO_BTF     # much faster build, much smaller packages
+make olddefconfig
+grep -E 'CONFIG_(DMABUF_MOVE_NOTIFY|PCI_P2PDMA)=' .config   # verify before building
+make -j$(nproc) bindeb-pkg
+sudo dpkg -i ../linux-image-*.deb ../linux-headers-*.deb
+sudo reboot                                         # amdgpu DKMS rebuilds for the new kernel
+```
+
+Check `mokutil --sb-state` first — with Secure Boot enabled a self-built kernel needs
+signing. The old kernel stays in GRUB, so this is revertible. Note that a self-built
+kernel leaves the distro's kernel maintenance path; prefer the HWE kernel for anything
+long-lived.
+
+`CONFIG_DMABUF_MOVE_NOTIFY` is the one that actually matters. `CONFIG_PCI_P2PDMA` is
+enabled alongside it because upstream `HSA_AMD_P2P` depends on both and it costs nothing.
+
+**Third option — one-line amdgpu DKMS patch, no kernel change.** Force the branch that
+keeps VRAM (its per-attachment `peer2peer` check is already satisfied):
+
+```bash
+S=/usr/src/amdgpu-<version>/amd/amdgpu/amdgpu_dma_buf.c
+sudo cp $S $S.orig
+sudo sed -i 's|if (!IS_ENABLED(CONFIG_DMABUF_MOVE_NOTIFY)) {|if (0) { /* WAR: kernel lacks MOVE_NOTIFY */|' $S
+sudo dkms build  amdgpu/<version> -k $(uname -r) --force
+sudo dkms install amdgpu/<version> -k $(uname -r) --force
+```
+
+Then either reboot, or reload the module (`modprobe -r amdgpu && modprobe amdgpu`) if
+nothing holds the GPUs (`lsmod | grep '^amdgpu'` must show `used_by=0` and
+`rocm-smi --showpids` must show no KFD PIDs). Reloading invalidates every container's GPU
+context, so it disturbs other users exactly as much as a reboot — it only saves time.
+Roll back with `sudo cp $S.orig $S` and rebuild.
+
+### Verification after the fix
+
+```bash
+grep -E 'CONFIG_(PCI_P2PDMA|DMABUF_MOVE_NOTIFY)=' /boot/config-$(uname -r)   # both =y
+./vmm_peer_probe                                                             # VERDICT: OK
+```
+
+Then re-run the EPv2 kernel bench; per-rank bandwidth should be in the same range as EPv1.
+
+---
+
+## About IOMMU — related but **not** the cause
+
+`amd_iommu=on iommu=pt` does **not** fix Issue 1. This was tested directly: with
+passthrough confirmed active (`dmesg` showing
+`iommu: Default domain type: Passthrough`, and
+`/sys/bus/pci/devices/<BDF>/iommu_group/type` reading `identity`), bandwidth and IOMMU
+transaction counters were unchanged. The buffer is pinned into host memory before any
+address-translation question arises.
+
+The tempting but wrong theory: IOMMU passthrough sets `adev->ram_is_direct_mapped`, which
+KFD's `reuse_dmamap()` uses to choose `KFD_MEM_ATT_SHARED` over `KFD_MEM_ATT_DMABUF`.
+That choice really does flip with `iommu=pt` — but both attachment types share the same
+scatter-gather BO, whose pages were already placed in host memory by the pin.
+**Attachment type is not the physical route.**
+
+**Still enable `iommu=pt` anyway.** It is the standard configuration for AMD GPU / HPC
+nodes, amdgpu uses `ram_is_direct_mapped` elsewhere, and it removes IOMMU translation
+overhead. Just do not let it stand in for the kernel config fix. Note that Ubuntu kernels
+default to translated mode (`CONFIG_IOMMU_DEFAULT_DMA_LAZY=y`,
+`CONFIG_IOMMU_DEFAULT_PASSTHROUGH` not set), so passthrough must be requested explicitly
+on the kernel command line.
+
+IOMMU is, however, an excellent **diagnostic instrument** for this issue, because host-DRAM
+DMA is translated by the IOMMU while XGMI peer traffic never touches it:
+
+```bash
+EV=""; for i in 0 1 2 3 4 5 6 7; do EV="$EV -e amd_iommu_$i/mem_trans_total/"; done
+sudo perf stat -a $EV -- sleep 8      # while an a2a / peer-write workload runs
+```
+
+On an affected machine one IOMMU counts billions of transactions during VMM peer traffic
+(64 B each — multiply out and it matches the observed bandwidth exactly). After the fix
+the same measurement drops by ~380x, down to the same noise level as non-VMM peer traffic.
+`amd-smi metric --pcie` is a coarser cross-check: on an affected box exactly one card —
+the one issuing the writes — shows sustained multi-GB/s PCIe traffic while all its peers
+stay idle, which is itself the tell that the peers are not the destination.
+
+---
+
+## Also worth knowing
+
+- **`CONFIG_HSA_AMD_P2P` cannot be relied on.** `amd/dkms/dkms-config.sh` tests for the
+  misspelled `CONFIG_DMABUF_MOVENOTIFY` (missing underscore), so the amdgpu DKMS build
+  derives `CONFIG_HSA_AMD_P2P=0` even on kernels where both real options are `=y`. Present
+  in at least amdgpu DKMS 6.14.14 and 6.16.13. Do not use `CONFIG_HSA_AMD_P2P` as a health
+  signal, and do not expect code under `#ifdef CONFIG_HSA_AMD_P2P` to be compiled in.
+
+- **KFD may report `max_bandwidth=0` for XGMI io-links**
+  (`/sys/class/kfd/kfd/topology/nodes/*/io_links/*/properties`) on some hosts while others
+  report `64000`, with no functional difference. It is unexplained but unrelated to
+  Issue 1 — `kfd_mem_attach()` never consults link bandwidth. Do not chase it.
+
+- **Micro-benchmarking peer bandwidth is noisy.** Use ≥1024 blocks per stream and take the
+  best of several repetitions. An under-parallelised harness produced a 1.5x spread between
+  consecutive identical runs, which is more than enough to invent or hide a regression.

--- a/.claude/skills/known-issues/vmm_peer_probe.cpp
+++ b/.claude/skills/known-issues/vmm_peer_probe.cpp
@@ -1,0 +1,166 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// vmm_peer_probe -- does granting peer access to a HIP VMM allocation evict it from VRAM?
+//
+// Allocates a VMM buffer on one GPU, grants peer access from another, and watches total
+// GPU VRAM usage across the box (via sysfs). On a kernel built without
+// CONFIG_DMABUF_MOVE_NOTIFY, amdgpu_dma_buf_pin() strips VRAM from the allowed domains
+// and pins the buffer into host system memory, so VRAM usage collapses at that point.
+//
+//   hipcc -O3 --offload-arch=gfx950 vmm_peer_probe.cpp -o vmm_peer_probe
+//   ./vmm_peer_probe [owner_dev] [peer_dev] [size_GB]
+//
+// See SKILL.md in this directory for the full write-up.
+#include <dirent.h>
+#include <hip/hip_runtime.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#define CK(x)                                                                        \
+  do {                                                                               \
+    hipError_t e = (x);                                                              \
+    if (e != hipSuccess) {                                                           \
+      printf("FAIL %s:%d %s -> %s\n", __FILE__, __LINE__, #x, hipGetErrorString(e)); \
+      return 2;                                                                      \
+    }                                                                                \
+  } while (0)
+
+// Sum of mem_info_vram_used over every DRM card that exposes it, in bytes.
+// Summing avoids having to map HIP device ordinals onto card indices. Scan the directory
+// rather than probing card0..cardN -- card numbering is not dense (an 8-GPU box can be
+// card0,8,16,...,56).
+static long long total_vram_used() {
+  DIR* d = opendir("/sys/class/drm");
+  if (!d) return -1;
+  long long total = 0;
+  bool any = false;
+  while (struct dirent* e = readdir(d)) {
+    if (strncmp(e->d_name, "card", 4) != 0) continue;
+    const char* n = e->d_name + 4;
+    if (!*n) continue;
+    bool digits = true;
+    for (const char* c = n; *c; c++)
+      if (*c < '0' || *c > '9') digits = false;
+    if (!digits) continue;  // skip card0-DP-1 etc.
+    std::string p = std::string("/sys/class/drm/") + e->d_name + "/device/mem_info_vram_used";
+    FILE* f = fopen(p.c_str(), "r");
+    if (!f) continue;
+    long long v = 0;
+    if (fscanf(f, "%lld", &v) == 1) {
+      total += v;
+      any = true;
+    }
+    fclose(f);
+  }
+  closedir(d);
+  return any ? total : -1;
+}
+
+static double gb(long long bytes) { return (double)bytes / (1024.0 * 1024.0 * 1024.0); }
+
+int main(int argc, char** argv) {
+  int owner = (argc > 1) ? atoi(argv[1]) : 1;
+  int peer = (argc > 2) ? atoi(argv[2]) : 0;
+  size_t GB = (argc > 3) ? atoll(argv[3]) : 8;
+  size_t bytes = GB << 30;
+
+  int ndev = 0;
+  CK(hipGetDeviceCount(&ndev));
+  if (owner >= ndev || peer >= ndev || owner == peer) {
+    printf("need two distinct devices < %d (got owner=%d peer=%d)\n", ndev, owner, peer);
+    return 2;
+  }
+  if (total_vram_used() < 0) {
+    printf(
+        "cannot read /sys/class/drm/card*/device/mem_info_vram_used -- "
+        "run on the host, not inside a container without /sys access\n");
+    return 2;
+  }
+
+  printf("# VMM peer placement probe: %zu GB on GPU%d, peer access from GPU%d\n", GB, owner, peer);
+
+  long long base = total_vram_used();
+
+  hipMemAllocationProp prop = {};
+  prop.type = (hipMemAllocationType)0x40000000;  // Uncached (fine-grained), what cco uses
+  prop.requestedHandleType = hipMemHandleTypePosixFileDescriptor;
+  prop.location.type = hipMemLocationTypeDevice;
+  prop.location.id = owner;
+
+  CK(hipSetDevice(owner));
+  size_t gran = 0;
+  CK(hipMemGetAllocationGranularity(&gran, &prop, hipMemAllocationGranularityRecommended));
+  size_t sz = ((bytes + gran - 1) / gran) * gran;
+
+  hipMemGenericAllocationHandle_t h;
+  CK(hipMemCreate(&h, sz, &prop, 0));
+  void* va = nullptr;
+  CK(hipMemAddressReserve(&va, sz, gran, nullptr, 0));
+  CK(hipMemMap(va, sz, 0, h, 0));
+
+  hipMemAccessDesc own{};
+  own.location.type = hipMemLocationTypeDevice;
+  own.location.id = owner;
+  own.flags = hipMemAccessFlagsProtReadWrite;
+  CK(hipMemSetAccess(va, sz, &own, 1));
+  CK(hipMemset(va, 1, sz));
+  CK(hipDeviceSynchronize());
+
+  long long after_alloc = total_vram_used();
+  printf("  owner-only        : VRAM in use %+7.2f GB vs baseline\n", gb(after_alloc - base));
+
+  hipMemAccessDesc both[2];
+  both[0] = own;
+  both[1].location.type = hipMemLocationTypeDevice;
+  both[1].location.id = peer;
+  both[1].flags = hipMemAccessFlagsProtReadWrite;
+  CK(hipMemSetAccess(va, sz, both, 2));
+  CK(hipDeviceSynchronize());
+
+  long long after_peer = total_vram_used();
+  printf("  peer access granted: VRAM in use %+7.2f GB vs baseline\n", gb(after_peer - base));
+
+  // The allocation should still be resident after the grant. Treat losing more than half
+  // of it as eviction; a healthy machine shows no change at all.
+  long long lost = after_alloc - after_peer;
+  bool affected = lost > (long long)(sz / 2);
+
+  printf("\n");
+  if (affected) {
+    printf("VERDICT: AFFECTED -- %.2f GB left VRAM when peer access was granted.\n", gb(lost));
+    printf(
+        "  The buffer was pinned into host system memory; peer \"writes\" now go to\n"
+        "  host DRAM over PCIe instead of to peer VRAM over XGMI.\n");
+    printf("  Check: grep -E 'CONFIG_(PCI_P2PDMA|DMABUF_MOVE_NOTIFY)=' /boot/config-$(uname -r)\n");
+    printf("  Both must be =y. See SKILL.md (Issue 1) for the fix.\n");
+  } else {
+    printf("VERDICT: OK -- the allocation stayed in VRAM after peer access was granted.\n");
+  }
+
+  CK(hipMemUnmap(va, sz));
+  CK(hipMemRelease(h));
+  CK(hipMemAddressFree(va, sz));
+  return affected ? 1 : 0;
+}


### PR DESCRIPTION
## What

Adds a `known-issues` skill documenting an environment problem that makes **mori-cco (EPv2) ~9x slower with no error message**, and links it from `deploy-mori`.

This is **not** a MORI bug — it is a kernel build-configuration problem, and it has already cost real debugging time on more than one machine.

## The issue

mori-cco registers peer memory through the **HIP VMM API**, which makes ROCr import the allocation into *every peer* as a **dma-buf**. On kernels built without `CONFIG_DMABUF_MOVE_NOTIFY` — notably the stock **Ubuntu 22.04 GA 5.15** kernel — `amdgpu_dma_buf_pin()` strips VRAM from the allowed domains and pins the buffer into **host system memory**:

```c
u32 domains = bo->allowed_domains;              /* VRAM | GTT */
if (!IS_ENABLED(CONFIG_DMABUF_MOVE_NOTIFY))
        domains &= ~AMDGPU_GEM_DOMAIN_VRAM;     /* <-- VRAM stripped */
return amdgpu_bo_pin(bo, domains);              /* GTT = host memory */
```

So peer "writes" go to host DRAM over the *writing* GPU's own PCIe link, not to peer VRAM over XGMI. Aggregate bandwidth is therefore capped at roughly one PCIe link **regardless of how many peers there are**.

**mori-shmem (EPv1) is unaffected** — it maps one BO into every GPU via `hsaKmtMapMemoryToGPUNodes`, with no dma-buf, no attach and no pin.

## Measured (8x MI355X, `HIDDEN=7168 TOPK=8 EPR=32`, bf16, 4096 tok/rank)

| | dispatch | combine |
|---|---|---|
| EPv1 (shmem / IPC handle) | 345 GB/s | 377 GB/s |
| EPv2 (cco / VMM) — affected kernel | **36 GB/s** | **54 GB/s** |
| EPv2 (cco / VMM) — after enabling the option | **340 GB/s** | **390 GB/s** |

Correctness passes in all three cases; the failure is entirely silent.

## Detection

```bash
grep -E 'CONFIG_(PCI_P2PDMA|DMABUF_MOVE_NOTIFY)=' /boot/config-$(uname -r)
```

Both must print `=y`. `vmm_peer_probe.cpp` (included) gives a direct runtime verdict — it allocates VMM memory, grants peer access, and checks whether the buffer stayed in VRAM:

```
# VMM peer placement probe: 8 GB on GPU1, peer access from GPU0
  owner-only         : VRAM in use   +8.48 GB vs baseline
  peer access granted: VRAM in use   +8.48 GB vs baseline

VERDICT: OK -- the allocation stayed in VRAM after peer access was granted.
```

## Also documented

- **Three fixes**: HWE kernel (preferred), rebuilding 5.15 with the two options, or a one-line amdgpu DKMS patch.
- **`iommu=pt` is *not* the fix.** It looks like a plausible suspect (`ram_is_direct_mapped` → `reuse_dmamap()` → `KFD_MEM_ATT_SHARED`), and that path really does change with it — but bandwidth and IOMMU counters are unchanged, because both attachment types share the same scatter-gather BO whose pages were already placed in host memory by the pin. The skill records this so nobody re-runs the experiment. It also explains how to use IOMMU counters as a *diagnostic* for the issue.
- **`CONFIG_HSA_AMD_P2P` cannot be used as a health signal**: `amd/dkms/dkms-config.sh` tests the misspelled `CONFIG_DMABUF_MOVENOTIFY` (missing underscore), so the amdgpu DKMS build derives it as `0` even on kernels where both real options are `=y`. Present in at least DKMS 6.14.14 and 6.16.13.

## Testing

- `vmm_peer_probe.cpp` compiles clean for gfx950 and was run on a healthy 8x MI355X box (kernel 6.8, both options `=y`) — reports `VERDICT: OK`, exit code 0.
- The `AFFECTED` path corresponds to the behaviour measured on the box that motivated this (8 GB allocation dropping out of VRAM the moment peer access was granted, with host RAM falling by the same amount).
- Docs-only otherwise; no build or runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)