### PR TITLE
perf(ep): optimize InterNodeV1LL dispatch on EP16

### DIFF
--- a/src/ops/dispatch_combine/internode_v1.cpp
+++ b/src/ops/dispatch_combine/internode_v1.cpp
@@ -347,12 +347,26 @@ inline __device__ void DispatchInterNodeLLSend(EpDispatchCombineArgs<T>& args) {
   finishedWarp = __shfl(finishedWarp, 0);
   if ((finishedWarp + 1) == (args.rdmaBlockNum * warpNum)) {
     if (laneId < nNodes) {
-      int proxyPe = laneId * config.gpuPerNode + (config.rank % config.gpuPerNode);
-      index_t numTokenSignal =
-          core::AtomicLoadRelaxed(args.blockFlagCounter + laneId) * warpSize + 1;
-      shmem::ShmemAtomicTypeNonFetchThread<uint64_t>(args.nodeRecvTokenNumMemObj,
-                                                     myNode * sizeof(uint64_t), numTokenSignal,
-                                                     core::AMO_ADD, proxyPe);
+      // nodeRecvTokenNum lets the peer tell "this chunk slot will never be
+      // signalled" apart from "it has not arrived yet", and tells combine how
+      // far to iterate. Both only need it when we left a slot unsignalled: if
+      // every slot the peer looks at got a signal from a put, its poll always
+      // terminates on chunkFlag and combine can use the static maxChunkNum
+      // bound. chunksSent <= maxChunkNum always holds, so equality means full
+      // coverage.
+      //
+      // Worth the branch because this is a second GPU-initiated RDMA atomic
+      // issued by the warp that just issued the put, and it sits on the critical
+      // path -- measured at ~3.3us of the send phase. At 4-32 tokens/rank one
+      // chunk covers everything, so it is always skipped there.
+      index_t chunksSent = core::AtomicLoadRelaxed(args.blockFlagCounter + laneId);
+      if (chunksSent < maxChunkNum) {
+        int proxyPe = laneId * config.gpuPerNode + (config.rank % config.gpuPerNode);
+        index_t numTokenSignal = chunksSent * warpSize + 1;
+        shmem::ShmemAtomicTypeNonFetchThread<uint64_t>(args.nodeRecvTokenNumMemObj,
+                                                       myNode * sizeof(uint64_t), numTokenSignal,
+                                                       core::AMO_ADD, proxyPe);
+      }
     }
     if (laneId == 0) args.interNodeBlocksBarrier[1] = 0;
   }
@@ -1110,8 +1124,14 @@ __forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs<T>
   int rdmaWarpNum = args.rdmaBlockNum * warpNum;
   for (int n = 0; n < (nNodes - 1); n++) {
     int node = (myNode + n + 1) % nNodes;
+    // The sender only signals nodeRecvTokenNum when it left a chunk slot without
+    // a signal (see DispatchInterNodeLLSend). A zero therefore means "every slot
+    // was signalled", not "nothing arrived", and the static maxChunkNum bound is
+    // the right one -- slots with no data read chunkFlag == 0 and are skipped
+    // inside the loop either way.
     uint64_t nodeCount = nodeRecvTokenNum[node];
-    if (nodeCount > 0) nodeCount -= 1;
+    nodeCount =
+        (nodeCount > 0) ? (nodeCount - 1) : static_cast<uint64_t>(maxChunkNum) * warpSize;
     if (nodeCount == 0) continue;
 
     // One whole vector step per warp. warpsPerToken was a fixed 4, which for


### PR DESCRIPTION
The v1_ll dispatch send phase issues a second GPU-initiated RDMA atomic right after the put, from the same warp, to publish how many chunks it sent. The receiver needs that number for two things: to tell "this chunk slot will never be signalled" apart from "it has not arrived yet" while polling, and to know how far combine should iterate.

Neither needs it when every slot the peer will look at already got a signal from a put. chunksSent <= maxChunkNum always holds -- it counts one atomicAdd per warpSize-wide chunk of curRankNumToken, and maxChunkNum is the same ceiling over maxNumInpTokenPerRank -- so equality means full coverage. There the poll always terminates on chunkFlag, and combine falls back to the static maxChunkNum bound; slots with no data read chunkFlag == 0 and are skipped inside the loop anyway.

A device-side timer around the send phase puts the barrier segment that issues this atomic at 540 cycles before and 208 after, ~3.3us.

End to end on 2x8 MI300X, AUTO launch config, num-qp 1, hidden 6144, same session, medians of 3 (dispatch, us):

  tokens/rank      4        8       16       32
  before        49.53    47.99    49.83    52.18
  after         47.29    47.66    48.89    51.75

The direction is consistent but the effect is small, and only the 16- and 32-token pairs have non-overlapping per-run ranges; 4 and 8 overlap. Combine is unchanged, as expected. At 4-32 tokens/rank one chunk covers everything so the atomic is always skipped; above that the branch keeps the old behaviour.
