### PR TITLE
perf(umbp): fix the local-path lock contention that fails the primitive concurrency gate

### DIFF
--- a/src/umbp/distributed/peer/backend/page_backend.cpp
+++ b/src/umbp/distributed/peer/backend/page_backend.cpp
@@ -291,7 +291,7 @@ void HostPageMemorySource::Release() {
 AllocateResult PageBackend::Allocate(const std::string& key, uint64_t size) {
   AllocateResult out;
   {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::unique_lock<std::shared_mutex> lock(mutex_);
     out = AllocateLocked(key, size);
   }
   // A full pool is the one state the commit-time round cannot have prevented
@@ -358,7 +358,7 @@ std::vector<AllocateResult> PageBackend::BatchAllocate(
   if (entries.empty()) return out;
   bool no_space = false;
   {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::unique_lock<std::shared_mutex> lock(mutex_);
     for (size_t i = 0; i < entries.size(); ++i) {
       out[i] = AllocateLocked(entries[i].key, entries[i].size);
       if (out[i].outcome == AllocateOutcome::kSuccessAllocated) {
@@ -378,7 +378,7 @@ std::vector<AllocateResult> PageBackend::BatchAllocate(
 bool PageBackend::Commit(uint64_t slot_id, const std::string& key, uint64_t& bytes_committed) {
   bool ok = false;
   {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::unique_lock<std::shared_mutex> lock(mutex_);
     ok = CommitLocked(slot_id, key, bytes_committed);
   }
   // Check-after-write, on the committing thread: there is no eviction thread,
@@ -424,7 +424,7 @@ bool PageBackend::CommitLocked(uint64_t slot_id, const std::string& key,
   owned.size = it->second.size;
   QueueEventLocked(KvEvent{KvEvent::Kind::ADD, key, tier_, owned.size});
   owned_[key] = std::move(owned);
-  TouchLruLocked(key, owned_[key]);
+  TouchLru(key, owned_[key]);
   pending_.erase(it);
   bytes_committed = owned_[key].size;
   return true;
@@ -434,7 +434,7 @@ std::vector<CommitResult> PageBackend::BatchCommit(const std::vector<CommitReque
   std::vector<CommitResult> out(entries.size());
   if (entries.empty()) return out;
   {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::unique_lock<std::shared_mutex> lock(mutex_);
     for (size_t i = 0; i < entries.size(); ++i) {
       out[i].success = CommitLocked(entries[i].slot_id, entries[i].key, out[i].bytes_committed);
     }
@@ -446,7 +446,7 @@ std::vector<CommitResult> PageBackend::BatchCommit(const std::vector<CommitReque
 }
 
 bool PageBackend::Abort(uint64_t slot_id) {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::unique_lock<std::shared_mutex> lock(mutex_);
   return AbortLocked(slot_id);
 }
 
@@ -461,7 +461,7 @@ bool PageBackend::AbortLocked(uint64_t slot_id) {
 std::vector<bool> PageBackend::BatchAbort(const std::vector<uint64_t>& slot_ids) {
   std::vector<bool> out(slot_ids.size(), false);
   if (slot_ids.empty()) return out;
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::unique_lock<std::shared_mutex> lock(mutex_);
   for (size_t i = 0; i < slot_ids.size(); ++i) out[i] = AbortLocked(slot_ids[i]);
   return out;
 }
@@ -471,7 +471,9 @@ std::vector<bool> PageBackend::BatchAbort(const std::vector<uint64_t>& slot_ids)
 // ---------------------------------------------------------------------------
 
 ResolvedEntry PageBackend::Resolve(const std::string& key) {
-  std::lock_guard<std::mutex> lock(mutex_);
+  // Shared: this reads owned_ only.  The lease is an atomic and the LRU has
+  // its own lock, so neither needs exclusion here.
+  std::shared_lock<std::shared_mutex> lock(mutex_);
   ResolvedEntry r;
   auto it = owned_.find(key);
   if (it == owned_.end()) return r;
@@ -481,10 +483,10 @@ ResolvedEntry PageBackend::Resolve(const std::string& key) {
   r.size = it->second.size;
   r.page_size = page_size_;
   // Extend the read lease so concurrent Evict reports bytes_freed=0 for
-  // this key.  steady_clock is monotonic and read_lease_ttl_ is fixed,
-  // so this assignment is always >= any previous deadline for the key.
-  it->second.read_lease_until = std::chrono::steady_clock::now() + read_lease_ttl_;
-  TouchLruLocked(key, it->second);
+  // this key.  CAS-max rather than a plain store: with a shared lock two
+  // readers can renew the same key at once, and neither may shorten it.
+  RenewLeaseAtomic(it->second, SteadyNs(std::chrono::steady_clock::now() + read_lease_ttl_));
+  TouchLru(key, it->second);
   return r;
 }
 
@@ -493,10 +495,18 @@ std::vector<ResolvedEntry> PageBackend::BatchResolve(const std::vector<std::stri
   (void)allow_file_refs;  // pages are this medium's storage; there is no file to name
   std::vector<ResolvedEntry> out(keys.size());
   if (keys.empty()) return out;
-  std::lock_guard<std::mutex> lock(mutex_);
+  // Shared: the whole batch -- hash lookups, page-vector copies and descriptor
+  // building -- is read-only against owned_.  This is the concurrency that the
+  // gated exists sweep measures, so it must not serialize.
+  std::shared_lock<std::shared_mutex> lock(mutex_);
   // One now() for the batch: it runs in well under a millisecond against a
   // TTL measured in seconds, so the last key loses nothing worth a syscall.
-  const auto lease_deadline = std::chrono::steady_clock::now() + read_lease_ttl_;
+  const int64_t lease_deadline = SteadyNs(std::chrono::steady_clock::now() + read_lease_ttl_);
+  // Collect the hits, then touch the LRU once for the whole batch instead of
+  // taking lru_mutex_ per key.  Nothing here can invalidate the pointers: a
+  // shared lock excludes every writer of owned_.
+  std::vector<std::pair<const std::string*, OwnedSlot*>> touched;
+  if (local_evict_enabled_) touched.reserve(keys.size());
   for (size_t i = 0; i < keys.size(); ++i) {
     auto it = owned_.find(keys[i]);
     if (it == owned_.end()) continue;
@@ -507,15 +517,19 @@ std::vector<ResolvedEntry> PageBackend::BatchResolve(const std::vector<std::stri
     entry.size = it->second.size;
     entry.page_size = page_size_;
     if (include_descs) entry.descs = BuildBufferDescsLocked(it->second.pages);
-    it->second.read_lease_until = lease_deadline;
-    TouchLruLocked(keys[i], it->second);
+    RenewLeaseAtomic(it->second, lease_deadline);
+    if (local_evict_enabled_) touched.emplace_back(&keys[i], &it->second);
+  }
+  if (!touched.empty()) {
+    std::lock_guard<std::mutex> lru_lock(lru_mutex_);
+    for (auto& [key, slot] : touched) TouchLruLocked(*key, *slot);
   }
   return out;
 }
 
 bool PageBackend::AcquireMigrationRead(const std::string& key, ResolvedEntry* resolved) {
   if (resolved == nullptr) return false;
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::unique_lock<std::shared_mutex> lock(mutex_);
   auto owned = owned_.find(key);
   if (owned == owned_.end() || pins_.find(key) != pins_.end()) return false;
   resolved->outcome = ResolveOutcome::kFound;
@@ -528,12 +542,12 @@ bool PageBackend::AcquireMigrationRead(const std::string& key, ResolvedEntry* re
 }
 
 void PageBackend::ReleaseMigrationRead(const std::string& key) {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::unique_lock<std::shared_mutex> lock(mutex_);
   pins_.erase(key);
 }
 
 bool PageBackend::Contains(const std::string& key) const {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::shared_lock<std::shared_mutex> lock(mutex_);
   return owned_.find(key) != owned_.end();
 }
 
@@ -544,7 +558,7 @@ bool PageBackend::Contains(const std::string& key) const {
 std::vector<EvictResult> PageBackend::Evict(const std::vector<std::string>& keys) {
   std::vector<EvictResult> out;
   out.reserve(keys.size());
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::unique_lock<std::shared_mutex> lock(mutex_);
   for (const auto& key : keys) {
     EvictResult r;
     r.key = key;
@@ -568,7 +582,7 @@ std::vector<EvictResult> PageBackend::Evict(const std::vector<std::string>& keys
     if (allocator_) allocator_->Deallocate(it->second.pages);
     r.bytes_freed = it->second.size;
     QueueEventLocked(KvEvent{KvEvent::Kind::REMOVE, key, tier_, 0});
-    RemoveFromLruLocked(it->second);
+    RemoveFromLru(it->second);
     owned_.erase(it);
     out.push_back(std::move(r));
   }
@@ -580,7 +594,7 @@ std::vector<EvictResult> PageBackend::Evict(const std::vector<std::string>& keys
 // ---------------------------------------------------------------------------
 
 std::optional<PageBackend::DramCopyPin> PageBackend::AcquireDramCopyPin(const std::string& key) {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::unique_lock<std::shared_mutex> lock(mutex_);
   auto it = owned_.find(key);
   if (it == owned_.end()) return std::nullopt;              // already evicted -> drop task
   if (pins_.find(key) != pins_.end()) return std::nullopt;  // duplicate task
@@ -594,7 +608,7 @@ std::optional<PageBackend::DramCopyPin> PageBackend::AcquireDramCopyPin(const st
 }
 
 void PageBackend::ReleaseDramCopyPin(const std::string& key, uint64_t pin_token) {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::unique_lock<std::shared_mutex> lock(mutex_);
   auto it = pins_.find(key);
   if (it == pins_.end() || it->second.token != pin_token) return;  // tolerate late/dup release
   pins_.erase(it);
@@ -630,7 +644,7 @@ std::vector<std::pair<const void*, size_t>> PageBackend::BuildCopySegmentsLocked
 // ---------------------------------------------------------------------------
 
 void PageBackend::ClearLocal() {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::unique_lock<std::shared_mutex> lock(mutex_);
   const auto now = std::chrono::steady_clock::now();
 
   // Pending slots become pre-clear via generation mismatch; their pages
@@ -657,19 +671,24 @@ void PageBackend::ClearLocal() {
   // in flight) until their lease deadline; free the rest immediately.  No
   // REMOVE events — the upcoming full-sync empty snapshot collapses
   // master's index.
+  const int64_t now_ns = SteadyNs(now);
   for (auto& [key, slot] : owned_) {
-    if (slot.read_lease_until > now) {
+    const int64_t lease_ns = slot.read_lease_ns.load(std::memory_order_relaxed);
+    if (lease_ns > now_ns) {
       DeferredFree df;
       df.key = key;
       df.pages = std::move(slot.pages);
-      df.release_at = slot.read_lease_until;
+      df.release_at = std::chrono::steady_clock::time_point(std::chrono::nanoseconds(lease_ns));
       deferred_frees_.push_back(std::move(df));
       continue;
     }
     if (allocator_) allocator_->Deallocate(slot.pages);
   }
   owned_.clear();
-  lru_.clear();
+  {
+    std::lock_guard<std::mutex> lru_lock(lru_mutex_);
+    lru_.clear();
+  }
 
   // Deadlines that mattered are already in deferred_frees_; the rest went
   // with owned_.
@@ -710,14 +729,14 @@ void PageBackend::QueueEventLocked(KvEvent event) {
 }
 
 std::vector<KvEvent> PageBackend::DrainPendingEvents() {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::unique_lock<std::shared_mutex> lock(mutex_);
   std::vector<KvEvent> drained;
   drained.swap(pending_events_);
   return drained;
 }
 
 void PageBackend::SetEventPublishing(bool enabled) {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::unique_lock<std::shared_mutex> lock(mutex_);
   event_publishing_ = enabled;
   // Whatever is already queued has no consumer either; drop it rather than
   // hold it for a master that will never register.
@@ -737,14 +756,17 @@ void PageBackend::EnableLocalEviction(double high_watermark, double low_watermar
         high_watermark, low_watermark);
     return;
   }
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::unique_lock<std::shared_mutex> lock(mutex_);
   local_evict_enabled_ = true;
   local_evict_high_wm_ = high_watermark;
   local_evict_low_wm_ = low_watermark;
   // Keys committed before this call are not in lru_ and would therefore be
   // invisible to a round.  Enabling before Init is the contract, but seed
   // anyway so a late enable degrades to "wrong order", not "never evicted".
-  for (auto& [key, slot] : owned_) TouchLruLocked(key, slot);
+  {
+    std::lock_guard<std::mutex> lru_lock(lru_mutex_);
+    for (auto& [key, slot] : owned_) TouchLruLocked(key, slot);
+  }
   MORI_UMBP_INFO("[PageBackend] local eviction ON tier={} high={} low={}", static_cast<int>(tier_),
                  high_watermark, low_watermark);
 }
@@ -766,13 +788,24 @@ void PageBackend::RemoveFromLruLocked(OwnedSlot& slot) {
   slot.in_lru = false;
 }
 
+void PageBackend::TouchLru(const std::string& key, OwnedSlot& slot) {
+  if (!local_evict_enabled_) return;
+  std::lock_guard<std::mutex> lru_lock(lru_mutex_);
+  TouchLruLocked(key, slot);
+}
+
+void PageBackend::RemoveFromLru(OwnedSlot& slot) {
+  std::lock_guard<std::mutex> lru_lock(lru_mutex_);
+  RemoveFromLruLocked(slot);
+}
+
 size_t PageBackend::MaybeEvictToLowWatermark() {
   // Only one round at a time.  A second committing thread backs off rather
   // than over-evicting, and try_lock keeps the put path non-blocking.
   std::unique_lock<std::mutex> round(local_evict_round_mutex_, std::try_to_lock);
   if (!round.owns_lock()) return 0;
 
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::unique_lock<std::shared_mutex> lock(mutex_);
   if (!local_evict_enabled_ || !allocator_) return 0;
 
   const uint64_t total = allocator_->TotalBytes();
@@ -789,17 +822,20 @@ size_t PageBackend::MaybeEvictToLowWatermark() {
   const auto now = std::chrono::steady_clock::now();
   uint64_t selected_bytes = 0;
   std::vector<std::string> victims;
-  for (auto it = lru_.rbegin(); it != lru_.rend() && selected_bytes < to_free; ++it) {
-    auto owned_it = owned_.find(*it);
-    if (owned_it == owned_.end()) continue;  // defensive; lru_/owned_ stay in sync
-    // Same two protections master-driven Evict honours: an in-flight read owns
-    // the pages until its lease expires, and a copy pin until the worker is
-    // done.  A round that finds only protected keys frees what it can and
-    // stops — it must not spin waiting for a reader.
-    if (HasActiveReadLeaseLocked(owned_it->second, now)) continue;
-    if (HasActivePinLocked(*it)) continue;
-    victims.push_back(*it);
-    selected_bytes += static_cast<uint64_t>(owned_it->second.pages.size()) * page_size_;
+  {
+    std::lock_guard<std::mutex> lru_lock(lru_mutex_);
+    for (auto it = lru_.rbegin(); it != lru_.rend() && selected_bytes < to_free; ++it) {
+      auto owned_it = owned_.find(*it);
+      if (owned_it == owned_.end()) continue;  // defensive; lru_/owned_ stay in sync
+      // Same two protections master-driven Evict honours: an in-flight read
+      // owns the pages until its lease expires, and a copy pin until the
+      // worker is done.  A round that finds only protected keys frees what it
+      // can and stops — it must not spin waiting for a reader.
+      if (HasActiveReadLeaseLocked(owned_it->second, now)) continue;
+      if (HasActivePinLocked(*it)) continue;
+      victims.push_back(*it);
+      selected_bytes += static_cast<uint64_t>(owned_it->second.pages.size()) * page_size_;
+    }
   }
 
   size_t freed = 0;
@@ -810,7 +846,7 @@ size_t PageBackend::MaybeEvictToLowWatermark() {
     // A REMOVE is queued for symmetry with master-driven Evict; with no master
     // event publishing is off and this is a no-op, so nothing accumulates.
     QueueEventLocked(KvEvent{KvEvent::Kind::REMOVE, key, tier_, 0});
-    RemoveFromLruLocked(owned_it->second);
+    RemoveFromLru(owned_it->second);
     owned_.erase(owned_it);
     ++freed;
   }
@@ -830,7 +866,7 @@ size_t PageBackend::MaybeEvictToLowWatermark() {
 }
 
 void PageBackend::SetAutoFlushHook(size_t threshold, std::function<void()> cb) {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::unique_lock<std::shared_mutex> lock(mutex_);
   auto_flush_threshold_ = threshold;
   auto_flush_cb_ = std::move(cb);
 }
@@ -848,12 +884,12 @@ std::vector<KvEvent> PageBackend::SnapshotOwnedKeysLocked() const {
 // Production full-sync uses SnapshotOwnedKeysForFullSync() below; tests use
 // this to assert owned state without disturbing the event outbox.
 std::vector<KvEvent> PageBackend::SnapshotOwnedKeys() const {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::unique_lock<std::shared_mutex> lock(mutex_);
   return SnapshotOwnedKeysLocked();
 }
 
 std::vector<KvEvent> PageBackend::SnapshotOwnedKeysForFullSync() {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::unique_lock<std::shared_mutex> lock(mutex_);
   auto out = SnapshotOwnedKeysLocked();
   // The snapshot is now authoritative: drop the queued delta (already
   // reflected in it) so the next delta carries only new events.
@@ -866,12 +902,12 @@ std::vector<KvEvent> PageBackend::SnapshotOwnedKeysForFullSync() {
 // ---------------------------------------------------------------------------
 
 uint64_t PageBackend::OwnedKeyCount() const {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::unique_lock<std::shared_mutex> lock(mutex_);
   return owned_.size();
 }
 
 TierCapacity PageBackend::Capacity() const {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::unique_lock<std::shared_mutex> lock(mutex_);
   TierCapacity cap;
   if (allocator_) {
     cap.total_bytes = allocator_->TotalBytes();
@@ -882,7 +918,7 @@ TierCapacity PageBackend::Capacity() const {
 }
 
 std::vector<BufferMemoryDescBytes> PageBackend::AllBufferDescs() const {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::unique_lock<std::shared_mutex> lock(mutex_);
   std::vector<BufferMemoryDescBytes> out;
   out.reserve(buffer_descs_.size());
   for (size_t i = 0; i < buffer_descs_.size(); ++i) {
@@ -893,7 +929,7 @@ std::vector<BufferMemoryDescBytes> PageBackend::AllBufferDescs() const {
 
 std::vector<BufferMemoryDescBytes> PageBackend::BufferDescsForPages(
     const std::vector<PageLocation>& pages) const {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::unique_lock<std::shared_mutex> lock(mutex_);
   return BuildBufferDescsLocked(pages);
 }
 
@@ -927,7 +963,7 @@ std::vector<BufferMemoryDescBytes> PageBackend::BuildBufferDescsLocked(
 
 bool PageBackend::HasActiveReadLeaseLocked(const OwnedSlot& slot,
                                            std::chrono::steady_clock::time_point now) {
-  return slot.read_lease_until > now;
+  return slot.read_lease_ns.load(std::memory_order_relaxed) > SteadyNs(now);
 }
 
 // ---------------------------------------------------------------------------
@@ -958,7 +994,7 @@ void PageBackend::ReaperLoop() {
 }
 
 void PageBackend::ReaperSweep() {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::unique_lock<std::shared_mutex> lock(mutex_);
   const auto now = std::chrono::steady_clock::now();
 
   // Expire pending slots whose deadline has passed.  No event is emitted:

--- a/src/umbp/distributed/peer/backend/page_backend.cpp
+++ b/src/umbp/distributed/peer/backend/page_backend.cpp
@@ -551,6 +551,16 @@ bool PageBackend::Contains(const std::string& key) const {
   return owned_.find(key) != owned_.end();
 }
 
+std::vector<bool> PageBackend::BatchContains(const std::vector<std::string>& keys) const {
+  std::vector<bool> out(keys.size(), false);
+  if (keys.empty()) return out;
+  // One lock and one hash lookup per key, and nothing allocated per key: an
+  // existence answer needs no page vector, no lease renewal and no LRU touch.
+  std::shared_lock<std::shared_mutex> lock(mutex_);
+  for (size_t i = 0; i < keys.size(); ++i) out[i] = owned_.find(keys[i]) != owned_.end();
+  return out;
+}
+
 // ---------------------------------------------------------------------------
 //  Eviction (skips leased / copy-pinned keys; emits REMOVE)
 // ---------------------------------------------------------------------------

--- a/src/umbp/distributed/pool/peer_pool.cpp
+++ b/src/umbp/distributed/pool/peer_pool.cpp
@@ -26,7 +26,9 @@
 
 #include <algorithm>
 #include <map>
+#include <numeric>
 #include <set>
+#include <shared_mutex>
 #include <stdexcept>
 #include <tuple>
 #include <utility>
@@ -786,6 +788,48 @@ std::vector<PoolResolvedEntry> PeerPool::BatchResolve(const std::vector<std::str
       placements_.erase(keys[i]);
       ForgetAccessLocked(keys[i]);
     }
+  }
+  return out;
+}
+
+std::vector<bool> PeerPool::BatchContains(const std::vector<std::string>& keys) {
+  std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
+  std::vector<bool> out(keys.size(), false);
+  if (keys.empty()) return out;
+
+  std::vector<uint32_t> read_order;
+  {
+    std::lock_guard<std::mutex> operation_lock(operation_mutex_);
+    if (backends_ == nullptr || policy_ == nullptr) return out;
+    read_order = policy_->ReadOrder(*backends_);
+  }
+
+  // Carry only the still-unanswered indices from one backend to the next, so a
+  // second medium is asked about exactly what the first one missed. Same shape
+  // as the resolve paths, and for the same reason: one call per backend, not
+  // one per key. The backend calls stay outside operation_mutex_.
+  std::vector<size_t> pending(keys.size());
+  std::iota(pending.begin(), pending.end(), 0);
+  std::vector<std::string> batch;
+  std::vector<size_t> still_missing;
+  for (uint32_t backend_id : read_order) {
+    if (pending.empty()) break;
+    auto* backend = backends_->Get(backend_id);
+    if (backend == nullptr) continue;
+    batch.clear();
+    batch.reserve(pending.size());
+    for (size_t i : pending) batch.push_back(keys[i]);
+
+    const auto hits = backend->BatchContains(batch);
+    still_missing.clear();
+    for (size_t j = 0; j < pending.size(); ++j) {
+      if (j < hits.size() && hits[j]) {
+        out[pending[j]] = true;
+      } else {
+        still_missing.push_back(pending[j]);
+      }
+    }
+    pending.swap(still_missing);
   }
   return out;
 }

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -2284,29 +2284,111 @@ PoolClient::BatchPutPlan PoolClient::PartitionBatchPutTargets(
 
 void PoolClient::ExecuteBatchPutPlan(const BatchPutPlan& plan,
                                      std::vector<PutEntryOutcome>* results) {
-  // Deferred local puts, parallel: per-key memcpy is lock-free (the allocator
-  // serializes Allocate/Commit); results is not vector<bool>-bit-packed, so
-  // workers write distinct indices directly. AddCounter / timing stay here.
+  // Deferred local puts.  Allocate and commit are one pool call each for the
+  // whole batch: PeerPool takes its operation lock, consults placement and
+  // pending state and builds its per-round containers once per call, so
+  // driving it a key at a time made that fixed cost -- not the copy -- the
+  // dominant term of a local put.  Only the copy is inherently per-key, and
+  // that is what stays parallel: distinct slots, distinct result indices, so
+  // workers still write directly.  Same shape as ExecuteLocalPutRangesBatch,
+  // which is why the ranged path never paid this.
   auto run_local_put = [&]() {
     const auto& local = plan.local_items;
     if (local.empty()) return;
+    if (default_pool_ == nullptr || registry_.Empty()) {
+      MORI_UMBP_ERROR("[PoolClient] Local Put requested but no default pool is initialized");
+      return;
+    }
     const int nthr = LocalCopyThreads("UMBP_DRAM_WRITE_THREADS");
     const auto t0 = std::chrono::steady_clock::now();
-    ParallelFor(local.size(), nthr, [&](size_t k) {
+
+    std::vector<PoolPlacementRequest> asks;
+    asks.reserve(local.size());
+    for (const auto& item : local) {
+      asks.push_back(PoolPlacementRequest{*item.key, item.size, item.route.tier,
+                                          /*backend_name=*/{}, item.route.logical_tier});
+    }
+    auto allocations = default_pool_->BatchAllocate(asks);
+    allocations.resize(local.size());
+
+    // `staged` carries the keys that reached the copy phase; every slot that
+    // does not survive placement, copy or commit lands in `to_abort`.
+    std::vector<PoolSlotRef> to_abort;
+    std::vector<size_t> staged;
+    std::vector<MediumBackend*> backend_of(local.size(), nullptr);
+    staged.reserve(local.size());
+    for (size_t k = 0; k < local.size(); ++k) {
+      const auto& alloc = allocations[k].allocation;
+      if (alloc.outcome == AllocateOutcome::kSuccessAlreadyExists) {
+        (*results)[local[k].index] = PutEntryOutcome::kAlreadyExists;
+        continue;
+      }
+      if (alloc.outcome != AllocateOutcome::kSuccessAllocated) continue;
+      auto* backend = registry_.Get(allocations[k].backend_id);
+      // A medium that publishes no buffer endpoints cannot be reached in-process
+      // at all; drop the reservation rather than fill a slot we cannot write.
+      if (backend == nullptr || backend->BufferCount() == 0) {
+        MORI_UMBP_WARN("[PoolClient] Local Put: tier={} has no in-process-addressable backend",
+                       static_cast<int>(local[k].route.tier));
+        to_abort.push_back(PoolSlotRef{allocations[k].backend_id, alloc.slot_id});
+        continue;
+      }
+      backend_of[k] = backend;
+      staged.push_back(k);
+    }
+
+    // vector<char>, not vector<bool>: workers write distinct indices.
+    std::vector<char> copied(local.size(), 0);
+    ParallelFor(staged.size(), nthr, [&](size_t s) {
+      const size_t k = staged[s];
       const auto& item = local[k];
-      switch (ExecuteLocalPut(*item.key, item.src, item.size, item.route.tier,
-                              item.route.logical_tier)) {
-        case PutAttemptOutcome::kSuccess:
-          (*results)[item.index] = PutEntryOutcome::kSucceeded;
-          break;
-        case PutAttemptOutcome::kSuccessAlreadyExists:
-          (*results)[item.index] = PutEntryOutcome::kAlreadyExists;
-          break;
-        case PutAttemptOutcome::kRetry:
-        case PutAttemptOutcome::kFatal:
-          break;
+      const auto& alloc = allocations[k].allocation;
+      std::vector<TransferItem> items;
+      if (BuildLocalPageTransfers(backend_of[k], alloc.pages, alloc.page_size,
+                                  const_cast<void*>(item.src), item.size, /*to_backend=*/true,
+                                  &items) &&
+          transfer_engine_->Transfer(items, /*failed_tags=*/nullptr)) {
+        copied[k] = 1;
       }
     });
+
+    std::vector<PoolCommitRequest> commits;
+    std::vector<size_t> commit_owner;
+    commits.reserve(staged.size());
+    commit_owner.reserve(staged.size());
+    for (size_t k : staged) {
+      const PoolSlotRef slot{allocations[k].backend_id, allocations[k].allocation.slot_id};
+      if (copied[k] == 0) {
+        to_abort.push_back(slot);
+        continue;
+      }
+      commits.push_back(PoolCommitRequest{slot, *local[k].key});
+      commit_owner.push_back(k);
+    }
+
+    double put_bytes = 0.0;
+    auto outcomes = default_pool_->BatchCommit(commits);
+    for (size_t j = 0; j < commit_owner.size(); ++j) {
+      if (j >= outcomes.size() || !outcomes[j].commit.success) {
+        to_abort.push_back(commits[j].slot);
+        continue;
+      }
+      const size_t k = commit_owner[j];
+      (*results)[local[k].index] = PutEntryOutcome::kSucceeded;
+      put_bytes += static_cast<double>(local[k].size);
+    }
+    if (!to_abort.empty()) default_pool_->BatchAbort(to_abort);
+
+    if (put_bytes > 0.0) {
+      // One update for the batch rather than two per key; the totals are the
+      // same, and AddCounter locks and materializes its help text every call.
+      CountMetric(MORI_UMBP_METRIC_CLIENT_OUTBOUND_PUT_BYTES_TOTAL,
+                  MORI_UMBP_METRIC_CLIENT_OUTBOUND_PUT_BYTES_TOTAL_HELP, {{"traffic", "local"}},
+                  put_bytes);
+      CountMetric(MORI_UMBP_METRIC_CLIENT_INBOUND_PUT_BYTES_TOTAL,
+                  MORI_UMBP_METRIC_CLIENT_INBOUND_PUT_BYTES_TOTAL_HELP, {{"traffic", "local"}},
+                  put_bytes);
+    }
     if (std::getenv("UMBP_LOCAL_COPY_TIMING")) {
       double sec = std::chrono::duration_cast<std::chrono::duration<double>>(
                        std::chrono::steady_clock::now() - t0)

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -4407,11 +4407,14 @@ std::vector<bool> PoolClient::BatchExists(const std::vector<std::string>& keys) 
   std::vector<std::string> unknown;
   std::vector<size_t> unknown_indices;
   if (config_.local_first) {
-    std::vector<size_t> all(keys.size());
-    std::iota(all.begin(), all.end(), 0);
-    std::vector<MediumBackend*> holders;
-    ResolveLocalBatch(keys, all, &holders, /*resolutions=*/nullptr);
-    for (size_t i = 0; i < keys.size(); ++i) out[i] = holders[i] != nullptr;
+    // Containment, not resolution: this only needs to know whether the key is
+    // here. A resolve would heap-copy the page vector of every key it finds and
+    // renew a read lease on it, and every byte of that is discarded one line
+    // below.
+    if (default_pool_ != nullptr) {
+      const auto local = default_pool_->BatchContains(keys);
+      for (size_t i = 0; i < keys.size() && i < local.size(); ++i) out[i] = local[i];
+    }
     for (size_t i = 0; i < keys.size(); ++i) {
       if (!out[i]) {
         unknown.push_back(keys[i]);

--- a/src/umbp/include/umbp/distributed/peer/backend/medium_backend.h
+++ b/src/umbp/include/umbp/distributed/peer/backend/medium_backend.h
@@ -351,6 +351,17 @@ class MediumBackend : public MetricSource {
   // interpreting a temporarily unresolvable object as absent.
   virtual bool Contains(const std::string& key) const = 0;
 
+  // Containment for a whole batch, in request order. Exists answers from this
+  // rather than from BatchResolve because a resolve builds -- and heap-copies --
+  // the page vector of every key it finds, which an existence check throws away.
+  // The default is the honest per-key loop; a backend that can answer the batch
+  // under one lock should override it.
+  virtual std::vector<bool> BatchContains(const std::vector<std::string>& keys) const {
+    std::vector<bool> out(keys.size(), false);
+    for (size_t i = 0; i < keys.size(); ++i) out[i] = Contains(keys[i]);
+    return out;
+  }
+
   // Master-driven eviction.  Idempotent; see EvictResult::bytes_freed.  One
   // result per key, in request order — the peer service relies on that to sum
   // freed bytes for a key mirrored across media.

--- a/src/umbp/include/umbp/distributed/peer/backend/page_backend.h
+++ b/src/umbp/include/umbp/distributed/peer/backend/page_backend.h
@@ -30,6 +30,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <shared_mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -384,14 +385,60 @@ class PageBackend : public MediumBackend {
     uint64_t size = 0;
     // Eviction fence, renewed by every Resolve.  Lives here rather than in a
     // map keyed by the same string, which cost a second hash of a ~128-byte
-    // key per resolve.  Default-constructed means no lease.
-    std::chrono::steady_clock::time_point read_lease_until{};
+    // key per resolve.  Zero means no lease.
+    //
+    // Atomic, and stored as a steady_clock nanosecond count rather than a
+    // time_point, because the resolve paths renew it under a SHARED lock:
+    // many readers may renew the same key at once.  Renewal is a CAS-max
+    // (RenewLeaseAtomic) so a slower thread can never shorten a lease another
+    // thread already extended.
+    std::atomic<int64_t> read_lease_ns{0};
     // Position in lru_, valid only while in_lru is true (local eviction on).
     // Held here for the same reason as the lease: the alternative is a second
     // map keyed by the same string.
+    //
+    // GUARDED BY lru_mutex_, not mutex_ -- the resolve paths touch the LRU
+    // while holding only a shared lock on mutex_.
     std::list<std::string>::iterator lru_it{};
     bool in_lru = false;
+
+    // std::atomic is neither copyable nor movable, but OwnedSlot is stored by
+    // value in owned_ and moved into place on commit, so the moves are spelled
+    // out.  Relaxed is enough: the map slot is exclusively owned at this point.
+    OwnedSlot() = default;
+    OwnedSlot(OwnedSlot&& other) noexcept
+        : pages(std::move(other.pages)),
+          size(other.size),
+          read_lease_ns(other.read_lease_ns.load(std::memory_order_relaxed)),
+          lru_it(other.lru_it),
+          in_lru(other.in_lru) {}
+    OwnedSlot& operator=(OwnedSlot&& other) noexcept {
+      if (this == &other) return *this;
+      pages = std::move(other.pages);
+      size = other.size;
+      read_lease_ns.store(other.read_lease_ns.load(std::memory_order_relaxed),
+                          std::memory_order_relaxed);
+      lru_it = other.lru_it;
+      in_lru = other.in_lru;
+      return *this;
+    }
+    OwnedSlot(const OwnedSlot&) = delete;
+    OwnedSlot& operator=(const OwnedSlot&) = delete;
   };
+
+  // steady_clock <-> the atomic lease representation.
+  static int64_t SteadyNs(std::chrono::steady_clock::time_point t) {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(t.time_since_epoch()).count();
+  }
+  // Extend `slot`'s lease to `deadline_ns` without ever shortening it.  Safe
+  // under a shared lock; concurrent renewals settle on the latest deadline.
+  static void RenewLeaseAtomic(OwnedSlot& slot, int64_t deadline_ns) {
+    int64_t current = slot.read_lease_ns.load(std::memory_order_relaxed);
+    while (current < deadline_ns &&
+           !slot.read_lease_ns.compare_exchange_weak(
+               current, deadline_ns, std::memory_order_relaxed, std::memory_order_relaxed)) {
+    }
+  }
 
   AllocateResult AllocateLocked(const std::string& key, uint64_t size);
   bool CommitLocked(uint64_t slot_id, const std::string& key, uint64_t& bytes_committed);
@@ -436,12 +483,17 @@ class PageBackend : public MediumBackend {
 
   // ---- local eviction (no-master deployments; see EnableLocalEviction) ----
 
-  // Caller MUST hold `mutex_`.  Move `key` to the MRU end, inserting it if it
-  // is not yet tracked.  No-op when local eviction is off.
+  // Caller MUST hold `lru_mutex_`.  Move `key` to the MRU end, inserting it if
+  // it is not yet tracked.  No-op when local eviction is off.
   void TouchLruLocked(const std::string& key, OwnedSlot& slot);
 
-  // Caller MUST hold `mutex_`.  Drop `key` from the LRU if tracked.
+  // Caller MUST hold `lru_mutex_`.  Drop `key` from the LRU if tracked.
   void RemoveFromLruLocked(OwnedSlot& slot);
+
+  // Self-locking wrappers for single-key callers.  Lock order is always
+  // mutex_ -> lru_mutex_, never the reverse.
+  void TouchLru(const std::string& key, OwnedSlot& slot);
+  void RemoveFromLru(OwnedSlot& slot);
 
   // Run one round if local eviction is on and usage has reached the high
   // watermark.  Takes `mutex_` itself, so callers must NOT hold it.  Returns
@@ -457,7 +509,14 @@ class PageBackend : public MediumBackend {
   };
 
   TierType tier_;
-  mutable std::mutex mutex_;
+  // Reader/writer, not exclusive: Resolve, BatchResolve and Contains are the
+  // hot path of a 100%-hit restore and only read owned_/pending_, so they take
+  // a shared lock and run concurrently.  Everything that mutates the index
+  // (Allocate, Commit, Abort, Evict, pins, ClearLocal) takes it exclusively.
+  // The two things the resolve paths still write -- the read lease and the LRU
+  // position -- were moved off this lock: the lease is an atomic on the slot,
+  // the LRU has lru_mutex_.
+  mutable std::shared_mutex mutex_;
   uint64_t page_size_;
   std::chrono::milliseconds pending_ttl_;
   std::chrono::milliseconds read_lease_ttl_;
@@ -502,6 +561,11 @@ class PageBackend : public MediumBackend {
   // Front = most recently committed/resolved, back = eviction candidate.
   // Empty and unmaintained unless local_evict_enabled_.
   std::list<std::string> lru_;
+  // Guards lru_ and the per-slot lru_it/in_lru fields.  Separate from mutex_
+  // so a resolve can record an access while holding only a shared lock; the
+  // critical section is a list splice, not a hash lookup plus a page-vector
+  // copy.  Always taken after mutex_ when both are held.
+  mutable std::mutex lru_mutex_;
   bool local_evict_enabled_ = false;
   double local_evict_high_wm_ = 0.9;
   double local_evict_low_wm_ = 0.7;

--- a/src/umbp/include/umbp/distributed/peer/backend/page_backend.h
+++ b/src/umbp/include/umbp/distributed/peer/backend/page_backend.h
@@ -260,6 +260,7 @@ class PageBackend : public MediumBackend {
   bool AcquireMigrationRead(const std::string& key, ResolvedEntry* resolved) override;
   void ReleaseMigrationRead(const std::string& key) override;
   bool Contains(const std::string& key) const override;
+  std::vector<bool> BatchContains(const std::vector<std::string>& keys) const override;
   std::vector<EvictResult> Evict(const std::vector<std::string>& keys) override;
 
   uint64_t PageSize() const override { return page_size_; }

--- a/src/umbp/include/umbp/distributed/pool/peer_pool.h
+++ b/src/umbp/include/umbp/distributed/pool/peer_pool.h
@@ -102,6 +102,11 @@ class PeerPool {
   std::vector<bool> BatchAbort(const std::vector<PoolSlotRef>& slots);
   std::vector<PoolResolvedEntry> BatchResolve(const std::vector<std::string>& keys,
                                               bool include_descs, bool allow_file_refs = false);
+  // Existence only, in request order. Cheaper than BatchResolve, which
+  // heap-copies the page vector of every key it finds -- work an existence
+  // check discards. Takes no read lease and does not touch recency: asking
+  // whether a key is here is not a read of it.
+  std::vector<bool> BatchContains(const std::vector<std::string>& keys);
   std::vector<EvictResult> Evict(const std::vector<std::string>& keys, PoolEvictMode mode);
   void ClearLocal();
   std::vector<KvEvent> DrainPendingEvents();


### PR DESCRIPTION
## What this fixes

The primitive concurrency gate added in #634 fails on this branch. It scores the
1→8 rank ratio of `batch_exists` against a 2.00x floor and reads **1.96x**.

The cause is `69607252` ("Refactor/umbp drop standalone client", #620) — but not
in the way its diff suggests. The per-key `default_pool_->BatchAllocate({request})`
call already existed at `d427be3a`, which measures clean. #620 is what *activated*
it: `WithEmbeddedDefaults` made the standalone server resolve to the embedded pool,
where before it fell back to `StandaloneClient` / `DRAMTier`. That path held a
`shared_mutex` for its slot map and a separate lock for its LRU; the replacement
serializes everything behind one exclusive lock and drives it one key at a time.

It is **contention, not per-operation cost**. The local put path is internally
parallel (`ParallelFor`, `UMBP_DRAM_WRITE_THREADS`, default 4), so a 1-rank
measurement is not contention-free. Varying only the thread count at 1 rank:

| put keys/s | 1 thread | 4 threads |
|---|---|---|
| `094c3c64` (DRAMTier) | 178,897 | 171,803 |
| this branch's base (PeerPool) | 231,114 | **59,363** |

The new path is 29% *faster* single-threaded. The whole regression appears only
under concurrency.

## The three changes

1. **`PageBackend` resolves under a shared lock.** `mutex_` becomes a
   `std::shared_mutex`; `Resolve` / `BatchResolve` / `Contains` take shared locks.
   `read_lease_until` becomes an atomic renewed by a CAS-max loop so renewal needs
   no write access, and the LRU moves behind its own lock with `BatchResolve`
   splicing the whole batch under one acquisition instead of one per key.

2. **A local put batch takes one pool call, not one per key.** `ExecuteBatchPutPlan`
   called `ExecuteLocalPut` per key from inside a `ParallelFor`, and each call took
   `PeerPool::BatchAllocate` and `BatchCommit` with a single-element vector — both
   under `operation_mutex_`, each building per-round containers and calling
   `FindOwnerLocked`. Now: one `BatchAllocate`, `ParallelFor` over the copies alone,
   one `BatchCommit`. This is what `ExecuteLocalPutRangesBatch` already did, which is
   why `put_ranges` never regressed while `put` did.

3. **`Exists` answers by containment instead of resolving.** `BatchExists` used
   nothing but `holders[i] != nullptr`, while a resolve heap-copies the page vector
   of every key it finds, renews a read lease and touches the LRU. Adds
   `MediumBackend::BatchContains` (virtual, with a default that loops the existing
   `Contains()`, so no other backend changes), a `PageBackend` override doing one
   shared lock and one hash lookup per key with nothing allocated, and
   `PeerPool::BatchContains`.

## Results

n06-21, interleaved A/B, warm rounds only, `umbp_prim_ci.py --arms nomaster`:

**The gate** (`exists` scaling@0, 1→8, floor 2.00x):

| | 1 rank | 8 ranks | 1→8 | gate |
|---|---|---|---|---|
| `094c3c64` (pre-regression) | 2,600,001 | 8,899,559 | 3.42x | PASS |
| base (`1366c0d5`) | 1,579,422 | 3,093,791 | **1.96x** | **FAIL** |
| this PR | 2,362,440 | 7,788,361 | **3.30x** | **PASS** |

**Per primitive**, as a fraction of `094c3c64`:

| | before | after |
|---|---|---|
| `put` @1 / @8 | 0.31x / 0.37x | 0.82x / 0.88x |
| `exists` @1 / @8 | 0.70x / 0.84x | 0.91x / 0.88x |
| `get` @1 / @8 | 0.87x / 1.12x | ~0.90x / ~1.09x |
| `get_ranges` @8 | 1.43x | ~1.00x |

`put` alone goes 66,062 → 167,078 keys/s at 1 rank (2.53x), and 2.3–2.5x at every
rank count.

## Trade-off, stated plainly

`get_ranges` gives up the improvement the base had *over* `094c3c64`: it ends at
parity (~654k vs 650k keys/s @8) rather than 1.43x. Mechanism: every local call
site passes `include_descs=false`, so the only per-key allocation left in
`BatchResolve` is the `entry.pages` vector copy. The exclusive lock admitted one
thread at a time; the shared lock admits eight, trading mutex serialization for
allocator contention. That is also why `exists` — which discards those pages —
gains while `get_ranges`, which needs them, does not. Removing that copy for
readers (a lease-scoped view instead of a copy) is the natural follow-up and is
deliberately not in this PR: it carries real lifetime risk and deserves its own
review.

A fourth change — making `PeerPool::operation_mutex_` a `shared_mutex` too — was
implemented, measured, and **dropped**: it bought ~0.1x of gate margin (2.76x vs
2.65x) while costing 22% on `get_ranges@8` and 13% on `put_ranges@8`.

## Testing

- `ctest -R umbp`: **30/30**. (`umbp_ssd_ranged_io` fails intermittently on a fixed
  gRPC port collision under load — "Address already in use" — and passes on retry;
  unrelated to these changes.)
- The gate harness reports **no bad rows in any round**, including the absent-key
  passes, which are what would catch a containment answer wrongly saying "missing".

## Note on semantics

An existence probe no longer renews a read lease or counts toward recency. That is
intentional: asking whether a key is present is not a read of it, and a probe should
not keep a key alive or promote it over keys that were actually used. Nothing
depended on the old behavior — a `get` does its own resolve and takes the lease it
needs there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
