### PR TITLE
fix(EPv2): align staging pool capacity with EpMaxRecv to prevent metadata loss

### DIFF
--- a/src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp
+++ b/src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp
@@ -63,10 +63,14 @@ using index_t = int32_t;
 #define MORI_COMB_BARSLEEP 15
 #define MORI_COMB_BARSPREAD 16
 
-// MORI_EP_WORLD_SIZE is emitted by RenderEpSource before #include-ing this
-// header, so the global arrays below are sized to the exact config.
+// MORI_EP_WORLD_SIZE and MORI_EP_MAX_RECV are emitted by RenderEpSource before
+// #include-ing this header, so the global arrays below are sized to the exact
+// config. The fallbacks are for bare C++ callers only.
 #ifndef MORI_EP_WORLD_SIZE
 #define MORI_EP_WORLD_SIZE 8
+#endif
+#ifndef MORI_EP_MAX_RECV
+#define MORI_EP_MAX_RECV (MORI_EP_WORLD_SIZE * 32768)
 #endif
 
 template <typename T>
@@ -203,7 +207,7 @@ __device__ __forceinline__ gfx1250_TDM_GROUP1 TdmSplitShape(const TdmSplit128& s
   return TdmShape2D(32, sp.rows);
 }
 
-#define CUSPLIT_POOL_SLOTS (MORI_EP_WORLD_SIZE * 32768)
+#define CUSPLIT_POOL_SLOTS (MORI_EP_WORLD_SIZE * MORI_EP_MAX_RECV)
 #define CUSPLIT_MAX_BLOCKS 512
 #define CUSPLIT_MAX_TOPK 16
 

--- a/src/ops/dispatch_combine_v2/ep_spec.cpp
+++ b/src/ops/dispatch_combine_v2/ep_spec.cpp
@@ -163,7 +163,8 @@ std::string RenderEpSource(const EpCfg& cfg, const std::string& entry, const cha
                 "\n#define MORI_EP_SCALE_SLOTS " +
                 std::to_string((long long)cfg.worldSize * EpMaxRecv(cfg)) + "\n";
   }
-  std::string worldDef = "#define MORI_EP_WORLD_SIZE " + std::to_string(cfg.worldSize) + "\n";
+  std::string worldDef = "#define MORI_EP_WORLD_SIZE " + std::to_string(cfg.worldSize) + "\n" +
+                         "#define MORI_EP_MAX_RECV " + std::to_string(EpMaxRecv(cfg)) + "\n";
   return std::string("// mori jit v2 — generated, do not edit.\n") + worldDef + scaleDefs +
          "#include \"" + header +
          "\"\n"


### PR DESCRIPTION
 ## Summary

  `d335c033` replaced the hardcoded `CUSPLIT_MAX_GPUS` (8) with `MORI_EP_WORLD_SIZE` in the staging pool macro. For a 4-GPU configuration this halved
  `_stgCap` from 65536 to 32768.

  However, `_stgCap` is guarded against `ab` — the **absolute** recv-buffer index (cumulative across all peers) — which can reach `EpMaxRecv` (= `worldSize
  × maxTokPerRank` = 65536). When `ab > _stgCap`, two guards silently skip metadata operations:

  - **Write side** (lines 424/446): `if (myDestTokId < _stgCap)` / `if (dt >= _stgCap) continue`
  - **Read side** (lines 520/600): `if (ab + cc > _stgCapM) continue`

  Token payloads are copied unconditionally in Phase 1, so they land correctly — but **indices, weights, scales, and srcmap are silently dropped** for any
  token whose absolute position exceeds `_stgCap`.

  ## Root Cause

  `CUSPLIT_POOL_SLOTS = MORI_EP_WORLD_SIZE * 32768` gives `_stgCap = 32768` for EP4, but `EpMaxRecv = 65536`. The staging pool is undersized relative to the
  recv-buffer capacity it must cover.

  ## Fix

  - Emit `MORI_EP_MAX_RECV` (= `EpMaxRecv(cfg)`) from `RenderEpSource` alongside the existing `MORI_EP_WORLD_SIZE`.
  - Redefine `CUSPLIT_POOL_SLOTS` as `MORI_EP_WORLD_SIZE × MORI_EP_MAX_RECV`.

  This makes `_stgCap = EpMaxRecv`, matching `recvCapM`, so the guards never fire incorrectly.