### PR TITLE
examples: address a torch symmetric tensor as a CCO LSA window

### DIFF
--- a/examples/cco/README.md
+++ b/examples/cco/README.md
@@ -18,6 +18,9 @@ examples/cco/
 | `python/04_flydsl_lsa_put` | py | FlyDSL LSA: direct peer-pointer store in the kernel |
 | `python/05_flydsl_lsa_allreduce` | py | FlyDSL LSA custom all-reduce (peer pointers + device signal barrier) |
 | `python/06_flydsl_gda_modes` | py | FlyDSL GDA template matrix: (thread_mode, coop) × signal |
+| `python/07_flydsl_sdma` | py | FlyDSL SDMA put/get over the copy engine |
+| `python/08_torch_symm_import` | py | import a `torch.symm_mem` tensor into the flat LSA space, no copy |
+| `python/09_torch_symm_lsa_all2all` | py | mori's own torch symm-mem backend + Triton `lsa_ptr` all-to-all |
 | `ir/test_triton_cco.py` | py | Triton DevComm queries and LSA/SDMA/GDA device APIs |
 | `cpp/01_lsa_put.cpp` | c++ | intra-node LSA put (includes only `cco.hpp`) |
 | `cpp/02_gda_put.cpp` | c++ | GPU-initiated RDMA put + signal/wait (includes only `cco_scale_out.hpp`) |

--- a/examples/cco/python/09_torch_symm_lsa_all2all/main.py
+++ b/examples/cco/python/09_torch_symm_lsa_all2all/main.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+CCO Example 09 — mori's torch SymmetricMemory backend, addressed as an LSA window
+=================================================================================
+
+Example 08 imports a tensor from whichever symmetric-memory backend torch picked.
+This one names mori's own (``symm_mem.set_backend("MORI")``) and then does the
+whole exchange through CCO, so the two halves of mori meet:
+
+  * ``mori.allocator`` owns the allocation and its lifetime -- it is a torch
+    tensor, freed when Python drops it;
+  * CCO owns the peer addressing -- ``register_external_window()`` aliases the
+    tensor's HIP VMM handle into the flat LSA space with no copy.
+
+``symm_mem.rendezvous()`` is deliberately never called: the backend's own peer
+exchange would duplicate what ``ccoWindowRegister`` already does. The kernel is
+Triton (``mori.ir.triton.cco``) and computes each peer address arithmetically
+with ``Window.lsa_ptr`` rather than loading it from a pointer array.
+
+All-to-all: rank r writes its chunk into every peer's slot r, then each rank
+checks that slot p holds rank p's sentinel.
+
+    mpirun --allow-run-as-root -np 2 python main.py
+"""
+
+import sys
+
+try:
+    from mpi4py import MPI
+except ImportError:
+    print("ERROR: mpi4py required.  pip install mpi4py")
+    sys.exit(1)
+
+import torch  # must be imported before mori.cco
+import torch.distributed._symmetric_memory as symm_mem
+import triton
+import triton.language as tl
+
+import mori.allocator  # noqa: F401  -- importing registers the "MORI" backend
+from mori.cco import Communicator
+from mori.ir.triton import cco
+
+PER_RANK_VMM = 1 * 1024 * 1024 * 1024
+CHUNK_ELEMS = 4096  # int32 per peer
+BLOCK = 512
+
+
+@triton.jit(do_not_specialize=["chunk_elems", "rank_id"])
+def a2a_lsa_kernel(window, send_ptr, chunk_elems, rank_id, BLOCK: tl.constexpr):
+    """One program per (peer, block): push my chunk into that peer's slot."""
+    peer = tl.program_id(0)
+    blk = tl.program_id(1)
+
+    chunk = chunk_elems.to(tl.int64)
+    # The peer's window base plus the slot it reserves for me. lsa_ptr is
+    # arithmetic on the flat VA, so no pointer table is dereferenced.
+    dst_addr = cco.Window.lsa_ptr(window, peer, rank_id.to(tl.int64) * chunk * 4)
+    dst = dst_addr.to(tl.pointer_type(tl.int32), bitcast=True)
+    src = (
+        send_ptr.to(tl.pointer_type(tl.int32), bitcast=True) + peer.to(tl.int64) * chunk
+    )
+
+    offs = blk * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < chunk_elems
+    tl.store(dst + offs, tl.load(src + offs, mask=mask), mask=mask)
+
+
+def main():
+    comm_mpi = MPI.COMM_WORLD
+    rank = comm_mpi.Get_rank()
+    nranks = comm_mpi.Get_size()
+    if nranks < 2:
+        if rank == 0:
+            print("This example needs at least 2 ranks (mpirun -np 2).")
+        return 1
+
+    local = rank % torch.cuda.device_count()
+    torch.cuda.set_device(local)
+    device = torch.device("cuda", local)
+
+    symm_mem.set_backend("MORI")
+    recv = symm_mem.empty(nranks * CHUNK_ELEMS, dtype=torch.int32, device=device)
+    recv.zero_()
+    # Ordinary local memory. Chunk p carries a value identifying (me -> p).
+    send = torch.empty(nranks * CHUNK_ELEMS, dtype=torch.int32, device=device)
+    for p in range(nranks):
+        send[p * CHUNK_ELEMS : (p + 1) * CHUNK_ELEMS] = rank * 1000 + p
+    torch.cuda.synchronize()
+
+    uid = Communicator.get_unique_id() if rank == 0 else None
+    uid = comm_mpi.bcast(uid, root=0)
+
+    errors = 0
+    with Communicator.init(nranks, rank, uid, per_rank_vmm=PER_RANK_VMM) as comm:
+        if rank == 0:
+            print(
+                f"CommCreate: {nranks} ranks, backend={symm_mem.get_backend(device)}, "
+                f"{CHUNK_ELEMS * 4} B per peer"
+            )
+
+        # Import the torch tensor into the flat LSA space (no copy).
+        win = comm.register_external_window(recv.data_ptr(), recv.nbytes)
+        print(
+            f"[rank {rank}] torch data_ptr={recv.data_ptr():#x} -> "
+            f"cco flat local_ptr={win.local_ptr:#x}",
+            flush=True,
+        )
+        comm.barrier()
+
+        grid = (nranks, (CHUNK_ELEMS + BLOCK - 1) // BLOCK)
+        a2a_lsa_kernel[grid](
+            win.handle,
+            send.data_ptr(),
+            CHUNK_ELEMS,
+            rank,
+            BLOCK=BLOCK,
+            extern_libs=cco.get_extern_libs(),
+        )
+        torch.cuda.synchronize()
+        comm.barrier()
+
+        # Slot p must now hold what rank p sent me. First and last element, since
+        # the window started zeroed and a short copy would leave the tail at 0.
+        host = recv.cpu().tolist()
+        for p in range(nranks):
+            want = p * 1000 + rank
+            for i in (0, CHUNK_ELEMS - 1):
+                got = host[p * CHUNK_ELEMS + i]
+                if got != want:
+                    errors += 1
+                    print(
+                        f"[rank {rank}] slot {p}[{i}]: got {got}, want {want}",
+                        flush=True,
+                    )
+        if errors == 0:
+            print(
+                f"[rank {rank}] all {nranks} slots hold the right sender's data "
+                f"(via lsa_ptr, no buffer_ptrs)",
+                flush=True,
+            )
+        comm.barrier()
+
+    all_errors = comm_mpi.allreduce(errors, op=MPI.SUM)
+    if rank == 0:
+        print("SUCCESS" if all_errors == 0 else f"FAILED ({all_errors} mismatches)")
+    return 0 if all_errors == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/torch_symm_all2all/README.md
+++ b/examples/torch_symm_all2all/README.md
@@ -1,8 +1,8 @@
 # All-to-all over the mori torch SymmetricMemory backend
 
-One-shot all-to-all against a symmetric window, written twice — `all2all_hip.py` and
-`all2all_triton.py`. Each is self-contained and runs on its own; neither uses mori's shmem
-or cco. The only thing either needs from the backend is the peer pointers torch publishes:
+One-shot all-to-all against a symmetric window, written three ways — `all2all_hip.py`,
+`all2all_triton.py` and `all2all_lsa.py`. Each is self-contained and runs on its own. The
+first two need nothing from mori but the peer pointers torch publishes:
 
 ```
 recv slot of rank p, chunk from rank r  ==  peers[p] + r*chunk_bytes
@@ -11,6 +11,7 @@ recv slot of rank p, chunk from rank r  ==  peers[p] + r*chunk_bytes
 ```bash
 torchrun --nnodes=1 --nproc_per_node=8 all2all_hip.py --chunk-kib 256
 torchrun --nnodes=1 --nproc_per_node=8 all2all_triton.py --chunk-kib 256
+torchrun --nnodes=1 --nproc_per_node=8 all2all_lsa.py --chunk-kib 256
 ```
 
 Needs **torch >= 2.9**: `symm_mem.set_backend()`, and the SymmetricMemory interface the
@@ -60,6 +61,40 @@ is the same dwordx4-per-lane store the HIP kernel does. One Triton detail worth 
 the kernel is declared `@triton.jit(do_not_specialize=["chunk_elems", "rank_id",
 "blocks_per_peer"])`, because Triton turns an `int` argument that happens to equal `1` into
 a `constexpr` — without it, **rank 1 alone** fails to compile.
+
+## The LSA version
+
+`all2all_lsa.py` is the same push again, with the peer address *computed* instead of
+loaded. It is the one file here that does use cco: `register_external_window()` aliases the
+tensor's VMM handle into cco's flat LSA space, and the kernel asks the window for the
+address.
+
+```python
+win  = comm.register_external_window(recv.data_ptr(), recv.nbytes)   # no copy
+addr = cco.Window.lsa_ptr(window, peer, rank_id * chunk_bytes)       # in the kernel
+```
+
+`symm_mem.rendezvous()` is never called: the backend's own peer exchange would duplicate
+what `ccoWindowRegister` already does. torch keeps the allocation and its lifetime, cco
+takes the addressing. cco has its own rendezvous, so the example passes a `ccoUniqueId`
+through torch's process group; and `import torch` must come before `import mori.cco`, or
+the two LLVM copies collide at import time.
+
+It measures the same as the pointer array — 8×gfx950, 4 MiB per peer, three repeats each:
+
+| | run 1 | run 2 | run 3 |
+|---|---|---|---|
+| `all2all_lsa.py` | 1924.7 | 1964.3 | 1862.9 GB/s |
+| `all2all_triton.py` | 1944.5 | 1922.3 | 1914.4 GB/s |
+
+which is the point: the reason to write against the window is not throughput. An address
+array can only describe peers that are directly load/store-able, while `ccoWindowDevice`
+also carries the RDMA MR for peers that are not, so this is the addressing mode a
+scale-out version has to be built on. See [ROCm/mori#557](https://github.com/ROCm/mori/issues/557).
+
+Use the same `blocks_per_peer` heuristic as its siblings. An earlier draft capped it at 16
+and lost ~6% at 8 ranks, which reads exactly like an addressing-mode difference and is not
+one.
 
 ## Measured
 

--- a/examples/torch_symm_all2all/all2all_lsa.py
+++ b/examples/torch_symm_all2all/all2all_lsa.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""All-to-all on a torch symmetric tensor addressed as a CCO LSA window.
+
+Same push as ``all2all_triton.py``, with the peer address computed rather than
+loaded: ``cco.Window.lsa_ptr(win, peer, off)`` instead of an index into
+``buffer_ptrs_dev``. torch still owns the allocation and its lifetime; CCO owns
+the peer addressing, so ``symm_mem.rendezvous()`` is never called here --
+``register_external_window()`` aliases the tensor's VMM handle into the flat LSA
+space instead, with no copy::
+
+    t   = symm_mem.empty(...)                          # MORI backend, HIP VMM
+    win = comm.register_external_window(t.data_ptr(), nbytes)
+    ...
+    addr = cco.Window.lsa_ptr(window, peer, offset)     # inside the kernel
+
+Run it the same way as its siblings::
+
+    torchrun --nnodes=1 --nproc_per_node=8 all2all_lsa.py --chunk-kib 256
+
+Why bother, when the pointer array measures the same (see README): the window is
+what carries the things an address array cannot express. ``ccoWindowDevice``
+already holds the RDMA MR for peers with no LSA slot, so this is the addressing
+mode a scale-out version has to be written against. See ROCm/mori#557.
+"""
+
+import argparse
+import functools
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+import triton
+import triton.language as tl
+
+import mori.allocator  # noqa: F401  -- importing registers the "MORI" backend
+from mori.cco import Communicator
+from mori.ir.triton import cco
+
+# One communicator's flat VA reservation. Nothing here needs it to be large; the
+# window is an alias of the torch tensor, not an allocation out of this space.
+PER_RANK_VMM = 1 << 30
+BLOCK = 1024
+NUM_WARPS = 4
+
+
+@triton.jit(do_not_specialize=["chunk_elems", "rank_id", "blocks_per_peer"])
+def all2all_push_lsa(
+    window,
+    send_ptr,
+    chunk_elems,
+    rank_id,
+    blocks_per_peer,
+    BLOCK: tl.constexpr,
+):
+    """Push my chunk into every peer's receive slot, addressed through the window."""
+    pid = tl.program_id(0)
+    peer = pid // blocks_per_peer
+    sub = pid % blocks_per_peer
+
+    # peer's window base + my slot within it. No pointer array is dereferenced:
+    # lsa_ptr is arithmetic on the flat VA, so the address is known without a load.
+    # 64-bit from here on: chunk_elems*world_size overflows i32 past 8 GiB of window.
+    chunk = chunk_elems.to(tl.int64)
+    dst_addr = cco.Window.lsa_ptr(window, peer, rank_id.to(tl.int64) * chunk * 4)
+    dst = dst_addr.to(tl.pointer_type(tl.int32), bitcast=True)
+    src = (
+        send_ptr.to(tl.pointer_type(tl.int32), bitcast=True) + peer.to(tl.int64) * chunk
+    )
+
+    span = blocks_per_peer * BLOCK
+    for start in range(sub * BLOCK, chunk_elems, span):
+        offs = start + tl.arange(0, BLOCK)
+        mask = offs < chunk_elems
+        tl.store(dst + offs, tl.load(src + offs, mask=mask), mask=mask)
+
+
+@functools.cache
+def _blocks_per_peer(chunk_elems: int, world_size: int, device) -> int:
+    """Two blocks per CU across peers, capped by how much there is to slice.
+
+    Same heuristic as the sibling examples: one block per destination rank would
+    idle all but world_size CUs and keep too few writes in flight to cover
+    interconnect latency.
+    """
+    cus = torch.cuda.get_device_properties(device).multi_processor_count
+    bpp = max(1, cus * 2 // max(1, world_size))
+    return int(min(bpp, max(1, chunk_elems // BLOCK)))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--chunk-kib", type=int, default=256, help="payload per peer")
+    ap.add_argument("--warmup", type=int, default=10)
+    ap.add_argument("--iters", type=int, default=50)
+    args = ap.parse_args()
+
+    dist.init_process_group("gloo")
+    rank_id = dist.get_rank()
+    world_size = dist.get_world_size()
+    local_rank = int(os.environ.get("LOCAL_RANK", rank_id))
+    torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank)
+
+    chunk_bytes = args.chunk_kib * 1024
+    elems = chunk_bytes // 4
+
+    symm_mem.set_backend("MORI")
+    recv = symm_mem.empty(world_size * elems, dtype=torch.int32, device=device)
+    recv.zero_()
+    send = torch.empty(world_size * elems, dtype=torch.int32, device=device)
+    for p in range(world_size):
+        send[p * elems : (p + 1) * elems] = rank_id * 1000 + p
+    torch.cuda.synchronize()
+
+    # CCO's own rendezvous. torch's process group only carries the token.
+    token = [Communicator.get_unique_id() if rank_id == 0 else None]
+    dist.broadcast_object_list(token, src=0)
+
+    with Communicator.init(
+        world_size, rank_id, token[0], per_rank_vmm=PER_RANK_VMM
+    ) as comm:
+        win = comm.register_external_window(recv.data_ptr(), recv.nbytes)
+        blocks_per_peer = _blocks_per_peer(elems, world_size, device)
+        extern_libs = cco.get_extern_libs()
+
+        if rank_id == 0:
+            print(
+                f"kernel=Triton/LSA  world={world_size}  chunk={args.chunk_kib} KiB  "
+                f"blocks_per_peer={blocks_per_peer}"
+            )
+            print(f"window handle: {win.handle:#x}, local flat VA: {win.local_ptr:#x}")
+
+        def push():
+            all2all_push_lsa[(world_size * blocks_per_peer,)](
+                win.handle,
+                send.data_ptr(),
+                elems,
+                rank_id,
+                blocks_per_peer,
+                BLOCK=BLOCK,
+                num_warps=NUM_WARPS,
+                extern_libs=extern_libs,
+            )
+
+        # Peers write into this window, so everyone must finish clearing before
+        # anyone pushes.
+        comm.barrier()
+        push()
+        torch.cuda.synchronize()
+        comm.barrier()
+
+        errors = 0
+        for r in range(world_size):
+            got, want = recv[r * elems].item(), r * 1000 + rank_id
+            if got != want:
+                errors += 1
+                print(f"[rank {rank_id}] chunk {r}: got {got}, want {want}", flush=True)
+        failed = torch.tensor([errors], dtype=torch.int64)
+        dist.all_reduce(failed, op=dist.ReduceOp.SUM)
+        if rank_id == 0 and failed.item() == 0:
+            print(f"correctness: OK ({world_size}x{world_size} chunks)")
+
+        for _ in range(args.warmup):
+            push()
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        torch.cuda.synchronize()
+        comm.barrier()
+        start.record()
+        for _ in range(args.iters):
+            push()
+        end.record()
+        torch.cuda.synchronize()
+        ms = start.elapsed_time(end) / args.iters
+
+        # Only (world_size-1) chunks leave the device; the self chunk stays local.
+        gbps = torch.tensor(
+            [(world_size - 1) * chunk_bytes / (ms / 1e3) / 1e9], dtype=torch.float64
+        )
+        dist.all_reduce(gbps, op=dist.ReduceOp.SUM)
+        if rank_id == 0:
+            print(f"{ms * 1e3:7.1f} us/iter, {gbps.item():8.1f} GB/s aggregate")
+            print("SUCCESS" if failed.item() == 0 else "FAILED")
+        comm.barrier()
+
+    dist.destroy_process_group()
+    return 0 if failed.item() == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two examples showing mori's torch SymmetricMemory backend (#544) and CCO's window meeting, without changing either. torch keeps the allocation and its lifetime; `register_external_window()` aliases the tensor's VMM handle into CCO's flat LSA space with no copy, so the kernel computes peer addresses with `Window.lsa_ptr` instead of loading them out of `buffer_ptrs`. `symm_mem.rendezvous()` is never called -- the backend's own exchange would duplicate `ccoWindowRegister`.

```python
t    = symm_mem.empty(...)                                  # MORI backend, HIP VMM
win  = comm.register_external_window(t.data_ptr(), t.nbytes)  # no copy
addr = cco.Window.lsa_ptr(window, peer, offset)             # in the kernel
```

### What is here

| | |
|---|---|
| `examples/torch_symm_all2all/all2all_lsa.py` | a third form of the existing all-to-all, so the addressing modes are directly comparable |
| `examples/cco/python/09_torch_symm_lsa_all2all` | the same idea in the CCO family, next to 08; driven by the Triton device bindings from #594 |

Also fills in 07/08/09 in the CCO example table, which stopped at 06.

### Measured

Both verified at 2, 4 and 8 ranks on 8x gfx950 (ROCm 7.14 / torch 2.12). Same kernel shape, 4 MiB per peer, three repeats:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| `all2all_lsa.py` | 1924.7 | 1964.3 | 1862.9 GB/s |
| `all2all_triton.py` | 1944.5 | 1922.3 | 1914.4 GB/s |

Parity is the expected result and is the point: an address array can only describe peers that are directly load/store-able, while `ccoWindowDevice` also carries the RDMA MR for peers that are not, so this is the addressing mode a scale-out version has to be built on.

This is stage 2 of #557, as examples only -- **nothing here changes the backend's public surface**. Making `rendezvous()` itself return a `ccoWindow` needs a policy for caching a communicator per process group, which belongs in that issue.

### Two things the examples had to learn

Both are in the README now:

- `import torch` must come before `import mori.cco`, or the two LLVM copies collide at import (`spirv-expand-step registered more than once`).
- Use the same `blocks_per_peer` heuristic as the siblings. An earlier draft capped it at 16 and lost ~6% at 8 ranks, which reads exactly like an addressing-mode difference and is not one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
