### PR TITLE
fix: use strided offsets in run_single_once when batch_contiguous is disabled

### DIFF
--- a/tests/python/io/benchmark.py
+++ b/tests/python/io/benchmark.py
@@ -942,8 +942,13 @@ class MoriIoBenchmark:
             transfer_uids.append(self.engine.allocate_transfer_uid())
 
         func, arg_list = None, []
+        if not self.batch_contiguous:
+            stride = buffer_size + 1
+            offsets = [i * stride for i in range(transfer_batch_size)]
+        else:
+            offsets = [i * buffer_size for i in range(transfer_batch_size)]
         for i in range(transfer_batch_size):
-            offset = buffer_size * i
+            offset = offsets[i]
             if self.enable_sess:
                 func = self.sess.read if self.op_type == "read" else self.sess.write
                 arg_list.append(


### PR DESCRIPTION
## Summary

- `run_single_once()` always used contiguous offsets (`buffer_size * i`) regardless of `batch_contiguous`
- When `batch_contiguous=False`, buffer is allocated with strided layout `(buffer_size + 1) * i`, causing each transfer to read from wrong positions (overlapping gap bytes)
- Target receives corrupted data; validation fails with `AssertionError` at `benchmark.py:705`
- Fix: use strided offsets in `run_single_once()` when `batch_contiguous=False`

## Test plan

- [x] Ran MORI-IO internode write benchmark **without** `--batch-contiguous` — previously failed with AssertionError, now passes
- [x] Ran MORI-IO internode write benchmark **with** `--batch-contiguous` — still passes (no regression)
- Tested on 2-node ionic RDMA setup (crsuse2-m2m-v2-017 / crsuse2-m2m-v2-024)
