### PR TITLE
bugfix: mlx5 ci hung

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -891,29 +891,62 @@ jobs:
             done
           done
 
+      - name: Reset GPU processes before EP internode stress
+        run: |
+          # Bench runs 20 torchrun sessions; lingering workers or mlx5 UAR mappings can
+          # leave the first stress case hung until timeout 600 (exit 124).
+          $CT exec $CONTAINER bash -c 'pkill -9 -f "[t]orchrun" 2>/dev/null || true; pkill -9 -f "[t]est_dispatch_combine_internode" 2>/dev/null || true; pkill -9 -f "[t]ests\.python\.io\.benchmark" 2>/dev/null || true; sleep 3'
+          ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST \
+            "$CT exec $CONTAINER bash -c 'pkill -9 -f \"[t]orchrun\" 2>/dev/null || true; pkill -9 -f \"[t]est_dispatch_combine_internode\" 2>/dev/null || true; pkill -9 -f \"[t]ests\\.python\\.io\\.benchmark\" 2>/dev/null || true; sleep 3'"
+
       - name: MORI-EP internode normal kernel stress
         run: |
-          SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_test.sh"
-          PORT=29160
-          for KERNEL in v1 v1_ll; do
-            for TOKENS in 64 128 1024 2048 4096; do
-              echo "=== stress kernel=$KERNEL max-tokens=$TOKENS port=$PORT ==="
-              NODE2_CMD=(
-                $CT exec -e MORI_INTERNODE_TIMEOUT=600 $CONTAINER bash $SCRIPT
-                --rank 1 --master-addr $NODE1_HOST --master-port $PORT
-                --ifname $NODE2_IFNAME
-                --cmd stress --kernel-type $KERNEL --max-tokens $TOKENS
-              )
-              ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
-              $CT exec -e MORI_INTERNODE_TIMEOUT=600 $CONTAINER bash $SCRIPT \
-                --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
-                --ifname $NODE1_IFNAME \
-                --cmd stress --kernel-type $KERNEL --max-tokens $TOKENS
-              wait
-              sleep 1
-              PORT=$((PORT + 1))
+          reset_ep_gpu() {
+            $CT exec $CONTAINER bash -c 'pkill -9 -f "[t]orchrun" 2>/dev/null || true; pkill -9 -f "[t]est_dispatch_combine_internode" 2>/dev/null || true; pkill -9 -f "[t]ests\.python\.io\.benchmark" 2>/dev/null || true; sleep 3'
+            ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST \
+              "$CT exec $CONTAINER bash -c 'pkill -9 -f \"[t]orchrun\" 2>/dev/null || true; pkill -9 -f \"[t]est_dispatch_combine_internode\" 2>/dev/null || true; pkill -9 -f \"[t]ests\\.python\\.io\\.benchmark\" 2>/dev/null || true; sleep 3'"
+          }
+          run_stress_sweep() {
+            local rc=0
+            SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_test.sh"
+            PORT=29160
+            for KERNEL in v1 v1_ll; do
+              for TOKENS in 64 128 1024 2048 4096; do
+                echo "=== stress kernel=$KERNEL max-tokens=$TOKENS port=$PORT ==="
+                NODE2_CMD=(
+                  $CT exec -e MORI_INTERNODE_TIMEOUT=600 $CONTAINER bash $SCRIPT
+                  --rank 1 --master-addr $NODE1_HOST --master-port $PORT
+                  --ifname $NODE2_IFNAME
+                  --cmd stress --kernel-type $KERNEL --max-tokens $TOKENS
+                )
+                ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
+                $CT exec -e MORI_INTERNODE_TIMEOUT=600 $CONTAINER bash $SCRIPT \
+                  --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
+                  --ifname $NODE1_IFNAME \
+                  --cmd stress --kernel-type $KERNEL --max-tokens $TOKENS
+                wait
+                case_rc=$?
+                if [ $case_rc -ne 0 ]; then
+                  rc=$case_rc
+                  break 2
+                fi
+                sleep 1
+                PORT=$((PORT + 1))
+              done
             done
-          done
+            return $rc
+          }
+          set +e
+          run_stress_sweep
+          stress_rc=$?
+          if [ $stress_rc -ne 0 ]; then
+            echo "::warning::EP internode stress failed (exit $stress_rc); resetting GPU processes and retrying once"
+            reset_ep_gpu
+            run_stress_sweep
+            stress_rc=$?
+          fi
+          set -e
+          exit $stress_rc
 
       - name: MORI-EP internode rail-only (MORI_ENABLE_RAIL_ONLY)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           # 8x ConnectX-7 NDR on InfiniBand, so no rdma_sl/rdma_tc: mlx5 applies
           # both only on the RoCE path. mlx5_8 is deliberately not in
           # rdma_devices -- it is the 100GbE port behind ens14np0 (the TCP
-          # rendezvous interface), not one of the 8 rails.
+          # rendezvous interface), not one of the 8 rails
           - platform: MI300X_MLX
             runner: [self-hosted, 300_mlx_p19_29]
             rdma_devices: mlx5_0,mlx5_1,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -619,17 +619,22 @@ jobs:
             pkill -9 -f '[t]orchrun.*test_dispatch_combine_internode' 2>/dev/null || true
           }
           cleanup_host
-          ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "
-            $CT ps -a --format '{{.Names}}' | { grep -E '^mori' || true; } | while read -r c; do
-              [ \"\$c\" = \"$CONTAINER\" ] && continue
-              echo \"Removing stale container: \$c\"
-              $CT rm -f \"\$c\" 2>/dev/null || true
-            done
-            pkill -9 -f '[c]oncurrent_put_thread' 2>/dev/null || true
-            pkill -9 -f '[t]est_dispatch_combine_internode' 2>/dev/null || true
-            pkill -9 -f '[t]ests\.python\.io\.benchmark' 2>/dev/null || true
-            pkill -9 -f '[t]orchrun.*test_dispatch_combine_internode' 2>/dev/null || true
-          "
+          # Feed cleanup via stdin so pkill patterns are not visible in the
+          # remote ssh "bash -c ..." cmdline (otherwise pkill can match and
+          # kill the session, returning ssh exit 255).
+          ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST bash -s "$CT" "$CONTAINER" <<'EOF'
+          CT=$1
+          CONTAINER=$2
+          $CT ps -a --format '{{.Names}}' | { grep -E '^mori' || true; } | while read -r c; do
+            [ "$c" = "$CONTAINER" ] && continue
+            echo "Removing stale container: $c"
+            $CT rm -f "$c" 2>/dev/null || true
+          done
+          pkill -9 -f '[c]oncurrent_put_thread' 2>/dev/null || true
+          pkill -9 -f '[t]est_dispatch_combine_internode' 2>/dev/null || true
+          pkill -9 -f '[t]ests\.python\.io\.benchmark' 2>/dev/null || true
+          pkill -9 -f '[t]orchrun.*test_dispatch_combine_internode' 2>/dev/null || true
+          EOF
 
       - name: Start container on node1
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           # 8x ConnectX-7 NDR on InfiniBand, so no rdma_sl/rdma_tc: mlx5 applies
           # both only on the RoCE path. mlx5_8 is deliberately not in
           # rdma_devices -- it is the 100GbE port behind ens14np0 (the TCP
-          # rendezvous interface), not one of the 8 rails
+          # rendezvous interface), not one of the 8 rails.
           - platform: MI300X_MLX
             runner: [self-hosted, 300_mlx_p19_29]
             rdma_devices: mlx5_0,mlx5_1,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_7
@@ -602,40 +602,6 @@ jobs:
       - name: Build CI image
         run: $CT build --network=host --build-arg BASE_IMAGE=$BASE_IMAGE -t $IMAGE -f docker/Dockerfile.dev .
 
-      - name: Cleanup stale mori containers and GPU processes
-        run: |
-          # Prior CI jobs, manual repros, or hung shmem/IBGDA tests can leave mori*
-          # containers and host processes holding /dev/kfd + mlx5. EP internode
-          # stress then hangs until timeout 600 (exit 124) on a dirty runner.
-          cleanup_host() {
-            $CT ps -a --format '{{.Names}}' | { grep -E '^mori' || true; } | while read -r c; do
-              [ "$c" = "$CONTAINER" ] && continue
-              echo "Removing stale container: $c"
-              $CT rm -f "$c" 2>/dev/null || true
-            done
-            pkill -9 -f '[c]oncurrent_put_thread' 2>/dev/null || true
-            pkill -9 -f '[t]est_dispatch_combine_internode' 2>/dev/null || true
-            pkill -9 -f '[t]ests\.python\.io\.benchmark' 2>/dev/null || true
-            pkill -9 -f '[t]orchrun.*test_dispatch_combine_internode' 2>/dev/null || true
-          }
-          cleanup_host
-          # Feed cleanup via stdin so pkill patterns are not visible in the
-          # remote ssh "bash -c ..." cmdline (otherwise pkill can match and
-          # kill the session, returning ssh exit 255).
-          ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST bash -s "$CT" "$CONTAINER" <<'EOF'
-          CT=$1
-          CONTAINER=$2
-          $CT ps -a --format '{{.Names}}' | { grep -E '^mori' || true; } | while read -r c; do
-            [ "$c" = "$CONTAINER" ] && continue
-            echo "Removing stale container: $c"
-            $CT rm -f "$c" 2>/dev/null || true
-          done
-          pkill -9 -f '[c]oncurrent_put_thread' 2>/dev/null || true
-          pkill -9 -f '[t]est_dispatch_combine_internode' 2>/dev/null || true
-          pkill -9 -f '[t]ests\.python\.io\.benchmark' 2>/dev/null || true
-          pkill -9 -f '[t]orchrun.*test_dispatch_combine_internode' 2>/dev/null || true
-          EOF
-
       - name: Start container on node1
         run: |
           $CT rm -f $CONTAINER 2>/dev/null || true
@@ -897,62 +863,29 @@ jobs:
             done
           done
 
-      - name: Reset GPU processes before EP internode stress
-        run: |
-          # Bench runs 20 torchrun sessions; lingering workers or mlx5 UAR mappings can
-          # leave the first stress case hung until timeout 600 (exit 124).
-          $CT exec $CONTAINER bash -c 'pkill -9 -f "[t]orchrun" 2>/dev/null || true; pkill -9 -f "[t]est_dispatch_combine_internode" 2>/dev/null || true; pkill -9 -f "[t]ests\.python\.io\.benchmark" 2>/dev/null || true; sleep 3'
-          ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST \
-            "$CT exec $CONTAINER bash -c 'pkill -9 -f \"[t]orchrun\" 2>/dev/null || true; pkill -9 -f \"[t]est_dispatch_combine_internode\" 2>/dev/null || true; pkill -9 -f \"[t]ests\\.python\\.io\\.benchmark\" 2>/dev/null || true; sleep 3'"
-
       - name: MORI-EP internode normal kernel stress
         run: |
-          reset_ep_gpu() {
-            $CT exec $CONTAINER bash -c 'pkill -9 -f "[t]orchrun" 2>/dev/null || true; pkill -9 -f "[t]est_dispatch_combine_internode" 2>/dev/null || true; pkill -9 -f "[t]ests\.python\.io\.benchmark" 2>/dev/null || true; sleep 3'
-            ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST \
-              "$CT exec $CONTAINER bash -c 'pkill -9 -f \"[t]orchrun\" 2>/dev/null || true; pkill -9 -f \"[t]est_dispatch_combine_internode\" 2>/dev/null || true; pkill -9 -f \"[t]ests\\.python\\.io\\.benchmark\" 2>/dev/null || true; sleep 3'"
-          }
-          run_stress_sweep() {
-            local rc=0
-            SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_test.sh"
-            PORT=29160
-            for KERNEL in v1 v1_ll; do
-              for TOKENS in 64 128 1024 2048 4096; do
-                echo "=== stress kernel=$KERNEL max-tokens=$TOKENS port=$PORT ==="
-                NODE2_CMD=(
-                  $CT exec -e MORI_INTERNODE_TIMEOUT=600 $CONTAINER bash $SCRIPT
-                  --rank 1 --master-addr $NODE1_HOST --master-port $PORT
-                  --ifname $NODE2_IFNAME
-                  --cmd stress --kernel-type $KERNEL --max-tokens $TOKENS
-                )
-                ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
-                $CT exec -e MORI_INTERNODE_TIMEOUT=600 $CONTAINER bash $SCRIPT \
-                  --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
-                  --ifname $NODE1_IFNAME \
-                  --cmd stress --kernel-type $KERNEL --max-tokens $TOKENS
-                wait
-                case_rc=$?
-                if [ $case_rc -ne 0 ]; then
-                  rc=$case_rc
-                  break 2
-                fi
-                sleep 1
-                PORT=$((PORT + 1))
-              done
+          SCRIPT="$GITHUB_WORKSPACE/tools/run_internode_test.sh"
+          PORT=29160
+          for KERNEL in v1 v1_ll; do
+            for TOKENS in 64 128 1024 2048 4096; do
+              echo "=== stress kernel=$KERNEL max-tokens=$TOKENS port=$PORT ==="
+              NODE2_CMD=(
+                $CT exec -e MORI_INTERNODE_TIMEOUT=600 $CONTAINER bash $SCRIPT
+                --rank 1 --master-addr $NODE1_HOST --master-port $PORT
+                --ifname $NODE2_IFNAME
+                --cmd stress --kernel-type $KERNEL --max-tokens $TOKENS
+              )
+              ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "${NODE2_CMD[*]}" &
+              $CT exec -e MORI_INTERNODE_TIMEOUT=600 $CONTAINER bash $SCRIPT \
+                --rank 0 --master-addr $NODE1_HOST --master-port $PORT \
+                --ifname $NODE1_IFNAME \
+                --cmd stress --kernel-type $KERNEL --max-tokens $TOKENS
+              wait
+              sleep 1
+              PORT=$((PORT + 1))
             done
-            return $rc
-          }
-          set +e
-          run_stress_sweep
-          stress_rc=$?
-          if [ $stress_rc -ne 0 ]; then
-            echo "::warning::EP internode stress failed (exit $stress_rc); resetting GPU processes and retrying once"
-            reset_ep_gpu
-            run_stress_sweep
-            stress_rc=$?
-          fi
-          set -e
-          exit $stress_rc
+          done
 
       - name: MORI-EP internode rail-only (MORI_ENABLE_RAIL_ONLY)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,13 +530,13 @@ jobs:
           # both only on the RoCE path. mlx5_8 is deliberately not in
           # rdma_devices -- it is the 100GbE port behind ens14np0 (the TCP
           # rendezvous interface), not one of the 8 rails.
-          # node1 is the runner itself (banff-ccs-aus-p19-29); node2 is the peer
-          # it drives over ssh (banff-ccs-aus-p20-29). Both addresses are the
+          # node1 is the runner itself (banff-ccs-aus-p19-05); node2 is the peer
+          # it drives over ssh (banff-ccs-aus-p19-14). Both addresses are the
           # ens14np0 100GbE port used for TCP rendezvous.
           - platform: MI300X_MLX
             runner: [self-hosted, 300_mlx_p19_29]
-            node1_host: 10.194.134.84
-            node2_host: 10.194.132.59
+            node1_host: 10.194.132.110
+            node2_host: 10.194.132.71
             node2_port: 22
             node1_ifname: ens14np0
             node2_ifname: ens14np0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -602,6 +602,35 @@ jobs:
       - name: Build CI image
         run: $CT build --network=host --build-arg BASE_IMAGE=$BASE_IMAGE -t $IMAGE -f docker/Dockerfile.dev .
 
+      - name: Cleanup stale mori containers and GPU processes
+        run: |
+          # Prior CI jobs, manual repros, or hung shmem/IBGDA tests can leave mori*
+          # containers and host processes holding /dev/kfd + mlx5. EP internode
+          # stress then hangs until timeout 600 (exit 124) on a dirty runner.
+          cleanup_host() {
+            $CT ps -a --format '{{.Names}}' | { grep -E '^mori' || true; } | while read -r c; do
+              [ "$c" = "$CONTAINER" ] && continue
+              echo "Removing stale container: $c"
+              $CT rm -f "$c" 2>/dev/null || true
+            done
+            pkill -9 -f '[c]oncurrent_put_thread' 2>/dev/null || true
+            pkill -9 -f '[t]est_dispatch_combine_internode' 2>/dev/null || true
+            pkill -9 -f '[t]ests\.python\.io\.benchmark' 2>/dev/null || true
+            pkill -9 -f '[t]orchrun.*test_dispatch_combine_internode' 2>/dev/null || true
+          }
+          cleanup_host
+          ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "
+            $CT ps -a --format '{{.Names}}' | { grep -E '^mori' || true; } | while read -r c; do
+              [ \"\$c\" = \"$CONTAINER\" ] && continue
+              echo \"Removing stale container: \$c\"
+              $CT rm -f \"\$c\" 2>/dev/null || true
+            done
+            pkill -9 -f '[c]oncurrent_put_thread' 2>/dev/null || true
+            pkill -9 -f '[t]est_dispatch_combine_internode' 2>/dev/null || true
+            pkill -9 -f '[t]ests\.python\.io\.benchmark' 2>/dev/null || true
+            pkill -9 -f '[t]orchrun.*test_dispatch_combine_internode' 2>/dev/null || true
+          "
+
       - name: Start container on node1
         run: |
           $CT rm -f $CONTAINER 2>/dev/null || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -654,9 +654,15 @@ jobs:
 
       - name: Start container on node2
         run: |
+          # node2 gets no checkout, so nothing there ever resets ownership the
+          # way "Fix workspace permissions" does on node1. The CI container runs
+          # as root, so the previous job leaves root-owned build output in the
+          # workspace and the rsync below dies on EPERM before anything builds.
           ssh $SSH_OPTS -p $NODE2_PORT $(whoami)@$NODE2_HOST "
             $CT rm -f $CONTAINER 2>/dev/null || true
             mkdir -p $GITHUB_WORKSPACE
+            $CT run --rm -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE $BASE_IMAGE \
+              chown -R $(id -u):$(id -g) $GITHUB_WORKSPACE 2>/dev/null || true
           "
           rsync -az --exclude='.git' \
             -e "ssh $SSH_OPTS -p $NODE2_PORT" \

--- a/examples/shmem/concurrent_put_imm_thread.cpp
+++ b/examples/shmem/concurrent_put_imm_thread.cpp
@@ -184,6 +184,10 @@ void ConcurrentPutImmThread() {
     HIP_RUNTIME_CHECK(hipMemsetD32(reinterpret_cast<uint32_t*>(buff2), myPe, numEle));
     HIP_RUNTIME_CHECK(hipDeviceSynchronize());
 
+    // Without this, PE 0's put-imm can land before PE 1 has run its memset, which
+    // then overwrites the delivered 42s -- PE 1's kernel spins on them forever.
+    MPI_Barrier(MPI_COMM_WORLD);
+
     if (myPe == 0) {
       printf("Running pure address API test...\n");
     }

--- a/include/mori/shmem/shmem_ibgda_kernels.hpp
+++ b/include/mori/shmem/shmem_ibgda_kernels.hpp
@@ -361,10 +361,16 @@ inline __device__ void Mlx5CollapsedCqDrain(core::WorkQueueHandle& wq,
 
     uint16_t comp16 = static_cast<uint16_t>(wqeCounter + 1);
     uint16_t delta = static_cast<uint16_t>(comp16 - static_cast<uint16_t>(cons));
-    uint32_t bound =
-        DrainToLive ? __hip_atomic_load(&wq.postIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT)
-                    : __hip_atomic_load(&wq.dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    if (delta != 0 && static_cast<int32_t>(delta) <= static_cast<int32_t>(bound - cons)) {
+    // Clamp against dbTouchIdx even when draining to postIdx. A completion cannot
+    // exist for a WQE that was never doorbelled, and postIdx counts reservations
+    // whose WQEs are not in the SQ yet, so it runs tens of thousands ahead here.
+    // Bounding by it accepts a wqe_counter that does not belong to the live window
+    // -- the 16-bit value then wraps into a plausible-looking delta -- and pushes
+    // doneIdx past WQEs the NIC has not fetched. The recycle gate hands those still
+    // live SQ slots out for reuse and the overwritten writes are silently dropped.
+    uint32_t doorbelled =
+        __hip_atomic_load(&wq.dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    if (delta != 0 && static_cast<int32_t>(delta) <= static_cast<int32_t>(doorbelled - cons)) {
       __hip_atomic_fetch_max(&wq.doneIdx, cons + delta, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
     }
     cons = __hip_atomic_load(&wq.doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);


### PR DESCRIPTION
* migrate mlx ci to 19-05 & 19-14

* fix mlx poll cq bug: clamp doneIdx against dbTouchIdx, not postIdx — the old
  window exceeded 65536, so a stale wqe_counter wrapped into a bogus advance and
  the recycle gate overwrote live SQ slots.