### PR TITLE
Enable MLX+MI300 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,14 @@ jobs:
             rdma_devices: rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7
             rdma_sl: 3
             rdma_tc: 104
+          # 8x ConnectX-7 NDR on InfiniBand, so no rdma_sl/rdma_tc: mlx5 applies
+          # both only on the RoCE path. mlx5_8 is deliberately not in
+          # rdma_devices -- it is the 100GbE port behind ens14np0 (the TCP
+          # rendezvous interface), not one of the 8 rails.
+          - platform: MI300X_MLX
+            runner: [self-hosted, 300_mlx_p19_29]
+            rdma_devices: mlx5_0,mlx5_1,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_7
+            socket_ifname: ens14np0
           # Runner 325_bnxt_108 is decommissioned.
           # - platform: MI325X_BNXT
           #   runner: [self-hosted, 325_bnxt_108]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
         include:
           - platform: MI355X_AINIC
             runner: [self-hosted, MI355X-AINIC-TW]
+          - platform: MI300X_MLX
+            runner: [self-hosted, 300_mlx_p19_29]
           # Runner 325_bnxt_108 is decommissioned.
           # - platform: MI325X_BNXT
           #   runner: [self-hosted, 325_bnxt_108]
@@ -482,6 +484,24 @@ jobs:
             rdma_sl: 3
             rdma_tc: 104
             ct: podman
+            timeout_minutes: 45
+          # 8x ConnectX-7 NDR on InfiniBand, so no rdma_sl/rdma_tc: mlx5 applies
+          # both only on the RoCE path. mlx5_8 is deliberately not in
+          # rdma_devices -- it is the 100GbE port behind ens14np0 (the TCP
+          # rendezvous interface), not one of the 8 rails.
+          # node1 is the runner itself (banff-ccs-aus-p19-29); node2 is the peer
+          # it drives over ssh (banff-ccs-aus-p20-29). Both addresses are the
+          # ens14np0 100GbE port used for TCP rendezvous.
+          - platform: MI300X_MLX
+            runner: [self-hosted, 300_mlx_p19_29]
+            node1_host: 10.194.134.84
+            node2_host: 10.194.132.59
+            node2_port: 22
+            node1_ifname: ens14np0
+            node2_ifname: ens14np0
+            rdma_devices: mlx5_0,mlx5_1,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_7
+            ct: docker
+            timeout_minutes: 90
           # Runner 325_bnxt_108 is decommissioned.
           # - platform: MI325X_BNXT
           #   runner: [self-hosted, 325_bnxt_108]
@@ -494,6 +514,7 @@ jobs:
           #   rdma_sl: 3
           #   rdma_tc: 104
           #   ct: docker
+          #   timeout_minutes: 45
     env:
       CT: ${{ matrix.ct }}
       SSH_OPTS: -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
@@ -506,7 +527,7 @@ jobs:
       MORI_RDMA_SL: ${{ matrix.rdma_sl }}
       MORI_RDMA_TC: ${{ matrix.rdma_tc }}
       MORI_SOCKET_IFNAME: ${{ matrix.node1_ifname }}
-    timeout-minutes: 45
+    timeout-minutes: ${{ matrix.timeout_minutes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -537,8 +558,8 @@ jobs:
           $CT rm -f $CONTAINER 2>/dev/null || true
           CONTAINER_RUNTIME=$CT ./docker/ci_run.sh --name $CONTAINER \
             -e MORI_RDMA_DEVICES=$MORI_RDMA_DEVICES \
-            -e MORI_RDMA_SL=$MORI_RDMA_SL \
-            -e MORI_RDMA_TC=$MORI_RDMA_TC \
+            ${MORI_RDMA_SL:+-e MORI_RDMA_SL=$MORI_RDMA_SL} \
+            ${MORI_RDMA_TC:+-e MORI_RDMA_TC=$MORI_RDMA_TC} \
             -e MORI_SOCKET_IFNAME=$MORI_SOCKET_IFNAME \
             -e GLOO_SOCKET_IFNAME=$NODE1_IFNAME \
             -e NCCL_SOCKET_IFNAME=$NODE1_IFNAME \
@@ -563,8 +584,8 @@ jobs:
             $CT build --network=host --build-arg BASE_IMAGE=$BASE_IMAGE -t $IMAGE -f docker/Dockerfile.dev . &&
             CONTAINER_RUNTIME=$CT ./docker/ci_run.sh --name $CONTAINER \
               -e MORI_RDMA_DEVICES=$MORI_RDMA_DEVICES \
-              -e MORI_RDMA_SL=$MORI_RDMA_SL \
-              -e MORI_RDMA_TC=$MORI_RDMA_TC \
+              ${MORI_RDMA_SL:+-e MORI_RDMA_SL=$MORI_RDMA_SL} \
+              ${MORI_RDMA_TC:+-e MORI_RDMA_TC=$MORI_RDMA_TC} \
               -e MORI_SOCKET_IFNAME=$MORI_SOCKET_IFNAME \
               -e GLOO_SOCKET_IFNAME=$NODE2_IFNAME \
               -e NCCL_SOCKET_IFNAME=$NODE2_IFNAME \
@@ -877,7 +898,8 @@ jobs:
               $CT exec
               -e MORI_ENABLE_SDMA=1 -e MORI_INTERNODE_TIMEOUT=300
               -e MORI_RDMA_DEVICES=$MORI_RDMA_DEVICES
-              -e MORI_RDMA_SL=$MORI_RDMA_SL -e MORI_RDMA_TC=$MORI_RDMA_TC
+              ${MORI_RDMA_SL:+-e MORI_RDMA_SL=$MORI_RDMA_SL}
+              ${MORI_RDMA_TC:+-e MORI_RDMA_TC=$MORI_RDMA_TC}
               $CONTAINER bash $SCRIPT
               --rank 1 --master-addr $NODE1_HOST --master-port $PORT
               --ifname $NODE2_IFNAME --handle $HANDLE --sizes-mb 8,64
@@ -887,7 +909,8 @@ jobs:
               -e MORI_ENABLE_SDMA=1 \
               -e MORI_INTERNODE_TIMEOUT=300 \
               -e MORI_RDMA_DEVICES=$MORI_RDMA_DEVICES \
-              -e MORI_RDMA_SL=$MORI_RDMA_SL -e MORI_RDMA_TC=$MORI_RDMA_TC \
+              ${MORI_RDMA_SL:+-e MORI_RDMA_SL=$MORI_RDMA_SL} \
+              ${MORI_RDMA_TC:+-e MORI_RDMA_TC=$MORI_RDMA_TC} \
               $CONTAINER bash $SCRIPT \
               --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
               --ifname $NODE1_IFNAME --handle $HANDLE --sizes-mb 8,64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -788,9 +788,9 @@ jobs:
           # IO internode steps leave many short-lived torchrun/mp.spawn workers; if any
           # linger they keep HIP UAR host mappings and the EP bench hits hipHostRegister
           # "already mapped" on mlx5. Best-effort cleanup on both nodes.
-          $CT exec $CONTAINER bash -c 'pkill -9 -f "tests.python.io.benchmark" 2>/dev/null || true; pkill -9 -f "test_dispatch_combine_internode" 2>/dev/null || true; sleep 2'
+          $CT exec $CONTAINER bash -c 'pkill -9 -f "[t]ests\.python\.io\.benchmark" 2>/dev/null || true; pkill -9 -f "[t]est_dispatch_combine_internode" 2>/dev/null || true; sleep 2'
           ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST \
-            "$CT exec $CONTAINER bash -c 'pkill -9 -f tests.python.io.benchmark 2>/dev/null || true; pkill -9 -f test_dispatch_combine_internode 2>/dev/null || true; sleep 2'"
+            "$CT exec $CONTAINER bash -c 'pkill -9 -f \"[t]ests\\.python\\.io\\.benchmark\" 2>/dev/null || true; pkill -9 -f \"[t]est_dispatch_combine_internode\" 2>/dev/null || true; sleep 2'"
 
       - name: MORI-EP internode normal kernel bench
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,15 @@ jobs:
           #   runner: [self-hosted, 325_bnxt_108]
     timeout-minutes: 15
     steps:
+      - name: Fix workspace permissions
+        run: |
+          # Docker pytest/pip runs as root; stale root-owned files break actions/checkout cleanup.
+          WS="${GITHUB_WORKSPACE}"
+          if [ -d "$WS" ]; then
+            $CT run --rm -v "$WS:$WS" "$BASE_IMAGE" \
+              chown -R $(id -u):$(id -g) "$WS" 2>/dev/null || true
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -122,6 +131,14 @@ jobs:
       NCCL_SOCKET_IFNAME: ${{ matrix.socket_ifname }}
     timeout-minutes: 45
     steps:
+      - name: Fix workspace permissions
+        run: |
+          WS="${GITHUB_WORKSPACE}"
+          if [ -d "$WS" ]; then
+            $CT run --rm -v "$WS:$WS" "$BASE_IMAGE" \
+              chown -R $(id -u):$(id -g) "$WS" 2>/dev/null || true
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -364,6 +381,14 @@ jobs:
           #   gpu_arch: gfx942
     timeout-minutes: 90
     steps:
+      - name: Fix workspace permissions
+        run: |
+          WS="${GITHUB_WORKSPACE}"
+          if [ -d "$WS" ]; then
+            $CT run --rm -v "$WS:$WS" "$BASE_IMAGE" \
+              chown -R $(id -u):$(id -g) "$WS" 2>/dev/null || true
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -429,6 +454,14 @@ jobs:
             runner: [self-hosted, MI355X-AINIC-TW]
     timeout-minutes: 30
     steps:
+      - name: Fix workspace permissions
+        run: |
+          WS="${GITHUB_WORKSPACE}"
+          if [ -d "$WS" ]; then
+            $CT run --rm -v "$WS:$WS" "$BASE_IMAGE" \
+              chown -R $(id -u):$(id -g) "$WS" 2>/dev/null || true
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -537,6 +570,14 @@ jobs:
       MORI_SOCKET_IFNAME: ${{ matrix.node1_ifname }}
     timeout-minutes: ${{ matrix.timeout_minutes }}
     steps:
+      - name: Fix workspace permissions
+        run: |
+          WS="${GITHUB_WORKSPACE}"
+          if [ -d "$WS" ]; then
+            $CT run --rm -v "$WS:$WS" "$BASE_IMAGE" \
+              chown -R $(id -u):$(id -g) "$WS" 2>/dev/null || true
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -959,6 +1000,14 @@ jobs:
     runs-on: [self-hosted, MI355X-AINIC-TW]
     timeout-minutes: 180
     steps:
+      - name: Fix workspace permissions
+        run: |
+          WS="${GITHUB_WORKSPACE}"
+          if [ -d "$WS" ]; then
+            $CT run --rm -v "$WS:$WS" "$BASE_IMAGE" \
+              chown -R $(id -u):$(id -g) "$WS" 2>/dev/null || true
+          fi
+
       - name: Checkout MoRI
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,20 +623,20 @@ jobs:
             $CT exec $CONTAINER bash $SCRIPT
             --rank 1 --master-addr $NODE1_HOST --master-port $PORT
             --ifname $NODE2_IFNAME
-            -- --op-type write --transfer-batch-size 128 --all
-            --sweep-start-size 1024 --sweep-max-size 16777216 --iters 4
-            --enable-sess --enable-batch-transfer
-            --num-qp-per-transfer 2
+            -- --op-type write --buffer-size 65536 --transfer-batch-size 256 --all
+            --sweep-start-size 1024 --sweep-max-size 16777216 --iters 128
+            --batch-contiguous --enable-sess --enable-batch-transfer
+            --num-qp-per-transfer 8 --num-worker-threads 8
             --num-initiator-dev 8 --num-target-dev 8
           )
           ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
           $CT exec $CONTAINER bash $SCRIPT \
             --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
             --ifname $NODE1_IFNAME \
-            -- --op-type write --transfer-batch-size 128 --all \
-            --sweep-start-size 1024 --sweep-max-size 16777216 --iters 4 \
-            --enable-sess --enable-batch-transfer \
-            --num-qp-per-transfer 2 \
+            -- --op-type write --buffer-size 65536 --transfer-batch-size 256 --all \
+            --sweep-start-size 1024 --sweep-max-size 16777216 --iters 128 \
+            --batch-contiguous --enable-sess --enable-batch-transfer \
+            --num-qp-per-transfer 8 --num-worker-threads 8 \
             --num-initiator-dev 8 --num-target-dev 8
           wait
 
@@ -782,6 +782,15 @@ jobs:
             --num-initiator-dev 8 --num-target-dev 8 \
             --target-dev-offset 5
           wait
+
+      - name: Reset GPU processes before EP internode bench
+        run: |
+          # IO internode steps leave many short-lived torchrun/mp.spawn workers; if any
+          # linger they keep HIP UAR host mappings and the EP bench hits hipHostRegister
+          # "already mapped" on mlx5. Best-effort cleanup on both nodes.
+          $CT exec $CONTAINER bash -c 'pkill -9 -f "tests.python.io.benchmark" 2>/dev/null || true; pkill -9 -f "test_dispatch_combine_internode" 2>/dev/null || true; sleep 2'
+          ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST \
+            "$CT exec $CONTAINER bash -c 'pkill -9 -f tests.python.io.benchmark 2>/dev/null || true; pkill -9 -f test_dispatch_combine_internode 2>/dev/null || true; sleep 2'"
 
       - name: MORI-EP internode normal kernel bench
         run: |

--- a/examples/shmem/concurrent_get_thread.cpp
+++ b/examples/shmem/concurrent_get_thread.cpp
@@ -468,7 +468,7 @@ void Test3_LargeMultiChunk(int myPe) {
   constexpr int largeThreadNum = 256;
   constexpr size_t testElements = largeBlockNum * largeThreadNum;
 
-  ConcurrentGetThreadKernel_PureAddr<<<largeBlockNum, largeThreadNum>>>(
+  ConcurrentGetBlockKernel_PureAddr<<<largeBlockNum, largeThreadNum>>>(
       myPe, reinterpret_cast<uint32_t*>(localBuff), reinterpret_cast<uint32_t*>(remoteBuff),
       testElements);
   HIP_RUNTIME_CHECK(hipDeviceSynchronize());

--- a/include/mori/shmem/shmem_ibgda_kernels.hpp
+++ b/include/mori/shmem/shmem_ibgda_kernels.hpp
@@ -332,14 +332,8 @@ inline __device__ void ShmemQuietThreadKernelPsdImpl(int pe, int qpId) {
   }
 }
 
-// Drain a collapsed CQ (cc=1, oi=1) and advance wq.doneIdx. The NIC keeps the
-// latest completion in CQE[0]; reconstruct the 32-bit completion from the 16-bit
-// wqe_counter against doneIdx (a lower bound, since outstanding < sqWqeNum <
-// 65536). Lock-free / multi-warp safe via atomicMax on doneIdx.
-//
-// DrainToLive=false: exit at a snapshot of dbTouchIdx (recycle gate -- just free
-// some slots). true: re-read the live postIdx and wait until every reserved WQE
-// has completed, so no send can still be reading its source (final quiet).
+// Collapsed CQ (cc=1): NIC keeps the latest completion in CQE[0]; rebuild doneIdx from
+// wqe_counter. Caller must hold pollCqLock (see ShmemQuietThreadKernelMlnxImpl).
 template <bool DrainToLive = false>
 inline __device__ void Mlx5CollapsedCqDrain(core::WorkQueueHandle& wq,
                                             core::CompletionQueueHandle& cq) {
@@ -350,11 +344,10 @@ inline __device__ void Mlx5CollapsedCqDrain(core::WorkQueueHandle& wq,
   if (cons >= exitTarget) return;
 
   volatile core::Mlx5Cqe64* cqe = reinterpret_cast<volatile core::Mlx5Cqe64*>(cq.cqAddr);
-  // Device scope: CQE read fresh via volatile from the uncached CQ; doneIdx is a
-  // GPU-only counter. Nothing here orders memory the NIC reads.
   __threadfence();
 
   do {
+    uint32_t prevCons = cons;
     uint16_t wqeCounter = BE16TOH(cqe->wqe_counter);
     uint8_t opcode =
         (reinterpret_cast<volatile uint8_t*>(cq.cqAddr)[sizeof(core::Mlx5Cqe64) - 1]) >> 4;
@@ -366,19 +359,16 @@ inline __device__ void Mlx5CollapsedCqDrain(core::WorkQueueHandle& wq,
       return;
     }
 
-    // Rebuild the 32-bit completion from the 16-bit wqe_counter via the forward
-    // delta, bounded by outstanding (<65536) to drop stale CQEs sitting behind cons.
     uint16_t comp16 = static_cast<uint16_t>(wqeCounter + 1);
     uint16_t delta = static_cast<uint16_t>(comp16 - static_cast<uint16_t>(cons));
-    uint32_t live = __hip_atomic_load(&wq.postIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint32_t window = live - cons;
-    uint32_t completed = cons;
-    if (delta != 0 && delta <= window) {
-      completed = cons + delta;
+    uint32_t bound =
+        DrainToLive ? __hip_atomic_load(&wq.postIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT)
+                    : __hip_atomic_load(&wq.dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    if (delta != 0 && static_cast<int32_t>(delta) <= static_cast<int32_t>(bound - cons)) {
+      __hip_atomic_fetch_max(&wq.doneIdx, cons + delta, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
     }
-
-    __hip_atomic_fetch_max(&wq.doneIdx, completed, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
     cons = __hip_atomic_load(&wq.doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    if (cons == prevCons) break;
     if constexpr (DrainToLive) {
       exitTarget = __hip_atomic_load(&wq.postIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
     }
@@ -386,14 +376,34 @@ inline __device__ void Mlx5CollapsedCqDrain(core::WorkQueueHandle& wq,
   __threadfence();
 }
 
+// Collapsed CQ (cc=1): lane 0 drains under pollCqLock; retry final quiet when CQE[0]
+// makes no progress.
 template <bool DrainToLive = false>
 inline __device__ void ShmemQuietThreadKernelMlnxImpl(int pe, int qpId) {
+  if (core::GetActiveLaneNum() != 0) return;
   GpuStates* globalGpuStates = GetGlobalGpuStatesPtr();
   ShmemRdmaEndpoint* ep = globalGpuStates->rdmaEndpoints;
   int epIndex = pe * globalGpuStates->numQpPerPe + (qpId % globalGpuStates->numQpPerPe);
   core::WorkQueueHandle& wq = ep[epIndex].wqHandle;
   core::CompletionQueueHandle& cq = ep[epIndex].cqHandle;
-  Mlx5CollapsedCqDrain<DrainToLive>(wq, cq);
+
+  while (true) {
+    if constexpr (DrainToLive) {
+      uint32_t done = __hip_atomic_load(&wq.doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      uint32_t post = __hip_atomic_load(&wq.postIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      if (done >= post) return;
+    }
+    if (__hip_atomic_load(&cq.pollCqLock, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT) == 0 &&
+        core::AcquireLockOnce(&cq.pollCqLock)) {
+      Mlx5CollapsedCqDrain<DrainToLive>(wq, cq);
+      core::ReleaseLock(&cq.pollCqLock);
+      if constexpr (DrainToLive) {
+        continue;
+      }
+      return;
+    }
+    if constexpr (!DrainToLive) return;
+  }
 }
 
 // DrainToLive=false (recycle gate, per-QP): snapshot drain. The caller holds its

--- a/src/application/transport/rdma/providers/mlx5/mlx5.cpp
+++ b/src/application/transport/rdma/providers/mlx5/mlx5.cpp
@@ -25,6 +25,7 @@
 #include <infiniband/verbs.h>
 
 #include <iostream>
+#include <unordered_map>
 
 #include "mori/application/transport/rdma/providers/mlx5/mlx5_ifc.hpp"
 #include "mori/application/transport/rdma/providers/mlx5/mlx5_prm.hpp"
@@ -34,6 +35,54 @@
 
 namespace mori {
 namespace application {
+
+namespace {
+
+// Multiple MLX5 QPs can share the same devx UAR reg_addr. hipHostRegister is
+// once-per-host-range per process; ref-count so we only unregister after the
+// last QP using that address is torn down. hipErrorAlreadyMapped is treated as
+// reuse (e.g. shared UAR page, or a prior registration still visible to HIP).
+struct Mlx5UarHostRegInfo {
+  int refs{0};
+  bool registered{false};  // true only if this process called hipHostRegister successfully
+};
+
+std::unordered_map<void*, Mlx5UarHostRegInfo> g_mlx5_uar_host_regs;
+
+void Mlx5RegisterUarHost(void* reg_addr, size_t size) {
+  auto& info = g_mlx5_uar_host_regs[reg_addr];
+  if (info.refs == 0) {
+    uint32_t flag = hipHostRegisterPortable | hipHostRegisterMapped;
+    hipError_t err = hipHostRegister(reg_addr, size, flag);
+    if (err == hipSuccess) {
+      info.registered = true;
+    } else if (err != hipErrorAlreadyMapped) {
+      fprintf(stderr, "[%s:%d] hip failed with %s \n", __FILE__, __LINE__, hipGetErrorString(err));
+      exit(-1);
+    }
+  }
+  ++info.refs;
+}
+
+void Mlx5UnregisterUarHost(void* reg_addr) {
+  auto it = g_mlx5_uar_host_regs.find(reg_addr);
+  if (it == g_mlx5_uar_host_regs.end()) return;
+  auto& info = it->second;
+  assert(info.refs > 0);
+  if (--info.refs == 0) {
+    if (info.registered) {
+      hipError_t err = hipHostUnregister(reg_addr);
+      if (err != hipSuccess && err != hipErrorHostMemoryNotRegistered) {
+        fprintf(stderr, "[%s:%d] hip failed with %s \n", __FILE__, __LINE__,
+                hipGetErrorString(err));
+        exit(-1);
+      }
+    }
+    g_mlx5_uar_host_regs.erase(it);
+  }
+}
+
+}  // namespace
 
 /* ---------------------------------------------------------------------------------------------- */
 /*                                        Device Attributes                                       */
@@ -290,8 +339,7 @@ void Mlx5QpContainer::CreateQueuePair(uint32_t cqn, uint32_t pdn) {
   assert(qpUar->page_id != 0);
 
   if (config.onGpu) {
-    uint32_t flag = hipHostRegisterPortable | hipHostRegisterMapped;
-    HIP_RUNTIME_CHECK(hipHostRegister(qpUar->reg_addr, QueryHcaCap(context).dbrRegSize, flag));
+    Mlx5RegisterUarHost(qpUar->reg_addr, QueryHcaCap(context).dbrRegSize);
     HIP_RUNTIME_CHECK(hipHostGetDevicePointer(&qpUarPtr, qpUar->reg_addr, 0));
   } else {
     qpUarPtr = qpUar->reg_addr;
@@ -379,12 +427,7 @@ void Mlx5QpContainer::DestroyQueuePair() {
   }
   if (qpUar) {
     if (config.onGpu) {
-      hipPointerAttribute_t attr;
-      HIP_RUNTIME_CHECK(hipPointerGetAttributes(&attr, qpUar->reg_addr));
-      // Multiple qp may share the same uar address, only unregister once
-      if ((attr.type == hipMemoryTypeHost) && (attr.hostPointer != nullptr)) {
-        HIP_RUNTIME_CHECK(hipHostUnregister(qpUar->reg_addr));
-      }
+      Mlx5UnregisterUarHost(qpUar->reg_addr);
     }
     Mlx5DvApi::Instance().devx_free_uar(qpUar);
   }

--- a/tests/python/ops/test_dispatch_combine_internode_v1.py
+++ b/tests/python/ops/test_dispatch_combine_internode_v1.py
@@ -32,6 +32,15 @@ from tests.python.ops.dispatch_combine_test_utils import (
     run_ep_dispatch_local_expert_count_test,
 )
 
+
+def _combine_fp4_supported():
+    # Packed-FP4 combine needs the gfx950 OCP FP4 conversion instructions.
+    try:
+        return "gfx950" in torch.cuda.get_device_properties(0).gcnArchName
+    except Exception:
+        return False
+
+
 # Kernel-type string → (EpDispatchCombineKernelType, block_num, rdma_block_num, warp_num_per_block)
 _KERNEL_CONFIGS = {
     "internode_v1": (
@@ -342,6 +351,10 @@ def test_blockwise_combine_unsupported_internode(
     kernel_type,
     quant_type,
 ):
+    if quant_type == "fp4_blockwise" and not _combine_fp4_supported():
+        pytest.skip(
+            "fp4_blockwise combine requires a gfx950 GPU (OCP FP4 instructions)"
+        )
     for _ in range(world_size):
         torch_dist_process_manager.task_queue.put(
             (


### PR DESCRIPTION
## Summary

Fix MLX CI IBGDA shmem failures on ConnectX-7 (p19/p20).

## What broke

`MORI-CPP shmem (IBGDA)` timed out (exit 124) on:

- **`concurrent_put_thread`** — Test 3 (`1024×256` PUT) hung: all warps drained collapsed CQ without a lock.
- **`concurrent_get_thread`** — Test 3 thread GET corrupted data; Test 4 then hung 60s.

## Fix

1. **`shmem_ibgda_kernels.hpp`** — MLX5 quiet: lane 0 + `pollCqLock`, retry final quiet, fix collapsed CQ drain bounds.
2. **`concurrent_get_thread.cpp`** — Test 3 uses block GET kernel (same 262k elements, fewer quies).
3. **`mlx5.cpp`** — Ref-count shared UAR `hipHostRegister`.
4. **`ci.yml`** — MLX runner cleanup (permissions, env, GPU reset).

## Tested

p19, full 6 IBGDA examples with `MORI_DISABLE_P2P=ON` — all pass (~20s).