### PR TITLE
feat(allocator): back symm_mem.rendezvous() with a CCO window

### DIFF
--- a/examples/cco/python/09_torch_symm_lsa_all2all/main.py
+++ b/examples/cco/python/09_torch_symm_lsa_all2all/main.py
@@ -31,7 +31,9 @@ whole exchange through CCO, so the two halves of mori meet:
   * ``mori.allocator`` owns the allocation and its lifetime -- it is a torch
     tensor, freed when Python drops it;
   * CCO owns the peer addressing -- ``rendezvous()`` registers the CCO window,
-    and ``window_handle()`` hands it back for the kernel to address through.
+    and ``window_handle()`` hands it back for the kernel to address through;
+    ``dev_comm()`` hands over the matching device communicator, which is what
+    tells the kernel which LSA rank it is.
 
 No ``Communicator`` is built here: the backend keeps one per process group and
 creates it on the first rendezvous. The kernel is Triton (``mori.ir.triton.cco``)
@@ -73,16 +75,21 @@ def _free_port() -> int:
         return int(sk.getsockname()[1])
 
 
-@triton.jit(do_not_specialize=["chunk_elems", "rank_id"])
-def a2a_lsa_kernel(window, send_ptr, chunk_elems, rank_id, BLOCK: tl.constexpr):
+@triton.jit(do_not_specialize=["chunk_elems"])
+def a2a_lsa_kernel(window, dev_comm, send_ptr, chunk_elems, BLOCK: tl.constexpr):
     """One program per (peer, block): push my chunk into that peer's slot."""
     peer = tl.program_id(0)
     blk = tl.program_id(1)
 
+    # lsa_ptr indexes by LSA rank, which is what the DevComm answers. On one node it
+    # equals the world rank; asking the DevComm is what keeps that an implementation
+    # detail rather than an assumption baked into the kernel.
+    my_lsa = cco.DevComm.lsa_rank(dev_comm)
+
     chunk = chunk_elems.to(tl.int64)
     # The peer's window base plus the slot it reserves for me. lsa_ptr is
     # arithmetic on the flat VA, so no pointer table is dereferenced.
-    dst_addr = cco.Window.lsa_ptr(window, peer, rank_id.to(tl.int64) * chunk * 4)
+    dst_addr = cco.Window.lsa_ptr(window, peer, my_lsa.to(tl.int64) * chunk * 4)
     dst = dst_addr.to(tl.pointer_type(tl.int32), bitcast=True)
     src = (
         send_ptr.to(tl.pointer_type(tl.int32), bitcast=True) + peer.to(tl.int64) * chunk
@@ -133,20 +140,21 @@ def main():
 
     hdl = symm_mem.rendezvous(recv, group_name)
     window = mori.allocator.window_handle(recv)
+    dev_comm = mori.allocator.dev_comm(group_name, key="a2a_lsa")
     if rank == 0:
         print(
             f"{nranks} ranks, backend={symm_mem.get_backend(device)}, "
             f"{CHUNK_ELEMS * 4} B per peer"
         )
-    print(f"[rank {rank}] cco window {window:#x}", flush=True)
+    print(f"[rank {rank}] cco window {window:#x}, dev_comm {dev_comm:#x}", flush=True)
 
     hdl.barrier(0)
     grid = (nranks, (CHUNK_ELEMS + BLOCK - 1) // BLOCK)
     a2a_lsa_kernel[grid](
         window,
+        dev_comm,
         send.data_ptr(),
         CHUNK_ELEMS,
-        rank,
         BLOCK=BLOCK,
         extern_libs=cco.get_extern_libs(),
     )

--- a/examples/cco/python/09_torch_symm_lsa_all2all/main.py
+++ b/examples/cco/python/09_torch_symm_lsa_all2all/main.py
@@ -132,7 +132,7 @@ def main():
     torch.cuda.synchronize()
 
     hdl = symm_mem.rendezvous(recv, group_name)
-    window = mori.allocator.window_handle(recv.data_ptr())
+    window = mori.allocator.window_handle(recv)
     if rank == 0:
         print(
             f"{nranks} ranks, backend={symm_mem.get_backend(device)}, "

--- a/examples/cco/python/09_torch_symm_lsa_all2all/main.py
+++ b/examples/cco/python/09_torch_symm_lsa_all2all/main.py
@@ -30,13 +30,13 @@ whole exchange through CCO, so the two halves of mori meet:
 
   * ``mori.allocator`` owns the allocation and its lifetime -- it is a torch
     tensor, freed when Python drops it;
-  * CCO owns the peer addressing -- ``register_external_window()`` aliases the
-    tensor's HIP VMM handle into the flat LSA space with no copy.
+  * CCO owns the peer addressing -- ``rendezvous()`` registers the CCO window,
+    and ``window_handle()`` hands it back for the kernel to address through.
 
-``symm_mem.rendezvous()`` is deliberately never called: the backend's own peer
-exchange would duplicate what ``ccoWindowRegister`` already does. The kernel is
-Triton (``mori.ir.triton.cco``) and computes each peer address arithmetically
-with ``Window.lsa_ptr`` rather than loading it from a pointer array.
+No ``Communicator`` is built here: the backend keeps one per process group and
+creates it on the first rendezvous. The kernel is Triton (``mori.ir.triton.cco``)
+and computes each peer address arithmetically with ``Window.lsa_ptr`` rather than
+loading it from a pointer array.
 
 All-to-all: rank r writes its chunk into every peer's slot r, then each rank
 checks that slot p holds rank p's sentinel.
@@ -44,6 +44,8 @@ checks that slot p holds rank p's sentinel.
     mpirun --allow-run-as-root -np 2 python main.py
 """
 
+import os
+import socket
 import sys
 
 try:
@@ -52,18 +54,23 @@ except ImportError:
     print("ERROR: mpi4py required.  pip install mpi4py")
     sys.exit(1)
 
-import torch  # must be imported before mori.cco
+import torch  # must be imported before anything that pulls in mori.cco
+import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
 import triton
 import triton.language as tl
 
-import mori.allocator  # noqa: F401  -- importing registers the "MORI" backend
-from mori.cco import Communicator
+import mori.allocator  # importing registers the "MORI" backend
 from mori.ir.triton import cco
 
-PER_RANK_VMM = 1 * 1024 * 1024 * 1024
 CHUNK_ELEMS = 4096  # int32 per peer
 BLOCK = 512
+
+
+def _free_port() -> int:
+    with socket.socket() as sk:
+        sk.bind(("", 0))
+        return int(sk.getsockname()[1])
 
 
 @triton.jit(do_not_specialize=["chunk_elems", "rank_id"])
@@ -99,7 +106,24 @@ def main():
     torch.cuda.set_device(local)
     device = torch.device("cuda", local)
 
+    # torch's process group is the only bootstrap; the backend builds cco's
+    # communicator behind rendezvous(). mpirun does not set the variables torch
+    # expects, so carry the master address over MPI.
+    master = comm_mpi.bcast(
+        (
+            (socket.gethostbyname(socket.gethostname()), _free_port())
+            if rank == 0
+            else None
+        ),
+        root=0,
+    )
+    os.environ.setdefault("MASTER_ADDR", master[0])
+    os.environ.setdefault("MASTER_PORT", str(master[1]))
+    dist.init_process_group("gloo", rank=rank, world_size=nranks)
+    group_name = dist.group.WORLD.group_name
     symm_mem.set_backend("MORI")
+    symm_mem.enable_symm_mem_for_group(group_name)
+
     recv = symm_mem.empty(nranks * CHUNK_ELEMS, dtype=torch.int32, device=device)
     recv.zero_()
     # Ordinary local memory. Chunk p carries a value identifying (me -> p).
@@ -108,59 +132,49 @@ def main():
         send[p * CHUNK_ELEMS : (p + 1) * CHUNK_ELEMS] = rank * 1000 + p
     torch.cuda.synchronize()
 
-    uid = Communicator.get_unique_id() if rank == 0 else None
-    uid = comm_mpi.bcast(uid, root=0)
-
-    errors = 0
-    with Communicator.init(nranks, rank, uid, per_rank_vmm=PER_RANK_VMM) as comm:
-        if rank == 0:
-            print(
-                f"CommCreate: {nranks} ranks, backend={symm_mem.get_backend(device)}, "
-                f"{CHUNK_ELEMS * 4} B per peer"
-            )
-
-        # Import the torch tensor into the flat LSA space (no copy).
-        win = comm.register_external_window(recv.data_ptr(), recv.nbytes)
+    hdl = symm_mem.rendezvous(recv, group_name)
+    window = mori.allocator.window_handle(recv.data_ptr())
+    if rank == 0:
         print(
-            f"[rank {rank}] torch data_ptr={recv.data_ptr():#x} -> "
-            f"cco flat local_ptr={win.local_ptr:#x}",
+            f"{nranks} ranks, backend={symm_mem.get_backend(device)}, "
+            f"{CHUNK_ELEMS * 4} B per peer"
+        )
+    print(f"[rank {rank}] cco window {window:#x}", flush=True)
+
+    hdl.barrier(0)
+    grid = (nranks, (CHUNK_ELEMS + BLOCK - 1) // BLOCK)
+    a2a_lsa_kernel[grid](
+        window,
+        send.data_ptr(),
+        CHUNK_ELEMS,
+        rank,
+        BLOCK=BLOCK,
+        extern_libs=cco.get_extern_libs(),
+    )
+    torch.cuda.synchronize()
+    hdl.barrier(0)
+
+    # Slot p must now hold what rank p sent me. First and last element, since the
+    # window started zeroed and a short copy would leave the tail at 0.
+    errors = 0
+    host = recv.cpu().tolist()
+    for p in range(nranks):
+        want = p * 1000 + rank
+        for i in (0, CHUNK_ELEMS - 1):
+            got = host[p * CHUNK_ELEMS + i]
+            if got != want:
+                errors += 1
+                print(
+                    f"[rank {rank}] slot {p}[{i}]: got {got}, want {want}", flush=True
+                )
+    if errors == 0:
+        print(
+            f"[rank {rank}] all {nranks} slots hold the right sender's data "
+            f"(via lsa_ptr, no buffer_ptrs)",
             flush=True,
         )
-        comm.barrier()
 
-        grid = (nranks, (CHUNK_ELEMS + BLOCK - 1) // BLOCK)
-        a2a_lsa_kernel[grid](
-            win.handle,
-            send.data_ptr(),
-            CHUNK_ELEMS,
-            rank,
-            BLOCK=BLOCK,
-            extern_libs=cco.get_extern_libs(),
-        )
-        torch.cuda.synchronize()
-        comm.barrier()
-
-        # Slot p must now hold what rank p sent me. First and last element, since
-        # the window started zeroed and a short copy would leave the tail at 0.
-        host = recv.cpu().tolist()
-        for p in range(nranks):
-            want = p * 1000 + rank
-            for i in (0, CHUNK_ELEMS - 1):
-                got = host[p * CHUNK_ELEMS + i]
-                if got != want:
-                    errors += 1
-                    print(
-                        f"[rank {rank}] slot {p}[{i}]: got {got}, want {want}",
-                        flush=True,
-                    )
-        if errors == 0:
-            print(
-                f"[rank {rank}] all {nranks} slots hold the right sender's data "
-                f"(via lsa_ptr, no buffer_ptrs)",
-                flush=True,
-            )
-        comm.barrier()
-
+    dist.destroy_process_group()
     all_errors = comm_mpi.allreduce(errors, op=MPI.SUM)
     if rank == 0:
         print("SUCCESS" if all_errors == 0 else f"FAILED ({all_errors} mismatches)")

--- a/examples/cco/python/09_torch_symm_lsa_all2all/main.py
+++ b/examples/cco/python/09_torch_symm_lsa_all2all/main.py
@@ -122,7 +122,6 @@ def main():
     dist.init_process_group("gloo", rank=rank, world_size=nranks)
     group_name = dist.group.WORLD.group_name
     symm_mem.set_backend("MORI")
-    symm_mem.enable_symm_mem_for_group(group_name)
 
     recv = symm_mem.empty(nranks * CHUNK_ELEMS, dtype=torch.int32, device=device)
     recv.zero_()

--- a/examples/torch_symm_all2all/README.md
+++ b/examples/torch_symm_all2all/README.md
@@ -70,15 +70,16 @@ tensor's VMM handle into cco's flat LSA space, and the kernel asks the window fo
 address.
 
 ```python
-win  = comm.register_external_window(recv.data_ptr(), recv.nbytes)   # no copy
-addr = cco.Window.lsa_ptr(window, peer, rank_id * chunk_bytes)       # in the kernel
+hdl    = symm_mem.rendezvous(recv, group_name)                  # registers the cco window
+window = mori.allocator.window_handle(recv.data_ptr())          # hand it to the kernel
+addr   = cco.Window.lsa_ptr(window, peer, rank_id * chunk_bytes)  # inside the kernel
 ```
 
-`symm_mem.rendezvous()` is never called: the backend's own peer exchange would duplicate
-what `ccoWindowRegister` already does. torch keeps the allocation and its lifetime, cco
-takes the addressing. cco has its own rendezvous, so the example passes a `ccoUniqueId`
-through torch's process group; and `import torch` must come before `import mori.cco`, or
-the two LLVM copies collide at import time.
+No `Communicator` is built: `rendezvous()` *is* the cco window registration, and the
+backend keeps one communicator per process group. `window_handle()` is the backend's own
+accessor -- torch's handle has nowhere to carry a window -- and it mirrors
+`NCCLSymmetricMemory::get_window()`. The example also uses `hdl.barrier(0)`, the backend's
+barrier over cco's, in place of `dist.barrier()`.
 
 It measures the same as the pointer array — 8×gfx950, 4 MiB per peer, three repeats each:
 

--- a/examples/torch_symm_all2all/README.md
+++ b/examples/torch_symm_all2all/README.md
@@ -70,10 +70,19 @@ tensor's VMM handle into cco's flat LSA space, and the kernel asks the window fo
 address.
 
 ```python
-hdl    = symm_mem.rendezvous(recv, group_name)                  # registers the cco window
-window = mori.allocator.window_handle(recv)                      # hand it to the kernel
-addr   = cco.Window.lsa_ptr(window, peer, rank_id * chunk_bytes)  # inside the kernel
+hdl      = symm_mem.rendezvous(recv, group_name)          # registers the cco window
+window   = mori.allocator.window_handle(recv)             # where to write
+dev_comm = mori.allocator.dev_comm(group_name, key="all2all_lsa")   # who I am
+...
+my_lsa = cco.DevComm.lsa_rank(dev_comm)                   # inside the kernel
+addr   = cco.Window.lsa_ptr(window, peer, my_lsa * chunk_bytes)
 ```
+
+Both indices `lsa_ptr` takes are **LSA** ranks. On one node they equal world ranks, which
+is why passing `rank_id` in from Python also works today and would quietly stop working
+with a second node. The DevComm is what answers it properly, and it is cached per
+`(group, key)` because the resources a collective needs — signal counts, QP counts,
+connection type — belong to that collective, not to the group.
 
 No `Communicator` is built: `rendezvous()` *is* the cco window registration, and the
 backend keeps one communicator per process group. `window_handle()` is the backend's own

--- a/examples/torch_symm_all2all/README.md
+++ b/examples/torch_symm_all2all/README.md
@@ -71,7 +71,7 @@ address.
 
 ```python
 hdl    = symm_mem.rendezvous(recv, group_name)                  # registers the cco window
-window = mori.allocator.window_handle(recv.data_ptr())          # hand it to the kernel
+window = mori.allocator.window_handle(recv)                      # hand it to the kernel
 addr   = cco.Window.lsa_ptr(window, peer, rank_id * chunk_bytes)  # inside the kernel
 ```
 

--- a/examples/torch_symm_all2all/README.md
+++ b/examples/torch_symm_all2all/README.md
@@ -217,12 +217,8 @@ this backend exposes the pointer array anyway, kernels would not notice.
 
 ## Notes
 
-`dist.barrier()` is used between the kernel and the reads because the backend has no
-device-side barrier yet (`barrier`/`put_signal`/`wait_signal` raise). Since none of them
-are implemented, the signal pad is not reserved either — appending torch's 9216-byte pad
-to a page-aligned window would cost a whole extra 2 MiB page, physical backing being
-2 MiB-paged. Build with `MORI_SYMM_SIGNAL_PAD=ON` to reserve it and
-`mori.allocator.signal_pad_supported()` to check at run time; torch's own `symm_mem`
-collectives synchronise through that pad, so they need the flag even though they never call
-this backend's `barrier()`. A real workload would want signal-pad synchronisation instead,
-which is why the timed loop measures the kernel alone.
+`dist.barrier()` is used between the kernel and the reads because the examples predate the
+backend's own `barrier()`, which now runs over cco's host barrier. The signal pad is always
+present -- its own cco window rather than a tail on the buffer -- so torch's `symm_mem`
+collectives work without a build flag. `put_signal`/`wait_signal` still raise: they need a
+`ccoDevComm`, which the backend does not create yet.

--- a/examples/torch_symm_all2all/all2all_hip.py
+++ b/examples/torch_symm_all2all/all2all_hip.py
@@ -151,7 +151,6 @@ def main():
     group_name = dist.group.WORLD.group_name
 
     symm_mem.set_backend("MORI")
-    symm_mem.enable_symm_mem_for_group(group_name)
 
     chunk_bytes = args.chunk_kib * 1024
     elems = chunk_bytes // 4

--- a/examples/torch_symm_all2all/all2all_lsa.py
+++ b/examples/torch_symm_all2all/all2all_lsa.py
@@ -125,7 +125,6 @@ def main() -> int:
 
     group_name = dist.group.WORLD.group_name
     symm_mem.set_backend("MORI")
-    symm_mem.enable_symm_mem_for_group(group_name)
     recv = symm_mem.empty(world_size * elems, dtype=torch.int32, device=device)
     recv.zero_()
     send = torch.empty(world_size * elems, dtype=torch.int32, device=device)

--- a/examples/torch_symm_all2all/all2all_lsa.py
+++ b/examples/torch_symm_all2all/all2all_lsa.py
@@ -30,7 +30,7 @@ comes straight out of the backend::
 
     t   = symm_mem.empty(...)              # MORI backend, HIP VMM
     hdl = symm_mem.rendezvous(t, group)    # registers the CCO window
-    win = mori.allocator.window_handle(t.data_ptr())
+    win = mori.allocator.window_handle(t)
     ...
     addr = cco.Window.lsa_ptr(window, peer, offset)     # inside the kernel
 
@@ -133,7 +133,7 @@ def main() -> int:
     torch.cuda.synchronize()
 
     hdl = symm_mem.rendezvous(recv, group_name)
-    window = mori.allocator.window_handle(recv.data_ptr())
+    window = mori.allocator.window_handle(recv)
     blocks_per_peer = _blocks_per_peer(elems, world_size, device)
     extern_libs = cco.get_extern_libs()
 

--- a/examples/torch_symm_all2all/all2all_lsa.py
+++ b/examples/torch_symm_all2all/all2all_lsa.py
@@ -25,12 +25,12 @@
 Same push as ``all2all_triton.py``, with the peer address computed rather than
 loaded: ``cco.Window.lsa_ptr(win, peer, off)`` instead of an index into
 ``buffer_ptrs_dev``. torch still owns the allocation and its lifetime; CCO owns
-the peer addressing, so ``symm_mem.rendezvous()`` is never called here --
-``register_external_window()`` aliases the tensor's VMM handle into the flat LSA
-space instead, with no copy::
+the peer addressing. ``rendezvous()`` is the CCO window registration now, so the window
+comes straight out of the backend::
 
-    t   = symm_mem.empty(...)                          # MORI backend, HIP VMM
-    win = comm.register_external_window(t.data_ptr(), nbytes)
+    t   = symm_mem.empty(...)              # MORI backend, HIP VMM
+    hdl = symm_mem.rendezvous(t, group)    # registers the CCO window
+    win = mori.allocator.window_handle(t.data_ptr())
     ...
     addr = cco.Window.lsa_ptr(window, peer, offset)     # inside the kernel
 
@@ -55,13 +55,9 @@ import torch.distributed._symmetric_memory as symm_mem
 import triton
 import triton.language as tl
 
-import mori.allocator  # noqa: F401  -- importing registers the "MORI" backend
-from mori.cco import Communicator
+import mori.allocator  # importing registers the "MORI" backend
 from mori.ir.triton import cco
 
-# One communicator's flat VA reservation. Nothing here needs it to be large; the
-# window is an alias of the torch tensor, not an allocation out of this space.
-PER_RANK_VMM = 1 << 30
 BLOCK = 1024
 NUM_WARPS = 4
 
@@ -127,7 +123,9 @@ def main() -> int:
     chunk_bytes = args.chunk_kib * 1024
     elems = chunk_bytes // 4
 
+    group_name = dist.group.WORLD.group_name
     symm_mem.set_backend("MORI")
+    symm_mem.enable_symm_mem_for_group(group_name)
     recv = symm_mem.empty(world_size * elems, dtype=torch.int32, device=device)
     recv.zero_()
     send = torch.empty(world_size * elems, dtype=torch.int32, device=device)
@@ -135,76 +133,70 @@ def main() -> int:
         send[p * elems : (p + 1) * elems] = rank_id * 1000 + p
     torch.cuda.synchronize()
 
-    # CCO's own rendezvous. torch's process group only carries the token.
-    token = [Communicator.get_unique_id() if rank_id == 0 else None]
-    dist.broadcast_object_list(token, src=0)
+    hdl = symm_mem.rendezvous(recv, group_name)
+    window = mori.allocator.window_handle(recv.data_ptr())
+    blocks_per_peer = _blocks_per_peer(elems, world_size, device)
+    extern_libs = cco.get_extern_libs()
 
-    with Communicator.init(
-        world_size, rank_id, token[0], per_rank_vmm=PER_RANK_VMM
-    ) as comm:
-        win = comm.register_external_window(recv.data_ptr(), recv.nbytes)
-        blocks_per_peer = _blocks_per_peer(elems, world_size, device)
-        extern_libs = cco.get_extern_libs()
-
-        if rank_id == 0:
-            print(
-                f"kernel=Triton/LSA  world={world_size}  chunk={args.chunk_kib} KiB  "
-                f"blocks_per_peer={blocks_per_peer}"
-            )
-            print(f"window handle: {win.handle:#x}, local flat VA: {win.local_ptr:#x}")
-
-        def push():
-            all2all_push_lsa[(world_size * blocks_per_peer,)](
-                win.handle,
-                send.data_ptr(),
-                elems,
-                rank_id,
-                blocks_per_peer,
-                BLOCK=BLOCK,
-                num_warps=NUM_WARPS,
-                extern_libs=extern_libs,
-            )
-
-        # Peers write into this window, so everyone must finish clearing before
-        # anyone pushes.
-        comm.barrier()
-        push()
-        torch.cuda.synchronize()
-        comm.barrier()
-
-        errors = 0
-        for r in range(world_size):
-            got, want = recv[r * elems].item(), r * 1000 + rank_id
-            if got != want:
-                errors += 1
-                print(f"[rank {rank_id}] chunk {r}: got {got}, want {want}", flush=True)
-        failed = torch.tensor([errors], dtype=torch.int64)
-        dist.all_reduce(failed, op=dist.ReduceOp.SUM)
-        if rank_id == 0 and failed.item() == 0:
-            print(f"correctness: OK ({world_size}x{world_size} chunks)")
-
-        for _ in range(args.warmup):
-            push()
-        start = torch.cuda.Event(enable_timing=True)
-        end = torch.cuda.Event(enable_timing=True)
-        torch.cuda.synchronize()
-        comm.barrier()
-        start.record()
-        for _ in range(args.iters):
-            push()
-        end.record()
-        torch.cuda.synchronize()
-        ms = start.elapsed_time(end) / args.iters
-
-        # Only (world_size-1) chunks leave the device; the self chunk stays local.
-        gbps = torch.tensor(
-            [(world_size - 1) * chunk_bytes / (ms / 1e3) / 1e9], dtype=torch.float64
+    if rank_id == 0:
+        print(
+            f"kernel=Triton/LSA  world={world_size}  chunk={args.chunk_kib} KiB  "
+            f"blocks_per_peer={blocks_per_peer}"
         )
-        dist.all_reduce(gbps, op=dist.ReduceOp.SUM)
-        if rank_id == 0:
-            print(f"{ms * 1e3:7.1f} us/iter, {gbps.item():8.1f} GB/s aggregate")
-            print("SUCCESS" if failed.item() == 0 else "FAILED")
-        comm.barrier()
+        print(f"cco window: {window:#x}")
+
+    def push():
+        all2all_push_lsa[(world_size * blocks_per_peer,)](
+            window,
+            send.data_ptr(),
+            elems,
+            rank_id,
+            blocks_per_peer,
+            BLOCK=BLOCK,
+            num_warps=NUM_WARPS,
+            extern_libs=extern_libs,
+        )
+
+    # Peers write into this window, so everyone must finish clearing before
+    # anyone pushes.
+    hdl.barrier(0)
+    push()
+    torch.cuda.synchronize()
+    hdl.barrier(0)
+
+    errors = 0
+    for r in range(world_size):
+        got, want = recv[r * elems].item(), r * 1000 + rank_id
+        if got != want:
+            errors += 1
+            print(f"[rank {rank_id}] chunk {r}: got {got}, want {want}", flush=True)
+    failed = torch.tensor([errors], dtype=torch.int64)
+    dist.all_reduce(failed, op=dist.ReduceOp.SUM)
+    if rank_id == 0 and failed.item() == 0:
+        print(f"correctness: OK ({world_size}x{world_size} chunks)")
+
+    for _ in range(args.warmup):
+        push()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    torch.cuda.synchronize()
+    hdl.barrier(0)
+    start.record()
+    for _ in range(args.iters):
+        push()
+    end.record()
+    torch.cuda.synchronize()
+    ms = start.elapsed_time(end) / args.iters
+
+    # Only (world_size-1) chunks leave the device; the self chunk stays local.
+    gbps = torch.tensor(
+        [(world_size - 1) * chunk_bytes / (ms / 1e3) / 1e9], dtype=torch.float64
+    )
+    dist.all_reduce(gbps, op=dist.ReduceOp.SUM)
+    if rank_id == 0:
+        print(f"{ms * 1e3:7.1f} us/iter, {gbps.item():8.1f} GB/s aggregate")
+        print("SUCCESS" if failed.item() == 0 else "FAILED")
+    hdl.barrier(0)
 
     dist.destroy_process_group()
     return 0 if failed.item() == 0 else 1

--- a/examples/torch_symm_all2all/all2all_lsa.py
+++ b/examples/torch_symm_all2all/all2all_lsa.py
@@ -31,8 +31,9 @@ comes straight out of the backend::
     t   = symm_mem.empty(...)              # MORI backend, HIP VMM
     hdl = symm_mem.rendezvous(t, group)    # registers the CCO window
     win = mori.allocator.window_handle(t)
+    dc  = mori.allocator.dev_comm(group, key="all2all_lsa")
     ...
-    addr = cco.Window.lsa_ptr(window, peer, offset)     # inside the kernel
+    addr = cco.Window.lsa_ptr(window, cco.DevComm.lsa_rank(dev_comm), offset)
 
 Run it the same way as its siblings::
 
@@ -62,12 +63,12 @@ BLOCK = 1024
 NUM_WARPS = 4
 
 
-@triton.jit(do_not_specialize=["chunk_elems", "rank_id", "blocks_per_peer"])
+@triton.jit(do_not_specialize=["chunk_elems", "blocks_per_peer"])
 def all2all_push_lsa(
     window,
+    dev_comm,
     send_ptr,
     chunk_elems,
-    rank_id,
     blocks_per_peer,
     BLOCK: tl.constexpr,
 ):
@@ -76,11 +77,16 @@ def all2all_push_lsa(
     peer = pid // blocks_per_peer
     sub = pid % blocks_per_peer
 
+    # Both indices lsa_ptr takes are LSA ranks, not world ranks -- the two coincide on one
+    # node and stop coinciding the moment there is a second. The DevComm is what answers
+    # "which one am I", so the kernel does not need the rank passed in at all.
+    my_lsa = cco.DevComm.lsa_rank(dev_comm)
+
     # peer's window base + my slot within it. No pointer array is dereferenced:
     # lsa_ptr is arithmetic on the flat VA, so the address is known without a load.
     # 64-bit from here on: chunk_elems*world_size overflows i32 past 8 GiB of window.
     chunk = chunk_elems.to(tl.int64)
-    dst_addr = cco.Window.lsa_ptr(window, peer, rank_id.to(tl.int64) * chunk * 4)
+    dst_addr = cco.Window.lsa_ptr(window, peer, my_lsa.to(tl.int64) * chunk * 4)
     dst = dst_addr.to(tl.pointer_type(tl.int32), bitcast=True)
     src = (
         send_ptr.to(tl.pointer_type(tl.int32), bitcast=True) + peer.to(tl.int64) * chunk
@@ -134,6 +140,10 @@ def main() -> int:
 
     hdl = symm_mem.rendezvous(recv, group_name)
     window = mori.allocator.window_handle(recv)
+    # The second handle the backend hands out: topology and barriers for the kernel.
+    # Cached per (group, key) -- a different collective would ask under its own key,
+    # because the resources it needs are its own.
+    dev_comm = mori.allocator.dev_comm(group_name, key="all2all_lsa")
     blocks_per_peer = _blocks_per_peer(elems, world_size, device)
     extern_libs = cco.get_extern_libs()
 
@@ -142,14 +152,14 @@ def main() -> int:
             f"kernel=Triton/LSA  world={world_size}  chunk={args.chunk_kib} KiB  "
             f"blocks_per_peer={blocks_per_peer}"
         )
-        print(f"cco window: {window:#x}")
+        print(f"cco window: {window:#x}, dev_comm: {dev_comm:#x}")
 
     def push():
         all2all_push_lsa[(world_size * blocks_per_peer,)](
             window,
+            dev_comm,
             send.data_ptr(),
             elems,
-            rank_id,
             blocks_per_peer,
             BLOCK=BLOCK,
             num_warps=NUM_WARPS,

--- a/examples/torch_symm_all2all/all2all_triton.py
+++ b/examples/torch_symm_all2all/all2all_triton.py
@@ -151,7 +151,6 @@ def main():
     group_name = dist.group.WORLD.group_name
 
     symm_mem.set_backend("MORI")
-    symm_mem.enable_symm_mem_for_group(group_name)
 
     chunk_bytes = args.chunk_kib * 1024
     elems = chunk_bytes // 4

--- a/python/mori/allocator/__init__.py
+++ b/python/mori/allocator/__init__.py
@@ -90,6 +90,7 @@ __all__ = [
     "register_symm_backend",
     "signal_pad_supported",
     "window_handle",
+    "dev_comm",
 ]
 
 logger = logging.getLogger(__name__)
@@ -235,6 +236,21 @@ def window_handle(data_ptr: int, signal_pad: bool = False) -> int:
     ``buffer_ptrs``.
     """
     return _ext().window_handle(data_ptr, signal_pad)
+
+
+def dev_comm(group_name: str, key: str = "default", lsa_barrier_count: int = 1) -> int:
+    """Device ``ccoDevComm`` pointer for a group, as a kernel argument.
+
+    Created on first use and cached per ``(group_name, key)``. The key exists because a
+    DevComm is parameterised by signal counts, QP counts and connection type -- properties
+    of the algorithm about to run, not of the group -- so two collectives over one group
+    want two of them. torch's NCCL backend keys the same cache on ``__builtin_FUNCTION()``;
+    from Python that would be stack inspection, so pass a key explicitly instead.
+
+    Rendezvous a tensor with the group first: that is what creates the communicator this
+    hangs off. Intra-node only today -- the connection type is fixed to NONE.
+    """
+    return _ext().dev_comm(group_name, key, lsa_barrier_count)
 
 
 def _register_on_import() -> None:

--- a/python/mori/allocator/__init__.py
+++ b/python/mori/allocator/__init__.py
@@ -55,12 +55,14 @@ CCO's own export have to agree on that type, since CCO re-exports what it import
 It is a floor rather than a budget -- CCO quantises it up to 4 GiB -- and it bounds live
 symmetric memory per rank, not allocations over time, because slots are recycled on free.
 
-``barrier``/``put_signal``/``wait_signal`` are not implemented and raise, so no signal
-pad is reserved in the window -- torch's 9216-byte pad would cost a whole extra 2 MiB page
-on a page-aligned allocation. Build with ``MORI_SYMM_SIGNAL_PAD=ON`` to reserve it, and
-check ``signal_pad_supported()`` at run time. torch's own ``symm_mem`` collectives
-synchronise through the pad, so they need that build; ``dist.barrier()`` is the stand-in
-without it.
+The signal pad is always there, as its own CCO allocation and window rather than a tail
+appended to the buffer -- the same split NCCL's backend uses. torch's own ``symm_mem``
+collectives synchronise through it, so they work without any build flag.
+
+``barrier()`` runs over CCO's host barrier, which means the current stream is drained
+first: stronger than the device-side barrier torch asks for, and heavier.
+``put_signal``/``wait_signal`` still raise -- point-to-point signalling needs a
+``ccoDevComm``, which this backend does not create yet.
 
 ``rendezvous()`` takes the tensor's *storage* base, so ``get_offset()`` is 0 by
 construction: every ``alloc()`` is its own VMM allocation. Handing it a view
@@ -73,8 +75,7 @@ The extension is optional and its ABI tracks the installed torch, so it is a plu
 makes a failure fatal, ``OFF`` skips it), and a build that did not happen or no longer
 loads is compiled here on first import from the sources shipped in ``_jit-sources``. So
 switching torch does not require reinstalling mori. ``MORI_SYMM_FORCE_JIT=1`` ignores the
-prebuilt module, which is also how ``MORI_SYMM_SIGNAL_PAD=ON`` can be turned on without
-rebuilding mori itself.
+prebuilt module.
 """
 
 import atexit
@@ -88,6 +89,7 @@ __all__ = [
     "handle_type",
     "register_symm_backend",
     "signal_pad_supported",
+    "window_handle",
 ]
 
 logger = logging.getLogger(__name__)
@@ -138,13 +140,6 @@ def _jit_ext():
 
     rocm = os.environ.get("ROCM_PATH", "/opt/rocm")
     flags = ["-std=c++17", "-O3", "-D__HIP_PLATFORM_AMD__=1", "-DUSE_ROCM=1"]
-    if os.environ.get("MORI_SYMM_SIGNAL_PAD", "OFF").strip().upper() in {
-        "1",
-        "ON",
-        "TRUE",
-        "YES",
-    }:
-        flags.append("-DMORI_SYMM_SIGNAL_PAD=1")
     logger.info("compiling mori_torch_symm from %s", source)
     # libmori_cco sits in the package directory, wherever mori was installed.
     pkg = str(Path(__file__).resolve().parent.parent)
@@ -224,12 +219,22 @@ def handle_type(device_index: int = 0) -> Literal["fabric", "posix_fd"]:
 def signal_pad_supported() -> bool:
     """Whether windows carry torch's signal pad.
 
-    False unless built with ``MORI_SYMM_SIGNAL_PAD=ON``. Without the pad, torch's own
-    ``symm_mem`` collectives raise -- their kernels synchronise through it -- and
-    ``dist.barrier()`` is the stand-in. With it they work, since they use the pad
-    directly; this backend's ``barrier``/``put_signal``/``wait_signal`` raise either way.
+    Always true now: the pad is its own CCO window. Kept because callers written against
+    the earlier build-flag behaviour still check it.
     """
     return bool(_ext().signal_pad_supported)
+
+
+def window_handle(data_ptr: int, signal_pad: bool = False) -> int:
+    """The cco window backing a rendezvous'd tensor, as an integer handle.
+
+    Backend-specific on purpose: torch's ``SymmetricMemory`` has nowhere to carry a
+    window, so NCCL's backend exposes ``get_window()`` on its own class and this does
+    the same, keyed by the tensor pointer. Pass it to a kernel that addresses peers with
+    cco's device API (``mori.ir.triton.cco.Window.lsa_ptr``) instead of walking
+    ``buffer_ptrs``.
+    """
+    return _ext().window_handle(data_ptr, signal_pad)
 
 
 def _register_on_import() -> None:

--- a/python/mori/allocator/__init__.py
+++ b/python/mori/allocator/__init__.py
@@ -230,16 +230,21 @@ def signal_pad_supported() -> bool:
     return bool(_ext().signal_pad_supported)
 
 
-def window_handle(data_ptr: int, signal_pad: bool = False) -> int:
+def window_handle(tensor, signal_pad: bool = False) -> int:
     """The cco window backing a rendezvous'd tensor, as an integer handle.
 
     Backend-specific on purpose: torch's ``SymmetricMemory`` has nowhere to carry a
-    window, so NCCL's backend exposes ``get_window()`` on its own class and this does
-    the same, keyed by the tensor pointer. Pass it to a kernel that addresses peers with
-    cco's device API (``mori.ir.triton.cco.Window.lsa_ptr``) instead of walking
-    ``buffer_ptrs``.
+    window, so NCCL's backend exposes ``get_window()`` on its own class. Python only ever
+    sees the base class, so this is a lookup keyed by the tensor instead.
+
+    Takes the tensor rather than a pointer because the window belongs to the *storage*:
+    ``rendezvous(t[512:])`` registers the whole storage, so a view has to resolve to the
+    same window rather than to "pointer is not a mori allocation".
+
+    Pass the result to a kernel that addresses peers with cco's device API
+    (``mori.ir.triton.cco.Window.lsa_ptr``) instead of walking ``buffer_ptrs``.
     """
-    return _ext().window_handle(data_ptr, signal_pad)
+    return _ext().window_handle(tensor.untyped_storage().data_ptr(), signal_pad)
 
 
 def dev_comm(group_name: str, key: str = "default", lsa_barrier_count: int = 1) -> int:

--- a/python/mori/allocator/__init__.py
+++ b/python/mori/allocator/__init__.py
@@ -37,6 +37,10 @@ own Store, so there is no second bootstrap channel to configure::
     hdl = symm_mem.rendezvous(t, group_name)
     peer = hdl.get_buffer(1, (1024,), torch.bfloat16)
 
+``enable_symm_mem_for_group()`` is not needed: the group is resolved with
+``resolve_process_group()``, the way torch's own CUDA and NCCL backends do it, rather
+than through the ``GroupInfo`` registry that only that deprecated call populates.
+
 Peers are exposed the way torch's model expects, as the ``buffer_ptrs`` /
 ``buffer_ptrs_dev`` array -- one base address per rank, same as every other backend.
 

--- a/python/mori/allocator/__init__.py
+++ b/python/mori/allocator/__init__.py
@@ -41,6 +41,14 @@ own Store, so there is no second bootstrap channel to configure::
 ``resolve_process_group()``, the way torch's own CUDA and NCCL backends do it, rather
 than through the ``GroupInfo`` registry that only that deprecated call populates.
 
+Known constraint on the POSIX-fd path (gfx9, i.e. MI300/MI355): CCO names its rendezvous
+socket after the local slot offset, and freeing a window returns that slot to a per-rank
+allocator. Ranks that free symmetric tensors in *different* orders therefore get different
+offsets, and a later ``rendezvous()`` fails with a P2P fd exchange timeout. Free order is
+unconstrained as far as torch is concerned, so keep it uniform across ranks until that
+naming changes. The fabric path is unaffected -- peer addressing is computed from each
+rank's own offset.
+
 Peers are exposed the way torch's model expects, as the ``buffer_ptrs`` /
 ``buffer_ptrs_dev`` array -- one base address per rank, same as every other backend.
 

--- a/python/mori/allocator/__init__.py
+++ b/python/mori/allocator/__init__.py
@@ -21,8 +21,12 @@
 # SOFTWARE.
 """Register mori as a torch SymmetricMemory backend. Requires **torch >= 2.9**.
 
-Self-contained: plain HIP VMM, no shmem or cco allocator involved, so no mori bootstrap
-is needed -- torch's process group is the only rendezvous::
+torch owns the allocation and its lifetime; CCO owns the peer addressing. ``alloc`` is
+plain HIP VMM, and ``rendezvous`` hands that allocation to ``ccoWindowRegister``, which
+aliases it into CCO's flat LSA space -- so ``buffer_ptrs`` are ``ccoGetPeerPtr`` results
+and agree with the device-side ``Window.lsa_ptr`` by construction. CCO's communicator is
+created on the first rendezvous of a process group and its unique id travels over torch's
+own Store, so there is no second bootstrap channel to configure::
 
     import torch.distributed._symmetric_memory as symm_mem
     from mori.allocator import register_symm_backend
@@ -44,7 +48,12 @@ for the staged plan.
 
 The handle type is probed per device: fabric where supported, POSIX fd otherwise. gfx9
 (MI300/MI355) has no fabric support -- ``hipMemCreate`` itself reports "operation not
-supported" -- so those fall back to fd, which needs no configuration.
+supported" -- so those fall back to fd, which needs no configuration. The allocation and
+CCO's own export have to agree on that type, since CCO re-exports what it imports.
+
+``MORI_SYMM_PER_RANK_VMM`` sizes the communicator's flat VA reservation (default 4 GiB).
+It is a floor rather than a budget -- CCO quantises it up to 4 GiB -- and it bounds live
+symmetric memory per rank, not allocations over time, because slots are recycled on free.
 
 ``barrier``/``put_signal``/``wait_signal`` are not implemented and raise, so no signal
 pad is reserved in the window -- torch's 9216-byte pad would cost a whole extra 2 MiB page
@@ -71,6 +80,7 @@ rebuilding mori itself.
 import atexit
 import logging
 import os
+from pathlib import Path
 from typing import Literal
 
 __all__ = [
@@ -136,12 +146,20 @@ def _jit_ext():
     }:
         flags.append("-DMORI_SYMM_SIGNAL_PAD=1")
     logger.info("compiling mori_torch_symm from %s", source)
+    # libmori_cco sits in the package directory, wherever mori was installed.
+    pkg = str(Path(__file__).resolve().parent.parent)
     return load(
         name="mori_torch_symm",
         sources=[str(source)],
         extra_include_paths=[str(root / "include"), f"{rocm}/include"],
         extra_cflags=flags,
-        extra_ldflags=[f"-L{rocm}/lib", "-lamdhip64"],
+        extra_ldflags=[
+            f"-L{rocm}/lib",
+            "-lamdhip64",
+            f"-L{pkg}",
+            "-lmori_cco",
+            f"-Wl,-rpath,{pkg}",
+        ],
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -990,15 +990,12 @@ def _torch_symm_extension():
     mode = _torch_symm_mode()
     if mode == "OFF":
         return []
-    # rendezvous() is a cco window now, so the extension links libmori_cco.
-    if not _env_flag("BUILD_CCO", "ON"):
-        if mode == "ON":
-            raise RuntimeError(
-                "BUILD_TORCH_SYMM=ON needs BUILD_CCO=ON: the SymmetricMemory backend "
-                "links libmori_cco"
-            )
-        print("[mori] BUILD_CCO=OFF, so the torch SymmetricMemory backend is skipped")
-        return []
+    # rendezvous() is a cco window now, so the extension links libmori_cco. There is
+    # deliberately no BUILD_CCO check here: that env var is not forwarded to cmake
+    # (only BUILD_CCO_SDMA is), so reading it would gate on a flag that does not
+    # control whether libmori_cco is built. A build that really has no libmori_cco
+    # -- CMAKE_ARGS="-DBUILD_CCO=OFF" -- fails at link, which AUTO already reports
+    # and skips, and which BUILD_TORCH_SYMM=ON already turns into a hard error.
     if _TorchCppExtension is None:
         if mode == "ON":
             raise RuntimeError(

--- a/setup.py
+++ b/setup.py
@@ -1017,14 +1017,7 @@ def _torch_symm_extension():
         library_dirs=[f"{rocm}/lib", str(_root_dir.resolve() / "python" / "mori")],
         libraries=["amdhip64", "c10_hip", "torch_hip", "mori_cco"],
         runtime_library_dirs=["$ORIGIN"],
-        extra_compile_args=["-std=c++17"]
-        # barrier/put_signal/wait_signal are unimplemented, so the signal pad is not
-        # reserved by default; it would cost a whole 2 MiB page on a page-aligned window.
-        + (
-            ["-DMORI_SYMM_SIGNAL_PAD=1"]
-            if _env_flag("MORI_SYMM_SIGNAL_PAD", "OFF")
-            else []
-        ),
+        extra_compile_args=["-std=c++17"],
     )
     ext._mori_torch_ext = True
     return [ext]

--- a/setup.py
+++ b/setup.py
@@ -990,6 +990,15 @@ def _torch_symm_extension():
     mode = _torch_symm_mode()
     if mode == "OFF":
         return []
+    # rendezvous() is a cco window now, so the extension links libmori_cco.
+    if not _env_flag("BUILD_CCO", "ON"):
+        if mode == "ON":
+            raise RuntimeError(
+                "BUILD_TORCH_SYMM=ON needs BUILD_CCO=ON: the SymmetricMemory backend "
+                "links libmori_cco"
+            )
+        print("[mori] BUILD_CCO=OFF, so the torch SymmetricMemory backend is skipped")
+        return []
     if _TorchCppExtension is None:
         if mode == "ON":
             raise RuntimeError(
@@ -1003,8 +1012,11 @@ def _torch_symm_extension():
         name="mori.mori_torch_symm",
         sources=["src/allocator/symm_backend.cpp"],
         include_dirs=[str(_root_dir.resolve() / "include"), f"{rocm}/include"],
-        library_dirs=[f"{rocm}/lib"],
-        libraries=["amdhip64", "c10_hip", "torch_hip"],
+        # libmori_cco is the peer-exchange half of the backend; it lands next to this
+        # module in the package, hence the $ORIGIN runpath.
+        library_dirs=[f"{rocm}/lib", str(_root_dir.resolve() / "python" / "mori")],
+        libraries=["amdhip64", "c10_hip", "torch_hip", "mori_cco"],
+        runtime_library_dirs=["$ORIGIN"],
         extra_compile_args=["-std=c++17"]
         # barrier/put_signal/wait_signal are unimplemented, so the signal pad is not
         # reserved by default; it would cost a whole 2 MiB page on a page-aligned window.

--- a/src/allocator/symm_backend.cpp
+++ b/src/allocator/symm_backend.cpp
@@ -121,8 +121,26 @@ size_t PerRankVmmSize() {
 // reserves the flat VA once, so the two lifetimes do not line up without this.
 struct CcoGroup {
   ccoComm* comm = nullptr;
+
+  // group -> key -> devcomm, the shape torch's NCCL backend uses. A DevComm is
+  // parameterised by ccoDevCommRequirements -- signal counts, QP counts, connection
+  // type -- and those are properties of the algorithm that will run, not of the group,
+  // so two collectives on one group need two of them. NCCL keys this on
+  // __builtin_FUNCTION(); callers here pass the key explicitly.
+  struct DevCommEntry {
+    mori::cco::ccoDevComm host{};
+    mori::cco::ccoDevComm* device = nullptr;  // kernel-argument copy
+  };
+  std::mutex dev_mu;
+  std::unordered_map<std::string, DevCommEntry> dev_comms;
+
   ~CcoGroup() {
-    if (comm && !c10d::symmetric_memory::is_finalizing()) (void)mori::cco::ccoCommDestroy(comm);
+    if (!comm || c10d::symmetric_memory::is_finalizing()) return;
+    for (auto& [key, e] : dev_comms) {
+      if (e.device) mori::cco::ccoDevCommFreeDeviceCopy(e.device);
+      (void)mori::cco::ccoDevCommDestroy(comm, &e.host);
+    }
+    (void)mori::cco::ccoCommDestroy(comm);
   }
 };
 
@@ -502,6 +520,37 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
     }
   }
 
+  // A device communicator for this group, created on first use and cached under `key`.
+  // Deliberately not built during rendezvous: rendezvous knows a buffer and a group, and
+  // nothing about how many signals or QPs the kernel that follows will want.
+  uint64_t DevCommPtr(const std::string& group_name, const std::string& key,
+                      int lsa_barrier_count) {
+    std::shared_ptr<CcoGroup> group;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      auto it = cco_groups_.find(group_name);
+      TORCH_CHECK(it != cco_groups_.end(), "mori symm backend: no communicator for group ",
+                  group_name, ". Have you rendezvoused a tensor with this group?");
+      group = it->second;
+    }
+
+    std::lock_guard<std::mutex> lock(group->dev_mu);
+    auto it = group->dev_comms.find(key);
+    if (it == group->dev_comms.end()) {
+      CcoGroup::DevCommEntry e{};
+      mori::cco::ccoDevCommRequirements reqs = CCO_DEV_COMM_REQUIREMENTS_INITIALIZER;
+      // Intra-node only for now: no RDMA connections, just LSA barriers. Scale-out is
+      // where the caller will need to choose these, which is the reason for the key.
+      reqs.gdaConnectionType = mori::cco::CCO_GDA_CONNECTION_NONE;
+      reqs.lsaBarrierCount = lsa_barrier_count;
+      MORI_CCO_CHECK(mori::cco::ccoDevCommCreate(group->comm, &reqs, &e.host));
+      e.device = mori::cco::ccoDevCommCopyToDevice(&e.host);
+      TORCH_CHECK(e.device != nullptr, "mori symm backend: ccoDevCommCopyToDevice failed");
+      it = group->dev_comms.emplace(key, e).first;
+    }
+    return reinterpret_cast<uint64_t>(it->second.device);
+  }
+
   // The backend-specific escape hatch, keyed by the tensor pointer because torch's
   // handle has nowhere to carry it. Returns the cco window a kernel can address through.
   uint64_t WindowHandle(void* ptr, bool signal_pad) {
@@ -571,6 +620,10 @@ uint64_t WindowHandle(uint64_t data_ptr, bool signal_pad) {
   return AllocatorSingleton()->WindowHandle(reinterpret_cast<void*>(data_ptr), signal_pad);
 }
 
+uint64_t DevCommPtr(const std::string& group_name, const std::string& key, int lsa_barrier_count) {
+  return AllocatorSingleton()->DevCommPtr(group_name, key, lsa_barrier_count);
+}
+
 std::string HandleTypeName(int dev) {
   return ProbeHandleType(dev) == hipMemHandleTypeFabricCompat ? "fabric" : "posix_fd";
 }
@@ -609,5 +662,8 @@ PYBIND11_MODULE(mori_torch_symm, m) {
         "cco window handle for a rendezvous'd tensor (backend-specific; torch's "
         "SymmetricMemory has no slot for it)");
   // The pad is its own cco window now, so it is always there.
+  m.def("dev_comm", &mori::allocator::DevCommPtr, py::arg("group_name"), py::arg("key") = "default",
+        py::arg("lsa_barrier_count") = 1,
+        "device ccoDevComm pointer for a group, cached per (group, key)");
   m.attr("signal_pad_supported") = true;
 }

--- a/src/allocator/symm_backend.cpp
+++ b/src/allocator/symm_backend.cpp
@@ -35,19 +35,21 @@
 // way to map them, but that layout is not part of the API here: exposing it belongs with
 // mori's cco window, which already defines it. See ROCm/mori#557.
 //
-// Handle type is probed per device -- fabric where supported, POSIX fd otherwise (gfx9 has
-// none). Fabric handles are portable bytes and ride the torch Store; fds need SCM_RIGHTS.
+// The peer exchange is CCO's: rendezvous hands the tensor to ccoWindowRegister, which
+// aliases it into the flat LSA space and returns a window. buffer_ptrs are then
+// ccoGetPeerPtr results, so host and device (Window.lsa_ptr) agree by construction.
+// Handle type is still probed per device for the allocation itself -- fabric where
+// supported, POSIX fd otherwise (gfx9 has none).
 
 #include <hip/hip_runtime.h>
 #include <pybind11/pybind11.h>
-#include <sys/socket.h>
-#include <sys/un.h>
 #include <torch/version.h>
 #include <unistd.h>
 
 #include <cstdlib>
 #include <cstring>
 #include <memory>
+#include <mori/cco/cco.hpp>
 #include <mutex>
 #include <string>
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.hpp>
@@ -100,6 +102,37 @@ constexpr size_t kSignalPadBytes = 0;
 #endif
 
 size_t RoundUp(size_t v, size_t m) { return ((v + m - 1) / m) * m; }
+
+using mori::cco::ccoComm;
+using mori::cco::ccoWindow_t;
+
+#define MORI_CCO_CHECK(expr)                                       \
+  do {                                                             \
+    int _rc = (expr);                                              \
+    TORCH_CHECK(_rc == 0, #expr, " failed with cco status ", _rc); \
+  } while (0)
+
+// cco reserves its flat VA once per communicator and quantises the per-rank stride
+// up to 4 GiB, so this is a floor rather than a budget: any request at or below
+// 4 GiB produces the same reservation. It bounds live symmetric memory per rank,
+// not the number of allocations over time -- slots are recycled on free.
+size_t PerRankVmmSize() {
+  static const size_t v = [] {
+    const char* e = getenv("MORI_SYMM_PER_RANK_VMM");
+    return e ? static_cast<size_t>(std::strtoull(e, nullptr, 0)) : (size_t{4} << 30);
+  }();
+  return v;
+}
+
+// One communicator per torch process group, made on the first rendezvous and kept
+// for the process. torch calls rendezvous once per allocation, whereas ccoCommCreate
+// reserves the flat VA once, so the two lifetimes do not line up without this.
+struct CcoGroup {
+  ccoComm* comm = nullptr;
+  ~CcoGroup() {
+    if (comm && !c10d::symmetric_memory::is_finalizing()) (void)mori::cco::ccoCommDestroy(comm);
+  }
+};
 
 // Teardown can run while the HIP runtime is already unwinding, in which case any VMM call
 // segfaults. is_finalizing() catches torch's own shutdown; this catches the rest by
@@ -172,95 +205,11 @@ hipMemAllocationHandleType ProbeHandleType(int dev) {
   return chosen;
 }
 
-// An fd is an index into one process's table, so it needs SCM_RIGHTS. torch has an
-// IpcChannel for this but does not export it, hence this local equivalent.
-class FdChannel {
- public:
-  explicit FdChannel(int rank) : path_(Path(getpid(), rank)) {
-    sock_ = ::socket(AF_UNIX, SOCK_DGRAM, 0);
-    TORCH_CHECK(sock_ >= 0, "mori symm backend: socket() failed");
-    ::unlink(path_.c_str());
-    sockaddr_un addr{};
-    addr.sun_family = AF_UNIX;
-    std::strncpy(addr.sun_path, path_.c_str(), sizeof(addr.sun_path) - 1);
-    TORCH_CHECK(::bind(sock_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0,
-                "mori symm backend: bind(", path_, ") failed");
-  }
-
-  ~FdChannel() {
-    if (sock_ >= 0) ::close(sock_);
-    ::unlink(path_.c_str());
-  }
-
-  static std::string Path(int pid, int rank) {
-    return "/tmp/mori_symm_" + std::to_string(pid) + "_" + std::to_string(rank);
-  }
-
-  // The payload carries the sender's rank: datagrams from different owners can arrive in
-  // any order, so the receiver must not assume one round per owner.
-  void SendFd(const std::string& dst, int fd, int sender_rank) {
-    sockaddr_un addr{};
-    addr.sun_family = AF_UNIX;
-    std::strncpy(addr.sun_path, dst.c_str(), sizeof(addr.sun_path) - 1);
-
-    int tag = sender_rank;
-    iovec iov{&tag, sizeof(tag)};
-    char control[CMSG_SPACE(sizeof(int))] = {};
-    msghdr msg{};
-    msg.msg_name = &addr;
-    msg.msg_namelen = sizeof(addr);
-    msg.msg_iov = &iov;
-    msg.msg_iovlen = 1;
-    msg.msg_control = control;
-    msg.msg_controllen = sizeof(control);
-
-    cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
-    cmsg->cmsg_level = SOL_SOCKET;
-    cmsg->cmsg_type = SCM_RIGHTS;
-    cmsg->cmsg_len = CMSG_LEN(sizeof(int));
-    std::memcpy(CMSG_DATA(cmsg), &fd, sizeof(int));
-
-    // The peer may not have bound yet.
-    ssize_t n = -1;
-    for (int retry = 0; retry < 400 && n < 0; ++retry) {
-      n = ::sendmsg(sock_, &msg, 0);
-      if (n < 0) ::usleep(5000);
-    }
-    TORCH_CHECK(n >= 0, "mori symm backend: sendmsg to ", dst, " failed");
-  }
-
-  // Returns (sender_rank, fd).
-  std::pair<int, int> RecvFd() {
-    int tag = -1;
-    iovec iov{&tag, sizeof(tag)};
-    char control[CMSG_SPACE(sizeof(int))] = {};
-    msghdr msg{};
-    msg.msg_iov = &iov;
-    msg.msg_iovlen = 1;
-    msg.msg_control = control;
-    msg.msg_controllen = sizeof(control);
-
-    TORCH_CHECK(::recvmsg(sock_, &msg, 0) >= 0, "mori symm backend: recvmsg failed");
-    cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
-    TORCH_CHECK(cmsg && cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS,
-                "mori symm backend: no SCM_RIGHTS in received message");
-    int fd = -1;
-    std::memcpy(&fd, CMSG_DATA(cmsg), sizeof(int));
-    return {tag, fd};
-  }
-
- private:
-  std::string path_;
-  int sock_ = -1;
-};
-
-// What each rank publishes through the torch Store.
-struct RendezvousReq {
+// All that still crosses the Store here: the size agreement torch requires. The
+// handle exchange that used to live in this struct is ccoWindowRegister's job now.
+struct SizeCheck {
   size_t alloc_size;
   size_t buffer_size;
-  int device_idx;
-  int pid;
-  hipMemFabricHandle_compat_t fabric;  // meaningful only on the fabric path
 };
 
 struct Block {
@@ -270,16 +219,9 @@ struct Block {
   int device_idx = 0;
   hipMemGenericAllocationHandle_t handle{};
   hipMemAllocationHandleType handle_type = hipMemHandleTypePosixFileDescriptor;
-  int export_fd = -1;  // closed in free(), after hipMemRelease -- see the fd-lifetime note below
   std::optional<std::string> default_group_name;
   c10::intrusive_ptr<SymmetricMemory> symm;
 };
-
-// ROCm 7.14 ties a shareable fd's lifetime to the allocation it names: the fd must not
-// be closed until after hipMemRelease of that handle. Close it earlier and the physical
-// memory is never returned -- measured at a full allocation leaked per export. Closing it
-// before the mapping is granted is worse still: hipMemSetAccess then fails outright.
-// ROCm 7.2 cared about neither, which is why both only surfaced once CI ran this.
 
 constexpr const char* kNoSignalPad =
     "Signal-pad support is compiled out (MORI_SYMM_SIGNAL_PAD=0), so no pad is reserved "
@@ -287,26 +229,24 @@ constexpr const char* kNoSignalPad =
 
 class MoriSymmetricMemory : public SymmetricMemory {
  public:
-  MoriSymmetricMemory(char* flat_base, size_t span, size_t stride, size_t buffer_size,
-                      std::vector<hipMemGenericAllocationHandle_t> handles,
-                      std::vector<int> peer_fds, int rank, int world_size, int device_idx)
-      : flat_base_(flat_base),
-        span_(span),
-        stride_(stride),
+  MoriSymmetricMemory(std::shared_ptr<CcoGroup> group, ccoWindow_t win, void* local_ptr,
+                      std::vector<void*> buffers, size_t buffer_size, int rank, int world_size,
+                      int device_idx)
+      : group_(std::move(group)),
+        win_(win),
+        local_ptr_(local_ptr),
+        buffers_(std::move(buffers)),
         buffer_size_(buffer_size),
-        handles_(std::move(handles)),
-        peer_fds_(std::move(peer_fds)),
         rank_(rank),
         world_size_(world_size),
         device_(c10::DeviceType::CUDA, device_idx) {
     rank_to_global_rank_.resize(world_size_);
-    buffers_.reserve(world_size_);
     signal_pads_.reserve(world_size_);
     for (int r = 0; r < world_size_; ++r) {
       rank_to_global_rank_[r] = r;
-      char* slot = flat_base_ + static_cast<size_t>(r) * stride_;
-      buffers_.push_back(slot);
-      signal_pads_.push_back(kSignalPadBytes ? slot + buffer_size_ : nullptr);
+      signal_pads_.push_back(kSignalPadBytes && buffers_[r]
+                                 ? static_cast<char*>(buffers_[r]) + buffer_size_
+                                 : nullptr);
     }
 
     const size_t arr = world_size_ * sizeof(void*);
@@ -323,23 +263,18 @@ class MoriSymmetricMemory : public SymmetricMemory {
 
   ~MoriSymmetricMemory() override {
     if (!RuntimeUsable()) return;  // leak rather than crash on the way out
-    // Usually reached from free(), which has already synchronised; not when a Python
-    // reference outlived the tensor. Sync on the window's own device either way.
     DeviceGuard guard(device_.index());
     (void)hipDeviceSynchronize();
     if (buffers_dev_) (void)hipFree(buffers_dev_);
     if (signal_pads_dev_) (void)hipFree(signal_pads_dev_);
     if (rank_to_global_rank_dev_) (void)hipFree(rank_to_global_rank_dev_);
-    for (int r = 0; r < world_size_; ++r) {
-      (void)hipMemUnmap(flat_base_ + static_cast<size_t>(r) * stride_, stride_);
-      // handles_[rank_] is the Block's own handle, borrowed for the self slot. The
-      // allocator's free() releases it, and releasing it twice segfaults.
-      if (r != rank_) {
-        (void)hipMemRelease(handles_[r]);
-        if (r < static_cast<int>(peer_fds_.size()) && peer_fds_[r] >= 0) ::close(peer_fds_[r]);
-      }
+    // Purely local: ccoWindowDeregister unmaps this rank's view of its peers and
+    // drops the handles it imported, with no collective inside. That is what lets
+    // torch tensors die in whatever order Python's GC picks.
+    if (group_ && group_->comm) {
+      (void)mori::cco::ccoWindowDeregister(group_->comm, win_);
+      (void)mori::cco::ccoMemFree(group_->comm, local_ptr_);
     }
-    (void)hipMemAddressFree(flat_base_, span_);
   }
 
   std::vector<void*> get_buffer_ptrs() override { return buffers_; }
@@ -393,12 +328,10 @@ class MoriSymmetricMemory : public SymmetricMemory {
   }
 
  private:
-  char* flat_base_;
-  size_t span_;
-  size_t stride_;
+  std::shared_ptr<CcoGroup> group_;  // keeps the communicator alive for this window
+  ccoWindow_t win_;
+  void* local_ptr_;  // cco's flat-VA alias of the torch tensor
   size_t buffer_size_;
-  std::vector<hipMemGenericAllocationHandle_t> handles_;
-  std::vector<int> peer_fds_;  // outlive their handles; see the note above
   int rank_;
   int world_size_;
   c10::Device device_;
@@ -460,13 +393,15 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
     // rather than in the window's destructor, which a never-rendezvous'd block has none of.
     DeviceGuard guard(block->device_idx);
     (void)hipDeviceSynchronize();
-    // Drop the window first: its self slot maps this same handle, so the mapping has to
-    // go before the release below. Relying on ~Block to do it later would reverse that.
-    block->symm.reset();
+    // Our own reference goes first, the window second. cco exported this allocation to
+    // a shareable fd when it imported it, and closes that fd inside ccoMemFree; on
+    // ROCm 7.14 the fd has to outlive every hipMemRelease of the allocation it names,
+    // ours included, or the physical memory is never returned. cco's retained handle
+    // keeps the allocation alive across these three calls.
     (void)hipMemUnmap(block->ptr, block->alloc_size);
     (void)hipMemAddressFree(block->ptr, block->alloc_size);
     (void)hipMemRelease(block->handle);
-    if (block->export_fd >= 0) ::close(block->export_fd);
+    block->symm.reset();
   }
 
   size_t get_alloc_size(void* ptr) override {
@@ -489,87 +424,42 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
     const int world_size = info.world_size;
 
     DeviceGuard guard(block->device_idx);
-    const bool use_fabric = (block->handle_type == hipMemHandleTypeFabricCompat);
 
-    RendezvousReq local{};
-    local.alloc_size = block->alloc_size;
-    local.buffer_size = block->buffer_size;
-    local.device_idx = block->device_idx;
-    local.pid = getpid();
-    if (use_fabric) {
-      MORI_HIP_CHECK(hipMemExportToShareableHandle(&local.fabric, block->handle,
-                                                   hipMemHandleTypeFabricCompat, 0));
-    }
-    auto reqs = store_exchange_.all_gather(info.store, rank, world_size, local);
+    // torch's contract is that every rank hands in the same size. cco's register is
+    // collective and would deadlock or mismap on a mismatch, so say so first.
+    SizeCheck local{block->alloc_size, block->buffer_size};
+    auto sizes = store_exchange_.all_gather(info.store, rank, world_size, local);
     for (int r = 0; r < world_size; ++r) {
       TORCH_CHECK(
-          reqs[r].alloc_size == local.alloc_size && reqs[r].buffer_size == local.buffer_size,
-          "mori symm backend: rank ", r, " allocated ", reqs[r].buffer_size,
-          " bytes but this rank "
-          "allocated ",
-          local.buffer_size, "; symm_mem.empty must be symmetric across ranks");
+          sizes[r].alloc_size == local.alloc_size && sizes[r].buffer_size == local.buffer_size,
+          "mori symm backend: rank ", r, " allocated ", sizes[r].buffer_size,
+          " bytes but this rank allocated ", local.buffer_size,
+          "; symm_mem.empty must be symmetric across ranks");
     }
 
-    const size_t stride = block->alloc_size;
-    const size_t span = static_cast<size_t>(world_size) * stride;
-    auto prop = MakeProp(block->device_idx, block->handle_type);
-    size_t gran = 0;
-    MORI_HIP_CHECK(
-        hipMemGetAllocationGranularity(&gran, &prop, hipMemAllocationGranularityRecommended));
+    auto group = GetOrCreateGroup(*name, info);
 
-    void* flat = nullptr;
-    MORI_HIP_CHECK(hipMemAddressReserve(&flat, span, gran, nullptr, 0));
-    auto map_slot = [&](int r, hipMemGenericAllocationHandle_t h) {
-      char* slot = static_cast<char*>(flat) + static_cast<size_t>(r) * stride;
-      MORI_HIP_CHECK(hipMemMap(slot, stride, 0, h, 0));
-      SetRwAccess(slot, stride, block->device_idx);
-    };
+    // Overload C: retain the tensor's VMM handle, alias it into the flat LSA slot,
+    // and register the window. No copy, and no second peer exchange of our own --
+    // this is the exchange the backend used to hand-roll over SCM_RIGHTS.
+    ccoWindow_t win{};
+    void* local_ptr = nullptr;
+    MORI_CCO_CHECK(
+        mori::cco::ccoWindowRegister(group->comm, block->ptr, block->alloc_size, &win, &local_ptr));
 
-    std::vector<hipMemGenericAllocationHandle_t> handles(world_size);
-    std::vector<int> peer_fds(world_size, -1);
-
-    // A second alias of our own allocation, so the stride is uniform across all ranks.
-    // The handle is borrowed from the Block rather than retained: one owner, one release.
-    handles[rank] = block->handle;
-    map_slot(rank, handles[rank]);
-
-    if (use_fabric) {
-      for (int r = 0; r < world_size; ++r) {
-        if (r == rank) continue;
-        MORI_HIP_CHECK(hipMemImportFromShareableHandle(&handles[r], &reqs[r].fabric,
-                                                       hipMemHandleTypeFabricCompat));
-        map_slot(r, handles[r]);
-      }
-    } else {
-      // Send ours to everyone, then take world-1 fds in whatever order they land.
-      FdChannel chan(rank);
-      int fd = -1;
-      MORI_HIP_CHECK(hipMemExportToShareableHandle(&fd, block->handle,
-                                                   hipMemHandleTypePosixFileDescriptor, 0));
-      for (int peer = 0; peer < world_size; ++peer) {
-        if (peer != rank) chan.SendFd(FdChannel::Path(reqs[peer].pid, peer), fd, rank);
-      }
-      block->export_fd = fd;  // closed by free(), after the release
-
-      for (int i = 0; i < world_size - 1; ++i) {
-        auto [owner, peer_fd] = chan.RecvFd();
-        TORCH_CHECK(owner >= 0 && owner < world_size && owner != rank,
-                    "mori symm backend: bad owner tag ", owner, " in fd exchange");
-        MORI_HIP_CHECK(hipMemImportFromShareableHandle(
-            &handles[owner], reinterpret_cast<void*>(static_cast<intptr_t>(peer_fd)),
-            hipMemHandleTypePosixFileDescriptor));
-        // Close only after the handle is mapped and granted. ROCm 7.14 still needs the fd
-        // until then: closing first leaves a handle that imports and maps fine but whose
-        // hipMemSetAccess fails with "invalid argument". ROCm 7.2 did not care, which is
-        // why this stayed invisible until CI began running the backend.
-        map_slot(owner, handles[owner]);
-        peer_fds[owner] = peer_fd;
-      }
+    // buffer_ptrs is now one source of truth with the device-side lsa_ptr: both are
+    // flatBase + peerLsaRank*stride + slotOffset. A peer outside the LSA team comes
+    // back null, which is how a scale-out window will report unreachable peers.
+    std::vector<void*> buffers(world_size);
+    for (int r = 0; r < world_size; ++r) {
+      buffers[r] = mori::cco::ccoGetPeerPtr(group->comm, local_ptr, r);
+      TORCH_CHECK(buffers[r] != nullptr, "mori symm backend: rank ", r,
+                  " is not reachable by load/store; this backend is single-node only");
     }
 
-    auto symm = c10::make_intrusive<MoriSymmetricMemory>(
-        static_cast<char*>(flat), span, stride, block->buffer_size, std::move(handles),
-        std::move(peer_fds), rank, world_size, block->device_idx);
+    auto symm = c10::make_intrusive<MoriSymmetricMemory>(group, win, local_ptr, std::move(buffers),
+                                                         block->buffer_size, rank, world_size,
+                                                         block->device_idx);
     block->symm = symm;
     return symm;
   }
@@ -595,7 +485,6 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
       (void)hipMemUnmap(block->ptr, block->alloc_size);
       (void)hipMemAddressFree(block->ptr, block->alloc_size);
       (void)hipMemRelease(block->handle);
-      if (block->export_fd >= 0) ::close(block->export_fd);
     }
   }
 
@@ -605,9 +494,38 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
     return it == blocks_.end() ? nullptr : it->second;
   }
 
+  // One communicator per group, built on first use. The uid rides torch's own
+  // Store, so cco's rendezvous needs no second bootstrap channel.
+  std::shared_ptr<CcoGroup> GetOrCreateGroup(const std::string& name,
+                                             const c10d::symmetric_memory::GroupInfo& info) {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      auto it = cco_groups_.find(name);
+      if (it != cco_groups_.end()) return it->second;
+    }
+
+    mori::cco::ccoUniqueId uid{};
+    if (info.rank == 0) MORI_CCO_CHECK(mori::cco::ccoGetUniqueId(&uid));
+    auto ids = store_exchange_.all_gather(info.store, info.rank, info.world_size, uid);
+
+    auto group = std::make_shared<CcoGroup>();
+    MORI_CCO_CHECK(mori::cco::ccoCommCreate(ids[0], info.world_size, info.rank, PerRankVmmSize(),
+                                            &group->comm));
+    // ccoCommCreate leaves a tolerated probe failure latched in HIP's per-thread
+    // sticky slot. torch checks that slot around every launch, so without this the
+    // caller's next kernel is blamed for it. Consuming it here, at the call site that
+    // caused it, is the narrow form -- not a blanket clear at the Python boundary.
+    (void)hipGetLastError();
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto [it, inserted] = cco_groups_.emplace(name, std::move(group));
+    return it->second;
+  }
+
  private:
   std::mutex mutex_;
   std::unordered_map<void*, std::shared_ptr<Block>> blocks_;
+  std::unordered_map<std::string, std::shared_ptr<CcoGroup>> cco_groups_;
   c10d::symmetric_memory::StoreExchange store_exchange_{"mori_symm_backend"};
 };
 

--- a/src/allocator/symm_backend.cpp
+++ b/src/allocator/symm_backend.cpp
@@ -41,6 +41,7 @@
 // Handle type is still probed per device for the allocation itself -- fabric where
 // supported, POSIX fd otherwise (gfx9 has none).
 
+#include <c10/hip/HIPStream.h>
 #include <hip/hip_runtime.h>
 #include <pybind11/pybind11.h>
 #include <torch/version.h>
@@ -86,20 +87,11 @@ using c10d::symmetric_memory::SymmetricMemoryAllocator;
     TORCH_CHECK(_e == hipSuccess, #expr, " failed: ", hipGetErrorString(_e)); \
   } while (0)
 
-// Match torch's signal pad size so layouts stay comparable across backends.
-// Signal-pad support. barrier()/put_signal()/wait_signal() are unimplemented, so by
-// default no pad is reserved: the ops report unsupported and every window costs exactly
-// its buffer. Physical backing is 2 MiB-paged, so a 9216 B pad appended to a page-aligned
-// request costs a whole extra page -- 2 MiB on a 64 MiB window. Build with
-// -DMORI_SYMM_SIGNAL_PAD=1 to reserve torch's pad once the ops exist.
-#ifndef MORI_SYMM_SIGNAL_PAD
-#define MORI_SYMM_SIGNAL_PAD 0
-#endif
-#if MORI_SYMM_SIGNAL_PAD
+// torch's signal pad size. It gets its own cco allocation and window rather than being
+// appended to the user's buffer, which is what NCCL's backend does too: appending 9216 B
+// to a page-aligned request cost a whole extra 2 MiB page, and that cost is why the pad
+// used to be compiled out.
 constexpr size_t kSignalPadBytes = 9216;
-#else
-constexpr size_t kSignalPadBytes = 0;
-#endif
 
 size_t RoundUp(size_t v, size_t m) { return ((v + m - 1) / m) * m; }
 
@@ -223,39 +215,31 @@ struct Block {
   c10::intrusive_ptr<SymmetricMemory> symm;
 };
 
-constexpr const char* kNoSignalPad =
-    "Signal-pad support is compiled out (MORI_SYMM_SIGNAL_PAD=0), so no pad is reserved "
-    "in the window; rebuild with -DMORI_SYMM_SIGNAL_PAD=1 to allocate it.";
-
 class MoriSymmetricMemory : public SymmetricMemory {
  public:
   MoriSymmetricMemory(std::shared_ptr<CcoGroup> group, ccoWindow_t win, void* local_ptr,
-                      std::vector<void*> buffers, size_t buffer_size, int rank, int world_size,
+                      ccoWindow_t pad_win, void* pad_ptr, std::vector<void*> buffers,
+                      std::vector<void*> signal_pads, size_t buffer_size, int rank, int world_size,
                       int device_idx)
       : group_(std::move(group)),
         win_(win),
         local_ptr_(local_ptr),
+        pad_win_(pad_win),
+        pad_ptr_(pad_ptr),
         buffers_(std::move(buffers)),
+        signal_pads_(std::move(signal_pads)),
         buffer_size_(buffer_size),
         rank_(rank),
         world_size_(world_size),
         device_(c10::DeviceType::CUDA, device_idx) {
     rank_to_global_rank_.resize(world_size_);
-    signal_pads_.reserve(world_size_);
-    for (int r = 0; r < world_size_; ++r) {
-      rank_to_global_rank_[r] = r;
-      signal_pads_.push_back(kSignalPadBytes && buffers_[r]
-                                 ? static_cast<char*>(buffers_[r]) + buffer_size_
-                                 : nullptr);
-    }
+    for (int r = 0; r < world_size_; ++r) rank_to_global_rank_[r] = r;
 
     const size_t arr = world_size_ * sizeof(void*);
     MORI_HIP_CHECK(hipMalloc(&buffers_dev_, arr));
     MORI_HIP_CHECK(hipMemcpy(buffers_dev_, buffers_.data(), arr, hipMemcpyHostToDevice));
-    if (kSignalPadBytes) {
-      MORI_HIP_CHECK(hipMalloc(&signal_pads_dev_, arr));
-      MORI_HIP_CHECK(hipMemcpy(signal_pads_dev_, signal_pads_.data(), arr, hipMemcpyHostToDevice));
-    }
+    MORI_HIP_CHECK(hipMalloc(&signal_pads_dev_, arr));
+    MORI_HIP_CHECK(hipMemcpy(signal_pads_dev_, signal_pads_.data(), arr, hipMemcpyHostToDevice));
     MORI_HIP_CHECK(hipMalloc(&rank_to_global_rank_dev_, world_size_ * sizeof(int)));
     MORI_HIP_CHECK(hipMemcpy(rank_to_global_rank_dev_, rank_to_global_rank_.data(),
                              world_size_ * sizeof(int), hipMemcpyHostToDevice));
@@ -272,21 +256,17 @@ class MoriSymmetricMemory : public SymmetricMemory {
     // drops the handles it imported, with no collective inside. That is what lets
     // torch tensors die in whatever order Python's GC picks.
     if (group_ && group_->comm) {
+      (void)mori::cco::ccoWindowDeregister(group_->comm, pad_win_);
+      (void)mori::cco::ccoMemFree(group_->comm, pad_ptr_);
       (void)mori::cco::ccoWindowDeregister(group_->comm, win_);
       (void)mori::cco::ccoMemFree(group_->comm, local_ptr_);
     }
   }
 
   std::vector<void*> get_buffer_ptrs() override { return buffers_; }
-  std::vector<void*> get_signal_pad_ptrs() override {
-    TORCH_CHECK(kSignalPadBytes != 0, kNoSignalPad);
-    return signal_pads_;
-  }
+  std::vector<void*> get_signal_pad_ptrs() override { return signal_pads_; }
   void** get_buffer_ptrs_dev() override { return buffers_dev_; }
-  void** get_signal_pad_ptrs_dev() override {
-    TORCH_CHECK(kSignalPadBytes != 0, kNoSignalPad);
-    return signal_pads_dev_;
-  }
+  void** get_signal_pad_ptrs_dev() override { return signal_pads_dev_; }
   size_t get_buffer_size() override { return buffer_size_; }
   size_t get_offset() override { return 0; }
   // Every alloc() is its own VMM allocation, so torch's storage starts at the window
@@ -311,26 +291,50 @@ class MoriSymmetricMemory : public SymmetricMemory {
   const std::vector<int>& get_rank_to_global_rank() override { return rank_to_global_rank_; }
   int* get_rank_to_global_rank_dev() override { return rank_to_global_rank_dev_; }
 
-  // Every rank is mapped for load/store; there is no RDMA fallback in this backend.
-  bool world_within_direct_access() override { return true; }
-
-  void barrier(int, size_t) override {
-    TORCH_CHECK(false,
-                "mori symm backend: barrier is not implemented; synchronise on the "
-                "host with dist.barrier() for now. ",
-                kNoSignalPad);
+  // True only if cco mapped every peer. A null entry means that rank needs RDMA, which
+  // this backend cannot drive yet -- but reporting it honestly is what lets torch fall
+  // back rather than dereference a null pointer.
+  bool world_within_direct_access() override {
+    for (void* p : buffers_)
+      if (p == nullptr) return false;
+    return true;
   }
+
+  // cco's barrier is a host collective, while torch's is meant to be stream-ordered,
+  // so the current stream is drained first. That makes this stronger than asked for --
+  // every rank's prior GPU work is complete before any rank returns -- and heavier.
+  // A device-side barrier belongs with a DevComm, which this backend does not own yet.
+  void barrier(int channel, size_t /*timeout_ms*/) override {
+    TORCH_CHECK(channel == 0,
+                "mori symm backend: only channel 0 exists; cco's barrier is comm-wide");
+    TORCH_CHECK(group_ && group_->comm, "mori symm backend: window has no communicator");
+    DeviceGuard guard(device_.index());
+    MORI_HIP_CHECK(hipStreamSynchronize(c10::hip::getCurrentHIPStream()));
+    MORI_CCO_CHECK(mori::cco::ccoBarrierAll(group_->comm));
+  }
+
+  // Point-to-point signalling needs cco signals, which live on a ccoDevComm that this
+  // backend does not create yet. torch's own collectives do not call these -- they
+  // synchronise through the signal pad above.
   void put_signal(int, int, size_t) override {
-    TORCH_CHECK(false, "mori symm backend: put_signal is not implemented. ", kNoSignalPad);
+    TORCH_CHECK(false, "mori symm backend: put_signal is not implemented yet");
   }
   void wait_signal(int, int, size_t) override {
-    TORCH_CHECK(false, "mori symm backend: wait_signal is not implemented. ", kNoSignalPad);
+    TORCH_CHECK(false, "mori symm backend: wait_signal is not implemented yet");
   }
+
+  // Backend-specific, deliberately not part of torch's interface -- the same shape as
+  // NCCLSymmetricMemory::get_window(). A kernel that wants flat-VA addressing takes the
+  // window and calls cco's device API on it instead of walking buffer_ptrs.
+  ccoWindow_t get_window() const { return win_; }
+  ccoWindow_t get_signal_pad_window() const { return pad_win_; }
 
  private:
   std::shared_ptr<CcoGroup> group_;  // keeps the communicator alive for this window
   ccoWindow_t win_;
   void* local_ptr_;  // cco's flat-VA alias of the torch tensor
+  ccoWindow_t pad_win_;
+  void* pad_ptr_;  // the signal pad: cco's own allocation, not part of the tensor
   size_t buffer_size_;
   int rank_;
   int world_size_;
@@ -353,7 +357,7 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
     size_t gran = 0;
     MORI_HIP_CHECK(
         hipMemGetAllocationGranularity(&gran, &prop, hipMemAllocationGranularityRecommended));
-    const size_t alloc_size = RoundUp(size + kSignalPadBytes, gran);
+    const size_t alloc_size = RoundUp(size, gran);
 
     hipMemGenericAllocationHandle_t handle{};
     MORI_HIP_CHECK(hipMemCreate(&handle, alloc_size, &prop, 0));
@@ -447,19 +451,29 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
     MORI_CCO_CHECK(
         mori::cco::ccoWindowRegister(group->comm, block->ptr, block->alloc_size, &win, &local_ptr));
 
+    // torch's signal pad, as its own allocation and window rather than a tail on the
+    // user's buffer. cco owns this one outright, so it is overload B.
+    void* pad_ptr = nullptr;
+    MORI_CCO_CHECK(mori::cco::ccoMemAlloc(group->comm, kSignalPadBytes, &pad_ptr));
+    MORI_HIP_CHECK(hipMemset(pad_ptr, 0, kSignalPadBytes));
+    ccoWindow_t pad_win{};
+    MORI_CCO_CHECK(mori::cco::ccoWindowRegister(group->comm, pad_ptr, kSignalPadBytes, &pad_win));
+
     // buffer_ptrs is now one source of truth with the device-side lsa_ptr: both are
-    // flatBase + peerLsaRank*stride + slotOffset. A peer outside the LSA team comes
-    // back null, which is how a scale-out window will report unreachable peers.
-    std::vector<void*> buffers(world_size);
+    // flatBase + peerLsaRank*stride + slotOffset. A peer outside the LSA team comes back
+    // null, and that is left as null on purpose -- it is how torch's own backends report
+    // a peer that has to be reached by RDMA rather than by load/store.
+    std::vector<void*> buffers(world_size), pads(world_size);
     for (int r = 0; r < world_size; ++r) {
       buffers[r] = mori::cco::ccoGetPeerPtr(group->comm, local_ptr, r);
-      TORCH_CHECK(buffers[r] != nullptr, "mori symm backend: rank ", r,
-                  " is not reachable by load/store; this backend is single-node only");
+      pads[r] = mori::cco::ccoGetPeerPtr(group->comm, pad_ptr, r);
     }
+    TORCH_CHECK(buffers[rank] != nullptr,
+                "mori symm backend: cco did not map this rank's own window");
 
-    auto symm = c10::make_intrusive<MoriSymmetricMemory>(group, win, local_ptr, std::move(buffers),
-                                                         block->buffer_size, rank, world_size,
-                                                         block->device_idx);
+    auto symm = c10::make_intrusive<MoriSymmetricMemory>(
+        group, win, local_ptr, pad_win, pad_ptr, std::move(buffers), std::move(pads),
+        block->buffer_size, rank, world_size, block->device_idx);
     block->symm = symm;
     return symm;
   }
@@ -486,6 +500,18 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
       (void)hipMemAddressFree(block->ptr, block->alloc_size);
       (void)hipMemRelease(block->handle);
     }
+  }
+
+  // The backend-specific escape hatch, keyed by the tensor pointer because torch's
+  // handle has nowhere to carry it. Returns the cco window a kernel can address through.
+  uint64_t WindowHandle(void* ptr, bool signal_pad) {
+    auto block = FindBlock(ptr);
+    TORCH_CHECK(block != nullptr, "mori symm backend: pointer is not a mori allocation");
+    TORCH_CHECK(block->symm != nullptr,
+                "mori symm backend: rendezvous this tensor before asking for its window");
+    auto* mem = static_cast<MoriSymmetricMemory*>(block->symm.get());
+    return reinterpret_cast<uint64_t>(signal_pad ? mem->get_signal_pad_window()
+                                                 : mem->get_window());
   }
 
   std::shared_ptr<Block> FindBlock(void* ptr) {
@@ -541,6 +567,10 @@ c10::intrusive_ptr<MoriSymmAllocator>& AllocatorSingleton() {
 
 void Shutdown() { AllocatorSingleton()->Shutdown(); }
 
+uint64_t WindowHandle(uint64_t data_ptr, bool signal_pad) {
+  return AllocatorSingleton()->WindowHandle(reinterpret_cast<void*>(data_ptr), signal_pad);
+}
+
 std::string HandleTypeName(int dev) {
   return ProbeHandleType(dev) == hipMemHandleTypeFabricCompat ? "fabric" : "posix_fd";
 }
@@ -560,6 +590,8 @@ void RegisterTorchSymmBackend() {
 }  // namespace mori
 
 // Importing the extension registers the backend.
+namespace py = pybind11;
+
 PYBIND11_MODULE(mori_torch_symm, m) {
   mori::allocator::RegisterTorchSymmBackend();
   m.def("register_backend", &mori::allocator::RegisterTorchSymmBackend,
@@ -572,5 +604,10 @@ PYBIND11_MODULE(mori_torch_symm, m) {
   // Whether the window carries torch's signal pad. False by default, and then anything
   // that synchronises on the device -- barrier(), put/wait_signal(), and torch's own
   // symm_mem collectives, which barrier internally -- raises instead.
-  m.attr("signal_pad_supported") = mori::allocator::kSignalPadBytes != 0;
+  m.def("window_handle", &mori::allocator::WindowHandle, py::arg("data_ptr"),
+        py::arg("signal_pad") = false,
+        "cco window handle for a rendezvous'd tensor (backend-specific; torch's "
+        "SymmetricMemory has no slot for it)");
+  // The pad is its own cco window now, so it is always there.
+  m.attr("signal_pad_supported") = true;
 }

--- a/src/allocator/symm_backend.cpp
+++ b/src/allocator/symm_backend.cpp
@@ -53,6 +53,7 @@
 #include <mori/cco/cco.hpp>
 #include <mutex>
 #include <string>
+#include <torch/csrc/distributed/c10d/GroupRegistry.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp>
 #include <unordered_map>
@@ -441,16 +442,21 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
     auto name = group_name.has_value() ? group_name : block->default_group_name;
     TORCH_CHECK(name.has_value(),
                 "mori symm backend: group_name given neither at allocation nor rendezvous");
-    auto& info = c10d::symmetric_memory::get_group_info(*name);
-    const int rank = info.rank;
-    const int world_size = info.world_size;
+    // Resolve the process group directly rather than going through torch's GroupInfo
+    // registry. That registry is only ever populated by enable_symm_mem_for_group(),
+    // which torch has deprecated -- and torch's own CUDA and NCCL backends both take
+    // this route instead, so callers no longer have to make that deprecated call.
+    auto group = c10d::resolve_process_group(*name);
+    const int rank = group->getRank();
+    const int world_size = group->getSize();
+    auto store = group->getStore();
 
     DeviceGuard guard(block->device_idx);
 
     // torch's contract is that every rank hands in the same size. cco's register is
     // collective and would deadlock or mismap on a mismatch, so say so first.
     SizeCheck local{block->alloc_size, block->buffer_size};
-    auto sizes = store_exchange_.all_gather(info.store, rank, world_size, local);
+    auto sizes = store_exchange_.all_gather(store, rank, world_size, local);
     for (int r = 0; r < world_size; ++r) {
       TORCH_CHECK(
           sizes[r].alloc_size == local.alloc_size && sizes[r].buffer_size == local.buffer_size,
@@ -459,23 +465,24 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
           "; symm_mem.empty must be symmetric across ranks");
     }
 
-    auto group = GetOrCreateGroup(*name, info);
+    auto cco_group = GetOrCreateGroup(*name, store, rank, world_size);
 
     // Overload C: retain the tensor's VMM handle, alias it into the flat LSA slot,
     // and register the window. No copy, and no second peer exchange of our own --
     // this is the exchange the backend used to hand-roll over SCM_RIGHTS.
     ccoWindow_t win{};
     void* local_ptr = nullptr;
-    MORI_CCO_CHECK(
-        mori::cco::ccoWindowRegister(group->comm, block->ptr, block->alloc_size, &win, &local_ptr));
+    MORI_CCO_CHECK(mori::cco::ccoWindowRegister(cco_group->comm, block->ptr, block->alloc_size,
+                                                &win, &local_ptr));
 
     // torch's signal pad, as its own allocation and window rather than a tail on the
     // user's buffer. cco owns this one outright, so it is overload B.
     void* pad_ptr = nullptr;
-    MORI_CCO_CHECK(mori::cco::ccoMemAlloc(group->comm, kSignalPadBytes, &pad_ptr));
+    MORI_CCO_CHECK(mori::cco::ccoMemAlloc(cco_group->comm, kSignalPadBytes, &pad_ptr));
     MORI_HIP_CHECK(hipMemset(pad_ptr, 0, kSignalPadBytes));
     ccoWindow_t pad_win{};
-    MORI_CCO_CHECK(mori::cco::ccoWindowRegister(group->comm, pad_ptr, kSignalPadBytes, &pad_win));
+    MORI_CCO_CHECK(
+        mori::cco::ccoWindowRegister(cco_group->comm, pad_ptr, kSignalPadBytes, &pad_win));
 
     // buffer_ptrs is now one source of truth with the device-side lsa_ptr: both are
     // flatBase + peerLsaRank*stride + slotOffset. A peer outside the LSA team comes back
@@ -483,14 +490,14 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
     // a peer that has to be reached by RDMA rather than by load/store.
     std::vector<void*> buffers(world_size), pads(world_size);
     for (int r = 0; r < world_size; ++r) {
-      buffers[r] = mori::cco::ccoGetPeerPtr(group->comm, local_ptr, r);
-      pads[r] = mori::cco::ccoGetPeerPtr(group->comm, pad_ptr, r);
+      buffers[r] = mori::cco::ccoGetPeerPtr(cco_group->comm, local_ptr, r);
+      pads[r] = mori::cco::ccoGetPeerPtr(cco_group->comm, pad_ptr, r);
     }
     TORCH_CHECK(buffers[rank] != nullptr,
                 "mori symm backend: cco did not map this rank's own window");
 
     auto symm = c10::make_intrusive<MoriSymmetricMemory>(
-        group, win, local_ptr, pad_win, pad_ptr, std::move(buffers), std::move(pads),
+        cco_group, win, local_ptr, pad_win, pad_ptr, std::move(buffers), std::move(pads),
         block->buffer_size, rank, world_size, block->device_idx);
     block->symm = symm;
     return symm;
@@ -572,7 +579,8 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
   // One communicator per group, built on first use. The uid rides torch's own
   // Store, so cco's rendezvous needs no second bootstrap channel.
   std::shared_ptr<CcoGroup> GetOrCreateGroup(const std::string& name,
-                                             const c10d::symmetric_memory::GroupInfo& info) {
+                                             const c10::intrusive_ptr<c10d::Store>& store, int rank,
+                                             int world_size) {
     {
       std::lock_guard<std::mutex> lock(mutex_);
       auto it = cco_groups_.find(name);
@@ -580,12 +588,12 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
     }
 
     mori::cco::ccoUniqueId uid{};
-    if (info.rank == 0) MORI_CCO_CHECK(mori::cco::ccoGetUniqueId(&uid));
-    auto ids = store_exchange_.all_gather(info.store, info.rank, info.world_size, uid);
+    if (rank == 0) MORI_CCO_CHECK(mori::cco::ccoGetUniqueId(&uid));
+    auto ids = store_exchange_.all_gather(store, rank, world_size, uid);
 
     auto group = std::make_shared<CcoGroup>();
-    MORI_CCO_CHECK(mori::cco::ccoCommCreate(ids[0], info.world_size, info.rank, PerRankVmmSize(),
-                                            &group->comm));
+    MORI_CCO_CHECK(
+        mori::cco::ccoCommCreate(ids[0], world_size, rank, PerRankVmmSize(), &group->comm));
     // ccoCommCreate leaves a tolerated probe failure latched in HIP's per-thread
     // sticky slot. torch checks that slot around every launch, so without this the
     // caller's next kernel is blamed for it. Consuming it here, at the call site that

--- a/src/allocator/symm_backend.cpp
+++ b/src/allocator/symm_backend.cpp
@@ -89,11 +89,16 @@ using c10d::symmetric_memory::SymmetricMemoryAllocator;
     TORCH_CHECK(_e == hipSuccess, #expr, " failed: ", hipGetErrorString(_e)); \
   } while (0)
 
-// torch's signal pad size. It gets its own cco allocation and window rather than being
-// appended to the user's buffer, which is what NCCL's backend does too: appending 9216 B
-// to a page-aligned request cost a whole extra 2 MiB page, and that cost is why the pad
-// used to be compiled out.
-constexpr size_t kSignalPadBytes = 9216;
+// The pad gets its own cco allocation and window rather than being appended to the
+// user's buffer, which is what NCCL's backend does too: appending it to a page-aligned
+// request cost a whole extra 2 MiB page, and that cost is why the pad used to be
+// compiled out.
+//
+// Its size comes from torch, not from a constant: set_signal_pad_size() is documented
+// for kernels that need more than the 9216 B default, and on torch >= 2.10 the base
+// class answers get_signal_pad_size() from that global. Sizing the allocation from
+// anything else means torch hands out a pad tensor larger than what is backed.
+size_t SignalPadBytes() { return c10d::symmetric_memory::get_signal_pad_size(); }
 
 size_t RoundUp(size_t v, size_t m) { return ((v + m - 1) / m) * m; }
 
@@ -123,6 +128,8 @@ size_t PerRankVmmSize() {
 // reserves the flat VA once, so the two lifetimes do not line up without this.
 struct CcoGroup {
   ccoComm* comm = nullptr;
+  int rank = -1;
+  int world_size = 0;
 
   // group -> key -> devcomm, the shape torch's NCCL backend uses. A DevComm is
   // parameterised by ccoDevCommRequirements -- signal counts, QP counts, connection
@@ -247,14 +254,15 @@ struct Block {
 class MoriSymmetricMemory : public SymmetricMemory {
  public:
   MoriSymmetricMemory(std::shared_ptr<CcoGroup> group, ccoWindow_t win, void* local_ptr,
-                      ccoWindow_t pad_win, void* pad_ptr, std::vector<void*> buffers,
-                      std::vector<void*> signal_pads, size_t buffer_size, int rank, int world_size,
-                      int device_idx)
+                      ccoWindow_t pad_win, void* pad_ptr, size_t pad_size,
+                      std::vector<void*> buffers, std::vector<void*> signal_pads,
+                      size_t buffer_size, int rank, int world_size, int device_idx)
       : group_(std::move(group)),
         win_(win),
         local_ptr_(local_ptr),
         pad_win_(pad_win),
         pad_ptr_(pad_ptr),
+        pad_size_(pad_size),
         buffers_(std::move(buffers)),
         signal_pads_(std::move(signal_pads)),
         buffer_size_(buffer_size),
@@ -306,9 +314,9 @@ class MoriSymmetricMemory : public SymmetricMemory {
   // concrete base method, where 'override' is itself a compile error. Hence the guard
   // rather than defining it unconditionally.
 #if MORI_TORCH_AT_LEAST(2, 10)
-  // provided by the base class
+  // provided by the base class, from the same global this window was sized with
 #else
-  size_t get_signal_pad_size() override { return kSignalPadBytes; }
+  size_t get_signal_pad_size() override { return pad_size_; }
 #endif
 
   bool has_multicast_support() override { return false; }
@@ -339,6 +347,11 @@ class MoriSymmetricMemory : public SymmetricMemory {
                 "mori symm backend: only channel 0 exists; cco's barrier is comm-wide");
     TORCH_CHECK(group_ && group_->comm, "mori symm backend: window has no communicator");
     DeviceGuard guard(device_.index());
+    // Same invariant as everywhere else in this file: one thread at a time in this
+    // comm. ccoBarrierAll goes through the socket bootstrap, whose unexpected-message
+    // list is not itself synchronised, so two threads barriering the same group can
+    // drop a queued connection and wait forever.
+    std::lock_guard<std::mutex> lock(group_->mu);
     MORI_HIP_CHECK(hipStreamSynchronize(c10::hip::getCurrentHIPStream()));
     MORI_CCO_CHECK(mori::cco::ccoBarrierAll(group_->comm));
   }
@@ -364,7 +377,8 @@ class MoriSymmetricMemory : public SymmetricMemory {
   ccoWindow_t win_;
   void* local_ptr_;  // cco's flat-VA alias of the torch tensor
   ccoWindow_t pad_win_;
-  void* pad_ptr_;  // the signal pad: cco's own allocation, not part of the tensor
+  void* pad_ptr_;    // the signal pad: cco's own allocation, not part of the tensor
+  size_t pad_size_;  // what torch asked for when this window was made
   size_t buffer_size_;
   int rank_;
   int world_size_;
@@ -412,6 +426,22 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
     return ptr;
   }
 
+  // The one place that knows the teardown order. free() and Shutdown() both go
+  // through it: they used to disagree, and the disagreement was exactly the ordering
+  // ROCm 7.14 cares about.
+  //
+  // Our own reference goes first, the window second. cco exported this allocation to a
+  // shareable fd when it imported it and closes that fd inside ccoMemFree; on ROCm 7.14
+  // the fd has to outlive every hipMemRelease of the allocation it names, ours included,
+  // or the physical memory is never returned. cco's retained handle keeps the allocation
+  // alive across these three calls.
+  static void ReleaseBlock(Block& block) {
+    (void)hipMemUnmap(block.ptr, block.alloc_size);
+    (void)hipMemAddressFree(block.ptr, block.alloc_size);
+    (void)hipMemRelease(block.handle);
+    block.symm.reset();
+  }
+
   void free(void* ptr) override {
     std::shared_ptr<Block> block;
     {
@@ -427,15 +457,7 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
     // rather than in the window's destructor, which a never-rendezvous'd block has none of.
     DeviceGuard guard(block->device_idx);
     (void)hipDeviceSynchronize();
-    // Our own reference goes first, the window second. cco exported this allocation to
-    // a shareable fd when it imported it, and closes that fd inside ccoMemFree; on
-    // ROCm 7.14 the fd has to outlive every hipMemRelease of the allocation it names,
-    // ours included, or the physical memory is never returned. cco's retained handle
-    // keeps the allocation alive across these three calls.
-    (void)hipMemUnmap(block->ptr, block->alloc_size);
-    (void)hipMemAddressFree(block->ptr, block->alloc_size);
-    (void)hipMemRelease(block->handle);
-    block->symm.reset();
+    ReleaseBlock(*block);
   }
 
   size_t get_alloc_size(void* ptr) override {
@@ -492,19 +514,19 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
     // torch's signal pad, as its own allocation and window rather than a tail on the
     // user's buffer. cco owns this one outright, so it is overload B.
     void* pad_ptr = nullptr;
-    MORI_CCO_CHECK(mori::cco::ccoMemAlloc(cco_group->comm, kSignalPadBytes, &pad_ptr));
+    const size_t pad_size = SignalPadBytes();
+    MORI_CCO_CHECK(mori::cco::ccoMemAlloc(cco_group->comm, pad_size, &pad_ptr));
     // Not hipMemset: ccoMemAlloc memory is fabric-exportable, and hipMemset returns
     // hipErrorOutOfMemory on UALink fabric pools (ROCm 7.15). cco hit this first and
     // routes its own DevComm resource window around it -- see CcoZeroWindowMem in
     // src/cco/cco_init.cpp. A host->device copy is also synchronous, so the pad is
     // observably zero before the collective register below lets a peer write to it.
     {
-      const std::vector<char> zeros(kSignalPadBytes, 0);
-      MORI_HIP_CHECK(hipMemcpy(pad_ptr, zeros.data(), kSignalPadBytes, hipMemcpyHostToDevice));
+      const std::vector<char> zeros(pad_size, 0);
+      MORI_HIP_CHECK(hipMemcpy(pad_ptr, zeros.data(), pad_size, hipMemcpyHostToDevice));
     }
     ccoWindow_t pad_win{};
-    MORI_CCO_CHECK(
-        mori::cco::ccoWindowRegister(cco_group->comm, pad_ptr, kSignalPadBytes, &pad_win));
+    MORI_CCO_CHECK(mori::cco::ccoWindowRegister(cco_group->comm, pad_ptr, pad_size, &pad_win));
 
     // buffer_ptrs is now one source of truth with the device-side lsa_ptr: both are
     // flatBase + peerLsaRank*stride + slotOffset. A peer outside the LSA team comes back
@@ -520,7 +542,7 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
     cco_lock.unlock();
 
     auto symm = c10::make_intrusive<MoriSymmetricMemory>(
-        cco_group, win, local_ptr, pad_win, pad_ptr, std::move(buffers), std::move(pads),
+        cco_group, win, local_ptr, pad_win, pad_ptr, pad_size, std::move(buffers), std::move(pads),
         block->buffer_size, rank, world_size, block->device_idx);
     block->symm = symm;
     return symm;
@@ -543,10 +565,7 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
     for (auto& [ptr, block] : taken) {
       DeviceGuard guard(block->device_idx);
       (void)hipDeviceSynchronize();
-      block->symm.reset();  // unmaps the flat span
-      (void)hipMemUnmap(block->ptr, block->alloc_size);
-      (void)hipMemAddressFree(block->ptr, block->alloc_size);
-      (void)hipMemRelease(block->handle);
+      ReleaseBlock(*block);
     }
   }
 
@@ -620,13 +639,34 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
 
   // One communicator per group, built on first use. The uid rides torch's own
   // Store, so cco's rendezvous needs no second bootstrap channel.
+  // torch recycles process group names: destroy_process_group() resets
+  // _world.group_count to 0 and the default group is named from that counter, so a
+  // second init_process_group() hands out "0" again. Keyed on the name alone, this
+  // cache would then serve a communicator bound to the previous group's peers, and the
+  // ranks holding it would block in ccoWindowRegister against a peer set that no longer
+  // exists, with no diagnostic. Every incarnation gets a fresh Store, so a marker in it
+  // tells them apart; Store::check does not block on a missing key.
+  static constexpr const char* kGroupMarker = "mori_symm_backend/comm_epoch";
+
   std::shared_ptr<CcoGroup> GetOrCreateGroup(const std::string& name,
                                              const c10::intrusive_ptr<c10d::Store>& store, int rank,
                                              int world_size) {
+    const bool marked = store->check({kGroupMarker});
     {
       std::lock_guard<std::mutex> lock(mutex_);
       auto it = cco_groups_.find(name);
-      if (it != cco_groups_.end()) return it->second;
+      if (it != cco_groups_.end()) {
+        if (marked) {
+          TORCH_CHECK(it->second->rank == rank && it->second->world_size == world_size,
+                      "mori symm backend: group '", name, "' was rendezvous'd as rank ",
+                      it->second->rank, "/", it->second->world_size, " and is now rank ", rank, "/",
+                      world_size, "; torch reuses group names after destroy_process_group()");
+          return it->second;
+        }
+        // Fresh Store behind a recycled name: the cached communicator belongs to a
+        // group that no longer exists. Drop it rather than rendezvous against dead peers.
+        cco_groups_.erase(it);
+      }
     }
 
     mori::cco::ccoUniqueId uid{};
@@ -634,8 +674,12 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
     auto ids = store_exchange_.all_gather(store, rank, world_size, uid);
 
     auto group = std::make_shared<CcoGroup>();
+    group->rank = rank;
+    group->world_size = world_size;
     MORI_CCO_CHECK(
         mori::cco::ccoCommCreate(ids[0], world_size, rank, PerRankVmmSize(), &group->comm));
+    // Mark this incarnation, after the create so a failure leaves nothing behind.
+    store->set(kGroupMarker, std::vector<uint8_t>{1});
     // ccoCommCreate leaves a tolerated probe failure latched in HIP's per-thread
     // sticky slot. torch checks that slot around every launch, so without this the
     // caller's next kernel is blamed for it. Consuming it here, at the call site that

--- a/src/allocator/symm_backend.cpp
+++ b/src/allocator/symm_backend.cpp
@@ -25,10 +25,11 @@
 // register_availability() makes "MORI" selectable; torch then drives symm_mem.empty ->
 // alloc, symm_mem.rendezvous -> rendezvous, and torch.ops.symm_mem.* on the result.
 //
-// Deliberately does not use mori's shmem or cco allocators: both keep peer offsets
-// aligned only while every rank allocates AND frees in the same order, which torch cannot
-// hold (tensors die on Python GC, whose order is not synchronised across ranks). Here each
-// allocation is independent and free() is local, so divergent free order is harmless.
+// alloc() is plain HIP VMM, kept independent per rank; CCO owns the peer mapping from
+// rendezvous() onward. Window teardown is local -- ccoWindowDeregister runs no collective
+// -- so tensors may die in whatever order Python's GC picks. The POSIX-fd path does embed
+// the local slot offset in its rendezvous socket path, so a genuinely rank-divergent free
+// order can make a *later* register fail; it fails loudly rather than silently.
 //
 // Peers are published torch's way, as the buffer_ptrs / buffer_ptrs_dev array. They happen
 // to sit in one flat span (peer(r) == flat_base + r*stride) because that is the cheapest
@@ -131,6 +132,7 @@ struct CcoGroup {
   struct DevCommEntry {
     mori::cco::ccoDevComm host{};
     mori::cco::ccoDevComm* device = nullptr;  // kernel-argument copy
+    int lsa_barrier_count = 0;                // what it was built with
   };
   std::mutex dev_mu;
   std::unordered_map<std::string, DevCommEntry> dev_comms;
@@ -271,9 +273,9 @@ class MoriSymmetricMemory : public SymmetricMemory {
     if (buffers_dev_) (void)hipFree(buffers_dev_);
     if (signal_pads_dev_) (void)hipFree(signal_pads_dev_);
     if (rank_to_global_rank_dev_) (void)hipFree(rank_to_global_rank_dev_);
-    // Purely local: ccoWindowDeregister unmaps this rank's view of its peers and
-    // drops the handles it imported, with no collective inside. That is what lets
-    // torch tensors die in whatever order Python's GC picks.
+    // Purely local: ccoWindowDeregister unmaps this rank's view of its peers and drops
+    // the handles it imported, with no collective inside, so this can run on whichever
+    // thread drops the last reference and in whatever order across ranks.
     if (group_ && group_->comm) {
       (void)mori::cco::ccoWindowDeregister(group_->comm, pad_win_);
       (void)mori::cco::ccoMemFree(group_->comm, pad_ptr_);
@@ -479,7 +481,15 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
     // user's buffer. cco owns this one outright, so it is overload B.
     void* pad_ptr = nullptr;
     MORI_CCO_CHECK(mori::cco::ccoMemAlloc(cco_group->comm, kSignalPadBytes, &pad_ptr));
-    MORI_HIP_CHECK(hipMemset(pad_ptr, 0, kSignalPadBytes));
+    // Not hipMemset: ccoMemAlloc memory is fabric-exportable, and hipMemset returns
+    // hipErrorOutOfMemory on UALink fabric pools (ROCm 7.15). cco hit this first and
+    // routes its own DevComm resource window around it -- see CcoZeroWindowMem in
+    // src/cco/cco_init.cpp. A host->device copy is also synchronous, so the pad is
+    // observably zero before the collective register below lets a peer write to it.
+    {
+      const std::vector<char> zeros(kSignalPadBytes, 0);
+      MORI_HIP_CHECK(hipMemcpy(pad_ptr, zeros.data(), kSignalPadBytes, hipMemcpyHostToDevice));
+    }
     ccoWindow_t pad_win{};
     MORI_CCO_CHECK(
         mori::cco::ccoWindowRegister(cco_group->comm, pad_ptr, kSignalPadBytes, &pad_win));
@@ -541,8 +551,23 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
       group = it->second;
     }
 
+    int dev = -1;
+    MORI_HIP_CHECK(hipGetDevice(&dev));
+    DeviceGuard guard(dev);
+
     std::lock_guard<std::mutex> lock(group->dev_mu);
     auto it = group->dev_comms.find(key);
+    if (it != group->dev_comms.end()) {
+      // The key is supposed to encode the parameterisation, so a mismatch means two
+      // callers disagree about what this key means. Returning the first one's DevComm
+      // would hand the second a barrier array smaller than the ids its kernel uses.
+      TORCH_CHECK(it->second.lsa_barrier_count == lsa_barrier_count,
+                  "mori symm backend: dev_comm key '", key,
+                  "' already exists with "
+                  "lsa_barrier_count=",
+                  it->second.lsa_barrier_count, ", cannot serve ", lsa_barrier_count,
+                  "; use a different key");
+    }
     if (it == group->dev_comms.end()) {
       CcoGroup::DevCommEntry e{};
       mori::cco::ccoDevCommRequirements reqs = CCO_DEV_COMM_REQUIREMENTS_INITIALIZER;
@@ -552,7 +577,11 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
       reqs.lsaBarrierCount = lsa_barrier_count;
       MORI_CCO_CHECK(mori::cco::ccoDevCommCreate(group->comm, &reqs, &e.host));
       e.device = mori::cco::ccoDevCommCopyToDevice(&e.host);
-      TORCH_CHECK(e.device != nullptr, "mori symm backend: ccoDevCommCopyToDevice failed");
+      if (e.device == nullptr) {
+        (void)mori::cco::ccoDevCommDestroy(group->comm, &e.host);
+        TORCH_CHECK(false, "mori symm backend: ccoDevCommCopyToDevice failed");
+      }
+      e.lsa_barrier_count = lsa_barrier_count;
       it = group->dev_comms.emplace(key, e).first;
     }
     return reinterpret_cast<uint64_t>(it->second.device);

--- a/src/allocator/symm_backend.cpp
+++ b/src/allocator/symm_backend.cpp
@@ -134,7 +134,15 @@ struct CcoGroup {
     mori::cco::ccoDevComm* device = nullptr;  // kernel-argument copy
     int lsa_barrier_count = 0;                // what it was built with
   };
-  std::mutex dev_mu;
+  // Serialises everything this process does with `comm`. cco's own allocMutex is
+  // documented as covering allocTable/windows/windowTableEntries against concurrent
+  // MemAlloc/MemFree/WindowRegister/WindowDeregister (include/mori/cco/cco.hpp), but
+  // only MemAlloc/MemImport/MemFree actually take it -- the window paths do not. That
+  // did not matter while cco was driven from explicit single-threaded user code; it
+  // does now, because torch drops the last reference to a tensor on whatever thread
+  // happens to hold it, so ~MoriSymmetricMemory can deregister a window while another
+  // thread is registering one. Also guards dev_comms, so there is no lock ordering.
+  std::mutex mu;
   std::unordered_map<std::string, DevCommEntry> dev_comms;
 
   ~CcoGroup() {
@@ -277,6 +285,7 @@ class MoriSymmetricMemory : public SymmetricMemory {
     // the handles it imported, with no collective inside, so this can run on whichever
     // thread drops the last reference and in whatever order across ranks.
     if (group_ && group_->comm) {
+      std::lock_guard<std::mutex> lock(group_->mu);
       (void)mori::cco::ccoWindowDeregister(group_->comm, pad_win_);
       (void)mori::cco::ccoMemFree(group_->comm, pad_ptr_);
       (void)mori::cco::ccoWindowDeregister(group_->comm, win_);
@@ -472,6 +481,9 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
     // Overload C: retain the tensor's VMM handle, alias it into the flat LSA slot,
     // and register the window. No copy, and no second peer exchange of our own --
     // this is the exchange the backend used to hand-roll over SCM_RIGHTS.
+    // Held across the registers and the peer-pointer reads: see CcoGroup::mu.
+    std::unique_lock<std::mutex> cco_lock(cco_group->mu);
+
     ccoWindow_t win{};
     void* local_ptr = nullptr;
     MORI_CCO_CHECK(mori::cco::ccoWindowRegister(cco_group->comm, block->ptr, block->alloc_size,
@@ -505,6 +517,7 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
     }
     TORCH_CHECK(buffers[rank] != nullptr,
                 "mori symm backend: cco did not map this rank's own window");
+    cco_lock.unlock();
 
     auto symm = c10::make_intrusive<MoriSymmetricMemory>(
         cco_group, win, local_ptr, pad_win, pad_ptr, std::move(buffers), std::move(pads),
@@ -555,7 +568,7 @@ class MoriSymmAllocator : public SymmetricMemoryAllocator {
     MORI_HIP_CHECK(hipGetDevice(&dev));
     DeviceGuard guard(dev);
 
-    std::lock_guard<std::mutex> lock(group->dev_mu);
+    std::lock_guard<std::mutex> lock(group->mu);
     auto it = group->dev_comms.find(key);
     if (it != group->dev_comms.end()) {
       // The key is supposed to encode the parameterisation, so a mismatch means two

--- a/tests/python/allocator/test_torch_symm_backend.py
+++ b/tests/python/allocator/test_torch_symm_backend.py
@@ -85,8 +85,10 @@ def _run(rank, world_size, port):
         # torch's handle has no slot for it, same as NCCL's get_window().
         from mori.allocator import window_handle
 
-        assert window_handle(t.data_ptr()) != 0
-        assert window_handle(t.data_ptr(), signal_pad=True) != 0
+        assert window_handle(t) != 0
+        assert window_handle(t, signal_pad=True) != 0
+        # The window belongs to the storage, so a view resolves to the same one.
+        assert window_handle(t[n // 2 :]) == window_handle(t)
 
         # A DevComm is parameterised by the algorithm that will run, so it is cached per
         # (group, key) rather than per group -- two collectives want two of them.

--- a/tests/python/allocator/test_torch_symm_backend.py
+++ b/tests/python/allocator/test_torch_symm_backend.py
@@ -89,6 +89,17 @@ def _run(rank, world_size, port):
         assert window_handle(t.data_ptr()) != 0
         assert window_handle(t.data_ptr(), signal_pad=True) != 0
 
+        # A DevComm is parameterised by the algorithm that will run, so it is cached per
+        # (group, key) rather than per group -- two collectives want two of them.
+        from mori.allocator import dev_comm
+
+        a = dev_comm(group_name, key="all2all")
+        assert a != 0
+        assert dev_comm(group_name, key="all2all") == a, "same key must reuse"
+        assert dev_comm(group_name, key="reduce") != a, "different key must not share"
+        with pytest.raises(RuntimeError, match="rendezvous"):
+            dev_comm("no-such-group")
+
         dist.barrier()
 
 

--- a/tests/python/allocator/test_torch_symm_backend.py
+++ b/tests/python/allocator/test_torch_symm_backend.py
@@ -42,7 +42,6 @@ def _run(rank, world_size, port):
 
         symm_mem.set_backend("MORI")
         assert symm_mem.get_backend(device) == "MORI"
-        symm_mem.enable_symm_mem_for_group(group_name)
         assert handle_type(rank) in ("fabric", "posix_fd")
 
         n = 1024
@@ -114,7 +113,6 @@ def _run_release(rank, world_size, port):
         torch.cuda.set_device(device)
         group_name = dist.group.WORLD.group_name
         symm_mem.set_backend("MORI")
-        symm_mem.enable_symm_mem_for_group(group_name)
 
         mib = 1 << 20
         rounds = 4

--- a/tests/python/allocator/test_torch_symm_backend.py
+++ b/tests/python/allocator/test_torch_symm_backend.py
@@ -87,7 +87,8 @@ def _run(rank, world_size, port):
 
         assert window_handle(t) != 0
         assert window_handle(t, signal_pad=True) != 0
-        # The window belongs to the storage, so a view resolves to the same one.
+        # The wrapper resolves a view to its storage, so both name the same window.
+        # (This pins the Python side; the C++ lookup only ever sees the storage base.)
         assert window_handle(t[n // 2 :]) == window_handle(t)
 
         # A DevComm is parameterised by the algorithm that will run, so it is cached per
@@ -98,6 +99,11 @@ def _run(rank, world_size, port):
         assert a != 0
         assert dev_comm(group_name, key="all2all") == a, "same key must reuse"
         assert dev_comm(group_name, key="reduce") != a, "different key must not share"
+        # The key is supposed to encode the parameterisation, so asking for a bigger
+        # barrier array under a key that already exists must complain rather than hand
+        # back the smaller one.
+        with pytest.raises(RuntimeError, match="already exists"):
+            dev_comm(group_name, key="all2all", lsa_barrier_count=8)
         with pytest.raises(RuntimeError, match="rendezvous"):
             dev_comm("no-such-group")
 

--- a/tests/python/allocator/test_torch_symm_backend.py
+++ b/tests/python/allocator/test_torch_symm_backend.py
@@ -68,16 +68,26 @@ def _run(rank, world_size, port):
             peer = hdl.get_buffer(pe, (4,), torch.float32)
             assert abs(peer[0].item() - (pe + 1)) < 1e-6, f"peer {pe} mismatch"
 
-        # torch's own collective, on mori memory. It barriers on the device, so it needs
-        # the signal pad; without it the backend must say so rather than corrupt memory.
+        # The signal pad is its own cco window now, so it is always there and torch's
+        # own collectives -- which synchronise through it -- work unconditionally.
+        assert signal_pad_supported()
+        pads = hdl.signal_pad_ptrs
+        assert len(pads) == world_size and all(p for p in pads)
+
         expect = float(sum(r + 1 for r in range(world_size)))
-        if signal_pad_supported():
-            out = torch.ops.symm_mem.one_shot_all_reduce(t, "sum", group_name)
-            torch.cuda.synchronize()
-            assert abs(out[0].item() - expect) < 1e-3
-        else:
-            with pytest.raises(RuntimeError, match="MORI_SYMM_SIGNAL_PAD"):
-                torch.ops.symm_mem.one_shot_all_reduce(t, "sum", group_name)
+        out = torch.ops.symm_mem.one_shot_all_reduce(t, "sum", group_name)
+        torch.cuda.synchronize()
+        assert abs(out[0].item() - expect) < 1e-3
+
+        # The backend's own barrier, over cco's host barrier.
+        hdl.barrier(0)
+
+        # Backend-specific escape hatch: the cco window a kernel can address through.
+        # torch's handle has no slot for it, same as NCCL's get_window().
+        from mori.allocator import window_handle
+
+        assert window_handle(t.data_ptr()) != 0
+        assert window_handle(t.data_ptr(), signal_pad=True) != 0
 
         dist.barrier()
 


### PR DESCRIPTION
Stage 2 of #557: `symm_mem.rendezvous()` becomes a CCO window registration, so the backend and CCO stop building two peer mappings for the same memory.

Modelled on torch's own NCCL backend, which draws the same lines — `NCCLSymmetricMemory` registers the buffer window at rendezvous, gives the signal pad a separate allocation and window, exposes `get_window()` outside torch's interface, and hands out `ncclDevComm`s lazily from a two-level `group -> key` map.

### What changes

| | before | after |
|---|---|---|
| peer exchange | `FdChannel` over SCM_RIGHTS + a hand-rolled flat span | `ccoWindowRegister`; `buffer_ptrs` are `ccoGetPeerPtr` results |
| signal pad | 9216 B appended to the buffer, **compiled out by default** | its own CCO allocation and window, sized from torch |
| `MORI_SYMM_SIGNAL_PAD` | build flag | gone |
| `barrier()` | raises | `ccoBarrierAll` |
| group resolution | torch's deprecated `GroupInfo` registry | `resolve_process_group()`, as CUDA/NCCL do |
| null peer in `buffer_ptrs` | rejected | allowed; `world_within_direct_access()` answers from the array |
| window / devcomm | not reachable | `window_handle(tensor)`, `dev_comm(group, key=...)` |

`torch.ops.symm_mem.one_shot_all_reduce` now works without a rebuild, and callers no longer have to make the deprecated `enable_symm_mem_for_group()` call. Net **−70 lines** in the backend, and the ROCm 7.14 fd-lifetime hazard leaves the file entirely — CCO already closes its exported fds after `hipMemRelease`.

The DevComm is deliberately **not** created at rendezvous. `ccoDevCommRequirements` is signal counts, QP counts and connection type — properties of the algorithm about to run, not of the buffer — so it is created on first use and cached per `(group, key)`, as NCCL does.

### Ordering hazards found while building this

Each costs a full allocation per cycle and is silent:

- `ccoCommCreate` leaves a tolerated probe failure latched in HIP's sticky error slot, and torch checks that slot around every launch, so the caller's next kernel gets blamed. Consumed with `hipGetLastError()` at our own call site.
- `free()` must drop our handle reference **before** the window: CCO closes the fd it exported in `ccoMemFree`, and on ROCm 7.14 that fd has to outlive every release of the allocation it names. `test_symm_release` catches it.
- The pad is `ccoMemAlloc` memory, so it must not be `hipMemset` — CCO hit this first (`CcoZeroWindowMem`, `cco_init.cpp:406`) and routes its own resource window around it. This would have thrown "out of memory" for a 9216 B buffer on a fabric box, *after* the buffer's collective register, hanging the peers.

### Review fixes

- **Group cache keyed to the PG incarnation.** torch recycles group names — `destroy_process_group()` resets `_world.group_count` — so a name-keyed cache could serve a communicator for a group that no longer exists. Each incarnation gets a fresh Store; a marker in it tells them apart, and a hit also checks rank/world_size.
- **`barrier()` takes the group mutex** like every other call into the communicator.
- **Pad sized from `get_signal_pad_size()`**, not a constant, so `set_signal_pad_size()` cannot hand out a tensor larger than the allocation behind it.
- **One `ReleaseBlock()`** for `free()` and `Shutdown()`, which had drifted into opposite teardown orders.

### Verified

8x gfx950 / ROCm 7.14 / torch 2.12, at 2, 4 and 8 ranks. CI green including `CCO unit test`, where the allocator tests run.

- `tests/python/allocator` — covers `one_shot_all_reduce`, `barrier(0)`, `window_handle` (including on a view), and the DevComm caching rules.
- `all2all_triton.py`, which only walks `buffer_ptrs_dev` — ~1.9 TB/s, unchanged.
- `all2all_lsa.py` and cco example 09 — both take the window and DevComm from the backend now, and lost ~30 lines of bootstrap each.

### Known issues

- **The gfx1250 / fabric path has no coverage.** The `hipMemset` bug above was on that path, so it is "was broken, believed fixed, still untested". Handle-type agreement between `alloc()` and CCO's re-export is also load-bearing and only exercised on the POSIX-fd side.
- **POSIX-fd free order.** CCO names its rendezvous socket after the local slot offset (`cco_init.cpp:1261`), and freeing returns that slot to a per-rank allocator, so ranks freeing in different orders can make a later `rendezvous()` fail with an fd-exchange timeout. torch places no ordering requirement on frees, so this is a real constraint; it belongs in CCO and is documented in the module docstring for now.
- `put_signal`/`wait_signal` raise. They need CCO signals, which now have a DevComm to hang off.
- `barrier()` drains the current stream because `ccoBarrierAll` is a host collective — correct and stronger than torch asks for, but heavier, and unmeasured.
- The locking gap this exposed in CCO is #632. This PR carries its own per-communicator mutex, so it does not depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
