### PR TITLE
perf(ep): skip the nodeRecvTokenNum atomic when every chunk slot is signalled

### DIFF
--- a/src/ops/dispatch_combine/internode_v1.cpp
+++ b/src/ops/dispatch_combine/internode_v1.cpp
@@ -347,12 +347,26 @@ inline __device__ void DispatchInterNodeLLSend(EpDispatchCombineArgs<T>& args) {
   finishedWarp = __shfl(finishedWarp, 0);
   if ((finishedWarp + 1) == (args.rdmaBlockNum * warpNum)) {
     if (laneId < nNodes) {
-      int proxyPe = laneId * config.gpuPerNode + (config.rank % config.gpuPerNode);
-      index_t numTokenSignal =
-          core::AtomicLoadRelaxed(args.blockFlagCounter + laneId) * warpSize + 1;
-      shmem::ShmemAtomicTypeNonFetchThread<uint64_t>(args.nodeRecvTokenNumMemObj,
-                                                     myNode * sizeof(uint64_t), numTokenSignal,
-                                                     core::AMO_ADD, proxyPe);
+      // nodeRecvTokenNum lets the peer tell "this chunk slot will never be
+      // signalled" apart from "it has not arrived yet", and tells combine how
+      // far to iterate. Both only need it when we left a slot unsignalled: if
+      // every slot the peer looks at got a signal from a put, its poll always
+      // terminates on chunkFlag and combine can use the static maxChunkNum
+      // bound. chunksSent <= maxChunkNum always holds, so equality means full
+      // coverage.
+      //
+      // Worth the branch because this is a second GPU-initiated RDMA atomic
+      // issued by the warp that just issued the put, and it sits on the critical
+      // path -- measured at ~3.3us of the send phase. At 4-32 tokens/rank one
+      // chunk covers everything, so it is always skipped there.
+      index_t chunksSent = core::AtomicLoadRelaxed(args.blockFlagCounter + laneId);
+      if (chunksSent < maxChunkNum) {
+        int proxyPe = laneId * config.gpuPerNode + (config.rank % config.gpuPerNode);
+        index_t numTokenSignal = chunksSent * warpSize + 1;
+        shmem::ShmemAtomicTypeNonFetchThread<uint64_t>(args.nodeRecvTokenNumMemObj,
+                                                       myNode * sizeof(uint64_t), numTokenSignal,
+                                                       core::AMO_ADD, proxyPe);
+      }
     }
     if (laneId == 0) args.interNodeBlocksBarrier[1] = 0;
   }
@@ -1110,8 +1124,14 @@ __forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs<T>
   int rdmaWarpNum = args.rdmaBlockNum * warpNum;
   for (int n = 0; n < (nNodes - 1); n++) {
     int node = (myNode + n + 1) % nNodes;
+    // The sender only signals nodeRecvTokenNum when it left a chunk slot without
+    // a signal (see DispatchInterNodeLLSend). A zero therefore means "every slot
+    // was signalled", not "nothing arrived", and the static maxChunkNum bound is
+    // the right one -- slots with no data read chunkFlag == 0 and are skipped
+    // inside the loop either way.
     uint64_t nodeCount = nodeRecvTokenNum[node];
-    if (nodeCount > 0) nodeCount -= 1;
+    nodeCount =
+        (nodeCount > 0) ? (nodeCount - 1) : static_cast<uint64_t>(maxChunkNum) * warpSize;
     if (nodeCount == 0) continue;
 
     // One whole vector step per warp. warpsPerToken was a fixed 4, which for


### PR DESCRIPTION
## What

In `DispatchInterNodeLLSend`, when every chunk slot of a destination node will be signalled by an RDMA put, the extra `nodeRecvTokenNum` atomic carries no information the receiver does not already have. This PR skips the atomic in exactly that case, and lets combine fall back to a static upper bound (`maxChunkNum`) when the counter was never written.

When a destination node has more chunk slots than the puts cover (above ~32 tokens/rank in this EP16 config), the old behaviour is kept unchanged.

## Why

At small token counts the dispatch send phase is latency-bound on the interconnect, so removing one RDMA atomic per round shows up directly in dispatch kernel time.

## Measured (MI300X x2, EP16, hidden 6144, 3 reps)

| tokens/rank | dispatch before | dispatch after | delta |
| --- | --- | --- | --- |
| 4 | 49.5 us | 47.1 us | -4.8% |
| 8 | 49.8 us | 48.2 us | -3.2% |
| 16 | 50.6 us | 48.4 us | -4.3% |
| 32 | 51.2 us | 49.3 us | -3.7% |

Medians of per-run medians. Combine is unchanged, as expected.

The direction is consistent across all four sizes, but the effect is small: only the 16- and 32-token pairs have non-overlapping per-run ranges, while 4 and 8 overlap run-to-run noise (~1-2%).

## Correctness

Dispatch/combine correctness check at 4 / 8 / 16 / 128 tokens per rank, 16/16 ranks clean. The 128-token case exercises the multi-chunk path where the atomic is still emitted.