### PR TITLE
fix(cco): Group lanes by CQ before PSD non-CCQE poll

### DIFF
--- a/include/mori/cco/cco_scale_out.hpp
+++ b/include/mori/cco/cco_scale_out.hpp
@@ -287,46 +287,63 @@ __device__ inline static void quietUntil(core::RdmaEndpointDevice* ep, uint32_t 
     }
 #else
     // Non-CCQE: warp-parallel poll with color bit alternation.
-    const uint64_t activeMask = core::GetActiveLaneMask();
-    const uint32_t myLogicalLaneId = core::GetActiveLaneNum(activeMask);
+    //
+    // The poll below is only correct when every participating lane shares one
+    // CQ: the pollCqLock is acquired by the first active lane and broadcast to
+    // the rest, each lane derives its CQ slot from its index within the active
+    // mask, and a ballot elects a single lane to commit cq_consumer/doneIdx.
+    // Callers can legitimately arrive with lanes on different endpoints (e.g.
+    // flush() fans peers across the cooperative group), so group the active
+    // lanes by CQ and give each distinct CQ its own turn.
     const int myLaneId = core::WarpLaneId();
     constexpr uint32_t MAX_GREED = 10;
     constexpr uint32_t CQ_DOORBELL_GRACE = 100;
-    uint32_t wqeCounter;
+    const unsigned long long myCqKey = reinterpret_cast<unsigned long long>(cq);
 
-    while ((wq->doneIdx - targetIdx) & PENDING_WORK_MASK) {
-      if (!core::spin_lock_try_acquire_shared(&cq->pollCqLock, activeMask)) continue;
-      uint32_t greedRemaining = MAX_GREED;
+    bool needTurn = true;
+    for (uint64_t turns = __ballot(needTurn); turns != 0; turns = __ballot(needTurn)) {
+      const int lead = __ffsll(static_cast<unsigned long long>(turns)) - 1;
+      if (myCqKey != __shfl(myCqKey, lead)) continue;
+      needTurn = false;
+
+      const uint64_t activeMask = core::GetActiveLaneMask();
+      const uint32_t myLogicalLaneId = core::GetActiveLaneNum(activeMask);
+      uint32_t wqeCounter;
+
       while ((wq->doneIdx - targetIdx) & PENDING_WORK_MASK) {
-        const uint64_t oldDoneIdx = wq->doneIdx;
-        const uint32_t curConsIdx = cq->cq_consumer;
-        uint32_t myCqPos = curConsIdx + myLogicalLaneId;
-        const int opcode =
-            core::PollCq<core::ProviderType::PSD>(cq->cqAddr, cq->cqeNum, &myCqPos, &wqeCounter);
-        if (opcode > 0) {
-          MORI_PRINTF("quietUntil[PSD]: poll err %d\n", opcode);
-          assert(false);
-        }
-        asm volatile("" ::: "memory");
-        const uint64_t successMask = __ballot(opcode == 0);
-        const int highestLane = core::GetLastActiveLaneID(successMask);
-        if (highestLane == -1) continue;
-        if (myLaneId == highestLane) {
-          cq->cq_consumer = myCqPos + 1;
-          if (((cq->cq_consumer - cq->cq_dbpos) & (cq->cqeNum - 1)) >= CQ_DOORBELL_GRACE) {
-            cq->cq_dbpos = cq->cq_consumer;
-            core::UpdateCqDbrRecord<core::ProviderType::PSD>(*cq, myCqPos + 1);
+        if (!core::spin_lock_try_acquire_shared(&cq->pollCqLock, activeMask)) continue;
+        uint32_t greedRemaining = MAX_GREED;
+        while ((wq->doneIdx - targetIdx) & PENDING_WORK_MASK) {
+          const uint64_t oldDoneIdx = wq->doneIdx;
+          const uint32_t curConsIdx = cq->cq_consumer;
+          uint32_t myCqPos = curConsIdx + myLogicalLaneId;
+          const int opcode =
+              core::PollCq<core::ProviderType::PSD>(cq->cqAddr, cq->cqeNum, &myCqPos, &wqeCounter);
+          if (opcode > 0) {
+            MORI_PRINTF("quietUntil[PSD]: poll err %d\n", opcode);
+            assert(false);
           }
-          wq->doneIdx = wqeCounter;
+          asm volatile("" ::: "memory");
+          const uint64_t successMask = __ballot(opcode == 0);
+          const int highestLane = core::GetLastActiveLaneID(successMask);
+          if (highestLane == -1) continue;
+          if (myLaneId == highestLane) {
+            cq->cq_consumer = myCqPos + 1;
+            if (((cq->cq_consumer - cq->cq_dbpos) & (cq->cqeNum - 1)) >= CQ_DOORBELL_GRACE) {
+              cq->cq_dbpos = cq->cq_consumer;
+              core::UpdateCqDbrRecord<core::ProviderType::PSD>(*cq, myCqPos + 1);
+            }
+            wq->doneIdx = wqeCounter;
+          }
+          if (!((wq->doneIdx - targetIdx) & PENDING_WORK_MASK)) {
+            if (wq->doneIdx == oldDoneIdx) break;
+            if (greedRemaining == 0) break;
+            --greedRemaining;
+          }
         }
-        if (!((wq->doneIdx - targetIdx) & PENDING_WORK_MASK)) {
-          if (wq->doneIdx == oldDoneIdx) break;
-          if (greedRemaining == 0) break;
-          --greedRemaining;
-        }
+        core::spin_lock_release_shared(&cq->pollCqLock, activeMask);
+        break;
       }
-      core::spin_lock_release_shared(&cq->pollCqLock, activeMask);
-      break;
     }
 #endif
   } else if constexpr (PrvdType == core::ProviderType::MLX5) {

--- a/include/mori/cco/cco_scale_out.hpp
+++ b/include/mori/cco/cco_scale_out.hpp
@@ -1282,8 +1282,9 @@ template <typename Coop>
 __device__ inline void ccoGda<PrvdType>::flush(Coop coop) {
   static_assert(!std::is_same_v<Coop, ccoCoopThread>,
                 "flush() requires at least ccoCoopWarp. "
-                "ccoCoopThread causes each thread to independently enter quietUntil "
-                "on different QPs, breaking the warp-level pollCqLock.");
+                "ccoCoopThread reports size()==1, so every thread walks every peer and "
+                "flushes each QP once per thread, duplicating doorbell rings and "
+                "advancing cq->needConsIdx once per thread.");
   coop.sync();
   ccoIbgdaContext* ibgda = reinterpret_cast<ccoIbgdaContext*>(_gdaHandle);
   for (int teamPeer = coop.thread_rank(); teamPeer < this->nRanks; teamPeer += coop.size()) {
@@ -1305,8 +1306,9 @@ template <ccoTeamMode TeamMode, typename Coop>
 __device__ inline void ccoGda<PrvdType>::flush(int peer, Coop coop) {
   static_assert(!std::is_same_v<Coop, ccoCoopThread>,
                 "flush(peer) requires at least ccoCoopWarp. "
-                "ccoCoopThread allows concurrent per-thread calls on different QPs, "
-                "which breaks the warp-level pollCqLock inside quietUntil.");
+                "With ccoCoopThread every thread runs the body, so two threads passing the "
+                "same peer each flush that QP and advance cq->needConsIdx twice. "
+                "(Lanes on *different* QPs are fine: quietUntil groups active lanes by CQ.)");
   coop.sync();
   if (coop.thread_rank() == 0) {
     int worldPeer = resolveWorldPeer<TeamMode>(peer);
@@ -1346,9 +1348,10 @@ template <core::ProviderType PrvdType>
 template <typename Coop>
 __device__ inline void ccoGda<PrvdType>::wait(ccoGdaRequest_t& request, Coop coop) {
   static_assert(!std::is_same_v<Coop, ccoCoopThread>,
-                "wait() requires at least ccoCoopWarp. "
-                "ccoCoopThread allows concurrent per-thread calls on different QPs, "
-                "which breaks the warp-level pollCqLock inside quietUntil.");
+                "wait() requires at least ccoCoopWarp, for consistency with flush(). "
+                "The pollCqLock hazard no longer applies here — the body is a pure poll and "
+                "quietUntil groups active lanes by CQ — so this one is relaxable if a "
+                "per-thread caller ever needs it.");
   coop.sync();
   if (coop.thread_rank() == 0) {
     ccoIbgdaContext* ibgda = reinterpret_cast<ccoIbgdaContext*>(_gdaHandle);
@@ -1364,8 +1367,9 @@ template <typename LocalAction, typename Coop>
 __device__ inline void ccoGda<PrvdType>::counter(LocalAction localAction, Coop coop) {
   static_assert(!std::is_same_v<Coop, ccoCoopThread>,
                 "counter() requires at least ccoCoopWarp. "
-                "ccoCoopThread causes each thread to independently enter quietUntil "
-                "on different QPs, breaking the warp-level pollCqLock.");
+                "ccoCoopThread reports size()==1 and makes thread_rank()==0 true for every "
+                "thread, so every thread walks every peer and counterBuf is incremented "
+                "once per thread instead of once.");
   coop.sync();
 
   ccoIbgdaContext* ibgda = reinterpret_cast<ccoIbgdaContext*>(_gdaHandle);
@@ -1455,8 +1459,9 @@ template <core::ProviderType PrvdType, typename Coop>
 __device__ inline void ccoGdaBarrierSession<PrvdType, Coop>::sync(Coop) {
   static_assert(!std::is_same_v<Coop, ccoCoopThread>,
                 "GDA barrier requires at least ccoCoopWarp. "
-                "ccoCoopThread causes each thread to independently enter signalImpl / "
-                "waitSignalImpl on different QPs, breaking the warp-level pollCqLock.");
+                "ccoCoopThread reports size()==1, so every thread signals every peer and the "
+                "remote signal is incremented once per thread; coop.sync() also degenerates "
+                "to a no-op, removing the phase-1/phase-2 separation.");
   this->coop.sync();
 
   ccoIbgdaContext* ibgda = reinterpret_cast<ccoIbgdaContext*>(gda._gdaHandle);


### PR DESCRIPTION
## Motivation

On Pensando/ionic (`ProviderType::PSD`), GPU-initiated RDMA hangs as soon as a rank has more than one peer. `test_gda_put` passes at 2 ranks and hangs at 3+; `test_gda_get` and `test_gda_signal_ut` hang at 3; `test_gda_barrier` passes `basic` and `multi` but hangs in `data_vis`. All ranks reach `DevCommCreate OK` and then spin at 100% GPU with no completion ever arriving. The identical commit passes at 2–8 ranks on ConnectX-7 (`ProviderType::MLX5`), and `ib_write_bw` between the same NICs is healthy at 282–291 Gb/s, so neither the test code nor the fabric is at fault.

### Root Cause

`quietUntil`'s PSD non-CCQE branch is a **wavefront-cooperative algorithm that assumes every active lane is polling the same CQ**. Three separate parts of it encode that assumption:

- `spin_lock_try_acquire_shared(&cq->pollCqLock, activeMask)` (`core/utils/utils.hpp:287`) CASes the lock **only on the first active lane** and `__shfl`s the result to the rest.
- `myLogicalLaneId = GetActiveLaneNum(activeMask)` is the lane's index *within the active mask*, used as a slot offset so that N lanes read N consecutive CQEs of one shared CQ.
- The `__ballot` / `highestLane` reduction elects a **single** lane to commit `cq->cq_consumer` and `wq->doneIdx`.

But `ccoGda::flush(Coop)` deliberately fans peers across the threads of the cooperative group:

```cpp
for (int teamPeer = coop.thread_rank(); teamPeer < this->nRanks; teamPeer += coop.size()) {
  if (teamPeer == this->rank) continue;
  int qpIdx = worldPeer * ibgda->numQpPerPe + (contextId % ibgda->numQpPerPe);
  core::RdmaEndpointDevice* ep = &ibgda->endpoints[qpIdx];   // different ep per lane
  impl::flushAsyncImpl<PrvdType>(ep, ep->qpn, &postIdx);
  impl::waitImpl<PrvdType>(ep, postIdx);                     // -> quietUntil
}
```

With `ccoCoopBlock` and `blockDim=64` (one wavefront), a rank with 2 peers sends lanes 1 and 2 into `quietUntil` holding **different endpoints**. The assumption then breaks three ways:

1. Lane 2 is told it holds a lock that was never acquired on its CQ — only lane 1's `pollCqLock` was CAS'd, and only lane 1's is released.
2. Lane 2 reads **its own** CQ at `cq_consumer + 1`, because its index within the active mask is 1. Its completion is sitting at `cq_consumer + 0` and is never observed.
3. Only the ballot winner commits, so the losing lane's `wq->doneIdx` is never advanced and its `while ((wq->doneIdx - targetIdx) & PENDING_WORK_MASK)` loop never terminates.

This accounts for every observation:

- **2 ranks pass** — one peer means one active lane, so `myLogicalLaneId == 0`, one lock, one committer. The degenerate case is correct.
- **3+ ranks hang** — two or more lanes, on different CQs, in one wavefront.
- **MLX5 passes at every rank count** — its `quietUntil` is entirely per-lane and lock-free (no `activeMask`, no ballot, no shared lock), so the same `flush()` fan-out is harmless there.
- **`barrier` splits `basic`/`multi` PASS vs `data_vis` HANG** — only `data_vis` pushes data across multiple peers.

The codebase already documents this precondition. `flush(peer)` and `wait()` carry a `static_assert` rejecting `ccoCoopThread` with exactly this reasoning — *"ccoCoopThread allows concurrent per-thread calls on different QPs, which breaks the warp-level pollCqLock inside quietUntil"* — but `ccoCoopBlock` creates the identical hazard and passes the assert.

## Modifications

One file, `include/mori/cco/cco_scale_out.hpp`, +49 / −32, entirely within the `#else` (non-CCQE) branch of `quietUntil<PSD>`.

Group the active lanes by CQ pointer and give each distinct CQ its own turn, reusing the `__ballot` / `__shfl` turn-loop idiom that `put()` already uses to group lanes by peer:

```cpp
bool needTurn = true;
for (uint64_t turns = __ballot(needTurn); turns != 0; turns = __ballot(needTurn)) {
  const int lead = __ffsll(static_cast<unsigned long long>(turns)) - 1;
  if (myCqKey != __shfl(myCqKey, lead)) continue;
  needTurn = false;

  const uint64_t activeMask = core::GetActiveLaneMask();
  const uint32_t myLogicalLaneId = core::GetActiveLaneNum(activeMask);
  ...
}
```

`activeMask` and `myLogicalLaneId` moved **inside** the turn, so they describe only the lanes sharing that one CQ — which is what makes the shared `pollCqLock` and the per-lane slot offset correct again. `myLaneId` stays outside, since the physical lane id is turn-invariant.

**The poll body itself is unchanged**; most of the diff is re-indentation by one level. `git diff -w` collapses it to **+19 / −2**, which is the real extent of the change and the recommended way to review it.

The fix was made in `quietUntil` rather than in `flush()` because `flush()` is not the only caller that can arrive with lanes on different endpoints — `reserveWqeSlots` and `waitSqSpace` reach `quietUntil` from `putImpl`'s flow control as well. Fixing the primitive covers all of them.

### Scope

The change is inside `if constexpr (PrvdType == core::ProviderType::PSD)` **and** inside `#else` of `#ifdef IONIC_CCQE`. It is dead code on MLX5 and BNXT, and dead code on ionic builds that define `IONIC_CCQE`.

## Test Results

### Environment

| | |
|---|---|
| Host | `smc300x-ccs-aus-a18-19`, 8× MI300X gfx942 |
| NIC | Pensando ionic, 8 RoCE rails `roce_ai0..7`, fw `1.117.5-a-77` |
| cmake | `Mori device NIC: ionic (sysfs, mlx5=0 bnxt=0 ionic=9)` → `PSD` |
| Build | `Release`, `GPU_TARGETS=gfx942`, `WITH_MPI=OFF`; fork mode (`./test N`) |
| Sanity | `granularity=2097152` at `ccoCommCreate`; all rails `up`/MTU 8800 before and after every run, nothing re-enumerated |

Two environment notes that shaped the A/B matrix: this libionic has no `ionic_dv_pd_set_dmabuf_alloc` (`dlsym` fails), so CQ/SQ/RQ rings use the bare-VA path and the dma-buf ring switch is inert here; and CCQE **is** active at runtime (`cqe mode: ccqe mode`, fw above the `1.117.5-a-58` minimum).

The MLX5 column below is the original single-node ConnectX-7 measurement of the same commit (8× MI300X gfx942, 8 RoCE rails, `CCO_GDA_BUILD_PROVIDER = ProviderType::MLX5`). It was **not** re-run after the fix, because the change is unreachable on MLX5 — see Scope.

### Before Fix

| test                               | ranks | ionic | mlx5 |
| ---------------------------------- | ----- | ----- | ---- |
| test_gda_put                     | 2     | PASS  | PASS |
| test_gda_put                     | 3     | HANG  | PASS |
| test_gda_put                     | 4     | HANG  | PASS |
| test_gda_put                     | 6     | —     | PASS |
| test_gda_put                     | 8     | —     | PASS |
| test_gda_get                     | 3     | HANG  | PASS |
| test_gda_get                     | 8     | —     | PASS |
| test_gda_barrier basic/multi | 3     | PASS  | PASS |
| test_gda_barrier data_vis      | 3     | HANG  | PASS |
| test_gda_barrier all 3 subtests  | 2/4/8 | —     | PASS |

### After Fix

| test                            | ranks   | ionic | mlx5 (OCI) |
| ------------------------------- | ------- | --------------------------- | ---------- |
| test_gda_put                    | 2       | PASS                        | PASS       |
| test_gda_put                    | 3       | PASS                        | PASS       |
| test_gda_put                    | 4       | PASS                        | PASS       |
| test_gda_put                    | 6       | PASS                        | PASS       |
| test_gda_put                    | 8       | PASS                        | PASS       |
| test_gda_get                    | 3       | PASS                        | PASS       |
| test_gda_get                    | 8       | PASS                        | PASS       |
| test_gda_barrier basic/multi    | 3       | PASS                        | PASS       |
| test_gda_barrier data_vis       | 3       | PASS                        | PASS       |
| test_gda_barrier all 3 subtests | 2/3/4/8 | PASS                        | PASS       |