### PR TITLE
perf(ep): rework how EP tuning picks and saves, remove small-token host overhead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ python/mori/tools/mori.conf
 
 # crash core dumps
 core.*
+
+# Tuning/bench tool output (tools/*_tuning.sh, tools/verify_tuned_config.sh)
+/logs/

--- a/docs/MORI-EP-GUIDE.md
+++ b/docs/MORI-EP-GUIDE.md
@@ -689,18 +689,30 @@ bash tools/batch_internode_tuning.sh \
     --tokens-list "128,4096" --tuning-scope full
 ```
 
-**Step 2: Quick sweep**
+**Step 2: Sweep**
 
 ```bash
 # Single group
 bash tools/batch_internode_tuning.sh \
     --master-addr <HOST0> --peer-host <USER>@<HOST1> --ifname <IFNAME> \
     --kernel-type v1 --num-qp 2 --dtype fp4 --combine-dtype bf16 \
-    --quant-type fp8_direct_cast --tuning-scope quick
+    --quant-type fp8_direct_cast
 
 # All 6 groups at once
 bash tools/run_all_internode_tuning.sh \
     --master-addr <HOST0> --peer-host <USER>@<HOST1> --ifname <IFNAME>
+```
+
+Both default to `--tuning-scope full`. `quick` sweeps a reduced candidate
+grid — 3 `warp_per_block` values against full's 5, plus a narrower
+`rdma_block_num` set — so its winner is not a result worth committing, and
+combining it with a config output is rejected rather than silently accepted.
+Use it for exploration only, with saving turned off:
+
+```bash
+bash tools/run_all_internode_tuning.sh \
+    --master-addr <HOST0> --peer-host <USER>@<HOST1> --ifname <IFNAME> \
+    --tuning-scope quick --config-output ''
 ```
 
 For docker environments, add `--docker <CONTAINER> --ssh-key <KEY>`.

--- a/docs/MORI-EP-GUIDE.md
+++ b/docs/MORI-EP-GUIDE.md
@@ -595,16 +595,19 @@ Each file contains rules sorted by (dtype, hidden_dim, num_tokens):
       "rdma_block_num": 32,
       "warp_per_block": 8,
       "bandwidth_gbps": 4.13,
-      "rdma_bandwidth_gbps": 4.13,
-      "xgmi_bandwidth_gbps": 13.2,
-      "ll_bandwidth_gbps": 16.5
+      "avg_rdma_bandwidth_gbps": 4.13,
+      "avg_xgmi_bandwidth_gbps": 13.2,
+      "avg_ll_bandwidth_gbps": 16.5,
+      "avg_latency_us": 128.4,
+      "bandwidth_metric": "grand_mean"
     }
   ]
 }
 ```
 
 - `bandwidth_gbps` — The bandwidth that matters for this kernel (RDMA BW for v1, LL BW for v1_ll/async_ll), recorded for readers. Nothing reads it at runtime: only `block_num` / `rdma_block_num` / `warp_per_block` are.
-- `rdma_bandwidth_gbps` / `xgmi_bandwidth_gbps` / `ll_bandwidth_gbps` — All three BW types recorded for analysis (inter-node only).
+- `avg_rdma_bandwidth_gbps` / `avg_xgmi_bandwidth_gbps` / `avg_ll_bandwidth_gbps` — All three BW types recorded for analysis (inter-node only).
+- `avg_latency_us` — Grand-mean latency, the quantity the inter-node tuner selects on. The intra-node tuner writes this as `latency_us`.
 
 New tuning results replace the matching rule unconditionally, printing the old and new config and their latency/bandwidth delta. Two tuning runs come from different hosts, ROCm versions and machine load, so no numeric rule can reliably decide whether a new result is worth keeping — the JSON's git diff is where that call gets made. Re-run tuning if a printed delta looks wrong.
 
@@ -715,7 +718,34 @@ bash tools/run_all_internode_tuning.sh \
     --tuning-scope quick --config-output ''
 ```
 
-For docker environments, add `--docker <CONTAINER> --ssh-key <KEY>`.
+For docker environments, add `--docker <PEER_CONTAINER>`. If the driver node
+also runs mori inside a container, add `--local-docker <RANK0_CONTAINER>`
+rather than invoking the script from inside that container — the peer is
+reached over SSH, so a containerised driver would need its own SSH key to the
+other node. `--ssh-key <KEY>` is only needed when the driver's default key is
+not the right one. Set the RDMA traffic class with `--rdma-tc <TC>` (and the
+service level with `--rdma-sl <SL>`); these are passed through to both ranks,
+which do **not** inherit the caller's environment.
+
+**Step 3: Verify what was written**
+
+The sweep only times each candidate — `run_bench_once` never compares output,
+so nothing in tuning itself confirms the winning geometry is correct. Check the
+JSON before committing it:
+
+```bash
+bash tools/verify_tuned_config.sh \
+    --master-addr <HOST0> --peer-host <USER>@<HOST1> --ifname <IFNAME> \
+    --local-docker <RANK0_CONTAINER> --docker <PEER_CONTAINER> \
+    --kernel-type v1_ll --num-qp 1 --dtype fp8_e4m3_fnuz \
+    --combine-dtype bf16 --quant-type none \
+    --tokens-list "4,8,16,32" --hidden-dims "6144"
+```
+
+It re-runs each shape under `MORI_EP_LAUNCH_CONFIG_MODE=AUTO` with `--cmd test`,
+so every op is built from whatever the JSON now holds and 500 rounds of
+dispatch/combine output are compared against expected values. Exit status is
+non-zero if any shape crashes, hangs, or produces wrong output.
 
 **Scripts:**
 
@@ -723,6 +753,7 @@ For docker environments, add `--docker <CONTAINER> --ssh-key <KEY>`.
 |--------|---------|
 | `tools/batch_internode_tuning.sh` | Sweep one (kernel, dtype, quant) group across all token sizes |
 | `tools/run_all_internode_tuning.sh` | Run all 6 inter-node groups sequentially |
+| `tools/verify_tuned_config.sh` | Correctness-check the saved configs before committing them |
 
 ### Tuning on a New GPU Platform
 

--- a/docs/MORI-EP-GUIDE.md
+++ b/docs/MORI-EP-GUIDE.md
@@ -603,10 +603,12 @@ Each file contains rules sorted by (dtype, hidden_dim, num_tokens):
 }
 ```
 
-- `bandwidth_gbps` — The primary metric used for keep-best comparison (RDMA BW for v1, LL BW for v1_ll/async_ll).
+- `bandwidth_gbps` — The bandwidth that matters for this kernel (RDMA BW for v1, LL BW for v1_ll/async_ll), recorded for readers. Nothing reads it at runtime: only `block_num` / `rdma_block_num` / `warp_per_block` are.
 - `rdma_bandwidth_gbps` / `xgmi_bandwidth_gbps` / `ll_bandwidth_gbps` — All three BW types recorded for analysis (inter-node only).
 
-New tuning results merge into existing files using a keep-best strategy: a rule is only updated if the new bandwidth exceeds the existing one.
+New tuning results replace the matching rule unconditionally, printing the old and new config and their latency/bandwidth delta. Two tuning runs come from different hosts, ROCm versions and machine load, so no numeric rule can reliably decide whether a new result is worth keeping — the JSON's git diff is where that call gets made. Re-run tuning if a printed delta looks wrong.
+
+> Inter-node `bandwidth_gbps` is the grand mean across ranks and rounds, matching the "Average" row of the table `--cmd bench` prints, so a saved rule can be checked against a bench run directly. Rules carry `bandwidth_metric` recording this; rules written before it existed hold the slowest-rank mean and have no such field, and a re-tune that replaces one prints both bandwidths without a percentage rather than comparing across the two definitions.
 
 ### Intra-node Tuning
 

--- a/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
+++ b/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
@@ -46,38 +46,20 @@ _CLI_TO_KERNEL_TYPE_NAME = {
 
 _FP4_DTYPE = getattr(torch, "float4_e2m1fn_x2", None)
 
-# Relative bandwidth improvement required to update the best config during
-# tuning. Default 0: take any improvement. Raise it (e.g.
-# MORI_EP_TUNING_MARGIN=0.02) to require a clearer win before a config
-# replaces the incumbent.
-#
-# An *absolute* GB/s margin (which this used to be) cannot work at all: 1.0
-# GB/s is ~40% of the total spread at 4 tokens, where the whole sweep lives in
-# 2-3 GB/s, and under 2% at large token counts.
+# Relative bandwidth improvement a candidate needs to replace the current
+# best during tuning. Default 0 (any improvement wins); raise via
+# MORI_EP_TUNING_MARGIN for a clearer-win requirement. Must be relative, not
+# absolute GB/s: a fixed 1.0 GB/s is ~40% of the sweep's spread at 4 tokens
+# but under 2% at large ones.
 _BW_REL_MARGIN = float(os.environ.get("MORI_EP_TUNING_MARGIN", "0.0"))
 
-# Rounds benchmarked per config during tuning, and the statistic used to score
-# each one. Override with MORI_EP_TUNING_ROUNDS / MORI_EP_TUNING_STAT to
-# experiment without editing this file.
-#
-# Default statistic is the mean, matching --cmd bench's own reporting and
-# matching what main always did: the mean is pulled up hard by a single bad
-# round, so a config with a fine typical case but a heavy worst-case tail
-# cannot win on a lucky sample the way it can under a median.
-#
-# This is not a hypothetical tradeoff. A customer's MI308 production run of
-# the median-scored, no-margin tuner picked larger/more-parallel geometries
-# (up to block=80 warp=16 rdma=53) whose median edged out the baseline while
-# their Worst regressed 30-45% at bs=16/32, with Best essentially unchanged --
-# the exact signature median-blind-to-tail selection produces, and not one
-# environment noise alone would produce (noise would not spare Best while
-# inflating Worst for one selection method only). A full-sweep sanity check
-# on an idle 2x8 MI300X pair (no contention, different SKU) did not reproduce
-# the same magnitude, so treat the mechanism as demonstrated and the exact
-# severity as hardware/load dependent, not as bounded by that check.
-#
-# MORI_EP_TUNING_STAT=median restores the previous behaviour for anyone who
-# still wants resistance to a single stalled round instead of tail-awareness.
+# Rounds per candidate and the statistic used to score it. Override with
+# MORI_EP_TUNING_ROUNDS / MORI_EP_TUNING_STAT. Default statistic is mean,
+# matching --cmd bench and main: mean is pulled up by one bad round, so it
+# penalizes a config with a good typical case but a bad worst-case tail;
+# median can't see that tail at all. MORI_EP_TUNING_STAT=median restores the
+# tail-blind behavior for anyone who wants single-round outlier resistance
+# instead.
 _TUNING_ROUNDS = int(os.environ.get("MORI_EP_TUNING_ROUNDS", "9"))
 _TUNING_STAT = os.environ.get("MORI_EP_TUNING_STAT", "mean")
 if _TUNING_STAT not in ("mean", "median"):
@@ -89,13 +71,8 @@ if _TUNING_STAT not in ("mean", "median"):
 def _beats(new_bw, new_cfg, best_bw, best_cfg):
     """Should *new_cfg* replace *best_cfg* as the tuning winner?
 
-    A candidate wins outright only when it clears the relative noise margin.
-    Inside the margin the two are statistically indistinguishable, so we break
-    the tie deterministically on block_num (fewer CUs for the same bandwidth
-    leaves more of the GPU for overlapping work) instead of letting whichever
-    sample happened to land higher decide. Determinism matters as much as the
-    choice itself: it is what stops the saved JSON from churning between
-    equivalent configs on every re-tune.
+    Wins outright past the margin; within it, ties break on smaller
+    block_num so re-tuning the same hardware is deterministic.
     """
     if best_cfg is None:
         return True

--- a/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
+++ b/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
@@ -46,12 +46,18 @@ _CLI_TO_KERNEL_TYPE_NAME = {
 
 _FP4_DTYPE = getattr(torch, "float4_e2m1fn_x2", None)
 
-# Bandwidth improvement must exceed this *relative* margin to update the best
-# config during tuning. An absolute GB/s margin cannot work across the whole
-# operating range: 1.0 GB/s is ~40% of the total spread at 4 tokens (where the
-# whole sweep lives in 2-3 GB/s) and <2% at large token counts, so the same
-# constant is simultaneously far too strict and far too loose.
-_BW_REL_MARGIN = 0.02
+# Relative bandwidth improvement required to update the best config during
+# tuning. Default 0: take any improvement, which is what you want when tuning
+# to find the fastest config. Raise it (e.g. MORI_EP_TUNING_MARGIN=0.02) to
+# trade a little peak performance for stability -- run-to-run spread here is
+# 10-20%, so with no margin the winner is partly whichever config drew the
+# luckiest sample. The median-over-rounds scoring below is the primary defence
+# against that; the margin is a second, optional one.
+#
+# An *absolute* GB/s margin (which this used to be) cannot work at all: 1.0
+# GB/s is ~40% of the total spread at 4 tokens, where the whole sweep lives in
+# 2-3 GB/s, and under 2% at large token counts.
+_BW_REL_MARGIN = float(os.environ.get("MORI_EP_TUNING_MARGIN", "0.0"))
 
 # Rounds benchmarked per config during tuning. Scored by median across rounds
 # (not mean) so a single stalled round cannot decide the winner.

--- a/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
+++ b/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
@@ -47,21 +47,43 @@ _CLI_TO_KERNEL_TYPE_NAME = {
 _FP4_DTYPE = getattr(torch, "float4_e2m1fn_x2", None)
 
 # Relative bandwidth improvement required to update the best config during
-# tuning. Default 0: take any improvement, which is what you want when tuning
-# to find the fastest config. Raise it (e.g. MORI_EP_TUNING_MARGIN=0.02) to
-# trade a little peak performance for stability -- run-to-run spread here is
-# 10-20%, so with no margin the winner is partly whichever config drew the
-# luckiest sample. The median-over-rounds scoring below is the primary defence
-# against that; the margin is a second, optional one.
+# tuning. Default 0: take any improvement. Raise it (e.g.
+# MORI_EP_TUNING_MARGIN=0.02) to require a clearer win before a config
+# replaces the incumbent.
 #
 # An *absolute* GB/s margin (which this used to be) cannot work at all: 1.0
 # GB/s is ~40% of the total spread at 4 tokens, where the whole sweep lives in
 # 2-3 GB/s, and under 2% at large token counts.
 _BW_REL_MARGIN = float(os.environ.get("MORI_EP_TUNING_MARGIN", "0.0"))
 
-# Rounds benchmarked per config during tuning. Scored by median across rounds
-# (not mean) so a single stalled round cannot decide the winner.
-_TUNING_ROUNDS = 9
+# Rounds benchmarked per config during tuning, and the statistic used to score
+# each one. Override with MORI_EP_TUNING_ROUNDS / MORI_EP_TUNING_STAT to
+# experiment without editing this file.
+#
+# Default statistic is the mean, matching --cmd bench's own reporting and
+# matching what main always did: the mean is pulled up hard by a single bad
+# round, so a config with a fine typical case but a heavy worst-case tail
+# cannot win on a lucky sample the way it can under a median.
+#
+# This is not a hypothetical tradeoff. A customer's MI308 production run of
+# the median-scored, no-margin tuner picked larger/more-parallel geometries
+# (up to block=80 warp=16 rdma=53) whose median edged out the baseline while
+# their Worst regressed 30-45% at bs=16/32, with Best essentially unchanged --
+# the exact signature median-blind-to-tail selection produces, and not one
+# environment noise alone would produce (noise would not spare Best while
+# inflating Worst for one selection method only). A full-sweep sanity check
+# on an idle 2x8 MI300X pair (no contention, different SKU) did not reproduce
+# the same magnitude, so treat the mechanism as demonstrated and the exact
+# severity as hardware/load dependent, not as bounded by that check.
+#
+# MORI_EP_TUNING_STAT=median restores the previous behaviour for anyone who
+# still wants resistance to a single stalled round instead of tail-awareness.
+_TUNING_ROUNDS = int(os.environ.get("MORI_EP_TUNING_ROUNDS", "9"))
+_TUNING_STAT = os.environ.get("MORI_EP_TUNING_STAT", "mean")
+if _TUNING_STAT not in ("mean", "median"):
+    raise ValueError(
+        f"MORI_EP_TUNING_STAT must be 'mean' or 'median', got {_TUNING_STAT!r}"
+    )
 
 
 def _beats(new_bw, new_cfg, best_bw, best_cfg):
@@ -1536,15 +1558,18 @@ class EpDispatchCombineTestCase:
                     # kept: (rounds, world_size, 6)
                     # cols: d_rdma, d_xgmi, d_lat, c_rdma, c_xgmi, c_lat
 
-                    # Selection: per-rank median across kept rounds, min rank.
-                    # Median (not mean) so one stalled round cannot decide a config.
-                    rank_meds = kept.median(dim=0).values  # (world_size, 6)
-                    if is_ll_kernel:
-                        disp_bw = (rank_meds[:, 1] * ll_scale).min().item()
-                        comb_bw = (rank_meds[:, 4] * ll_scale).min().item()
+                    # Selection: per-rank stat across kept rounds, min rank. See
+                    # _TUNING_STAT above for why mean is the default.
+                    if _TUNING_STAT == "median":
+                        rank_stat = kept.median(dim=0).values  # (world_size, 6)
                     else:
-                        disp_bw = rank_meds[:, 0].min().item()
-                        comb_bw = rank_meds[:, 3].min().item()
+                        rank_stat = kept.mean(dim=0)  # (world_size, 6)
+                    if is_ll_kernel:
+                        disp_bw = (rank_stat[:, 1] * ll_scale).min().item()
+                        comb_bw = (rank_stat[:, 4] * ll_scale).min().item()
+                    else:
+                        disp_bw = rank_stat[:, 0].min().item()
+                        comb_bw = rank_stat[:, 3].min().item()
 
                     # Stats via shared code (same as bench PrettyTable)
                     disp_stats = self._build_phase_stats(kept, 0, 1, 2, ll_scale)

--- a/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
+++ b/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
@@ -94,12 +94,20 @@ def _beats(new_lat, new_cfg, best_lat, best_cfg):
 
     Wins outright past the margin; within it, ties break on the
     lexicographically smaller (block_num, warp_per_block, rdma_block_num)
-    tuple so re-tuning the same hardware is deterministic regardless of sweep
-    order. (Comparing only new_cfg[0] here used to be equivalent to a no-op:
-    the sweep visits block_num in ascending order, so a later candidate's
-    block_num is never smaller than the incumbent's -- the full-tuple
-    comparison actually does the tie-break instead of relying on visitation
-    order, so this keeps working if the sweep is ever parallelized.)
+    tuple, so a tie resolves to the smaller geometry rather than to whichever
+    candidate happened to be measured first.
+
+    The tie-break cannot fire under the current sweep, which visits
+    block/warp/rdma in ascending order: new_cfg is then always greater than
+    best_cfg. That is deliberate, not an accident to rely on -- but note what
+    would happen if the sweep were reordered or parallelized. The caller
+    overwrites best_lat with the winner's latency, so a tie-break win at
+    MORI_EP_TUNING_MARGIN > 0 installs a *worse* latency as the new baseline,
+    and the next comparison is made against it: the incumbent can ratchet
+    steadily worse, each step individually "within the margin". Before
+    changing the visit order, split the comparison baseline from the selected
+    candidate -- keep the best latency ever seen for the margin test and let
+    only cfg/stats follow the tie-break.
     """
     if best_cfg is None:
         return True
@@ -139,8 +147,8 @@ def _headline_bw(stats, kernel_type):
     Rules already on disk keep their slowest-rank value until re-tuned, so
     bandwidth_gbps is only comparable within one tuning run's output -- which
     is all it was ever good for, given two runs come from different hosts and
-    load. The slowest-rank figure is still printed per candidate for reference
-    (see the sweep's summary), just not saved.
+    load. The slowest-rank figure is still printed next to the winner in the
+    sweep's summary, as a straggler check, just not saved.
     """
     return stats["ll"][2] if _is_ll_kernel(kernel_type) else stats["rdma"][2]
 

--- a/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
+++ b/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
@@ -1576,7 +1576,7 @@ class EpDispatchCombineTestCase:
                         print(
                             f"\n{'=' * 60}\n"
                             f"[{config_idx}/{total_configs}] "
-                            f"block_num={bn}, warp={warp}, rdma_block_num={rdma_bn}\n"
+                            f"block={bn} warp={warp} rdma={rdma_bn}\n"
                             f"{'=' * 60}"
                         )
                     bench_result = self.run_bench_once(

--- a/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
+++ b/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
@@ -1493,12 +1493,21 @@ class EpDispatchCombineTestCase:
     def tuning_dispatch_combine(
         self, max_num_token, save_tuning_config=None, skip_verify=False
     ):
+        tuning_scope = os.environ.get("MORI_TUNING_SCOPE", "full")
+        if save_tuning_config and tuning_scope == "quick":
+            raise ValueError(
+                "MORI_TUNING_SCOPE=quick cannot be combined with "
+                "--save-tuning-config: quick only sweeps 3 warp_per_block "
+                "candidates against full's 5, plus a narrower rdma_block_num "
+                "set, so a quick-scope winner is not a result worth "
+                "committing as a saved config. Re-run with MORI_TUNING_SCOPE "
+                "unset (or =full) to save."
+            )
+
         op = mori.ops.EpDispatchCombineOp(self.config)
         sm_count = torch.cuda.get_device_properties(
             self.rank % self.gpu_per_node
         ).multi_processor_count
-
-        tuning_scope = os.environ.get("MORI_TUNING_SCOPE", "full")
 
         block_set = set()
         # Small-block candidates below the doubling sequence's usual 32 floor.

--- a/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
+++ b/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
@@ -52,7 +52,11 @@ _FP4_DTYPE = getattr(torch, "float4_e2m1fn_x2", None)
 # fixed threshold cannot work across the whole operating range (e.g. a 1.0
 # GB/s bandwidth margin used to be ~40% of the sweep's spread at 4 tokens
 # but under 2% at large ones).
-_TUNING_MARGIN = float(os.environ.get("MORI_EP_TUNING_MARGIN", "0.0"))
+#
+# `os.environ.get(k, default)` only substitutes default when the var is
+# *unset* -- MORI_EP_TUNING_MARGIN="" would reach float("") and crash at
+# import time, so fall back on an empty string too.
+_TUNING_MARGIN = float(os.environ.get("MORI_EP_TUNING_MARGIN") or "0.0")
 
 # Rounds benchmarked per candidate during tuning. Default matches main's
 # longstanding hardcoded value; override with MORI_EP_TUNING_ROUNDS. (This used
@@ -60,7 +64,16 @@ _TUNING_MARGIN = float(os.environ.get("MORI_EP_TUNING_MARGIN", "0.0"))
 # experiment that wanted more samples to resist a single stalled round. Now
 # that selection is back to mean (see _beats), that extra defense isn't doing
 # anything for us, so there's no reason to pay the ~1.8x longer sweep.)
-_TUNING_ROUNDS = int(os.environ.get("MORI_EP_TUNING_ROUNDS", "5"))
+_TUNING_ROUNDS = int(os.environ.get("MORI_EP_TUNING_ROUNDS") or "5")
+if _TUNING_ROUNDS < 2:
+    # tuning_dispatch_combine drops round 0 as in-loop warmup (`kept =
+    # all_data[1:]`, matching what bench does); at 1 round that leaves an
+    # empty tensor and _compute_stats' .min()/.max()/.mean() blow up with a
+    # shape error that says nothing about rounds being the cause.
+    raise ValueError(
+        f"MORI_EP_TUNING_ROUNDS must be >= 2 (round 0 is dropped as warmup), "
+        f"got {_TUNING_ROUNDS}"
+    )
 
 
 def _beats(new_lat, new_cfg, best_lat, best_cfg):
@@ -73,30 +86,47 @@ def _beats(new_lat, new_cfg, best_lat, best_cfg):
     on paper yet look worse in the printed table it was supposedly chosen
     from; using the printed number for both closes that gap by construction.
 
-    Wins outright past the margin; within it, ties break on smaller
-    block_num so re-tuning the same hardware is deterministic.
+    Wins outright past the margin; within it, ties break on the
+    lexicographically smaller (block_num, warp_per_block, rdma_block_num)
+    tuple so re-tuning the same hardware is deterministic regardless of sweep
+    order. (Comparing only new_cfg[0] here used to be equivalent to a no-op:
+    the sweep visits block_num in ascending order, so a later candidate's
+    block_num is never smaller than the incumbent's -- the full-tuple
+    comparison actually does the tie-break instead of relying on visitation
+    order, so this keeps working if the sweep is ever parallelized.)
     """
     if best_cfg is None:
         return True
     if new_lat < best_lat * (1.0 - _TUNING_MARGIN):
         return True
-    if new_lat <= best_lat * (1.0 + _TUNING_MARGIN) and new_cfg[0] < best_cfg[0]:
+    if new_lat <= best_lat * (1.0 + _TUNING_MARGIN) and new_cfg < best_cfg:
         return True
     return False
 
 
 def _headline_bw(stats, kernel_type):
-    """The winner's own avg bandwidth, for the JSON's top-level bandwidth_gbps.
+    """The winner's own bandwidth, for the JSON's top-level bandwidth_gbps.
 
     Selection no longer runs on bandwidth (see _beats), but the saved config
     still wants one representative bandwidth number; per-metric averages
     (rdma/xgmi/ll) are saved alongside it regardless of kernel type.
+
+    Deliberately the slowest-rank mean (stats["*_worst_rank"]), not the
+    grand-mean stats["rdma"/"ll"][2] this file prints as "Average":
+    tuning_config.save_tuning_result gates overwriting an existing rule on
+    `new_bw > old_bw`, and every rule already on disk (including ones this PR
+    doesn't touch, e.g. other GPU models/kernel types) was written under the
+    old, main-derived definition of bandwidth_gbps -- slowest-rank mean
+    bandwidth. Saving the grand mean instead would systematically read higher
+    than a same-performance old entry (grand mean >= slowest-rank mean by
+    construction) and silently overwrite still-good rules on the first re-tune
+    with this code, even with zero real improvement.
     """
     is_ll_kernel = kernel_type in (
         mori.ops.EpDispatchCombineKernelType.InterNodeV1LL,
         mori.ops.EpDispatchCombineKernelType.AsyncLL,
     )
-    return stats["ll"][2] if is_ll_kernel else stats["rdma"][2]
+    return stats["ll_worst_rank"] if is_ll_kernel else stats["rdma_worst_rank"]
 
 
 def _perf_report():
@@ -1350,16 +1380,22 @@ class EpDispatchCombineTestCase:
     def _build_phase_stats(self, kept, col_rdma, col_xgmi, col_lat, ll_scale):
         """Compute (worst, best, avg) stats for one phase from gathered data.
 
-        Returns dict with keys rdma, xgmi, ll, lat — each a (worst, best, avg) tuple.
-        Uses the same ``_compute_stats`` as PrettyTable, so values are identical.
+        Returns dict with keys rdma, xgmi, ll, lat — each a (worst, best, avg)
+        tuple identical to what PrettyTable prints — plus rdma_worst_rank and
+        ll_worst_rank (see _headline_bw for why those need to exist alongside
+        the grand-mean numbers above).
         """
         _s = self._compute_stats
         xgmi_s = _s(kept[:, :, col_xgmi])
+        rdma_worst_rank = kept[:, :, col_rdma].mean(dim=0).min().item()
+        xgmi_worst_rank = kept[:, :, col_xgmi].mean(dim=0).min().item()
         return {
             "rdma": _s(kept[:, :, col_rdma]),
             "xgmi": xgmi_s,
             "ll": tuple(v * ll_scale for v in xgmi_s),
             "lat": _s(kept[:, :, col_lat]),
+            "rdma_worst_rank": rdma_worst_rank,
+            "ll_worst_rank": xgmi_worst_rank * ll_scale,
         }
 
     @staticmethod
@@ -1504,6 +1540,8 @@ class EpDispatchCombineTestCase:
             "xgmi": (0, 0, 0),
             "ll": (0, 0, 0),
             "lat": (0, 0, 0),
+            "rdma_worst_rank": 0,
+            "ll_worst_rank": 0,
         }
         best_disp_stats = dict(_zero_stats)
         best_comb_stats = dict(_zero_stats)

--- a/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
+++ b/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
@@ -46,9 +46,36 @@ _CLI_TO_KERNEL_TYPE_NAME = {
 
 _FP4_DTYPE = getattr(torch, "float4_e2m1fn_x2", None)
 
-# Bandwidth improvement must exceed this margin (GB/s) to update the best
-# config during tuning. Prevents config churn from run-to-run noise.
-_BW_NOISE_MARGIN = 1.0
+# Bandwidth improvement must exceed this *relative* margin to update the best
+# config during tuning. An absolute GB/s margin cannot work across the whole
+# operating range: 1.0 GB/s is ~40% of the total spread at 4 tokens (where the
+# whole sweep lives in 2-3 GB/s) and <2% at large token counts, so the same
+# constant is simultaneously far too strict and far too loose.
+_BW_REL_MARGIN = 0.02
+
+# Rounds benchmarked per config during tuning. Scored by median across rounds
+# (not mean) so a single stalled round cannot decide the winner.
+_TUNING_ROUNDS = 9
+
+
+def _beats(new_bw, new_cfg, best_bw, best_cfg):
+    """Should *new_cfg* replace *best_cfg* as the tuning winner?
+
+    A candidate wins outright only when it clears the relative noise margin.
+    Inside the margin the two are statistically indistinguishable, so we break
+    the tie deterministically on block_num (fewer CUs for the same bandwidth
+    leaves more of the GPU for overlapping work) instead of letting whichever
+    sample happened to land higher decide. Determinism matters as much as the
+    choice itself: it is what stops the saved JSON from churning between
+    equivalent configs on every re-tune.
+    """
+    if best_cfg is None:
+        return True
+    if new_bw > best_bw * (1.0 + _BW_REL_MARGIN):
+        return True
+    if new_bw >= best_bw * (1.0 - _BW_REL_MARGIN) and new_cfg[0] < best_cfg[0]:
+        return True
+    return False
 
 
 def _perf_report():
@@ -1493,7 +1520,7 @@ class EpDispatchCombineTestCase:
                         max_num_token,
                         op,
                         test_data,
-                        repeat=5,
+                        repeat=_TUNING_ROUNDS,
                         block_num=bn,
                         rdma_block_num=rdma_bn,
                         warp_per_block=warp,
@@ -1503,26 +1530,28 @@ class EpDispatchCombineTestCase:
                     # kept: (rounds, world_size, 6)
                     # cols: d_rdma, d_xgmi, d_lat, c_rdma, c_xgmi, c_lat
 
-                    # Selection: per-rank avg across kept rounds, min rank
-                    rank_means = kept.mean(dim=0)  # (world_size, 6)
+                    # Selection: per-rank median across kept rounds, min rank.
+                    # Median (not mean) so one stalled round cannot decide a config.
+                    rank_meds = kept.median(dim=0).values  # (world_size, 6)
                     if is_ll_kernel:
-                        disp_bw = (rank_means[:, 1] * ll_scale).min().item()
-                        comb_bw = (rank_means[:, 4] * ll_scale).min().item()
+                        disp_bw = (rank_meds[:, 1] * ll_scale).min().item()
+                        comb_bw = (rank_meds[:, 4] * ll_scale).min().item()
                     else:
-                        disp_bw = rank_means[:, 0].min().item()
-                        comb_bw = rank_means[:, 3].min().item()
+                        disp_bw = rank_meds[:, 0].min().item()
+                        comb_bw = rank_meds[:, 3].min().item()
 
                     # Stats via shared code (same as bench PrettyTable)
                     disp_stats = self._build_phase_stats(kept, 0, 1, 2, ll_scale)
                     comb_stats = self._build_phase_stats(kept, 3, 4, 5, ll_scale)
 
-                    if disp_bw > best_disp_bw + _BW_NOISE_MARGIN:
+                    cand = (bn, warp, rdma_bn)
+                    if _beats(disp_bw, cand, best_disp_bw, best_disp_config):
                         best_disp_bw = disp_bw
-                        best_disp_config = (bn, warp, rdma_bn)
+                        best_disp_config = cand
                         best_disp_stats = disp_stats
-                    if comb_bw > best_comb_bw + _BW_NOISE_MARGIN:
+                    if _beats(comb_bw, cand, best_comb_bw, best_comb_config):
                         best_comb_bw = comb_bw
-                        best_comb_config = (bn, warp, rdma_bn)
+                        best_comb_config = cand
                         best_comb_stats = comb_stats
 
                     if self.rank == 0:

--- a/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
+++ b/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
@@ -75,6 +75,13 @@ if _TUNING_ROUNDS < 2:
         f"got {_TUNING_ROUNDS}"
     )
 
+# Debug aid only, no effect on selection: print every candidate's full
+# PrettyTable (same _print_phase_table bench uses) instead of just the
+# one-line "disp sel=... comb sel=..." summary, so a candidate's raw
+# Best/Worst/Average can be compared directly against a --cmd bench run of
+# that same block/warp/rdma without re-deriving it from the summary line.
+_TUNING_VERBOSE = os.environ.get("MORI_EP_TUNING_VERBOSE", "0") == "1"
+
 
 def _beats(new_lat, new_cfg, best_lat, best_cfg):
     """Should *new_cfg* replace *best_cfg* as the tuning winner?
@@ -1557,6 +1564,9 @@ class EpDispatchCombineTestCase:
                 self.run_test_once(op, test_data, error_round, wr_i)
             assert len(error_round) == 0, f"Warmup failed: {error_round}"
 
+        disp_dtype_str = str(self.config.data_type).split(".")[-1]
+        comb_dtype_str = str(self.combine_data_type).split(".")[-1]
+
         config_idx = 0
         for bn in block_list:
             for warp in warp_list:
@@ -1609,10 +1619,19 @@ class EpDispatchCombineTestCase:
                             f"comb sel={comb_lat:.1f}us xgmi={ca:.1f}  "
                             f"(best disp={best_disp_lat:.1f}us comb={best_comb_lat:.1f}us)"
                         )
+                        if _TUNING_VERBOSE:
+                            self._print_phase_table(
+                                f"Dispatch ({disp_dtype_str}) "
+                                f"block={bn} warp={warp} rdma={rdma_bn}",
+                                disp_stats,
+                            )
+                            self._print_phase_table(
+                                f"Combine ({comb_dtype_str}) "
+                                f"block={bn} warp={warp} rdma={rdma_bn}",
+                                comb_stats,
+                            )
 
         if self.rank == 0:
-            disp_dtype_str = str(self.config.data_type).split(".")[-1]
-            comb_dtype_str = str(self.combine_data_type).split(".")[-1]
             print(f"\n{'=' * 70}")
             print("Tuning Result (best config chosen by grand-mean latency)")
             print(f"{'=' * 70}")

--- a/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
+++ b/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
@@ -1502,6 +1502,17 @@ class EpDispatchCombineTestCase:
         tuning_scope = os.environ.get("MORI_TUNING_SCOPE", "full")
 
         block_set = set()
+        # Small-block candidates below the doubling sequence's usual 32 floor.
+        # Measured on MI300X EP16 v1_ll (tok=4/8/16/32): 8 loses everywhere;
+        # 16 ties the eventual winner at 4 tokens (48.83 vs 48.46us, within
+        # noise) but is clearly worse from 8 tokens up (e.g. 56.29 vs
+        # 49.01us dispatch at 8 tokens). Left in the sweep rather than
+        # hardcoded per-arch, so a re-tune (including on a different
+        # sm_count like MI308's 80) empirically finds out whether either
+        # actually wins there instead of assuming this MI300X result holds.
+        for extra in (8, 16):
+            if extra < sm_count:
+                block_set.add(extra)
         pow2 = 32
         while pow2 <= sm_count:
             block_set.add(pow2)

--- a/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
+++ b/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
@@ -118,6 +118,21 @@ def _beats(new_lat, new_cfg, best_lat, best_cfg):
     return False
 
 
+def _launch_params_str(block_num, warp_per_block, rdma_block_num):
+    """Render one phase's launch geometry for a table title.
+
+    -1 means "not overridden on the command line", in which case the op resolves
+    the value itself (from the tuning config, else a built-in default), so the
+    number that ends up running is not known here -- say `auto` rather than
+    print -1 as if it were a block count.
+    """
+
+    def _v(x):
+        return "auto" if x is None or x < 0 else str(x)
+
+    return f"block={_v(block_num)} warp={_v(warp_per_block)} rdma={_v(rdma_block_num)}"
+
+
 def _is_ll_kernel(kernel_type):
     return kernel_type in (
         mori.ops.EpDispatchCombineKernelType.InterNodeV1LL,
@@ -1116,9 +1131,12 @@ class EpDispatchCombineTestCase:
         op,
         test_data,
         repeat=10,
-        block_num=-1,
-        rdma_block_num=-1,
-        warp_per_block=-1,
+        disp_block_num=-1,
+        disp_rdma_block_num=-1,
+        disp_warp_per_block=-1,
+        comb_block_num=-1,
+        comb_rdma_block_num=-1,
+        comb_warp_per_block=-1,
     ):
         num_events = 3 * repeat + 1
         events = [torch.cuda.Event(enable_timing=True) for i in range(num_events)]
@@ -1145,9 +1163,9 @@ class EpDispatchCombineTestCase:
                 all_rank_weights[self.rank],
                 all_rank_scales[self.rank],
                 all_rank_indices[self.rank],
-                block_num=block_num,
-                rdma_block_num=rdma_block_num,
-                warp_per_block=warp_per_block,
+                block_num=disp_block_num,
+                rdma_block_num=disp_rdma_block_num,
+                warp_per_block=disp_warp_per_block,
             )
             if i == warmup_rounds - 1:
                 torch.cuda.synchronize()
@@ -1158,9 +1176,9 @@ class EpDispatchCombineTestCase:
                 combine_input,
                 None,
                 all_rank_indices[self.rank],
-                block_num=block_num,
-                rdma_block_num=rdma_block_num,
-                warp_per_block=warp_per_block,
+                block_num=comb_block_num,
+                rdma_block_num=comb_rdma_block_num,
+                warp_per_block=comb_warp_per_block,
             )
             torch.cuda.synchronize()
         total_rdma_recv_num_token = compute_rdma_algo_token_count(
@@ -1197,9 +1215,9 @@ class EpDispatchCombineTestCase:
                 all_rank_weights[self.rank],
                 all_rank_scales[self.rank],
                 all_rank_indices[self.rank],
-                block_num=block_num,
-                rdma_block_num=rdma_block_num,
-                warp_per_block=warp_per_block,
+                block_num=disp_block_num,
+                rdma_block_num=disp_rdma_block_num,
+                warp_per_block=disp_warp_per_block,
             )
             events[3 * i + 1].record()
             combine_input = self._convert_for_combine(dispatch_output)
@@ -1209,9 +1227,9 @@ class EpDispatchCombineTestCase:
                 combine_input,
                 None,
                 all_rank_indices[self.rank],
-                block_num=block_num,
-                rdma_block_num=rdma_block_num,
-                warp_per_block=warp_per_block,
+                block_num=comb_block_num,
+                rdma_block_num=comb_rdma_block_num,
+                warp_per_block=comb_warp_per_block,
             )
             events[3 * i + 3].record()
         torch.cuda.synchronize()
@@ -1295,9 +1313,12 @@ class EpDispatchCombineTestCase:
     def bench_dispatch_combine(
         self,
         max_num_token,
-        block_num=-1,
-        rdma_block_num=-1,
-        warp_per_block=-1,
+        disp_block_num=-1,
+        disp_rdma_block_num=-1,
+        disp_warp_per_block=-1,
+        comb_block_num=-1,
+        comb_rdma_block_num=-1,
+        comb_warp_per_block=-1,
         skip_verify=False,
     ):
         op = mori.ops.EpDispatchCombineOp(self.config)
@@ -1324,9 +1345,12 @@ class EpDispatchCombineTestCase:
             op,
             test_data,
             repeat,
-            block_num=block_num,
-            rdma_block_num=rdma_block_num,
-            warp_per_block=warp_per_block,
+            disp_block_num=disp_block_num,
+            disp_rdma_block_num=disp_rdma_block_num,
+            disp_warp_per_block=disp_warp_per_block,
+            comb_block_num=comb_block_num,
+            comb_rdma_block_num=comb_rdma_block_num,
+            comb_warp_per_block=comb_warp_per_block,
         )
         ll_mode_scale = bench_result[-1]
         all_data, _ = self._all_gather_bench_data(bench_result)
@@ -1372,8 +1396,18 @@ class EpDispatchCombineTestCase:
 
         disp_dtype_str = str(self.config.data_type).split(".")[-1]
         comb_dtype_str = str(self.combine_data_type).split(".")[-1]
-        disp_title = f"Dispatch Performance ({disp_dtype_str})"
-        comb_title = f"Combine Performance ({comb_dtype_str})"
+        # Name the launch config each table was produced with. Dispatch and
+        # combine can be given different values, so a table without it cannot be
+        # matched back to the run that produced it -- which is the whole point of
+        # feeding a tuning result back through bench.
+        disp_title = (
+            f"Dispatch Performance ({disp_dtype_str}) "
+            f"{_launch_params_str(disp_block_num, disp_warp_per_block, disp_rdma_block_num)}"
+        )
+        comb_title = (
+            f"Combine Performance ({comb_dtype_str}) "
+            f"{_launch_params_str(comb_block_num, comb_warp_per_block, comb_rdma_block_num)}"
+        )
         if self.combine_data_type != self.config.data_type:
             disp_elem = torch.tensor([], dtype=self.config.data_type).element_size()
             comb_elem = torch.tensor([], dtype=self.combine_data_type).element_size()
@@ -1622,14 +1656,21 @@ class EpDispatchCombineTestCase:
                             f"block={bn} warp={warp} rdma={rdma_bn}\n"
                             f"{'=' * 60}"
                         )
+                    # Common sweep: one candidate drives both phases, so a
+                    # single pass times dispatch and combine under the same
+                    # geometry. The two argmins below are still independent --
+                    # the winners may differ, and each is saved on its own.
                     bench_result = self.run_bench_once(
                         max_num_token,
                         op,
                         test_data,
                         repeat=_EP_ROUNDS,
-                        block_num=bn,
-                        rdma_block_num=rdma_bn,
-                        warp_per_block=warp,
+                        disp_block_num=bn,
+                        disp_rdma_block_num=rdma_bn,
+                        disp_warp_per_block=warp,
+                        comb_block_num=bn,
+                        comb_rdma_block_num=rdma_bn,
+                        comb_warp_per_block=warp,
                     )
                     all_data, ll_scale = self._all_gather_bench_data(bench_result)
                     kept = all_data[1:]  # skip round 0, same as bench
@@ -1822,9 +1863,12 @@ def test_dispatch_combine(
     cmd="test",
     sweep_token_interval=64,
     combine_dtype=None,
-    block_num=-1,
-    rdma_block_num=-1,
-    warp_per_block=-1,
+    disp_block_num=-1,
+    disp_rdma_block_num=-1,
+    disp_warp_per_block=-1,
+    comb_block_num=-1,
+    comb_rdma_block_num=-1,
+    comb_warp_per_block=-1,
     max_total_recv_tokens=0,
     hidden_dim=7168,
     save_tuning_config=None,
@@ -1859,9 +1903,12 @@ def test_dispatch_combine(
         elif cmd == "bench":
             bench_stats = test_case.bench_dispatch_combine(
                 max_tokens,
-                block_num=block_num,
-                rdma_block_num=rdma_block_num,
-                warp_per_block=warp_per_block,
+                disp_block_num=disp_block_num,
+                disp_rdma_block_num=disp_rdma_block_num,
+                disp_warp_per_block=disp_warp_per_block,
+                comb_block_num=comb_block_num,
+                comb_rdma_block_num=comb_rdma_block_num,
+                comb_warp_per_block=comb_warp_per_block,
                 skip_verify=skip_verify,
             )
             if global_rank == 0 and bench_stats is not None:
@@ -1977,23 +2024,67 @@ parser.add_argument(
         "'fp8_direct_cast' is the current BF16<->FP8 direct cast path."
     ),
 )
+# Launch geometry for bench mode. Tuning selects dispatch and combine
+# independently and saves a separate block/warp/rdma triple for each, so bench
+# has to be able to set them separately too -- otherwise a saved tuning result
+# whose two triples differ cannot be replayed through bench at all.
+#
+# --block-num/--warp-per-block/--rdma-block-num set both phases; the per-phase
+# flags override them. Naming matches the intranode benchmark
+# (tests/python/ops/bench_dispatch_combine.py).
 parser.add_argument(
     "--block-num",
     type=int,
     default=None,
-    help="Override block_num for bench mode.",
+    help="Override block_num for both phases in bench mode.",
 )
 parser.add_argument(
     "--warp-per-block",
     type=int,
     default=None,
-    help="Override warp_per_block for bench mode.",
+    help="Override warp_per_block for both phases in bench mode.",
 )
 parser.add_argument(
     "--rdma-block-num",
     type=int,
     default=None,
-    help="Override rdma_block_num for bench mode.",
+    help="Override rdma_block_num for both phases in bench mode.",
+)
+parser.add_argument(
+    "--dispatch-block-num",
+    type=int,
+    default=None,
+    help="Override block_num for dispatch only (wins over --block-num).",
+)
+parser.add_argument(
+    "--dispatch-warp-per-block",
+    type=int,
+    default=None,
+    help="Override warp_per_block for dispatch only (wins over --warp-per-block).",
+)
+parser.add_argument(
+    "--dispatch-rdma-block-num",
+    type=int,
+    default=None,
+    help="Override rdma_block_num for dispatch only (wins over --rdma-block-num).",
+)
+parser.add_argument(
+    "--combine-block-num",
+    type=int,
+    default=None,
+    help="Override block_num for combine only (wins over --block-num).",
+)
+parser.add_argument(
+    "--combine-warp-per-block",
+    type=int,
+    default=None,
+    help="Override warp_per_block for combine only (wins over --warp-per-block).",
+)
+parser.add_argument(
+    "--combine-rdma-block-num",
+    type=int,
+    default=None,
+    help="Override rdma_block_num for combine only (wins over --rdma-block-num).",
 )
 parser.add_argument(
     "--max-recv-total-tokens",
@@ -2048,6 +2139,28 @@ if __name__ == "__main__":
     if sentinel_pattern.isdigit():
         sentinel_pattern = int(sentinel_pattern)
 
+    def _phase_param(per_phase, shared):
+        """Per-phase flag wins over the shared one; -1 means let the op decide."""
+        for v in (per_phase, shared):
+            if v is not None:
+                return v
+        return -1
+
+    disp_block_num = _phase_param(args_cli.dispatch_block_num, args_cli.block_num)
+    disp_rdma_block_num = _phase_param(
+        args_cli.dispatch_rdma_block_num, args_cli.rdma_block_num
+    )
+    disp_warp_per_block = _phase_param(
+        args_cli.dispatch_warp_per_block, args_cli.warp_per_block
+    )
+    comb_block_num = _phase_param(args_cli.combine_block_num, args_cli.block_num)
+    comb_rdma_block_num = _phase_param(
+        args_cli.combine_rdma_block_num, args_cli.rdma_block_num
+    )
+    comb_warp_per_block = _phase_param(
+        args_cli.combine_warp_per_block, args_cli.warp_per_block
+    )
+
     world_size = num_node * gpu_per_node
     torch.multiprocessing.spawn(
         test_dispatch_combine,
@@ -2062,9 +2175,12 @@ if __name__ == "__main__":
             args_cli.cmd,
             args_cli.sweep_token_interval,
             combine_dtype,
-            args_cli.block_num if args_cli.block_num is not None else -1,
-            args_cli.rdma_block_num if args_cli.rdma_block_num is not None else -1,
-            args_cli.warp_per_block if args_cli.warp_per_block is not None else -1,
+            disp_block_num,
+            disp_rdma_block_num,
+            disp_warp_per_block,
+            comb_block_num,
+            comb_rdma_block_num,
+            comb_warp_per_block,
             args_cli.max_recv_total_tokens,
             args_cli.hidden_dim,
             args_cli.save_tuning_config,

--- a/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
+++ b/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
@@ -110,29 +110,39 @@ def _beats(new_lat, new_cfg, best_lat, best_cfg):
     return False
 
 
-def _headline_bw(stats, kernel_type):
-    """The winner's own bandwidth, for the JSON's top-level bandwidth_gbps.
-
-    Selection no longer runs on bandwidth (see _beats), but the saved config
-    still wants one representative bandwidth number; per-metric averages
-    (rdma/xgmi/ll) are saved alongside it regardless of kernel type.
-
-    Deliberately the slowest-rank mean (stats["*_worst_rank"]), not the
-    grand-mean stats["rdma"/"ll"][2] this file prints as "Average":
-    tuning_config.save_tuning_result gates overwriting an existing rule on
-    `new_bw > old_bw`, and every rule already on disk (including ones this PR
-    doesn't touch, e.g. other GPU models/kernel types) was written under the
-    old, main-derived definition of bandwidth_gbps -- slowest-rank mean
-    bandwidth. Saving the grand mean instead would systematically read higher
-    than a same-performance old entry (grand mean >= slowest-rank mean by
-    construction) and silently overwrite still-good rules on the first re-tune
-    with this code, even with zero real improvement.
-    """
-    is_ll_kernel = kernel_type in (
+def _is_ll_kernel(kernel_type):
+    return kernel_type in (
         mori.ops.EpDispatchCombineKernelType.InterNodeV1LL,
         mori.ops.EpDispatchCombineKernelType.AsyncLL,
     )
-    return stats["ll_worst_rank"] if is_ll_kernel else stats["rdma_worst_rank"]
+
+
+def _headline_bw(stats, kernel_type):
+    """The winner's bandwidth for the JSON's top-level bandwidth_gbps.
+
+    Which of the recorded bandwidths is the meaningful one depends on the
+    kernel: LL kernels move their payload over xGMI (reported as LL bandwidth),
+    v1 over RDMA. bandwidth_gbps is that pick, so a reader does not have to
+    know the rule; avg_rdma/xgmi/ll_bandwidth_gbps are all saved alongside it
+    regardless.
+
+    The grand mean -- the same number this file prints as the table's
+    "Average" row, so a saved rule can be checked against a --cmd bench run of
+    that block/warp/rdma without re-deriving anything. It used to be the
+    slowest-rank mean instead, purely so it stayed comparable with rules
+    written by older code: save_tuning_result gated overwriting on
+    `new_bw > old_bw`, and reading higher than a same-performance old entry
+    would have overwritten still-good rules. That gate is gone (nothing
+    numeric decides overwrites now), and with it the reason to report a
+    quantity nothing else prints.
+
+    Rules already on disk keep their slowest-rank value until re-tuned, so
+    bandwidth_gbps is only comparable within one tuning run's output -- which
+    is all it was ever good for, given two runs come from different hosts and
+    load. The slowest-rank figure is still printed per candidate for reference
+    (see the sweep's summary), just not saved.
+    """
+    return stats["ll"][2] if _is_ll_kernel(kernel_type) else stats["rdma"][2]
 
 
 def _perf_report():
@@ -262,6 +272,8 @@ def _save_internode_tuning_result(
 ):
     from pathlib import Path
     from mori.ops.tuning_config import (
+        BANDWIDTH_METRIC_GRAND_MEAN,
+        BANDWIDTH_METRIC_KEY,
         TuningConfigManager,
         dtype_to_config_str,
         build_config_filename,
@@ -300,6 +312,7 @@ def _save_internode_tuning_result(
         "avg_xgmi_bandwidth_gbps": round(_stats_avg(best_disp_all_bw, "xgmi"), 2),
         "avg_ll_bandwidth_gbps": round(_stats_avg(best_disp_all_bw, "ll"), 2),
         "avg_latency_us": round(_stats_avg(best_disp_all_bw, "lat"), 2),
+        BANDWIDTH_METRIC_KEY: BANDWIDTH_METRIC_GRAND_MEAN,
     }
 
     combine_entry = {
@@ -316,6 +329,7 @@ def _save_internode_tuning_result(
         "avg_xgmi_bandwidth_gbps": round(_stats_avg(best_comb_all_bw, "xgmi"), 2),
         "avg_ll_bandwidth_gbps": round(_stats_avg(best_comb_all_bw, "ll"), 2),
         "avg_latency_us": round(_stats_avg(best_comb_all_bw, "lat"), 2),
+        BANDWIDTH_METRIC_KEY: BANDWIDTH_METRIC_GRAND_MEAN,
     }
 
     if config_path == "auto":
@@ -1388,8 +1402,10 @@ class EpDispatchCombineTestCase:
 
         Returns dict with keys rdma, xgmi, ll, lat — each a (worst, best, avg)
         tuple identical to what PrettyTable prints — plus rdma_worst_rank and
-        ll_worst_rank (see _headline_bw for why those need to exist alongside
-        the grand-mean numbers above).
+        ll_worst_rank, the per-rank means' minimum. Those two are printed
+        alongside the tuning summary as a straggler check and are not saved or
+        used for selection; "worst" inside the tuples above is the minimum over
+        individual samples, which is a different (noisier) quantity.
         """
         _s = self._compute_stats
         xgmi_s = _s(kept[:, :, col_xgmi])
@@ -1661,6 +1677,21 @@ class EpDispatchCombineTestCase:
                 self._print_phase_table(
                     f"{label} ({dtype_s}) block={cfg[0]} warp={cfg[1]} rdma={cfg[2]}",
                     st,
+                )
+                # Slowest-rank bandwidth, for reference only -- neither the
+                # sweep nor the saved rule uses it. Worth seeing next to the
+                # table's Average because a large gap between the two means the
+                # ranks disagree, i.e. that Average is smoothing over a
+                # straggler rather than describing every rank.
+                worst_key = (
+                    "ll_worst_rank"
+                    if _is_ll_kernel(self.config.kernel_type)
+                    else "rdma_worst_rank"
+                )
+                print(
+                    f"  {label.strip()} slowest-rank bandwidth: "
+                    f"{st[worst_key]:.2f} GB/s "
+                    f"(table Average: {_headline_bw(st, self.config.kernel_type):.2f} GB/s)"
                 )
             print(f"{'=' * 70}")
 

--- a/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
+++ b/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
@@ -2161,6 +2161,31 @@ if __name__ == "__main__":
         args_cli.combine_warp_per_block, args_cli.warp_per_block
     )
 
+    # Only --cmd bench forwards these; test/test_sentinel/sweep build their own
+    # ops and let the op resolve the geometry. Silently ignoring nine flags is
+    # how a "control run" ends up measuring the default config while its author
+    # believes otherwise, so say it.
+    if args_cli.cmd != "bench" and any(
+        v is not None
+        for v in (
+            args_cli.block_num,
+            args_cli.warp_per_block,
+            args_cli.rdma_block_num,
+            args_cli.dispatch_block_num,
+            args_cli.dispatch_warp_per_block,
+            args_cli.dispatch_rdma_block_num,
+            args_cli.combine_block_num,
+            args_cli.combine_warp_per_block,
+            args_cli.combine_rdma_block_num,
+        )
+    ):
+        print(
+            f"Warning: block/warp/rdma launch overrides are ignored when "
+            f"--cmd {args_cli.cmd}; only --cmd bench applies them. To pin a "
+            f"geometry elsewhere, use MORI_EP_LAUNCH_CONFIG_MODE=AUTO with a "
+            f"tuning config."
+        )
+
     world_size = num_node * gpu_per_node
     torch.multiprocessing.spawn(
         test_dispatch_combine,

--- a/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
+++ b/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
@@ -1331,14 +1331,14 @@ class EpDispatchCombineTestCase:
                     ),
                 ),
             ]
-            for phase, cols in _labels:
-                for i in range(all_data.shape[0]):
-                    rd = all_data[i]
-                    if cols is _labels[0][1]:
-                        print(f"Round {i}")
+            for i in range(all_data.shape[0]):
+                rd = all_data[i]
+                print(f"Round {i}")
+                for phase, cols in _labels:
                     for name, col, unit in cols:
+                        vals = [round(v, 2) for v in rd[:, col].tolist()]
                         print(
-                            f"  {phase} {name} {rd[:, col].int().tolist()}"
+                            f"  {phase} {name} {vals}"
                             f" avg {rd[:, col].mean():.2f} {unit}"
                         )
 

--- a/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
+++ b/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
@@ -46,41 +46,53 @@ _CLI_TO_KERNEL_TYPE_NAME = {
 
 _FP4_DTYPE = getattr(torch, "float4_e2m1fn_x2", None)
 
-# Relative bandwidth improvement a candidate needs to replace the current
-# best during tuning. Default 0 (any improvement wins); raise via
-# MORI_EP_TUNING_MARGIN for a clearer-win requirement. Must be relative, not
-# absolute GB/s: a fixed 1.0 GB/s is ~40% of the sweep's spread at 4 tokens
-# but under 2% at large ones.
-_BW_REL_MARGIN = float(os.environ.get("MORI_EP_TUNING_MARGIN", "0.0"))
+# Relative improvement a candidate needs to replace the current best during
+# tuning. Default 0 (any improvement wins); raise via MORI_EP_TUNING_MARGIN
+# for a clearer-win requirement. Must be relative, not an absolute unit: a
+# fixed threshold cannot work across the whole operating range (e.g. a 1.0
+# GB/s bandwidth margin used to be ~40% of the sweep's spread at 4 tokens
+# but under 2% at large ones).
+_TUNING_MARGIN = float(os.environ.get("MORI_EP_TUNING_MARGIN", "0.0"))
 
-# Rounds per candidate and the statistic used to score it. Override with
-# MORI_EP_TUNING_ROUNDS / MORI_EP_TUNING_STAT. Default statistic is mean,
-# matching --cmd bench and main: mean is pulled up by one bad round, so it
-# penalizes a config with a good typical case but a bad worst-case tail;
-# median can't see that tail at all. MORI_EP_TUNING_STAT=median restores the
-# tail-blind behavior for anyone who wants single-round outlier resistance
-# instead.
+# Rounds benchmarked per candidate during tuning. Override with
+# MORI_EP_TUNING_ROUNDS.
 _TUNING_ROUNDS = int(os.environ.get("MORI_EP_TUNING_ROUNDS", "9"))
-_TUNING_STAT = os.environ.get("MORI_EP_TUNING_STAT", "mean")
-if _TUNING_STAT not in ("mean", "median"):
-    raise ValueError(
-        f"MORI_EP_TUNING_STAT must be 'mean' or 'median', got {_TUNING_STAT!r}"
-    )
 
 
-def _beats(new_bw, new_cfg, best_bw, best_cfg):
+def _beats(new_lat, new_cfg, best_lat, best_cfg):
     """Should *new_cfg* replace *best_cfg* as the tuning winner?
+
+    Selection metric is the grand-mean latency (lower is better) -- the same
+    quantity _build_phase_stats/_compute_stats compute and this file prints
+    as "Average", not a separate slowest-rank bandwidth figure. Picking a
+    config on one metric while reporting another let a config win the sweep
+    on paper yet look worse in the printed table it was supposedly chosen
+    from; using the printed number for both closes that gap by construction.
 
     Wins outright past the margin; within it, ties break on smaller
     block_num so re-tuning the same hardware is deterministic.
     """
     if best_cfg is None:
         return True
-    if new_bw > best_bw * (1.0 + _BW_REL_MARGIN):
+    if new_lat < best_lat * (1.0 - _TUNING_MARGIN):
         return True
-    if new_bw >= best_bw * (1.0 - _BW_REL_MARGIN) and new_cfg[0] < best_cfg[0]:
+    if new_lat <= best_lat * (1.0 + _TUNING_MARGIN) and new_cfg[0] < best_cfg[0]:
         return True
     return False
+
+
+def _headline_bw(stats, kernel_type):
+    """The winner's own avg bandwidth, for the JSON's top-level bandwidth_gbps.
+
+    Selection no longer runs on bandwidth (see _beats), but the saved config
+    still wants one representative bandwidth number; per-metric averages
+    (rdma/xgmi/ll) are saved alongside it regardless of kernel type.
+    """
+    is_ll_kernel = kernel_type in (
+        mori.ops.EpDispatchCombineKernelType.InterNodeV1LL,
+        mori.ops.EpDispatchCombineKernelType.AsyncLL,
+    )
+    return stats["ll"][2] if is_ll_kernel else stats["rdma"][2]
 
 
 def _perf_report():
@@ -1466,12 +1478,6 @@ class EpDispatchCombineTestCase:
                 set(v for v in [bn // 4, bn // 2, bn * 2 // 3] if 1 <= v < bn)
             )
 
-        is_ll_kernel = self.config.kernel_type in (
-            mori.ops.EpDispatchCombineKernelType.InterNodeV1LL,
-            mori.ops.EpDispatchCombineKernelType.AsyncLL,
-        )
-        bw_label = "LL BW" if is_ll_kernel else "RDMA BW"
-
         total_configs = sum(
             len(warp_list) * len(rdma_candidates_for(bn)) for bn in block_list
         )
@@ -1481,12 +1487,12 @@ class EpDispatchCombineTestCase:
                 f"skip_verify={skip_verify}\n"
                 f"block_num candidates ({len(block_list)}): {block_list}\n"
                 f"warp_per_block candidates: {warp_list}\n"
-                f"BW metric: {bw_label}\n"
+                f"Selection metric: grand-mean latency (same as printed Average)\n"
                 f"Total configurations: {total_configs}"
             )
 
-        best_disp_bw = 0
-        best_comb_bw = 0
+        best_disp_lat = float("inf")
+        best_comb_lat = float("inf")
         best_disp_config = None
         best_comb_config = None
         _zero_stats = {
@@ -1535,46 +1541,38 @@ class EpDispatchCombineTestCase:
                     # kept: (rounds, world_size, 6)
                     # cols: d_rdma, d_xgmi, d_lat, c_rdma, c_xgmi, c_lat
 
-                    # Selection: per-rank stat across kept rounds, min rank. See
-                    # _TUNING_STAT above for why mean is the default.
-                    if _TUNING_STAT == "median":
-                        rank_stat = kept.median(dim=0).values  # (world_size, 6)
-                    else:
-                        rank_stat = kept.mean(dim=0)  # (world_size, 6)
-                    if is_ll_kernel:
-                        disp_bw = (rank_stat[:, 1] * ll_scale).min().item()
-                        comb_bw = (rank_stat[:, 4] * ll_scale).min().item()
-                    else:
-                        disp_bw = rank_stat[:, 0].min().item()
-                        comb_bw = rank_stat[:, 3].min().item()
-
-                    # Stats via shared code (same as bench PrettyTable)
+                    # Stats via shared code (same as bench PrettyTable). Selection
+                    # uses disp_stats["lat"][2]/comb_stats["lat"][2] below -- the
+                    # exact grand-mean latency this same dict prints as "Average"
+                    # (see _beats' docstring for why that identity matters).
                     disp_stats = self._build_phase_stats(kept, 0, 1, 2, ll_scale)
                     comb_stats = self._build_phase_stats(kept, 3, 4, 5, ll_scale)
+                    disp_lat = disp_stats["lat"][2]
+                    comb_lat = comb_stats["lat"][2]
 
                     cand = (bn, warp, rdma_bn)
-                    if _beats(disp_bw, cand, best_disp_bw, best_disp_config):
-                        best_disp_bw = disp_bw
+                    if _beats(disp_lat, cand, best_disp_lat, best_disp_config):
+                        best_disp_lat = disp_lat
                         best_disp_config = cand
                         best_disp_stats = disp_stats
-                    if _beats(comb_bw, cand, best_comb_bw, best_comb_config):
-                        best_comb_bw = comb_bw
+                    if _beats(comb_lat, cand, best_comb_lat, best_comb_config):
+                        best_comb_lat = comb_lat
                         best_comb_config = cand
                         best_comb_stats = comb_stats
 
                     if self.rank == 0:
                         da, ca = disp_stats["xgmi"][2], comb_stats["xgmi"][2]
                         print(
-                            f"  disp sel={disp_bw:.1f} xgmi={da:.1f}  "
-                            f"comb sel={comb_bw:.1f} xgmi={ca:.1f}  "
-                            f"(best disp={best_disp_bw:.1f} comb={best_comb_bw:.1f})"
+                            f"  disp sel={disp_lat:.1f}us xgmi={da:.1f}  "
+                            f"comb sel={comb_lat:.1f}us xgmi={ca:.1f}  "
+                            f"(best disp={best_disp_lat:.1f}us comb={best_comb_lat:.1f}us)"
                         )
 
         if self.rank == 0:
             disp_dtype_str = str(self.config.data_type).split(".")[-1]
             comb_dtype_str = str(self.combine_data_type).split(".")[-1]
             print(f"\n{'=' * 70}")
-            print("Tuning Result (best config chosen by slowest-rank XGMI BW)")
+            print("Tuning Result (best config chosen by grand-mean latency)")
             print(f"{'=' * 70}")
             for label, dtype_s, cfg, st in [
                 ("Dispatch", disp_dtype_str, best_disp_config, best_disp_stats),
@@ -1595,10 +1593,10 @@ class EpDispatchCombineTestCase:
                     combine_hidden_dim=self.combine_hidden_dim,
                     combine_data_type=self.combine_data_type,
                     best_disp_config=best_disp_config,
-                    best_disp_bw=best_disp_bw,
+                    best_disp_bw=_headline_bw(best_disp_stats, self.config.kernel_type),
                     best_disp_all_bw=best_disp_stats,
                     best_comb_config=best_comb_config,
-                    best_comb_bw=best_comb_bw,
+                    best_comb_bw=_headline_bw(best_comb_stats, self.config.kernel_type),
                     best_comb_all_bw=best_comb_stats,
                 )
 

--- a/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
+++ b/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
@@ -58,21 +58,20 @@ _FP4_DTYPE = getattr(torch, "float4_e2m1fn_x2", None)
 # import time, so fall back on an empty string too.
 _TUNING_MARGIN = float(os.environ.get("MORI_EP_TUNING_MARGIN") or "0.0")
 
-# Rounds benchmarked per candidate during tuning. Default matches main's
-# longstanding hardcoded value; override with MORI_EP_TUNING_ROUNDS. (This used
-# to default to 9 -- that was carried over from an abandoned median-scoring
-# experiment that wanted more samples to resist a single stalled round. Now
-# that selection is back to mean (see _beats), that extra defense isn't doing
-# anything for us, so there's no reason to pay the ~1.8x longer sweep.)
-_TUNING_ROUNDS = int(os.environ.get("MORI_EP_TUNING_ROUNDS") or "5")
-if _TUNING_ROUNDS < 2:
-    # tuning_dispatch_combine drops round 0 as in-loop warmup (`kept =
-    # all_data[1:]`, matching what bench does); at 1 round that leaves an
-    # empty tensor and _compute_stats' .min()/.max()/.mean() blow up with a
-    # shape error that says nothing about rounds being the cause.
+# Rounds benchmarked per config, shared by both --cmd bench and --cmd tuning
+# (each candidate during a sweep) so the two measure on equal footing --
+# bench's own number for a config should be comparable to what tuning saw
+# for that same config during its sweep. Override with MORI_EP_ROUNDS;
+# default 10 matches bench's longstanding hardcoded value.
+_EP_ROUNDS = int(os.environ.get("MORI_EP_ROUNDS") or "10")
+if _EP_ROUNDS < 2:
+    # Both call sites drop round 0 as in-loop warmup (`kept = all_data[1:]`);
+    # at 1 round that leaves an empty tensor and _compute_stats'
+    # .min()/.max()/.mean() blow up with a shape error that says nothing
+    # about rounds being the cause.
     raise ValueError(
-        f"MORI_EP_TUNING_ROUNDS must be >= 2 (round 0 is dropped as warmup), "
-        f"got {_TUNING_ROUNDS}"
+        f"MORI_EP_ROUNDS must be >= 2 (round 0 is dropped as warmup), "
+        f"got {_EP_ROUNDS}"
     )
 
 # Debug aid only, no effect on selection: print every candidate's full
@@ -1286,7 +1285,7 @@ class EpDispatchCombineTestCase:
             only_my_rank=skip_verify,
         )
 
-        repeat = 10
+        repeat = _EP_ROUNDS
 
         if not skip_verify:
             error_round = set()
@@ -1594,7 +1593,7 @@ class EpDispatchCombineTestCase:
                         max_num_token,
                         op,
                         test_data,
-                        repeat=_TUNING_ROUNDS,
+                        repeat=_EP_ROUNDS,
                         block_num=bn,
                         rdma_block_num=rdma_bn,
                         warp_per_block=warp,

--- a/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
+++ b/examples/ops/dispatch_combine/test_dispatch_combine_internode.py
@@ -54,9 +54,13 @@ _FP4_DTYPE = getattr(torch, "float4_e2m1fn_x2", None)
 # but under 2% at large ones).
 _TUNING_MARGIN = float(os.environ.get("MORI_EP_TUNING_MARGIN", "0.0"))
 
-# Rounds benchmarked per candidate during tuning. Override with
-# MORI_EP_TUNING_ROUNDS.
-_TUNING_ROUNDS = int(os.environ.get("MORI_EP_TUNING_ROUNDS", "9"))
+# Rounds benchmarked per candidate during tuning. Default matches main's
+# longstanding hardcoded value; override with MORI_EP_TUNING_ROUNDS. (This used
+# to default to 9 -- that was carried over from an abandoned median-scoring
+# experiment that wanted more samples to resist a single stalled round. Now
+# that selection is back to mean (see _beats), that extra defense isn't doing
+# anything for us, so there's no reason to pay the ~1.8x longer sweep.)
+_TUNING_ROUNDS = int(os.environ.get("MORI_EP_TUNING_ROUNDS", "5"))
 
 
 def _beats(new_lat, new_cfg, best_lat, best_cfg):

--- a/examples/ops/dispatch_combine/test_low_latency.py
+++ b/examples/ops/dispatch_combine/test_low_latency.py
@@ -43,6 +43,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import argparse
 import json
 import os
 import sys
@@ -655,9 +656,16 @@ def test_main(
 
 
 # noinspection PyUnboundLocalVariable
-def test_loop(local_rank: int, num_local_ranks: int):
+def test_loop(
+    local_rank: int,
+    num_local_ranks: int,
+    num_tokens: int = 128,
+    hidden: int = 7168,
+    num_topk: int = 8,
+    num_experts: int = 288,
+    do_pressure_test: bool = False,
+):
     rank, num_ranks, group, num_nodes = init_dist(local_rank, num_local_ranks)
-    num_tokens, hidden, num_topk, num_experts = 128, 7168, 8, 288
 
     test_main(
         num_tokens,
@@ -671,7 +679,6 @@ def test_loop(local_rank: int, num_local_ranks: int):
         seed=1,
     )
 
-    do_pressure_test = False
     for seed in range(int(1e9) if do_pressure_test else 0):
         if local_rank == 0:
             print(f"Testing with seed {seed} ...", flush=True)
@@ -706,7 +713,39 @@ def test_loop(local_rank: int, num_local_ranks: int):
     dist.destroy_process_group()
 
 
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="DeepEP-style low-latency dispatch/combine test for MORI-EP."
+    )
+    # Defaults reproduce the shape this test has always run, so existing
+    # invocations are unaffected.
+    p.add_argument("--num-tokens", type=int, default=128, help="tokens per rank")
+    p.add_argument("--hidden", type=int, default=7168, help="hidden dimension")
+    p.add_argument("--num-topk", type=int, default=8, help="experts per token")
+    p.add_argument("--num-experts", type=int, default=288, help="experts in total")
+    p.add_argument(
+        "--num-processes", type=int, default=8, help="ranks per node (GPUs to use)"
+    )
+    p.add_argument(
+        "--pressure-test",
+        action="store_true",
+        help="loop over seeds forever, re-checking the output hash each time",
+    )
+    return p.parse_args()
+
+
 if __name__ == "__main__":
     # TODO: you may modify NUMA binding for less CPU overhead
-    num_processes = 8
-    torch.multiprocessing.spawn(test_loop, args=(num_processes,), nprocs=num_processes)
+    args = parse_args()
+    torch.multiprocessing.spawn(
+        test_loop,
+        args=(
+            args.num_processes,
+            args.num_tokens,
+            args.hidden,
+            args.num_topk,
+            args.num_experts,
+            args.pressure_test,
+        ),
+        nprocs=args.num_processes,
+    )

--- a/python/mori/ops/dispatch_combine.py
+++ b/python/mori/ops/dispatch_combine.py
@@ -515,9 +515,7 @@ class EpDispatchCombineOp:
         # once here: probing the environment per call would reintroduce exactly
         # the kind of host-side cost this cache removes.
         self._view_cache = (
-            None
-            if os.environ.get("MORI_EP_DISABLE_VIEW_CACHE", "0") == "1"
-            else {}
+            None if os.environ.get("MORI_EP_DISABLE_VIEW_CACHE", "0") == "1" else {}
         )
 
         self.local_expert_count = torch.zeros(
@@ -960,7 +958,6 @@ class EpDispatchCombineOp:
             # so the reservation stays at the pointer arrays.
         return base
 
-
     def _cached_view(self, key, ptr, shape, dtype):
         """Memoized ``from_gpu_ptr`` over a handle-owned shmem buffer.
 
@@ -1317,9 +1314,14 @@ class EpDispatchCombineOp:
 
         out_ptr, outW_ptr, outS_ptr, outI_ptr, total_ptr = self._dispatch_out_ptrs
         max_recv = self._cpp_config.max_num_tokens_to_recv()
-        out = self._cached_view("disp_out", out_ptr, (max_recv, hidden_dim), input.dtype)
+        out = self._cached_view(
+            "disp_out", out_ptr, (max_recv, hidden_dim), input.dtype
+        )
         out_weights = self._cached_view(
-            "disp_w", outW_ptr, (max_recv, self.config.num_experts_per_token), torch.float32
+            "disp_w",
+            outW_ptr,
+            (max_recv, self.config.num_experts_per_token),
+            torch.float32,
         )
         out_scales = None
         if has_scales and outS_ptr:
@@ -1327,7 +1329,10 @@ class EpDispatchCombineOp:
                 "disp_s", outS_ptr, (max_recv, self.config.scale_dim), scales.dtype
             )
         out_indices = self._cached_view(
-            "disp_i", outI_ptr, (max_recv, self.config.num_experts_per_token), TOPK_IDX_DTYPE
+            "disp_i",
+            outI_ptr,
+            (max_recv, self.config.num_experts_per_token),
+            TOPK_IDX_DTYPE,
         )
         total_recv = (
             routing.total_recv_token_num

--- a/python/mori/ops/dispatch_combine.py
+++ b/python/mori/ops/dispatch_combine.py
@@ -969,10 +969,14 @@ class EpDispatchCombineOp:
         dispatch+combine round measured ~60us of host time, and at small token
         counts the host submission path is what paces the GPU.
 
-        The cache key includes the pointer, so if a buffer were ever
-        reallocated the lookup misses and a correct view is built rather than a
-        stale one being returned. Entries are bounded by the number of distinct
-        (shape, dtype) a given op is called with -- one, for a fixed model.
+        The cache key includes the pointer so that shape/dtype/pointer together
+        determine the entry. It is not protection against reallocation: the
+        pointers themselves are snapshotted once in __init__ and never
+        refreshed, so a realloc would leave both the key and the view stale.
+        That assumption is pre-existing -- the buffers are handle-owned and have
+        no realloc path -- and this cache does not weaken it. Entries are
+        bounded by the number of distinct (shape, dtype) a given op is called
+        with -- one, for a fixed model.
 
         The returned tensor aliases exactly the memory a fresh view would, and
         the kernels overwrite it in place either way, so callers see no change

--- a/python/mori/ops/dispatch_combine.py
+++ b/python/mori/ops/dispatch_combine.py
@@ -1007,6 +1007,19 @@ class EpDispatchCombineOp:
     def get_launch_config(
         self, is_dispatch=True, block_num=-1, rdma_block_num=-1, warp_per_block=-1
     ):
+        """Resolve saved launch params. Not the path dispatch()/combine() take.
+
+        Those call _resolve_launch_params with ``dtype=input.dtype``, i.e. each
+        phase is looked up with the dtype of its own input tensor. This method
+        has no such argument and uses ``config.data_type`` for both, which is
+        the *dispatch* dtype (and is itself deprecated -- the kernel infers the
+        real dtype from the input tensor). So for a combine rule saved under a
+        different combine dtype, this returns None where the runtime matches.
+
+        Nothing in the repository calls this; it is kept as public API. A
+        caller that wants the combine geometry for a mixed-dtype config should
+        look the rule up directly with the combine dtype.
+        """
         rules = self._dispatch_rules if is_dispatch else self._combine_rules
         if rules:
             from mori.ops.tuning_config import TuningConfigManager

--- a/python/mori/ops/dispatch_combine.py
+++ b/python/mori/ops/dispatch_combine.py
@@ -511,6 +511,15 @@ class EpDispatchCombineOp:
         self._dispatch_out_ptrs = mori_cpp.get_dispatch_output_ptrs(self._handle, True)
         self._combine_out_ptrs = mori_cpp.get_combine_output_ptrs(self._handle, True)
 
+        # Output tensor views over the two pointer sets above. Read the opt-out
+        # once here: probing the environment per call would reintroduce exactly
+        # the kind of host-side cost this cache removes.
+        self._view_cache = (
+            None
+            if os.environ.get("MORI_EP_DISABLE_VIEW_CACHE", "0") == "1"
+            else {}
+        )
+
         self.local_expert_count = torch.zeros(
             config.num_experts_per_rank, dtype=torch.int32, device="cuda"
         )
@@ -951,6 +960,36 @@ class EpDispatchCombineOp:
             # so the reservation stays at the pointer arrays.
         return base
 
+
+    def _cached_view(self, key, ptr, shape, dtype):
+        """Memoized ``from_gpu_ptr`` over a handle-owned shmem buffer.
+
+        dispatch()/combine() hand back views over buffers whose addresses are
+        snapshotted once in __init__ (self._dispatch_out_ptrs /
+        self._combine_out_ptrs) and whose shapes are fixed by the config, yet a
+        fresh view was built on every call. Each rebuild walks
+        __cuda_array_interface__ and queries the current device; six of them per
+        dispatch+combine round measured ~60us of host time, and at small token
+        counts the host submission path is what paces the GPU.
+
+        The cache key includes the pointer, so if a buffer were ever
+        reallocated the lookup misses and a correct view is built rather than a
+        stale one being returned. Entries are bounded by the number of distinct
+        (shape, dtype) a given op is called with -- one, for a fixed model.
+
+        The returned tensor aliases exactly the memory a fresh view would, and
+        the kernels overwrite it in place either way, so callers see no change
+        beyond object identity.
+        """
+        if self._view_cache is None:
+            return from_gpu_ptr(ptr, shape, dtype)
+        ck = (key, ptr, tuple(shape), dtype)
+        t = self._view_cache.get(ck)
+        if t is None:
+            t = from_gpu_ptr(ptr, shape, dtype)
+            self._view_cache[ck] = t
+        return t
+
     def _launch(self, func_name, grid, block, shared_mem, stream, args_ptr):
         func = self._get_func(func_name)
         func.launch_struct(grid, block, shared_mem, stream, args_ptr)
@@ -1278,22 +1317,22 @@ class EpDispatchCombineOp:
 
         out_ptr, outW_ptr, outS_ptr, outI_ptr, total_ptr = self._dispatch_out_ptrs
         max_recv = self._cpp_config.max_num_tokens_to_recv()
-        out = from_gpu_ptr(out_ptr, (max_recv, hidden_dim), input.dtype)
-        out_weights = from_gpu_ptr(
-            outW_ptr, (max_recv, self.config.num_experts_per_token), torch.float32
+        out = self._cached_view("disp_out", out_ptr, (max_recv, hidden_dim), input.dtype)
+        out_weights = self._cached_view(
+            "disp_w", outW_ptr, (max_recv, self.config.num_experts_per_token), torch.float32
         )
         out_scales = None
         if has_scales and outS_ptr:
-            out_scales = from_gpu_ptr(
-                outS_ptr, (max_recv, self.config.scale_dim), scales.dtype
+            out_scales = self._cached_view(
+                "disp_s", outS_ptr, (max_recv, self.config.scale_dim), scales.dtype
             )
-        out_indices = from_gpu_ptr(
-            outI_ptr, (max_recv, self.config.num_experts_per_token), TOPK_IDX_DTYPE
+        out_indices = self._cached_view(
+            "disp_i", outI_ptr, (max_recv, self.config.num_experts_per_token), TOPK_IDX_DTYPE
         )
         total_recv = (
             routing.total_recv_token_num
             if use_routing_handle
-            else from_gpu_ptr(total_ptr, (1,), TOPK_IDX_DTYPE)
+            else self._cached_view("disp_total", total_ptr, (1,), TOPK_IDX_DTYPE)
         )
 
         if return_routing:
@@ -1692,14 +1731,16 @@ class EpDispatchCombineOp:
             raise ValueError(f"Unsupported combine kernel_type: {kt}")
 
         out_ptr, outW_ptr = self._combine_out_ptrs
-        out = from_gpu_ptr(
+        out = self._cached_view(
+            "comb_out",
             out_ptr,
             (self.config.max_num_inp_token_per_rank, hidden_dim),
             input.dtype,
         )
         out_weights = None
         if weight_ptr and outW_ptr:
-            out_weights = from_gpu_ptr(
+            out_weights = self._cached_view(
+                "comb_w",
                 outW_ptr,
                 (
                     self.config.max_num_inp_token_per_rank,

--- a/python/mori/ops/tuning_config.py
+++ b/python/mori/ops/tuning_config.py
@@ -327,25 +327,55 @@ def _rule_geometry(rule: dict) -> str:
     )
 
 
+def _is_number(value) -> bool:
+    """True for a value a percentage can be computed from.
+
+    Rules are read back from JSON that a person may have edited, so a field can
+    hold a string or null. bool is excluded because ``True`` would otherwise
+    pass as 1.0.
+    """
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
 def _format_delta(
-    old: float | None, new: float | None, unit: str, comparable: bool = True
+    old: float | None,
+    new: float | None,
+    unit: str,
+    comparable: bool = True,
+    lower_is_better: bool = False,
 ) -> str:
     """`old -> new (+x.x%)`, or a bare value when there is nothing to compare.
 
     ``comparable=False`` still shows both numbers but drops the percentage:
     a percentage between two differently-defined quantities reads as a
     performance change when it is only a change of definition.
+
+    ``lower_is_better`` labels the percentage rather than flipping its sign.
+    Latency and bandwidth are printed on adjacent lines in the same format, so
+    an unlabelled "+30.0%" reads as an improvement on both -- while for latency
+    it is a 30% regression. Since latency is what the inter-node tuner now
+    selects on, that is the line a reviewer reads to judge a run.
     """
     if new is None:
-        return "n/a"
-    if not old:
+        # Still show what is being replaced: dropping it here would make a
+        # replacement of a known value indistinguishable from a fresh rule.
+        return "n/a" if not _is_number(old) else f"{old:.2f} -> n/a"
+    if not _is_number(old):
+        # Only "no comparable old value" -- distinct from old == 0.0, which is
+        # a real reading the writers do emit (_stats_avg returns 0.0 when the
+        # stats dict is empty) and which must not be silently dropped.
         return f"{new:.2f}{unit}"
     if not comparable:
         return (
             f"{old:.2f} -> {new:.2f}{unit} "
             f"(old value used a different metric, not comparable)"
         )
+    if old == 0:
+        return f"{old:.2f} -> {new:.2f}{unit} (old value was 0, no ratio)"
     pct = (new - old) / old * 100.0
+    if lower_is_better and pct != 0.0:
+        label = "worse" if pct > 0 else "better"
+        return f"{old:.2f} -> {new:.2f}{unit} ({pct:+.1f}%, {label})"
     return f"{old:.2f} -> {new:.2f}{unit} ({pct:+.1f}%)"
 
 
@@ -385,7 +415,7 @@ def _report_rule_change(phase: str, merge_key, old_rule: dict, new_rule: dict) -
         f"[mori-tuning] REPLACED {phase} rule {merge_key}\n"
         f"               config:  {geo}\n"
         f"               latency: "
-        f"{_format_delta(_rule_latency(old_rule), _rule_latency(new_rule), 'us')}\n"
+        f"{_format_delta(_rule_latency(old_rule), _rule_latency(new_rule), 'us', lower_is_better=True)}\n"
         f"               bw:      "
         f"{_format_delta(old_rule.get('bandwidth_gbps'), new_rule.get('bandwidth_gbps'), ' GB/s', bw_comparable)}",
         flush=True,

--- a/python/mori/ops/tuning_config.py
+++ b/python/mori/ops/tuning_config.py
@@ -145,7 +145,11 @@ _TUNING_CONFIGS_DIR = Path(__file__).parent / "tuning_configs"
 # tuning run that finds something faster actually persists it. Set
 # MORI_EP_TUNING_MARGIN to require a real margin instead, which keeps the
 # checked-in JSON from churning when a re-tune only lands higher on noise.
-_SAVE_REL_MARGIN = float(os.environ.get("MORI_EP_TUNING_MARGIN", "0.0"))
+#
+# `os.environ.get(k, default)` only substitutes default when the var is
+# *unset* -- MORI_EP_TUNING_MARGIN="" would reach float("") and crash, so
+# fall back on an empty string too.
+_SAVE_REL_MARGIN = float(os.environ.get("MORI_EP_TUNING_MARGIN") or "0.0")
 
 _gpu_model_cache: str | None = None
 _gpu_model_detected: bool = False

--- a/python/mori/ops/tuning_config.py
+++ b/python/mori/ops/tuning_config.py
@@ -140,9 +140,12 @@ def dtype_to_config_str(dtype: torch.dtype) -> str:
 _SUPPORTED_VERSION = "1.0"
 _TUNING_CONFIGS_DIR = Path(__file__).parent / "tuning_configs"
 
-# A re-tune must beat the recorded bandwidth by this much before it is allowed
-# to overwrite an existing rule. Keeps saved configs stable under noise.
-_SAVE_REL_MARGIN = 0.02
+# Relative improvement a re-tune must show before it overwrites an existing
+# rule. Default 0: any improvement wins, matching the tuner's own default so a
+# tuning run that finds something faster actually persists it. Set
+# MORI_EP_TUNING_MARGIN to require a real margin instead, which keeps the
+# checked-in JSON from churning when a re-tune only lands higher on noise.
+_SAVE_REL_MARGIN = float(os.environ.get("MORI_EP_TUNING_MARGIN", "0.0"))
 
 _gpu_model_cache: str | None = None
 _gpu_model_detected: bool = False

--- a/python/mori/ops/tuning_config.py
+++ b/python/mori/ops/tuning_config.py
@@ -140,6 +140,10 @@ def dtype_to_config_str(dtype: torch.dtype) -> str:
 _SUPPORTED_VERSION = "1.0"
 _TUNING_CONFIGS_DIR = Path(__file__).parent / "tuning_configs"
 
+# A re-tune must beat the recorded bandwidth by this much before it is allowed
+# to overwrite an existing rule. Keeps saved configs stable under noise.
+_SAVE_REL_MARGIN = 0.02
+
 _gpu_model_cache: str | None = None
 _gpu_model_detected: bool = False
 
@@ -616,7 +620,10 @@ class TuningConfigManager:
         if matched_idx is not None:
             old_bw = rules[matched_idx].get("bandwidth_gbps", 0)
             new_bw = entry.get("bandwidth_gbps", 0)
-            if new_bw > old_bw:
+            # Require a margin, not just any improvement: without it a re-tune
+            # that lands 0.01 GB/s higher purely on measurement noise rewrites
+            # the checked-in rule, so the file churns on every run.
+            if new_bw > old_bw * (1.0 + _SAVE_REL_MARGIN):
                 rules[matched_idx] = entry
                 logger.info(
                     "Updated %s rule for %s (%.2f -> %.2f GB/s)",

--- a/python/mori/ops/tuning_config.py
+++ b/python/mori/ops/tuning_config.py
@@ -140,17 +140,6 @@ def dtype_to_config_str(dtype: torch.dtype) -> str:
 _SUPPORTED_VERSION = "1.0"
 _TUNING_CONFIGS_DIR = Path(__file__).parent / "tuning_configs"
 
-# Relative improvement a re-tune must show before it overwrites an existing
-# rule. Default 0: any improvement wins, matching the tuner's own default so a
-# tuning run that finds something faster actually persists it. Set
-# MORI_EP_TUNING_MARGIN to require a real margin instead, which keeps the
-# checked-in JSON from churning when a re-tune only lands higher on noise.
-#
-# `os.environ.get(k, default)` only substitutes default when the var is
-# *unset* -- MORI_EP_TUNING_MARGIN="" would reach float("") and crash, so
-# fall back on an empty string too.
-_SAVE_REL_MARGIN = float(os.environ.get("MORI_EP_TUNING_MARGIN") or "0.0")
-
 _gpu_model_cache: str | None = None
 _gpu_model_detected: bool = False
 
@@ -297,6 +286,120 @@ class LaunchParams:
     block_num: int
     rdma_block_num: int
     warp_per_block: int
+
+
+# ---------------------------------------------------------------------------
+# Save reporting
+#
+# BANDWIDTH_METRIC_KEY records how a rule's bandwidth_gbps was computed, so a
+# re-tune can tell whether the old value is comparable with the new one. Rules
+# written before this existed carry no key at all, which reads as "unknown" and
+# is correctly treated as not comparable with anything.
+#
+# A tuning run overwrites the matching rule unconditionally -- see
+# save_tuning_result. Two tuning runs are rarely comparable (different host,
+# ROCm version, machine load, time), so no numeric rule can reliably decide
+# "is this new result good enough to keep", and a wrong decision in the
+# *keep the old rule* direction is invisible: you get a stale config and no
+# indication your run was discarded. Overwriting instead makes the change
+# reviewable in the JSON's git diff, which is where it can actually be judged.
+#
+# These print rather than logger.info deliberately. This library's logger sits
+# at WARNING by default, so an info-level line here would never reach the
+# person running the tuning -- exactly the silent-discard failure the gate
+# used to have.
+# ---------------------------------------------------------------------------
+
+
+BANDWIDTH_METRIC_KEY = "bandwidth_metric"
+
+#: Value for BANDWIDTH_METRIC_KEY when bandwidth_gbps is the mean over all
+#: ranks and rounds -- the "Average" row of the table tuning prints.
+BANDWIDTH_METRIC_GRAND_MEAN = "grand_mean"
+
+
+def _rule_geometry(rule: dict) -> str:
+    """block/warp/rdma of a rule, in the order tuning prints them."""
+    return (
+        f"block={rule.get('block_num')} "
+        f"warp={rule.get('warp_per_block')} "
+        f"rdma={rule.get('rdma_block_num')}"
+    )
+
+
+def _format_delta(
+    old: float | None, new: float | None, unit: str, comparable: bool = True
+) -> str:
+    """`old -> new (+x.x%)`, or a bare value when there is nothing to compare.
+
+    ``comparable=False`` still shows both numbers but drops the percentage:
+    a percentage between two differently-defined quantities reads as a
+    performance change when it is only a change of definition.
+    """
+    if new is None:
+        return "n/a"
+    if not old:
+        return f"{new:.2f}{unit}"
+    if not comparable:
+        return (
+            f"{old:.2f} -> {new:.2f}{unit} "
+            f"(old value used a different metric, not comparable)"
+        )
+    pct = (new - old) / old * 100.0
+    return f"{old:.2f} -> {new:.2f}{unit} ({pct:+.1f}%)"
+
+
+def _rule_latency(rule: dict) -> float | None:
+    """A rule's latency, whichever of the two spellings it uses.
+
+    The inter-node tuner writes avg_latency_us, the intra-node one
+    latency_us. Reading only the first left every intra-node save reporting
+    "latency: n/a" -- dropping the field that matters most on the one line
+    that exists to make the change reviewable.
+    """
+    for key in ("avg_latency_us", "latency_us"):
+        value = rule.get(key)
+        if value is not None:
+            return value
+    return None
+
+
+def _report_rule_change(phase: str, merge_key, old_rule: dict, new_rule: dict) -> None:
+    old_geo, new_geo = _rule_geometry(old_rule), _rule_geometry(new_rule)
+    geo = (
+        f"{old_geo}  ->  {new_geo}" if old_geo != new_geo else f"{new_geo} (unchanged)"
+    )
+    # Inter-node bandwidth_gbps changed meaning (slowest-rank mean -> grand
+    # mean); a rule written before that carries no marker. Percentages across
+    # the two are meaningless and read as a big win -- grand mean >=
+    # slowest-rank mean by construction -- which is exactly backwards for a
+    # report meant to help judge whether to keep the new result.
+    #
+    # Both sides missing the marker means neither side changed definition, so
+    # they *are* comparable: that is the intra-node path, whose bandwidth_gbps
+    # was never redefined. Only a mismatch indicates a redefinition.
+    old_metric = old_rule.get(BANDWIDTH_METRIC_KEY)
+    new_metric = new_rule.get(BANDWIDTH_METRIC_KEY)
+    bw_comparable = old_metric == new_metric
+    print(
+        f"[mori-tuning] REPLACED {phase} rule {merge_key}\n"
+        f"               config:  {geo}\n"
+        f"               latency: "
+        f"{_format_delta(_rule_latency(old_rule), _rule_latency(new_rule), 'us')}\n"
+        f"               bw:      "
+        f"{_format_delta(old_rule.get('bandwidth_gbps'), new_rule.get('bandwidth_gbps'), ' GB/s', bw_comparable)}",
+        flush=True,
+    )
+
+
+def _report_rule_added(phase: str, merge_key, rule: dict) -> None:
+    print(
+        f"[mori-tuning] ADDED {phase} rule {merge_key}\n"
+        f"               config:  {_rule_geometry(rule)}\n"
+        f"               latency: {_format_delta(None, _rule_latency(rule), 'us')}\n"
+        f"               bw:      {_format_delta(None, rule.get('bandwidth_gbps'), ' GB/s')}",
+        flush=True,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -561,6 +664,12 @@ class TuningConfigManager:
 
         ``topk`` participates in the merge key, so tuning the same shape at a
         different top-k adds a rule instead of overwriting the existing one.
+
+        A matching rule is replaced unconditionally, and what changed is
+        printed (see the "Save reporting" section above for why there is no
+        keep-best comparison guarding this). ``bandwidth_gbps`` is recorded for
+        readers, not consulted here -- nothing in the runtime lookup path reads
+        it either, only block_num/rdma_block_num/warp_per_block are.
         """
         path = Path(path)
 
@@ -625,31 +734,11 @@ class TuningConfigManager:
                 break
 
         if matched_idx is not None:
-            old_bw = rules[matched_idx].get("bandwidth_gbps", 0)
-            new_bw = entry.get("bandwidth_gbps", 0)
-            # Require a margin, not just any improvement: without it a re-tune
-            # that lands 0.01 GB/s higher purely on measurement noise rewrites
-            # the checked-in rule, so the file churns on every run.
-            if new_bw > old_bw * (1.0 + _SAVE_REL_MARGIN):
-                rules[matched_idx] = entry
-                logger.info(
-                    "Updated %s rule for %s (%.2f -> %.2f GB/s)",
-                    phase,
-                    merge_key,
-                    old_bw,
-                    new_bw,
-                )
-            else:
-                logger.info(
-                    "Kept existing %s rule for %s (existing %.2f >= new %.2f GB/s)",
-                    phase,
-                    merge_key,
-                    old_bw,
-                    new_bw,
-                )
+            _report_rule_change(phase, merge_key, rules[matched_idx], entry)
+            rules[matched_idx] = entry
         else:
+            _report_rule_added(phase, merge_key, entry)
             rules.append(entry)
-            logger.info("Added %s rule: %s", phase, merge_key)
 
         rules.sort(key=sort_key)
         data["rules"] = rules

--- a/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_combine.json
+++ b/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_combine.json
@@ -12,14 +12,14 @@
       "hidden_dim": 6144,
       "zero_copy": false,
       "quant_type": "none",
-      "block_num": 64,
+      "block_num": 128,
       "rdma_block_num": 32,
       "warp_per_block": 4,
-      "bandwidth_gbps": 5.43,
-      "avg_rdma_bandwidth_gbps": 1.43,
-      "avg_xgmi_bandwidth_gbps": 4.75,
-      "avg_ll_bandwidth_gbps": 5.43,
-      "avg_latency_us": 69.04
+      "bandwidth_gbps": 4.29,
+      "avg_rdma_bandwidth_gbps": 1.38,
+      "avg_xgmi_bandwidth_gbps": 4.59,
+      "avg_ll_bandwidth_gbps": 5.25,
+      "avg_latency_us": 71.32
     },
     {
       "dtype": "bf16",
@@ -27,14 +27,14 @@
       "hidden_dim": 6144,
       "zero_copy": false,
       "quant_type": "none",
-      "block_num": 64,
+      "block_num": 128,
       "rdma_block_num": 32,
       "warp_per_block": 4,
-      "bandwidth_gbps": 11.59,
-      "avg_rdma_bandwidth_gbps": 2.85,
-      "avg_xgmi_bandwidth_gbps": 9.23,
-      "avg_ll_bandwidth_gbps": 11.59,
-      "avg_latency_us": 69.11
+      "bandwidth_gbps": 9.45,
+      "avg_rdma_bandwidth_gbps": 2.72,
+      "avg_xgmi_bandwidth_gbps": 8.82,
+      "avg_ll_bandwidth_gbps": 11.07,
+      "avg_latency_us": 72.45
     },
     {
       "dtype": "bf16",
@@ -45,11 +45,11 @@
       "block_num": 32,
       "rdma_block_num": 21,
       "warp_per_block": 4,
-      "bandwidth_gbps": 23.58,
-      "avg_rdma_bandwidth_gbps": 5.7,
-      "avg_xgmi_bandwidth_gbps": 18.61,
-      "avg_ll_bandwidth_gbps": 23.58,
-      "avg_latency_us": 69.16
+      "bandwidth_gbps": 20.65,
+      "avg_rdma_bandwidth_gbps": 5.62,
+      "avg_xgmi_bandwidth_gbps": 18.34,
+      "avg_ll_bandwidth_gbps": 23.25,
+      "avg_latency_us": 70.05
     },
     {
       "dtype": "bf16",
@@ -60,11 +60,11 @@
       "block_num": 64,
       "rdma_block_num": 32,
       "warp_per_block": 4,
-      "bandwidth_gbps": 43.81,
-      "avg_rdma_bandwidth_gbps": 10.52,
-      "avg_xgmi_bandwidth_gbps": 34.57,
-      "avg_ll_bandwidth_gbps": 43.81,
-      "avg_latency_us": 74.8
+      "bandwidth_gbps": 39.81,
+      "avg_rdma_bandwidth_gbps": 10.47,
+      "avg_xgmi_bandwidth_gbps": 34.42,
+      "avg_ll_bandwidth_gbps": 43.62,
+      "avg_latency_us": 75.26
     }
   ]
 }

--- a/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_combine.json
+++ b/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_combine.json
@@ -27,14 +27,14 @@
       "hidden_dim": 6144,
       "zero_copy": false,
       "quant_type": "none",
-      "block_num": 32,
-      "rdma_block_num": 21,
+      "block_num": 64,
+      "rdma_block_num": 32,
       "warp_per_block": 4,
-      "bandwidth_gbps": 11.48,
-      "avg_rdma_bandwidth_gbps": 2.82,
-      "avg_xgmi_bandwidth_gbps": 9.15,
-      "avg_ll_bandwidth_gbps": 11.48,
-      "avg_latency_us": 69.82
+      "bandwidth_gbps": 11.59,
+      "avg_rdma_bandwidth_gbps": 2.85,
+      "avg_xgmi_bandwidth_gbps": 9.23,
+      "avg_ll_bandwidth_gbps": 11.59,
+      "avg_latency_us": 69.11
     },
     {
       "dtype": "bf16",
@@ -50,6 +50,21 @@
       "avg_xgmi_bandwidth_gbps": 18.61,
       "avg_ll_bandwidth_gbps": 23.58,
       "avg_latency_us": 69.16
+    },
+    {
+      "dtype": "bf16",
+      "num_tokens": 32,
+      "hidden_dim": 6144,
+      "zero_copy": false,
+      "quant_type": "none",
+      "block_num": 64,
+      "rdma_block_num": 32,
+      "warp_per_block": 4,
+      "bandwidth_gbps": 43.81,
+      "avg_rdma_bandwidth_gbps": 10.52,
+      "avg_xgmi_bandwidth_gbps": 34.57,
+      "avg_ll_bandwidth_gbps": 43.81,
+      "avg_latency_us": 74.8
     }
   ]
 }

--- a/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_combine.json
+++ b/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_combine.json
@@ -12,14 +12,14 @@
       "hidden_dim": 6144,
       "zero_copy": false,
       "quant_type": "none",
-      "block_num": 128,
-      "rdma_block_num": 32,
+      "block_num": 16,
+      "rdma_block_num": 10,
       "warp_per_block": 4,
-      "bandwidth_gbps": 4.29,
-      "avg_rdma_bandwidth_gbps": 1.38,
-      "avg_xgmi_bandwidth_gbps": 4.59,
-      "avg_ll_bandwidth_gbps": 5.25,
-      "avg_latency_us": 71.32
+      "bandwidth_gbps": 4.32,
+      "avg_rdma_bandwidth_gbps": 1.39,
+      "avg_xgmi_bandwidth_gbps": 4.64,
+      "avg_ll_bandwidth_gbps": 5.3,
+      "avg_latency_us": 70.73
     },
     {
       "dtype": "bf16",
@@ -60,11 +60,11 @@
       "block_num": 64,
       "rdma_block_num": 32,
       "warp_per_block": 4,
-      "bandwidth_gbps": 39.81,
-      "avg_rdma_bandwidth_gbps": 10.47,
-      "avg_xgmi_bandwidth_gbps": 34.42,
-      "avg_ll_bandwidth_gbps": 43.62,
-      "avg_latency_us": 75.26
+      "bandwidth_gbps": 40.51,
+      "avg_rdma_bandwidth_gbps": 10.49,
+      "avg_xgmi_bandwidth_gbps": 34.47,
+      "avg_ll_bandwidth_gbps": 43.68,
+      "avg_latency_us": 75.07
     }
   ]
 }

--- a/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_combine.json
+++ b/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_combine.json
@@ -12,14 +12,15 @@
       "hidden_dim": 6144,
       "zero_copy": false,
       "quant_type": "none",
-      "block_num": 16,
-      "rdma_block_num": 10,
+      "block_num": 128,
+      "rdma_block_num": 32,
       "warp_per_block": 4,
-      "bandwidth_gbps": 4.32,
-      "avg_rdma_bandwidth_gbps": 1.39,
-      "avg_xgmi_bandwidth_gbps": 4.64,
-      "avg_ll_bandwidth_gbps": 5.3,
-      "avg_latency_us": 70.73
+      "bandwidth_gbps": 5.33,
+      "avg_rdma_bandwidth_gbps": 1.4,
+      "avg_xgmi_bandwidth_gbps": 4.66,
+      "avg_ll_bandwidth_gbps": 5.33,
+      "avg_latency_us": 70.32,
+      "bandwidth_metric": "grand_mean"
     },
     {
       "dtype": "bf16",
@@ -27,14 +28,15 @@
       "hidden_dim": 6144,
       "zero_copy": false,
       "quant_type": "none",
-      "block_num": 128,
+      "block_num": 64,
       "rdma_block_num": 32,
       "warp_per_block": 4,
-      "bandwidth_gbps": 9.45,
-      "avg_rdma_bandwidth_gbps": 2.72,
-      "avg_xgmi_bandwidth_gbps": 8.82,
-      "avg_ll_bandwidth_gbps": 11.07,
-      "avg_latency_us": 72.45
+      "bandwidth_gbps": 11.53,
+      "avg_rdma_bandwidth_gbps": 2.83,
+      "avg_xgmi_bandwidth_gbps": 9.18,
+      "avg_ll_bandwidth_gbps": 11.53,
+      "avg_latency_us": 69.57,
+      "bandwidth_metric": "grand_mean"
     },
     {
       "dtype": "bf16",
@@ -45,11 +47,12 @@
       "block_num": 32,
       "rdma_block_num": 21,
       "warp_per_block": 4,
-      "bandwidth_gbps": 20.65,
-      "avg_rdma_bandwidth_gbps": 5.62,
-      "avg_xgmi_bandwidth_gbps": 18.34,
-      "avg_ll_bandwidth_gbps": 23.25,
-      "avg_latency_us": 70.05
+      "bandwidth_gbps": 23.31,
+      "avg_rdma_bandwidth_gbps": 5.64,
+      "avg_xgmi_bandwidth_gbps": 18.4,
+      "avg_ll_bandwidth_gbps": 23.31,
+      "avg_latency_us": 69.93,
+      "bandwidth_metric": "grand_mean"
     },
     {
       "dtype": "bf16",
@@ -60,11 +63,12 @@
       "block_num": 64,
       "rdma_block_num": 32,
       "warp_per_block": 4,
-      "bandwidth_gbps": 40.51,
-      "avg_rdma_bandwidth_gbps": 10.49,
-      "avg_xgmi_bandwidth_gbps": 34.47,
-      "avg_ll_bandwidth_gbps": 43.68,
-      "avg_latency_us": 75.07
+      "bandwidth_gbps": 43.54,
+      "avg_rdma_bandwidth_gbps": 10.46,
+      "avg_xgmi_bandwidth_gbps": 34.36,
+      "avg_ll_bandwidth_gbps": 43.54,
+      "avg_latency_us": 75.33,
+      "bandwidth_metric": "grand_mean"
     }
   ]
 }

--- a/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_combine.json
+++ b/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_combine.json
@@ -13,13 +13,13 @@
       "zero_copy": false,
       "quant_type": "none",
       "block_num": 128,
-      "rdma_block_num": 64,
+      "rdma_block_num": 32,
       "warp_per_block": 4,
-      "bandwidth_gbps": 4.37,
-      "avg_rdma_bandwidth_gbps": 1.45,
-      "avg_xgmi_bandwidth_gbps": 4.83,
-      "avg_ll_bandwidth_gbps": 5.52,
-      "avg_latency_us": 67.88
+      "bandwidth_gbps": 5.14,
+      "avg_rdma_bandwidth_gbps": 1.64,
+      "avg_xgmi_bandwidth_gbps": 5.46,
+      "avg_ll_bandwidth_gbps": 6.24,
+      "avg_latency_us": 59.95
     },
     {
       "dtype": "bf16",
@@ -27,14 +27,14 @@
       "hidden_dim": 6144,
       "zero_copy": false,
       "quant_type": "none",
-      "block_num": 32,
-      "rdma_block_num": 8,
-      "warp_per_block": 4,
-      "bandwidth_gbps": 9.41,
-      "avg_rdma_bandwidth_gbps": 2.77,
-      "avg_xgmi_bandwidth_gbps": 8.99,
-      "avg_ll_bandwidth_gbps": 11.29,
-      "avg_latency_us": 71.14
+      "block_num": 128,
+      "rdma_block_num": 64,
+      "warp_per_block": 6,
+      "bandwidth_gbps": 11.07,
+      "avg_rdma_bandwidth_gbps": 3.15,
+      "avg_xgmi_bandwidth_gbps": 10.21,
+      "avg_ll_bandwidth_gbps": 12.81,
+      "avg_latency_us": 62.51
     },
     {
       "dtype": "bf16",
@@ -42,14 +42,14 @@
       "hidden_dim": 6144,
       "zero_copy": false,
       "quant_type": "none",
-      "block_num": 32,
-      "rdma_block_num": 16,
+      "block_num": 256,
+      "rdma_block_num": 64,
       "warp_per_block": 4,
-      "bandwidth_gbps": 21.59,
-      "avg_rdma_bandwidth_gbps": 5.88,
-      "avg_xgmi_bandwidth_gbps": 19.18,
-      "avg_ll_bandwidth_gbps": 24.31,
-      "avg_latency_us": 67.06
+      "bandwidth_gbps": 23.24,
+      "avg_rdma_bandwidth_gbps": 6.24,
+      "avg_xgmi_bandwidth_gbps": 20.36,
+      "avg_ll_bandwidth_gbps": 25.8,
+      "avg_latency_us": 63.09
     }
   ]
 }

--- a/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_combine.json
+++ b/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_combine.json
@@ -12,14 +12,14 @@
       "hidden_dim": 6144,
       "zero_copy": false,
       "quant_type": "none",
-      "block_num": 128,
+      "block_num": 64,
       "rdma_block_num": 32,
       "warp_per_block": 4,
-      "bandwidth_gbps": 5.14,
-      "avg_rdma_bandwidth_gbps": 1.64,
-      "avg_xgmi_bandwidth_gbps": 5.46,
-      "avg_ll_bandwidth_gbps": 6.24,
-      "avg_latency_us": 59.95
+      "bandwidth_gbps": 5.43,
+      "avg_rdma_bandwidth_gbps": 1.43,
+      "avg_xgmi_bandwidth_gbps": 4.75,
+      "avg_ll_bandwidth_gbps": 5.43,
+      "avg_latency_us": 69.04
     },
     {
       "dtype": "bf16",
@@ -27,14 +27,14 @@
       "hidden_dim": 6144,
       "zero_copy": false,
       "quant_type": "none",
-      "block_num": 128,
-      "rdma_block_num": 64,
-      "warp_per_block": 6,
-      "bandwidth_gbps": 11.07,
-      "avg_rdma_bandwidth_gbps": 3.15,
-      "avg_xgmi_bandwidth_gbps": 10.21,
-      "avg_ll_bandwidth_gbps": 12.81,
-      "avg_latency_us": 62.51
+      "block_num": 32,
+      "rdma_block_num": 21,
+      "warp_per_block": 4,
+      "bandwidth_gbps": 11.48,
+      "avg_rdma_bandwidth_gbps": 2.82,
+      "avg_xgmi_bandwidth_gbps": 9.15,
+      "avg_ll_bandwidth_gbps": 11.48,
+      "avg_latency_us": 69.82
     },
     {
       "dtype": "bf16",
@@ -42,14 +42,14 @@
       "hidden_dim": 6144,
       "zero_copy": false,
       "quant_type": "none",
-      "block_num": 256,
-      "rdma_block_num": 64,
+      "block_num": 32,
+      "rdma_block_num": 21,
       "warp_per_block": 4,
-      "bandwidth_gbps": 23.24,
-      "avg_rdma_bandwidth_gbps": 6.24,
-      "avg_xgmi_bandwidth_gbps": 20.36,
-      "avg_ll_bandwidth_gbps": 25.8,
-      "avg_latency_us": 63.09
+      "bandwidth_gbps": 23.58,
+      "avg_rdma_bandwidth_gbps": 5.7,
+      "avg_xgmi_bandwidth_gbps": 18.61,
+      "avg_ll_bandwidth_gbps": 23.58,
+      "avg_latency_us": 69.16
     }
   ]
 }

--- a/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_combine.json
+++ b/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_combine.json
@@ -1,0 +1,55 @@
+{
+  "version": "1.0",
+  "gpu_arch": "gfx942",
+  "gpu_model": "mi300x",
+  "kernel_type": "InterNodeV1LL",
+  "ep_size": 16,
+  "phase": "combine",
+  "rules": [
+    {
+      "dtype": "bf16",
+      "num_tokens": 4,
+      "hidden_dim": 6144,
+      "zero_copy": false,
+      "quant_type": "none",
+      "block_num": 128,
+      "rdma_block_num": 64,
+      "warp_per_block": 4,
+      "bandwidth_gbps": 4.37,
+      "avg_rdma_bandwidth_gbps": 1.45,
+      "avg_xgmi_bandwidth_gbps": 4.83,
+      "avg_ll_bandwidth_gbps": 5.52,
+      "avg_latency_us": 67.88
+    },
+    {
+      "dtype": "bf16",
+      "num_tokens": 8,
+      "hidden_dim": 6144,
+      "zero_copy": false,
+      "quant_type": "none",
+      "block_num": 32,
+      "rdma_block_num": 8,
+      "warp_per_block": 4,
+      "bandwidth_gbps": 9.41,
+      "avg_rdma_bandwidth_gbps": 2.77,
+      "avg_xgmi_bandwidth_gbps": 8.99,
+      "avg_ll_bandwidth_gbps": 11.29,
+      "avg_latency_us": 71.14
+    },
+    {
+      "dtype": "bf16",
+      "num_tokens": 16,
+      "hidden_dim": 6144,
+      "zero_copy": false,
+      "quant_type": "none",
+      "block_num": 32,
+      "rdma_block_num": 16,
+      "warp_per_block": 4,
+      "bandwidth_gbps": 21.59,
+      "avg_rdma_bandwidth_gbps": 5.88,
+      "avg_xgmi_bandwidth_gbps": 19.18,
+      "avg_ll_bandwidth_gbps": 24.31,
+      "avg_latency_us": 67.06
+    }
+  ]
+}

--- a/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_dispatch.json
+++ b/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_dispatch.json
@@ -10,14 +10,14 @@
       "dtype": "fp8_e4m3_fnuz",
       "num_tokens": 4,
       "hidden_dim": 6144,
-      "block_num": 64,
-      "rdma_block_num": 42,
+      "block_num": 32,
+      "rdma_block_num": 21,
       "warp_per_block": 4,
-      "bandwidth_gbps": 3.88,
-      "avg_rdma_bandwidth_gbps": 1.02,
-      "avg_xgmi_bandwidth_gbps": 3.4,
-      "avg_ll_bandwidth_gbps": 3.88,
-      "avg_latency_us": 48.2
+      "bandwidth_gbps": 3.91,
+      "avg_rdma_bandwidth_gbps": 1.03,
+      "avg_xgmi_bandwidth_gbps": 3.42,
+      "avg_ll_bandwidth_gbps": 3.91,
+      "avg_latency_us": 48.04
     },
     {
       "dtype": "fp8_e4m3_fnuz",
@@ -39,11 +39,24 @@
       "block_num": 64,
       "rdma_block_num": 42,
       "warp_per_block": 4,
-      "bandwidth_gbps": 16.48,
-      "avg_rdma_bandwidth_gbps": 3.99,
-      "avg_xgmi_bandwidth_gbps": 13.01,
-      "avg_ll_bandwidth_gbps": 16.48,
-      "avg_latency_us": 49.5
+      "bandwidth_gbps": 16.61,
+      "avg_rdma_bandwidth_gbps": 4.02,
+      "avg_xgmi_bandwidth_gbps": 13.11,
+      "avg_ll_bandwidth_gbps": 16.61,
+      "avg_latency_us": 49.1
+    },
+    {
+      "dtype": "fp8_e4m3_fnuz",
+      "num_tokens": 32,
+      "hidden_dim": 6144,
+      "block_num": 128,
+      "rdma_block_num": 64,
+      "warp_per_block": 4,
+      "bandwidth_gbps": 31.3,
+      "avg_rdma_bandwidth_gbps": 7.51,
+      "avg_xgmi_bandwidth_gbps": 24.7,
+      "avg_ll_bandwidth_gbps": 31.3,
+      "avg_latency_us": 52.44
     }
   ]
 }

--- a/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_dispatch.json
+++ b/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_dispatch.json
@@ -10,40 +10,40 @@
       "dtype": "fp8_e4m3_fnuz",
       "num_tokens": 4,
       "hidden_dim": 6144,
-      "block_num": 32,
-      "rdma_block_num": 21,
+      "block_num": 64,
+      "rdma_block_num": 42,
       "warp_per_block": 4,
-      "bandwidth_gbps": 3.2,
-      "avg_rdma_bandwidth_gbps": 1.04,
-      "avg_xgmi_bandwidth_gbps": 3.46,
-      "avg_ll_bandwidth_gbps": 3.95,
-      "avg_latency_us": 47.43
+      "bandwidth_gbps": 3.88,
+      "avg_rdma_bandwidth_gbps": 1.02,
+      "avg_xgmi_bandwidth_gbps": 3.4,
+      "avg_ll_bandwidth_gbps": 3.88,
+      "avg_latency_us": 48.2
     },
     {
       "dtype": "fp8_e4m3_fnuz",
       "num_tokens": 8,
       "hidden_dim": 6144,
       "block_num": 64,
-      "rdma_block_num": 32,
+      "rdma_block_num": 42,
       "warp_per_block": 4,
-      "bandwidth_gbps": 6.81,
-      "avg_rdma_bandwidth_gbps": 2.02,
-      "avg_xgmi_bandwidth_gbps": 6.55,
-      "avg_ll_bandwidth_gbps": 8.22,
-      "avg_latency_us": 48.83
+      "bandwidth_gbps": 8.36,
+      "avg_rdma_bandwidth_gbps": 2.05,
+      "avg_xgmi_bandwidth_gbps": 6.66,
+      "avg_ll_bandwidth_gbps": 8.36,
+      "avg_latency_us": 48.1
     },
     {
       "dtype": "fp8_e4m3_fnuz",
       "num_tokens": 16,
       "hidden_dim": 6144,
       "block_num": 64,
-      "rdma_block_num": 32,
+      "rdma_block_num": 42,
       "warp_per_block": 4,
-      "bandwidth_gbps": 14.42,
-      "avg_rdma_bandwidth_gbps": 3.96,
-      "avg_xgmi_bandwidth_gbps": 12.94,
-      "avg_ll_bandwidth_gbps": 16.39,
-      "avg_latency_us": 49.72
+      "bandwidth_gbps": 16.48,
+      "avg_rdma_bandwidth_gbps": 3.99,
+      "avg_xgmi_bandwidth_gbps": 13.01,
+      "avg_ll_bandwidth_gbps": 16.48,
+      "avg_latency_us": 49.5
     }
   ]
 }

--- a/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_dispatch.json
+++ b/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_dispatch.json
@@ -10,14 +10,14 @@
       "dtype": "fp8_e4m3_fnuz",
       "num_tokens": 4,
       "hidden_dim": 6144,
-      "block_num": 64,
-      "rdma_block_num": 42,
+      "block_num": 16,
+      "rdma_block_num": 8,
       "warp_per_block": 4,
-      "bandwidth_gbps": 3.04,
-      "avg_rdma_bandwidth_gbps": 1.02,
-      "avg_xgmi_bandwidth_gbps": 3.4,
-      "avg_ll_bandwidth_gbps": 3.88,
-      "avg_latency_us": 48.46
+      "bandwidth_gbps": 3.19,
+      "avg_rdma_bandwidth_gbps": 1.03,
+      "avg_xgmi_bandwidth_gbps": 3.43,
+      "avg_ll_bandwidth_gbps": 3.92,
+      "avg_latency_us": 47.79
     },
     {
       "dtype": "fp8_e4m3_fnuz",
@@ -50,13 +50,13 @@
       "num_tokens": 32,
       "hidden_dim": 6144,
       "block_num": 128,
-      "rdma_block_num": 85,
+      "rdma_block_num": 64,
       "warp_per_block": 4,
-      "bandwidth_gbps": 28.29,
-      "avg_rdma_bandwidth_gbps": 7.4,
-      "avg_xgmi_bandwidth_gbps": 24.31,
-      "avg_ll_bandwidth_gbps": 30.81,
-      "avg_latency_us": 53.24
+      "bandwidth_gbps": 28.09,
+      "avg_rdma_bandwidth_gbps": 7.42,
+      "avg_xgmi_bandwidth_gbps": 24.39,
+      "avg_ll_bandwidth_gbps": 30.91,
+      "avg_latency_us": 53.14
     }
   ]
 }

--- a/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_dispatch.json
+++ b/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_dispatch.json
@@ -13,37 +13,37 @@
       "block_num": 32,
       "rdma_block_num": 21,
       "warp_per_block": 4,
-      "bandwidth_gbps": 3.47,
-      "avg_rdma_bandwidth_gbps": 1.14,
-      "avg_xgmi_bandwidth_gbps": 3.8,
-      "avg_ll_bandwidth_gbps": 4.34,
-      "avg_latency_us": 43.18
+      "bandwidth_gbps": 3.2,
+      "avg_rdma_bandwidth_gbps": 1.04,
+      "avg_xgmi_bandwidth_gbps": 3.46,
+      "avg_ll_bandwidth_gbps": 3.95,
+      "avg_latency_us": 47.43
     },
     {
       "dtype": "fp8_e4m3_fnuz",
       "num_tokens": 8,
       "hidden_dim": 6144,
-      "block_num": 32,
-      "rdma_block_num": 16,
-      "warp_per_block": 8,
-      "bandwidth_gbps": 7.25,
-      "avg_rdma_bandwidth_gbps": 2.19,
-      "avg_xgmi_bandwidth_gbps": 7.1,
-      "avg_ll_bandwidth_gbps": 8.91,
-      "avg_latency_us": 45.16
+      "block_num": 64,
+      "rdma_block_num": 32,
+      "warp_per_block": 4,
+      "bandwidth_gbps": 6.81,
+      "avg_rdma_bandwidth_gbps": 2.02,
+      "avg_xgmi_bandwidth_gbps": 6.55,
+      "avg_ll_bandwidth_gbps": 8.22,
+      "avg_latency_us": 48.83
     },
     {
       "dtype": "fp8_e4m3_fnuz",
       "num_tokens": 16,
       "hidden_dim": 6144,
-      "block_num": 32,
-      "rdma_block_num": 16,
-      "warp_per_block": 8,
-      "bandwidth_gbps": 15.58,
-      "avg_rdma_bandwidth_gbps": 4.21,
-      "avg_xgmi_bandwidth_gbps": 13.74,
-      "avg_ll_bandwidth_gbps": 17.41,
-      "avg_latency_us": 46.84
+      "block_num": 64,
+      "rdma_block_num": 32,
+      "warp_per_block": 4,
+      "bandwidth_gbps": 14.42,
+      "avg_rdma_bandwidth_gbps": 3.96,
+      "avg_xgmi_bandwidth_gbps": 12.94,
+      "avg_ll_bandwidth_gbps": 16.39,
+      "avg_latency_us": 49.72
     }
   ]
 }

--- a/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_dispatch.json
+++ b/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_dispatch.json
@@ -10,27 +10,29 @@
       "dtype": "fp8_e4m3_fnuz",
       "num_tokens": 4,
       "hidden_dim": 6144,
-      "block_num": 16,
-      "rdma_block_num": 8,
+      "block_num": 64,
+      "rdma_block_num": 16,
       "warp_per_block": 4,
-      "bandwidth_gbps": 3.19,
-      "avg_rdma_bandwidth_gbps": 1.03,
-      "avg_xgmi_bandwidth_gbps": 3.43,
-      "avg_ll_bandwidth_gbps": 3.92,
-      "avg_latency_us": 47.79
+      "bandwidth_gbps": 3.87,
+      "avg_rdma_bandwidth_gbps": 1.02,
+      "avg_xgmi_bandwidth_gbps": 3.38,
+      "avg_ll_bandwidth_gbps": 3.87,
+      "avg_latency_us": 48.42,
+      "bandwidth_metric": "grand_mean"
     },
     {
       "dtype": "fp8_e4m3_fnuz",
       "num_tokens": 8,
       "hidden_dim": 6144,
       "block_num": 64,
-      "rdma_block_num": 42,
+      "rdma_block_num": 32,
       "warp_per_block": 4,
-      "bandwidth_gbps": 6.54,
-      "avg_rdma_bandwidth_gbps": 2.01,
-      "avg_xgmi_bandwidth_gbps": 6.56,
-      "avg_ll_bandwidth_gbps": 8.23,
-      "avg_latency_us": 49.01
+      "bandwidth_gbps": 8.27,
+      "avg_rdma_bandwidth_gbps": 2.03,
+      "avg_xgmi_bandwidth_gbps": 6.59,
+      "avg_ll_bandwidth_gbps": 8.27,
+      "avg_latency_us": 48.52,
+      "bandwidth_metric": "grand_mean"
     },
     {
       "dtype": "fp8_e4m3_fnuz",
@@ -39,11 +41,12 @@
       "block_num": 64,
       "rdma_block_num": 32,
       "warp_per_block": 4,
-      "bandwidth_gbps": 14.45,
-      "avg_rdma_bandwidth_gbps": 4.0,
-      "avg_xgmi_bandwidth_gbps": 13.06,
-      "avg_ll_bandwidth_gbps": 16.55,
-      "avg_latency_us": 49.27
+      "bandwidth_gbps": 16.37,
+      "avg_rdma_bandwidth_gbps": 3.96,
+      "avg_xgmi_bandwidth_gbps": 12.92,
+      "avg_ll_bandwidth_gbps": 16.37,
+      "avg_latency_us": 49.84,
+      "bandwidth_metric": "grand_mean"
     },
     {
       "dtype": "fp8_e4m3_fnuz",
@@ -52,11 +55,12 @@
       "block_num": 128,
       "rdma_block_num": 64,
       "warp_per_block": 4,
-      "bandwidth_gbps": 28.09,
-      "avg_rdma_bandwidth_gbps": 7.42,
-      "avg_xgmi_bandwidth_gbps": 24.39,
-      "avg_ll_bandwidth_gbps": 30.91,
-      "avg_latency_us": 53.14
+      "bandwidth_gbps": 30.68,
+      "avg_rdma_bandwidth_gbps": 7.37,
+      "avg_xgmi_bandwidth_gbps": 24.21,
+      "avg_ll_bandwidth_gbps": 30.68,
+      "avg_latency_us": 53.54,
+      "bandwidth_metric": "grand_mean"
     }
   ]
 }

--- a/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_dispatch.json
+++ b/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_dispatch.json
@@ -10,14 +10,14 @@
       "dtype": "fp8_e4m3_fnuz",
       "num_tokens": 4,
       "hidden_dim": 6144,
-      "block_num": 32,
-      "rdma_block_num": 21,
+      "block_num": 64,
+      "rdma_block_num": 42,
       "warp_per_block": 4,
-      "bandwidth_gbps": 3.91,
-      "avg_rdma_bandwidth_gbps": 1.03,
-      "avg_xgmi_bandwidth_gbps": 3.42,
-      "avg_ll_bandwidth_gbps": 3.91,
-      "avg_latency_us": 48.04
+      "bandwidth_gbps": 3.04,
+      "avg_rdma_bandwidth_gbps": 1.02,
+      "avg_xgmi_bandwidth_gbps": 3.4,
+      "avg_ll_bandwidth_gbps": 3.88,
+      "avg_latency_us": 48.46
     },
     {
       "dtype": "fp8_e4m3_fnuz",
@@ -26,37 +26,37 @@
       "block_num": 64,
       "rdma_block_num": 42,
       "warp_per_block": 4,
-      "bandwidth_gbps": 8.36,
-      "avg_rdma_bandwidth_gbps": 2.05,
-      "avg_xgmi_bandwidth_gbps": 6.66,
-      "avg_ll_bandwidth_gbps": 8.36,
-      "avg_latency_us": 48.1
+      "bandwidth_gbps": 6.54,
+      "avg_rdma_bandwidth_gbps": 2.01,
+      "avg_xgmi_bandwidth_gbps": 6.56,
+      "avg_ll_bandwidth_gbps": 8.23,
+      "avg_latency_us": 49.01
     },
     {
       "dtype": "fp8_e4m3_fnuz",
       "num_tokens": 16,
       "hidden_dim": 6144,
       "block_num": 64,
-      "rdma_block_num": 42,
+      "rdma_block_num": 32,
       "warp_per_block": 4,
-      "bandwidth_gbps": 16.61,
-      "avg_rdma_bandwidth_gbps": 4.02,
-      "avg_xgmi_bandwidth_gbps": 13.11,
-      "avg_ll_bandwidth_gbps": 16.61,
-      "avg_latency_us": 49.1
+      "bandwidth_gbps": 14.45,
+      "avg_rdma_bandwidth_gbps": 4.0,
+      "avg_xgmi_bandwidth_gbps": 13.06,
+      "avg_ll_bandwidth_gbps": 16.55,
+      "avg_latency_us": 49.27
     },
     {
       "dtype": "fp8_e4m3_fnuz",
       "num_tokens": 32,
       "hidden_dim": 6144,
       "block_num": 128,
-      "rdma_block_num": 64,
+      "rdma_block_num": 85,
       "warp_per_block": 4,
-      "bandwidth_gbps": 31.3,
-      "avg_rdma_bandwidth_gbps": 7.51,
-      "avg_xgmi_bandwidth_gbps": 24.7,
-      "avg_ll_bandwidth_gbps": 31.3,
-      "avg_latency_us": 52.44
+      "bandwidth_gbps": 28.29,
+      "avg_rdma_bandwidth_gbps": 7.4,
+      "avg_xgmi_bandwidth_gbps": 24.31,
+      "avg_ll_bandwidth_gbps": 30.81,
+      "avg_latency_us": 53.24
     }
   ]
 }

--- a/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_dispatch.json
+++ b/python/mori/ops/tuning_configs/gfx942_mi300x_InterNodeV1LL_ep16_dispatch.json
@@ -1,0 +1,49 @@
+{
+  "version": "1.0",
+  "gpu_arch": "gfx942",
+  "gpu_model": "mi300x",
+  "kernel_type": "InterNodeV1LL",
+  "ep_size": 16,
+  "phase": "dispatch",
+  "rules": [
+    {
+      "dtype": "fp8_e4m3_fnuz",
+      "num_tokens": 4,
+      "hidden_dim": 6144,
+      "block_num": 32,
+      "rdma_block_num": 21,
+      "warp_per_block": 4,
+      "bandwidth_gbps": 3.47,
+      "avg_rdma_bandwidth_gbps": 1.14,
+      "avg_xgmi_bandwidth_gbps": 3.8,
+      "avg_ll_bandwidth_gbps": 4.34,
+      "avg_latency_us": 43.18
+    },
+    {
+      "dtype": "fp8_e4m3_fnuz",
+      "num_tokens": 8,
+      "hidden_dim": 6144,
+      "block_num": 32,
+      "rdma_block_num": 16,
+      "warp_per_block": 8,
+      "bandwidth_gbps": 7.25,
+      "avg_rdma_bandwidth_gbps": 2.19,
+      "avg_xgmi_bandwidth_gbps": 7.1,
+      "avg_ll_bandwidth_gbps": 8.91,
+      "avg_latency_us": 45.16
+    },
+    {
+      "dtype": "fp8_e4m3_fnuz",
+      "num_tokens": 16,
+      "hidden_dim": 6144,
+      "block_num": 32,
+      "rdma_block_num": 16,
+      "warp_per_block": 8,
+      "bandwidth_gbps": 15.58,
+      "avg_rdma_bandwidth_gbps": 4.21,
+      "avg_xgmi_bandwidth_gbps": 13.74,
+      "avg_ll_bandwidth_gbps": 17.41,
+      "avg_latency_us": 46.84
+    }
+  ]
+}

--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -37,7 +37,42 @@ import os
 
 os.environ.setdefault("MORI_SHMEM_HEAP_SIZE", "6G")
 
-_BW_NOISE_MARGIN = 1.0
+# Relative bandwidth improvement a candidate needs to take the lead during the
+# sweep. Default 0: any improvement wins.
+#
+# This was an absolute 1.0 GB/s, which cannot work across the operating range.
+# Where a whole sweep sits in the low single-digit GB/s -- small token counts --
+# nothing after the first candidate can ever clear +1.0, so the sweep silently
+# returns whatever it happened to measure first; where bandwidth is in the
+# hundreds it is under 1%, so it stops filtering noise at all. The inter-node
+# tuner had the same bug and the same fix (MORI_EP_TUNING_MARGIN, shared here
+# so one setting covers both).
+#
+# `os.environ.get(k, default)` only substitutes default when the var is
+# *unset* -- MORI_EP_TUNING_MARGIN="" would reach float("") and crash, so fall
+# back on an empty string too.
+_BW_REL_MARGIN = float(os.environ.get("MORI_EP_TUNING_MARGIN") or "0.0")
+
+
+def _bw_beats(new_bw, new_cfg, best_bw, best_cfg):
+    """Should *new_cfg* take the lead? Higher bandwidth is better here.
+
+    Note the direction: this path selects on bandwidth, while the inter-node
+    tuner selects on latency, so the comparisons are inverted relative to its
+    _beats().
+
+    Wins outright past the margin; within it, ties break on the
+    lexicographically smaller (block_num, warp_per_block) so re-tuning the same
+    hardware is deterministic instead of depending on which candidate the sweep
+    reached first.
+    """
+    if best_cfg is None:
+        return True
+    if new_bw > best_bw * (1.0 + _BW_REL_MARGIN):
+        return True
+    if new_bw >= best_bw * (1.0 - _BW_REL_MARGIN) and new_cfg < best_cfg:
+        return True
+    return False
 
 
 def _emit_intra_perf(
@@ -1268,13 +1303,14 @@ def _bench_dispatch_combine(
                         call_local_expert_count=call_local_expert_count,
                     )
 
-                    if disp_bw > best_disp_bw + _BW_NOISE_MARGIN:
+                    cand = (block_num, warp_per_block)
+                    if _bw_beats(disp_bw, cand, best_disp_bw, best_disp_config):
                         best_disp_bw = disp_bw
-                        best_disp_config = (block_num, warp_per_block)
+                        best_disp_config = cand
                         best_disp_lat = disp_lat
-                    if comb_bw > best_comb_bw + _BW_NOISE_MARGIN:
+                    if _bw_beats(comb_bw, cand, best_comb_bw, best_comb_config):
                         best_comb_bw = comb_bw
-                        best_comb_config = (block_num, warp_per_block)
+                        best_comb_config = cand
                         best_comb_lat = comb_lat
 
             # --- Extra dispatch sweep: over-subscribe, fix combine at best ---
@@ -1306,9 +1342,10 @@ def _bench_dispatch_combine(
                             call_local_expert_count=call_local_expert_count,
                         )
 
-                        if disp_bw > best_disp_bw + _BW_NOISE_MARGIN:
+                        cand = (block_num, warp_per_block)
+                        if _bw_beats(disp_bw, cand, best_disp_bw, best_disp_config):
                             best_disp_bw = disp_bw
-                            best_disp_config = (block_num, warp_per_block)
+                            best_disp_config = cand
                             best_disp_lat = disp_lat
 
             if rank == 0:

--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -62,9 +62,16 @@ def _bw_beats(new_bw, new_cfg, best_bw, best_cfg):
     _beats().
 
     Wins outright past the margin; within it, ties break on the
-    lexicographically smaller (block_num, warp_per_block) so re-tuning the same
-    hardware is deterministic instead of depending on which candidate the sweep
-    reached first.
+    lexicographically smaller (block_num, warp_per_block), so a tie resolves to
+    the smaller geometry rather than to whichever candidate the sweep reached
+    first.
+
+    As in the inter-node _beats(), the tie-break cannot fire under the current
+    ascending sweep order, and the same caveat applies before reordering it:
+    the caller overwrites best_bw with the winner's bandwidth, so a tie-break
+    win at MORI_EP_TUNING_MARGIN > 0 installs a *lower* bandwidth as the
+    baseline for the next comparison and the incumbent can ratchet downward.
+    Split the comparison baseline from the selected candidate first.
     """
     if best_cfg is None:
         return True

--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -1227,6 +1227,17 @@ def _bench_dispatch_combine(
             sm_count = torch.cuda.get_device_properties(rank).multi_processor_count
             tuning_scope = os.environ.get("MORI_TUNING_SCOPE", "full")
 
+            if save_tuning_config and tuning_scope == "quick":
+                raise ValueError(
+                    "MORI_TUNING_SCOPE=quick cannot be combined with "
+                    "--save-tuning-config: quick sweeps 3 warp_per_block "
+                    "candidates against full's 9, and only powers of two for "
+                    "block_num against full's step-8 grid over the same "
+                    "range, so a quick-scope winner is not a result worth "
+                    "committing as a saved config. Re-run with "
+                    "MORI_TUNING_SCOPE unset (or =full) to save."
+                )
+
             if tuning_scope == "quick":
                 block_set = set()
                 pow2 = 32

--- a/tests/python/ops/bench_dispatch_combine.py
+++ b/tests/python/ops/bench_dispatch_combine.py
@@ -1534,29 +1534,45 @@ if __name__ == "__main__":
             "'fp8_blockwise' is the BF16<->FP8 blockwise quant path."
         ),
     )
+    # --block-num/--warp-per-block set both phases; the per-phase flags override
+    # them. Same shape as the internode benchmark
+    # (examples/ops/dispatch_combine/test_dispatch_combine_internode.py), which
+    # additionally carries an rdma_block_num triple that has no meaning here.
+    parser.add_argument(
+        "--block-num",
+        type=int,
+        default=None,
+        help="Override block_num for both phases. Ignored when --cmd tuning.",
+    )
+    parser.add_argument(
+        "--warp-per-block",
+        type=int,
+        default=None,
+        help="Override warp_per_block for both phases. Ignored when --cmd tuning.",
+    )
     parser.add_argument(
         "--dispatch-block-num",
         type=int,
         default=None,
-        help="Override dispatch block_num for bench/stress. Ignored when --cmd tuning.",
+        help="Override dispatch block_num for bench/stress (wins over --block-num).",
     )
     parser.add_argument(
         "--dispatch-warp-per-block",
         type=int,
         default=None,
-        help="Override dispatch warp_per_block for bench/stress. Ignored when --cmd tuning.",
+        help="Override dispatch warp_per_block for bench/stress (wins over --warp-per-block).",
     )
     parser.add_argument(
         "--combine-block-num",
         type=int,
         default=None,
-        help="Override combine block_num for bench/stress. Ignored when --cmd tuning.",
+        help="Override combine block_num for bench/stress (wins over --block-num).",
     )
     parser.add_argument(
         "--combine-warp-per-block",
         type=int,
         default=None,
-        help="Override combine warp_per_block for bench/stress. Ignored when --cmd tuning.",
+        help="Override combine warp_per_block for bench/stress (wins over --warp-per-block).",
     )
     parser.add_argument(
         "--world-size",
@@ -1760,6 +1776,19 @@ if __name__ == "__main__":
     base_hidden_dim = args.hidden_dim
     dispatch_hidden_dim = (
         base_hidden_dim // 2 if _is_fp4x2_dtype(dispatch_dtype) else base_hidden_dim
+    )
+
+    # Per-phase flag wins over the shared one; None means let the op decide.
+    def _phase_param(per_phase, shared):
+        return per_phase if per_phase is not None else shared
+
+    args.dispatch_block_num = _phase_param(args.dispatch_block_num, args.block_num)
+    args.dispatch_warp_per_block = _phase_param(
+        args.dispatch_warp_per_block, args.warp_per_block
+    )
+    args.combine_block_num = _phase_param(args.combine_block_num, args.block_num)
+    args.combine_warp_per_block = _phase_param(
+        args.combine_warp_per_block, args.warp_per_block
     )
 
     print(

--- a/tools/batch_internode_tuning.sh
+++ b/tools/batch_internode_tuning.sh
@@ -142,12 +142,30 @@ echo "============================================================"
 echo ""
 
 # ---- Verify SSH connectivity ----
+#
+# DOCKER_EXEC is probed rather than fixed: `docker exec` needs access to the
+# docker daemon socket, which comes from membership in the `docker` group, not
+# from being root. Where the operator is in that group, plain `docker exec`
+# works and `sudo` fails outright on hosts that grant no sudo rights at all.
+# Try unprivileged first, fall back to sudo, and report both failures together
+# rather than blaming SSH for a permissions problem.
+DOCKER_EXEC=""
 echo "Verifying SSH to $PEER_HOST ..."
 if [[ -n "$DOCKER" ]]; then
-    if ! ssh "${SSH_OPTS[@]}" "$PEER_HOST" "sudo docker exec $DOCKER bash -c 'echo ok'" &>/dev/null; then
-        echo "Error: Cannot SSH to $PEER_HOST or docker exec into $DOCKER failed"
+    for candidate in "docker exec" "sudo -n docker exec"; do
+        if ssh "${SSH_OPTS[@]}" "$PEER_HOST" "$candidate $DOCKER bash -c 'echo ok'" &>/dev/null; then
+            DOCKER_EXEC="$candidate"
+            break
+        fi
+    done
+    if [[ -z "$DOCKER_EXEC" ]]; then
+        echo "Error: cannot reach container '$DOCKER' on $PEER_HOST."
+        echo "       Tried 'docker exec' and 'sudo -n docker exec'. Check that"
+        echo "       passwordless SSH works, the container is running, and the"
+        echo "       remote user is in the docker group (or has sudo rights)."
         exit 1
     fi
+    echo "  docker exec prefix:  $DOCKER_EXEC"
 else
     if ! ssh "${SSH_OPTS[@]}" "$PEER_HOST" "echo ok" &>/dev/null; then
         echo "Error: Cannot SSH to $PEER_HOST (passwordless SSH required)"
@@ -202,7 +220,7 @@ launch_peer() {
     local CMD="$1"
     if [[ -n "$DOCKER" ]]; then
         ssh "${SSH_OPTS[@]}" "$PEER_HOST" \
-            "sudo docker exec -w $REMOTE_REPO_ROOT $DOCKER bash -c \"$CMD\"" &
+            "$DOCKER_EXEC -w $REMOTE_REPO_ROOT $DOCKER bash -c \"$CMD\"" &
     else
         ssh "${SSH_OPTS[@]}" "$PEER_HOST" "bash -lc '$CMD'" &
     fi
@@ -216,7 +234,7 @@ cleanup_peer() {
     local KILL_CMD='pkill -9 -f torchrun; pkill -9 -f test_dispatch_combine_internode; pkill -9 -f "multiprocessing.spawn"'
     if [[ -n "$DOCKER" ]]; then
         ssh "${SSH_OPTS[@]}" "$PEER_HOST" \
-            "sudo docker exec $DOCKER bash -c '$KILL_CMD'" 2>/dev/null || true
+            "$DOCKER_EXEC $DOCKER bash -c '$KILL_CMD'" 2>/dev/null || true
     else
         ssh "${SSH_OPTS[@]}" "$PEER_HOST" "$KILL_CMD" 2>/dev/null || true
     fi
@@ -228,7 +246,7 @@ KILL_ALL='pkill -9 -f torchrun; pkill -9 -f test_dispatch_combine_internode; pki
 eval "$KILL_ALL" 2>/dev/null || true
 if [[ -n "$DOCKER" ]]; then
     ssh "${SSH_OPTS[@]}" "$PEER_HOST" \
-        "sudo docker exec $DOCKER bash -c '$KILL_ALL'" 2>/dev/null || true
+        "$DOCKER_EXEC $DOCKER bash -c '$KILL_ALL'" 2>/dev/null || true
 else
     ssh "${SSH_OPTS[@]}" "$PEER_HOST" "$KILL_ALL" 2>/dev/null || true
 fi

--- a/tools/batch_internode_tuning.sh
+++ b/tools/batch_internode_tuning.sh
@@ -103,7 +103,13 @@ done
 
 # ---- Validate required args ----
 for var in MASTER_ADDR PEER_HOST IFNAME; do
-    [[ -z "${!var}" ]] && { echo "Error: --${var,,} is required"; exit 1; }
+    if [[ -z "${!var}" ]]; then
+        # ${var,,} lowercases but leaves the underscores, which would name a
+        # flag that does not exist (--master_addr for --master-addr).
+        flag="--${var,,}"
+        echo "Error: ${flag//_/-} is required"
+        exit 1
+    fi
 done
 
 [[ -z "$REMOTE_REPO_ROOT" ]] && REMOTE_REPO_ROOT="$REPO_ROOT"
@@ -297,7 +303,7 @@ launch_peer() {
 cleanup_peer() {
     kill "$PEER_PID" 2>/dev/null || true
     wait "$PEER_PID" 2>/dev/null || true
-    local KILL_CMD='pkill -9 -f "[t]orchrun"; pkill -9 -f "[t]est_dispatch_combine_internode"; pkill -9 -f "[m]ultiprocessing.spawn"'
+    local KILL_CMD='pkill -9 -f "[t]orchrun.*test_dispatch_combine_internode"; pkill -9 -f "[t]est_dispatch_combine_internode"'
     if [[ -n "$DOCKER" ]]; then
         ssh "${SSH_OPTS[@]}" "$PEER_HOST" \
             "$DOCKER_EXEC $DOCKER bash -c '$KILL_CMD'" 2>/dev/null || true
@@ -308,7 +314,7 @@ cleanup_peer() {
 
 # ---- Pre-run: kill residual processes ----
 echo "Cleaning up residual processes..."
-KILL_ALL='pkill -9 -f "[t]orchrun"; pkill -9 -f "[t]est_dispatch_combine_internode"; pkill -9 -f "[m]ultiprocessing.spawn"'
+KILL_ALL='pkill -9 -f "[t]orchrun.*test_dispatch_combine_internode"; pkill -9 -f "[t]est_dispatch_combine_internode"'
 kill_local "$KILL_ALL"
 if [[ -n "$DOCKER" ]]; then
     ssh "${SSH_OPTS[@]}" "$PEER_HOST" \
@@ -372,7 +378,7 @@ for HIDDEN_DIM in "${HIDDEN_DIM_ARRAY[@]}"; do
         fi
 
         # Always cleanup peer
-        kill_local 'pkill -9 -f "[t]orchrun"; pkill -9 -f "[t]est_dispatch_combine_internode"; pkill -9 -f "[m]ultiprocessing.spawn"'
+        kill_local 'pkill -9 -f "[t]orchrun.*test_dispatch_combine_internode"; pkill -9 -f "[t]est_dispatch_combine_internode"'
         cleanup_peer
         sleep 2
     done

--- a/tools/batch_internode_tuning.sh
+++ b/tools/batch_internode_tuning.sh
@@ -15,23 +15,29 @@ set -euo pipefail
 #
 # Usage examples:
 #
-#   # Quick test (single config, quick scope)
+#   # Single shape
 #   bash tools/batch_internode_tuning.sh \
 #       --master-addr <HOST0> --peer-host <USER>@<HOST1> --ifname <IFNAME> \
-#       --kernel-type v1 --num-qp 2 --tokens-list "128" --tuning-scope quick
+#       --kernel-type v1 --num-qp 2 --tokens-list "128"
 #
 #   # With docker (remote node runs inside a container)
 #   bash tools/batch_internode_tuning.sh \
 #       --master-addr <HOST0> --peer-host <USER>@<HOST1> --ifname <IFNAME> \
 #       --docker <CONTAINER> --ssh-key <SSH_KEY_PATH> \
 #       --kernel-type v1 --num-qp 2 --dtype fp4 --combine-dtype bf16 \
-#       --quant-type fp8_direct_cast --tuning-scope quick
+#       --quant-type fp8_direct_cast
 #
-#   # Full tuning: v1_ll, fp8→bf16
+#   # v1_ll, fp8→bf16
 #   bash tools/batch_internode_tuning.sh \
 #       --master-addr <HOST0> --peer-host <USER>@<HOST1> --ifname <IFNAME> \
 #       --kernel-type v1_ll --num-qp 2 --dtype fp8_e4m3_fnuz --combine-dtype bf16 \
-#       --quant-type none --tuning-scope quick
+#       --quant-type none
+#
+#   # Exploratory quick sweep -- reduced candidate grid, cannot be saved, so
+#   # saving has to be turned off explicitly
+#   bash tools/batch_internode_tuning.sh \
+#       --master-addr <HOST0> --peer-host <USER>@<HOST1> --ifname <IFNAME> \
+#       --kernel-type v1 --num-qp 2 --tuning-scope quick --config-output ''
 # ============================================================================
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -94,6 +100,19 @@ for var in MASTER_ADDR PEER_HOST IFNAME; do
 done
 
 [[ -z "$REMOTE_REPO_ROOT" ]] && REMOTE_REPO_ROOT="$REPO_ROOT"
+
+# Saving requires the full sweep. The tuning script itself refuses this
+# combination, but it does so per combo after both ranks are up; catching it
+# here fails in a second instead of after a two-node launch, and says which of
+# the two knobs to change.
+if [[ "$TUNING_SCOPE" == "quick" && -n "$CONFIG_OUTPUT" ]]; then
+    echo "Error: --tuning-scope quick cannot write a tuning config."
+    echo "       quick sweeps a reduced candidate grid, so its winner is not"
+    echo "       a result worth committing. Either run the full sweep"
+    echo "       (--tuning-scope full) or explore without saving"
+    echo "       (--config-output '')."
+    exit 1
+fi
 
 # ---- SSH options ----
 SSH_OPTS=(-o BatchMode=yes -o ConnectTimeout=10)
@@ -231,7 +250,7 @@ launch_peer() {
 cleanup_peer() {
     kill "$PEER_PID" 2>/dev/null || true
     wait "$PEER_PID" 2>/dev/null || true
-    local KILL_CMD='pkill -9 -f torchrun; pkill -9 -f test_dispatch_combine_internode; pkill -9 -f "multiprocessing.spawn"'
+    local KILL_CMD='pkill -9 -f "[t]orchrun"; pkill -9 -f "[t]est_dispatch_combine_internode"; pkill -9 -f "[m]ultiprocessing.spawn"'
     if [[ -n "$DOCKER" ]]; then
         ssh "${SSH_OPTS[@]}" "$PEER_HOST" \
             "$DOCKER_EXEC $DOCKER bash -c '$KILL_CMD'" 2>/dev/null || true
@@ -242,7 +261,7 @@ cleanup_peer() {
 
 # ---- Pre-run: kill residual processes ----
 echo "Cleaning up residual processes..."
-KILL_ALL='pkill -9 -f torchrun; pkill -9 -f test_dispatch_combine_internode; pkill -9 -f "multiprocessing.spawn"'
+KILL_ALL='pkill -9 -f "[t]orchrun"; pkill -9 -f "[t]est_dispatch_combine_internode"; pkill -9 -f "[m]ultiprocessing.spawn"'
 eval "$KILL_ALL" 2>/dev/null || true
 if [[ -n "$DOCKER" ]]; then
     ssh "${SSH_OPTS[@]}" "$PEER_HOST" \

--- a/tools/batch_internode_tuning.sh
+++ b/tools/batch_internode_tuning.sh
@@ -20,10 +20,13 @@ set -euo pipefail
 #       --master-addr <HOST0> --peer-host <USER>@<HOST1> --ifname <IFNAME> \
 #       --kernel-type v1 --num-qp 2 --tokens-list "128"
 #
-#   # With docker (remote node runs inside a container)
+#   # With docker on both nodes, driver staying on the host. --local-docker
+#   # reaches rank 0's container with `docker exec` the same way --docker
+#   # reaches the peer's, so SSH runs from the host and its keys never have to
+#   # be copied into a container.
 #   bash tools/batch_internode_tuning.sh \
 #       --master-addr <HOST0> --peer-host <USER>@<HOST1> --ifname <IFNAME> \
-#       --docker <CONTAINER> --ssh-key <SSH_KEY_PATH> \
+#       --local-docker <CONTAINER0> --docker <CONTAINER1> \
 #       --kernel-type v1 --num-qp 2 --dtype fp4 --combine-dtype bf16 \
 #       --quant-type fp8_direct_cast
 #
@@ -54,8 +57,10 @@ PEER_HOST=""
 IFNAME=""
 REMOTE_REPO_ROOT=""
 DOCKER=""
+LOCAL_DOCKER=""
 SSH_KEY=""
 RDMA_SL=""
+RDMA_TC=""
 TUNING_SCOPE="full"
 KERNEL_TYPE="v1"
 NUM_QP=1
@@ -77,8 +82,10 @@ while [[ $# -gt 0 ]]; do
         --ifname)            IFNAME="$2";            shift 2 ;;
         --remote-repo-root)  REMOTE_REPO_ROOT="$2";  shift 2 ;;
         --docker)            DOCKER="$2";            shift 2 ;;
+        --local-docker)      LOCAL_DOCKER="$2";      shift 2 ;;
         --ssh-key)           SSH_KEY="$2";           shift 2 ;;
         --rdma-sl)           RDMA_SL="$2";           shift 2 ;;
+        --rdma-tc)           RDMA_TC="$2";           shift 2 ;;
         --tuning-scope)      TUNING_SCOPE="$2";      shift 2 ;;
         --kernel-type)       KERNEL_TYPE="$2";       shift 2 ;;
         --num-qp)            NUM_QP="$2";            shift 2 ;;
@@ -138,9 +145,11 @@ echo "============================================================"
 echo "  master_addr:         $MASTER_ADDR"
 echo "  peer_host:           $PEER_HOST"
 echo "  ifname:              $IFNAME"
-echo "  docker:              ${DOCKER:-<none, direct execution>}"
+echo "  docker (peer):       ${DOCKER:-<none, direct execution>}"
+echo "  docker (local):      ${LOCAL_DOCKER:-<none, direct execution>}"
 echo "  ssh_key:             ${SSH_KEY:-<default>}"
 echo "  rdma_sl:             ${RDMA_SL:-<not set>}"
+echo "  rdma_tc:             ${RDMA_TC:-<not set>}"
 echo "  tuning_scope:        $TUNING_SCOPE"
 echo "  kernel_type:         $KERNEL_TYPE"
 echo "  num_qp:              $NUM_QP"
@@ -194,6 +203,43 @@ fi
 echo "SSH OK"
 echo ""
 
+# ---- Resolve how rank 0 is launched ----
+#
+# --local-docker exists so the driver itself can stay on the host while mori
+# lives in a container: rank 0 is then reached with `docker exec` locally, the
+# same way the peer is reached remotely. Without it the driver has to run
+# inside the container, which means the container needs SSH access to the peer
+# -- i.e. a private key has to be placed inside a container purely so the
+# script can reach the other node.
+LOCAL_DOCKER_EXEC=""
+if [[ -n "$LOCAL_DOCKER" ]]; then
+    for candidate in "docker exec" "sudo -n docker exec"; do
+        if $candidate "$LOCAL_DOCKER" bash -c 'echo ok' &>/dev/null; then
+            LOCAL_DOCKER_EXEC="$candidate"
+            break
+        fi
+    done
+    if [[ -z "$LOCAL_DOCKER_EXEC" ]]; then
+        echo "Error: cannot exec into local container '$LOCAL_DOCKER'."
+        echo "       Tried 'docker exec' and 'sudo -n docker exec'. Check that"
+        echo "       the container is running and this user is in the docker"
+        echo "       group (or has sudo rights)."
+        exit 1
+    fi
+    echo "Local rank runs in container '$LOCAL_DOCKER' via: $LOCAL_DOCKER_EXEC"
+    echo ""
+fi
+
+# Run a cleanup command where rank 0 lives, so a timed-out `docker exec` does
+# not leave the torchrun processes running inside the container.
+kill_local() {
+    if [[ -n "$LOCAL_DOCKER" ]]; then
+        $LOCAL_DOCKER_EXEC "$LOCAL_DOCKER" bash -c "$1" 2>/dev/null || true
+    else
+        eval "$1" 2>/dev/null || true
+    fi
+}
+
 # ---- Build common python args (shared by both ranks) ----
 build_py_args() {
     local MAX_TOKENS="$1"
@@ -227,6 +273,7 @@ build_torchrun_cmd() {
     ENV_VARS+=" MORI_TUNING_SCOPE=$TUNING_SCOPE"
     ENV_VARS+=" OMP_NUM_THREADS=4"
     [[ -n "$RDMA_SL" ]] && ENV_VARS+=" MORI_RDMA_SL=$RDMA_SL"
+    [[ -n "$RDMA_TC" ]] && ENV_VARS+=" MORI_RDMA_TC=$RDMA_TC"
 
     echo "cd $THE_REPO_ROOT && $ENV_VARS" \
          "torchrun --nnodes=2 --node_rank=$NODE_RANK --nproc_per_node=1" \
@@ -262,7 +309,7 @@ cleanup_peer() {
 # ---- Pre-run: kill residual processes ----
 echo "Cleaning up residual processes..."
 KILL_ALL='pkill -9 -f "[t]orchrun"; pkill -9 -f "[t]est_dispatch_combine_internode"; pkill -9 -f "[m]ultiprocessing.spawn"'
-eval "$KILL_ALL" 2>/dev/null || true
+kill_local "$KILL_ALL"
 if [[ -n "$DOCKER" ]]; then
     ssh "${SSH_OPTS[@]}" "$PEER_HOST" \
         "$DOCKER_EXEC $DOCKER bash -c '$KILL_ALL'" 2>/dev/null || true
@@ -298,7 +345,14 @@ for HIDDEN_DIM in "${HIDDEN_DIM_ARRAY[@]}"; do
 
         # Launch local (rank 0) with timeout
         set +e
-        timeout "$TIMEOUT_SEC" bash -c "$CMD_RANK0" 2>&1 | tee -a "$LOG_FILE"
+        # Unquoted $LOCAL_DOCKER_EXEC on purpose: it is "docker exec" or
+        # "sudo -n docker exec" and has to split into separate words.
+        if [[ -n "$LOCAL_DOCKER" ]]; then
+            LOCAL_RUN=($LOCAL_DOCKER_EXEC -w "$REPO_ROOT" "$LOCAL_DOCKER" bash -c "$CMD_RANK0")
+        else
+            LOCAL_RUN=(bash -c "$CMD_RANK0")
+        fi
+        timeout "$TIMEOUT_SEC" "${LOCAL_RUN[@]}" 2>&1 | tee -a "$LOG_FILE"
         EXIT_CODE=${PIPESTATUS[0]}
         set -e
 
@@ -318,6 +372,7 @@ for HIDDEN_DIM in "${HIDDEN_DIM_ARRAY[@]}"; do
         fi
 
         # Always cleanup peer
+        kill_local 'pkill -9 -f "[t]orchrun"; pkill -9 -f "[t]est_dispatch_combine_internode"; pkill -9 -f "[m]ultiprocessing.spawn"'
         cleanup_peer
         sleep 2
     done

--- a/tools/batch_intranode_tuning.sh
+++ b/tools/batch_intranode_tuning.sh
@@ -94,6 +94,18 @@ fi
 
 export MORI_TUNING_SCOPE="$TUNING_SCOPE"
 
+# Saving requires the full sweep. bench_dispatch_combine.py refuses this
+# combination too, but only once the ranks are up; catching it here fails
+# immediately and names the two knobs that resolve it.
+if [[ "$TUNING_SCOPE" == "quick" && -n "$CONFIG_OUTPUT" ]]; then
+    echo "Error: --tuning-scope quick cannot write a tuning config."
+    echo "       quick sweeps a reduced candidate grid, so its winner is not"
+    echo "       a result worth committing. Either run the full sweep"
+    echo "       (--tuning-scope full) or explore without saving"
+    echo "       (--config-output '')."
+    exit 1
+fi
+
 # ---- Convert comma-separated lists to arrays ----
 IFS=',' read -ra TOKEN_ARRAY <<< "$TOKENS_LIST"
 IFS=',' read -ra HIDDEN_DIM_ARRAY <<< "$HIDDEN_DIMS"
@@ -137,8 +149,13 @@ PY_COMMON_ARGS=(
     --dtype "$DTYPE"
     --zero-copy "$ZERO_COPY"
     --quant-type "$QUANT_TYPE"
-    --save-tuning-config "$CONFIG_OUTPUT"
 )
+
+# Omit the flag entirely when empty, matching batch_internode_tuning.sh, so
+# --config-output '' means "do not save" rather than passing an empty path.
+if [[ -n "$CONFIG_OUTPUT" ]]; then
+    PY_COMMON_ARGS+=(--save-tuning-config "$CONFIG_OUTPUT")
+fi
 
 if [[ -n "$COMBINE_DTYPE" ]]; then
     PY_COMMON_ARGS+=(--combine-dtype "$COMBINE_DTYPE")

--- a/tools/run_all_internode_tuning.sh
+++ b/tools/run_all_internode_tuning.sh
@@ -68,7 +68,13 @@ while [[ $# -gt 0 ]]; do
 done
 
 for var in MASTER_ADDR PEER_HOST IFNAME; do
-    [[ -z "${!var}" ]] && { echo "Error: --${var,,} is required"; exit 1; }
+    if [[ -z "${!var}" ]]; then
+        # ${var,,} lowercases but leaves the underscores, which would name a
+        # flag that does not exist (--master_addr for --master-addr).
+        flag="--${var,,}"
+        echo "Error: ${flag//_/-} is required"
+        exit 1
+    fi
 done
 
 COMMON_ARGS=(

--- a/tools/run_all_internode_tuning.sh
+++ b/tools/run_all_internode_tuning.sh
@@ -1,13 +1,21 @@
 #!/usr/bin/env bash
 set -uo pipefail
 
-# Master script: run the full EP16 internode tuning matrix (quick mode)
+# Master script: run the full EP16 internode tuning matrix
 # Runs 6 kernel/dtype combos × 7 token sizes = 42 total tuning jobs
+#
+# Defaults to the full sweep because the output is the committed tuning JSON;
+# quick is exploratory only and cannot be saved, so pair it with
+# --config-output '':
+#
+#   bash tools/run_all_internode_tuning.sh ... \
+#       --tuning-scope quick --config-output ''
 #
 # Usage:
 #   bash tools/run_all_internode_tuning.sh \
 #       --master-addr <HOST0> --peer-host <USER>@<HOST1> --ifname <IFNAME> \
-#       [--docker <CONTAINER>] [--ssh-key <KEY>] [--num-qp 2] [--tuning-scope quick]
+#       [--docker <CONTAINER>] [--ssh-key <KEY>] [--num-qp 2] \
+#       [--tuning-scope full|quick] [--config-output <PATH|auto|''>]
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -21,10 +29,15 @@ IFNAME=""
 DOCKER=""
 SSH_KEY=""
 NUM_QP=2
-TUNING_SCOPE="quick"
+# full, not quick: this script's output is the committed tuning JSON, and
+# saving requires the full sweep (batch_internode_tuning.sh rejects
+# quick+save). Pass --tuning-scope quick explicitly for an exploratory run,
+# and add --config-output '' to it so nothing is written.
+TUNING_SCOPE="full"
 HIDDEN_DIMS="7168"
 TOKENS_LIST="64,128,256,512,1024,2048,4096"
 TIMEOUT_LARGE=7200
+CONFIG_OUTPUT="auto"
 
 # ---- Parse args (pass-through to batch_internode_tuning.sh) ----
 while [[ $# -gt 0 ]]; do
@@ -39,6 +52,7 @@ while [[ $# -gt 0 ]]; do
         --hidden-dims)   HIDDEN_DIMS="$2";   shift 2 ;;
         --tokens-list)   TOKENS_LIST="$2";   shift 2 ;;
         --timeout)       TIMEOUT_LARGE="$2"; shift 2 ;;
+        --config-output) CONFIG_OUTPUT="$2"; shift 2 ;;
         *) echo "Unknown option: $1"; exit 1 ;;
     esac
 done
@@ -54,6 +68,7 @@ COMMON_ARGS=(
     --num-qp "$NUM_QP"
     --tuning-scope "$TUNING_SCOPE"
     --hidden-dims "$HIDDEN_DIMS"
+    --config-output "$CONFIG_OUTPUT"
 )
 [[ -n "$DOCKER" ]]  && COMMON_ARGS+=(--docker "$DOCKER")
 [[ -n "$SSH_KEY" ]] && COMMON_ARGS+=(--ssh-key "$SSH_KEY")

--- a/tools/run_all_internode_tuning.sh
+++ b/tools/run_all_internode_tuning.sh
@@ -38,6 +38,11 @@ HIDDEN_DIMS="7168"
 TOKENS_LIST="64,128,256,512,1024,2048,4096"
 TIMEOUT_LARGE=7200
 CONFIG_OUTPUT="auto"
+LOCAL_DOCKER=""
+RDMA_SL=""
+RDMA_TC=""
+MASTER_PORT=""
+GPU_PER_NODE=""
 
 # ---- Parse args (pass-through to batch_internode_tuning.sh) ----
 while [[ $# -gt 0 ]]; do
@@ -53,6 +58,11 @@ while [[ $# -gt 0 ]]; do
         --tokens-list)   TOKENS_LIST="$2";   shift 2 ;;
         --timeout)       TIMEOUT_LARGE="$2"; shift 2 ;;
         --config-output) CONFIG_OUTPUT="$2"; shift 2 ;;
+        --local-docker)  LOCAL_DOCKER="$2";  shift 2 ;;
+        --rdma-sl)       RDMA_SL="$2";       shift 2 ;;
+        --rdma-tc)       RDMA_TC="$2";       shift 2 ;;
+        --master-port)   MASTER_PORT="$2";   shift 2 ;;
+        --gpu-per-node)  GPU_PER_NODE="$2";  shift 2 ;;
         *) echo "Unknown option: $1"; exit 1 ;;
     esac
 done
@@ -70,8 +80,13 @@ COMMON_ARGS=(
     --hidden-dims "$HIDDEN_DIMS"
     --config-output "$CONFIG_OUTPUT"
 )
-[[ -n "$DOCKER" ]]  && COMMON_ARGS+=(--docker "$DOCKER")
-[[ -n "$SSH_KEY" ]] && COMMON_ARGS+=(--ssh-key "$SSH_KEY")
+[[ -n "$DOCKER" ]]       && COMMON_ARGS+=(--docker "$DOCKER")
+[[ -n "$LOCAL_DOCKER" ]] && COMMON_ARGS+=(--local-docker "$LOCAL_DOCKER")
+[[ -n "$SSH_KEY" ]]      && COMMON_ARGS+=(--ssh-key "$SSH_KEY")
+[[ -n "$RDMA_SL" ]]      && COMMON_ARGS+=(--rdma-sl "$RDMA_SL")
+[[ -n "$RDMA_TC" ]]      && COMMON_ARGS+=(--rdma-tc "$RDMA_TC")
+[[ -n "$MASTER_PORT" ]]  && COMMON_ARGS+=(--master-port "$MASTER_PORT")
+[[ -n "$GPU_PER_NODE" ]] && COMMON_ARGS+=(--gpu-per-node "$GPU_PER_NODE")
 
 # Auto-detect FP8 dtype: OCP (fp8_e4m3) vs FNUZ (fp8_e4m3_fnuz)
 FP8_DTYPE=$(python3 -c "
@@ -171,3 +186,10 @@ echo "# Total: $TOTAL_COMBOS combos"
 echo "# Failed: $TOTAL_FAILED"
 echo "# Results: $RESULT_LOG"
 echo "################################################################"
+
+# Propagate failure. This script ran every combo and then exited 0 regardless,
+# so a caller (or CI) could not tell a clean matrix from one where all six
+# groups died -- which is now easy to hit, since batch_internode_tuning.sh
+# rejects --tuning-scope quick together with a config output in under a second.
+[[ $TOTAL_FAILED -gt 0 ]] && exit 1
+exit 0

--- a/tools/run_all_intranode_tuning.sh
+++ b/tools/run_all_intranode_tuning.sh
@@ -9,10 +9,12 @@ set -euo pipefail
 #   gfx942 (MI300X/MI308X) → fp8_e4m3_fnuz (FNUZ format)
 #
 # Usage:
-#   bash tools/run_all_intranode_tuning.sh [--tuning-scope quick] [--gpus 0,1,2,3,4,5,6,7]
+#   bash tools/run_all_intranode_tuning.sh [--gpus 0,1,2,3,4,5,6,7]
 #
 # Options are forwarded to batch_intranode_tuning.sh. Common overrides:
-#   --tuning-scope quick|full    (default: quick)
+#   --tuning-scope quick|full    (default: full -- quick sweeps a reduced
+#                                 grid and cannot be saved, so pair it with
+#                                 --config-output '')
 #   --tokens-list "128,4096"     (default: 64,128,256,512,1024,2048,4096)
 #   --gpus "0,1,2,3"            (default: all visible)
 #   --timeout 3600               (default: 3600)

--- a/tools/verify_tuned_config.sh
+++ b/tools/verify_tuned_config.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================================
+# Verify a saved EP tuning config against the actual correctness check
+#
+# Runs on the DRIVER node (rank 0). Launches the peer node (rank 1) via SSH.
+# Sweeps the same (max_tokens x hidden_dim) combinations batch_internode_tuning.sh
+# does, but with --cmd test under MORI_EP_LAUNCH_CONFIG_MODE=AUTO instead of
+# --cmd tuning: each combo's dispatch/combine op is built with whatever
+# block_num/warp_per_block/rdma_block_num AUTO mode looks up from
+# python/mori/ops/tuning_configs/*.json for that shape, and --cmd test then
+# runs 500 rounds actually comparing dispatch/combine output against the
+# expected values.
+#
+# Why this exists: the tuning sweep in test_dispatch_combine_internode.py only
+# times each (block, warp, rdma) candidate -- run_bench_once never compares
+# output, so nothing in the sweep itself confirms the winning candidate it
+# writes to disk produces correct results, only that it was fast. This script
+# is the correctness check that closes that gap, run once against the winner
+# instead of 75 times against every candidate (which would make the sweep
+# itself far slower for a question the sweep doesn't need answered while
+# picking a fastest config).
+#
+# Prerequisites: same as batch_internode_tuning.sh (passwordless SSH to the
+# peer node, matching repo path or --remote-repo-root, --ifname reachable on
+# both nodes). Intended to run right after batch_internode_tuning.sh writes a
+# JSON, before that JSON is committed.
+#
+# Usage examples:
+#
+#   # Verify what a full tuning run just wrote, same shapes as tuning
+#   bash tools/verify_tuned_config.sh \
+#       --master-addr <HOST0> --peer-host <USER>@<HOST1> --ifname <IFNAME> \
+#       --kernel-type v1_ll --num-qp 2 --dtype fp8_e4m3_fnuz \
+#       --combine-dtype bf16 --quant-type none \
+#       --tokens-list "4,8,16" --hidden-dims "6144"
+#
+#   # With docker (remote node runs inside a container)
+#   bash tools/verify_tuned_config.sh \
+#       --master-addr <HOST0> --peer-host <USER>@<HOST1> --ifname <IFNAME> \
+#       --docker <CONTAINER> --ssh-key <SSH_KEY_PATH> \
+#       --kernel-type v1_ll --num-qp 2 --tokens-list "4,8,16" --hidden-dims "6144"
+#
+# Exit status: non-zero if any shape reports a nonzero "error times" on any
+# rank, or times out, or crashes -- the same signal batch_internode_tuning.sh
+# uses for its own per-combo failures.
+# ============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INTERNODE_SCRIPT="examples/ops/dispatch_combine/test_dispatch_combine_internode.py"
+LOG_DIR="$REPO_ROOT/logs"
+
+mkdir -p "$LOG_DIR"
+
+# ---- Defaults ----
+MASTER_ADDR=""
+MASTER_PORT=1234
+PEER_HOST=""
+IFNAME=""
+REMOTE_REPO_ROOT=""
+DOCKER=""
+SSH_KEY=""
+RDMA_SL=""
+KERNEL_TYPE="v1"
+NUM_QP=1
+TOKENS_LIST="64,128,256,512,1024,2048,4096"
+HIDDEN_DIMS="7168"
+DTYPE="fp4"
+COMBINE_DTYPE="bf16"
+QUANT_TYPE="fp8_direct_cast"
+GPU_PER_NODE=8
+TIMEOUT_SEC=600
+
+# ---- Parse args ----
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --master-addr)       MASTER_ADDR="$2";       shift 2 ;;
+        --master-port)       MASTER_PORT="$2";       shift 2 ;;
+        --peer-host)         PEER_HOST="$2";         shift 2 ;;
+        --ifname)            IFNAME="$2";            shift 2 ;;
+        --remote-repo-root)  REMOTE_REPO_ROOT="$2";  shift 2 ;;
+        --docker)            DOCKER="$2";            shift 2 ;;
+        --ssh-key)            SSH_KEY="$2";          shift 2 ;;
+        --rdma-sl)            RDMA_SL="$2";           shift 2 ;;
+        --kernel-type)        KERNEL_TYPE="$2";       shift 2 ;;
+        --num-qp)             NUM_QP="$2";            shift 2 ;;
+        --tokens-list)        TOKENS_LIST="$2";       shift 2 ;;
+        --hidden-dims)        HIDDEN_DIMS="$2";       shift 2 ;;
+        --dtype)              DTYPE="$2";             shift 2 ;;
+        --combine-dtype)      COMBINE_DTYPE="$2";     shift 2 ;;
+        --quant-type)         QUANT_TYPE="$2";        shift 2 ;;
+        --gpu-per-node)       GPU_PER_NODE="$2";      shift 2 ;;
+        --timeout)            TIMEOUT_SEC="$2";       shift 2 ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# ---- Validate required args ----
+for var in MASTER_ADDR PEER_HOST IFNAME; do
+    [[ -z "${!var}" ]] && { echo "Error: --${var,,} is required"; exit 1; }
+done
+
+[[ -z "$REMOTE_REPO_ROOT" ]] && REMOTE_REPO_ROOT="$REPO_ROOT"
+
+# ---- SSH options ----
+SSH_OPTS=(-o BatchMode=yes -o ConnectTimeout=10)
+[[ -n "$SSH_KEY" ]] && SSH_OPTS+=(-i "$SSH_KEY")
+
+# ---- Convert comma-separated lists to arrays ----
+IFS=',' read -ra TOKEN_ARRAY <<< "$TOKENS_LIST"
+IFS=',' read -ra HIDDEN_DIM_ARRAY <<< "$HIDDEN_DIMS"
+
+# ---- Build log filename ----
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+COMB_TAG="${COMBINE_DTYPE:-$DTYPE}"
+QUANT_TAG=""
+[[ "$QUANT_TYPE" != "none" ]] && QUANT_TAG="_${QUANT_TYPE}"
+LOG_FILE="${LOG_DIR}/verify_tuned_${KERNEL_TYPE}_ep$((GPU_PER_NODE*2))_${DTYPE}_${COMB_TAG}${QUANT_TAG}_${TIMESTAMP}.log"
+
+TOTAL_COMBOS=$(( ${#HIDDEN_DIM_ARRAY[@]} * ${#TOKEN_ARRAY[@]} ))
+
+# ---- Print summary ----
+echo "============================================================"
+echo "Verify Tuned Config (correctness, not speed)"
+echo "============================================================"
+echo "  master_addr:         $MASTER_ADDR"
+echo "  peer_host:           $PEER_HOST"
+echo "  ifname:              $IFNAME"
+echo "  docker:              ${DOCKER:-<none, direct execution>}"
+echo "  ssh_key:             ${SSH_KEY:-<default>}"
+echo "  rdma_sl:             ${RDMA_SL:-<not set>}"
+echo "  kernel_type:         $KERNEL_TYPE"
+echo "  num_qp:              $NUM_QP"
+echo "  gpu_per_node:        $GPU_PER_NODE"
+echo "  ep_size:             $((GPU_PER_NODE * 2))"
+echo "  tokens_list:         ${TOKEN_ARRAY[*]}"
+echo "  hidden_dims:         ${HIDDEN_DIM_ARRAY[*]}"
+echo "  dtype:               $DTYPE"
+echo "  combine_dtype:       ${COMBINE_DTYPE:-same as dtype}"
+echo "  quant_type:          $QUANT_TYPE"
+echo "  timeout:             ${TIMEOUT_SEC}s per combo"
+echo "  total combos:        $TOTAL_COMBOS"
+echo "  log:                 $LOG_FILE"
+echo "  local repo:          $REPO_ROOT"
+echo "  remote repo:         $REMOTE_REPO_ROOT"
+echo "============================================================"
+echo ""
+echo "Each combo reads block_num/warp_per_block/rdma_block_num from"
+echo "python/mori/ops/tuning_configs/*.json via MORI_EP_LAUNCH_CONFIG_MODE=AUTO"
+echo "-- this verifies whatever is currently on disk, not a fixed geometry."
+echo ""
+
+# ---- Verify SSH connectivity ----
+echo "Verifying SSH to $PEER_HOST ..."
+if [[ -n "$DOCKER" ]]; then
+    if ! ssh "${SSH_OPTS[@]}" "$PEER_HOST" "sudo docker exec $DOCKER bash -c 'echo ok'" &>/dev/null; then
+        echo "Error: Cannot SSH to $PEER_HOST or docker exec into $DOCKER failed"
+        exit 1
+    fi
+else
+    if ! ssh "${SSH_OPTS[@]}" "$PEER_HOST" "echo ok" &>/dev/null; then
+        echo "Error: Cannot SSH to $PEER_HOST (passwordless SSH required)"
+        exit 1
+    fi
+fi
+echo "SSH OK"
+echo ""
+
+# ---- Build common python args (shared by both ranks) ----
+build_py_args() {
+    local MAX_TOKENS="$1"
+    local HIDDEN_DIM="$2"
+
+    local ARGS=(
+        --cmd test
+        --kernel-type "$KERNEL_TYPE"
+        --num-qp "$NUM_QP"
+        --max-tokens "$MAX_TOKENS"
+        --hidden-dim "$HIDDEN_DIM"
+        --dtype "$DTYPE"
+        --quant-type "$QUANT_TYPE"
+    )
+    [[ -n "$COMBINE_DTYPE" ]] && ARGS+=(--combine-dtype "$COMBINE_DTYPE")
+    echo "${ARGS[@]}"
+}
+
+# ---- Build torchrun command for one rank ----
+build_torchrun_cmd() {
+    local NODE_RANK="$1"
+    local THE_REPO_ROOT="$2"
+    local PY_ARGS="$3"
+
+    local ENV_VARS="GPU_PER_NODE=$GPU_PER_NODE"
+    ENV_VARS+=" GLOO_SOCKET_IFNAME=$IFNAME"
+    ENV_VARS+=" MORI_SOCKET_IFNAME=$IFNAME"
+    ENV_VARS+=" PYTHONPATH=${THE_REPO_ROOT}/python:${THE_REPO_ROOT}"
+    ENV_VARS+=" MORI_EP_LAUNCH_CONFIG_MODE=AUTO"
+    ENV_VARS+=" OMP_NUM_THREADS=4"
+    [[ -n "$RDMA_SL" ]] && ENV_VARS+=" MORI_RDMA_SL=$RDMA_SL"
+
+    echo "cd $THE_REPO_ROOT && $ENV_VARS" \
+         "torchrun --nnodes=2 --node_rank=$NODE_RANK --nproc_per_node=1" \
+         "--master_addr=$MASTER_ADDR --master_port=$MASTER_PORT" \
+         "$INTERNODE_SCRIPT $PY_ARGS"
+}
+
+# ---- Launch remote (rank 1) ----
+launch_peer() {
+    local CMD="$1"
+    if [[ -n "$DOCKER" ]]; then
+        ssh "${SSH_OPTS[@]}" "$PEER_HOST" \
+            "sudo docker exec -w $REMOTE_REPO_ROOT $DOCKER bash -c \"$CMD\"" &
+    else
+        ssh "${SSH_OPTS[@]}" "$PEER_HOST" "bash -lc '$CMD'" &
+    fi
+    PEER_PID=$!
+}
+
+# ---- Kill remote processes ----
+cleanup_peer() {
+    kill "$PEER_PID" 2>/dev/null || true
+    wait "$PEER_PID" 2>/dev/null || true
+    local KILL_CMD='pkill -9 -f torchrun; pkill -9 -f test_dispatch_combine_internode; pkill -9 -f "multiprocessing.spawn"'
+    if [[ -n "$DOCKER" ]]; then
+        ssh "${SSH_OPTS[@]}" "$PEER_HOST" \
+            "sudo docker exec $DOCKER bash -c '$KILL_CMD'" 2>/dev/null || true
+    else
+        ssh "${SSH_OPTS[@]}" "$PEER_HOST" "$KILL_CMD" 2>/dev/null || true
+    fi
+}
+
+# ---- Pre-run: kill residual processes ----
+echo "Cleaning up residual processes..."
+KILL_ALL='pkill -9 -f torchrun; pkill -9 -f test_dispatch_combine_internode; pkill -9 -f "multiprocessing.spawn"'
+eval "$KILL_ALL" 2>/dev/null || true
+if [[ -n "$DOCKER" ]]; then
+    ssh "${SSH_OPTS[@]}" "$PEER_HOST" \
+        "sudo docker exec $DOCKER bash -c '$KILL_ALL'" 2>/dev/null || true
+else
+    ssh "${SSH_OPTS[@]}" "$PEER_HOST" "$KILL_ALL" 2>/dev/null || true
+fi
+sleep 2
+echo "Cleanup done"
+echo ""
+
+COMBO_IDX=0
+FAILED=0
+FAILED_COMBOS=""
+HUNG_COMBOS=""
+
+for HIDDEN_DIM in "${HIDDEN_DIM_ARRAY[@]}"; do
+    for TOKENS in "${TOKEN_ARRAY[@]}"; do
+        COMBO_IDX=$((COMBO_IDX + 1))
+        echo ""
+        echo "############################################################"
+        echo "[$(date)] [$COMBO_IDX/$TOTAL_COMBOS] kernel=$KERNEL_TYPE, hidden_dim=$HIDDEN_DIM, max_tokens=$TOKENS"
+        echo "############################################################"
+        echo ""
+
+        PY_ARGS=$(build_py_args "$TOKENS" "$HIDDEN_DIM")
+
+        CMD_RANK0=$(build_torchrun_cmd 0 "$REPO_ROOT" "$PY_ARGS")
+        CMD_RANK1=$(build_torchrun_cmd 1 "$REMOTE_REPO_ROOT" "$PY_ARGS")
+
+        # Launch peer (rank 1) via SSH in background
+        launch_peer "$CMD_RANK1"
+        sleep 3
+
+        # Launch local (rank 0) with timeout, capture output to grep for errors
+        COMBO_LOG="$(mktemp)"
+        set +e
+        timeout "$TIMEOUT_SEC" bash -c "$CMD_RANK0" 2>&1 | tee "$COMBO_LOG" | tee -a "$LOG_FILE"
+        EXIT_CODE=${PIPESTATUS[0]}
+        set -e
+
+        # test_dispatch_combine() prints one "error times:  N" line per rank;
+        # any nonzero N is a real dispatch/combine output mismatch, not noise.
+        BAD_RANKS=$(grep -cE "error times: +[1-9]" "$COMBO_LOG" || true)
+        rm -f "$COMBO_LOG"
+
+        if [[ $EXIT_CODE -eq 124 ]]; then
+            FAILED=$((FAILED + 1))
+            HUNG_COMBOS="${HUNG_COMBOS}\n  hidden_dim=$HIDDEN_DIM, max_tokens=$TOKENS"
+            echo ""
+            echo "!!! TIMEOUT (${TIMEOUT_SEC}s): hidden_dim=$HIDDEN_DIM, max_tokens=$TOKENS — possible kernel hang !!!"
+            echo ""
+        elif [[ $EXIT_CODE -ne 0 ]]; then
+            FAILED=$((FAILED + 1))
+            FAILED_COMBOS="${FAILED_COMBOS}\n  hidden_dim=$HIDDEN_DIM, max_tokens=$TOKENS (exit $EXIT_CODE)"
+            echo ""
+            echo "!!! FAILED (exit $EXIT_CODE): hidden_dim=$HIDDEN_DIM, max_tokens=$TOKENS !!!"
+            echo ""
+        elif [[ "$BAD_RANKS" -gt 0 ]]; then
+            FAILED=$((FAILED + 1))
+            FAILED_COMBOS="${FAILED_COMBOS}\n  hidden_dim=$HIDDEN_DIM, max_tokens=$TOKENS ($BAD_RANKS rank(s) reported errors)"
+            echo ""
+            echo "!!! INCORRECT: hidden_dim=$HIDDEN_DIM, max_tokens=$TOKENS — $BAD_RANKS rank(s) reported nonzero error times !!!"
+            echo "!!! The saved (block_num, warp_per_block, rdma_block_num) for this shape does not produce correct output. !!!"
+            echo ""
+        else
+            echo "[$(date)] Verified correct [$COMBO_IDX/$TOTAL_COMBOS]"
+        fi
+
+        # Always cleanup peer
+        cleanup_peer
+        sleep 2
+    done
+done
+
+echo ""
+echo "============================================================"
+echo "Verify tuned config complete"
+echo "  Total:    $TOTAL_COMBOS"
+echo "  Failed:   $FAILED"
+if [[ -n "$FAILED_COMBOS" ]]; then
+    echo -e "  Incorrect/crashed:$FAILED_COMBOS"
+fi
+if [[ -n "$HUNG_COMBOS" ]]; then
+    echo -e "  Hung:$HUNG_COMBOS"
+fi
+echo "  Log:      $LOG_FILE"
+echo "============================================================"
+
+[[ $FAILED -gt 0 ]] && exit 1
+exit 0

--- a/tools/verify_tuned_config.sh
+++ b/tools/verify_tuned_config.sh
@@ -52,9 +52,11 @@ set -euo pipefail
 #       --docker <CONTAINER> --ssh-key <SSH_KEY_PATH> \
 #       --kernel-type v1_ll --num-qp 2 --tokens-list "4,8,16" --hidden-dims "6144"
 #
-# Exit status: non-zero if any shape reports a nonzero "error times" on any
-# rank, or times out, or crashes -- the same signal batch_internode_tuning.sh
-# uses for its own per-combo failures.
+# Exit status: non-zero if any shape crashes, times out, or reports a rank
+# error -- the same signal batch_internode_tuning.sh uses for its own per-combo
+# failures. A geometry that produces wrong output shows up as a crash: the
+# comparisons in run_test_once are bare `assert`s, so a mismatch raises rather
+# than being counted.
 # ============================================================================
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -74,6 +76,7 @@ DOCKER=""
 LOCAL_DOCKER=""
 SSH_KEY=""
 RDMA_SL=""
+RDMA_TC=""
 KERNEL_TYPE="v1"
 NUM_QP=1
 TOKENS_LIST="64,128,256,512,1024,2048,4096"
@@ -96,6 +99,7 @@ while [[ $# -gt 0 ]]; do
         --local-docker)      LOCAL_DOCKER="$2";      shift 2 ;;
         --ssh-key)            SSH_KEY="$2";          shift 2 ;;
         --rdma-sl)            RDMA_SL="$2";           shift 2 ;;
+        --rdma-tc)            RDMA_TC="$2";           shift 2 ;;
         --kernel-type)        KERNEL_TYPE="$2";       shift 2 ;;
         --num-qp)             NUM_QP="$2";            shift 2 ;;
         --tokens-list)        TOKENS_LIST="$2";       shift 2 ;;
@@ -144,6 +148,7 @@ echo "  docker (peer):       ${DOCKER:-<none, direct execution>}"
 echo "  docker (local):      ${LOCAL_DOCKER:-<none, direct execution>}"
 echo "  ssh_key:             ${SSH_KEY:-<default>}"
 echo "  rdma_sl:             ${RDMA_SL:-<not set>}"
+echo "  rdma_tc:             ${RDMA_TC:-<not set>}"
 echo "  kernel_type:         $KERNEL_TYPE"
 echo "  num_qp:              $NUM_QP"
 echo "  gpu_per_node:        $GPU_PER_NODE"
@@ -162,7 +167,9 @@ echo "============================================================"
 echo ""
 echo "Each combo reads block_num/warp_per_block/rdma_block_num from"
 echo "python/mori/ops/tuning_configs/*.json via MORI_EP_LAUNCH_CONFIG_MODE=AUTO"
-echo "-- this verifies whatever is currently on disk, not a fixed geometry."
+echo "-- the preflight below reports which phases actually have a matching"
+echo "rule; a phase without one runs on the built-in geometry and is NOT"
+echo "verified by this run."
 echo ""
 
 # ---- Verify SSH connectivity ----
@@ -268,6 +275,7 @@ build_torchrun_cmd() {
     ENV_VARS+=" MORI_EP_LAUNCH_CONFIG_MODE=AUTO"
     ENV_VARS+=" OMP_NUM_THREADS=4"
     [[ -n "$RDMA_SL" ]] && ENV_VARS+=" MORI_RDMA_SL=$RDMA_SL"
+    [[ -n "$RDMA_TC" ]] && ENV_VARS+=" MORI_RDMA_TC=$RDMA_TC"
 
     echo "cd $THE_REPO_ROOT && $ENV_VARS" \
          "torchrun --nnodes=2 --node_rank=$NODE_RANK --nproc_per_node=1" \
@@ -314,6 +322,83 @@ sleep 2
 echo "Cleanup done"
 echo ""
 
+# ---- Preflight: is there anything on disk for these shapes to verify? ----
+#
+# AUTO mode fails open. If the JSON for this gpu/kernel/ep is missing,
+# unparseable, or simply has no rule matching the dtype the op queries with,
+# dispatch_combine.py falls back to its built-in geometry, logs at DEBUG (this
+# library's logger sits at WARNING), and the run passes -- so without this
+# check the script would report "Verified correct" having verified nothing.
+#
+# Only a necessary condition is checked -- that rules exist for the queried
+# dtype -- rather than replaying lookup()'s full ceiling/topk matching, so this
+# cannot drift out of step with it and silently start passing.
+PREFLIGHT_PY="$LOG_DIR/.verify_preflight.py"
+cat > "$PREFLIGHT_PY" <<'PYEOF'
+import sys
+from mori.ops.tuning_config import (
+    TuningConfigManager, kernel_type_to_config_str, detect_gpu_model,
+)
+from mori.jit.config import detect_gpu_arch
+import mori
+
+kt_arg, ep_size, disp_dtype = sys.argv[1], int(sys.argv[2]), sys.argv[3]
+kt = {
+    "v0": mori.ops.EpDispatchCombineKernelType.IntraNode,
+    "v1": mori.ops.EpDispatchCombineKernelType.InterNodeV1,
+    "v1_ll": mori.ops.EpDispatchCombineKernelType.InterNodeV1LL,
+    "async_ll": mori.ops.EpDispatchCombineKernelType.AsyncLL,
+}[kt_arg]
+kt_str = kernel_type_to_config_str(kt)
+arch, model = detect_gpu_arch(), detect_gpu_model()
+mgr = TuningConfigManager.get_instance(arch, kt_str, ep_size, model)
+print("  config file:     %s_%s_%s_ep%d" % (arch, model, kt_str, ep_size))
+ok = True
+for phase, rules in (("dispatch", mgr.dispatch_rules), ("combine", mgr.combine_rules)):
+    rules = rules or []
+    dtypes = sorted({r["dtype"] for r in rules})
+    hit = disp_dtype in dtypes
+    print("  %-8s rules:  %d (dtypes: %s) queried with %s -> %s"
+          % (phase, len(rules), ",".join(dtypes) or "-", disp_dtype,
+             "MATCH" if hit else "NO MATCH"))
+    if not hit:
+        ok = False
+        print("  !! %s has no rule for the queried dtype: it will run on the "
+              "built-in" % phase)
+        print("     geometry, so this run does NOT verify its saved config.")
+        if phase == "combine":
+            print("     Known cause: combine rules are saved under the COMBINE "
+                  "dtype, but")
+            print("     get_launch_config() looks both phases up with "
+                  "config.data_type.")
+sys.exit(0 if ok else 3)
+PYEOF
+
+echo "Resolving which saved rules this run will actually use ..."
+set +e
+if [[ -n "$LOCAL_DOCKER" ]]; then
+    $LOCAL_DOCKER_EXEC -w "$REPO_ROOT" "$LOCAL_DOCKER" \
+        python3 "$PREFLIGHT_PY" "$KERNEL_TYPE" "$((GPU_PER_NODE * 2))" "$DTYPE"
+else
+    python3 "$PREFLIGHT_PY" "$KERNEL_TYPE" "$((GPU_PER_NODE * 2))" "$DTYPE"
+fi
+PREFLIGHT_RC=$?
+set -e
+rm -f "$PREFLIGHT_PY"
+
+if [[ $PREFLIGHT_RC -eq 3 ]]; then
+    PREFLIGHT_INCOMPLETE=1
+    echo ""
+    echo "WARNING: at least one phase will not be verified (see above)."
+elif [[ $PREFLIGHT_RC -ne 0 ]]; then
+    echo "Error: could not resolve the tuning config (exit $PREFLIGHT_RC)."
+    echo "       Refusing to report a verification that would prove nothing."
+    exit 1
+else
+    PREFLIGHT_INCOMPLETE=0
+fi
+echo ""
+
 COMBO_IDX=0
 FAILED=0
 FAILED_COMBOS=""
@@ -351,8 +436,17 @@ for HIDDEN_DIM in "${HIDDEN_DIM_ARRAY[@]}"; do
         EXIT_CODE=${PIPESTATUS[0]}
         set -e
 
-        # test_dispatch_combine() prints one "error times:  N" line per rank;
-        # any nonzero N is a real dispatch/combine output mismatch, not noise.
+        # A wrong result surfaces as a NON-ZERO EXIT, not as a count: every
+        # comparison in run_test_once is a bare `assert`, so the first mismatch
+        # raises and torchrun propagates the failure. The branch below is the
+        # one that catches an incorrect config.
+        #
+        # The "error times: N" line each rank prints is NOT that signal and
+        # cannot currently fire: its counter, error_round, is passed into
+        # run_test_once but never added to anywhere in the file, so N is always
+        # 0. Grepping it anyway costs nothing and starts working if that
+        # counter is ever populated upstream -- but it must not be mistaken for
+        # the correctness check, which is the exit code.
         BAD_RANKS=$(grep -cE "error times: +[1-9]" "$COMBO_LOG" || true)
         rm -f "$COMBO_LOG"
 
@@ -400,6 +494,17 @@ if [[ -n "$HUNG_COMBOS" ]]; then
     echo -e "  Hung:$HUNG_COMBOS"
 fi
 echo "  Log:      $LOG_FILE"
+if [[ "$PREFLIGHT_INCOMPLETE" -eq 1 ]]; then
+    echo ""
+    echo "  NOTE: not every phase was covered -- see the preflight warning at"
+    echo "        the top of this run. A phase with no matching rule ran on the"
+    echo "        built-in geometry, so a pass says nothing about its saved"
+    echo "        config."
+fi
+echo "  Scope:    ranks 0-$((GPU_PER_NODE - 1)) only. The peer node's output is"
+echo "            not captured and its exit status is not collected, so a"
+echo "            peer-side failure surfaces here only as a hang or as rank 0"
+echo "            failing in a collective."
 echo "============================================================"
 
 [[ $FAILED -gt 0 ]] && exit 1

--- a/tools/verify_tuned_config.sh
+++ b/tools/verify_tuned_config.sh
@@ -153,12 +153,30 @@ echo "-- this verifies whatever is currently on disk, not a fixed geometry."
 echo ""
 
 # ---- Verify SSH connectivity ----
+#
+# DOCKER_EXEC is probed rather than fixed: `docker exec` needs access to the
+# docker daemon socket, which comes from membership in the `docker` group, not
+# from being root. Where the operator is in that group, plain `docker exec`
+# works and `sudo` fails outright on hosts that grant no sudo rights at all.
+# Try unprivileged first, fall back to sudo, and report both failures together
+# rather than blaming SSH for a permissions problem.
+DOCKER_EXEC=""
 echo "Verifying SSH to $PEER_HOST ..."
 if [[ -n "$DOCKER" ]]; then
-    if ! ssh "${SSH_OPTS[@]}" "$PEER_HOST" "sudo docker exec $DOCKER bash -c 'echo ok'" &>/dev/null; then
-        echo "Error: Cannot SSH to $PEER_HOST or docker exec into $DOCKER failed"
+    for candidate in "docker exec" "sudo -n docker exec"; do
+        if ssh "${SSH_OPTS[@]}" "$PEER_HOST" "$candidate $DOCKER bash -c 'echo ok'" &>/dev/null; then
+            DOCKER_EXEC="$candidate"
+            break
+        fi
+    done
+    if [[ -z "$DOCKER_EXEC" ]]; then
+        echo "Error: cannot reach container '$DOCKER' on $PEER_HOST."
+        echo "       Tried 'docker exec' and 'sudo -n docker exec'. Check that"
+        echo "       passwordless SSH works, the container is running, and the"
+        echo "       remote user is in the docker group (or has sudo rights)."
         exit 1
     fi
+    echo "  docker exec prefix:  $DOCKER_EXEC"
 else
     if ! ssh "${SSH_OPTS[@]}" "$PEER_HOST" "echo ok" &>/dev/null; then
         echo "Error: Cannot SSH to $PEER_HOST (passwordless SSH required)"
@@ -211,7 +229,7 @@ launch_peer() {
     local CMD="$1"
     if [[ -n "$DOCKER" ]]; then
         ssh "${SSH_OPTS[@]}" "$PEER_HOST" \
-            "sudo docker exec -w $REMOTE_REPO_ROOT $DOCKER bash -c \"$CMD\"" &
+            "$DOCKER_EXEC -w $REMOTE_REPO_ROOT $DOCKER bash -c \"$CMD\"" &
     else
         ssh "${SSH_OPTS[@]}" "$PEER_HOST" "bash -lc '$CMD'" &
     fi
@@ -225,7 +243,7 @@ cleanup_peer() {
     local KILL_CMD='pkill -9 -f torchrun; pkill -9 -f test_dispatch_combine_internode; pkill -9 -f "multiprocessing.spawn"'
     if [[ -n "$DOCKER" ]]; then
         ssh "${SSH_OPTS[@]}" "$PEER_HOST" \
-            "sudo docker exec $DOCKER bash -c '$KILL_CMD'" 2>/dev/null || true
+            "$DOCKER_EXEC $DOCKER bash -c '$KILL_CMD'" 2>/dev/null || true
     else
         ssh "${SSH_OPTS[@]}" "$PEER_HOST" "$KILL_CMD" 2>/dev/null || true
     fi
@@ -237,7 +255,7 @@ KILL_ALL='pkill -9 -f torchrun; pkill -9 -f test_dispatch_combine_internode; pki
 eval "$KILL_ALL" 2>/dev/null || true
 if [[ -n "$DOCKER" ]]; then
     ssh "${SSH_OPTS[@]}" "$PEER_HOST" \
-        "sudo docker exec $DOCKER bash -c '$KILL_ALL'" 2>/dev/null || true
+        "$DOCKER_EXEC $DOCKER bash -c '$KILL_ALL'" 2>/dev/null || true
 else
     ssh "${SSH_OPTS[@]}" "$PEER_HOST" "$KILL_ALL" 2>/dev/null || true
 fi

--- a/tools/verify_tuned_config.sh
+++ b/tools/verify_tuned_config.sh
@@ -115,7 +115,13 @@ done
 
 # ---- Validate required args ----
 for var in MASTER_ADDR PEER_HOST IFNAME; do
-    [[ -z "${!var}" ]] && { echo "Error: --${var,,} is required"; exit 1; }
+    if [[ -z "${!var}" ]]; then
+        # ${var,,} lowercases but leaves the underscores, which would name a
+        # flag that does not exist (--master_addr for --master-addr).
+        flag="--${var,,}"
+        echo "Error: ${flag//_/-} is required"
+        exit 1
+    fi
 done
 
 [[ -z "$REMOTE_REPO_ROOT" ]] && REMOTE_REPO_ROOT="$REPO_ROOT"
@@ -299,7 +305,7 @@ launch_peer() {
 cleanup_peer() {
     kill "$PEER_PID" 2>/dev/null || true
     wait "$PEER_PID" 2>/dev/null || true
-    local KILL_CMD='pkill -9 -f "[t]orchrun"; pkill -9 -f "[t]est_dispatch_combine_internode"; pkill -9 -f "[m]ultiprocessing.spawn"'
+    local KILL_CMD='pkill -9 -f "[t]orchrun.*test_dispatch_combine_internode"; pkill -9 -f "[t]est_dispatch_combine_internode"'
     if [[ -n "$DOCKER" ]]; then
         ssh "${SSH_OPTS[@]}" "$PEER_HOST" \
             "$DOCKER_EXEC $DOCKER bash -c '$KILL_CMD'" 2>/dev/null || true
@@ -310,7 +316,7 @@ cleanup_peer() {
 
 # ---- Pre-run: kill residual processes ----
 echo "Cleaning up residual processes..."
-KILL_ALL='pkill -9 -f "[t]orchrun"; pkill -9 -f "[t]est_dispatch_combine_internode"; pkill -9 -f "[m]ultiprocessing.spawn"'
+KILL_ALL='pkill -9 -f "[t]orchrun.*test_dispatch_combine_internode"; pkill -9 -f "[t]est_dispatch_combine_internode"'
 kill_local "$KILL_ALL"
 if [[ -n "$DOCKER" ]]; then
     ssh "${SSH_OPTS[@]}" "$PEER_HOST" \
@@ -436,6 +442,14 @@ for HIDDEN_DIM in "${HIDDEN_DIM_ARRAY[@]}"; do
         EXIT_CODE=${PIPESTATUS[0]}
         set -e
 
+        # Patterns are anchored on this script's name, not a bare "torchrun".
+        # Without --local-docker the driver runs on the host, where pkill sees
+        # every process the user owns on that node, so a bare pattern would
+        # take out an unrelated concurrent job. The bracket form additionally
+        # stops the kill chain matching its own command line -- the first
+        # pkill would otherwise kill the shell running it, leaving the rest
+        # unexecuted and the python workers alive.
+        #
         # A wrong result surfaces as a NON-ZERO EXIT, not as a count: every
         # comparison in run_test_once is a bare `assert`, so the first mismatch
         # raises and torchrun propagates the failure. The branch below is the
@@ -476,7 +490,7 @@ for HIDDEN_DIM in "${HIDDEN_DIM_ARRAY[@]}"; do
         # Always cleanup both ranks. `timeout` kills the local `docker exec`
         # client, not the torchrun it started inside the container, so rank 0
         # needs an explicit kill too or a hung combo poisons the next one.
-        kill_local 'pkill -9 -f "[t]orchrun"; pkill -9 -f "[t]est_dispatch_combine_internode"; pkill -9 -f "[m]ultiprocessing.spawn"'
+        kill_local 'pkill -9 -f "[t]orchrun.*test_dispatch_combine_internode"; pkill -9 -f "[t]est_dispatch_combine_internode"'
         cleanup_peer
         sleep 2
     done

--- a/tools/verify_tuned_config.sh
+++ b/tools/verify_tuned_config.sh
@@ -36,7 +36,17 @@ set -euo pipefail
 #       --combine-dtype bf16 --quant-type none \
 #       --tokens-list "4,8,16" --hidden-dims "6144"
 #
-#   # With docker (remote node runs inside a container)
+#   # With docker on both nodes, driver staying on the host. --local-docker
+#   # reaches rank 0's container with `docker exec` the same way --docker
+#   # reaches the peer's, so SSH runs from the host and its keys never have to
+#   # be copied into a container.
+#   bash tools/verify_tuned_config.sh \
+#       --master-addr <HOST0> --peer-host <USER>@<HOST1> --ifname <IFNAME> \
+#       --local-docker <CONTAINER0> --docker <CONTAINER1> \
+#       --kernel-type v1_ll --num-qp 2 --tokens-list "4,8,16" --hidden-dims "6144"
+#
+#   # Driver already running inside a container (omit --local-docker); the
+#   # container then needs its own SSH access to the peer.
 #   bash tools/verify_tuned_config.sh \
 #       --master-addr <HOST0> --peer-host <USER>@<HOST1> --ifname <IFNAME> \
 #       --docker <CONTAINER> --ssh-key <SSH_KEY_PATH> \
@@ -61,6 +71,7 @@ PEER_HOST=""
 IFNAME=""
 REMOTE_REPO_ROOT=""
 DOCKER=""
+LOCAL_DOCKER=""
 SSH_KEY=""
 RDMA_SL=""
 KERNEL_TYPE="v1"
@@ -82,6 +93,7 @@ while [[ $# -gt 0 ]]; do
         --ifname)            IFNAME="$2";            shift 2 ;;
         --remote-repo-root)  REMOTE_REPO_ROOT="$2";  shift 2 ;;
         --docker)            DOCKER="$2";            shift 2 ;;
+        --local-docker)      LOCAL_DOCKER="$2";      shift 2 ;;
         --ssh-key)            SSH_KEY="$2";          shift 2 ;;
         --rdma-sl)            RDMA_SL="$2";           shift 2 ;;
         --kernel-type)        KERNEL_TYPE="$2";       shift 2 ;;
@@ -128,7 +140,8 @@ echo "============================================================"
 echo "  master_addr:         $MASTER_ADDR"
 echo "  peer_host:           $PEER_HOST"
 echo "  ifname:              $IFNAME"
-echo "  docker:              ${DOCKER:-<none, direct execution>}"
+echo "  docker (peer):       ${DOCKER:-<none, direct execution>}"
+echo "  docker (local):      ${LOCAL_DOCKER:-<none, direct execution>}"
 echo "  ssh_key:             ${SSH_KEY:-<default>}"
 echo "  rdma_sl:             ${RDMA_SL:-<not set>}"
 echo "  kernel_type:         $KERNEL_TYPE"
@@ -185,6 +198,44 @@ else
 fi
 echo "SSH OK"
 echo ""
+
+# ---- Resolve how rank 0 is launched ----
+#
+# --local-docker exists so the driver itself can stay on the host while mori
+# lives in a container: rank 0 is then reached with `docker exec` locally, the
+# same way the peer is reached remotely. Without it the driver has to run
+# inside the container, which means the container needs SSH access to the peer
+# -- i.e. a private key has to be placed inside a container purely so the
+# script can reach the other node. Running on the host instead uses the SSH
+# credentials that are already there and keeps them out of the container.
+LOCAL_DOCKER_EXEC=""
+if [[ -n "$LOCAL_DOCKER" ]]; then
+    for candidate in "docker exec" "sudo -n docker exec"; do
+        if $candidate "$LOCAL_DOCKER" bash -c 'echo ok' &>/dev/null; then
+            LOCAL_DOCKER_EXEC="$candidate"
+            break
+        fi
+    done
+    if [[ -z "$LOCAL_DOCKER_EXEC" ]]; then
+        echo "Error: cannot exec into local container '$LOCAL_DOCKER'."
+        echo "       Tried 'docker exec' and 'sudo -n docker exec'. Check that"
+        echo "       the container is running and this user is in the docker"
+        echo "       group (or has sudo rights)."
+        exit 1
+    fi
+    echo "Local rank runs in container '$LOCAL_DOCKER' via: $LOCAL_DOCKER_EXEC"
+    echo ""
+fi
+
+# Run a cleanup command where rank 0 lives, so a timed-out `docker exec` does
+# not leave the torchrun processes running inside the container.
+kill_local() {
+    if [[ -n "$LOCAL_DOCKER" ]]; then
+        $LOCAL_DOCKER_EXEC "$LOCAL_DOCKER" bash -c "$1" 2>/dev/null || true
+    else
+        eval "$1" 2>/dev/null || true
+    fi
+}
 
 # ---- Build common python args (shared by both ranks) ----
 build_py_args() {
@@ -252,7 +303,7 @@ cleanup_peer() {
 # ---- Pre-run: kill residual processes ----
 echo "Cleaning up residual processes..."
 KILL_ALL='pkill -9 -f torchrun; pkill -9 -f test_dispatch_combine_internode; pkill -9 -f "multiprocessing.spawn"'
-eval "$KILL_ALL" 2>/dev/null || true
+kill_local "$KILL_ALL"
 if [[ -n "$DOCKER" ]]; then
     ssh "${SSH_OPTS[@]}" "$PEER_HOST" \
         "$DOCKER_EXEC $DOCKER bash -c '$KILL_ALL'" 2>/dev/null || true
@@ -289,7 +340,14 @@ for HIDDEN_DIM in "${HIDDEN_DIM_ARRAY[@]}"; do
         # Launch local (rank 0) with timeout, capture output to grep for errors
         COMBO_LOG="$(mktemp)"
         set +e
-        timeout "$TIMEOUT_SEC" bash -c "$CMD_RANK0" 2>&1 | tee "$COMBO_LOG" | tee -a "$LOG_FILE"
+        # Unquoted $LOCAL_DOCKER_EXEC on purpose: it is "docker exec" or
+        # "sudo -n docker exec" and has to split into separate words.
+        if [[ -n "$LOCAL_DOCKER" ]]; then
+            LOCAL_RUN=($LOCAL_DOCKER_EXEC -w "$REPO_ROOT" "$LOCAL_DOCKER" bash -c "$CMD_RANK0")
+        else
+            LOCAL_RUN=(bash -c "$CMD_RANK0")
+        fi
+        timeout "$TIMEOUT_SEC" "${LOCAL_RUN[@]}" 2>&1 | tee "$COMBO_LOG" | tee -a "$LOG_FILE"
         EXIT_CODE=${PIPESTATUS[0]}
         set -e
 
@@ -321,7 +379,10 @@ for HIDDEN_DIM in "${HIDDEN_DIM_ARRAY[@]}"; do
             echo "[$(date)] Verified correct [$COMBO_IDX/$TOTAL_COMBOS]"
         fi
 
-        # Always cleanup peer
+        # Always cleanup both ranks. `timeout` kills the local `docker exec`
+        # client, not the torchrun it started inside the container, so rank 0
+        # needs an explicit kill too or a hung combo poisons the next one.
+        kill_local 'pkill -9 -f torchrun; pkill -9 -f test_dispatch_combine_internode; pkill -9 -f "multiprocessing.spawn"'
         cleanup_peer
         sleep 2
     done

--- a/tools/verify_tuned_config.sh
+++ b/tools/verify_tuned_config.sh
@@ -22,6 +22,13 @@ set -euo pipefail
 # itself far slower for a question the sweep doesn't need answered while
 # picking a fastest config).
 #
+# --timeout is PER COMBO and defaults to 600s, which suits small shapes only:
+# each combo runs 500 rounds and run_test_once compares output with per-token
+# Python loops, so cost grows with max_tokens (measured: ~40s for 500 rounds at
+# 4 tokens). The default --tokens-list reaches 4096 and needs far more; a run
+# that is merely slow is reported as "possible kernel hang", so raise --timeout
+# rather than trusting that message.
+#
 # Prerequisites: same as batch_internode_tuning.sh (passwordless SSH to the
 # peer node, matching repo path or --remote-repo-root, --ifname reachable on
 # both nodes). Intended to run right after batch_internode_tuning.sh writes a
@@ -468,7 +475,10 @@ for HIDDEN_DIM in "${HIDDEN_DIM_ARRAY[@]}"; do
             FAILED=$((FAILED + 1))
             HUNG_COMBOS="${HUNG_COMBOS}\n  hidden_dim=$HIDDEN_DIM, max_tokens=$TOKENS"
             echo ""
-            echo "!!! TIMEOUT (${TIMEOUT_SEC}s): hidden_dim=$HIDDEN_DIM, max_tokens=$TOKENS — possible kernel hang !!!"
+            echo "!!! TIMEOUT (${TIMEOUT_SEC}s): hidden_dim=$HIDDEN_DIM, max_tokens=$TOKENS !!!"
+            echo "!!! Either a kernel hang, or just too little time: 500 rounds at this"
+            echo "!!! token count may legitimately need more than ${TIMEOUT_SEC}s. Re-run"
+            echo "!!! this shape with a larger --timeout before calling it a hang."
             echo ""
         elif [[ $EXIT_CODE -ne 0 ]]; then
             FAILED=$((FAILED + 1))

--- a/tools/verify_tuned_config.sh
+++ b/tools/verify_tuned_config.sh
@@ -291,7 +291,7 @@ launch_peer() {
 cleanup_peer() {
     kill "$PEER_PID" 2>/dev/null || true
     wait "$PEER_PID" 2>/dev/null || true
-    local KILL_CMD='pkill -9 -f torchrun; pkill -9 -f test_dispatch_combine_internode; pkill -9 -f "multiprocessing.spawn"'
+    local KILL_CMD='pkill -9 -f "[t]orchrun"; pkill -9 -f "[t]est_dispatch_combine_internode"; pkill -9 -f "[m]ultiprocessing.spawn"'
     if [[ -n "$DOCKER" ]]; then
         ssh "${SSH_OPTS[@]}" "$PEER_HOST" \
             "$DOCKER_EXEC $DOCKER bash -c '$KILL_CMD'" 2>/dev/null || true
@@ -302,7 +302,7 @@ cleanup_peer() {
 
 # ---- Pre-run: kill residual processes ----
 echo "Cleaning up residual processes..."
-KILL_ALL='pkill -9 -f torchrun; pkill -9 -f test_dispatch_combine_internode; pkill -9 -f "multiprocessing.spawn"'
+KILL_ALL='pkill -9 -f "[t]orchrun"; pkill -9 -f "[t]est_dispatch_combine_internode"; pkill -9 -f "[m]ultiprocessing.spawn"'
 kill_local "$KILL_ALL"
 if [[ -n "$DOCKER" ]]; then
     ssh "${SSH_OPTS[@]}" "$PEER_HOST" \
@@ -382,7 +382,7 @@ for HIDDEN_DIM in "${HIDDEN_DIM_ARRAY[@]}"; do
         # Always cleanup both ranks. `timeout` kills the local `docker exec`
         # client, not the torchrun it started inside the container, so rank 0
         # needs an explicit kill too or a hung combo poisons the next one.
-        kill_local 'pkill -9 -f torchrun; pkill -9 -f test_dispatch_combine_internode; pkill -9 -f "multiprocessing.spawn"'
+        kill_local 'pkill -9 -f "[t]orchrun"; pkill -9 -f "[t]est_dispatch_combine_internode"; pkill -9 -f "[m]ultiprocessing.spawn"'
         cleanup_peer
         sleep 2
     done

--- a/tools/verify_tuned_config.sh
+++ b/tools/verify_tuned_config.sh
@@ -355,7 +355,12 @@ from mori.ops.tuning_config import (
 from mori.jit.config import detect_gpu_arch
 import mori
 
-kt_arg, ep_size, disp_dtype = sys.argv[1], int(sys.argv[2]), sys.argv[3]
+kt_arg, ep_size = sys.argv[1], int(sys.argv[2])
+# Each phase is looked up with the dtype of ITS OWN input tensor: the call
+# sites pass dtype=input.dtype to _resolve_launch_params, and combine's input
+# has already been converted to the combine dtype. Checking combine against the
+# dispatch dtype would report a mismatch that the runtime does not have.
+queried = {"dispatch": sys.argv[3], "combine": sys.argv[4] or sys.argv[3]}
 kt = {
     "v0": mori.ops.EpDispatchCombineKernelType.IntraNode,
     "v1": mori.ops.EpDispatchCombineKernelType.InterNodeV1,
@@ -370,20 +375,17 @@ ok = True
 for phase, rules in (("dispatch", mgr.dispatch_rules), ("combine", mgr.combine_rules)):
     rules = rules or []
     dtypes = sorted({r["dtype"] for r in rules})
-    hit = disp_dtype in dtypes
+    dt = queried[phase]
+    hit = dt in dtypes
     print("  %-8s rules:  %d (dtypes: %s) queried with %s -> %s"
-          % (phase, len(rules), ",".join(dtypes) or "-", disp_dtype,
+          % (phase, len(rules), ",".join(dtypes) or "-", dt,
              "MATCH" if hit else "NO MATCH"))
     if not hit:
         ok = False
-        print("  !! %s has no rule for the queried dtype: it will run on the "
-              "built-in" % phase)
-        print("     geometry, so this run does NOT verify its saved config.")
-        if phase == "combine":
-            print("     Known cause: combine rules are saved under the COMBINE "
-                  "dtype, but")
-            print("     get_launch_config() looks both phases up with "
-                  "config.data_type.")
+        print("  !! %s has no rule for the dtype it is looked up with, so it "
+              "will run" % phase)
+        print("     on the built-in geometry and this run does NOT verify its "
+              "saved config.")
 sys.exit(0 if ok else 3)
 PYEOF
 
@@ -391,9 +393,9 @@ echo "Resolving which saved rules this run will actually use ..."
 set +e
 if [[ -n "$LOCAL_DOCKER" ]]; then
     $LOCAL_DOCKER_EXEC -w "$REPO_ROOT" "$LOCAL_DOCKER" \
-        python3 "$PREFLIGHT_PY" "$KERNEL_TYPE" "$((GPU_PER_NODE * 2))" "$DTYPE"
+        python3 "$PREFLIGHT_PY" "$KERNEL_TYPE" "$((GPU_PER_NODE * 2))" "$DTYPE" "$COMBINE_DTYPE"
 else
-    python3 "$PREFLIGHT_PY" "$KERNEL_TYPE" "$((GPU_PER_NODE * 2))" "$DTYPE"
+    python3 "$PREFLIGHT_PY" "$KERNEL_TYPE" "$((GPU_PER_NODE * 2))" "$DTYPE" "$COMBINE_DTYPE"
 fi
 PREFLIGHT_RC=$?
 set -e


### PR DESCRIPTION
## Summary

Small-token (4/8/16) EP16 dispatch/combine on MI300X is bound by the **host
submission path**, not by the kernels. The series started there and grew to
cover the tuning machinery that was supposed to measure it, which turned out to
be unable to pick a winner at all.

**Runtime**

1. **`perf(ep)`** — memoize the six output tensor views that `dispatch()` /
   `combine()` rebuilt on every call. This is the −32% below. Opt out with
   `MORI_EP_DISABLE_VIEW_CACHE=1`.

**Tuning correctness**

2. **`fix(ep)`** — the tuning margin was an absolute `1.0 GB/s`. Where a whole
   sweep sits in the low single digits (4/8 tokens: 3.9 / 8.3 GB/s) nothing
   after the first candidate could ever clear it, so the sweep returned
   whatever it measured first; at 32 tokens (30.7 GB/s) it was under 4% and
   filtered almost nothing. Now relative, via `MORI_EP_TUNING_MARGIN`,
   **defaulting to 0** (any improvement wins). The same bug and the same fix
   applied to the intra-node tuner, which shares the env var.
3. **`fix(ep)`** — selection used a slowest-rank bandwidth while the summary
   printed a grand mean, so a config could win the sweep on a number the table
   it was chosen from never showed. Both are now the grand-mean **latency**,
   the quantity printed as the table's "Average" row.
4. **`refactor(ep)`** — **the keep-best save gate is gone.** It compared
   `new_bw > old_bw` across two tuning runs from different hosts, ROCm
   versions and machine load, and on a "keep" it said so at `logger.info`,
   which this library's WARNING-level logger never emits. A discarded run was
   completely silent. Saves are now unconditional and always print what
   changed; the JSON's git diff is where the call actually gets made.
5. **`refactor(ep)`** — `bandwidth_gbps` is now the grand mean too, matching
   the printed table, and rules carry `bandwidth_metric` recording that. A
   re-tune that replaces a rule written under the old definition prints both
   numbers without a percentage instead of reporting a definition change as a
   20%+ win.
6. **`fix(ep)`** — `MORI_TUNING_SCOPE=quick` together with
   `--save-tuning-config` is now **rejected**, in both tuners and both batch
   scripts. quick sweeps a reduced grid (inter-node: 3 `warp_per_block` against
   full's 5; intra-node: 3 against 9, and powers of two only for `block_num`),
   so its winner is not a result worth committing. This changed the documented
   workflow — see *Behaviour changes for existing users*.
7. **`feat(ep)`** — `tools/verify_tuned_config.sh`, because the sweep only
   times candidates and never compares output: nothing confirmed the geometry
   it wrote was correct, only that it was fast.

**Supporting**

8. **`feat(ep)`** — `MORI_EP_ROUNDS` (default 10) now sets the rounds for both
   `--cmd bench` and each tuning candidate, so the two measure on equal
   footing. Round 0 is dropped as warmup; values below 2 are rejected.
9. **`feat(ep)`** — `MORI_EP_TUNING_VERBOSE=1` prints each candidate's full
   table; `block_num` 8 and 16 added to the sweep's candidate list;
   `rdma_worst_rank` / `ll_worst_rank` printed next to the winner as a
   straggler check (not saved, not used for selection).
10. **`feat(ep)`** — tuned InterNodeV1LL EP16 configs for MI300X at hidden
    6144. **Read the caveat in *About the shipped configs* before relying on
    these.**
11. **`feat(ep)`** — `test_low_latency.py`'s shape is configurable instead of
    hardcoded.
12. **Tooling** — `docker exec` is probed rather than assuming `sudo`;
    `--local-docker` runs rank 0 in a container so the driver can stay on the
    host and its SSH keys never enter a container; `--rdma-tc` plumbs
    `MORI_RDMA_TC` through to both ranks (it was silently dropped —
    `build_torchrun_cmd` names the environment explicitly and the ranks start
    via `docker exec`/`ssh`, neither of which inherits the caller's); the
    cleanup `pkill` chain no longer kills itself and is scoped to this
    script rather than every `torchrun` the user owns on the node; `run_all_internode_tuning.sh`
    propagates a non-zero exit; `/logs/` is gitignored.

No kernel changes — see *What is not here*.

## Measurements

EP16 = 2 × 8 MI300X, `v1_ll`, hidden 6144, `fp8_e4m3_fnuz` dispatch / `bf16`
combine, topk 8, `--num-qp 1`. Medians over 3–5 runs; single runs are not
meaningful here (see *Measurement caveats*).

Final validation with `test_low_latency.py --num-tokens 4 --hidden 6144`:

| | pre-change | this PR | |
|---|---|---|---|
| end-to-end `bench()` avg_t | 216.8 us | **147.4 us** | **−32%** |
| end-to-end min_t | 199.5 us | **134.2 us** | −33% |
| `bench_kineto` dispatch | 62.0 us | 59.7 us | unchanged |
| `bench_kineto` combine | 100.2 us | 96.3 us | unchanged |

The last two rows are the point: **GPU kernel time does not move**, the entire
gain is host-side. `bench_kineto` explicitly uses a large kernel plus a barrier
to *"eliminate the unbalanced CPU launch overhead"*, so it is structurally
blind to this class of problem — which is why it went unnoticed.

Same picture from `test_dispatch_combine_internode.py`, A/B in a single
session:

| | pre-change | this PR | |
|---|---|---|---|
| combine | 144.7 us | **86.8 us** | **−40%** |
| wall/round | 220.9 us | **162.4 us** | **−26%** |
| host enqueue/round | 204.3 us | **142.7 us** | −30% |
| dispatch | 81.8 us | 74.2 us | −9% |

Reproduced on a second, independent node pair with the same numbers (combine
150→88, wall 222→164, enqueue 211→146), so this is not a property of one
machine.

### Why the regime is overhead-bound

| test | result | conclusion |
|---|---|---|
| hidden 1024 vs 6144 (6× data) | 93→85 us / 147→145 us — unchanged | not data-bound |
| grid 304 → 24 blocks | 12.13 → 12.05 us | not grid-bound |
| host enqueue vs wall | 204 us vs 221 us per round | **host-bound** |

Latency is also flat across 4/8/16 tokens.

## Behaviour changes for existing users

- **`--tuning-scope quick` can no longer write a config.** The documented
  "quick sweep" workflow in `MORI-EP-GUIDE.md` did exactly that, and
  `run_all_internode_tuning.sh` defaulted to quick while always passing a
  config output — so with no arguments it would now have failed all 42 jobs.
  Its default is therefore flipped to **full**, the guide is updated, and both
  batch scripts reject the combination up front (in a second, rather than after
  a two-node launch) naming the two knobs that resolve it. quick remains
  available for exploration with `--config-output ''`.
- **Saving overwrites unconditionally.** A re-tune that measures worse will now
  replace a good rule. That is deliberate — the alternative failed silently —
  but it means the printed delta is the thing to read, and a bad run should be
  discarded with `git checkout` rather than trusted to be filtered out.
- **Tuning rounds default 5 → 10** (`MORI_EP_ROUNDS`), so a sweep takes about
  twice as long. That buys a tuner that can distinguish configs at all.

## About the shipped configs

**The configs are a reproducible starting point, not a proven optimum.** The
tuner measures in the same host-bound regime this PR is about, so at 4 tokens
its metric cannot cleanly separate geometries.

Re-tuning the same four shapes three times on one node pair reproduced 6 of the
8 saved geometries exactly and put the other two in a flat region (latency
within 1-4% of the saved rule). Two of the 24 measurements were whole-sweep
degradations of 25-31% that landed on a different shape each run -- in both
cases the *fastest* of all 105 candidates for that shape was the degraded one,
so the tuner picked correctly and the run itself was bad. The mandatory save
report is what made those visible; under the old gate they would have been
discarded in silence.

`verify_tuned_config.sh` reports, before running anything, which phases have a
rule that will actually be selected, and refuses to claim it verified a phase
that fell back to the built-in geometry:

```
  dispatch rules:  4 (dtypes: fp8_e4m3_fnuz) queried with fp8_e4m3_fnuz -> MATCH
  combine  rules:  4 (dtypes: bf16) queried with bf16 -> MATCH
```

## Review notes on the memoization

The addresses come from `_dispatch_out_ptrs` / `_combine_out_ptrs`, which
`__init__` already snapshots once from handle-owned symmetric shmem
(`GetShmemDispatchOutTokMemObj()` etc., selected by the immutable
`config.kernelType`, allocated at handle construction with no realloc path).
**The pointer-stability assumption is pre-existing** — this change caches a
view over pointers the code already treats as fixed, and does not add a
reallocation guarantee (a realloc would leave both the key and the view stale,
exactly as before).

- **Growth**: bounded by the distinct `(shape, dtype)` an op is called with —
  one, for a fixed model.
- **Lifetime**: entries alias handle-owned memory and live on the op, so
  nothing is retained beyond it.
- **Object identity**: callers now get the same object rather than an equal
  one. Both alias the same buffer and the kernels overwrite it in place, so the
  only visible change is identity. Any caller that expected two `dispatch()`
  results to be independent snapshots was already broken.
- **Concurrency**: worst case two threads build the same view and one wins;
  both are equivalent.
- **Opt-out**: `MORI_EP_DISABLE_VIEW_CACHE=1`, read once in `__init__` —
  probing the environment per call would reintroduce the cost this removes.

Correctness: `--cmd test` at 4 and 16 tokens, 500 rounds, on all 16 ranks,
completed without raising. Note that the `error times: N` line those runs print
is *not* the evidence — `error_round` is never populated anywhere in the file,
so that counter is always 0. Every comparison in `run_test_once` is a bare
`assert`, so the signal is that the run finished at all.

## `--num-qp`: 1 is best, and here is why

Swept with the host off the critical path so the parameter can actually show,
5 runs each:

| `--num-qp` | 1 | 2 | 3 | 4 |
|---|---|---|---|---|
| round (us) | **149.8** | 160.1 | 168.4 | 170.8 |

Monotonic, and the distributions for 1 and 4 do not overlap (qp1 max 162.2 <
qp4 min 165.6). It holds at every size tested: **−12.3%** at 4 tokens, −3.1% at
128, −5.1% at 512.

The mechanism is in the combine cross-device barrier, which issues **one RDMA
atomic per QP**:

```cpp
for (int i = 0; i < config.numQpPerPe; i++) {
  shmem::ShmemAtomicTypeNonFetchThread<uint64_t>(..., core::AMO_ADD, proxyPe, i);
}
```

Meanwhile the data path picks a QP with
`qpId = (tokenId / warpSize) % numQpPerPe`, which is always 0 at 4 tokens. So
extra QPs buy nothing and cost extra RDMA atomic issues — span-profiling puts a
single GPU-initiated RDMA issue at ~13–16 us, which matches the ~21 us gap
between qp=1 and qp=4.

Two notes: measured plainly, this is invisible (158.4 vs 161.8 us, inside the
noise) because the host dominates. And `MORI_NUM_QP_PER_PE` (transport-level QP
count, default 4) is a *different* knob and had no measurable effect (152.7 vs
151.3 us); only the op config's `numQpPerPe` matters.

This is a usage recommendation; the default is left alone here.

## Reproducing

Two nodes, `$R` = 0 / 1, start node 1 first.

```bash
export MORI_RDMA_TC=41 GPU_PER_NODE=8
export GLOO_SOCKET_IFNAME=<IFNAME> MORI_SOCKET_IFNAME=<IFNAME>

# baseline: pre-change behaviour
export MORI_EP_DISABLE_VIEW_CACHE=1
torchrun --nnodes=2 --node_rank=$R --nproc_per_node=1 \
  --master_addr=<HOST0> --master_port=1234 \
  examples/ops/dispatch_combine/test_dispatch_combine_internode.py \
  --cmd bench --kernel-type v1_ll --num-qp 1 \
  --max-tokens 4 --hidden-dim 6144 \
  --dtype fp8_e4m3_fnuz --combine-dtype bf16 --quant-type none \
  --block-num 32 --warp-per-block 4 --rdma-block-num 8

# this PR: drop the opt-out and rerun the identical torchrun command
unset MORI_EP_DISABLE_VIEW_CACHE
```

Tuning and verification, driver on the host with mori in containers on both
nodes:

```bash
bash tools/batch_internode_tuning.sh \
    --master-addr <HOST0> --peer-host <USER>@<HOST1> --ifname <IFNAME> \
    --local-docker <RANK0_CONTAINER> --docker <PEER_CONTAINER> --rdma-tc 41 \
    --kernel-type v1_ll --num-qp 1 \
    --dtype fp8_e4m3_fnuz --combine-dtype bf16 --quant-type none \
    --tokens-list "4,8,16,32" --hidden-dims "6144"

bash tools/verify_tuned_config.sh <same connection and shape flags>
```

End-to-end numbers above come from `test_low_latency.py --num-tokens 4 --hidden
6144`, which this series makes configurable.

**Measurement caveats**, all of which produced wrong conclusions during this
work:

- The first run after a JIT-cache wipe or an idle period reads **40–80% slow**.
  Discard one run before comparing.
- Run-to-run spread is 10–20%, and roughly 1 run in 5 lands in a reproducible
  slow mode (~1.5×). Compare medians over ≥3 runs, never a single one.
- `EpDispatchCopyToStaging` makes a good canary: nothing here touches it, so a
  reading above ~5 us means the environment is bad rather than the patch.

## What is not here

**No kernel optimization.** Four kernel changes were implemented, verified
correct, and measured against per-kernel GPU time from the CUDA profiler — all
within noise (136.0/136.2 vs 135.5/135.5 us): a `MultiWarpIter` minimum slice,
skipping combine padding slots, an `s_sleep` poll backoff, and counting only
active blocks in the dispatch send barrier.

Where the GPU time actually goes, at 4 tokens / hidden 6144 (136 us total): the
two LL kernels are **82%** of it, and fitting the token sweep gives dispatch ≈
**50 us + 0.5 us/token** and combine ≈ **46 us + 0.48 us/token**. At 4 tokens
that intercept is 98% of the cost.

That fixed cost is not the fabric — `ib_write_lat` on the same NIC pair is 10.7
us for the 24 KB a 4-token dispatch moves. Span-profiling with
`MORI_TRACE_SPAN` locates it:

- one warp spends **16.2 us issuing a single RDMA put** while the other 127
  leave the send phase in 1.24 us; the recv phase's 17.25 us warp-ramp is
  exactly that warp arriving late
- combine's median warp does **14.26 us of real work** — `warpsPerToken` is
  pinned at 4, so each warp gathers 8 experts × 1536 elements over XGMI

The put cannot simply be trimmed: downgrading its four `__threadfence_system()`
calls to agent scope regresses everything (dispatch 55 → 131 us) because the
NIC stops seeing the payload.

Worth filing separately:

1. `ENABLE_PROFILER=ON` does not build on `main` — `intranode_ll.hpp`
   references three `Slot` enumerators that are never declared, because the
   generator groups slots by source-file stem while `Slot` there aliases
   `intranode.hpp`'s enum.
2. **Tuning configs frequently do not take effect**, three independent reasons:
   `MORI_EP_LAUNCH_CONFIG_MODE` defaults to `MANUAL`, so the shipped JSONs are
   inert unless a caller opts in; tuning writes to the repo while the op reads
   the installed copy; on a miss `_find_fallback_config` silently substitutes
   another GPU model's file (observed running **mi308x** configs on MI300X),
   announcing it at `logger.info`. Each of these is a silent fallback with no
   warning a user will see.
3. `get_launch_config` looks both phases up with `config.data_type`, so for a
   mixed-dtype config it returns nothing for combine. It is not on the runtime
   path -- `dispatch()`/`combine()` go through `_resolve_launch_params` with
   `dtype=input.dtype`, which is correct -- and nothing in the repository calls
   it, so this is latent. Documented in place rather than changed, since fixing
   it means deciding what its signature should be.
4. `error_round` in `test_dispatch_combine_internode.py` is passed to
   `run_test_once` and never written, so every `error times:` line the test
   prints reads 0 regardless of outcome. It reads like a correctness summary
   and is not one.
