### PR TITLE
perf(umbp): keep PeerPool resolve off the metadata lock

### DIFF
--- a/src/umbp/distributed/pool/peer_pool.cpp
+++ b/src/umbp/distributed/pool/peer_pool.cpp
@@ -70,10 +70,12 @@ void PeerPool::StopTransitionWorker() {
 
 void PeerPool::TouchLocked(const std::string& key) {
   auto access = last_access_.find(key);
-  if (access != last_access_.end()) access_order_.erase(access->second);
-  const uint64_t stamp = ++access_clock_;
-  last_access_[key] = stamp;
-  access_order_[stamp] = key;
+  if (access != last_access_.end()) {
+    access_order_.splice(access_order_.begin(), access_order_, access->second);
+    return;
+  }
+  access_order_.push_front(key);
+  last_access_.emplace(key, access_order_.begin());
 }
 
 void PeerPool::ForgetAccessLocked(const std::string& key) {
@@ -130,10 +132,10 @@ size_t PeerPool::EnqueueWatermarkCandidatesLocked(LogicalTierGraph::TierIndex ti
     candidates.push_back({TierTransitionKind::kOffload, key, backend_id, tier_index});
   };
 
-  // Coldest first: access_order_ is keyed by access stamp, so the keys least
-  // likely to be read again leave the tier before the rest.
-  for (const auto& [stamp, key] : access_order_) {
-    (void)stamp;
+  // Coldest first: access_order_ keeps the hottest key at the front, so walking
+  // it backwards reaches the keys least likely to be read again first.
+  for (auto it = access_order_.rbegin(); it != access_order_.rend(); ++it) {
+    const std::string& key = *it;
     auto placement = placements_.find(key);
     if (placement == placements_.end()) continue;
     consider(key, placement->second);
@@ -539,29 +541,52 @@ std::vector<bool> PeerPool::BatchAbort(const std::vector<PoolSlotRef>& slots) {
 
 std::vector<PoolResolvedEntry> PeerPool::BatchResolve(const std::vector<std::string>& keys,
                                                       bool include_descs) {
-  std::lock_guard<std::mutex> operation_lock(operation_mutex_);
+  // Three phases, and only the first and last hold operation_mutex_. The backend
+  // lookups in between are the expensive part of a resolve, and every backend
+  // guards itself, so holding the pool lock across them only serializes callers
+  // that could have run side by side. Under TP that is every rank at once: the
+  // ranged-call timers showed resolve queueing into a 0 -> 30 ms staircase
+  // across a wave of concurrent batches, 84% of ranged-get time.
+  //
+  // placements_ is a hint, so acting on a stale one costs at most one extra
+  // backend probe, and phase 3 repairs it exactly as the miss path already did.
   std::vector<PoolResolvedEntry> out(keys.size());
-  if (backends_ == nullptr || policy_ == nullptr || keys.empty()) return out;
+  if (keys.empty()) return out;
 
   std::vector<std::optional<uint32_t>> preferred(keys.size());
-  for (size_t i = 0; i < keys.size(); ++i) {
-    auto it = placements_.find(keys[i]);
-    if (it != placements_.end()) preferred[i] = it->second;
+  std::vector<uint32_t> read_order;
+  {
+    std::lock_guard<std::mutex> operation_lock(operation_mutex_);
+    if (backends_ == nullptr || policy_ == nullptr) return out;
+    for (size_t i = 0; i < keys.size(); ++i) {
+      auto it = placements_.find(keys[i]);
+      if (it != placements_.end()) preferred[i] = it->second;
+    }
+    // Snapshot the order under the lock so a concurrent backend add or remove
+    // cannot be observed halfway through the walk below.
+    read_order = policy_->ReadOrder(*backends_);
   }
 
-  std::vector<std::vector<bool>> attempted(
-      keys.size(), std::vector<bool>(BackendRegistry::kMaxBackends, false));
+  // One bit per (key, backend) in a flat word per key. A vector<bool> per key
+  // heap-allocated once per key, and a 1023-key batch is the common shape here.
+  static_assert(BackendRegistry::kMaxBackends <= 16, "attempted mask is 16 bits wide");
+  std::vector<uint16_t> attempted(keys.size(), 0);
 
   const auto resolve = [&](uint32_t backend_id, const std::vector<size_t>& indices) {
     auto* backend = backends_->Get(backend_id);
     if (backend == nullptr || indices.empty()) return;
+    // The single-backend tier -- the common deployment -- sends every key to one
+    // backend in order, so hand it `keys` directly. Copying it first cost an
+    // allocation and a ~128-byte string copy per key for nothing.
+    bool identity = indices.size() == keys.size();
+    for (size_t i = 0; identity && i < indices.size(); ++i) identity = indices[i] == i;
     std::vector<std::string> backend_keys;
-    backend_keys.reserve(indices.size());
+    if (!identity) backend_keys.reserve(indices.size());
     for (size_t index : indices) {
-      attempted[index][backend_id] = true;
-      backend_keys.push_back(keys[index]);
+      attempted[index] |= static_cast<uint16_t>(1u << backend_id);
+      if (!identity) backend_keys.push_back(keys[index]);
     }
-    auto results = backend->BatchResolve(backend_keys, include_descs);
+    auto results = backend->BatchResolve(identity ? keys : backend_keys, include_descs);
     for (size_t i = 0; i < indices.size() && i < results.size(); ++i) {
       const size_t index = indices[i];
       const ResolveOutcome outcome = EffectiveResolveOutcome(results[i]);
@@ -594,12 +619,13 @@ std::vector<PoolResolvedEntry> PeerPool::BatchResolve(const std::vector<std::str
   }
   for (const auto& [backend_id, indices] : preferred_groups) resolve(backend_id, indices);
 
-  const auto read_order = policy_->ReadOrder(*backends_);
   for (uint32_t backend_id : read_order) {
     if (backend_id >= BackendRegistry::kMaxBackends) continue;
     std::vector<size_t> unresolved;
     for (size_t i = 0; i < keys.size(); ++i) {
-      if (!out[i].resolved.found && !attempted[i][backend_id]) unresolved.push_back(i);
+      if (!out[i].resolved.found && (attempted[i] & (1u << backend_id)) == 0) {
+        unresolved.push_back(i);
+      }
     }
     resolve(backend_id, unresolved);
   }
@@ -612,6 +638,22 @@ std::vector<PoolResolvedEntry> PeerPool::BatchResolve(const std::vector<std::str
   });
   if (batch_busy) return out;
 
+  // Probe the backends for the keys that resolved to nothing before retaking the
+  // lock: Contains() is another backend call, and phase 3 exists to mutate maps,
+  // not to wait on media.
+  std::vector<std::optional<uint32_t>> repaired(keys.size());
+  for (size_t i = 0; i < keys.size(); ++i) {
+    if (out[i].resolved.found) continue;
+    for (uint32_t backend_id : read_order) {
+      auto* backend = backends_->Get(backend_id);
+      if (backend != nullptr && backend->Contains(keys[i])) {
+        repaired[i] = backend_id;
+        break;
+      }
+    }
+  }
+
+  std::lock_guard<std::mutex> operation_lock(operation_mutex_);
   for (size_t i = 0; i < keys.size(); ++i) {
     if (out[i].resolved.found) {
       placements_[keys[i]] = out[i].backend_id;
@@ -628,22 +670,13 @@ std::vector<PoolResolvedEntry> PeerPool::BatchResolve(const std::vector<std::str
               {TierTransitionKind::kPromotion, keys[i], out[i].backend_id, *source_tier});
         }
       }
+    } else if (repaired[i].has_value()) {
+      placements_[keys[i]] = *repaired[i];
     } else {
-      bool exists = false;
-      for (uint32_t backend_id : read_order) {
-        auto* backend = backends_->Get(backend_id);
-        if (backend != nullptr && backend->Contains(keys[i])) {
-          placements_[keys[i]] = backend_id;
-          exists = true;
-          break;
-        }
-      }
       // A key the backends no longer hold must leave the access index too, or
       // it accumulates there for the life of the process and skews LRU order.
-      if (!exists) {
-        placements_.erase(keys[i]);
-        ForgetAccessLocked(keys[i]);
-      }
+      placements_.erase(keys[i]);
+      ForgetAccessLocked(keys[i]);
     }
   }
   return out;

--- a/src/umbp/distributed/pool/peer_pool.cpp
+++ b/src/umbp/distributed/pool/peer_pool.cpp
@@ -42,6 +42,13 @@ PeerPool::PeerPool(BackendRegistry* backends, std::unique_ptr<PoolPolicy> policy
     tier_scan_backoff_.assign(tier_graph_->TierCount(),
                               std::chrono::steady_clock::time_point{});
     queued_by_tier_.assign(tier_graph_->TierCount(), 0);
+    for (size_t tier = 0; tier < tier_graph_->TierCount(); ++tier) {
+      const auto& node = tier_graph_->NodeAt(tier);
+      if (node.trigger == PoolOffloadTrigger::kWatermark && !node.offload_to.empty()) {
+        track_access_order_ = true;
+        break;
+      }
+    }
     transition_worker_ = std::thread(&PeerPool::TransitionWorkerLoop, this);
   }
 }
@@ -69,6 +76,7 @@ void PeerPool::StopTransitionWorker() {
 }
 
 void PeerPool::TouchLocked(const std::string& key) {
+  if (!track_access_order_) return;
   auto access = last_access_.find(key);
   if (access != last_access_.end()) {
     access_order_.splice(access_order_.begin(), access_order_, access->second);
@@ -541,43 +549,95 @@ std::vector<bool> PeerPool::BatchAbort(const std::vector<PoolSlotRef>& slots) {
 
 std::vector<PoolResolvedEntry> PeerPool::BatchResolve(const std::vector<std::string>& keys,
                                                       bool include_descs) {
-  // Three phases, and only the first and last hold operation_mutex_. The backend
-  // lookups in between are the expensive part of a resolve, and every backend
-  // guards itself, so holding the pool lock across them only serializes callers
-  // that could have run side by side. Under TP that is every rank at once: the
-  // ranged-call timers showed resolve queueing into a 0 -> 30 ms staircase
-  // across a wave of concurrent batches, 84% of ranged-get time.
-  //
-  // placements_ is a hint, so acting on a stale one costs at most one extra
-  // backend probe, and phase 3 repairs it exactly as the miss path already did.
+  std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
   std::vector<PoolResolvedEntry> out(keys.size());
   if (keys.empty()) return out;
 
+  // A no-tier, single-backend pool needs placement metadata for allocate,
+  // commit, and eviction, but a hit whose placement already names that sole
+  // backend cannot repair or transition anything. Resolve it directly and
+  // avoid building the preferred/attempted/group vectors plus taking the
+  // metadata lock again after backend IO. This is the common no-master,
+  // 100%-hit restore shape.
+  uint32_t direct_backend_id = BackendRegistry::kMaxBackends;
+  MediumBackend* direct_backend = nullptr;
+  {
+    std::lock_guard<std::mutex> operation_lock(operation_mutex_);
+    if (backends_ != nullptr && policy_ != nullptr && tier_graph_ == nullptr &&
+        !track_access_order_ && backends_->Size() == 1) {
+      const std::vector<uint32_t> order = policy_->ReadOrder(*backends_);
+      if (order.size() == 1 && order.front() < BackendRegistry::kMaxBackends) {
+        const uint32_t backend_id = order.front();
+        bool all_placed_here = true;
+        for (const auto& key : keys) {
+          const auto placement = placements_.find(key);
+          if (placement == placements_.end() || placement->second != backend_id) {
+            all_placed_here = false;
+            break;
+          }
+        }
+        if (all_placed_here) {
+          direct_backend_id = backend_id;
+          direct_backend = backends_->Get(backend_id);
+        }
+      }
+    }
+  }
+  if (direct_backend != nullptr) {
+    auto resolved = direct_backend->BatchResolve(keys, include_descs);
+    bool batch_busy = false;
+    bool all_found = resolved.size() == keys.size();
+    std::vector<bool> failed_but_owned(keys.size(), false);
+    for (size_t i = 0; i < resolved.size() && i < out.size(); ++i) {
+      const ResolveOutcome outcome = EffectiveResolveOutcome(resolved[i]);
+      batch_busy |= outcome == ResolveOutcome::kBusy;
+      all_found &= outcome == ResolveOutcome::kFound;
+      if (outcome == ResolveOutcome::kFailed) {
+        failed_but_owned[i] = direct_backend->Contains(keys[i]);
+      }
+      out[i].backend_id = direct_backend_id;
+      out[i].tier = direct_backend->Tier();
+      out[i].resolved = std::move(resolved[i]);
+      out[i].resolved.outcome = outcome;
+    }
+    if (batch_busy || all_found) return out;
+    // A plain miss is authoritative, while kFailed needs one ownership probe:
+    // a backend can still own a key whose descriptor shape it cannot return.
+    // Finalize stale placements here instead of running the whole routing
+    // pipeline and resolving the same backend a second time.
+    std::lock_guard<std::mutex> operation_lock(operation_mutex_);
+    for (size_t i = 0; i < out.size(); ++i) {
+      if (out[i].resolved.found || failed_but_owned[i]) continue;
+      const auto placement = placements_.find(keys[i]);
+      if (placement == placements_.end() || placement->second != direct_backend_id) continue;
+      placements_.erase(placement);
+      ForgetAccessLocked(keys[i]);
+    }
+    return out;
+  }
+
+  uint64_t planned_clear_epoch = 0;
   std::vector<std::optional<uint32_t>> preferred(keys.size());
   std::vector<uint32_t> read_order;
   {
     std::lock_guard<std::mutex> operation_lock(operation_mutex_);
     if (backends_ == nullptr || policy_ == nullptr) return out;
+    planned_clear_epoch = clear_epoch_;
     for (size_t i = 0; i < keys.size(); ++i) {
       auto it = placements_.find(keys[i]);
       if (it != placements_.end()) preferred[i] = it->second;
     }
-    // Snapshot the order under the lock so a concurrent backend add or remove
-    // cannot be observed halfway through the walk below.
     read_order = policy_->ReadOrder(*backends_);
   }
 
-  // One bit per (key, backend) in a flat word per key. A vector<bool> per key
-  // heap-allocated once per key, and a 1023-key batch is the common shape here.
+  // A flat mask avoids one heap allocation per key in the common 1023-key
+  // ranged-get batch.
   static_assert(BackendRegistry::kMaxBackends <= 16, "attempted mask is 16 bits wide");
   std::vector<uint16_t> attempted(keys.size(), 0);
 
   const auto resolve = [&](uint32_t backend_id, const std::vector<size_t>& indices) {
     auto* backend = backends_->Get(backend_id);
     if (backend == nullptr || indices.empty()) return;
-    // The single-backend tier -- the common deployment -- sends every key to one
-    // backend in order, so hand it `keys` directly. Copying it first cost an
-    // allocation and a ~128-byte string copy per key for nothing.
     bool identity = indices.size() == keys.size();
     for (size_t i = 0; identity && i < indices.size(); ++i) identity = indices[i] == i;
     std::vector<std::string> backend_keys;
@@ -630,38 +690,67 @@ std::vector<PoolResolvedEntry> PeerPool::BatchResolve(const std::vector<std::str
     resolve(backend_id, unresolved);
   }
 
-  // A caller retries the whole batch on BUSY and discards this response.  Do
+  // Classify once. A 100%-hit restore must not allocate a key-sized repair
+  // vector merely to discover that there is nothing to repair.
+  bool batch_busy = false;
+  bool all_found = true;
+  for (const auto& entry : out) {
+    batch_busy |= EffectiveResolveOutcome(entry.resolved) == ResolveOutcome::kBusy;
+    all_found &= entry.resolved.found;
+  }
+  // A caller retries the whole batch on BUSY and discards this response. Do
   // not count hits, repair placements, or enqueue promotions for a response
   // whose page locations will never be consumed.
-  const bool batch_busy = std::any_of(out.begin(), out.end(), [](const auto& entry) {
-    return EffectiveResolveOutcome(entry.resolved) == ResolveOutcome::kBusy;
-  });
   if (batch_busy) return out;
 
-  // Probe the backends for the keys that resolved to nothing before retaking the
-  // lock: Contains() is another backend call, and phase 3 exists to mutate maps,
-  // not to wait on media.
-  std::vector<std::optional<uint32_t>> repaired(keys.size());
-  for (size_t i = 0; i < keys.size(); ++i) {
-    if (out[i].resolved.found) continue;
-    for (uint32_t backend_id : read_order) {
-      auto* backend = backends_->Get(backend_id);
+  // Contains is backend work too; keep it off the pool metadata lock. A
+  // placement snapshot check below prevents this repair from overwriting a
+  // commit or migration that publishes while these probes are running.
+  std::vector<std::optional<uint32_t>> repaired;
+  if (!all_found) {
+    repaired.resize(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+      if (out[i].resolved.found) continue;
+      // kMissing is an authoritative negative result from every attempted
+      // backend. Only kFailed is ambiguous: the selected backend may still own
+      // the key but be unable to materialize its descriptor.
+      if (EffectiveResolveOutcome(out[i].resolved) != ResolveOutcome::kFailed) continue;
+      auto* backend = backends_->Get(out[i].backend_id);
       if (backend != nullptr && backend->Contains(keys[i])) {
-        repaired[i] = backend_id;
-        break;
+        repaired[i] = out[i].backend_id;
       }
     }
   }
 
   std::lock_guard<std::mutex> operation_lock(operation_mutex_);
+  // ClearLocal takes lifecycle_mutex_ exclusively, so this is defensive
+  // against future lifecycle paths that may invalidate an in-flight plan.
+  if (clear_epoch_ != planned_clear_epoch) return out;
+
+  const auto placement_unchanged = [&](size_t index) {
+    auto current = placements_.find(keys[index]);
+    if (!preferred[index].has_value()) return current == placements_.end();
+    return current != placements_.end() && current->second == *preferred[index];
+  };
+
   for (size_t i = 0; i < keys.size(); ++i) {
     if (out[i].resolved.found) {
-      placements_[keys[i]] = out[i].backend_id;
-      TouchLocked(keys[i]);
+      // A migration or commit may have published a newer owner while backend
+      // IO ran. Repair only the placement snapshot this resolve actually used;
+      // never move the logical owner backwards to a source that is draining.
+      const bool metadata_current = placement_unchanged(i);
+      if (metadata_current) placements_[keys[i]] = out[i].backend_id;
+      // A concurrent discard may have removed the key entirely. Do not
+      // resurrect only its LRU entry from a resolve that started earlier.
+      const bool still_placed =
+          metadata_current || placements_.find(keys[i]) != placements_.end();
+      if (still_placed) TouchLocked(keys[i]);
       if (tier_graph_ != nullptr) {
         ++tier_read_hits_[tier_graph_->NameForBackend(out[i].backend_id)];
         const auto source_tier = tier_graph_->TierIndexForBackendId(out[i].backend_id);
-        if (source_tier.has_value() && *source_tier != tier_graph_->EntryTierIndex() &&
+        if (metadata_current && source_tier.has_value() &&
+            *source_tier != tier_graph_->EntryTierIndex() &&
+            migrating_keys_.count(keys[i]) == 0 &&
             !tier_graph_->AtOrAbove(tier_graph_->EntryTierIndex(),
                                     tier_graph_->NodeAt(tier_graph_->EntryTierIndex())
                                         .high_watermark) &&
@@ -670,9 +759,14 @@ std::vector<PoolResolvedEntry> PeerPool::BatchResolve(const std::vector<std::str
               {TierTransitionKind::kPromotion, keys[i], out[i].backend_id, *source_tier});
         }
       }
-    } else if (repaired[i].has_value()) {
-      placements_[keys[i]] = *repaired[i];
     } else {
+      // A concurrent commit or transition changed the placement after the
+      // snapshot; its publication is newer than this miss and must win.
+      if (!placement_unchanged(i)) continue;
+      if (repaired[i].has_value()) {
+        placements_[keys[i]] = *repaired[i];
+        continue;
+      }
       // A key the backends no longer hold must leave the access index too, or
       // it accumulates there for the life of the process and skews LRU order.
       placements_.erase(keys[i]);
@@ -768,6 +862,7 @@ std::vector<EvictResult> PeerPool::Evict(const std::vector<std::string>& keys,
 }
 
 void PeerPool::ClearLocal() {
+  std::unique_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
   std::unique_lock<std::mutex> operation_lock(operation_mutex_);
   {
     std::lock_guard<std::mutex> lock(transition_mutex_);
@@ -789,6 +884,7 @@ void PeerPool::ClearLocal() {
   last_access_.clear();
   access_order_.clear();
   promote_hit_counts_.clear();
+  ++clear_epoch_;
 }
 
 std::vector<KvEvent> PeerPool::DrainPendingEvents() {

--- a/src/umbp/include/umbp/distributed/pool/peer_pool.h
+++ b/src/umbp/include/umbp/distributed/pool/peer_pool.h
@@ -7,6 +7,7 @@
 #include <condition_variable>
 #include <cstdint>
 #include <deque>
+#include <list>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -156,9 +157,11 @@ class PeerPool {
   // Pool favors correctness over concurrent dispatch; later policies can shard
   // this by key without changing the public interface.
   mutable std::mutex operation_mutex_;
-  // Ordered so watermark offload can walk candidates in key order without
-  // materializing and sorting every placement first.
-  std::map<std::string, uint32_t> placements_;
+  // Unordered on purpose: every use is a point lookup, insert or erase, and
+  // BatchResolve publishes one entry per key with the pool lock held, where an
+  // ordered tree spends that critical section on string comparisons for an
+  // ordering nothing reads.
+  std::unordered_map<std::string, uint32_t> placements_;
   // A migration may install its target while an independent read lease delays
   // source deletion. Eviction retries must drain only that source, never fan
   // out and delete the durable target.
@@ -170,16 +173,18 @@ class PeerPool {
   std::condition_variable transition_idle_cv_;
   std::unordered_map<std::string, PendingPlacement> pending_keys_;
   std::map<std::pair<uint32_t, uint64_t>, std::string> pending_slots_;
-  std::unordered_map<std::string, uint64_t> last_access_;
+  std::unordered_map<std::string, std::list<std::string>::iterator> last_access_;
   // Reads served for a key from a tier whose trigger is kOnHits. Separate from
-  // last_access_, which is an LRU stamp and carries no count. Cleared when the
+  // last_access_, which is an LRU position and carries no count. Cleared when the
   // promotion is queued and whenever the key leaves the access index, so it
   // cannot outlive the key it counts for.
   std::unordered_map<std::string, uint32_t> promote_hit_counts_;
-  // Reverse index of last_access_, so the least recently used key is the first
-  // element rather than the result of sorting every placement.
-  std::map<uint64_t, std::string> access_order_;
-  uint64_t access_clock_ = 0;
+  // Reverse index of last_access_, hottest at the front, so the least recently
+  // used key is reached without sorting every placement. An intrusive list
+  // rather than a stamp-keyed tree: BatchResolve touches one entry per resolved
+  // key with the pool lock held, and a tree insert paid a node allocation plus
+  // a copy of the ~128-byte key each time. A splice pays neither.
+  std::list<std::string> access_order_;
   // Earliest next scan per tier, moved forward only when a scan found nothing
   // to queue. A pressured tier with no candidates must not make every commit
   // batch pay for another walk.

--- a/src/umbp/include/umbp/distributed/pool/peer_pool.h
+++ b/src/umbp/include/umbp/distributed/pool/peer_pool.h
@@ -12,6 +12,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <shared_mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -152,15 +153,22 @@ class PeerPool {
   TransferEngine* transfer_engine_;
   std::shared_ptr<const LogicalTierGraph> tier_graph_;
   TierTransitionExecutor transition_executor_;
+  // Only watermark-driven offload consumes recency order. On-evict policies
+  // name their victim explicitly, and non-tiered pools never read the LRU.
+  bool track_access_order_ = false;
 
+  // Resolve dispatch deliberately drops operation_mutex_ while thread-safe
+  // backends do their work. ClearLocal takes this exclusively so it cannot
+  // invalidate an SSD staging result while a resolve is between its plan and
+  // publish phases.
+  mutable std::shared_mutex lifecycle_mutex_;
   // Serializes policy decisions with backend lifecycle operations. The first
-  // Pool favors correctness over concurrent dispatch; later policies can shard
-  // this by key without changing the public interface.
+  // Pool still uses one metadata lock, but slow resolve dispatch does not hold
+  // it; later policies can shard the protected state by key without changing
+  // the public interface.
   mutable std::mutex operation_mutex_;
-  // Unordered on purpose: every use is a point lookup, insert or erase, and
-  // BatchResolve publishes one entry per key with the pool lock held, where an
-  // ordered tree spends that critical section on string comparisons for an
-  // ordering nothing reads.
+  // Every use is a point lookup, insert or erase. Keeping this unordered avoids
+  // string comparisons in BatchResolve's publish critical section.
   std::unordered_map<std::string, uint32_t> placements_;
   // A migration may install its target while an independent read lease delays
   // source deletion. Eviction retries must drain only that source, never fan
@@ -179,11 +187,8 @@ class PeerPool {
   // promotion is queued and whenever the key leaves the access index, so it
   // cannot outlive the key it counts for.
   std::unordered_map<std::string, uint32_t> promote_hit_counts_;
-  // Reverse index of last_access_, hottest at the front, so the least recently
-  // used key is reached without sorting every placement. An intrusive list
-  // rather than a stamp-keyed tree: BatchResolve touches one entry per resolved
-  // key with the pool lock held, and a tree insert paid a node allocation plus
-  // a copy of the ~128-byte key each time. A splice pays neither.
+  // Hottest key is at the front. Stable list iterators let a touch splice an
+  // existing key without allocating a tree node or copying the key.
   std::list<std::string> access_order_;
   // Earliest next scan per tier, moved forward only when a scan found nothing
   // to queue. A pressured tier with no candidates must not make every commit
@@ -191,6 +196,8 @@ class PeerPool {
   std::vector<std::chrono::steady_clock::time_point> tier_scan_backoff_;
   TierTransitionMetrics transition_metrics_;
   std::map<std::string, uint64_t> tier_read_hits_;
+  // Invalidates a resolve plan if a clear completed while it was dispatched.
+  uint64_t clear_epoch_ = 0;
 
   std::mutex transition_mutex_;
   std::condition_variable transition_cv_;

--- a/src/umbp/include/umbp/standalone/standalone_process_client.h
+++ b/src/umbp/include/umbp/standalone/standalone_process_client.h
@@ -99,6 +99,11 @@ class StandaloneProcessClient : public IUMBPClient {
   // Resolves `ptr` against the registered host regions. On success writes the
   // region-relative `offset` and the matched region's worker VA `region_base`.
   bool OffsetFor(uintptr_t ptr, size_t size, uint64_t* offset, uint64_t* region_base) const;
+  // The batch paths translate one pointer per RANGE -- a 1023-key ranged get
+  // carries roughly 5k of them -- so they take registration_mu_ once for the
+  // whole request and call this instead of a lock round trip per range.
+  bool OffsetForLocked(uintptr_t ptr, size_t size, uint64_t* offset,
+                       uint64_t* region_base) const;
   // Not const: a successful Ping is where the server's backend mode and ranged
   // capability become known, and they are cached on the client.
   bool WaitReady(int timeout_ms);

--- a/src/umbp/standalone/standalone_process_client.cpp
+++ b/src/umbp/standalone/standalone_process_client.cpp
@@ -272,6 +272,11 @@ void StandaloneProcessClient::MaybeAutoStart() {
 bool StandaloneProcessClient::OffsetFor(uintptr_t ptr, size_t size, uint64_t* offset,
                                         uint64_t* region_base) const {
   std::lock_guard<std::mutex> lock(registration_mu_);
+  return OffsetForLocked(ptr, size, offset, region_base);
+}
+
+bool StandaloneProcessClient::OffsetForLocked(uintptr_t ptr, size_t size, uint64_t* offset,
+                                              uint64_t* region_base) const {
   for (const auto& region : regions_) {
     if (ptr < region.base) continue;
     uintptr_t rel = ptr - region.base;
@@ -436,18 +441,21 @@ std::vector<bool> StandaloneProcessClient::BatchGetRanges(
 
   ::umbp::BatchRangeDataRequest req;
   req.set_client_id(ClientId());
-  for (size_t i = 0; i < keys.size(); ++i) {
-    if (dsts[i].size() > std::numeric_limits<uint32_t>::max()) return failed;
-    req.add_keys(keys[i]);
-    req.add_range_counts(static_cast<uint32_t>(dsts[i].size()));
-    for (size_t j = 0; j < dsts[i].size(); ++j) {
-      uint64_t shm_offset = 0;
-      uint64_t region_base = 0;
-      if (!OffsetFor(dsts[i][j], sizes[i][j], &shm_offset, &region_base)) return failed;
-      req.add_shm_offsets(shm_offset);
-      req.add_region_bases(region_base);
-      req.add_sizes(sizes[i][j]);
-      req.add_object_offsets(src_offsets[i][j]);
+  {
+    std::lock_guard<std::mutex> registration_lock(registration_mu_);
+    for (size_t i = 0; i < keys.size(); ++i) {
+      if (dsts[i].size() > std::numeric_limits<uint32_t>::max()) return failed;
+      req.add_keys(keys[i]);
+      req.add_range_counts(static_cast<uint32_t>(dsts[i].size()));
+      for (size_t j = 0; j < dsts[i].size(); ++j) {
+        uint64_t shm_offset = 0;
+        uint64_t region_base = 0;
+        if (!OffsetForLocked(dsts[i][j], sizes[i][j], &shm_offset, &region_base)) return failed;
+        req.add_shm_offsets(shm_offset);
+        req.add_region_bases(region_base);
+        req.add_sizes(sizes[i][j]);
+        req.add_object_offsets(src_offsets[i][j]);
+      }
     }
   }
 
@@ -472,19 +480,22 @@ std::vector<bool> StandaloneProcessClient::BatchPutRanges(
 
   ::umbp::BatchRangeDataRequest req;
   req.set_client_id(ClientId());
-  for (size_t i = 0; i < keys.size(); ++i) {
-    if (srcs[i].size() > std::numeric_limits<uint32_t>::max()) return failed;
-    req.add_keys(keys[i]);
-    req.add_object_sizes(object_sizes[i]);
-    req.add_range_counts(static_cast<uint32_t>(srcs[i].size()));
-    for (size_t j = 0; j < srcs[i].size(); ++j) {
-      uint64_t shm_offset = 0;
-      uint64_t region_base = 0;
-      if (!OffsetFor(srcs[i][j], sizes[i][j], &shm_offset, &region_base)) return failed;
-      req.add_shm_offsets(shm_offset);
-      req.add_region_bases(region_base);
-      req.add_sizes(sizes[i][j]);
-      req.add_object_offsets(dst_offsets[i][j]);
+  {
+    std::lock_guard<std::mutex> registration_lock(registration_mu_);
+    for (size_t i = 0; i < keys.size(); ++i) {
+      if (srcs[i].size() > std::numeric_limits<uint32_t>::max()) return failed;
+      req.add_keys(keys[i]);
+      req.add_object_sizes(object_sizes[i]);
+      req.add_range_counts(static_cast<uint32_t>(srcs[i].size()));
+      for (size_t j = 0; j < srcs[i].size(); ++j) {
+        uint64_t shm_offset = 0;
+        uint64_t region_base = 0;
+        if (!OffsetForLocked(srcs[i][j], sizes[i][j], &shm_offset, &region_base)) return failed;
+        req.add_shm_offsets(shm_offset);
+        req.add_region_bases(region_base);
+        req.add_sizes(sizes[i][j]);
+        req.add_object_offsets(dst_offsets[i][j]);
+      }
     }
   }
 

--- a/tests/cpp/umbp/distributed/test_peer_pool.cpp
+++ b/tests/cpp/umbp/distributed/test_peer_pool.cpp
@@ -12,6 +12,7 @@
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "umbp/distributed/peer/backend/instrumented_backend.h"
@@ -145,6 +146,46 @@ class BlockingAllocateBackend final : public MockBackend {
     std::vector<AllocateResult> results(entries.size());
     for (auto& result : results) result.outcome = AllocateOutcome::kFailedNoSpace;
     return results;
+  }
+
+  bool WaitUntilEntered() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return cv_.wait_for(lock, std::chrono::seconds(5), [this] { return entered_; });
+  }
+
+  void Release() {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      released_ = true;
+    }
+    cv_.notify_all();
+  }
+
+ private:
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  bool entered_ = false;
+  bool released_ = false;
+};
+
+// Parks one backend resolve so the test can prove PeerPool does not retain its
+// peer-wide metadata lock while a medium performs slow IO.
+class BlockingResolveBackend final : public MockBackend {
+ public:
+  explicit BlockingResolveBackend(TierType tier) : MockBackend(tier) {}
+
+  std::vector<ResolvedEntry> BatchResolve(const std::vector<std::string>& keys,
+                                          bool include_descs) override {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      entered_ = true;
+    }
+    cv_.notify_all();
+    {
+      std::unique_lock<std::mutex> lock(mutex_);
+      cv_.wait_for(lock, std::chrono::seconds(5), [this] { return released_; });
+    }
+    return MockBackend::BatchResolve(keys, include_descs);
   }
 
   bool WaitUntilEntered() {
@@ -701,6 +742,92 @@ TEST(PeerPool, MigrationDoesNotBlockConcurrentPoolOperations) {
   EXPECT_EQ(concurrent.wait_for(std::chrono::seconds(2)), std::future_status::ready);
   blocking->Release();
   EXPECT_EQ(concurrent.get(), 1u);
+}
+
+TEST(PeerPool, SlowResolveDoesNotBlockUnrelatedPreferredBackend) {
+  BackendRegistry registry;
+  auto slow = std::make_unique<BlockingResolveBackend>(TierType::SSD);
+  auto* blocking = slow.get();
+  ASSERT_TRUE(registry.Register("slow", std::move(slow)));
+  ASSERT_TRUE(registry.Register("fast", std::make_unique<MockBackend>(TierType::DRAM)));
+  PeerPool pool(&registry, MakeSingleBackendPolicy());
+  CommitKey(&pool, "fast-key", "fast");
+
+  auto slow_resolve =
+      std::async(std::launch::async, [&] { return pool.BatchResolve({"missing"}, false); });
+  ASSERT_TRUE(blocking->WaitUntilEntered());
+
+  // The preferred placement resolves entirely on the fast backend. It must
+  // not queue behind unrelated IO already running on another medium.
+  auto fast_resolve =
+      std::async(std::launch::async, [&] { return pool.BatchResolve({"fast-key"}, false); });
+  const auto status = fast_resolve.wait_for(std::chrono::seconds(2));
+  blocking->Release();
+
+  EXPECT_EQ(status, std::future_status::ready);
+  auto fast_result = fast_resolve.get();
+  ASSERT_EQ(fast_result.size(), 1u);
+  EXPECT_TRUE(fast_result.front().resolved.found);
+  EXPECT_EQ(slow_resolve.get().size(), 1u);
+}
+
+TEST(PeerPool, ResolveMissDoesNotEraseConcurrentCommit) {
+  BackendRegistry registry;
+  auto slow = std::make_unique<BlockingResolveBackend>(TierType::SSD);
+  auto* blocking = slow.get();
+  ASSERT_TRUE(registry.Register("slow", std::move(slow)));
+  ASSERT_TRUE(registry.Register("fast", std::make_unique<MockBackend>(TierType::DRAM)));
+  PeerPool pool(&registry, MakeSingleBackendPolicy());
+
+  auto stale_resolve =
+      std::async(std::launch::async, [&] { return pool.BatchResolve({"raced"}, false); });
+  ASSERT_TRUE(blocking->WaitUntilEntered());
+
+  auto concurrent_commit = std::async(std::launch::async, [&] {
+    auto allocation = pool.BatchAllocate({PutRequest("raced", "fast")}).front();
+    bool committed = false;
+    if (allocation.allocation.outcome == AllocateOutcome::kSuccessAllocated) {
+      committed =
+          pool.BatchCommit({PoolCommitRequest{
+                                {allocation.backend_id, allocation.allocation.slot_id},
+                                "raced"}})
+              .front()
+              .commit.success;
+    }
+    return std::make_pair(allocation, committed);
+  });
+  const auto status = concurrent_commit.wait_for(std::chrono::seconds(2));
+  blocking->Release();
+
+  EXPECT_EQ(status, std::future_status::ready);
+  const auto [allocation, committed] = concurrent_commit.get();
+  EXPECT_TRUE(committed);
+  EXPECT_EQ(allocation.backend_id, registry.BackendId(registry.Get("fast")));
+  EXPECT_EQ(stale_resolve.get().size(), 1u);
+  EXPECT_EQ(pool.PlacementBackend("raced"),
+            std::optional<uint32_t>{registry.BackendId(registry.Get("fast"))});
+}
+
+TEST(PeerPool, ClearWaitsForInFlightResolveAndLeavesNoStalePlacement) {
+  BackendRegistry registry;
+  auto backend = std::make_unique<BlockingResolveBackend>(TierType::DRAM);
+  auto* blocking = backend.get();
+  ASSERT_TRUE(registry.Register("dram", std::move(backend)));
+  PeerPool pool(&registry, MakeSingleBackendPolicy());
+  CommitKey(&pool, "clear-race", "dram");
+
+  auto resolve =
+      std::async(std::launch::async, [&] { return pool.BatchResolve({"clear-race"}, false); });
+  ASSERT_TRUE(blocking->WaitUntilEntered());
+
+  auto clear = std::async(std::launch::async, [&] { pool.ClearLocal(); });
+  EXPECT_EQ(clear.wait_for(std::chrono::milliseconds(100)), std::future_status::timeout);
+  blocking->Release();
+
+  ASSERT_TRUE(resolve.get().front().resolved.found);
+  clear.get();
+  EXPECT_EQ(pool.PlacementBackend("clear-race"), std::nullopt);
+  EXPECT_FALSE(registry.Get("dram")->Contains("clear-race"));
 }
 
 TEST(PeerPool, ReadPromotesColdKeyWithoutDeletingSource) {


### PR DESCRIPTION
## Summary

`4636fb9` (original tier management) made TP8 256K / 100%-hit restore serialize in `PeerPool::BatchResolve()`: `operation_mutex_` was held across backend IO. This PR is two commits on top of `refactor/umbp-backend-agnostic`:

- `3d60bb1` — three-phase resolve (lock only for placement hints / publish) plus once-per-request `registration_mu_` in the standalone client. Same change as #629.
- `73c31f6` — single-backend hit path hands the batch to that backend without re-walking placement under the lock; `ClearLocal` waits for in-flight resolves; a miss no longer erases a placement a concurrent commit just published.

Supersedes #629 (same lock split, plus the hit-path / lifecycle follow-up). Please review this PR instead of updating `perf/umbp-peer-pool-resolve`.

## Numbers

Standalone process, **no master**, inner Distributed DRAM **64KiB** pages, DeepSeek-V4-Pro TP8, 256K, 99.9% hit, `load_ms = ttft_ms - dev_ms`. Topology `StandaloneProcess+Distributed ×8`.

Do not treat #629's 654.8 → 153.1 ms figures as the headline.

**n09-21, 3 reps** (`warm_ms` within ~0.02%):

| group | tree | load_ms | ttft_ms | warm_ms |
|---|---|---:|---:|---:|
| A | `a6970dc` (pre-tier-management) | 107.0 | 282.0 | 62390.7 |
| B | `4636fb9` original tier management | **605.3** | 778.0 | 62401.7 |

**n08-25, 5 reps** (`warm_ms` A / this PR within ~0.003%; B +0.2%):

| group | tree | load_ms | ttft_ms | spread | warm_ms |
|---|---|---:|---:|---:|---:|
| A | `a6970dc` | 116.8 | 292.2 | 5.6% | 62320.9 |
| B | `4636fb9` original tier management | **655.9** | 832.3 | 19.7% | 62445.7 |
| this PR | `73c31f6` (`09876ba` + `3d60bb1` + `73c31f6`) | **115.3** | 290.7 | 4.0% | 62319.5 |

this PR ttft samples: `[281.0, 284.5, 290.7, 292.2, 292.3]`.

Factory-DRAM Local (no Distributed inner) did **not** regress: A 102.8 vs B 102.3.

90 ms is still open after restoring ~110–116 ms Distributed.

## Test plan

- [x] n09-21 Distributed A/B, 3 reps, 64KiB, standalone no-master
- [x] n09-21 Local A/B, 5/3 reps: no Local regression
- [x] n08-25 Distributed A/B, 5 reps
- [x] unit tests on this HEAD (`test_peer_pool` 29/29)
- [x] E2E on this HEAD (`73c31f6`), same Distributed + 64KiB shape on n08-25

## Test result

Original tier management is a ~5.6–5.7× Distributed restore regression on both nodes. This PR restores n08-25 5-rep load from 655.9 ms to 115.3 ms, in the noise of `a6970dc` (116.8 ms). `test_peer_pool` 29/29 passed on this SHA.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
