### PR TITLE
fix(cco): take allocMutex on the window paths, as its comment already promises

### DIFF
--- a/src/cco/cco_init.cpp
+++ b/src/cco/cco_init.cpp
@@ -1086,13 +1086,22 @@ int ccoMemFree(ccoComm* comm, void* ptr) {
 /* ========================================================================== */
 
 int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin) {
-  auto it = comm->allocTable.find(ptr);
-  if (it == comm->allocTable.end()) {
-    MORI_SHMEM_ERROR("ccoWindowRegister: ptr {} not in allocTable", ptr);
-    return -1;
+  // allocMutex only for the lookup, not for the whole function: the peer exchange
+  // below is collective, and the callers that allocate (the other two overloads)
+  // reach ccoMemAlloc / ccoMemImport, which take this mutex themselves. Holding a
+  // reference past the unlock is fine -- rehashing invalidates iterators, not
+  // references to elements.
+  ccoComm::AllocMeta* metaPtr = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(comm->allocMutex);
+    auto it = comm->allocTable.find(ptr);
+    if (it == comm->allocTable.end()) {
+      MORI_SHMEM_ERROR("ccoWindowRegister: ptr {} not in allocTable", ptr);
+      return -1;
+    }
+    metaPtr = &it->second;
   }
-
-  auto& meta = it->second;
+  auto& meta = *metaPtr;
   size_t slotOffset = meta.slotOffset;
   void* localPtr = ptr;
   int worldSize = comm->worldSize;
@@ -1385,7 +1394,6 @@ int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin
   tableEntry.base = reinterpret_cast<uintptr_t>(localPtr);
   tableEntry.size = static_cast<uintptr_t>(size);
   tableEntry.devPtr = devPtr;
-  comm->windowTableEntries.push_back(tableEntry);
 
   auto* wh = new ccoWindowHost();
   wh->localPtr = localPtr;
@@ -1393,7 +1401,15 @@ int ccoWindowRegister(ccoComm* comm, void* ptr, size_t size, ccoWindow_t* outWin
   wh->devPtr = devPtr;
   wh->peerRkeys_gpu = peerRkeys_gpu;
   wh->peerImportedHandles = std::move(p2pImportedHandles);
-  comm->windows.push_back(wh);
+
+  // Publish both under the lock: ccoWindowDeregister walks these vectors, and a
+  // push_back that reallocates under it invalidates the index and the pointer it is
+  // holding.
+  {
+    std::lock_guard<std::mutex> lock(comm->allocMutex);
+    comm->windowTableEntries.push_back(tableEntry);
+    comm->windows.push_back(wh);
+  }
 
   *outWin = devPtr;
 
@@ -1479,6 +1495,12 @@ void* ccoGetPeerPtr(ccoComm* comm, void* localPtr, int pe) {
 /* ========================================================================== */
 
 int ccoWindowDeregister(ccoComm* comm, ccoWindow_t win) {
+  // Whole function: it searches and mutates windows / windowTableEntries, reads
+  // allocTable, and deletes the host record. Unlike the register overloads it calls
+  // nothing that takes this mutex, so holding it throughout is safe. The HIP calls
+  // inside will block a concurrent MemAlloc, which is acceptable -- window teardown
+  // is rare and already serialised against itself by the caller in practice.
+  std::lock_guard<std::mutex> lock(comm->allocMutex);
   ccoWindowHost* wh = nullptr;
   size_t idx = 0;
   for (size_t i = 0; i < comm->windows.size(); i++) {


### PR DESCRIPTION
`allocMutex`'s own comment (`include/mori/cco/cco.hpp:892`) says it

> protects allocTable, windows, windowTableEntries against concurrent MemAlloc / MemFree / WindowRegister / WindowDeregister from multiple threads sharing the same ccoComm

but only `ccoMemAlloc`, `ccoMemImport` and `ccoMemFree` take it. The two window functions named in that sentence never do:

| | |
|---|---|
| `ccoWindowRegister` | `push_back` to `windowTableEntries` and `windows` (`cco_init.cpp:1388,1396`), and reads `allocTable` (`:1089`) |
| `ccoWindowDeregister` | walks `windows` by index, erases from both vectors (`:1484,1536`), reads `allocTable` (`:1499`), `delete`s the host record |

Two races follow. A `push_back` that reallocates under a concurrent `Deregister` invalidates the index and the `ccoWindowHost*` it is holding. And a `find` on `allocTable` racing a rehash driven by the three `Mem*` writers is undefined behaviour, not a stale read.

### Why now

Nothing in tree hit this, because cco has only ever been driven from single-threaded host code. #628 changes that: it puts `ccoWindowRegister` on torch's `rendezvous()` and `ccoWindowDeregister` on torch's object lifetime, and torch drops a tensor's last reference on whichever thread happens to be holding it — an autograd thread, a dataloader worker, wherever the GC lands.

#628 carries its own per-communicator mutex so it is safe to merge without this, and that lock stays afterwards as defence in depth. This is the underlying gap.

### Why the lock is taken in pieces

It cannot simply wrap the register overloads:

- overloads A and C reach `ccoMemAlloc` / `ccoMemImport` / `ccoMemFree` (`:1425,1445,1430,1450`), which take the mutex themselves — wrapping them self-deadlocks;
- the overload that does the work has the collective peer exchange (allgather / SCM_RIGHTS) in the middle, which must not be held under a lock.

So it is taken twice and narrowly: around the `allocTable` lookup, and around publishing the window. The element reference is kept across the unlock deliberately — rehashing invalidates iterators, not references to elements.

`ccoWindowDeregister` calls nothing that takes the mutex, so it holds it throughout. The HIP calls inside will block a concurrent `ccoMemAlloc`; that seemed the right trade for teardown that is rare and already collective-adjacent, but splitting it into detach-under-lock then release-outside is a straightforward follow-up if the contention matters.

### Verified

8x gfx950 / ROCm 7.14, in the CI container:

- `tools/run_cco_tests.sh <build> 4` — all pass (`test_host`, `test_lsa_allreduce`, `test_lsa_barrier`, `test_sdma_signal`, `test_sdma_warp_issue`, `test_team`), GDA-FULL skipped as on the runner.
- SDMA C++ tests at 8 ranks with `MORI_ENABLE_SDMA=1` — all pass.
- `test_sdma_block` failed once during the sweep; that was a harness misread, and it samples 10/10 on this branch and 10/10 on unmodified `main`.

Not covered: no test exercises concurrent register/deregister, so this fixes a race by inspection rather than by reproduction. Writing one would mean driving two threads at one `ccoComm`, which is exactly the shape #628 introduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
