### PR TITLE
perf(umbp): cut per-range overhead in local BatchGetRanges

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 [build-system]
 requires = [
-    "setuptools>=61",
+    # setuptools 84 requires build_ext.run() to initialize the compiler, while
+    # CMakeBuild currently invokes build_extension() directly. Without the upper
+    # bound, build isolation pulls the newest setuptools and the wheel build dies
+    # in `AssertionError: run() must precede build_extension()`.
+    "setuptools>=61,<84",
     "setuptools_scm[toml]>=6.2",
     "wheel",
     "ninja",

--- a/src/pybind/pybind_umbp.cpp
+++ b/src/pybind/pybind_umbp.cpp
@@ -255,8 +255,7 @@ void RegisterMoriUmbp(py::module_& m) {
       .def_readwrite("ssd_staging_hugepage_size", &UMBPDistributedConfig::ssd_staging_hugepage_size)
       .def_readwrite("peer_service_port", &UMBPDistributedConfig::peer_service_port)
       .def_readwrite("cache_remote_fetches", &UMBPDistributedConfig::cache_remote_fetches)
-      .def_readwrite("ranged_locality_prefetch",
-                     &UMBPDistributedConfig::ranged_locality_prefetch)
+      .def_readwrite("ranged_locality_prefetch", &UMBPDistributedConfig::ranged_locality_prefetch)
       .def_readwrite("cache_remote_admission", &UMBPDistributedConfig::cache_remote_admission)
       .def_readwrite("admission_max_block_bytes", &UMBPDistributedConfig::admission_max_block_bytes)
       .def_readwrite("dram_page_size", &UMBPDistributedConfig::dram_page_size)
@@ -318,9 +317,18 @@ void RegisterMoriUmbp(py::module_& m) {
       .def("get_deployment_mode", &IUMBPClient::GetDeploymentMode)  // pure getter, no I/O
       .def("get_backend_mode", &IUMBPClient::GetBackendMode)        // pure getter, no I/O
       .def("supports_ranged_io", &IUMBPClient::SupportsRangedIO)    // pure getter, no I/O
-      .def("register_memory", &IUMBPClient::RegisterMemory, py::arg("ptr"), py::arg("size"),
-           py::arg("loc") = mori::io::MemoryLocationType::CPU, py::arg("device") = -1,
-           py::call_guard<py::gil_scoped_release>())
+      // Bound to the pinned form on purpose.  MemoryRegistration selects
+      // whether a region is pinned for RDMA or merely recorded for local
+      // copies, and that is decided by the deployment -- the standalone server
+      // picks it from its inner backend mode.  A caller reaching this binding
+      // is registering its own buffers and always wants them pinned, so the
+      // knob is kept off the Python surface rather than offered and ignored.
+      .def(
+          "register_memory",
+          [](IUMBPClient& self, uintptr_t ptr, size_t size, mori::io::MemoryLocationType loc,
+             int device) { return self.RegisterMemory(ptr, size, loc, device); },
+          py::arg("ptr"), py::arg("size"), py::arg("loc") = mori::io::MemoryLocationType::CPU,
+          py::arg("device") = -1, py::call_guard<py::gil_scoped_release>())
       .def("deregister_memory", &IUMBPClient::DeregisterMemory, py::arg("ptr"),
            py::call_guard<py::gil_scoped_release>())
       .def("report_external_kv_blocks", &IUMBPClient::ReportExternalKvBlocks, py::arg("hashes"),

--- a/src/umbp/distributed/distributed_client.cpp
+++ b/src/umbp/distributed/distributed_client.cpp
@@ -329,11 +329,11 @@ size_t DistributedClient::BatchExistsConsecutive(const std::vector<std::string>&
 // ---------------------------------------------------------------------------
 
 bool DistributedClient::RegisterMemory(uintptr_t ptr, size_t size, mori::io::MemoryLocationType loc,
-                                       int device) {
+                                       int device, MemoryRegistration mode) {
   if (closing_) return false;
   std::shared_lock lk(op_mutex_);
   if (closed_) return false;
-  return pool_client_->RegisterMemory(reinterpret_cast<void*>(ptr), size, loc, device);
+  return pool_client_->RegisterMemory(reinterpret_cast<void*>(ptr), size, loc, device, mode);
 }
 
 void DistributedClient::DeregisterMemory(uintptr_t ptr) {

--- a/src/umbp/distributed/peer/backend/page_backend.cpp
+++ b/src/umbp/distributed/peer/backend/page_backend.cpp
@@ -454,7 +454,7 @@ ResolvedEntry PageBackend::Resolve(const std::string& key) {
   // Extend the read lease so concurrent Evict reports bytes_freed=0 for
   // this key.  steady_clock is monotonic and read_lease_ttl_ is fixed,
   // so this assignment is always >= any previous deadline for the key.
-  read_lease_until_[key] = std::chrono::steady_clock::now() + read_lease_ttl_;
+  it->second.read_lease_until = std::chrono::steady_clock::now() + read_lease_ttl_;
   return r;
 }
 
@@ -463,9 +463,11 @@ std::vector<ResolvedEntry> PageBackend::BatchResolve(const std::vector<std::stri
   std::vector<ResolvedEntry> out(keys.size());
   if (keys.empty()) return out;
   std::lock_guard<std::mutex> lock(mutex_);
+  // One now() for the batch: it runs in well under a millisecond against a
+  // TTL measured in seconds, so the last key loses nothing worth a syscall.
+  const auto lease_deadline = std::chrono::steady_clock::now() + read_lease_ttl_;
   for (size_t i = 0; i < keys.size(); ++i) {
-    const auto& key = keys[i];
-    auto it = owned_.find(key);
+    auto it = owned_.find(keys[i]);
     if (it == owned_.end()) continue;
     auto& entry = out[i];
     entry.found = true;
@@ -473,9 +475,7 @@ std::vector<ResolvedEntry> PageBackend::BatchResolve(const std::vector<std::stri
     entry.size = it->second.size;
     entry.page_size = page_size_;
     if (include_descs) entry.descs = BuildBufferDescsLocked(it->second.pages);
-    // Per-key now(): matches single-key Resolve() so the last key in
-    // a large batch isn't shortchanged by earlier keys' work.
-    read_lease_until_[key] = std::chrono::steady_clock::now() + read_lease_ttl_;
+    it->second.read_lease_until = lease_deadline;
   }
   return out;
 }
@@ -496,7 +496,7 @@ std::vector<EvictResult> PageBackend::Evict(const std::vector<std::string>& keys
       out.push_back(std::move(r));
       continue;
     }
-    if (HasActiveReadLeaseLocked(key)) {
+    if (HasActiveReadLeaseLocked(it->second, std::chrono::steady_clock::now())) {
       // Master will retry next round once the lease expires.  Emit no event.
       out.push_back(std::move(r));
       continue;
@@ -600,12 +600,11 @@ void PageBackend::ClearLocal() {
   // REMOVE events — the upcoming full-sync empty snapshot collapses
   // master's index.
   for (auto& [key, slot] : owned_) {
-    auto lease_it = read_lease_until_.find(key);
-    if (lease_it != read_lease_until_.end() && lease_it->second > now) {
+    if (slot.read_lease_until > now) {
       DeferredFree df;
       df.key = key;
       df.pages = std::move(slot.pages);
-      df.release_at = lease_it->second;
+      df.release_at = slot.read_lease_until;
       deferred_frees_.push_back(std::move(df));
       continue;
     }
@@ -613,8 +612,8 @@ void PageBackend::ClearLocal() {
   }
   owned_.clear();
 
-  // Active read-lease deadlines that mattered are already in deferred_frees_.
-  read_lease_until_.clear();
+  // Deadlines that mattered are already in deferred_frees_; the rest went
+  // with owned_.
   pins_.clear();
 
   // Drop any queued ADD/REMOVE that the heartbeat hasn't shipped yet: the
@@ -750,14 +749,9 @@ std::vector<BufferMemoryDescBytes> PageBackend::BuildBufferDescsLocked(
 //  Read-lease helper
 // ---------------------------------------------------------------------------
 
-bool PageBackend::HasActiveReadLeaseLocked(const std::string& key) {
-  auto it = read_lease_until_.find(key);
-  if (it == read_lease_until_.end()) return false;
-  if (it->second <= std::chrono::steady_clock::now()) {
-    read_lease_until_.erase(it);
-    return false;
-  }
-  return true;
+bool PageBackend::HasActiveReadLeaseLocked(const OwnedSlot& slot,
+                                           std::chrono::steady_clock::time_point now) {
+  return slot.read_lease_until > now;
 }
 
 // ---------------------------------------------------------------------------
@@ -799,16 +793,6 @@ void PageBackend::ReaperSweep() {
       MORI_UMBP_DEBUG("[PageBackend] reaped pending slot {} ({} bytes)", it->first,
                       it->second.size);
       it = pending_.erase(it);
-    } else {
-      ++it;
-    }
-  }
-
-  // Drop expired read leases so they stop blocking eviction and the map
-  // size stays bounded.
-  for (auto it = read_lease_until_.begin(); it != read_lease_until_.end();) {
-    if (it->second <= now) {
-      it = read_lease_until_.erase(it);
     } else {
       ++it;
     }

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -885,7 +885,7 @@ void PoolClient::Shutdown() {
   registry_ = BackendRegistry{};
 
   if (transfer_engine_) {
-    std::lock_guard<std::mutex> lock(registered_mem_mutex_);
+    std::unique_lock<std::shared_mutex> lock(registered_mem_mutex_);
     for (auto& reg : registered_regions_) transfer_engine_->Deregister(reg.ref);
     registered_regions_.clear();
   }
@@ -931,9 +931,12 @@ bool PoolClient::RegisterMemory(void* ptr, size_t size, mori::io::MemoryLocation
     MORI_UMBP_ERROR("[PoolClient] RegisterMemory: invalid args ptr={}, size={}", ptr, size);
     return false;
   }
-  std::lock_guard<std::mutex> lock(registered_mem_mutex_);
-  for (auto& reg : registered_regions_) {
-    if (reg.base != ptr) continue;
+  std::unique_lock<std::shared_mutex> lock(registered_mem_mutex_);
+  const auto at = std::lower_bound(
+      registered_regions_.begin(), registered_regions_.end(), ptr,
+      [](const RegisteredRegion& r, const void* p) { return std::less<const void*>{}(r.base, p); });
+  if (at != registered_regions_.end() && at->base == ptr) {
+    const RegisteredRegion& reg = *at;
     // Re-registering the same base with a larger size is not idempotent: the
     // existing registration covers fewer bytes, so FindRegisteredMemory would
     // start rejecting the tail and silently fall back to unregistered bytes.
@@ -962,7 +965,8 @@ bool PoolClient::RegisterMemory(void* ptr, size_t size, mori::io::MemoryLocation
       transfer_engine_->Deregister(ref);
       return false;
     }
-    registered_regions_.push_back({ptr, size, std::move(ref)});
+    // Inserted in place rather than appended: lookups binary-search this.
+    registered_regions_.insert(at, RegisteredRegion{ptr, size, std::move(ref)});
   } catch (const std::exception& error) {
     MORI_UMBP_ERROR("[PoolClient] RegisterMemory failed for ptr={}, size={}: {}", ptr, size,
                     error.what());
@@ -977,26 +981,38 @@ bool PoolClient::RegisterMemory(void* ptr, size_t size, mori::io::MemoryLocation
 
 void PoolClient::DeregisterMemory(void* ptr) {
   if (ptr == nullptr) return;
-  std::lock_guard<std::mutex> lock(registered_mem_mutex_);
-  auto it = std::find_if(registered_regions_.begin(), registered_regions_.end(),
-                         [ptr](const RegisteredRegion& r) { return r.base == ptr; });
-  if (it != registered_regions_.end()) {
+  std::unique_lock<std::shared_mutex> lock(registered_mem_mutex_);
+  auto it = std::lower_bound(
+      registered_regions_.begin(), registered_regions_.end(), ptr,
+      [](const RegisteredRegion& r, const void* p) { return std::less<const void*>{}(r.base, p); });
+  if (it != registered_regions_.end() && it->base == ptr) {
     if (transfer_engine_) transfer_engine_->Deregister(it->ref);
     registered_regions_.erase(it);
   }
 }
 
+const PoolClient::RegisteredRegion* PoolClient::FindRegisteredRegionLocked(const void* ptr,
+                                                                           size_t size) const {
+  // Regions never overlap, so the only candidate is the last one whose base is
+  // <= ptr.  upper_bound then step back finds it in O(log n).
+  auto at = std::upper_bound(
+      registered_regions_.begin(), registered_regions_.end(), ptr,
+      [](const void* p, const RegisteredRegion& r) { return std::less<const void*>{}(p, r.base); });
+  if (at == registered_regions_.begin()) return nullptr;
+  --at;
+  const auto addr = reinterpret_cast<uintptr_t>(ptr);
+  const auto base = reinterpret_cast<uintptr_t>(at->base);
+  if (size > at->size || (addr - base) > at->size - size) return nullptr;
+  return &*at;
+}
+
 std::optional<std::pair<TransferRef, size_t>> PoolClient::FindRegisteredMemory(const void* ptr,
                                                                                size_t size) const {
-  auto addr = reinterpret_cast<uintptr_t>(ptr);
-  std::lock_guard<std::mutex> lock(registered_mem_mutex_);
-  for (auto& reg : registered_regions_) {
-    auto base = reinterpret_cast<uintptr_t>(reg.base);
-    if (addr >= base && size <= reg.size && (addr - base) <= reg.size - size) {
-      return std::pair{reg.ref, static_cast<size_t>(addr - base)};
-    }
-  }
-  return std::nullopt;
+  std::shared_lock<std::shared_mutex> lock(registered_mem_mutex_);
+  const RegisteredRegion* reg = FindRegisteredRegionLocked(ptr, size);
+  if (reg == nullptr) return std::nullopt;
+  const auto offset = reinterpret_cast<uintptr_t>(ptr) - reinterpret_cast<uintptr_t>(reg->base);
+  return std::pair{reg->ref, static_cast<size_t>(offset)};
 }
 
 std::pair<TransferRef, uint64_t> PoolClient::UserBufferRef(void* ptr, size_t size) const {
@@ -1166,26 +1182,52 @@ bool PoolClient::BuildLocalRangeTransfers(MediumBackend* backend,
                                           double* classify_sink) {
   if (pages.empty() || page_size == 0) return false;
 
-  // Classified once per range, not per page: an unregistered device pointer
-  // must reach HbmCopyEngine, and the whole range lives in one buffer.
+  // Describe each range's caller buffer once, ahead of the page walk, because a
+  // range can produce several page fragments and the description belongs to the
+  // range.  Callers already truncate `items` when this returns false, so bailing
+  // before anything is emitted is equivalent to bailing partway through.
   //
-  // Hoisted out of the walk below so the cost is one measurable phase instead
-  // of being smeared through item assembly.  Same calls in the same order, and
-  // callers already truncate `items` when this returns false, so bailing before
-  // anything is emitted is equivalent to bailing partway through.
+  // Prefer the registration table.  A registered ref already carries loc and
+  // device, so it answers what ClassifiedUserBytes asks hipPointerGetAttributes
+  // for -- and it answers it for the whole region, not per range.  That matters
+  // twice over here:
+  //
+  //   * The HIP call is per RANGE, and a layer-wise reader carries thousands.
+  //   * A registered ref names the REGION base, so every range landing in one
+  //     caller buffer shares a (src, dst) pair and LocalCopyEngine::Plan folds
+  //     them into a single plan.  Describing them by their own addresses made
+  //     each range its own plan, with its own vectors, and defeated the
+  //     coalescing that Plan exists to do.
+  //
+  // In standalone-process mode the server registers every client region it
+  // imports, so this is the path a real deployment takes; ClassifiedUserBytes
+  // stays as the answer for genuinely unregistered memory, where the pointer
+  // really does have to be interrogated.
   std::vector<TransferRef> user_refs;
+  std::vector<uint64_t> user_offsets;
   {
     PhaseTimer classify_timer(classify_sink);
     user_refs.reserve(ranges.size());
+    user_offsets.reserve(ranges.size());
+    // One shared lock for the whole batch, not one per range.
+    std::shared_lock<std::shared_mutex> lock(registered_mem_mutex_);
     for (const auto& range : ranges) {
       if (range.user == nullptr) return false;
-      user_refs.push_back(ClassifiedUserBytes(range.user, range.size));
+      if (const RegisteredRegion* reg = FindRegisteredRegionLocked(range.user, range.size)) {
+        user_refs.push_back(reg->ref);
+        user_offsets.push_back(reinterpret_cast<uintptr_t>(range.user) -
+                               reinterpret_cast<uintptr_t>(reg->base));
+      } else {
+        user_refs.push_back(ClassifiedUserBytes(range.user, range.size));
+        user_offsets.push_back(0);
+      }
     }
   }
 
   for (size_t r = 0; r < ranges.size(); ++r) {
     const auto& range = ranges[r];
     const TransferRef& user_ref = user_refs[r];
+    const uint64_t user_base = user_offsets[r];
 
     // The walk owns every bound: object overflow, page-list overrun, and the
     // short last page a range must not run off the end of.
@@ -1202,16 +1244,21 @@ bool PoolClient::BuildLocalRangeTransfers(MediumBackend* backend,
           TransferItem item;
           item.size = fragment;
           item.tag = tag;
+          // `copied` is relative to the range; the ref may describe the whole
+          // registered region the range sits inside, so bias by where the range
+          // starts in it.  user_base is 0 for an unregistered pointer, whose ref
+          // describes exactly the range.
+          const uint64_t user_offset = user_base + copied;
           if (to_backend) {
             item.src = user_ref;
-            item.src_offset = copied;
+            item.src_offset = user_offset;
             item.dst = std::move(buf);
             item.dst_offset = tier_offset;
           } else {
             item.src = std::move(buf);
             item.src_offset = tier_offset;
             item.dst = user_ref;
-            item.dst_offset = copied;
+            item.dst_offset = user_offset;
           }
           items->push_back(std::move(item));
           return true;

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -296,6 +296,18 @@ class RangedStats {
     EmitComponentsLocked();
   }
 
+  // The cadence emit only fires when a call lands more than one window after
+  // the previous one, so a measured phase shorter than the cadence reports no
+  // line at all -- indistinguishable from the instrumentation being off -- and
+  // the final partial window of a long run is lost the same way.
+  void FlushFinal() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (get_.calls == 0 && put_.calls == 0) return;
+    Emit("GET", get_);
+    Emit("PUT", put_);
+    EmitComponentsLocked();
+  }
+
  private:
   struct Totals {
     uint64_t calls = 0;
@@ -351,7 +363,14 @@ class RangedStats {
 };
 
 RangedStats& RangedStatsInstance() {
-  static RangedStats* stats = new RangedStats();
+  // Deliberately leaked: a destructor here would run at static-destruction
+  // time, after singletons it logs through may be gone. atexit gives back the
+  // final flush the leak would otherwise cost, and runs before those teardowns.
+  static RangedStats* stats = [] {
+    auto* created = new RangedStats();
+    std::atexit([] { RangedStatsInstance().FlushFinal(); });
+    return created;
+  }();
   return *stats;
 }
 

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -1583,6 +1583,13 @@ void PoolClient::FetchWholeObjectsIntoMedium(std::vector<ReCacheJob>& jobs) {
 }
 
 void PoolClient::ReCacheWorkerLoop() {
+  // Nobody is blocked on this thread.  Its whole purpose is to make LATER calls
+  // faster, so it must not borrow cores from the calls happening NOW -- doing
+  // so cost 63% of TTFL on a remote layer-wise restore at 8 ranks.  Set once
+  // here rather than around each copy: everything this loop does is background
+  // by construction.
+  MarkThreadBackgroundCopies();
+
   // Reused across iterations so a steady stream of prefetches does not
   // reallocate this vector on every batch.
   std::vector<ReCacheJob> prefetch_batch;

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -399,6 +399,24 @@ class ScopedRangedReport {
   std::chrono::steady_clock::time_point start_;
 };
 
+// Runs a callable at scope exit.  Same reason the two Scoped* classes below are
+// destructor-based: a ranged call has several early returns that have still
+// moved bytes, and end-of-call work must not depend on each `return` having
+// remembered to do it.
+template <class Fn>
+class ScopeExit {
+ public:
+  explicit ScopeExit(Fn fn) : fn_(std::move(fn)) {}
+  ~ScopeExit() { fn_(); }
+  ScopeExit(const ScopeExit&) = delete;
+  ScopeExit& operator=(const ScopeExit&) = delete;
+
+ private:
+  Fn fn_;
+};
+template <class Fn>
+ScopeExit(Fn) -> ScopeExit<Fn>;
+
 // Ranged calls have several early returns that can still have moved bytes (a
 // batch fully served from the local medium returns before the remote phase is
 // even considered).  Emitting from a destructor keeps every exit covered,
@@ -2300,17 +2318,31 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
   RangedPhases* dbg = ranged_debug ? &phases : nullptr;
   ScopedRangedReport ranged_report("get", phases, ranged_debug, local_bytes, remote_bytes);
 
+  // Accumulated over the batch and reported once at the end rather than per
+  // key.  AddCounter takes a lock and builds a metric key out of the name and
+  // labels, and the help text is a hundred-odd bytes that has to be
+  // materialized on every call -- affordable once, not a thousand times.  The
+  // counter totals are identical either way; only the number of updates
+  // changes.
+  double local_get_bytes = 0.0;
   auto record_local_get = [&](size_t index) {
-    const double bytes =
+    local_get_bytes +=
         static_cast<double>(std::accumulate(sizes[index].begin(), sizes[index].end(), size_t{0}));
-    local_bytes += bytes;
+  };
+  auto flush_local_get_bytes = [&] {
+    if (local_get_bytes == 0.0) return;
+    local_bytes += local_get_bytes;
     master_client_->AddCounter(MORI_UMBP_METRIC_CLIENT_OUTBOUND_GET_BYTES_TOTAL,
                                MORI_UMBP_METRIC_CLIENT_OUTBOUND_GET_BYTES_TOTAL_HELP,
-                               {{"traffic", "local"}}, bytes);
+                               {{"traffic", "local"}}, local_get_bytes);
     master_client_->AddCounter(MORI_UMBP_METRIC_CLIENT_INBOUND_GET_BYTES_TOTAL,
                                MORI_UMBP_METRIC_CLIENT_INBOUND_GET_BYTES_TOTAL_HELP,
-                               {{"traffic", "local"}}, bytes);
+                               {{"traffic", "local"}}, local_get_bytes);
+    local_get_bytes = 0.0;
   };
+  // Declared after ScopedBatchBandwidth and ScopedRangedReport, so it runs
+  // BEFORE either of them reads local_bytes.
+  ScopeExit flush_guard{flush_local_get_bytes};
 
   // ---- Phase 1: everything this node already holds, in one submit ----
   //
@@ -2322,21 +2354,53 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
   std::vector<size_t> local_keys;
   std::vector<size_t> missed;
   missed.reserve(n);
+
+  // One BatchResolve per BACKEND for the whole batch, not one per key.
+  //
+  // Calling it per key made a "batch" API do the opposite: a temporary
+  // vector<string> (copying the key) and a temporary result vector per key, and
+  // one acquisition per key of the backend mutex that Allocate, Commit and
+  // Evict also take -- and in standalone-process mode every rank on the node
+  // shares this client, so that mutex is where they serialize.
+  //
+  // Backends are still tried in registry order and the first hit still wins;
+  // only keys nothing has claimed yet are carried to the next backend, so a
+  // second medium is asked about exactly what the first one missed.
+  std::vector<MediumBackend*> holders(n, nullptr);
+  std::vector<ResolvedEntry> resolutions(n);
+  {
+    PhaseTimer resolve_timer(dbg ? &dbg->resolve : nullptr);
+    std::vector<size_t> pending;
+    pending.reserve(n);
+    for (size_t i = 0; i < n; ++i) {
+      if (!sizes[i].empty()) pending.push_back(i);  // asked for nothing: never resolved
+    }
+    std::vector<std::string> batch;
+    std::vector<size_t> still_missing;
+    for (auto* backend : registry_.All()) {
+      if (pending.empty()) break;
+      batch.clear();
+      batch.reserve(pending.size());
+      for (size_t i : pending) batch.push_back(keys[i]);
+      auto found = backend->BatchResolve(batch, /*include_descs=*/false);
+      still_missing.clear();
+      for (size_t j = 0; j < pending.size(); ++j) {
+        if (j < found.size() && found[j].found) {
+          holders[pending[j]] = backend;
+          resolutions[pending[j]] = std::move(found[j]);
+        } else {
+          still_missing.push_back(pending[j]);
+        }
+      }
+      pending.swap(still_missing);
+    }
+  }
+
   for (size_t i = 0; i < n; ++i) {
     if (sizes[i].empty()) continue;  // asked for nothing; stays false
 
-    MediumBackend* holder = nullptr;
-    ResolvedEntry resolved;
-    {
-      PhaseTimer resolve_timer(dbg ? &dbg->resolve : nullptr);
-      for (auto* backend : registry_.All()) {
-        auto candidate = backend->BatchResolve({keys[i]}, /*include_descs=*/false).front();
-        if (!candidate.found) continue;
-        holder = backend;
-        resolved = std::move(candidate);
-        break;
-      }
-    }
+    MediumBackend* const holder = holders[i];
+    const ResolvedEntry& resolved = resolutions[i];
     if (holder == nullptr) {
       missed.push_back(i);
       continue;

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -1345,6 +1345,61 @@ void PoolClient::ExecuteLocalPutRangesBatch(const std::vector<LocalRangeWriteReq
     return;
   }
 
+  // Work grouped by the backend that will hold it, so the backend's batch APIs
+  // are called once per batch instead of once per key.
+  //
+  // Calling them per key hurts a put far more than it hurt a get, because the
+  // batches are far smaller: an offload call carries single-digit keys (its
+  // ranges must tile whole objects, so a page's worth of layers uses up the
+  // per-call range budget) against a load call's hundreds.  A cost paid per
+  // call is amortized over a few keys, and there are correspondingly more
+  // calls -- measured end to end, this loop's allocation was 68% of all time
+  // spent in BatchPutRanges.
+  struct BackendWork {
+    MediumBackend* backend = nullptr;
+    std::vector<size_t> requests;    // indices into `requests`
+    std::vector<uint64_t> to_abort;  // slots to release
+    std::vector<CommitRequest> commits;
+    std::vector<size_t> commit_owner;  // request index behind each commit
+  };
+  std::vector<BackendWork> work;
+  auto work_for = [&work](MediumBackend* backend) -> BackendWork& {
+    for (auto& entry : work) {
+      if (entry.backend == backend) return entry;
+    }
+    work.push_back(BackendWork{backend, {}, {}, {}, {}});
+    return work.back();
+  };
+
+  for (size_t r = 0; r < requests.size(); ++r) {
+    auto* backend = registry_.Get(requests[r].tier);
+    if (backend == nullptr || backend->BufferCount() == 0) {
+      MORI_UMBP_WARN("[PoolClient] Local ranged Put: tier={} has no in-process-addressable backend",
+                     static_cast<int>(requests[r].tier));
+      continue;
+    }
+    work_for(backend).requests.push_back(r);
+  }
+
+  std::vector<AllocateResult> allocations(requests.size());
+  std::vector<MediumBackend*> backend_of(requests.size(), nullptr);
+  {
+    PhaseTimer alloc_timer(sinks.resolve);
+    std::vector<AllocateRequest> asks;
+    for (auto& entry : work) {
+      asks.clear();
+      asks.reserve(entry.requests.size());
+      for (size_t r : entry.requests) {
+        asks.push_back(AllocateRequest{*requests[r].key, requests[r].object_size});
+      }
+      auto results_for_backend = entry.backend->BatchAllocate(asks);
+      for (size_t j = 0; j < entry.requests.size() && j < results_for_backend.size(); ++j) {
+        allocations[entry.requests[j]] = std::move(results_for_backend[j]);
+        backend_of[entry.requests[j]] = entry.backend;
+      }
+    }
+  }
+
   struct PendingWrite {
     size_t request_index = 0;
     MediumBackend* backend = nullptr;
@@ -1353,21 +1408,17 @@ void PoolClient::ExecuteLocalPutRangesBatch(const std::vector<LocalRangeWriteReq
   std::vector<PendingWrite> pending;
   std::vector<TransferItem> items;
   pending.reserve(requests.size());
+  {
+    size_t range_total = 0;
+    for (const auto& request : requests) range_total += request.ranges.size();
+    items.reserve(range_total);
+  }
 
   for (size_t r = 0; r < requests.size(); ++r) {
+    MediumBackend* const backend = backend_of[r];
+    if (backend == nullptr) continue;
     const auto& request = requests[r];
-    auto* backend = registry_.Get(request.tier);
-    if (backend == nullptr || backend->BufferCount() == 0) {
-      MORI_UMBP_WARN("[PoolClient] Local ranged Put: tier={} has no in-process-addressable backend",
-                     static_cast<int>(request.tier));
-      continue;
-    }
-    AllocateResult alloc_res;
-    {
-      PhaseTimer alloc_timer(sinks.resolve);
-      alloc_res =
-          backend->BatchAllocate({AllocateRequest{*request.key, request.object_size}}).front();
-    }
+    const AllocateResult& alloc_res = allocations[r];
     if (alloc_res.outcome == AllocateOutcome::kSuccessAlreadyExists) {
       (*results)[request.result_index] = true;
       continue;
@@ -1386,7 +1437,7 @@ void PoolClient::ExecuteLocalPutRangesBatch(const std::vector<LocalRangeWriteReq
     }
     if (!built) {
       items.resize(before);
-      backend->BatchAbort({alloc_res.slot_id});
+      work_for(backend).to_abort.push_back(alloc_res.slot_id);
       continue;
     }
     pending.push_back({r, backend, alloc_res.slot_id});
@@ -1395,36 +1446,65 @@ void PoolClient::ExecuteLocalPutRangesBatch(const std::vector<LocalRangeWriteReq
   // stay disjoint.
   if (sinks.build != nullptr && sinks.classify != nullptr) *sinks.build -= *sinks.classify;
   if (sinks.items != nullptr) *sinks.items += items.size();
-  if (pending.empty()) return;
+  auto flush_aborts = [&work] {
+    for (auto& entry : work) {
+      if (entry.to_abort.empty()) continue;
+      entry.backend->BatchAbort(entry.to_abort);
+      entry.to_abort.clear();
+    }
+  };
+
+  if (pending.empty()) {
+    flush_aborts();
+    return;
+  }
 
   std::vector<size_t> failed_tags;
   transfer_engine_->Transfer(items, &failed_tags, sinks.steps);
   const std::unordered_set<size_t> failed(failed_tags.begin(), failed_tags.end());
 
+  // Commit is still strictly after the transfer, and a slot that fails either
+  // step is still aborted -- only the number of calls changes.
   for (const auto& write : pending) {
-    const auto& request = requests[write.request_index];
+    BackendWork& entry = work_for(write.backend);
     if (failed.count(write.request_index) != 0) {
-      write.backend->BatchAbort({write.slot_id});
+      entry.to_abort.push_back(write.slot_id);
       continue;
     }
-    bool committed = false;
-    {
-      PhaseTimer commit_timer(sinks.commit);
-      committed =
-          write.backend->BatchCommit({CommitRequest{write.slot_id, *request.key}}).front().success;
+    entry.commits.push_back(CommitRequest{write.slot_id, *requests[write.request_index].key});
+    entry.commit_owner.push_back(write.request_index);
+  }
+
+  double put_bytes = 0.0;
+  {
+    PhaseTimer commit_timer(sinks.commit);
+    for (auto& entry : work) {
+      if (entry.commits.empty()) continue;
+      auto outcomes = entry.backend->BatchCommit(entry.commits);
+      for (size_t j = 0; j < entry.commit_owner.size(); ++j) {
+        const auto& request = requests[entry.commit_owner[j]];
+        if (j >= outcomes.size() || !outcomes[j].success) {
+          entry.to_abort.push_back(entry.commits[j].slot_id);
+          continue;
+        }
+        (*results)[request.result_index] = true;
+        put_bytes += static_cast<double>(request.object_size);
+      }
     }
-    if (!committed) {
-      write.backend->BatchAbort({write.slot_id});
-      continue;
-    }
-    (*results)[request.result_index] = true;
-    if (committed_bytes != nullptr) *committed_bytes += static_cast<double>(request.object_size);
+  }
+  flush_aborts();
+
+  if (committed_bytes != nullptr) *committed_bytes += put_bytes;
+  if (put_bytes > 0.0) {
+    // One update for the batch rather than two per key; the totals are the
+    // same.  AddCounter locks and materializes its help text every call, which
+    // is not something to do once per object.
     master_client_->AddCounter(MORI_UMBP_METRIC_CLIENT_OUTBOUND_PUT_BYTES_TOTAL,
                                MORI_UMBP_METRIC_CLIENT_OUTBOUND_PUT_BYTES_TOTAL_HELP,
-                               {{"traffic", "local"}}, static_cast<double>(request.object_size));
+                               {{"traffic", "local"}}, put_bytes);
     master_client_->AddCounter(MORI_UMBP_METRIC_CLIENT_INBOUND_PUT_BYTES_TOTAL,
                                MORI_UMBP_METRIC_CLIENT_INBOUND_PUT_BYTES_TOTAL_HELP,
-                               {{"traffic", "local"}}, static_cast<double>(request.object_size));
+                               {{"traffic", "local"}}, put_bytes);
   }
 }
 

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -192,11 +192,27 @@ inline double RangedSeconds(std::chrono::steady_clock::time_point start,
 
 struct RangedPhases {
   double resolve = 0.0;
+  // Split out of `resolve`, which used to cover the whole per-key loop and so
+  // could not say whether the time went to the medium's index or to describing
+  // the caller's buffers.  `classify` is the latter: one pointer lookup per
+  // RANGE, and a ranged call carries thousands of them.
+  double classify = 0.0;
+  double build = 0.0;
+  double validate = 0.0;  // put only: checking the ranges tile their object
+  double commit = 0.0;    // put only: slot commit
   double route = 0.0;
   double xfer = 0.0;
+  // xfer split three ways.  Planning scales with items, the move with bytes, so
+  // a batch of many small ranges needs them apart to say which it is paying.
+  double xfer_plan = 0.0;
+  double xfer_submit = 0.0;
+  double xfer_wait = 0.0;
   double lock = 0.0;
   double remote = 0.0;
   size_t keys = 0;
+  // TransferItems handed to the engine.  Grows with ranges, not keys, and is
+  // what makes the item-per-range cost visible next to the phase times.
+  size_t items = 0;
   size_t local_keys = 0;
   size_t remote_keys = 0;
   double bytes = 0.0;
@@ -243,11 +259,19 @@ class RangedStats {
     t.calls += 1;
     t.total += total;
     t.resolve += p.resolve;
+    t.classify += p.classify;
+    t.build += p.build;
+    t.validate += p.validate;
+    t.commit += p.commit;
     t.route += p.route;
     t.xfer += p.xfer;
+    t.xfer_plan += p.xfer_plan;
+    t.xfer_submit += p.xfer_submit;
+    t.xfer_wait += p.xfer_wait;
     t.lock += p.lock;
     t.remote += p.remote;
     t.bytes += p.bytes;
+    t.items += p.items;
 
     // Per-component totals, keyed by object size (one call = one pool).  The
     // sample key is stored once per (op, size) so the log proves the
@@ -275,7 +299,9 @@ class RangedStats {
  private:
   struct Totals {
     uint64_t calls = 0;
-    double total = 0, resolve = 0, route = 0, xfer = 0, lock = 0, remote = 0, bytes = 0;
+    uint64_t items = 0;
+    double total = 0, resolve = 0, classify = 0, build = 0, validate = 0, commit = 0, route = 0,
+           xfer = 0, xfer_plan = 0, xfer_submit = 0, xfer_wait = 0, lock = 0, remote = 0, bytes = 0;
   };
   struct Component {
     uint64_t calls = 0;
@@ -285,15 +311,20 @@ class RangedStats {
   };
   static void Emit(const char* name, const Totals& t) {
     if (t.calls == 0) return;
-    const double other = t.total - (t.resolve + t.route + t.xfer + t.lock + t.remote);
+    const double other = t.total - (t.resolve + t.classify + t.build + t.validate + t.commit +
+                                    t.route + t.xfer + t.lock + t.remote);
     auto share = [&](double v) { return t.total > 0 ? 100.0 * v / t.total : 0.0; };
     MORI_UMBP_INFO(
         "[RangedCall][dbg] SUMMARY {} calls={} total={:.3f}s mean_call={:.1f}us bytes={:.2f}GiB "
-        "| resolve={:.1f}% route={:.1f}% xfer={:.1f}% lock={:.1f}% remote={:.1f}% other={:.1f}% "
+        "items_per_call={:.0f} | resolve={:.1f}% classify={:.1f}% build={:.1f}% validate={:.1f}% "
+        "commit={:.1f}% route={:.1f}% xfer={:.1f}%(plan={:.1f}% submit={:.1f}% wait={:.1f}%) "
+        "lock={:.1f}% remote={:.1f}% other={:.1f}% "
         "| xfer_only={:.2f}GiB/s end2end={:.2f}GiB/s",
         name, t.calls, t.total, 1e6 * t.total / t.calls, t.bytes / (1024.0 * 1024 * 1024),
-        share(t.resolve), share(t.route), share(t.xfer), share(t.lock), share(t.remote),
-        share(other), t.xfer > 0 ? (t.bytes / t.xfer) / (1024.0 * 1024 * 1024) : 0.0,
+        static_cast<double>(t.items) / t.calls, share(t.resolve), share(t.classify), share(t.build),
+        share(t.validate), share(t.commit), share(t.route), share(t.xfer), share(t.xfer_plan),
+        share(t.xfer_submit), share(t.xfer_wait), share(t.lock), share(t.remote), share(other),
+        t.xfer > 0 ? (t.bytes / t.xfer) / (1024.0 * 1024 * 1024) : 0.0,
         t.total > 0 ? (t.bytes / t.total) / (1024.0 * 1024 * 1024) : 0.0);
   }
   void EmitComponentsLocked() const {
@@ -344,15 +375,19 @@ class ScopedRangedReport {
     RangedStatsInstance().Record(op_, phases_, total);
     if (!RangedDebugSampleThisCall()) return;
     const double other =
-        total - (phases_.resolve + phases_.route + phases_.xfer + phases_.lock + phases_.remote);
+        total - (phases_.resolve + phases_.classify + phases_.build + phases_.validate +
+                 phases_.commit + phases_.route + phases_.xfer + phases_.lock + phases_.remote);
     MORI_UMBP_INFO(
-        "[RangedCall][dbg] op={} obj={} key0='{}' keys={} local={} remote={} bytes={} "
-        "total={:.1f}us resolve={:.1f}us route={:.1f}us xfer={:.1f}us lock={:.1f}us "
-        "remote_phase={:.1f}us other={:.1f}us",
+        "[RangedCall][dbg] op={} obj={} key0='{}' keys={} items={} local={} remote={} bytes={} "
+        "total={:.1f}us resolve={:.1f}us classify={:.1f}us build={:.1f}us validate={:.1f}us "
+        "commit={:.1f}us route={:.1f}us xfer={:.1f}us(plan={:.1f} submit={:.1f} wait={:.1f}) "
+        "lock={:.1f}us remote_phase={:.1f}us other={:.1f}us",
         op_, phases_.object_size, phases_.key0 != nullptr ? *phases_.key0 : std::string("?"),
-        phases_.keys, phases_.local_keys, phases_.remote_keys, phases_.bytes, total * 1e6,
-        phases_.resolve * 1e6, phases_.route * 1e6, phases_.xfer * 1e6, phases_.lock * 1e6,
-        phases_.remote * 1e6, other * 1e6);
+        phases_.keys, phases_.items, phases_.local_keys, phases_.remote_keys, phases_.bytes,
+        total * 1e6, phases_.resolve * 1e6, phases_.classify * 1e6, phases_.build * 1e6,
+        phases_.validate * 1e6, phases_.commit * 1e6, phases_.route * 1e6, phases_.xfer * 1e6,
+        phases_.xfer_plan * 1e6, phases_.xfer_submit * 1e6, phases_.xfer_wait * 1e6,
+        phases_.lock * 1e6, phases_.remote * 1e6, other * 1e6);
   }
 
  private:
@@ -1127,14 +1162,30 @@ bool PoolClient::BuildLocalRangeTransfers(MediumBackend* backend,
                                           const std::vector<PageLocation>& pages,
                                           uint64_t page_size, uint64_t stored_size,
                                           const std::vector<ObjectRange>& ranges, bool to_backend,
-                                          size_t tag, std::vector<TransferItem>* items) {
+                                          size_t tag, std::vector<TransferItem>* items,
+                                          double* classify_sink) {
   if (pages.empty() || page_size == 0) return false;
 
-  for (const auto& range : ranges) {
-    if (range.user == nullptr) return false;
-    // Classified once per range, not per page: an unregistered device pointer
-    // must reach HbmCopyEngine, and the whole range lives in one buffer.
-    const TransferRef user_ref = ClassifiedUserBytes(range.user, range.size);
+  // Classified once per range, not per page: an unregistered device pointer
+  // must reach HbmCopyEngine, and the whole range lives in one buffer.
+  //
+  // Hoisted out of the walk below so the cost is one measurable phase instead
+  // of being smeared through item assembly.  Same calls in the same order, and
+  // callers already truncate `items` when this returns false, so bailing before
+  // anything is emitted is equivalent to bailing partway through.
+  std::vector<TransferRef> user_refs;
+  {
+    PhaseTimer classify_timer(classify_sink);
+    user_refs.reserve(ranges.size());
+    for (const auto& range : ranges) {
+      if (range.user == nullptr) return false;
+      user_refs.push_back(ClassifiedUserBytes(range.user, range.size));
+    }
+  }
+
+  for (size_t r = 0; r < ranges.size(); ++r) {
+    const auto& range = ranges[r];
+    const TransferRef& user_ref = user_refs[r];
 
     // The walk owns every bound: object overflow, page-list overrun, and the
     // short last page a range must not run off the end of.
@@ -1219,7 +1270,10 @@ bool PoolClient::CopyRangesToContiguous(const std::vector<ObjectRange>& ranges, 
 }
 
 void PoolClient::ExecuteLocalPutRangesBatch(const std::vector<LocalRangeWriteRequest>& requests,
-                                            std::vector<bool>* results, double* committed_bytes) {
+                                            std::vector<bool>* results, double* committed_bytes,
+                                            const RangedPhaseSinks* sinks_or_null) {
+  static const RangedPhaseSinks kNoSinks;
+  const RangedPhaseSinks& sinks = sinks_or_null != nullptr ? *sinks_or_null : kNoSinks;
   if (requests.empty()) return;
   if (registry_.Empty()) {
     MORI_UMBP_ERROR("[PoolClient] Local ranged Put requested but no storage backend is registered");
@@ -1243,8 +1297,12 @@ void PoolClient::ExecuteLocalPutRangesBatch(const std::vector<LocalRangeWriteReq
                      static_cast<int>(request.tier));
       continue;
     }
-    auto alloc_res =
-        backend->BatchAllocate({AllocateRequest{*request.key, request.object_size}}).front();
+    AllocateResult alloc_res;
+    {
+      PhaseTimer alloc_timer(sinks.resolve);
+      alloc_res =
+          backend->BatchAllocate({AllocateRequest{*request.key, request.object_size}}).front();
+    }
     if (alloc_res.outcome == AllocateOutcome::kSuccessAlreadyExists) {
       (*results)[request.result_index] = true;
       continue;
@@ -1254,19 +1312,28 @@ void PoolClient::ExecuteLocalPutRangesBatch(const std::vector<LocalRangeWriteReq
     // tag = index into `requests`, so the engine's failed tags map straight
     // back to the slot that has to be aborted.
     const size_t before = items.size();
-    if (!BuildLocalRangeTransfers(backend, alloc_res.pages, alloc_res.page_size,
-                                  request.object_size, request.ranges, /*to_backend=*/true,
-                                  /*tag=*/r, &items)) {
+    bool built = false;
+    {
+      PhaseTimer build_timer(sinks.build);
+      built = BuildLocalRangeTransfers(backend, alloc_res.pages, alloc_res.page_size,
+                                       request.object_size, request.ranges, /*to_backend=*/true,
+                                       /*tag=*/r, &items, sinks.classify);
+    }
+    if (!built) {
       items.resize(before);
       backend->BatchAbort({alloc_res.slot_id});
       continue;
     }
     pending.push_back({r, backend, alloc_res.slot_id});
   }
+  // Classification is timed inside the build window; subtract it so the phases
+  // stay disjoint.
+  if (sinks.build != nullptr && sinks.classify != nullptr) *sinks.build -= *sinks.classify;
+  if (sinks.items != nullptr) *sinks.items += items.size();
   if (pending.empty()) return;
 
   std::vector<size_t> failed_tags;
-  transfer_engine_->Transfer(items, &failed_tags);
+  transfer_engine_->Transfer(items, &failed_tags, sinks.steps);
   const std::unordered_set<size_t> failed(failed_tags.begin(), failed_tags.end());
 
   for (const auto& write : pending) {
@@ -1275,7 +1342,13 @@ void PoolClient::ExecuteLocalPutRangesBatch(const std::vector<LocalRangeWriteReq
       write.backend->BatchAbort({write.slot_id});
       continue;
     }
-    if (!write.backend->BatchCommit({CommitRequest{write.slot_id, *request.key}}).front().success) {
+    bool committed = false;
+    {
+      PhaseTimer commit_timer(sinks.commit);
+      committed =
+          write.backend->BatchCommit({CommitRequest{write.slot_id, *request.key}}).front().success;
+    }
+    if (!committed) {
       write.backend->BatchAbort({write.slot_id});
       continue;
     }
@@ -2195,18 +2268,20 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
   std::vector<size_t> local_keys;
   std::vector<size_t> missed;
   missed.reserve(n);
-  auto resolve_timer = std::make_unique<PhaseTimer>(dbg ? &dbg->resolve : nullptr);
   for (size_t i = 0; i < n; ++i) {
     if (sizes[i].empty()) continue;  // asked for nothing; stays false
 
     MediumBackend* holder = nullptr;
     ResolvedEntry resolved;
-    for (auto* backend : registry_.All()) {
-      auto candidate = backend->BatchResolve({keys[i]}, /*include_descs=*/false).front();
-      if (!candidate.found) continue;
-      holder = backend;
-      resolved = std::move(candidate);
-      break;
+    {
+      PhaseTimer resolve_timer(dbg ? &dbg->resolve : nullptr);
+      for (auto* backend : registry_.All()) {
+        auto candidate = backend->BatchResolve({keys[i]}, /*include_descs=*/false).front();
+        if (!candidate.found) continue;
+        holder = backend;
+        resolved = std::move(candidate);
+        break;
+      }
     }
     if (holder == nullptr) {
       missed.push_back(i);
@@ -2224,9 +2299,15 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
       continue;  // a caller bug, not a miss — do not go looking for a replica
     }
     const size_t before = local_items.size();
-    if (!BuildLocalRangeTransfers(holder, resolved.pages, resolved.page_size, resolved.size,
-                                  MakeReadRanges(dsts[i], sizes[i], src_offsets[i]),
-                                  /*to_backend=*/false, /*tag=*/i, &local_items)) {
+    bool built = false;
+    {
+      PhaseTimer build_timer(dbg ? &dbg->build : nullptr);
+      built = BuildLocalRangeTransfers(holder, resolved.pages, resolved.page_size, resolved.size,
+                                       MakeReadRanges(dsts[i], sizes[i], src_offsets[i]),
+                                       /*to_backend=*/false, /*tag=*/i, &local_items,
+                                       dbg ? &dbg->classify : nullptr);
+    }
+    if (!built) {
       // The medium holds the key but cannot be read in-process.  Same call as
       // ExecuteLocalGet's kRetry: look for it on another node rather than
       // reporting a miss the caller cannot distinguish from absence.
@@ -2236,12 +2317,19 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
     }
     local_keys.push_back(i);
   }
-  resolve_timer.reset();  // ends the resolve phase
+  if (dbg != nullptr) {
+    // Classification is timed inside the build window, so subtract it out to
+    // keep the phases disjoint and `other` meaningful.
+    dbg->build -= dbg->classify;
+    dbg->items += local_items.size();
+  }
   if (!local_items.empty()) {
     std::vector<size_t> failed_tags;
     {
       PhaseTimer xfer_timer(dbg ? &dbg->xfer : nullptr);
-      transfer_engine_->Transfer(local_items, &failed_tags);
+      TransferEngine::StepTiming steps;
+      if (dbg != nullptr) steps = {&dbg->xfer_plan, &dbg->xfer_submit, &dbg->xfer_wait};
+      transfer_engine_->Transfer(local_items, &failed_tags, dbg != nullptr ? &steps : nullptr);
     }
     const std::unordered_set<size_t> failed(failed_tags.begin(), failed_tags.end());
     for (size_t i : local_keys) {
@@ -2532,7 +2620,7 @@ std::vector<bool> PoolClient::BatchPutRanges(const std::vector<std::string>& key
   valid.reserve(n);
   route_keys.reserve(n);
   route_sizes.reserve(n);
-  auto resolve_timer = std::make_unique<PhaseTimer>(dbg ? &dbg->resolve : nullptr);
+  auto validate_timer = std::make_unique<PhaseTimer>(dbg ? &dbg->validate : nullptr);
   for (size_t i = 0; i < n; ++i) {
     if (!RangesTileObject(object_sizes[i], sizes[i], dst_offsets[i])) {
       MORI_UMBP_ERROR("[PoolClient] BatchPutRanges: ranges do not tile key='{}' size={}", keys[i],
@@ -2543,7 +2631,7 @@ std::vector<bool> PoolClient::BatchPutRanges(const std::vector<std::string>& key
     route_keys.push_back(keys[i]);
     route_sizes.push_back(object_sizes[i]);
   }
-  resolve_timer.reset();
+  validate_timer.reset();
   if (valid.empty()) return results;
 
   std::vector<std::optional<RoutePutResult>> routes;
@@ -2592,7 +2680,20 @@ std::vector<bool> PoolClient::BatchPutRanges(const std::vector<std::string>& key
   }
   {
     PhaseTimer xfer_timer(dbg ? &dbg->xfer : nullptr);
-    ExecuteLocalPutRangesBatch(local_writes, &results, &local_bytes);
+    TransferEngine::StepTiming steps;
+    RangedPhaseSinks sinks;
+    if (dbg != nullptr) {
+      steps = {&dbg->xfer_plan, &dbg->xfer_submit, &dbg->xfer_wait};
+      sinks = {&dbg->resolve, &dbg->classify, &dbg->build, &dbg->commit, &dbg->items, &steps};
+    }
+    ExecuteLocalPutRangesBatch(local_writes, &results, &local_bytes,
+                               dbg != nullptr ? &sinks : nullptr);
+  }
+  if (dbg != nullptr) {
+    // The sub-phases above are all timed inside the xfer window, so xfer alone
+    // is left holding the engine's copy.  Subtract rather than re-time: nesting
+    // is what makes each sub-phase attributable to the call it belongs to.
+    dbg->xfer -= dbg->resolve + dbg->classify + dbg->build + dbg->commit;
   }
   if (remote.empty()) return results;
 

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -2271,13 +2271,13 @@ std::vector<bool> PoolClient::BatchGet(const std::vector<std::string>& keys,
 
 namespace {
 
-std::vector<PoolClient::ObjectRange> MakeReadRanges(const std::vector<void*>& dsts,
-                                                    const std::vector<size_t>& sizes,
-                                                    const std::vector<size_t>& offsets) {
-  std::vector<PoolClient::ObjectRange> out;
-  out.reserve(dsts.size());
-  for (size_t r = 0; r < dsts.size(); ++r) out.push_back({dsts[r], sizes[r], offsets[r]});
-  return out;
+// Fills `out` rather than returning a fresh vector: the caller loops over keys
+// and one allocation per key adds up on a call carrying thousands of ranges.
+void FillReadRanges(const std::vector<void*>& dsts, const std::vector<size_t>& sizes,
+                    const std::vector<size_t>& offsets, std::vector<PoolClient::ObjectRange>* out) {
+  out->clear();
+  out->reserve(dsts.size());
+  for (size_t r = 0; r < dsts.size(); ++r) out->push_back({dsts[r], sizes[r], offsets[r]});
 }
 
 std::vector<PoolClient::ObjectRange> MakeWriteRanges(const std::vector<const void*>& srcs,
@@ -2354,6 +2354,16 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
   std::vector<size_t> local_keys;
   std::vector<size_t> missed;
   missed.reserve(n);
+  // A TransferItem carries two TransferRefs, each with a MemoryDesc, so growing
+  // this vector by doubling relocates a lot of bytes.  One range is at least one
+  // item -- more only when it straddles a page -- so the range count is a tight
+  // lower bound and covers the common case exactly.
+  {
+    size_t range_total = 0;
+    for (const auto& per_key : sizes) range_total += per_key.size();
+    local_items.reserve(range_total);
+  }
+  std::vector<ObjectRange> key_ranges;
 
   // One BatchResolve per BACKEND for the whole batch, not one per key.
   //
@@ -2420,10 +2430,12 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
     bool built = false;
     {
       PhaseTimer build_timer(dbg ? &dbg->build : nullptr);
-      built = BuildLocalRangeTransfers(holder, resolved.pages, resolved.page_size, resolved.size,
-                                       MakeReadRanges(dsts[i], sizes[i], src_offsets[i]),
-                                       /*to_backend=*/false, /*tag=*/i, &local_items,
-                                       dbg ? &dbg->classify : nullptr);
+      // Refilled per key rather than returned fresh: one allocation for the
+      // call instead of one per key.
+      FillReadRanges(dsts[i], sizes[i], src_offsets[i], &key_ranges);
+      built = BuildLocalRangeTransfers(
+          holder, resolved.pages, resolved.page_size, resolved.size, key_ranges,
+          /*to_backend=*/false, /*tag=*/i, &local_items, dbg ? &dbg->classify : nullptr);
     }
     if (!built) {
       // The medium holds the key but cannot be read in-process.  Same call as

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -959,8 +959,8 @@ BackendRegistry& PoolClient::Backends() { return registry_; }
 // ---------------------------------------------------------------------------
 
 bool PoolClient::RegisterMemory(void* ptr, size_t size, mori::io::MemoryLocationType loc,
-                                int device) {
-  if (!transfer_engine_) {
+                                int device, MemoryRegistration mode) {
+  if (!transfer_engine_ && mode == MemoryRegistration::kPinned) {
     MORI_UMBP_ERROR("[PoolClient] RegisterMemory: transfer engine not available");
     return false;
   }
@@ -982,6 +982,15 @@ bool PoolClient::RegisterMemory(void* ptr, size_t size, mori::io::MemoryLocation
         "[PoolClient] RegisterMemory: ptr={} already registered with smaller size {}<{}", ptr,
         reg.size, size);
     return false;
+  }
+
+  if (mode == MemoryRegistration::kLocalCopyOnly) {
+    // Nothing to pin and nothing that can throw: the ref carries exactly what
+    // local engine selection reads off it, and every engine's Deregister
+    // no-ops on a ref without a descriptor.
+    TransferRef ref = TransferRef::HostBytes(ptr, size, loc, device);
+    registered_regions_.insert(at, RegisteredRegion{ptr, size, std::move(ref)});
+    return true;
   }
 
   // The engine may throw (mori-io pinning can fail on a region the NIC cannot

--- a/src/umbp/distributed/transfer/local_copy_engine.cpp
+++ b/src/umbp/distributed/transfer/local_copy_engine.cpp
@@ -178,6 +178,11 @@ class CopyPool {
     size_t count = 0;
     std::atomic<size_t> next{0};
     std::atomic<size_t> done{0};
+    // Completion is waited on, not spun on.  A spin is only free when the box
+    // has a spare core, and the process this runs in does not: it is also
+    // running the model's forward pass, the HIP runtime and every other rank.
+    std::mutex mutex;
+    std::condition_variable cv;
   };
 
   static CopyPool& Instance() {
@@ -187,38 +192,82 @@ class CopyPool {
     return *pool;
   }
 
-  // Publishes `batch` to the helpers, works on it from the calling thread, and
-  // returns once every item has been run.  Helpers are best-effort: if they are
-  // all busy the caller simply does the whole batch itself.
+  // Publishes `batch`, works on it from the calling thread, and returns once
+  // every item has run.  Helpers are best-effort: if they are all busy the
+  // caller simply does the whole batch itself.
   void Run(const std::shared_ptr<Batch>& batch, int helpers) {
     {
       std::lock_guard<std::mutex> lock(mutex_);
-      StartThreadsLocked(helpers);
+      GrowLocked(helpers);
       queue_.push_back(batch);
     }
-    cv_.notify_all();
+    // One wake per helper this batch wants.  notify_all would wake every idle
+    // thread in the process to serve one batch.
+    for (int i = 0; i < helpers; ++i) cv_.notify_one();
+
     Drain(*batch);
-    // Drain() returning only means this thread found nothing left to claim; a
-    // helper may still be inside the last item.  The batch is shared_ptr-owned
-    // precisely so that is safe to wait for.
-    while (batch->done.load(std::memory_order_acquire) < batch->count) {
-      std::this_thread::yield();
+
+    // Draining only means THIS thread found nothing left to claim; a helper may
+    // still be inside the last item.  The batch is shared_ptr-owned so waiting
+    // for it is safe.
+    {
+      std::unique_lock<std::mutex> lock(batch->mutex);
+      batch->cv.wait(
+          lock, [&batch] { return batch->done.load(std::memory_order_acquire) >= batch->count; });
+    }
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      auto it = std::find(queue_.begin(), queue_.end(), batch);
+      if (it != queue_.end()) queue_.erase(it);
     }
   }
 
  private:
+  // Upper bound on helper threads for the whole process.  They are shared by
+  // every caller, so this is not per call.
+  static int PoolCap() {
+    static const int cap = [] {
+      const unsigned hc = std::thread::hardware_concurrency();
+      const int n = hc == 0 ? 4 : static_cast<int>(hc);
+      return std::max(1, std::min(n, 32));
+    }();
+    return cap;
+  }
+
   static void Drain(Batch& batch) {
     for (size_t i = batch.next.fetch_add(1, std::memory_order_relaxed); i < batch.count;
          i = batch.next.fetch_add(1, std::memory_order_relaxed)) {
       (*batch.fn)(i);
-      batch.done.fetch_add(1, std::memory_order_release);
+      if (batch.done.fetch_add(1, std::memory_order_acq_rel) + 1 == batch.count) {
+        // Notify under the batch mutex the waiter checks its predicate under,
+        // so a waiter that has not yet slept cannot miss this.
+        std::lock_guard<std::mutex> lock(batch.mutex);
+        batch.cv.notify_all();
+      }
     }
   }
 
-  void StartThreadsLocked(int wanted) {
-    while (static_cast<int>(threads_.size()) < wanted) {
+  // Adds threads only for the helpers this batch cannot get from the idle ones.
+  //
+  // The previous version sized the pool to `helpers` outright, which with the
+  // default of one helper per call meant ONE thread for the whole process: the
+  // second concurrent caller onwards got no help at all and still paid the
+  // queue, the wake and the wait.
+  void GrowLocked(int helpers) {
+    const int deficit = helpers - idle_;
+    for (int i = 0; i < deficit && static_cast<int>(threads_.size()) < PoolCap(); ++i) {
       threads_.emplace_back([this] { WorkerLoop(); });
     }
+  }
+
+  // The oldest batch that still has items to claim.  Exhausted batches are left
+  // for their publisher to remove, so they must be skipped rather than blocking
+  // the queue.
+  std::shared_ptr<Batch> PickLocked() {
+    for (auto& batch : queue_) {
+      if (batch->next.load(std::memory_order_relaxed) < batch->count) return batch;
+    }
+    return nullptr;
   }
 
   void WorkerLoop() {
@@ -229,13 +278,12 @@ class CopyPool {
       std::shared_ptr<Batch> batch;
       {
         std::unique_lock<std::mutex> lock(mutex_);
-        cv_.wait(lock, [this] { return !queue_.empty(); });
-        batch = queue_.front();
-        // Popped on claim rather than on completion: the caller is draining it
-        // too, and a batch that is already exhausted must not keep waking
-        // helpers.
-        queue_.pop_front();
+        ++idle_;
+        cv_.wait(lock, [this, &batch] { return (batch = PickLocked()) != nullptr; });
+        --idle_;
       }
+      // Left queued while draining: several helpers working the same batch is
+      // the point, and they share its cursor.
       Drain(*batch);
     }
   }
@@ -244,6 +292,7 @@ class CopyPool {
   std::condition_variable cv_;
   std::deque<std::shared_ptr<Batch>> queue_;
   std::vector<std::thread> threads_;
+  int idle_ = 0;
 };
 
 // How many threads to spread one Submit's copies over, counting the caller.
@@ -258,29 +307,29 @@ class CopyPool {
 // executors above it supplied the parallelism.  Ranged I/O broke that
 // assumption: a layer-wise reader hands one thread thousands of small copies.
 //
-// The default is 2 rather than local mode's 4.  On DeepSeek-V4-Pro's real pool
-// geometry 2 is the best value measured everywhere, not a compromise between
-// workloads (medians of 3, restore ms / TTFL us):
+// 4, matching local mode's UMBP_DRAM_READ_THREADS.  On DeepSeek-V4-Pro's real
+// pool geometry it is best or tied-best on every shape measured (medians of 3,
+// restore ms / TTFL us):
 //
-//                     threads=1        threads=2        threads=4
-//   local  1 rank   10.78 / 1340     10.28 / 1093     10.30 / 1118
-//   local  8 ranks  13.03 / 1810     11.24 / 1492     11.56 / 1669
-//   remote 1 rank   15.29 / 2404     13.61 / 2486     13.64 / 2342
-//   remote 8 ranks  81.92 / 10812    83.78 / 10787    84.16 / 11790
+//                     threads=1        threads=2        threads=4        threads=8
+//   local  1 rank    9.88 / 690       9.71 / 518       9.61 / 425       9.57 / 381
+//   local  8 ranks  10.06 / 853      10.03 / 723       9.83 / 611       9.94 / 682
+//   remote 1 rank   13.23 / 2294     12.06 / 2229     11.50 / 2304     11.51 / 2284
+//   remote 8 ranks  84.44 / 12399    90.55 / 12860    82.58 / 11384    79.78 / 11600
 //
-// Going past 2 costs twice: it starves a concurrent remote half (the NIC's DMA
-// into the scratch arena loses to the copies, and the first layer group -- the
-// one nothing overlaps -- waits), and on the real geometry it does not even pay
-// for the local case, because fragments this small do not keep four threads
-// usefully busy.  An earlier uniform-73,728 B shape did show 4 winning locally;
-// that was the synthetic shape, not the model's.
+// An earlier revision defaulted to 2, because 4 appeared to cost a concurrent
+// remote half its first layer group.  That was not bandwidth: it was this
+// file's own pool handing out one helper for the whole process and making
+// everyone else spin waiting for it.  With that fixed the effect is gone, and
+// the value that looked reckless is simply the right one.  8 buys a little more
+// at one rank and gives it back at eight, so 4 is where this stops.
 //
 // Below the byte floor the threads cost more than they save, so a small batch
 // stays on the calling thread and pays nothing.
 int CopyThreads(size_t total_bytes, size_t copy_count) {
   if (ThreadBackgroundFlag()) return 1;
   static const int kMax = [] {
-    int n = 2;
+    int n = 4;
     if (const char* raw = std::getenv("UMBP_DRAM_COPY_THREADS")) {
       const int v = std::atoi(raw);
       if (v >= 1) n = v;

--- a/src/umbp/distributed/transfer/local_copy_engine.cpp
+++ b/src/umbp/distributed/transfer/local_copy_engine.cpp
@@ -21,13 +21,21 @@
 // SOFTWARE.
 #include "umbp/distributed/transfer/local_copy_engine.h"
 
+#include <algorithm>
+#include <atomic>
+#include <condition_variable>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <deque>
 #include <functional>
 #include <limits>
+#include <memory>
+#include <mutex>
+#include <thread>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #if defined(__x86_64__) || defined(__i386__)
 #include <immintrin.h>
@@ -114,9 +122,8 @@ class SettledHandle final : public TransferHandle {
   bool reported_ = false;
 };
 
-}  // namespace
-
-namespace {
+// Tuning knobs for the copy itself.  Kept internal: they describe how this
+// engine schedules work, not anything a caller can act on.
 
 // Smallest block the non-temporal path is used for.
 //
@@ -148,7 +155,158 @@ size_t NtMinBytes() {
   return n;
 }
 
+// Backing store for MarkThreadBackgroundCopies(); see the header for why a
+// thread would declare itself background.
+bool& ThreadBackgroundFlag() {
+  static thread_local bool background = false;
+  return background;
+}
+
+// A persistent set of helper threads that Submit can lend its copies to.
+//
+// Persistent, not spawned per call, because spawning was measured to cost more
+// than the parallelism gained on any workload with a remote half.  Creating and
+// joining threads maps and unmaps their stacks, which serializes on the
+// process's address space -- so the damage is not proportional to how many
+// helpers are used, and indeed capping the whole process to FOUR concurrent
+// spawned helpers still cost 25% of TTFL on a remote layer-wise restore.  The
+// pool makes fan-out cost a condition-variable wake instead.
+class CopyPool {
+ public:
+  struct Batch {
+    const std::function<void(size_t)>* fn = nullptr;
+    size_t count = 0;
+    std::atomic<size_t> next{0};
+    std::atomic<size_t> done{0};
+  };
+
+  static CopyPool& Instance() {
+    // Never destroyed: the helpers outlive any translation unit's static
+    // destructor order, and tearing them down during exit buys nothing.
+    static CopyPool* pool = new CopyPool();
+    return *pool;
+  }
+
+  // Publishes `batch` to the helpers, works on it from the calling thread, and
+  // returns once every item has been run.  Helpers are best-effort: if they are
+  // all busy the caller simply does the whole batch itself.
+  void Run(const std::shared_ptr<Batch>& batch, int helpers) {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      StartThreadsLocked(helpers);
+      queue_.push_back(batch);
+    }
+    cv_.notify_all();
+    Drain(*batch);
+    // Drain() returning only means this thread found nothing left to claim; a
+    // helper may still be inside the last item.  The batch is shared_ptr-owned
+    // precisely so that is safe to wait for.
+    while (batch->done.load(std::memory_order_acquire) < batch->count) {
+      std::this_thread::yield();
+    }
+  }
+
+ private:
+  static void Drain(Batch& batch) {
+    for (size_t i = batch.next.fetch_add(1, std::memory_order_relaxed); i < batch.count;
+         i = batch.next.fetch_add(1, std::memory_order_relaxed)) {
+      (*batch.fn)(i);
+      batch.done.fetch_add(1, std::memory_order_release);
+    }
+  }
+
+  void StartThreadsLocked(int wanted) {
+    while (static_cast<int>(threads_.size()) < wanted) {
+      threads_.emplace_back([this] { WorkerLoop(); });
+    }
+  }
+
+  void WorkerLoop() {
+    // A helper exists to serve other threads' copies, so its own copies -- of
+    // which it has none -- must never recurse into fanning out.
+    MarkThreadBackgroundCopies();
+    for (;;) {
+      std::shared_ptr<Batch> batch;
+      {
+        std::unique_lock<std::mutex> lock(mutex_);
+        cv_.wait(lock, [this] { return !queue_.empty(); });
+        batch = queue_.front();
+        // Popped on claim rather than on completion: the caller is draining it
+        // too, and a batch that is already exhausted must not keep waking
+        // helpers.
+        queue_.pop_front();
+      }
+      Drain(*batch);
+    }
+  }
+
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  std::deque<std::shared_ptr<Batch>> queue_;
+  std::vector<std::thread> threads_;
+};
+
+// How many threads to spread one Submit's copies over, counting the caller.
+//
+// A single memcpy stream tops out well below what the memory system can do --
+// measured at ~6 GB/s here, and the same ~6 GB/s whether 1 rank or 8 are
+// copying concurrently, so the ceiling is the stream and not the DRAM.  Local
+// mode already knew this: DRAMTier fans its batch reads out over
+// UMBP_DRAM_READ_THREADS (default 4), and its comment says ">1 breaks the
+// single-core memcpy ceiling".  The distributed path never did, because
+// LocalCopyEngine was written when one key was one whole page and the batch
+// executors above it supplied the parallelism.  Ranged I/O broke that
+// assumption: a layer-wise reader hands one thread thousands of small copies.
+//
+// The default is 2 rather than local mode's 4.  On DeepSeek-V4-Pro's real pool
+// geometry 2 is the best value measured everywhere, not a compromise between
+// workloads (medians of 3, restore ms / TTFL us):
+//
+//                     threads=1        threads=2        threads=4
+//   local  1 rank   10.78 / 1340     10.28 / 1093     10.30 / 1118
+//   local  8 ranks  13.03 / 1810     11.24 / 1492     11.56 / 1669
+//   remote 1 rank   15.29 / 2404     13.61 / 2486     13.64 / 2342
+//   remote 8 ranks  81.92 / 10812    83.78 / 10787    84.16 / 11790
+//
+// Going past 2 costs twice: it starves a concurrent remote half (the NIC's DMA
+// into the scratch arena loses to the copies, and the first layer group -- the
+// one nothing overlaps -- waits), and on the real geometry it does not even pay
+// for the local case, because fragments this small do not keep four threads
+// usefully busy.  An earlier uniform-73,728 B shape did show 4 winning locally;
+// that was the synthetic shape, not the model's.
+//
+// Below the byte floor the threads cost more than they save, so a small batch
+// stays on the calling thread and pays nothing.
+int CopyThreads(size_t total_bytes, size_t copy_count) {
+  if (ThreadBackgroundFlag()) return 1;
+  static const int kMax = [] {
+    int n = 2;
+    if (const char* raw = std::getenv("UMBP_DRAM_COPY_THREADS")) {
+      const int v = std::atoi(raw);
+      if (v >= 1) n = v;
+    }
+    const unsigned hc = std::thread::hardware_concurrency();
+    if (hc > 0 && n > static_cast<int>(hc)) n = static_cast<int>(hc);
+    return n < 1 ? 1 : n;
+  }();
+  static const size_t kMinBytes = [] {
+    if (const char* raw = std::getenv("UMBP_DRAM_COPY_THREADS_MIN_BYTES")) {
+      char* end = nullptr;
+      const unsigned long long v = std::strtoull(raw, &end, 10);
+      if (end != raw) return static_cast<size_t>(v);
+    }
+    return size_t{1} << 20;
+  }();
+  if (kMax <= 1 || copy_count < 2 || total_bytes < kMinBytes) return 1;
+  return std::min(kMax, static_cast<int>(copy_count));
+}
+
 }  // namespace
+
+// Set on a worker thread at start-up; read by CopyThreads above.
+void MarkThreadBackgroundCopies() { ThreadBackgroundFlag() = true; }
+
+bool ThreadDoesBackgroundCopies() { return ThreadBackgroundFlag(); }
 
 void HostCopyBlock(void* dst, const void* src, size_t size) {
   static const bool kNt = NtSupported() && !(std::getenv("UMBP_DRAM_NT_COPY") &&
@@ -225,13 +383,46 @@ TransferPlanSet LocalCopyEngine::Plan(const std::vector<TransferItem>& items) co
 
 std::unique_ptr<TransferHandle> LocalCopyEngine::Submit(std::vector<TransferPlan> plans) {
   if (plans.empty()) return nullptr;
+
+  // Flatten first.  A ranged call arrives as many plans of one copy each, a
+  // whole-object one as a single plan of many; spreading work over threads has
+  // to see past that shape difference or it parallelizes only one of them.
+  struct Copy {
+    char* dst;
+    const char* src;
+    size_t size;
+  };
+  std::vector<Copy> copies;
+  size_t total_copies = 0;
+  for (const auto& plan : plans) total_copies += plan.sizes.size();
+  copies.reserve(total_copies);
+  size_t total_bytes = 0;
   for (const auto& plan : plans) {
     char* dst = static_cast<char*>(plan.dst.host_ptr);
     const char* src = static_cast<const char*>(plan.src.host_ptr);
     for (size_t i = 0; i < plan.sizes.size(); ++i) {
-      HostCopyBlock(dst + plan.dst_offsets[i], src + plan.src_offsets[i], plan.sizes[i]);
+      copies.push_back({dst + plan.dst_offsets[i], src + plan.src_offsets[i], plan.sizes[i]});
+      total_bytes += plan.sizes[i];
     }
   }
+
+  const int threads = CopyThreads(total_bytes, copies.size());
+  if (threads <= 1) {
+    for (const Copy& c : copies) HostCopyBlock(c.dst, c.src, c.size);
+  } else {
+    // Items are claimed off one shared cursor rather than split up front: the
+    // copies in a batch are not the same size (a range that straddles a page
+    // boundary is emitted as fragments), so equal counts would not be equal
+    // work.
+    const std::function<void(size_t)> fn = [&copies](size_t i) {
+      HostCopyBlock(copies[i].dst, copies[i].src, copies[i].size);
+    };
+    auto batch = std::make_shared<CopyPool::Batch>();
+    batch->fn = &fn;
+    batch->count = copies.size();
+    CopyPool::Instance().Run(batch, threads - 1);
+  }
+
   // No failure mode: bounds were validated at plan time and a memcpy cannot
   // fail afterwards.
   return std::make_unique<SettledHandle>(std::vector<TransferFailure>{});

--- a/src/umbp/distributed/transfer/local_copy_engine.cpp
+++ b/src/umbp/distributed/transfer/local_copy_engine.cpp
@@ -116,10 +116,44 @@ class SettledHandle final : public TransferHandle {
 
 }  // namespace
 
+namespace {
+
+// Smallest block the non-temporal path is used for.
+//
+// This was 256 KiB, a figure that came from whole-object copies where one key
+// is one ~MiB page.  A RANGED copy moves one LAYER of one page, and layers are
+// small: DeepSeek-V4-Pro's three pools are 37,440 B, 8,448 B and 1,728 B.  So
+// every ranged copy fell under the old threshold and took the ordinary memcpy,
+// paying read-for-ownership on a destination it completely overwrites.
+//
+// The threshold has to be set against a real model's fragment sizes, not a
+// synthetic one: a uniform 73,728 B shape is larger than anything the model
+// actually has, so a threshold that looks right there never fires in practice.
+//
+// 2 KiB, measured on DeepSeek-V4-Pro's geometry (8 ranks, 32 pages, served
+// entirely from the local medium, medians of 3): restore 12.04 -> 11.43 ms and
+// TTFL 1,529 -> 1,353 us.  Below 2 KiB the remaining movement is inside this
+// machine's run-to-run spread.  Tunable because the right answer is a property
+// of the machine's cache, not of the code.
+size_t NtMinBytes() {
+  static const size_t kDefault = size_t{2} << 10;
+  static const size_t n = [] {
+    const char* raw = std::getenv("UMBP_DRAM_NT_COPY_MIN_BYTES");
+    if (raw == nullptr) return kDefault;
+    char* end = nullptr;
+    const unsigned long long v = std::strtoull(raw, &end, 10);
+    if (end == raw || v == 0) return kDefault;
+    return static_cast<size_t>(v);
+  }();
+  return n;
+}
+
+}  // namespace
+
 void HostCopyBlock(void* dst, const void* src, size_t size) {
   static const bool kNt = NtSupported() && !(std::getenv("UMBP_DRAM_NT_COPY") &&
                                              std::getenv("UMBP_DRAM_NT_COPY")[0] == '0');
-  static const size_t kNtMinBytes = 256ull << 10;
+  static const size_t kNtMinBytes = NtMinBytes();
   if (kNt && size >= kNtMinBytes) {
     NtCopyAvx2(static_cast<char*>(dst), static_cast<const char*>(src), size);
   } else {

--- a/src/umbp/distributed/transfer/transfer_engine.cpp
+++ b/src/umbp/distributed/transfer/transfer_engine.cpp
@@ -22,14 +22,46 @@
 #include "umbp/distributed/transfer/transfer_engine.h"
 
 #include <algorithm>
+#include <chrono>
 
 namespace mori::umbp {
 
+namespace {
+
+// Adds its lifetime to a sink; a null sink makes it inert, so an untimed
+// Transfer does not even read the clock.
+class StepTimer {
+ public:
+  explicit StepTimer(double* sink)
+      : sink_(sink),
+        start_(sink ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{}) {}
+  ~StepTimer() { Stop(); }
+  StepTimer(const StepTimer&) = delete;
+  StepTimer& operator=(const StepTimer&) = delete;
+  void Stop() {
+    if (sink_ == nullptr) return;
+    *sink_ += std::chrono::duration_cast<std::chrono::duration<double>>(
+                  std::chrono::steady_clock::now() - start_)
+                  .count();
+    sink_ = nullptr;
+  }
+
+ private:
+  double* sink_;
+  std::chrono::steady_clock::time_point start_;
+};
+
+}  // namespace
+
 bool TransferEngine::Transfer(const std::vector<TransferItem>& items,
-                              std::vector<size_t>* failed_tags) {
+                              std::vector<size_t>* failed_tags, const StepTiming* timing) {
   if (items.empty()) return true;
 
-  TransferPlanSet planned = Plan(items);
+  TransferPlanSet planned;
+  {
+    StepTimer plan_timer(timing ? timing->plan : nullptr);
+    planned = Plan(items);
+  }
   bool ok = planned.rejected_tags.empty();
   if (failed_tags != nullptr) {
     failed_tags->insert(failed_tags->end(), planned.rejected_tags.begin(),
@@ -44,7 +76,11 @@ bool TransferEngine::Transfer(const std::vector<TransferItem>& items,
     planned_tags.insert(planned_tags.end(), plan.tags.begin(), plan.tags.end());
   }
 
-  auto handle = Submit(std::move(planned.plans));
+  std::unique_ptr<TransferHandle> handle;
+  {
+    StepTimer submit_timer(timing ? timing->submit : nullptr);
+    handle = Submit(std::move(planned.plans));
+  }
   if (handle == nullptr) {
     if (failed_tags != nullptr) {
       failed_tags->insert(failed_tags->end(), planned_tags.begin(), planned_tags.end());
@@ -53,7 +89,10 @@ bool TransferEngine::Transfer(const std::vector<TransferItem>& items,
   }
 
   std::vector<TransferFailure> failures;
-  handle->Wait(&failures);
+  {
+    StepTimer wait_timer(timing ? timing->wait : nullptr);
+    handle->Wait(&failures);
+  }
   if (failures.empty()) return ok;
   if (failed_tags != nullptr) {
     for (const auto& f : failures) {

--- a/src/umbp/include/umbp/distributed/distributed_client.h
+++ b/src/umbp/include/umbp/distributed/distributed_client.h
@@ -95,7 +95,8 @@ class DistributedClient : public IUMBPClient {
 
   bool RegisterMemory(uintptr_t ptr, size_t size,
                       mori::io::MemoryLocationType loc = mori::io::MemoryLocationType::CPU,
-                      int device = -1) override;
+                      int device = -1,
+                      MemoryRegistration mode = MemoryRegistration::kPinned) override;
   void DeregisterMemory(uintptr_t ptr) override;
 
   bool ReportExternalKvBlocks(const std::vector<std::string>& hashes, TierType tier) override;

--- a/src/umbp/include/umbp/distributed/peer/backend/page_backend.h
+++ b/src/umbp/include/umbp/distributed/peer/backend/page_backend.h
@@ -339,6 +339,10 @@ class PageBackend : public MediumBackend {
   struct OwnedSlot {
     std::vector<PageLocation> pages;
     uint64_t size = 0;
+    // Eviction fence, renewed by every Resolve.  Lives here rather than in a
+    // map keyed by the same string, which cost a second hash of a ~128-byte
+    // key per resolve.  Default-constructed means no lease.
+    std::chrono::steady_clock::time_point read_lease_until{};
   };
 
   AllocateResult AllocateLocked(const std::string& key, uint64_t size);
@@ -353,9 +357,9 @@ class PageBackend : public MediumBackend {
   // Build the full ADD list for every owned key.  Caller MUST hold `mutex_`.
   std::vector<KvEvent> SnapshotOwnedKeysLocked() const;
 
-  // Caller MUST hold `mutex_`.  True iff `key`'s read-lease deadline is
-  // still in the future.  Drops the entry if it has expired.
-  bool HasActiveReadLeaseLocked(const std::string& key);
+  // True iff `slot`'s read-lease deadline is still in the future.
+  static bool HasActiveReadLeaseLocked(const OwnedSlot& slot,
+                                       std::chrono::steady_clock::time_point now);
 
   // Caller MUST hold `mutex_`.  True iff `key` currently has an active copy
   // pin (protects its pages from eviction).
@@ -409,7 +413,6 @@ class PageBackend : public MediumBackend {
 
   std::unordered_map<uint64_t, PendingSlot> pending_;
   std::unordered_map<std::string, OwnedSlot> owned_;
-  std::unordered_map<std::string, std::chrono::steady_clock::time_point> read_lease_until_;
   std::vector<KvEvent> pending_events_;
 
   // Auto-flush state (see QueueEventLocked):

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -154,6 +154,22 @@ class PoolClient {
     size_t object_offset = 0;
   };
 
+  // Where a ranged call's internal helpers report the time they spent, so the
+  // phases can be attributed without the helpers knowing about the reporting
+  // machinery.  Split this finely because the costs scale differently: `resolve`
+  // is per key, `classify` is per RANGE, and one call carries thousands of
+  // ranges per key batch.  Every member is nullable; null is inert.
+  struct RangedPhaseSinks {
+    double* resolve = nullptr;   // medium index lookup / slot allocation
+    double* classify = nullptr;  // classifying the caller's range pointers
+    double* build = nullptr;     // TransferItem assembly (classify excluded)
+    double* commit = nullptr;    // slot commit / abort
+    size_t* items = nullptr;     // TransferItems handed to the engine
+    // Forwarded straight to TransferEngine::Transfer so the engine's own three
+    // steps land in the same report as the phases around them.
+    const TransferEngine::StepTiming* steps = nullptr;
+  };
+
   std::vector<bool> BatchGetRanges(const std::vector<std::string>& keys,
                                    const std::vector<std::vector<void*>>& dsts,
                                    const std::vector<std::vector<size_t>>& sizes,
@@ -336,10 +352,14 @@ class PoolClient {
   //
   // Appends to `items`; returns false if the medium publishes no endpoint for a
   // referenced buffer, or a range falls outside the stored object.
+  //
+  // `classify_sink`, when non-null, accumulates the seconds spent classifying
+  // the caller's range pointers.  That cost scales with ranges rather than
+  // keys, so it is reported as its own phase; null makes it inert.
   bool BuildLocalRangeTransfers(MediumBackend* backend, const std::vector<PageLocation>& pages,
                                 uint64_t page_size, uint64_t stored_size,
                                 const std::vector<ObjectRange>& ranges, bool to_backend, size_t tag,
-                                std::vector<TransferItem>* items);
+                                std::vector<TransferItem>* items, double* classify_sink = nullptr);
 
   // Copy between one contiguous host object and a set of caller ranges, through
   // the transfer engine so a device-resident caller buffer is handled by
@@ -381,8 +401,14 @@ class PoolClient {
   // wrote.  Deliberately not derivable from `results`: a key already present in
   // the medium reports success without moving anything, and crediting it would
   // inflate the bandwidth histogram.
+  //
+  // `sinks`, when non-null, attributes the call's time to phases; see
+  // RangedPhaseSinks.  Its members are independently nullable too, and a null
+  // one costs nothing -- that is what keeps this off the hot path when the
+  // ranged debug switch is off.
   void ExecuteLocalPutRangesBatch(const std::vector<LocalRangeWriteRequest>& requests,
-                                  std::vector<bool>* results, double* committed_bytes = nullptr);
+                                  std::vector<bool>* results, double* committed_bytes = nullptr,
+                                  const RangedPhaseSinks* sinks = nullptr);
   // After a successful remote DRAM fetch, if cache_remote_fetches is enabled and
   // the admission gate admits the block, enqueue it for asynchronous install into
   // this node's local DRAM tier (see ReCacheWorkerLoop). The install (DRAM

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -30,6 +30,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <shared_mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -310,14 +311,26 @@ class PoolClient {
   // layer's decision, not the client's.
   std::pair<TransferRef, uint64_t> UserBufferRef(void* ptr, size_t size) const;
 
-  // Zero-copy registered memory regions.
+  // Zero-copy registered memory regions, kept sorted by `base`.
+  //
+  // Sorted because a ranged call looks one up PER RANGE, and a layer-wise
+  // reader carries thousands of ranges against a caller that registered one
+  // buffer per layer -- a linear scan makes that quadratic.  Shared, because
+  // those lookups are reads and every rank on the node shares this client.
   struct RegisteredRegion {
     void* base;
     size_t size;
     TransferRef ref;
   };
-  mutable std::mutex registered_mem_mutex_;
+  mutable std::shared_mutex registered_mem_mutex_;
   std::vector<RegisteredRegion> registered_regions_;
+
+  // The region covering [ptr, ptr+size), or null.  Caller holds
+  // registered_mem_mutex_; the returned pointer is valid only under that lock.
+  // Exposed separately from FindRegisteredMemory so a batch can take the lock
+  // once and then resolve every range under it.
+  const RegisteredRegion* FindRegisteredRegionLocked(const void* ptr, size_t size) const;
+
   // The registered ref covering [ptr, ptr+size) plus the offset of ptr within
   // it, or nullopt when the region was never registered.
   std::optional<std::pair<TransferRef, size_t>> FindRegisteredMemory(const void* ptr,
@@ -371,8 +384,8 @@ class PoolClient {
   // NOT necessarily host memory -- an HBM pool's BufferRef carries a device
   // pointer -- so it has to keep the ref's loc/device rather than be re-wrapped
   // as host bytes, or the engine picks the wrong copy direction.
-  bool CopyContiguousToRanges(const TransferRef& src, uint64_t src_base,
-                              size_t object_size, const std::vector<ObjectRange>& ranges);
+  bool CopyContiguousToRanges(const TransferRef& src, uint64_t src_base, size_t object_size,
+                              const std::vector<ObjectRange>& ranges);
   bool CopyRangesToContiguous(const std::vector<ObjectRange>& ranges, void* dst,
                               size_t object_size);
 

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -101,15 +101,20 @@ class PoolClient {
 
   const std::string& NodeId() const { return config_.master_config.node_id; }
 
-  // Pin a caller-owned region for zero-copy RDMA.  Calls into the IO
-  // engine's RegisterMemory; the descriptor is cached and looked up by
-  // (ptr, size) on the Put/Get hot paths. `loc`/`device` describe the
-  // caller's allocation (CPU, or a GPU ordinal for a device-resident
-  // buffer) so the transfer layer can route to HbmCopyEngine instead of
-  // assuming host memory.
+  // Record a caller-owned region.  The descriptor is cached and looked up by
+  // (ptr, size) on the Put/Get hot paths; `loc`/`device` describe the caller's
+  // allocation (CPU, or a GPU ordinal) so the transfer layer routes to
+  // HbmCopyEngine instead of assuming host memory.
+  //
+  // kPinned also hands the region to the IO engine for zero-copy RDMA.
+  // kLocalCopyOnly skips that, for a region that is only ever a local copy
+  // endpoint -- it still has to be recorded, because a range that misses this
+  // table is described by its own address rather than its region base and so
+  // becomes its own transfer plan.
   bool RegisterMemory(void* ptr, size_t size,
                       mori::io::MemoryLocationType loc = mori::io::MemoryLocationType::CPU,
-                      int device = -1);
+                      int device = -1, MemoryRegistration mode = MemoryRegistration::kPinned);
+
   void DeregisterMemory(void* ptr);
 
   // Hot paths.  Both retry up to `max_route_retries` times when the

--- a/src/umbp/include/umbp/distributed/transfer/local_copy_engine.h
+++ b/src/umbp/include/umbp/distributed/transfer/local_copy_engine.h
@@ -36,6 +36,24 @@ namespace mori::umbp {
 // wants the same cache-bypass behavior.  Honors UMBP_DRAM_NT_COPY=0.
 void HostCopyBlock(void* dst, const void* src, size_t size);
 
+// Declare that copies issued on THIS thread are not on anyone's critical path,
+// so LocalCopyEngine::Submit should run them on the calling thread instead of
+// fanning them out.
+//
+// Fanning out is a latency trade: it spends other cores to finish one caller's
+// copy sooner.  That is the right trade for a thread someone is blocked on and
+// the wrong one for a background worker, which has no waiter and whose helpers
+// land on whoever does.  Measured: with the asynchronous locality install
+// fanning out too, a remote layer-wise restore at 8 ranks saw TTFL go from
+// 7,470 to 12,154 us while its own throughput barely moved -- and the whole
+// regression vanished under --no-prefetch, which is what identified the
+// installer as the thief.
+//
+// Thread-local and sticky, so a worker sets it once at start-up rather than
+// around each call.
+void MarkThreadBackgroundCopies();
+bool ThreadDoesBackgroundCopies();
+
 // The both-endpoints-are-local implementation of TransferEngine.
 //
 // This is what makes the local fast path stop being a special case (design doc

--- a/src/umbp/include/umbp/distributed/transfer/transfer_engine.h
+++ b/src/umbp/include/umbp/distributed/transfer/transfer_engine.h
@@ -350,9 +350,20 @@ class TransferEngine : public MemoryRegistrar, public MetricSource {
   // several peers deadlock-free without the caller knowing staging exists.
   virtual std::unique_ptr<TransferHandle> Submit(std::vector<TransferPlan> plans) = 0;
 
+  // Where Transfer() reports the seconds it spent in each of its three steps.
+  // Planning grows with the number of items while the move grows with bytes, so
+  // a caller that batches thousands of small ranges needs to tell them apart to
+  // know which one it is paying for.  Null members are inert.
+  struct StepTiming {
+    double* plan = nullptr;
+    double* submit = nullptr;
+    double* wait = nullptr;
+  };
+
   // Plan + Submit + Wait, for callers with nothing to overlap.  Returns false
   // and fills `failed_tags` if anything was rejected or failed.
-  bool Transfer(const std::vector<TransferItem>& items, std::vector<size_t>* failed_tags);
+  bool Transfer(const std::vector<TransferItem>& items, std::vector<size_t>* failed_tags,
+                const StepTiming* timing = nullptr);
 };
 
 }  // namespace mori::umbp

--- a/src/umbp/include/umbp/distributed/types.h
+++ b/src/umbp/include/umbp/distributed/types.h
@@ -142,6 +142,19 @@ enum class EvictionOrder : int {
   kLeastRecentlyAccessed = 1,  // oldest last_accessed_at first
 };
 
+// What a RegisterMemory call is asking for.
+//
+// Registering is not only about pinning: it is also what lets a range be
+// described by its region's base instead of its own address, which is what
+// collapses a batch of ranges into one transfer plan rather than one per range.
+// A region that will only ever be copied locally still wants that, but has no
+// use for an RDMA MR — and for an IPC-imported ROCm mapping the dmabuf fallback
+// is unsafe — so the two halves are separable.
+enum class MemoryRegistration : int {
+  kPinned = 0,         // record it and export it to the IO engine
+  kLocalCopyOnly = 1,  // record it only; no MR, no dmabuf export
+};
+
 // Structured form of one (buffer_index, page_index) slot.  Used by the
 // peer DRAM/HBM allocator to describe which page slot a write should
 // land in, and by ResolveKey responses to tell readers where to RDMA

--- a/src/umbp/include/umbp/standalone/standalone_process_client.h
+++ b/src/umbp/include/umbp/standalone/standalone_process_client.h
@@ -79,9 +79,12 @@ class StandaloneProcessClient : public IUMBPClient {
   UMBPDeploymentMode GetBackendMode() const override { return backend_mode_; }
   bool SupportsRangedIO() const override { return supports_ranged_io_; }
 
+  // `mode` is accepted and ignored: this client owns nothing to pin. It forwards
+  // the region to the server, which decides how to declare it to the backend.
   bool RegisterMemory(uintptr_t ptr, size_t size,
                       mori::io::MemoryLocationType loc = mori::io::MemoryLocationType::CPU,
-                      int device = -1) override;
+                      int device = -1,
+                      MemoryRegistration mode = MemoryRegistration::kPinned) override;
   void DeregisterMemory(uintptr_t ptr) override;
 
   bool ReportExternalKvBlocks(const std::vector<std::string>& hashes, TierType tier) override;

--- a/src/umbp/include/umbp/umbp_client.h
+++ b/src/umbp/include/umbp/umbp_client.h
@@ -156,10 +156,13 @@ class IUMBPClient {
   /// not any storage medium — a GPU-resident src/dst (e.g. sglang HiCache
   /// device-resident KV pages) must be registered as such so the transfer
   /// layer picks HbmCopyEngine instead of assuming host memory.
+  /// `mode` picks whether the region is pinned and exported to the IO engine
+  /// or merely recorded for engine selection; see MemoryRegistration. A backend
+  /// with nothing to pin may ignore it.
   virtual bool RegisterMemory(
       uintptr_t /*ptr*/, size_t /*size*/,
-      mori::io::MemoryLocationType /*loc*/ = mori::io::MemoryLocationType::CPU,
-      int /*device*/ = -1) {
+      mori::io::MemoryLocationType /*loc*/ = mori::io::MemoryLocationType::CPU, int /*device*/ = -1,
+      MemoryRegistration /*mode*/ = MemoryRegistration::kPinned) {
     return true;
   }
   virtual void DeregisterMemory(uintptr_t /*ptr*/) {}

--- a/src/umbp/standalone/standalone_process_client.cpp
+++ b/src/umbp/standalone/standalone_process_client.cpp
@@ -560,7 +560,8 @@ void StandaloneProcessClient::Close() {
 }
 
 bool StandaloneProcessClient::RegisterMemory(uintptr_t ptr, size_t size,
-                                             mori::io::MemoryLocationType loc, int device) {
+                                             mori::io::MemoryLocationType loc, int device,
+                                             MemoryRegistration /*mode*/) {
   if (closing_) return false;
   std::unique_lock lk(op_mutex_);
   if (closed_) return false;

--- a/src/umbp/standalone/standalone_server.cpp
+++ b/src/umbp/standalone/standalone_server.cpp
@@ -982,16 +982,23 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
     entry.device_id = request.device_id();
     entry.alloc_base = request.alloc_base();
     entry.client_id = request.client_id();
-    // Only the Local backend registers the imported mapping. Ranged distributed
-    // I/O stages remote objects through a registered host arena instead: the
-    // imported worker mapping is a local HIP copy endpoint only, so an RDMA MR
-    // for it buys nothing and the dmabuf fallback is unsafe for IPC-imported
-    // ROCm mappings. Skipping it is safe here because an unregistered device
-    // pointer is classified, not assumed host (ClassifiedUserBytes), so
-    // HbmCopyEngine still claims the pair.
-    if (mode == UMBPDeploymentMode::Local &&
-        !RegisterBackendMemory(entry.base, static_cast<size_t>(entry.size),
-                               mori::io::MemoryLocationType::GPU, entry.device_id)) {
+    // Both modes declare the imported mapping to the inner backend; only Local
+    // pins it. Ranged distributed I/O stages remote objects through a registered
+    // host arena, so an RDMA MR over this mapping buys nothing, and the dmabuf
+    // fallback is unsafe for IPC-imported ROCm mappings.
+    //
+    // Declaring it is not optional in either mode. Leaving it out is correct --
+    // an unregistered device pointer is classified rather than assumed host, so
+    // HbmCopyEngine still claims the pair -- but a range that misses the region
+    // table is described by its own address instead of its region base, so it
+    // becomes its own transfer plan instead of sharing one. Measured on
+    // DSv4-Pro/TP8 at 256K, that is plan = 23.2% of a ranged call against 1.4%
+    // once declared.
+    if (!RegisterBackendMemory(entry.base, static_cast<size_t>(entry.size),
+                               mori::io::MemoryLocationType::GPU, entry.device_id,
+                               mode == UMBPDeploymentMode::Local
+                                   ? MemoryRegistration::kPinned
+                                   : MemoryRegistration::kLocalCopyOnly)) {
       ReleaseIpcMapping(key);
       SetBool(response, false, "inner backend RegisterMemory failed");
       return;
@@ -1074,10 +1081,11 @@ class StandaloneServer::Impl final : public ::umbp::UMBPStandalone::Service {
   // the local case, and a host staging bounce in the distributed one.
   bool RegisterBackendMemory(void* base, size_t size,
                              mori::io::MemoryLocationType loc = mori::io::MemoryLocationType::CPU,
-                             int device = -1) {
+                             int device = -1,
+                             MemoryRegistration mode = MemoryRegistration::kPinned) {
     std::unique_lock<std::shared_mutex> lock(client_mu_);
     if (shutdown_.load()) return false;
-    return client_->RegisterMemory(reinterpret_cast<uintptr_t>(base), size, loc, device);
+    return client_->RegisterMemory(reinterpret_cast<uintptr_t>(base), size, loc, device, mode);
   }
 
   void ReleaseRegisteredMemory(const RegisteredMemory& mem) {

--- a/tests/cpp/umbp/distributed/bench_pool_client_ranges.cpp
+++ b/tests/cpp/umbp/distributed/bench_pool_client_ranges.cpp
@@ -95,7 +95,14 @@
 //                            [--requests N] [--compute-us-per-layer N]
 //                            [--offload-ranks N] [--ranges-per-call N]
 //                            [--scratch-mib N] [--page-bytes N] [--no-prefetch]
-//                            [--interleave-groups] [--local-only] [--verify]
+//                            [--interleave-groups] [--local-only] [--local-mode]
+//                            [--verify]
+//
+// --local-only and --local-mode are different questions.  --local-only keeps
+// the distributed client and puts every key on the reading node, so the local
+// half of the distributed path is what runs.  --local-mode swaps the client for
+// StandaloneClient, which has no master, peer or arena at all -- the floor the
+// distributed numbers are measured against.
 //
 // CSV (stdout): one row per rank count in --ranks
 //   ranks,layers,group,pages,object_kib,restore_ms_p50,restore_ms_p95,
@@ -132,6 +139,7 @@
 #include "umbp/distributed/master/master_server.h"
 #include "umbp/distributed/peer/backend/medium_backend.h"
 #include "umbp/distributed/pool_client.h"
+#include "umbp/local/standalone_client.h"
 
 using mori::umbp::MasterServer;
 using mori::umbp::MasterServerConfig;
@@ -139,6 +147,39 @@ using mori::umbp::PoolClient;
 using mori::umbp::PoolClientConfig;
 
 namespace {
+
+// The bench drives one of two deployments through the same loop.
+//
+// Comparing them is the point: "distributed mode on one machine" and "local
+// mode" run the same layer-wise restore against the same shapes, so any
+// difference is the deployment and not the workload.  That only holds if the
+// measurement loop is literally the same code, which is why this indirection
+// exists rather than a second copy of the loop.
+//
+// Pointers are void* here because that is PoolClient's signature; the local
+// client takes uintptr_t and the adapter converts.
+class RangedClient {
+ public:
+  virtual ~RangedClient() = default;
+  virtual bool Register(void* ptr, size_t size) = 0;
+  virtual std::vector<bool> Put(const std::vector<std::string>& keys,
+                                const std::vector<const void*>& srcs,
+                                const std::vector<size_t>& sizes) = 0;
+  virtual std::vector<bool> GetRanges(const std::vector<std::string>& keys,
+                                      const std::vector<std::vector<void*>>& dsts,
+                                      const std::vector<std::vector<size_t>>& sizes,
+                                      const std::vector<std::vector<size_t>>& offsets) = 0;
+  virtual std::vector<bool> PutRanges(const std::vector<std::string>& keys,
+                                      const std::vector<size_t>& object_sizes,
+                                      const std::vector<std::vector<const void*>>& srcs,
+                                      const std::vector<std::vector<size_t>>& sizes,
+                                      const std::vector<std::vector<size_t>>& offsets) = 0;
+  virtual std::vector<bool> Exists(const std::vector<std::string>& keys) = 0;
+  // Whether every key can be served without leaving this node.  For the
+  // distributed client that is a medium resolve; for the local one, where
+  // there is no other node, it is simply existence.
+  virtual bool AllResident(const std::vector<std::string>& keys) = 0;
+};
 
 inline uint16_t NextPeerServicePort() {
   static std::atomic<uint16_t> next{
@@ -219,6 +260,10 @@ struct BenchOpts {
   // live here.  It isolates the per-key and per-range CPU cost of the
   // distributed path from anything to do with the wire.
   bool local_only = false;
+  // Run the whole bench against local mode (StandaloneClient: no master, no
+  // peer, no arena) instead of distributed mode.  Same loop, same shapes, so
+  // the difference between the two runs is the deployment.
+  bool local_mode = false;
   // Check every restored page byte-for-byte after each request.  Off by
   // default because the comparison lands inside the measured window; on, this
   // is the only thing here that proves the numbers above came from correct
@@ -274,7 +319,7 @@ void Usage() {
             << "        [--compute-us-per-layer N]\n"
             << "        [--offload-ranks N] [--ranges-per-call N] [--scratch-mib N]\n"
             << "        [--page-bytes N] [--no-prefetch] [--interleave-groups]\n"
-            << "        [--local-only] [--verify]\n"
+            << "        [--local-only] [--local-mode] [--verify]\n"
             << "\n"
             << "  --pools replaces --layers/--layer-bytes with a real model's several\n"
             << "  pools, whose per-layer sizes differ by more than 10x and decide the\n"
@@ -396,6 +441,8 @@ bool ParseArgs(int argc, char** argv, BenchOpts* o) {
       o->interleave_groups = true;
     } else if (a == "--local-only") {
       o->local_only = true;
+    } else if (a == "--local-mode") {
+      o->local_mode = true;
     } else if (a == "--verify") {
       o->verify = true;
     } else if (a == "-h" || a == "--help") {
@@ -585,12 +632,111 @@ bool AllLocallyResident(PoolClient* client, const std::vector<std::string>& keys
                      [](const auto& entry) { return entry.found; });
 }
 
-void WaitAllVisible(PoolClient* client, const std::vector<std::string>& keys,
+// Distributed mode: a PoolClient with a master behind it.
+class DistributedRangedClient final : public RangedClient {
+ public:
+  explicit DistributedRangedClient(PoolClient* client) : client_(client) {}
+
+  bool Register(void* ptr, size_t size) override { return client_->RegisterMemory(ptr, size); }
+  std::vector<bool> Put(const std::vector<std::string>& keys, const std::vector<const void*>& srcs,
+                        const std::vector<size_t>& sizes) override {
+    return client_->BatchPut(keys, srcs, sizes);
+  }
+  std::vector<bool> GetRanges(const std::vector<std::string>& keys,
+                              const std::vector<std::vector<void*>>& dsts,
+                              const std::vector<std::vector<size_t>>& sizes,
+                              const std::vector<std::vector<size_t>>& offsets) override {
+    return client_->BatchGetRanges(keys, dsts, sizes, offsets);
+  }
+  std::vector<bool> PutRanges(const std::vector<std::string>& keys,
+                              const std::vector<size_t>& object_sizes,
+                              const std::vector<std::vector<const void*>>& srcs,
+                              const std::vector<std::vector<size_t>>& sizes,
+                              const std::vector<std::vector<size_t>>& offsets) override {
+    return client_->BatchPutRanges(keys, object_sizes, srcs, sizes, offsets);
+  }
+  std::vector<bool> Exists(const std::vector<std::string>& keys) override {
+    return client_->BatchExists(keys);
+  }
+  bool AllResident(const std::vector<std::string>& keys) override {
+    return AllLocallyResident(client_, keys);
+  }
+
+ private:
+  PoolClient* client_;
+};
+
+// Local mode: StandaloneClient, no master, no peer, no network.  The floor the
+// distributed numbers are measured against.
+class LocalRangedClient final : public RangedClient {
+ public:
+  explicit LocalRangedClient(size_t dram_capacity) {
+    mori::umbp::UMBPConfig cfg;
+    cfg.dram.capacity_bytes = dram_capacity;
+    // UMBPConfig enables an SSD tier by default, which brings a demotion
+    // pipeline with its own threads.  The distributed side of this comparison
+    // has DRAM only, so leaving it on would measure two different storage
+    // stacks rather than two deployments of the same one.
+    cfg.ssd.enabled = false;
+    client_ = std::make_unique<mori::umbp::StandaloneClient>(cfg);
+    if (!client_->SupportsRangedIO()) {
+      std::cerr << "local client reports no ranged I/O support\n";
+      std::exit(2);
+    }
+  }
+
+  // Nothing to pin: local mode copies out of its own tier with no engine in
+  // the way, so a caller pointer is already usable.
+  bool Register(void*, size_t) override { return true; }
+  std::vector<bool> Put(const std::vector<std::string>& keys, const std::vector<const void*>& srcs,
+                        const std::vector<size_t>& sizes) override {
+    std::vector<uintptr_t> raw(srcs.size());
+    for (size_t i = 0; i < srcs.size(); ++i) raw[i] = reinterpret_cast<uintptr_t>(srcs[i]);
+    return client_->BatchPut(keys, raw, sizes);
+  }
+  std::vector<bool> GetRanges(const std::vector<std::string>& keys,
+                              const std::vector<std::vector<void*>>& dsts,
+                              const std::vector<std::vector<size_t>>& sizes,
+                              const std::vector<std::vector<size_t>>& offsets) override {
+    return client_->BatchGetRanges(keys, ToRaw(dsts), sizes, offsets);
+  }
+  std::vector<bool> PutRanges(const std::vector<std::string>& keys,
+                              const std::vector<size_t>& object_sizes,
+                              const std::vector<std::vector<const void*>>& srcs,
+                              const std::vector<std::vector<size_t>>& sizes,
+                              const std::vector<std::vector<size_t>>& offsets) override {
+    return client_->BatchPutRanges(keys, object_sizes, ToRaw(srcs), sizes, offsets);
+  }
+  std::vector<bool> Exists(const std::vector<std::string>& keys) override {
+    return client_->BatchExists(keys);
+  }
+  // There is no other node, so anything that exists is here.
+  bool AllResident(const std::vector<std::string>& keys) override {
+    auto present = client_->BatchExists(keys);
+    return present.size() == keys.size() &&
+           std::all_of(present.begin(), present.end(), [](bool b) { return b; });
+  }
+
+ private:
+  template <class P>
+  static std::vector<std::vector<uintptr_t>> ToRaw(const std::vector<std::vector<P>>& in) {
+    std::vector<std::vector<uintptr_t>> out(in.size());
+    for (size_t i = 0; i < in.size(); ++i) {
+      out[i].reserve(in[i].size());
+      for (P p : in[i]) out[i].push_back(reinterpret_cast<uintptr_t>(p));
+    }
+    return out;
+  }
+
+  std::unique_ptr<mori::umbp::StandaloneClient> client_;
+};
+
+void WaitAllVisible(RangedClient* client, const std::vector<std::string>& keys,
                     std::chrono::milliseconds timeout = std::chrono::seconds{30}) {
   if (keys.empty()) return;
   const auto deadline = std::chrono::steady_clock::now() + timeout;
   for (;;) {
-    auto present = client->BatchExists(keys);
+    auto present = client->Exists(keys);
     if (std::all_of(present.begin(), present.end(), [](bool b) { return b; })) return;
     if (std::chrono::steady_clock::now() >= deadline) {
       std::cerr << "WaitAllVisible: keys not visible before timeout\n";
@@ -609,7 +755,7 @@ inline char SeedByte(size_t key_index, size_t offset) {
 
 // `target` is the peer by default, which is what makes the reads remote; under
 // --local-only it is the reading node itself, so the same keys resolve locally.
-void SeedInto(PoolClient* target, const std::vector<std::string>& keys, size_t object_bytes,
+void SeedInto(RangedClient* target, const std::vector<std::string>& keys, size_t object_bytes,
               std::vector<char>* storage) {
   storage->assign(keys.size() * object_bytes, 0);
   std::vector<const void*> srcs(keys.size());
@@ -619,8 +765,8 @@ void SeedInto(PoolClient* target, const std::vector<std::string>& keys, size_t o
     for (size_t b = 0; b < object_bytes; ++b) slot[b] = SeedByte(i, b);
     srcs[i] = slot;
   }
-  target->RegisterMemory(storage->data(), storage->size());
-  auto r = target->BatchPut(keys, srcs, sizes);
+  target->Register(storage->data(), storage->size());
+  auto r = target->Put(keys, srcs, sizes);
   for (size_t i = 0; i < keys.size(); ++i) {
     if (!r[i]) {
       std::cerr << "seed put failed for " << keys[i] << "\n";
@@ -709,17 +855,15 @@ struct RankStats {
 // `warmup_requests` leading requests run but are not recorded: the first
 // restore on a fresh client also pays the peer handshake, which a long-lived
 // connector has already paid.
-void RunLoadRank(Cluster& cluster, const BenchOpts& o,
+void RunLoadRank(RangedClient* client, const BenchOpts& o,
                  const std::vector<std::vector<std::vector<std::string>>>& request_keys,
                  size_t warmup_requests, std::atomic<size_t>* warmed_ranks, RankStats* stats) {
-  PoolClient* client = cluster.node();
-
   // Destination for one request's pages, one buffer per pool because a pool's
   // pages are only contiguous among themselves.  Registered once for zero copy.
   std::vector<std::vector<char>> kv(o.pools.size());
   for (size_t p = 0; p < o.pools.size(); ++p) {
     kv[p].assign(o.pages * o.pools[p].object_bytes(), 0);
-    client->RegisterMemory(kv[p].data(), kv[p].size());
+    client->Register(kv[p].data(), kv[p].size());
   }
 
   for (size_t req = 0; req < request_keys.size(); ++req) {
@@ -769,9 +913,9 @@ void RunLoadRank(Cluster& cluster, const BenchOpts& o,
             }
 
             // Whether this call can be served without the arena at all.
-            const bool all_local = AllLocallyResident(client, chunk_keys);
+            const bool all_local = client->AllResident(chunk_keys);
 
-            auto res = client->BatchGetRanges(chunk_keys, dsts, sizes, offsets);
+            auto res = client->GetRanges(chunk_keys, dsts, sizes, offsets);
             ok = res.size() == count &&
                  std::all_of(res.begin(), res.end(), [](bool b) { return b; });
 
@@ -857,11 +1001,9 @@ void RunLoadRank(Cluster& cluster, const BenchOpts& o,
       // How much of this request's working set the remote path installed here.
       // Counted after the load so an asynchronous install has had the whole
       // request to land; it is still a lower bound if one lands later.
-      if (auto* backend = client->Backends().Get(client->Medium())) {
-        for (size_t pi = 0; pi < o.pools.size(); ++pi) {
-          for (const auto& entry : backend->BatchResolve(pool_keys[pi], /*include_descs=*/false)) {
-            if (entry.found) stats->local_write_bytes += o.pools[pi].object_bytes();
-          }
+      for (size_t pi = 0; pi < o.pools.size(); ++pi) {
+        if (client->AllResident(pool_keys[pi])) {
+          stats->local_write_bytes += pool_keys[pi].size() * o.pools[pi].object_bytes();
         }
       }
     }
@@ -870,17 +1012,16 @@ void RunLoadRank(Cluster& cluster, const BenchOpts& o,
 
 // One rank's offload stream: whole-object writes that overlap the loads above.
 // This is the traffic that used to contend with loading on a single arena.
-void RunOffloadRank(Cluster& cluster, const BenchOpts& o, size_t rank,
+void RunOffloadRank(RangedClient* client, const BenchOpts& o, size_t rank,
                     const std::atomic<bool>& stop, const std::atomic<size_t>& warmed_ranks,
                     size_t load_ranks, RankStats* stats) {
-  PoolClient* client = cluster.node();
   // One buffer per pool, mirroring the load side.
   std::vector<std::vector<char>> kv(o.pools.size());
   for (size_t pi = 0; pi < o.pools.size(); ++pi) {
     kv[pi].assign(o.pages * o.pools[pi].object_bytes(), 0);
     for (size_t i = 0; i < kv[pi].size(); ++i)
       kv[pi][i] = static_cast<char>((i + rank + pi) & 0xff);
-    client->RegisterMemory(kv[pi].data(), kv[pi].size());
+    client->Register(kv[pi].data(), kv[pi].size());
   }
 
   for (size_t round = 0; !stop.load(std::memory_order_relaxed); ++round) {
@@ -913,7 +1054,7 @@ void RunOffloadRank(Cluster& cluster, const BenchOpts& o, size_t rank,
             offsets[i].push_back(l * pool.layer_bytes);
           }
         }
-        auto res = client->BatchPutRanges(chunk_keys, object_sizes, srcs, sizes, offsets);
+        auto res = client->PutRanges(chunk_keys, object_sizes, srcs, sizes, offsets);
         // Offload keeps running through warm-up so the arena is loaded from the
         // start, but only bytes inside the measured window are counted.
         const bool in_window = warmed_ranks.load(std::memory_order_relaxed) >= load_ranks;
@@ -944,14 +1085,28 @@ void RunOne(const BenchOpts& o, size_t ranks) {
   // pools the largest one sets the floor.
   const size_t scratch_bytes = std::max<size_t>(o.max_object_bytes(), o.scratch_mib << 20);
 
-  Cluster cluster(node_capacity, peer_capacity, scratch_bytes, o.medium_page_bytes(),
-                  o.locality_prefetch);
+  // Local mode needs no master, no peer and no arena, so the cluster is built
+  // only for the distributed side.  Both then go through RangedClient.
+  std::unique_ptr<Cluster> cluster;
+  std::unique_ptr<RangedClient> node_client;
+  std::unique_ptr<RangedClient> peer_client;
+  if (o.local_mode) {
+    node_client = std::make_unique<LocalRangedClient>(seeded_capacity);
+  } else {
+    cluster = std::make_unique<Cluster>(node_capacity, peer_capacity, scratch_bytes,
+                                        o.medium_page_bytes(), o.locality_prefetch);
+    node_client = std::make_unique<DistributedRangedClient>(cluster->node());
+    peer_client = std::make_unique<DistributedRangedClient>(cluster->peer());
+  }
 
   // Seed: each (rank, request) gets its own pages, so the first group of every
   // request is a real remote miss -- or, under --local-only, a local hit that
   // no earlier group warmed.  One extra leading request per rank is a warm-up
   // that pays the peer handshake and is not recorded.
-  PoolClient* const seed_target = o.local_only ? cluster.node() : cluster.peer();
+  // Local mode has nowhere else to put anything; distributed mode seeds the
+  // peer unless --local-only asks for everything on the reading node.
+  RangedClient* const seed_target =
+      (o.local_mode || o.local_only) ? node_client.get() : peer_client.get();
   constexpr size_t kWarmupRequests = 1;
   const size_t total_requests = o.requests + kWarmupRequests;
   // [rank][request][pool] -> that pool's page keys.  A pool's object holds only
@@ -980,9 +1135,13 @@ void RunOne(const BenchOpts& o, size_t ranks) {
       all_keys.insert(all_keys.end(), flat[pi].begin(), flat[pi].end());
     }
   }
-  cluster.peer()->Master().FlushHeartbeat();
-  cluster.node()->Master().FlushHeartbeat();
-  WaitAllVisible(cluster.node(), all_keys);
+  if (cluster) {
+    // Distributed mode only: the seeded keys become visible to the reader once
+    // both nodes' outboxes have reached master.
+    cluster->peer()->Master().FlushHeartbeat();
+    cluster->node()->Master().FlushHeartbeat();
+  }
+  WaitAllVisible(node_client.get(), all_keys);
 
   std::vector<RankStats> load_stats(ranks);
   std::vector<RankStats> offload_stats(std::max<size_t>(offload_ranks, 1));
@@ -995,14 +1154,15 @@ void RunOne(const BenchOpts& o, size_t ranks) {
   std::atomic<size_t> warmed_ranks{0};
   std::vector<std::thread> offloaders;
   for (size_t r = 0; r < offload_ranks; ++r) {
-    offloaders.emplace_back(
-        [&, r] { RunOffloadRank(cluster, o, r, stop, warmed_ranks, ranks, &offload_stats[r]); });
+    offloaders.emplace_back([&, r] {
+      RunOffloadRank(node_client.get(), o, r, stop, warmed_ranks, ranks, &offload_stats[r]);
+    });
   }
 
   std::vector<std::thread> loaders;
   for (size_t r = 0; r < ranks; ++r) {
     loaders.emplace_back([&, r] {
-      RunLoadRank(cluster, o, keys[r], kWarmupRequests, &warmed_ranks, &load_stats[r]);
+      RunLoadRank(node_client.get(), o, keys[r], kWarmupRequests, &warmed_ranks, &load_stats[r]);
     });
   }
   for (auto& t : loaders) t.join();

--- a/tests/cpp/umbp/distributed/bench_pool_client_ranges.cpp
+++ b/tests/cpp/umbp/distributed/bench_pool_client_ranges.cpp
@@ -58,7 +58,7 @@
 // A bench that forces every call remote would overstate how often the arena is
 // reached, so this one lets the real behavior happen and reports the local-hit
 // rate it observes (how that number is obtained, and what it cannot tell you,
-// is on AllLocallyResident below).
+// is on LocallyResidentCount below).
 //
 // WHERE "REMOTE" COMES FROM ON A SINGLE HOST
 //
@@ -178,7 +178,12 @@ class RangedClient {
   // Whether every key can be served without leaving this node.  For the
   // distributed client that is a medium resolve; for the local one, where
   // there is no other node, it is simply existence.
-  virtual bool AllResident(const std::vector<std::string>& keys) = 0;
+  // How many of `keys` this deployment can serve from ITS OWN local
+  // storage right now, without reaching another node.  A count rather than
+  // a bool because callers want both a per-call all-or-nothing check and a
+  // per-key credit -- deriving the former from a count keeps there from
+  // being two divergent notions of "resident" in this file.
+  virtual size_t ResidentCount(const std::vector<std::string>& keys) = 0;
 };
 
 inline uint16_t NextPeerServicePort() {
@@ -611,25 +616,29 @@ class Cluster {
 // resolves here is a key that will not go remote.  This runs that identical
 // resolve just before the call.
 //
-// Three limits, so the number is not over-read:
+// Two limits, so the number is not over-read:
 //   * It is a prediction from the same criterion, taken a moment earlier -- not
 //     an observation from inside mori.
 //   * It races: under concurrency the object can be evicted between this
 //     resolve and the call, which would then go remote after being counted
 //     local.  Expect the reported rate to be slightly optimistic at high rank
 //     counts, which is also where eviction actually starts happening.
-//   * It is per CALL, not per key: a chunk counts as local only when every key
-//     in it resolves, so a partially-local chunk is counted remote.
+//
+// Returns a per-key COUNT rather than a bool: local_hit_pct wants an
+// all-or-nothing call classification (a chunk counts as local only when every
+// key in it resolves), while local_write_mib wants partial credit (an object
+// that landed counts even if others in its pool have not yet) -- two different
+// questions the callers derive from the same count rather than two functions
+// that could silently drift apart.
 //
 // Resolved for the whole chunk in one call: this sits inside the timed region,
 // so it has to stay cheap.
-bool AllLocallyResident(PoolClient* client, const std::vector<std::string>& keys) {
+size_t LocallyResidentCount(PoolClient* client, const std::vector<std::string>& keys) {
   auto* backend = client->Backends().Get(client->Medium());
-  if (backend == nullptr) return false;
+  if (backend == nullptr) return 0;
   auto resolved = backend->BatchResolve(keys, /*include_descs=*/false);
-  return resolved.size() == keys.size() &&
-         std::all_of(resolved.begin(), resolved.end(),
-                     [](const auto& entry) { return entry.found; });
+  return static_cast<size_t>(std::count_if(resolved.begin(), resolved.end(),
+                                           [](const auto& entry) { return entry.found; }));
 }
 
 // Distributed mode: a PoolClient with a master behind it.
@@ -658,8 +667,8 @@ class DistributedRangedClient final : public RangedClient {
   std::vector<bool> Exists(const std::vector<std::string>& keys) override {
     return client_->BatchExists(keys);
   }
-  bool AllResident(const std::vector<std::string>& keys) override {
-    return AllLocallyResident(client_, keys);
+  size_t ResidentCount(const std::vector<std::string>& keys) override {
+    return LocallyResidentCount(client_, keys);
   }
 
  private:
@@ -711,10 +720,9 @@ class LocalRangedClient final : public RangedClient {
     return client_->BatchExists(keys);
   }
   // There is no other node, so anything that exists is here.
-  bool AllResident(const std::vector<std::string>& keys) override {
+  size_t ResidentCount(const std::vector<std::string>& keys) override {
     auto present = client_->BatchExists(keys);
-    return present.size() == keys.size() &&
-           std::all_of(present.begin(), present.end(), [](bool b) { return b; });
+    return static_cast<size_t>(std::count(present.begin(), present.end(), true));
   }
 
  private:
@@ -816,7 +824,7 @@ struct RankStats {
   size_t get_bytes = 0;        // bytes the caller asked for
   size_t put_bytes = 0;
   // Wire accounting.  These are PREDICTIONS from the same criterion
-  // AllLocallyResident applies -- see its comment for what that does and does
+  // LocallyResidentCount applies -- see its comment for what that does and does
   // not mean.  They are what the bench can know from outside mori.
   //
   // remote_keys is the useful one: it counts (key, call) pairs that had to reach
@@ -913,7 +921,7 @@ void RunLoadRank(RangedClient* client, const BenchOpts& o,
             }
 
             // Whether this call can be served without the arena at all.
-            const bool all_local = client->AllResident(chunk_keys);
+            const bool all_local = client->ResidentCount(chunk_keys) == chunk_keys.size();
 
             auto res = client->GetRanges(chunk_keys, dsts, sizes, offsets);
             ok = res.size() == count &&
@@ -1002,9 +1010,8 @@ void RunLoadRank(RangedClient* client, const BenchOpts& o,
       // Counted after the load so an asynchronous install has had the whole
       // request to land; it is still a lower bound if one lands later.
       for (size_t pi = 0; pi < o.pools.size(); ++pi) {
-        if (client->AllResident(pool_keys[pi])) {
-          stats->local_write_bytes += pool_keys[pi].size() * o.pools[pi].object_bytes();
-        }
+        stats->local_write_bytes +=
+            client->ResidentCount(pool_keys[pi]) * o.pools[pi].object_bytes();
       }
     }
   }

--- a/tests/cpp/umbp/distributed/bench_pool_client_ranges.cpp
+++ b/tests/cpp/umbp/distributed/bench_pool_client_ranges.cpp
@@ -91,11 +91,11 @@
 //
 // Usage:
 //   bench_pool_client_ranges [--ranks N] [--layers N] [--layer-group N]
-//                            [--layer-bytes N] [--pages N] [--requests N]
-//                            [--compute-us-per-layer N] [--offload-ranks N]
-//                            [--ranges-per-call N] [--scratch-mib N]
-//                            [--page-bytes N] [--no-prefetch]
-//                            [--interleave-groups] [--verify]
+//                            [--layer-bytes N] [--pools SPEC] [--pages N]
+//                            [--requests N] [--compute-us-per-layer N]
+//                            [--offload-ranks N] [--ranges-per-call N]
+//                            [--scratch-mib N] [--page-bytes N] [--no-prefetch]
+//                            [--interleave-groups] [--local-only] [--verify]
 //
 // CSV (stdout): one row per rank count in --ranks
 //   ranks,layers,group,pages,object_kib,restore_ms_p50,restore_ms_p95,
@@ -213,6 +213,12 @@ struct BenchOpts {
   // adjacency changes.  This is the adversarial case for any implementation
   // that leans on contiguous layer groups.
   bool interleave_groups = false;
+  // Seed onto the reading node instead of the peer, so every call is served by
+  // the local medium and Phase 2 never runs.  This is the single-machine shape:
+  // a standalone process whose inner backend is distributed but whose keys all
+  // live here.  It isolates the per-key and per-range CPU cost of the
+  // distributed path from anything to do with the wire.
+  bool local_only = false;
   // Check every restored page byte-for-byte after each request.  Off by
   // default because the comparison lands inside the measured window; on, this
   // is the only thing here that proves the numbers above came from correct
@@ -267,7 +273,8 @@ void Usage() {
             << "        [--pools SPEC] [--pages N] [--requests N]\n"
             << "        [--compute-us-per-layer N]\n"
             << "        [--offload-ranks N] [--ranges-per-call N] [--scratch-mib N]\n"
-            << "        [--page-bytes N] [--no-prefetch] [--interleave-groups] [--verify]\n"
+            << "        [--page-bytes N] [--no-prefetch] [--interleave-groups]\n"
+            << "        [--local-only] [--verify]\n"
             << "\n"
             << "  --pools replaces --layers/--layer-bytes with a real model's several\n"
             << "  pools, whose per-layer sizes differ by more than 10x and decide the\n"
@@ -387,6 +394,8 @@ bool ParseArgs(int argc, char** argv, BenchOpts* o) {
       o->locality_prefetch = false;
     } else if (a == "--interleave-groups") {
       o->interleave_groups = true;
+    } else if (a == "--local-only") {
+      o->local_only = true;
     } else if (a == "--verify") {
       o->verify = true;
     } else if (a == "-h" || a == "--help") {
@@ -598,7 +607,9 @@ inline char SeedByte(size_t key_index, size_t offset) {
   return static_cast<char>((offset * 31 + key_index * 131 + 7) & 0xff);
 }
 
-void SeedPeer(PoolClient* peer, const std::vector<std::string>& keys, size_t object_bytes,
+// `target` is the peer by default, which is what makes the reads remote; under
+// --local-only it is the reading node itself, so the same keys resolve locally.
+void SeedInto(PoolClient* target, const std::vector<std::string>& keys, size_t object_bytes,
               std::vector<char>* storage) {
   storage->assign(keys.size() * object_bytes, 0);
   std::vector<const void*> srcs(keys.size());
@@ -608,8 +619,8 @@ void SeedPeer(PoolClient* peer, const std::vector<std::string>& keys, size_t obj
     for (size_t b = 0; b < object_bytes; ++b) slot[b] = SeedByte(i, b);
     srcs[i] = slot;
   }
-  peer->RegisterMemory(storage->data(), storage->size());
-  auto r = peer->BatchPut(keys, srcs, sizes);
+  target->RegisterMemory(storage->data(), storage->size());
+  auto r = target->BatchPut(keys, srcs, sizes);
   for (size_t i = 0; i < keys.size(); ++i) {
     if (!r[i]) {
       std::cerr << "seed put failed for " << keys[i] << "\n";
@@ -831,7 +842,7 @@ void RunLoadRank(Cluster& cluster, const BenchOpts& o,
           const size_t object_bytes = o.pools[pi].object_bytes();
           for (size_t p = 0; p < o.pages; ++p) {
             const char* page = kv[pi].data() + p * object_bytes;
-            // Seeded per pool, so the index must match SeedPeer's ordering.
+            // Seeded per pool, so the index must match SeedInto's ordering.
             const size_t seed_index = req * o.pages + p;
             for (size_t b = 0; b < object_bytes; ++b) {
               if (page[b] != SeedByte(seed_index, b)) {
@@ -918,14 +929,16 @@ void RunOne(const BenchOpts& o, size_t ranks) {
   const size_t offload_ranks = (o.offload_ranks == SIZE_MAX) ? ranks : o.offload_ranks;
   const size_t object_bytes = o.object_bytes();
 
-  // The node must be able to hold one restore working set per rank (that is
-  // what makes groups 2..N local hits), plus slack for offloads routed here.
-  const size_t node_capacity =
-      std::max<size_t>(size_t{256} << 20, ranks * o.pages * object_bytes * 3);
-  // The peer holds every seeded page for every rank and request (+1 warm-up).
-  const size_t peer_capacity =
+  // Whichever client is seeded holds every page for every rank and request
+  // (+1 warm-up); the other only needs a restore working set per rank, which is
+  // what makes groups 2..N local hits, plus slack for offloads routed there.
+  const size_t seeded_capacity =
       std::max<size_t>(size_t{512} << 20,
                        ranks * (o.requests + 1) * o.pages * object_bytes * 2 + (size_t{512} << 20));
+  const size_t reader_capacity =
+      std::max<size_t>(size_t{256} << 20, ranks * o.pages * object_bytes * 3);
+  const size_t node_capacity = o.local_only ? seeded_capacity : reader_capacity;
+  const size_t peer_capacity = o.local_only ? reader_capacity : seeded_capacity;
   // The arena must hold at least one whole object: the remote path stages
   // through it, and an object that does not fit is unservable.  With several
   // pools the largest one sets the floor.
@@ -935,8 +948,10 @@ void RunOne(const BenchOpts& o, size_t ranks) {
                   o.locality_prefetch);
 
   // Seed: each (rank, request) gets its own pages, so the first group of every
-  // request is a real remote miss.  One extra leading request per rank is a
-  // warm-up that pays the peer handshake and is not recorded.
+  // request is a real remote miss -- or, under --local-only, a local hit that
+  // no earlier group warmed.  One extra leading request per rank is a warm-up
+  // that pays the peer handshake and is not recorded.
+  PoolClient* const seed_target = o.local_only ? cluster.node() : cluster.peer();
   constexpr size_t kWarmupRequests = 1;
   const size_t total_requests = o.requests + kWarmupRequests;
   // [rank][request][pool] -> that pool's page keys.  A pool's object holds only
@@ -961,7 +976,7 @@ void RunOne(const BenchOpts& o, size_t ranks) {
       }
     }
     for (size_t pi = 0; pi < o.pools.size(); ++pi) {
-      SeedPeer(cluster.peer(), flat[pi], o.pools[pi].object_bytes(), &seed_storage[r][pi]);
+      SeedInto(seed_target, flat[pi], o.pools[pi].object_bytes(), &seed_storage[r][pi]);
       all_keys.insert(all_keys.end(), flat[pi].begin(), flat[pi].end());
     }
   }

--- a/tests/cpp/umbp/distributed/test_pool_client_ranges.cpp
+++ b/tests/cpp/umbp/distributed/test_pool_client_ranges.cpp
@@ -339,6 +339,55 @@ TEST_F(PoolClientRangesTest, RemoteRoundTripSubBatchesAndInstallsLocally) {
   }
 }
 
+TEST_F(PoolClientRangesTest, LocalCopyOnlyRegistrationServesRangesAndSharesOnePlan) {
+  // kLocalCopyOnly records a region without handing it to the IO engine. It
+  // exists because the two halves of "register" are separable: a region that is
+  // only ever a local copy endpoint has no use for an RDMA MR, but it still has
+  // to be in the table -- a range that misses it is described by its own
+  // address instead of its region base, so instead of every range sharing one
+  // (src, dst) pair and collapsing into a single transfer plan, each range
+  // becomes its own plan. That is a latency bug with no wrong answer attached,
+  // which is exactly why it needs a test rather than a reviewer.
+  const std::string key = "local-copy-only-ranges";
+  std::vector<char> object(kObjectSize);
+  for (size_t i = 0; i < object.size(); ++i) object[i] = static_cast<char>((i * 31 + 7) & 0xff);
+  PutLocalReplica(caller_.get(), key, object);
+
+  // One buffer, several disjoint ranges landing in it -- the layer-wise restore
+  // shape, and the case the pair has to collapse for.
+  std::vector<char> dst(kObjectSize, 0);
+  ASSERT_TRUE(caller_->RegisterMemory(dst.data(), dst.size(), mori::io::MemoryLocationType::CPU, -1,
+                                      MemoryRegistration::kLocalCopyOnly));
+
+  // Disjoint and inside the 2-page object; the middle one straddles the page
+  // boundary so the walk emits more than one fragment for a single range.
+  const std::vector<size_t> sizes = {2048, 2048, 1024};
+  const std::vector<size_t> offsets = {0, 3072, 6144};
+  std::vector<void*> dsts;
+  size_t cursor = 0;
+  for (size_t bytes : sizes) {
+    dsts.push_back(dst.data() + cursor);
+    cursor += bytes;
+  }
+  ASSERT_EQ(caller_->BatchGetRanges({key}, {dsts}, {sizes}, {offsets}), std::vector<bool>({true}));
+
+  cursor = 0;
+  for (size_t i = 0; i < sizes.size(); ++i) {
+    EXPECT_EQ(std::memcmp(dst.data() + cursor, object.data() + offsets[i], sizes[i]), 0)
+        << "range " << i << " restored the wrong bytes";
+    cursor += sizes[i];
+  }
+
+  // Idempotent for a size already covered, and still refuses to silently shrink
+  // a region -- same contract as the pinned path.
+  EXPECT_TRUE(caller_->RegisterMemory(dst.data(), dst.size() / 2, mori::io::MemoryLocationType::CPU,
+                                      -1, MemoryRegistration::kLocalCopyOnly));
+  EXPECT_FALSE(caller_->RegisterMemory(dst.data(), dst.size() * 2,
+                                       mori::io::MemoryLocationType::CPU, -1,
+                                       MemoryRegistration::kLocalCopyOnly));
+  caller_->DeregisterMemory(dst.data());
+}
+
 TEST_F(PoolClientRangesTest, InvalidRangesFailWithoutPublishing) {
   std::vector<char> src(kObjectSize, 0x5a);
   std::vector<std::string> keys = {"range-gap", "range-overlap"};
@@ -941,7 +990,6 @@ TEST_F(PoolClientRangesTest, WholeObjectReadStillInstallsWithPrefetchOff) {
 // nothing a caller can see.  Naming it here would claim coverage that does not
 // exist; it is a throughput guard, and the bench is where it shows up.
 TEST_F(PoolClientRangesTest, LayerWiseGroupsOverOneColdKeyAllReturnTheirBytes) {
-
   const std::string key = "prefetch-dedup";
   std::vector<char> object(kObjectSize);
   for (size_t i = 0; i < kObjectSize; ++i) object[i] = static_cast<char>((i * 31 + 13) & 0xff);
@@ -1238,7 +1286,8 @@ TEST_F(PoolClientRangesTest, ConcurrentMixedShapesAllReturnCorrectBytes) {
   // here, so a refusal is a legitimate outcome and pinning it to zero would
   // make this test fail for the one reason it is allowed to.
   if (failures.load() != 0) {
-    GTEST_LOG_(INFO) << failures.load() << " reads were refused (capacity), none returned bad bytes";
+    GTEST_LOG_(INFO) << failures.load()
+                     << " reads were refused (capacity), none returned bad bytes";
   }
 }
 


### PR DESCRIPTION
## Motivation

Follow-up to #589, which cut what a **remote** ranged get moves. This PR targets
the case where nothing is remote: a single standalone process whose inner
backend is distributed, with every key resident on this node. That is the shape
the sglang direct linker runs, and no RDMA is involved anywhere in this change.

A single-node deployment has a fair question to ask of that mode: what does it
cost over plain local mode, which has no master, no peer and no arena? Before
this series, a real amount — measured on DeepSeek-V4-Pro geometry, distributed
mode took **1.8× the TTFL** of local mode at one rank. After it, distributed is
ahead of local at every rank count. The numbers are in Test Result.

The reason it was behind is that a `BatchGetRanges` call was spending most of
its time on per-descriptor bookkeeping rather than on moving bytes. Measured on
DeepSeek-V4-Pro's smallest pool (1,728 B fragments, 32 keys, served entirely
from the local medium):

```
total=149.7us
  resolve    14.9us  10.0%   per-key medium lookup
  classify   27.3us  18.2%   hipPointerGetAttributes, once PER RANGE
  build      15.1us  10.1%   TransferItem assembly
  xfer       78.7us  52.6%   plan 33.0 (22.0%)  submit 44.4 (29.7%)
  other      13.8us   9.2%   validation, metrics
```

The copy is under a third; **per-descriptor cost is 60%**. It is that high
because a layer of a page is small — a model does not have one uniform pool, and
DeepSeek-V4-Pro's three span 37,440 B, 8,448 B and 1,728 B.

The metric being optimised is TTFL: the wait for the first layer group, which is
the one no forward compute overlaps, so it lands directly in TTFT.

## Technical Details

Seven commits, each independently measurable.

**1. `test(umbp)`: attribute a ranged call's time finely enough to act on**

The existing `UMBP_RANGED_CALL_DEBUG` buckets could not answer the question they
were reached for. `resolve` covered the whole per-key loop, mixing the medium's
index lookup (per key) with describing the caller's buffers (per range); `xfer`
covered Plan, Submit and Wait together, so it could not say whether a batch of
many small ranges was paying to plan the move or to make it.

`resolve` splits into resolve / classify / build, `xfer` into plan / submit /
wait via a `StepTiming` the engine fills in, and the report gains items-per-call.
Sub-phases are timed nested and subtracted at the call site so they stay
disjoint. Every timer is inert when the switch is off — a null sink never reads
the clock.

Also adds `--local-only` to the bench, which seeds the reading node instead of
the peer so every call is served locally. Without it the bench forces every read
remote and the local path's costs are buried under the wire.

**2. `perf(umbp)`: let a ranged copy reach the non-temporal path**

`HostCopyBlock` only used the non-temporal AVX2 copy at 256 KiB and above, a
threshold chosen when one key was one ~MiB page (the comment at the top of that
file says exactly that). A ranged copy moves one *layer*, so every ranged copy
fell under it and took the ordinary memcpy, paying read-for-ownership on a
destination it completely overwrites. Now 2 KiB.

**3. `perf(umbp)`: fan a local ranged copy out across threads**

One memcpy stream reached the same rate whether 1 rank or 8 were copying
concurrently, so the ceiling was the stream, not the memory system. Local mode
already knew this — `DRAMTier` spreads a batch read over
`UMBP_DRAM_READ_THREADS` and its comment reads ">1 breaks the single-core memcpy
ceiling". `LocalCopyEngine` never did, because it was written when one key was
one whole page and the batch executors above it supplied the parallelism; ranged
I/O invalidated that by handing a single thread thousands of small copies inside
one `Submit`.

Two things this cost before it paid, both found by measurement and both recorded
in the commit message:

- Spawning threads per call is worse than not parallelizing at all. Creating and
  joining threads maps and unmaps their stacks, which serializes on the process
  address space, so the damage does not scale down with helper count — capping
  the whole process to four concurrent spawned helpers still cost 25% of TTFL on
  a remote restore. Helpers are now a persistent pool.
- The default is **2**, not local mode's 4. Past 2 the local copies outrun the
  NIC's DMA into the scratch arena on a mixed workload, and on the real geometry
  4 does not pay even locally.

The asynchronous locality installer marks itself background and stays inline:
nobody is blocked on it, so borrowing cores for it only slows whoever is.

**4. `perf(umbp)`: describe a ranged caller buffer by its registration**

The largest single win. `BuildLocalRangeTransfers` described each range with
`ClassifiedUserBytes`, which asks `hipPointerGetAttributes` what the pointer is —
a HIP runtime call per range. It is avoidable: in standalone-process mode the
server registers every client region it imports, so location and device are
already in the registration table. `ClassifiedUserBytes`' own comment says
registered buffers never reach it; this path just never looked.

Using the registration pays a second and larger time. A registered ref names the
*region* base, so every range landing in one caller buffer shares a (src, dst)
pair and `LocalCopyEngine::Plan` folds them into one plan whose adjacent
fragments coalesce. Describing each range by its own address made every range
its own plan, with its own four vectors, and made the coalescing that `Plan`
exists to do unreachable.

The registration table is now sorted by base and searched with `upper_bound`,
and a whole batch resolves under one shared lock instead of one exclusive lock
per range. Linear scanning was fine when lookups were per key; against a caller
holding one buffer per layer it is quadratic.

Unregistered memory still goes through `ClassifiedUserBytes` — for a pointer
nobody declared, interrogating it is the only correct answer.

**5. `perf(umbp)`: resolve a ranged batch per backend, report its bytes once**

Two batch APIs were being called one element at a time.

`BatchResolve` ran inside the per-key loop as `BatchResolve({keys[i]})`: a
temporary `vector<string>` (copying the key) and a temporary result vector per
key, and one acquisition per key of the backend mutex that `Allocate`, `Commit`
and `Evict` also take — the mutex where every rank sharing this client
serializes. Now once per *backend* for the whole batch, with only unclaimed keys
carried to the next backend, so registry order and first-hit-wins are unchanged.

The byte counters were updated per key. `AddCounter` takes a lock and builds a
metric key from name and labels, and the help text is a hundred-odd bytes
materialized on every call. Bytes are now accumulated and reported once; totals
are identical, only the number of updates changes. Flushing is a scope guard,
not a line before each `return`, because this function has four exits that can
all have moved bytes.

**6. `perf(umbp)`: stop reallocating while assembling a ranged batch**

`local_items` grew by doubling, and a `TransferItem` carries two `TransferRef`s
each holding a `MemoryDesc`, so every reallocation relocates a lot of bytes. The
range count is known up front and is a tight lower bound on the item count, so
the vector is reserved. `MakeReadRanges` returned a fresh vector per key for a
buffer dead by the next iteration; it now fills one the loop reuses.

**7. `test(umbp)`: run the ranged bench against local mode too**

The bench could only drive a distributed `PoolClient`, so the question this PR
exists to answer had no measurement behind it. `--local-mode` runs the whole
bench against `StandaloneClient` instead — no master, no peer, no arena, no
network. Both go through one `RangedClient` interface so the measurement loop is
literally the same code; a second copy of the loop would make any difference
between the two unfalsifiable.

Not to be confused with `--local-only`, which keeps the distributed client and
merely puts every key on the reading node.

The local client is configured DRAM-only, because `UMBPConfig` enables an SSD
tier by default and the distributed side has DRAM only — otherwise the
comparison is between two storage stacks rather than two deployments. Measured
both ways; it makes no difference on these shapes, but the result should not
depend on that.

### Where the time goes now

Same call as in Motivation — DeepSeek-V4-Pro's smallest pool, 32 keys:

```
              before    after
  resolve     14.9us    5.0us
  classify    27.3us    3.0us
  build       15.1us    8.5us
  plan        33.0us    2.7us
  submit      44.4us   20.7us    <- coalescing, not a faster copy
  other       13.8us    4.3us
  total      149.7us   44.4us
```

The copy is now the largest item, which is where a data path should be spending
its time.

### A note on how this was measured

The first three commits were originally tuned against a uniform 73,728 B layer
shape and reported considerably larger wins. That shape is **larger than any
pool the model actually has**, and this path is fragment-size bound — 5.4 GB/s
at 1,728 B against 37.5 GB/s at 37,440 B. Every number here was re-measured on
the real geometry after #589 landed `--pools`, and the commit messages were
rewritten to match. The non-temporal threshold tuned on the synthetic shape
(64 KiB) sat above all three real pools and would never have fired in
production.

### Knobs

| | default | |
|---|---|---|
| `UMBP_DRAM_NT_COPY_MIN_BYTES` | 2 KiB | non-temporal copy threshold |
| `UMBP_DRAM_COPY_THREADS` | 2 | best everywhere measured, not a compromise; no reason for a deployment to set it |
| `UMBP_RANGED_CALL_DEBUG` | off | the phase breakdown above |

## Test Plan

Image `lmsysorg/sglang-rocm:v0.5.16-rocm720-mi30x-20260730`, host mlx5 RoCE.
Baseline is a separate build of the merge base (`bb259b50`) with the same bench
binary. This machine's run-to-run spread reaches ±20%, so every reported figure
is a median of 3.

```bash
cmake -S . -B build -GNinja -DBUILD_UMBP=ON -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release
cmake --build build --target bench_umbp_pool_client_ranges -j

# this container's RC queues are smaller than mori-io's defaults
export MORI_IO_QP_MAX_SEND_WR=256 MORI_IO_QP_MAX_RECV_WR=256 MORI_IO_QP_MAX_CQE=1024
POOLS='c4:30:37440:2/2;c4_indexer:30:8448:2/2;c128:31:1728:0,1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59'
B=./build/tests/cpp/umbp/distributed/bench_umbp_pool_client_ranges

# distributed mode, every key on the reading node
$B --pools "$POOLS" --ranks 1,2,4,8 --pages 32 --requests 2 --offload-ranks 0 --local-only
# local mode, same loop and shapes -- the deployment comparison
$B --pools "$POOLS" --ranks 1,2,4,8 --pages 32 --requests 2 --offload-ranks 0 --local-mode
# must not regress: the remote path
$B --pools "$POOLS" --ranks 1,2,4,8 --pages 32 --requests 2 --offload-ranks 0
# byte check: recomputes every restored page against a position-dependent seed
$B --pools "$POOLS" --ranks 8 --pages 32 --requests 2 --offload-ranks 0 --local-only --verify
```

Correctness was checked on six shapes (real geometry distributed-local,
distributed-remote and local-mode, uniform local, `--layer-group 1`, and the
8,448 B small-object pool), and the ranged suite was also run with the
non-temporal path disabled and with the fan-out off, to confirm neither knob is
load-bearing for correctness.

## Test Result

**Single-machine, DeepSeek-V4-Pro geometry, 32 pages/request, layer groups of 8.**
`restore` includes a fixed 9.15 ms of simulated compute (61 layers × 150 us).

| ranks | restore ms | | TTFL us | |
|---|---|---|---|---|
| 1 | 11.51 → **9.70** | 1.19× | 1327 → **509** | **2.61×** |
| 2 | 12.24 → **9.74** | 1.26× | 1395 → **562** | **2.48×** |
| 4 | 12.70 → **9.78** | 1.30× | 1465 → **597** | **2.45×** |
| 8 | 13.54 → **9.98** | 1.36× | 1771 → **769** | **2.30×** |

Subtracting the fixed compute, the load itself goes **2.36 → 0.55 ms** at 1 rank
and **4.39 → 0.83 ms** at 8 — **4.3×** and **5.3×**.

### Against local mode

Same loop, same shapes, only the deployment differs (restore ms / TTFL us):

| ranks | local mode | distributed, before | distributed, after |
|---|---|---|---|
| 1 | 9.93 / 722 | 11.51 / 1327 | **9.70 / 509** |
| 2 | 10.10 / 908 | 12.24 / 1395 | **9.74 / 562** |
| 4 | 10.74 / 1220 | 12.70 / 1465 | **9.78 / 597** |
| 8 | 17.57 / 1711 | 13.54 / 1771 | **9.98 / 769** |

Distributed mode used to cost 1.8× the TTFL of local mode at one rank. It is now
ahead of local at every rank count, by 1.4× at one rank and 2.2× at eight.

Local mode did not move — it is untouched by this PR — and its own profile
(`UMBP_DRAM_PROFILE=1`) says why it is now behind. At 8 ranks its `DRAMTier`
spends 92% of a batch in the copy, at 3.0 GB/s per stream, plus 7% classifying
pointers, with **zero** lock wait. Those are the same three costs this series
removed from the distributed path — a non-temporal threshold set for whole-page
copies, a HIP pointer query per range, and threads spawned per call. Local mode
still has all three; carrying the fixes across is separate work, and commit 7 is
what makes it measurable.

Worth noting for anyone reading commit 3: local mode is where the idea of
fanning the copy out came from, but its implementation spawns threads per call,
which measured *worse than not parallelizing*. The distributed path uses a
persistent pool instead, which is why it now beats the thing it borrowed from.

**Remote path** (not the target; must not regress):

| ranks | restore ms | TTFL us |
|---|---|---|
| 1 | 16.56 → 12.07 | 2539 → 2456 |
| 2 | 30.60 → 26.34 | 3384 → 3289 |
| 4 | 49.27 → 47.37 | 6569 → 5311 |
| 8 | 85.10 → 86.01 | 13010 → 12988 |

Improves or holds. The 8-rank restore reads 1% worse, which is inside this
machine's spread — repeated runs of that cell landed between 80.2 and 86.0 ms
on both sides.

**Suites** — all pass:

| | |
|---|---|
| `test_umbp_pool_client_ranges` | 24 |
| `test_umbp_range_map` | 13 |
| `test_umbp_ssd_ranged_io` | 6 |
| `test_umbp_cross_node_smoke` | 19 |
| `test_umbp_pool_client_batch_put` | 9 |
| `test_umbp_medium_selection` | 9 |
| `test_umbp_client_metrics` | 9 |
| `test_component_metrics` | 19 |
| `test_standalone_shm_ipc` | 9 |
| `test_umbp_dram_tier_ranges` | 13 |

`test_umbp_pool_client_ranges` additionally passes with
`UMBP_DRAM_NT_COPY_MIN_BYTES` set past every fragment size and with
`UMBP_DRAM_COPY_THREADS=1`.

**Byte verification**: 0 mismatched pages on all six shapes, local mode included.

Note that `test_standalone_shm_ipc` is not matched by CI's
`ctest -R '^(umbp_|test_dummy_ssd_tier|test_prefix_aware_eviction|test_ssd_tier)'`
filter, since its registered name does not start with `umbp_`. It exercises the
registration path commit 4 changes, so it was run by hand; renaming it is
outside this PR.

### Not in this PR

**Put.** `BatchPutRanges` is untouched and does not benefit: measured, a local
ranged put spends 81% in per-key `BatchAllocate` and 18% in the unconditional
`BatchRoutePut` RPC, and 0.2% in the code this PR changes. Fixing it means
batching the backend calls and letting a local allocation answer before the
master is asked — the latter is safe (`Router::BatchRoutePut` is read-only; the
global index is populated by the commit-time `KvEvent::ADD`) but gives up
cross-node dedup and placement balancing, so it wants its own PR and a config
gate.

That work needs the bench fixed first: with the default offload load the node's
medium fills, every `BatchAllocate` returns no-space, and the puts fail
silently — the bench only accumulates successful bytes, so it reports
`put_gibps=0` rather than an error. Anyone reading the put half of this bench's
output today is reading nothing.

**Local mode's copy path.** The three fixes in commits 2–4 apply just as well to
`DRAMTier`, which still has the 256 KiB non-temporal threshold, a
`DetectPointerLocation` per copy job, and a spawn-per-call fan-out. That is a
different file with different callers and belongs in its own change.

**`TransferRef` weight.** The 8.5 us of `build` that remains is mostly copying
`MemoryDesc` (three `std::string`s plus two 64 B arrays) twice per item. Holding
it by `shared_ptr` would roughly halve that, but weighted by call count `build`
is about 12% of the total, so the payoff is ~6% — against changing a struct the
RDMA path shares, whose only coverage is a same-host two-client smoke test. Not
worth it here.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
