### PR TITLE
feat(EPv2): support wide EP (larger than 32) in intranode kernels

### DIFF
--- a/include/mori/ops/dispatch_combine_v2/ep_cfg.hpp
+++ b/include/mori/ops/dispatch_combine_v2/ep_cfg.hpp
@@ -301,6 +301,11 @@ inline void EpApplyFields(T& dst, const std::string& prefix, const Has& has, con
 // ---------------------------------------------------------------------------
 constexpr int EpBlockThreads(const EpCfg& c) { return c.warpPerBlock * c.waveSize; }
 
+// True when worldSize exceeds a single wavefront. The per-peer loops in
+// dispatch Phase 2 and the XDB barrier then iterate more than once per lane
+// and need the multi-iteration-safe code path. Compile-time via the Cfg NTTP.
+constexpr bool EpIsWideEp(const EpCfg& c) { return c.worldSize > c.waveSize; }
+
 // Recv-slot capacity. The flat token index encodes (pe, localTokId) with this
 // stride, so host and device must agree exactly.
 constexpr int EpMaxRecv(const EpCfg& c) {
@@ -387,9 +392,10 @@ constexpr bool EpCfgIsValid(const EpCfg& c) {
          // re-encodes to the next peer and combine folds in a stranger's token.
          // Token dropping is not implemented, so reject the cap at construction.
          EpMaxRecv(c) >= c.worldSize * c.maxTokPerRank &&
-         // The dedup ballot and the grid-barrier peer loop both assume one lane
-         // per peer / per top-k slot within a single wavefront.
-         c.numExpertPerToken < c.waveSize && c.worldSize <= c.waveSize &&
+         // The dedup ballot assumes one lane per top-k slot within a wavefront.
+         // worldSize may exceed waveSize (wide EP) but must fit within one
+         // block so the combine XDB barrier's thdId < npes poll covers all peers.
+         c.numExpertPerToken < c.waveSize && c.worldSize <= EpBlockThreads(c) &&
          // WarpCopy moves whole 16 B chunks.
          (EpTokenBytes(c) % 16) == 0 &&
          // Scale rows are copied as dwords, so the row must be dword-sized.

--- a/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
+++ b/python/mori/ops/dispatch_combine_v2/intranode_kernels.py
@@ -616,7 +616,6 @@ def make_combine(
         warp = tid >> LOG2_WAVE
         global_warp_id = bid * warp_num_per_block + warp
         global_warp_num = block_num * warp_num_per_block
-        grid_thread_id = bid * (warp_num_per_block * WAVE) + tid
 
         window = cco.Window(arena)
         rsrc_tok_map = create_buffer_resource_from_addr(addr_tok_map)
@@ -635,11 +634,14 @@ def make_combine(
         # reset. Polling is local (peer pushes into our slots), so the extra
         # per-block spins add no remote traffic.
         phase = fx.Int64(buffer_load(rsrc_xdb_flag, bid, vec_width=1, dtype=T.i64()))
-        if grid_thread_id < npes:
-            xdb_remote = fx.Int64(
-                window.lsa_ptr(grid_thread_id, off_xdb_mem)
-            ) + fx.Int64(rank) * fx.Int64(8)
-            P.store_i64_system(xdb_remote, arith.constant(0), phase)
+        # Wave0 strided push: npes > WAVE would split across sibling waves
+        # with no forward-progress guarantee, deadlocking the barrier.
+        if global_warp_id == 0:
+            for p in range(lane, npes, WAVE):
+                xdb_remote = fx.Int64(window.lsa_ptr(p, off_xdb_mem)) + fx.Int64(
+                    rank
+                ) * fx.Int64(8)
+                P.store_i64_system(xdb_remote, arith.constant(0), phase)
         # advance this block's private counter for the next call (single writer)
         if tid == 0:
             buffer_store(phase + arith.constant(1, type=T.i64()), rsrc_xdb_flag, bid)
@@ -666,11 +668,13 @@ def make_combine(
         # slot, so a faster peer can lap us and overwrite its (monotonic) push with
         # a higher call count before our late blocks read it. `>=` still releases
         # (a peer being ahead is the safe direction); `==` would deadlock.
-        if tid < npes:
-            xdb_peer_slot = fx.Int64(
-                window.lsa_ptr(my_lsa_rank, off_xdb_mem)
-            ) + fx.Int64(tid) * fx.Int64(8)
-            P.spin_until_ge_i64(xdb_peer_slot, phase)
+        # Wave0 strided poll: same cross-wave deadlock avoidance as the push.
+        if warp == 0:
+            for p in range(lane, npes, WAVE):
+                xdb_peer_slot = fx.Int64(
+                    window.lsa_ptr(my_lsa_rank, off_xdb_mem)
+                ) + fx.Int64(p) * fx.Int64(8)
+                P.spin_until_ge_i64(xdb_peer_slot, phase)
         fx.barrier()
         # No acquire fence needed here: the gather reads peer out_tok via
         # non-temporal loads (cache-bypassing, always fresh from HBM), and the

--- a/src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp
+++ b/src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp
@@ -664,11 +664,14 @@ __device__ void EpDispatch1250xBody(EpArgs args) {
   if (thdId == 0) atomicAdd(args.gridBarrier, 1u);
   index_t* recvTokenNums = EpLocal<index_t>(win, args.offRecvNum);
   if (globalWarpId == 0) {
+    // Grid barrier hoisted before the peer loop so wide EP (worldSize > waveSize)
+    // multi-iterates safely — the barrier is consumed and reset exactly once.
+    EpWaitEq(args.gridBarrier, static_cast<unsigned int>(gridDim.x));
+    __hip_atomic_store(args.gridBarrier, 0u, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+
     for (int destPe = laneId; destPe < npes; destPe += WS) {
       index_t* signal = EpPeer<index_t>(win, destPe, args.offRecvNum) + myPe;
       EpWaitEq(signal, 0);
-      EpWaitEq(args.gridBarrier, static_cast<unsigned int>(gridDim.x));
-      __hip_atomic_store(args.gridBarrier, 0u, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
       index_t numTokenSignal = __hip_atomic_load(args.destPeTokenCounter + destPe, __ATOMIC_RELAXED,
                                                  __HIP_MEMORY_SCOPE_AGENT) +
                                1;
@@ -705,9 +708,19 @@ __device__ __forceinline__ void EpCrossDeviceBarrier1250x(EpArgs args, bool need
 
   if (needGridRendezvous) {
     if (thdId == 0) atomicAdd(args.gridBarrier, 1u);
-    if (globalThdId < npes) {
-      EpWaitEq(args.gridBarrier, static_cast<unsigned int>(gridDim.x));
-      __hip_atomic_store(args.gridBarrier, 0u, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    if constexpr (!EpIsWideEp(kCfg)) {
+      if (globalThdId < npes) {
+        EpWaitEq(args.gridBarrier, static_cast<unsigned int>(gridDim.x));
+        __hip_atomic_store(args.gridBarrier, 0u, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      }
+    } else {
+      // Wide EP: single-thread wait+reset avoids the race where warp 0 resets
+      // the barrier before warp 1 reads gridDim.x.
+      if (thdId == 0) {
+        EpWaitEq(args.gridBarrier, static_cast<unsigned int>(gridDim.x));
+        __hip_atomic_store(args.gridBarrier, 0u, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      }
+      __syncthreads();
     }
   }
 

--- a/src/ops/dispatch_combine_v2/ep_intranode_kernel.hpp
+++ b/src/ops/dispatch_combine_v2/ep_intranode_kernel.hpp
@@ -248,13 +248,13 @@ __device__ void EpDispatchBody(EpArgs args) {
   if (thdId == 0) atomicAdd(args.gridBarrier, 1u);
 
   // Phase 2: one warp announces this rank's per-destination counts, then reads
-  // back everyone else's. worldSize <= waveSize (EpCfgIsValid) so each lane
-  // handles at most one peer and the in-loop barrier reset is safe.
+  // back everyone else's. The grid barrier is hoisted before the peer loop so
+  // that wide EP (worldSize > waveSize) multi-iterates safely.
   if (globalWarpId == 0) {
-    for (int destPe = laneId; destPe < kNpes; destPe += kCfg.waveSize) {
-      EpWaitEq(args.gridBarrier, static_cast<unsigned int>(gridDim.x));
-      __hip_atomic_store(args.gridBarrier, 0u, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    EpWaitEq(args.gridBarrier, static_cast<unsigned int>(gridDim.x));
+    __hip_atomic_store(args.gridBarrier, 0u, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
 
+    for (int destPe = laneId; destPe < kNpes; destPe += kCfg.waveSize) {
       // +1 so a zero-token destination still sees a distinct "signal arrived".
       const int numTokenSignal = __hip_atomic_load(args.destPeTokenCounter + destPe,
                                                    __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT) +
@@ -299,13 +299,30 @@ __device__ __forceinline__ void EpCrossDeviceBarrier(EpArgs args, unsigned long 
   __threadfence_system();
   if (thdId == 0) atomicAdd(args.gridBarrier, 1u);
 
-  if (globalThdId < kNpes) {
-    EpWaitEq(args.gridBarrier, static_cast<unsigned int>(gridDim.x));
-    __hip_atomic_store(args.gridBarrier, 0u, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+  if constexpr (!EpIsWideEp(kCfg)) {
+    // Narrow path: all participating threads are in one warp, no multi-warp race.
+    if (globalThdId < kNpes) {
+      EpWaitEq(args.gridBarrier, static_cast<unsigned int>(gridDim.x));
+      __hip_atomic_store(args.gridBarrier, 0u, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
 
-    __threadfence_system();
-    __hip_atomic_store(EpPeer<unsigned long long>(win, globalThdId, args.offXdb) + args.rank, flag,
-                       __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+      __threadfence_system();
+      __hip_atomic_store(EpPeer<unsigned long long>(win, globalThdId, args.offXdb) + args.rank,
+                         flag, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+    }
+  } else {
+    // Wide path: peers span multiple warps — single-thread wait+reset avoids the
+    // race where warp 0 resets the barrier before warp 1 reads gridDim.x.
+    if (thdId == 0) {
+      EpWaitEq(args.gridBarrier, static_cast<unsigned int>(gridDim.x));
+      __hip_atomic_store(args.gridBarrier, 0u, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    }
+    __syncthreads();
+
+    if (globalThdId < kNpes) {
+      __threadfence_system();
+      __hip_atomic_store(EpPeer<unsigned long long>(win, globalThdId, args.offXdb) + args.rank,
+                         flag, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+    }
   }
 
   if (globalThdId == 0) atomicAdd(args.xdbFlag, 1ull);
@@ -315,10 +332,6 @@ __device__ __forceinline__ void EpCrossDeviceBarrier(EpArgs args, unsigned long 
     while (__hip_atomic_load(localBarrier + thdId, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM) !=
            flag) {
     }
-    // ACQUIRE. The poll is a relaxed load and orders nothing, so without this the
-    // block's vector L1 still holds pre-barrier data and the fold reads
-    // pre-staging zeros for slots another block just filled -- dropping whole
-    // contributions silently. worldSize <= waveSize, so this is one invalidate.
     __threadfence_system();
   }
   __syncthreads();

--- a/src/ops/dispatch_combine_v2/ep_spec.cpp
+++ b/src/ops/dispatch_combine_v2/ep_spec.cpp
@@ -97,7 +97,8 @@ EpCfg MakeEpCfg(const std::string& arch, const EpRequest& req, EpKernelKind kind
         " hidden=" + std::to_string(c.hiddenDim) + " topk=" + std::to_string(c.numExpertPerToken) +
         " wave=" + std::to_string(c.waveSize) + " warps=" + std::to_string(c.warpPerBlock) +
         " blocks=" + std::to_string(c.blockNum) +
-        "); token bytes must be 16 B aligned, topk and worldSize must fit in a wavefront");
+        "); token bytes must be 16 B aligned, topk must fit in a wavefront, "
+        "worldSize must fit in one block (worldSize <= warpPerBlock * waveSize)");
   }
   return c;
 }

--- a/tests/cpp/jit/test_jit_core.cpp
+++ b/tests/cpp/jit/test_jit_core.cpp
@@ -176,8 +176,24 @@ TEST(Geometry, ValidityRejectsWhatTheKernelCannotRun) {
   c.numExpertPerToken = 64;  // the dedup ballot needs topk < waveSize
   EXPECT_FALSE(EpCfgIsValid(c));
 
+  // Wide EP: worldSize > waveSize is valid when it fits within one block.
   c = ok;
-  c.worldSize = 128;  // the grid-barrier peer loop needs worldSize <= waveSize
+  c.worldSize = 64;
+  c.waveSize = 32;
+  c.warpPerBlock = 2;  // blockDim = 64 >= worldSize
+  EXPECT_TRUE(EpCfgIsValid(c));
+
+  c = ok;
+  c.worldSize = 48;
+  c.waveSize = 32;
+  c.warpPerBlock = 2;
+  EXPECT_TRUE(EpCfgIsValid(c));
+
+  // Still reject worldSize > blockDim.
+  c = ok;
+  c.worldSize = 128;
+  c.waveSize = 32;
+  c.warpPerBlock = 2;  // blockDim = 64 < 128
   EXPECT_FALSE(EpCfgIsValid(c));
 
   c = ok;


### PR DESCRIPTION
## Summary  
- Support EP configurations where `worldSize` exceeds the hardware wave size
  (e.g. EP36 on gfx1250 with WAVE=32), across both the C++ TDM kernels and the
  FlyDSL combine kernel.

### C++ TDM kernels (`ep_intranode_kernel.hpp`, `ep_intranode_1250x.hpp`)

  - **Phase 2 barrier hoist**: move the grid barrier wait+reset before the
    per-peer loop so that wide EP multi-iterates safely (barrier consumed and
    reset exactly once regardless of iteration count).
  - **Cross-device barrier**: add a multi-warp-safe wait+reset path via
    `if constexpr (EpIsWideEp(kCfg))` — single-thread wait+reset followed by
    `__syncthreads()` prevents the race where warp 0 resets the barrier before
    warp 1 reads `gridDim.x`. The narrow path is unchanged.
  - **Validation**: relax `EpCfgIsValid` to accept
    `worldSize <= warpPerBlock * waveSize` (one block) via `EpIsWideEp`, and
    cover the new geometry in `test_jit_core`.

### FlyDSL combine kernel (`intranode_kernels.py`)

  - **XDB barrier deadlock fix**: the combine cross-device barrier used a naive
    `grid_thread_id < npes` / `tid < npes` mapping for the signal push and poll.
    At `npes > WAVE` this spills active lanes onto a partially-active sibling
    wave; GPUs give no forward-progress guarantee between sibling waves, so the
    spinning wave0 can starve wave1 before it issues its stores — deadlocking
    peers whose flags come from the sibling wave. Fix: keep both push and poll
    within wave0 using a strided `for p in range(lane, npes, WAVE)` loop.