### PR TITLE
[AMD][DSV4] fix: recognize fp4_blockwise in the AUTO tuning config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,15 @@ jobs:
             cd $GITHUB_WORKSPACE && MORI_DISABLE_P2P=1 MORI_ENABLE_SDMA=0 timeout 300 pytest tests/python/ops/test_dispatch_combine_async_ll.py -v
           "
 
+      - name: MORI-EP (AUTO tuning config quant types, CPU)
+        run: |
+          # Pure mapping test: no GPU, no RDMA. Named explicitly because the
+          # only directory-level collection in this workflow is tests/python/io,
+          # so a file elsewhere under tests/python runs nowhere by default.
+          $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "
+            cd $GITHUB_WORKSPACE && timeout 60 pytest tests/python/test_tuning_config_quant_types.py -v
+          "
+
       - name: MORI-EP bench
         run: |
           $CT exec -e PYTHONPATH=$GITHUB_WORKSPACE $CONTAINER bash -c "

--- a/python/mori/ops/tuning_config.py
+++ b/python/mori/ops/tuning_config.py
@@ -88,7 +88,12 @@ _KERNEL_TYPE_NAMES = frozenset(
     {"IntraNode", "InterNode", "InterNodeV1", "InterNodeV1LL", "AsyncLL", "IntraNodeLL"}
 )
 
-_QUANT_TYPE_CONFIG_STRS = {"none", "fp8_direct_cast", "fp8_blockwise"}
+_QUANT_TYPE_CONFIG_STRS = {
+    "none",
+    "fp8_direct_cast",
+    "fp8_blockwise",
+    "fp4_blockwise",
+}
 
 
 def kernel_type_to_config_str(kernel_type) -> str:
@@ -118,6 +123,8 @@ def quant_type_to_config_str(quant_type) -> str:
             return "fp8_direct_cast"
         if name == "Fp8BlockwiseQuant":
             return "fp8_blockwise"
+        if name == "Fp4BlockwiseQuant":
+            return "fp4_blockwise"
     raise ValueError(f"Unknown quant_type: {quant_type!r}")
 
 

--- a/python/mori/ops/tuning_config.py
+++ b/python/mori/ops/tuning_config.py
@@ -88,12 +88,18 @@ _KERNEL_TYPE_NAMES = frozenset(
     {"IntraNode", "InterNode", "InterNodeV1", "InterNodeV1LL", "AsyncLL", "IntraNodeLL"}
 )
 
-_QUANT_TYPE_CONFIG_STRS = {
-    "none",
-    "fp8_direct_cast",
-    "fp8_blockwise",
-    "fp4_blockwise",
+# Single source for the quant-type mapping. Keyed by EpDispatchCombineQuantType
+# member name; the accepted config strings are derived rather than restated,
+# because holding the two in separate literals is what let them drift apart
+# (fp4_blockwise reached dispatch_combine.py but never the enum branch here).
+_QUANT_ENUM_TO_CONFIG_STR = {
+    "None_": "none",
+    "Fp8DirectCast": "fp8_direct_cast",
+    "Fp8BlockwiseQuant": "fp8_blockwise",
+    "Fp4BlockwiseQuant": "fp4_blockwise",
 }
+
+_QUANT_TYPE_CONFIG_STRS = frozenset(_QUANT_ENUM_TO_CONFIG_STR.values())
 
 
 def kernel_type_to_config_str(kernel_type) -> str:
@@ -117,14 +123,8 @@ def quant_type_to_config_str(quant_type) -> str:
             return "none"
     else:
         name = getattr(quant_type, "name", str(quant_type))
-        if name == "None_":
-            return "none"
-        if name == "Fp8DirectCast":
-            return "fp8_direct_cast"
-        if name == "Fp8BlockwiseQuant":
-            return "fp8_blockwise"
-        if name == "Fp4BlockwiseQuant":
-            return "fp4_blockwise"
+        if name in _QUANT_ENUM_TO_CONFIG_STR:
+            return _QUANT_ENUM_TO_CONFIG_STR[name]
     raise ValueError(f"Unknown quant_type: {quant_type!r}")
 
 

--- a/tests/python/test_tuning_config_quant_types.py
+++ b/tests/python/test_tuning_config_quant_types.py
@@ -1,0 +1,75 @@
+"""Regression tests for quant_type normalization in the AUTO tuning config.
+
+`quant_type_to_config_str` translates a quant type into the string the tuned
+lookup tables are keyed by. `dispatch_combine.py` gained full `fp4_blockwise`
+support -- `_QUANT_TYPE_MAP`, `_BLOCKWISE_COMBINE_QUANT_TYPES`,
+`_FP4_COMBINE_KERNELS` -- but this function was not updated alongside it, so
+passing `Fp4BlockwiseQuant` raised `ValueError`.
+
+That mattered more than a missing combine lookup: the exception escapes before
+*either* table is consulted, so a config using fp4 blockwise combine silently
+lost its tuned **dispatch** rules as well and fell back to hard-coded launch
+geometry. Nothing failed loudly; the only symptom was lost throughput.
+
+These pin both directions of the mapping and, deliberately, that a genuinely
+unknown type still raises -- the fix must not degrade into accepting anything.
+"""
+
+import pytest
+
+from mori.ops.dispatch_combine import EpDispatchCombineQuantType
+from mori.ops.tuning_config import (
+    _QUANT_TYPE_CONFIG_STRS,
+    quant_type_to_config_str,
+)
+
+
+@pytest.mark.parametrize(
+    "quant_type,expected",
+    [
+        (EpDispatchCombineQuantType.None_, "none"),
+        (EpDispatchCombineQuantType.Fp8DirectCast, "fp8_direct_cast"),
+        (EpDispatchCombineQuantType.Fp8BlockwiseQuant, "fp8_blockwise"),
+        (EpDispatchCombineQuantType.Fp4BlockwiseQuant, "fp4_blockwise"),
+    ],
+)
+def test_enum_maps_to_config_str(quant_type, expected):
+    """Every quant type dispatch_combine knows must be nameable here, or its
+    config silently loses tuned rules."""
+    assert quant_type_to_config_str(quant_type) == expected
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("none", "none"),
+        ("none_", "none"),
+        ("fp8_direct_cast", "fp8_direct_cast"),
+        ("fp8_blockwise", "fp8_blockwise"),
+        ("fp4_blockwise", "fp4_blockwise"),
+        ("  FP4_BlockWise  ", "fp4_blockwise"),
+    ],
+)
+def test_string_forms_normalize(text, expected):
+    assert quant_type_to_config_str(text) == expected
+
+
+def test_every_mapped_enum_is_in_the_config_str_set():
+    """The set gates the string path; a member reachable by enum but absent from
+    the set would normalize inconsistently depending on how it was supplied."""
+    # pybind11 enums are not directly iterable; go through __members__.
+    for quant_type in EpDispatchCombineQuantType.__members__.values():
+        try:
+            got = quant_type_to_config_str(quant_type)
+        except ValueError:
+            continue
+        assert got in _QUANT_TYPE_CONFIG_STRS
+
+
+@pytest.mark.parametrize("bad", ["", "fp16_blockwise", "fp4", "totally_unknown"])
+def test_unknown_quant_types_still_raise(bad):
+    """The fix adds one mapping; it must not turn this into a function that
+    accepts anything. An unnamed type should fail loudly rather than key the
+    lookup on a string no table contains."""
+    with pytest.raises(ValueError):
+        quant_type_to_config_str(bad)

--- a/tests/python/test_tuning_config_quant_types.py
+++ b/tests/python/test_tuning_config_quant_types.py
@@ -28,9 +28,11 @@ support -- `_QUANT_TYPE_MAP`, `_BLOCKWISE_COMBINE_QUANT_TYPES`,
 passing `Fp4BlockwiseQuant` raised `ValueError`.
 
 That mattered more than a missing combine lookup: the exception escapes before
-*either* table is consulted, so a config using fp4 blockwise combine silently
-lost its tuned **dispatch** rules as well and fell back to hard-coded launch
-geometry. Nothing failed loudly; the only symptom was lost throughput.
+*either* table is consulted, so a config using fp4 blockwise combine also lost
+its tuned **dispatch** rules and fell back to hard-coded launch geometry. The
+only signal is one `logger.warning` from the `except` in `dispatch_combine.py`
+("AUTO tuning: failed to load config"); results stay correct, so the cost is
+throughput nobody is looking for.
 
 These pin both directions of the mapping and, deliberately, that a genuinely
 unknown type still raises -- the fix must not degrade into accepting anything.
@@ -74,16 +76,20 @@ def test_string_forms_normalize(text, expected):
     assert quant_type_to_config_str(text) == expected
 
 
-def test_every_mapped_enum_is_in_the_config_str_set():
-    """The set gates the string path; a member reachable by enum but absent from
-    the set would normalize inconsistently depending on how it was supplied."""
+def test_every_enum_member_maps_into_the_config_str_set():
+    """Every member must map, and map into the set that gates the string path.
+
+    Deliberately no try/except around the call: an unmapped member is exactly
+    the defect this PR fixes, so swallowing its ValueError would make the test
+    green for the very drift it exists to catch. A member added to the enum
+    without a mapping must fail here.
+    """
     # pybind11 enums are not directly iterable; go through __members__.
-    for quant_type in EpDispatchCombineQuantType.__members__.values():
-        try:
-            got = quant_type_to_config_str(quant_type)
-        except ValueError:
-            continue
-        assert got in _QUANT_TYPE_CONFIG_STRS
+    for name, quant_type in EpDispatchCombineQuantType.__members__.items():
+        got = quant_type_to_config_str(quant_type)
+        assert (
+            got in _QUANT_TYPE_CONFIG_STRS
+        ), f"{name} maps to {got!r}, which is not an accepted config string"
 
 
 @pytest.mark.parametrize("bad", ["", "fp16_blockwise", "fp4", "totally_unknown"])

--- a/tests/python/test_tuning_config_quant_types.py
+++ b/tests/python/test_tuning_config_quant_types.py
@@ -1,3 +1,24 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 """Regression tests for quant_type normalization in the AUTO tuning config.
 
 `quant_type_to_config_str` translates a quant type into the string the tuned
@@ -16,7 +37,6 @@ unknown type still raises -- the fix must not degrade into accepting anything.
 """
 
 import pytest
-
 from mori.ops.dispatch_combine import EpDispatchCombineQuantType
 from mori.ops.tuning_config import (
     _QUANT_TYPE_CONFIG_STRS,


### PR DESCRIPTION
dispatch_combine.py supports fp4_blockwise combine throughout -- _QUANT_TYPE_MAP, _BLOCKWISE_COMBINE_QUANT_TYPES, _FP4_COMBINE_KERNELS -- but quant_type_to_config_str was never updated alongside it. Its enum branch stops at Fp8BlockwiseQuant and falls through to `raise ValueError`, so a config using fp4 blockwise combine cannot be normalized into the string the tuned tables are keyed by.

The cost is larger than a missing combine lookup. The exception escapes before either table is consulted, so such a config also loses its tuned *dispatch* rules and falls back to hard-coded launch geometry. The only signal is one  WARNING line from the enclosing `except` ("AUTO tuning: failed to load config"); results are unaffected, so the cost is throughput nobody is looking for.
Note on scope: no shipped config under `tuning_configs/` contains fp4_blockwise` (only `none` and `fp8_direct_cast`), so the combine lookup for fp4 still misses and falls back. The throughput recovered here is on dispatch.

Add "fp4_blockwise" to _QUANT_TYPE_CONFIG_STRS and the matching Fp4BlockwiseQuant enum branch, so both the string and enum forms normalize consistently.

Genuinely unknown quant types still raise: this closes a gap between two modules that had drifted apart, it does not make the function permissive.

Adds tests/python/test_tuning_config_quant_types.py covering both directions of every mapped type, the invariant that anything nameable by enum is also in the string set, and that unknown types still raise.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
