### PR TITLE
perf(EPv2): size the gfx1250 combine pull tile against the LDS budget

### DIFF
--- a/src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp
+++ b/src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp
@@ -792,18 +792,40 @@ __device__ void EpCombine1250xBody(EpArgs args) {
 
   EpMultiWarpIter mwIter(globalWarpNum, args.numTokens, hiddenDim);
 
-  constexpr int _cPullChunks = MORI_COMB_TDM;
   constexpr bool _cPullType = (sizeof(TokT) == 2 || sizeof(TokT) == 4);
   const int _cPullRowElems = 128 / (int)sizeof(TokT);
-  const int _cPullSrcMax = (npes <= 4 && npes < topk) ? npes : topk;
+  // Slots per warp. Dispatch already deduped (see ep_intranode_kernel.hpp), so a
+  // token reaches at most npes distinct ranks and never more than topk of them.
+  // Past npes >= topk this saturates at topk and stops tracking world size,
+  // which is what lets one budget cover EP4 through EP64 with one expression.
+  const int _cPullSrcMax = (npes < topk) ? npes : topk;
+  const size_t _cPullPtrBytes =
+      ((((size_t)(1 + (kCfg.useWeights ? 1 : 0)) * warpNum * topk * sizeof(void*)) + 127) &
+       ~(size_t)127);
+  // Solve for the tile rather than assume one. With a fixed chunk count the need
+  // is warpNum * srcMax * (hidden / TDM) * sizeof, which crosses the budget once
+  // srcMax passes 4 -- and crossing it costs 7x, because the fallback reads peer
+  // memory one element at a time with the fabric latency exposed. Chunking finer
+  // always fits: the floor is one row per slot, 8 KB at warp 8 with 8 slots. So
+  // after this the fallback is reachable only by dtype, never by world size.
+  // MORI_COMB_TDM stays the floor, so any shape that already fit is untouched.
+  const size_t _cPullSlotBytes =
+      ((size_t)MORI_COMB_LDS_BUDGET > _cPullPtrBytes)
+          ? ((size_t)MORI_COMB_LDS_BUDGET - _cPullPtrBytes) /
+                ((size_t)warpNum * (size_t)_cPullSrcMax)
+          : 0;
+  const int _cPullTileCap = (int)(_cPullSlotBytes / sizeof(TokT)) & ~(_cPullRowElems - 1);
+  const int _cPullFitChunks = (_cPullTileCap >= _cPullRowElems)
+                                  ? (((int)hiddenDim + _cPullTileCap - 1) / _cPullTileCap)
+                                  : MORI_COMB_TDM;
+  const int _cPullChunks =
+      (MORI_COMB_TDM > _cPullFitChunks) ? MORI_COMB_TDM : _cPullFitChunks;
   const int _cPullTileElems =
       (((int)((hiddenDim + _cPullChunks - 1) / _cPullChunks) + _cPullRowElems - 1) /
        _cPullRowElems) *
       _cPullRowElems;
   const size_t _cPullLdsNeed =
-      ((((size_t)(1 + (kCfg.useWeights ? 1 : 0)) * warpNum * topk * sizeof(void*)) + 127) &
-       ~(size_t)127) +
-      (size_t)warpNum * _cPullSrcMax * _cPullTileElems * sizeof(TokT);
+      _cPullPtrBytes + (size_t)warpNum * _cPullSrcMax * _cPullTileElems * sizeof(TokT);
   const bool _cPullOk = _cPullType && ((int)hiddenDim >= _cPullRowElems) &&
                         (_cPullTileElems >= _cPullRowElems) &&
                         (_cPullLdsNeed <= (size_t)MORI_COMB_LDS_BUDGET);

--- a/src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp
+++ b/src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp
@@ -809,17 +809,15 @@ __device__ void EpCombine1250xBody(EpArgs args) {
   // always fits: the floor is one row per slot, 8 KB at warp 8 with 8 slots. So
   // after this the fallback is reachable only by dtype, never by world size.
   // MORI_COMB_TDM stays the floor, so any shape that already fit is untouched.
-  const size_t _cPullSlotBytes =
-      ((size_t)MORI_COMB_LDS_BUDGET > _cPullPtrBytes)
-          ? ((size_t)MORI_COMB_LDS_BUDGET - _cPullPtrBytes) /
-                ((size_t)warpNum * (size_t)_cPullSrcMax)
-          : 0;
+  const size_t _cPullSlotBytes = ((size_t)MORI_COMB_LDS_BUDGET > _cPullPtrBytes)
+                                     ? ((size_t)MORI_COMB_LDS_BUDGET - _cPullPtrBytes) /
+                                           ((size_t)warpNum * (size_t)_cPullSrcMax)
+                                     : 0;
   const int _cPullTileCap = (int)(_cPullSlotBytes / sizeof(TokT)) & ~(_cPullRowElems - 1);
   const int _cPullFitChunks = (_cPullTileCap >= _cPullRowElems)
                                   ? (((int)hiddenDim + _cPullTileCap - 1) / _cPullTileCap)
                                   : MORI_COMB_TDM;
-  const int _cPullChunks =
-      (MORI_COMB_TDM > _cPullFitChunks) ? MORI_COMB_TDM : _cPullFitChunks;
+  const int _cPullChunks = (MORI_COMB_TDM > _cPullFitChunks) ? MORI_COMB_TDM : _cPullFitChunks;
   const int _cPullTileElems =
       (((int)((hiddenDim + _cPullChunks - 1) / _cPullChunks) + _cPullRowElems - 1) /
        _cPullRowElems) *


### PR DESCRIPTION
The TDM pull path took its tile from a fixed chunk count, so the LDS it needed was warpNum * srcMax * (hidden / MORI_COMB_TDM) * sizeof, where srcMax is how many distinct ranks a token landed on. At world 4 srcMax is 4 and that product is 230 KB, inside the 320 KB budget. At world 8 with topk 6 it is 6, the product is 345 KB, _cPullOk goes false, and combine drops to the per-element fallback that reads peer memory with the fabric latency exposed.

Measured on two gfx1250 nodes, 8 ranks over scale-up, against this commit's parent, ct=512, hidden 7168, comb 64x8, ITERS=50, median of 3 alternating rounds, CHECK on:

  world 8 topk 6   combine  619.2 us /  53.0 GB/s -> 81.1 us / 403.5 GB/s
  world 8 topk 8   combine   89.8 us / 423.7 GB/s -> 89.5 us / 422.0 GB/s
  world 4 topk 6   combine   60.9 us / 395.4 GB/s -> 60.7 us / 396.4 GB/s
  world 4 topk 8   combine   63.2 us / 414.9 GB/s -> 63.1 us / 416.4 GB/s

topk 8 at world 8 was never affected: srcMax == npes makes the QUAD gate true and that path sizes its tiles separately, so it never reads this budget. The broken band was topk 6, 7 and topk >= 9, with 5 and 8 fine on either side of it, which is why it went unnoticed.

Solving for the tile leaves every shape that already fit bit-identical -- world 4 still resolves to 2 chunks and the same 230144 bytes, hence the unchanged rows above -- and takes world size out of the inequality, because srcMax saturates at topk once npes >= topk. Bounding srcMax by min(npes, topk) instead of topk also stops over-reserving when topk > npes.

World 16/32/64 are covered by a host-side replica of the expression only (3 chunks, 312320 bytes at topk 8); no machine above 8 ranks was available.

Two adjacent changes were measured and left out, each 3/3 rounds slower at world 8 topk 6: letting the QUAD gate take topk < npes (+0.4 us, since a group then has more warps than the token has sources), and dropping the npes <= 4 guard on this path's compaction (+1.4 us, the ballot costs more than the reduce iterations it saves, which _CROW_DEAD already skipped).