### PR TITLE
Add multi-NIC OFI/libfabric backend for Slingshot/CXI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_CXX_FLAGS_O3DEBUG "-ggdb -O3")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+set(MORI_USE_LIBFABRIC ON)
 
 if(NOT DEFINED CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
   message(STATUS "Build type not set - defaulting to Release")
@@ -143,7 +144,7 @@ if(USE_ROCM)
     elseif(DEFINED ENV{HIP_PATH})
       set(MORI_ROCM_PATH "$ENV{HIP_PATH}")
     else()
-      set(MORI_ROCM_PATH "/opt/rocm")
+      set(MORI_ROCM_PATH "/rocm-7.2.2")
     endif()
   endif()
   if(NOT EXISTS "${MORI_ROCM_PATH}/lib/cmake/hip-lang/hip-lang-config.cmake")
@@ -230,7 +231,19 @@ if(HAVE_WNO_DEPRECATED_LITERAL_OPERATOR)
 endif()
 
 add_library(mori_logging INTERFACE)
-target_include_directories(mori_logging INTERFACE include)
+# Prefer the real pciutils header for PCI topology enumeration. The bundled
+# 3rdparty/local_pci stub has a no-op pci_scan_bus, so if it shadows the system
+# <pci/pci.h> the PCI tree is silently empty (breaks GPU/NIC affinity). Only fall
+# back to the stub when pciutils-devel/libpci-dev is genuinely absent.
+find_path(MORI_SYSTEM_PCI_HEADER pci/pci.h)
+if(MORI_SYSTEM_PCI_HEADER)
+  message(STATUS "Using system pciutils header: ${MORI_SYSTEM_PCI_HEADER}/pci/pci.h")
+  target_include_directories(mori_logging INTERFACE include)
+else()
+  message(WARNING "pciutils-devel/libpci-dev not found; using stub 3rdparty/local_pci "
+                  "— PCI topology detection is DISABLED (GPU/NIC affinity will not work)")
+  target_include_directories(mori_logging INTERFACE include 3rdparty/local_pci)
+endif()
 target_link_libraries(mori_logging INTERFACE spdlog::spdlog)
 
 if(HAVE_WNO_DEPRECATED_LITERAL_OPERATOR)

--- a/include/mori/application/topology/net.hpp
+++ b/include/mori/application/topology/net.hpp
@@ -21,6 +21,7 @@
 // SOFTWARE.
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -55,6 +56,9 @@ class TopoSystemNet {
 
  private:
   void Load();
+  // Enumerate HPE Slingshot (CXI) NICs from /sys/class/cxi. Fallback used only
+  // when ibverbs discovers no NICs (verbs-less hosts).
+  void LoadCxiNics();
 
  private:
   std::vector<std::unique_ptr<TopoNodeNic>> nics;

--- a/include/mori/io/backend.hpp
+++ b/include/mori/io/backend.hpp
@@ -88,6 +88,28 @@ inline std::ostream& operator<<(std::ostream& os, const RdmaBackendConfig& c) {
             << "] maxCqeNum[" << c.maxCqeNum << "] maxMsgSge[" << c.maxMsgSge << "]";
 }
 
+
+struct OfiBackendConfig : public BackendConfig {
+  OfiBackendConfig() : BackendConfig(BackendType::OFI) {}
+
+  // OFI provider hint, e.g. "cxi" for Slingshot, "verbs" for IB, "tcp" for dev/test.
+  // Empty string → let libfabric auto-select.
+  std::string providerHint{""};
+  // fi_cq polling: completions per fi_cq_read call.
+  int cqReadBatch{64};
+  // Pre-posted MR access flags (remote read + write).
+  uint64_t mrAccessFlags{0};  // 0 = auto-set in constructor
+  // Domain threading model (FI_THREAD_DOMAIN or FI_THREAD_SAFE).
+  int threadingModel{0};  // 0 = FI_THREAD_DOMAIN
+
+  OfiBackendConfig(const std::string& provider, int cqBatch = 64)
+      : BackendConfig(BackendType::OFI), providerHint(provider), cqReadBatch(cqBatch) {}
+};
+
+inline std::ostream& operator<<(std::ostream& os, const OfiBackendConfig& c) {
+  return os << "providerHint[" << c.providerHint << "] cqReadBatch[" << c.cqReadBatch << "]";
+}
+
 struct XgmiBackendConfig : public BackendConfig {
   XgmiBackendConfig() : BackendConfig(BackendType::XGMI) {}
   XgmiBackendConfig(int numStreams_, int numEvents_)
@@ -194,6 +216,10 @@ class Backend {
                                         TransferStatus* status) = 0;
 
   virtual bool CanHandle(const MemoryDesc& local, const MemoryDesc& remote) const { return true; }
+
+  // Backend-specific descriptor bytes advertised to peers via EngineDesc.
+  // Default is empty; backends override to publish their own metadata.
+  virtual DescBlob GetEngineDescBlob() const { return {}; }
 };
 
 }  // namespace io

--- a/include/mori/io/common.hpp
+++ b/include/mori/io/common.hpp
@@ -25,10 +25,13 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstdint>
 #include <functional>
 #include <msgpack.hpp>
 #include <mutex>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "mori/application/transport/p2p/p2p.hpp"
 #include "mori/application/transport/rdma/rdma.hpp"
@@ -70,7 +73,19 @@ struct BackendBitmap {
 };
 
 using EngineKey = std::string;
-using DescBlob = std::vector<std::byte>;
+// Per-backend descriptor payload, kept as an opaque byte vector on purpose:
+//   * Backend-agnostic: common.hpp must not depend on OFI/RDMA/XGMI-specific
+//     types (MR keys, fabric addr_names, IPC handles), so the payload stays a
+//     blob and each backend defines/parses its own struct privately.
+//   * Forward/backward compatible: adding or changing a backend's fields never
+//     touches this shared struct's wire layout; unknown blobs are simply carried
+//     through untouched by nodes that don't own that backend.
+//   * Efficient + portable: msgpack serializes std::vector<uint8_t> as a compact
+//     BIN field (not an int array), and uint8_t==unsigned char has an
+//     unconditional msgpack adaptor on every platform.
+// The cost is that consumers must reinterpret the bytes (raw handle or a
+// msgpack-decoded struct); this is done once and cached, never per transfer.
+using DescBlob = std::vector<uint8_t>;
 using BackendDescBlobMap = std::unordered_map<BackendType, DescBlob>;
 
 struct EngineDesc {
@@ -80,13 +95,18 @@ struct EngineDesc {
   std::string host;
   int port;
   int pid{0};
+  // Backend-supplied descriptor blobs, captured by IOEngine after each backend
+  // is created. Opaque bytes (see DescBlob) — e.g. OFI stores its addr_name.
+  BackendDescBlobMap backendDescs;
 
-  constexpr bool operator==(const EngineDesc& rhs) const noexcept {
+  bool operator==(const EngineDesc& rhs) const noexcept {
     return (key == rhs.key) && (nodeId == rhs.nodeId) && (hostname == rhs.hostname) &&
-           (host == rhs.host) && (port == rhs.port) && (pid == rhs.pid);
+           (host == rhs.host) && (port == rhs.port) && (pid == rhs.pid) &&
+           (backendDescs == rhs.backendDescs);
   }
 
-  MSGPACK_DEFINE(key, nodeId, hostname, host, port, pid);
+  // Append-only: new fields MUST go at the end to preserve wire compatibility.
+  MSGPACK_DEFINE(key, nodeId, hostname, host, port, pid, backendDescs);
 };
 
 using MemoryUniqueId = uint32_t;
@@ -125,15 +145,23 @@ struct MemoryDesc {
   // and offsets to the right address.
   uint64_t fabricOffset{0};     // data - allocation base
   uint64_t fabricAllocSize{0};  // full size of the exported allocation
+  // Per-backend inline memory metadata as opaque bytes (see DescBlob for why a
+  // byte vector). OFI publishes its MR key here so peers skip the control-plane
+  // fetch; base/size come from data/size.
+  BackendDescBlobMap backendDescs;
 
-  constexpr bool operator==(const MemoryDesc& rhs) const noexcept {
+  // Not constexpr: comparing backendDescs (unordered_map) is not a constant expr.
+  bool operator==(const MemoryDesc& rhs) const noexcept {
     return (engineKey == rhs.engineKey) && (id == rhs.id) && (deviceId == rhs.deviceId) &&
            (deviceBusId == rhs.deviceBusId) && (data == rhs.data) && (size == rhs.size) &&
-           (loc == rhs.loc) && (numaNode == rhs.numaNode) && (ipcOffset == rhs.ipcOffset);
+           (loc == rhs.loc) && (numaNode == rhs.numaNode) && (ipcOffset == rhs.ipcOffset) &&
+           (backendDescs == rhs.backendDescs);
   }
 
+  // Append-only: new fields MUST go at the end to preserve wire compatibility.
   MSGPACK_DEFINE(engineKey, id, deviceId, deviceBusId, data, size, loc, ipcHandle, numaNode,
-                 ipcOffset, fabricHandle, vpodId, vpodPpodId, fabricOffset, fabricAllocSize);
+                 ipcOffset, fabricHandle, vpodId, vpodPpodId, fabricOffset, fabricAllocSize,
+                 backendDescs);
 };
 
 using TransferUniqueId = uint64_t;

--- a/include/mori/io/engine.hpp
+++ b/include/mori/io/engine.hpp
@@ -152,6 +152,7 @@ class IOEngine {
   Backend* SelectBackend(const MemoryDesc& local, const MemoryDesc& remote);
   bool SupportsXgmiBackendByP2P() const;
   void EnsureXgmiBackendCreatedIfSupported();
+  void CaptureBackendDesc(BackendType type);
   void InvalidateRouteCache();
   void UpdateRouteCache(const RouteCacheKey& key, BackendType backendType);
   std::optional<BackendType> QueryRouteCache(const RouteCacheKey& key) const;

--- a/include/mori/io/enum.hpp
+++ b/include/mori/io/enum.hpp
@@ -30,6 +30,7 @@ enum class BackendType : uint32_t {
   RDMA = 2,
   TCP = 3,
   FABRIC = 4,  // Cross-node scale-up fabric (UALink / super-node vPOD)
+  OFI = 5,
 };
 
 using BackendTypeVec = std::vector<BackendType>;

--- a/python/mori/io/__init__.py
+++ b/python/mori/io/__init__.py
@@ -37,6 +37,7 @@ from mori.cpp import (
     RdmaBackendConfig,
     XgmiBackendConfig,
     FabricBackendConfig,
+    OfiBackendConfig,
     fabric_alloc,
     fabric_free,
     set_log_level,

--- a/python/mori/io/engine.py
+++ b/python/mori/io/engine.py
@@ -98,6 +98,8 @@ class IOEngine:
                 config = mori_cpp.XgmiBackendConfig()
             elif type is mori_cpp.BackendType.FABRIC:
                 config = mori_cpp.FabricBackendConfig()
+            elif type is mori_cpp.BackendType.OFI:
+                config = mori_cpp.OfiBackendConfig()
             else:
                 raise NotImplementedError("backend not implemented yet")
         result = self._engine.CreateBackend(type, config)

--- a/src/application/topology/gpu.cpp
+++ b/src/application/topology/gpu.cpp
@@ -27,6 +27,7 @@
 #include <cstdlib>
 
 #include "mori/application/utils/check.hpp"
+#include "mori/utils/mori_log.hpp"
 
 namespace mori {
 namespace application {
@@ -153,6 +154,7 @@ TopoNodeGpu* TopoSystemGpu::GetGpuByLogicalId(int id) const {
   std::string str;
   str.resize(13);
   HIP_RUNTIME_CHECK(hipDeviceGetPCIBusId(str.data(), str.size(), id));
+  MORI_APP_INFO("DeviceID={}, pciBusId={}", id, str);
   PciBusId target{str};
   for (auto& gpuPtr : gpus) {
     TopoNodeGpu* gpu = gpuPtr.get();

--- a/src/application/topology/net.cpp
+++ b/src/application/topology/net.cpp
@@ -21,10 +21,14 @@
 // SOFTWARE.
 #include "mori/application/topology/net.hpp"
 
+#include <cctype>
 #include <filesystem>
+#include <fstream>
 #include <regex>
+#include <string>
 
 #include "mori/application/transport/rdma/rdma.hpp"
+#include "mori/utils/mori_log.hpp"
 
 namespace mori {
 namespace application {
@@ -45,18 +49,82 @@ PciBusId ParseBusIdFromSysfs(std::filesystem::path path) {
   return PciBusId(0);
 }
 
+// Parse a CXI link-speed token (e.g. "ck400G", "BS200G", "cd50G") into Gbps.
+// The encoding is a 2-char media prefix + decimal rate + 'G'; only the digits
+// carry the rate, so extract the numeric run. Returns 0 if none is found.
+static double ParseCxiLinkGbps(const std::string& token) {
+  std::string digits;
+  for (char c : token) {
+    if (std::isdigit(static_cast<unsigned char>(c))) digits.push_back(c);
+  }
+  if (digits.empty()) return 0.0;
+  return static_cast<double>(std::stol(digits));
+}
+
 void TopoSystemNet::Load() {
-  application::RdmaContext rdma(application::RdmaBackendType::IBVerbs);
-  auto devices = rdma.GetRdmaDeviceList();
+  // Verbs (ibverbs) NICs. Absent on CXI/Slingshot-only hosts, so tolerate an
+  // empty list or enumeration failure and fall back to the CXI scan below.
+  try {
+    application::RdmaContext rdma(application::RdmaBackendType::IBVerbs);
+    auto devices = rdma.GetRdmaDeviceList();
 
-  for (auto& dev : devices) {
-    // TODO: finish nic plane
+    for (auto& dev : devices) {
+      // TODO: finish nic plane
+      TopoNodeNic* nic = new TopoNodeNic();
+      auto rPath = std::filesystem::canonical(dev->GetIbvDevice()->ibdev_path);
+      nic->name = dev->Name();
+      nic->busId = ParseBusIdFromSysfs(rPath);
+      nic->totalGbps = dev->TotalActiveGbps();
+
+      nics.emplace_back(nic);
+    }
+  } catch (const std::exception& e) {
+    MORI_APP_WARN("TopoSystemNet: ibverbs enumeration failed ({}); continuing with CXI scan",
+                  e.what());
+  }
+
+  // Only probe CXI when ibverbs discovered no NICs (verbs-less Slingshot hosts).
+  if (nics.empty()) LoadCxiNics();
+}
+
+void TopoSystemNet::LoadCxiNics() {
+  // HPE Slingshot (Cassini) NICs are not exposed through ibverbs; the kernel
+  // driver publishes them under /sys/class/cxi/cxiN, each with a `device`
+  // symlink to its PCI node. libfabric's CXI provider names its domains the
+  // same way (cxi0, cxi1, ...), so the sysfs entry name doubles as the NIC name.
+  const std::filesystem::path cxiRoot{"/sys/class/cxi"};
+  std::error_code ec;
+  if (!std::filesystem::exists(cxiRoot, ec)) return;
+
+  // Fallback when the link-speed attribute is missing/unreadable. Used only as a
+  // relative ranking weight; when NICs share it, selection falls through to NUMA
+  // then PCIe hops.
+  constexpr double kCxiDefaultGbps = 200.0;
+
+  for (const auto& entry : std::filesystem::directory_iterator(cxiRoot, ec)) {
+    const std::filesystem::path devLink = entry.path() / "device";
+    std::filesystem::path devPath = std::filesystem::canonical(devLink, ec);
+    if (ec) {
+      ec.clear();
+      continue;
+    }
+
+    PciBusId busId = ParseBusIdFromSysfs(devPath);
+    if (busId.packed == 0) continue;
+
+    // e.g. /sys/class/cxi/cxi0/device/port/0/link/speed -> "ck400G".
+    double gbps = kCxiDefaultGbps;
+    std::ifstream speedFile(entry.path() / "device" / "port" / "0" / "link" / "speed");
+    std::string speedToken;
+    if (speedFile && (speedFile >> speedToken)) {
+      double parsed = ParseCxiLinkGbps(speedToken);
+      if (parsed > 0.0) gbps = parsed;
+    }
+
     TopoNodeNic* nic = new TopoNodeNic();
-    auto rPath = std::filesystem::canonical(dev->GetIbvDevice()->ibdev_path);
-    nic->name = dev->Name();
-    nic->busId = ParseBusIdFromSysfs(rPath);
-    nic->totalGbps = dev->TotalActiveGbps();
-
+    nic->name = entry.path().filename().string();
+    nic->busId = busId;
+    nic->totalGbps = gbps;
     nics.emplace_back(nic);
   }
 }

--- a/src/application/topology/system.cpp
+++ b/src/application/topology/system.cpp
@@ -32,6 +32,7 @@
 
 #include "mori/application/transport/rdma/rdma.hpp"
 #include "mori/application/utils/check.hpp"
+#include "mori/utils/mori_log.hpp"
 
 namespace mori {
 namespace application {
@@ -63,14 +64,25 @@ std::vector<Candidate> CollectAndSortCandidates(TopoSystem* sys, int id) {
   TopoSystemNet* net = sys->GetTopoSystemNet();
 
   TopoNodeGpu* dev = gpu->GetGpuByLogicalId(id);
-  NumaNodeId gpuNumaNodeId = pci->Node(dev->busId)->NumaNode();
+  if (dev == nullptr) {
+    MORI_APP_WARN("Topology: GPU logical id {} not found; no NIC candidates", id);
+    return {};
+  }
+  TopoNodePci* devPci = pci->Node(dev->busId);
+  if (devPci == nullptr) {
+    MORI_APP_WARN("Topology: GPU {} bdf {} not in PCI tree; no NIC candidates", id,
+                  dev->busId.String());
+    return {};
+  }
+  NumaNodeId gpuNumaNodeId = devPci->NumaNode();
 
   // Collect nic candidates
   auto nics = net->GetNics();
   std::vector<Candidate> candidates;
   for (auto* nic : nics) {
-    TopoPathPci* path = pci->Path(dev->busId, nic->busId);
     TopoNodePci* nicPci = pci->Node(nic->busId);
+    if (!nicPci) continue;  // NIC BDF not present in the scanned PCI tree
+    TopoPathPci* path = pci->Path(dev->busId, nic->busId);
     if (!path) continue;
     candidates.push_back({path, nicPci, nic});
   }

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -29,3 +29,16 @@ set_target_properties(
   PROPERTIES BUILD_RPATH "$ORIGIN;${ROCM_PATH}/lib"
              INSTALL_RPATH "$ORIGIN;${ROCM_PATH}/lib"
              BUILD_WITH_INSTALL_RPATH TRUE)
+
+# ── libfabric (OFI backend) ─────────────────────────────────────────────────
+if(MORI_USE_LIBFABRIC)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(LIBFABRIC REQUIRED libfabric)
+  message(STATUS "libfabric include: ${LIBFABRIC_INCLUDE_DIRS}")
+  message(STATUS "libfabric lib:     ${LIBFABRIC_LIBRARIES}")
+  target_sources(mori_io PRIVATE ofi/backend_impl.cpp)
+  target_include_directories(mori_io PRIVATE ${LIBFABRIC_INCLUDE_DIRS})
+  target_link_libraries(mori_io ${LIBFABRIC_LIBRARIES})
+  target_compile_definitions(mori_io PUBLIC MORI_USE_LIBFABRIC)
+  target_link_directories(mori_io PUBLIC ${LIBFABRIC_LIBRARY_DIRS})
+endif()

--- a/src/io/engine.cpp
+++ b/src/io/engine.cpp
@@ -42,6 +42,9 @@
 #include "src/io/rdma/backend_impl.hpp"
 #include "src/io/roctx_mori.hpp"  // ADDITIVE: MORI_ROCTX-gated host-send roctx markers
 #include "src/io/xgmi/backend_impl.hpp"
+#ifdef MORI_USE_LIBFABRIC
+#include "src/io/ofi/backend_impl.hpp"
+#endif
 
 namespace mori {
 namespace io {
@@ -219,6 +222,7 @@ void IOEngine::CreateBackend(BackendType type, const BackendConfig& beConfig) {
       auto backend = std::make_unique<XgmiBackend>(desc.key, config, xgmiConfig);
       backends.insert({BackendType::XGMI, std::move(backend)});
       InvalidateRouteCache();
+      CaptureBackendDesc(BackendType::XGMI);
       return;
     }
 
@@ -251,17 +255,31 @@ void IOEngine::CreateBackend(BackendType type, const BackendConfig& beConfig) {
 
     backends.insert({type, std::move(backend)});
     InvalidateRouteCache();
+    CaptureBackendDesc(type);
     EnsureXgmiBackendCreatedIfSupported();
   } else if (type == BackendType::XGMI) {
     auto backend = std::make_unique<XgmiBackend>(desc.key, config,
                                                  static_cast<const XgmiBackendConfig&>(beConfig));
     backends.insert({type, std::move(backend)});
     InvalidateRouteCache();
+    CaptureBackendDesc(type);
   } else if (type == BackendType::FABRIC) {
     auto backend = std::make_unique<FabricBackend>(
         desc.key, config, static_cast<const FabricBackendConfig&>(beConfig));
     backends.insert({type, std::move(backend)});
     InvalidateRouteCache();
+    CaptureBackendDesc(type);
+  } else if (type == BackendType::OFI) {
+#ifdef MORI_USE_LIBFABRIC
+    const auto& ofiCfg = static_cast<const OfiBackendConfig&>(beConfig);
+    auto be = std::make_unique<OfiBackend>(desc.key, config, ofiCfg);
+    // OFI carries peer addresses inline in EngineDesc; no control-plane port.
+    backends.insert({type, std::move(be)});
+    InvalidateRouteCache();
+    CaptureBackendDesc(type);
+#else
+    throw std::runtime_error("MORI was built without libfabric support (MORI_USE_LIBFABRIC=OFF)");
+#endif
   } else {
     assert(false && "not implemented");
   }
@@ -331,6 +349,7 @@ void IOEngine::EnsureXgmiBackendCreatedIfSupported() {
     auto backend = std::make_unique<XgmiBackend>(desc.key, config, xgmiConfig);
     backends.insert({BackendType::XGMI, std::move(backend)});
     InvalidateRouteCache();
+    CaptureBackendDesc(BackendType::XGMI);
     MORI_IO_INFO("Auto-created XGMI backend after RDMA initialization");
   } catch (const std::exception& e) {
     MORI_IO_WARN("Auto-create XGMI backend failed: {}", e.what());
@@ -342,6 +361,13 @@ void IOEngine::EnsureXgmiBackendCreatedIfSupported() {
 void IOEngine::RemoveBackend(BackendType type) {
   backends.erase(type);
   InvalidateRouteCache();
+}
+
+void IOEngine::CaptureBackendDesc(BackendType type) {
+  auto it = backends.find(type);
+  if (it != backends.end()) {
+    desc.backendDescs[type] = it->second->GetEngineDescBlob();
+  }
 }
 
 void IOEngine::RegisterRemoteEngine(const EngineDesc& remote) {
@@ -436,6 +462,14 @@ Backend* IOEngine::SelectBackend(const MemoryDesc& local, const MemoryDesc& remo
     UpdateRouteCache(routeKey, BackendType::RDMA);
     return rdmaIt->second.get();
   }
+
+#ifdef MORI_USE_LIBFABRIC
+  auto ofiIt = backends.find(BackendType::OFI);
+  if (ofiIt != backends.end() && ofiIt->second->CanHandle(local, remote)) {
+    UpdateRouteCache(routeKey, BackendType::OFI);
+    return ofiIt->second.get();
+  }
+#endif
 
   // No backend can handle this pair (e.g. cross-node under XGMI-only fallback).
   return nullptr;

--- a/src/io/ofi/backend_impl.cpp
+++ b/src/io/ofi/backend_impl.cpp
@@ -1,0 +1,738 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+// MIT License — see root LICENSE file.
+//
+// MORI-IO OFI (libfabric) backend — Slingshot/CXI compatible.
+// Uses FI_EP_RDM + FI_MR_ENDPOINT + FI_MR_PROV_KEY (no FI_MR_VIRT_ADDR).
+// Data plane: fi_writemsg / fi_readmsg with offset-based RMA addresses.
+// Control plane: TCP sockets to exchange OFI addr-names and MR keys.
+
+#include "backend_impl.hpp"
+
+#include <cassert>
+#include <cerrno>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+#include "mori/application/topology/system.hpp"
+
+namespace mori {
+namespace io {
+
+namespace {
+// Inline MR metadata carried in MemoryDesc.backendDescs[OFI]. Base/size are the
+// desc's own data/size, so only the provider MR key + owning NIC need publishing.
+struct OfiMrBlob {
+  uint64_t key{0};
+  uint32_t nicId{0};  // remote endpoint that owns/serves this MR
+  MSGPACK_DEFINE(key, nicId);
+};
+
+// One advertised local endpoint address. Peers insert addrName into their AVs
+// and reference it by nicId (matched against OfiMrBlob.nicId).
+struct OfiNicAddr {
+  uint32_t             nicId{0};
+  std::vector<uint8_t> addrName;
+  MSGPACK_DEFINE(nicId, addrName);
+};
+
+// Engine-level OFI descriptor: the full per-NIC address list, published in
+// EngineDesc.backendDescs[OFI] and exchanged over the TCP HELLO.
+struct OfiEngineBlob {
+  std::vector<OfiNicAddr> nics;
+  MSGPACK_DEFINE(nics);
+};
+
+// Parse an EngineDesc/HELLO OFI blob into (nicId, addr) pairs. Falls back to
+// treating the bytes as a single legacy addr_name (nicId 0) if it is not a
+// valid OfiEngineBlob.
+std::vector<OfiControlPlane::NicAddr> ParseOfiEngineBlob(const uint8_t* data, size_t len) {
+  std::vector<OfiControlPlane::NicAddr> out;
+  try {
+    auto oh = msgpack::unpack(reinterpret_cast<const char*>(data), len);
+    OfiEngineBlob blob = oh.get().as<OfiEngineBlob>();
+    out.reserve(blob.nics.size());
+    for (auto& n : blob.nics) out.emplace_back(n.nicId, n.addrName);
+  } catch (...) {
+    out.clear();
+    out.emplace_back(0u, std::vector<uint8_t>(data, data + len));  // legacy single addr
+  }
+  return out;
+}
+}  // namespace
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ *  OfiManager
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+OfiManager::OfiManager(const OfiBackendConfig& cfg) {
+  // Build hints for a given HMEM setting so we can retry host-only on failure.
+  auto makeHints = [&cfg](bool withHmem) -> struct fi_info* {
+    struct fi_info* hints = fi_allocinfo();
+    if (!hints) throw std::runtime_error("fi_allocinfo failed");
+
+    hints->ep_attr->type = FI_EP_RDM;
+    hints->caps          = FI_MSG | FI_RMA;
+    hints->mode          = FI_CONTEXT | FI_CONTEXT2;
+
+    // Slingshot/CXI: FI_MR_ENDPOINT + FI_MR_PROV_KEY.  No FI_MR_VIRT_ADDR.
+    hints->domain_attr->mr_mode =
+        FI_MR_LOCAL | FI_MR_ALLOCATED | FI_MR_ENDPOINT | FI_MR_PROV_KEY;
+
+    if (withHmem) {
+      // Enable device-memory (ROCm/HBM) registration and transfers.
+      hints->caps |= FI_HMEM;
+      hints->domain_attr->mr_mode |= FI_MR_HMEM;
+    }
+
+    hints->domain_attr->threading = FI_THREAD_DOMAIN;
+
+    if (!cfg.providerHint.empty())
+      hints->fabric_attr->prov_name = strdup(cfg.providerHint.c_str());
+
+    return hints;
+  };
+
+  // First try with FI_HMEM so GPU buffers can be registered/transferred.
+  struct fi_info* hints = makeHints(/*withHmem=*/true);
+  int ret = fi_getinfo(FI_VERSION(1, 9), nullptr, nullptr, 0, hints, &info_);
+  fi_freeinfo(hints);
+  if (ret == 0) {
+    hmemEnabled_ = true;
+  } else {
+    // Host-only fallback (e.g. tcp dev/test providers without HMEM support).
+    MORI_IO_WARN("OfiManager: fi_getinfo with FI_HMEM failed ({}), retrying host-only",
+                 fi_strerror(-ret));
+    hints = makeHints(/*withHmem=*/false);
+    ret = fi_getinfo(FI_VERSION(1, 9), nullptr, nullptr, 0, hints, &info_);
+    fi_freeinfo(hints);
+    if (ret) throw std::runtime_error(std::string("fi_getinfo: ") + fi_strerror(-ret));
+    hmemEnabled_ = false;
+  }
+
+  // Detect whether provider expects virtual addresses (most don't for CXI).
+  virtAddr_ = (info_->domain_attr->mr_mode & FI_MR_VIRT_ADDR) != 0;
+
+  topo_.reset(new application::TopoSystem());
+
+  // Open one endpoint per unique provider domain (i.e. per physical NIC).
+  // fi_getinfo returns a linked list; dedup by domain name.
+  uint32_t nicId = 0;
+  for (struct fi_info* fi = info_; fi != nullptr; fi = fi->next) {
+    const char* dn = (fi->domain_attr && fi->domain_attr->name) ? fi->domain_attr->name : nullptr;
+    if (!dn) continue;
+    std::string dname(dn);
+    if (domainToNic_.count(dname)) continue;
+    OpenNic(fi, nicId);
+    domainToNic_[dname] = nicId;
+    ++nicId;
+  }
+  if (nics_.empty()) throw std::runtime_error("OfiManager: no usable OFI domains found");
+
+  MORI_IO_INFO("OfiManager: provider={} nics={} mr_mode=0x{:x} virtAddr={} hmem={}",
+               info_->fabric_attr->prov_name, nics_.size(),
+               (unsigned)info_->domain_attr->mr_mode, virtAddr_, hmemEnabled_);
+}
+
+void OfiManager::OpenNic(struct fi_info* fi, uint32_t nicId) {
+  OfiNic nic;
+  nic.nicId      = nicId;
+  nic.info       = fi;
+  nic.domainName = fi->domain_attr->name;
+
+  OFI_CHECK(fi_fabric(fi->fabric_attr, &nic.fabric, nullptr), "fi_fabric");
+  OFI_CHECK(fi_domain(nic.fabric, fi, &nic.domain, nullptr),  "fi_domain");
+
+  struct fi_av_attr av_attr{};
+  av_attr.type  = FI_AV_TABLE;
+  av_attr.count = 1024;
+  OFI_CHECK(fi_av_open(nic.domain, &av_attr, &nic.av, nullptr), "fi_av_open");
+
+  struct fi_cq_attr cq_attr{};
+  cq_attr.format = FI_CQ_FORMAT_DATA;
+  cq_attr.size   = 4096;
+  OFI_CHECK(fi_cq_open(nic.domain, &cq_attr, &nic.cq, nullptr), "fi_cq_open");
+
+  OFI_CHECK(fi_endpoint(nic.domain, fi, &nic.ep, nullptr),        "fi_endpoint");
+  OFI_CHECK(fi_ep_bind(nic.ep, &nic.cq->fid, FI_SEND | FI_RECV),  "fi_ep_bind CQ");
+  OFI_CHECK(fi_ep_bind(nic.ep, &nic.av->fid, 0),                  "fi_ep_bind AV");
+  OFI_CHECK(fi_enable(nic.ep),                                    "fi_enable ep");
+
+  MORI_IO_INFO("OfiManager: opened NIC {} domain={}", nicId, nic.domainName);
+  nics_.push_back(nic);
+}
+
+OfiManager::~OfiManager() {
+  for (auto& nic : nics_) {
+    if (nic.ep)     { fi_close(&nic.ep->fid);     nic.ep     = nullptr; }
+    if (nic.cq)     { fi_close(&nic.cq->fid);     nic.cq     = nullptr; }
+    if (nic.av)     { fi_close(&nic.av->fid);     nic.av     = nullptr; }
+    if (nic.domain) { fi_close(&nic.domain->fid); nic.domain = nullptr; }
+    if (nic.fabric) { fi_close(&nic.fabric->fid); nic.fabric = nullptr; }
+  }
+  nics_.clear();
+  if (info_) { fi_freeinfo(info_); info_ = nullptr; }
+}
+
+std::vector<uint8_t> OfiManager::GetAddrName(uint32_t nic) const {
+  const OfiNic& n = nics_.at(nic);
+  size_t len = n.info->src_addrlen ? n.info->src_addrlen : 128;
+  std::vector<uint8_t> buf(len);
+  int ret = fi_getname(&n.ep->fid, buf.data(), &len);
+  if (ret) throw std::runtime_error(std::string("fi_getname: ") + fi_strerror(-ret));
+  buf.resize(len);
+  return buf;
+}
+
+std::vector<uint8_t> OfiManager::BuildEngineBlob() const {
+  OfiEngineBlob blob;
+  blob.nics.reserve(nics_.size());
+  for (const auto& nic : nics_) {
+    OfiNicAddr na;
+    na.nicId    = nic.nicId;
+    na.addrName = GetAddrName(nic.nicId);
+    blob.nics.push_back(std::move(na));
+  }
+  msgpack::sbuffer sb;
+  msgpack::pack(sb, blob);
+  return std::vector<uint8_t>(reinterpret_cast<const uint8_t*>(sb.data()),
+                              reinterpret_cast<const uint8_t*>(sb.data()) + sb.size());
+}
+
+fi_addr_t OfiManager::InsertAddr(uint32_t localNic, const std::vector<uint8_t>& addrBytes) {
+  fi_addr_t addr = FI_ADDR_UNSPEC;
+  int ret = fi_av_insert(nics_.at(localNic).av, addrBytes.data(), 1, &addr, 0, nullptr);
+  if (ret != 1)
+    throw std::runtime_error(std::string("fi_av_insert returned ") + std::to_string(ret));
+  return addr;
+}
+
+uint32_t OfiManager::SelectLocalNic(int deviceId, int numaNode) {
+  if (nics_.size() <= 1) return 0;
+
+  std::vector<std::string> names;
+  try {
+    if (deviceId >= 0) {
+      names = topo_->MatchGpuAndNics(deviceId, static_cast<int>(nics_.size()));
+    } else {
+      names = topo_->MatchCpuNics(numaNode, static_cast<int>(nics_.size()));
+    }
+  } catch (const std::exception& e) {
+    MORI_IO_WARN("OfiManager: NIC affinity lookup failed ({}); using fallback NIC", e.what());
+  }
+  // TopoSystem NIC names (e.g. cxi0) match the provider domain name.
+  for (const auto& name : names) {
+    auto it = domainToNic_.find(name);
+    if (it != domainToNic_.end()) return it->second;
+  }
+  // No topology match (e.g. tcp/verbs dev providers): stable fallback.
+  return deviceId >= 0 ? static_cast<uint32_t>(deviceId % nics_.size()) : 0u;
+}
+
+OfiMemRegion OfiManager::RegisterMr(uint32_t nic, void* buf, size_t size, uint64_t accessFlags,
+                                    bool isDevice, int deviceId) {
+  if (accessFlags == 0)
+    accessFlags = FI_SEND | FI_RECV | FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE;
+
+  if (isDevice && !hmemEnabled_)
+    throw std::runtime_error(
+        "OfiManager::RegisterMr: GPU buffer registration requested but the OFI "
+        "provider did not negotiate FI_HMEM. Rebuild libfabric with ROCm/HMEM "
+        "support or use a host-memory KV cache.");
+
+  OfiNic& n = nics_.at(nic);
+  OfiMemRegion mr{};
+  mr.bufBase = reinterpret_cast<uintptr_t>(buf);
+  mr.size    = size;
+  mr.nicId   = nic;
+
+  // Use fi_mr_regattr so we can set the HMEM interface for device buffers.
+  struct iovec iov = {.iov_base = buf, .iov_len = size};
+  struct fi_mr_attr attr{};
+  attr.mr_iov     = &iov;
+  attr.iov_count  = 1;
+  attr.access     = accessFlags;
+  attr.offset     = 0;
+  attr.requested_key = 0;
+  attr.context    = nullptr;
+  // ROCr needs no per-device index, so attr.device stays zeroed.
+  attr.iface      = isDevice ? FI_HMEM_ROCR : FI_HMEM_SYSTEM;
+  (void)deviceId;
+
+  OFI_CHECK(fi_mr_regattr(n.domain, &attr, 0, &mr.mr), "fi_mr_regattr");
+  OFI_CHECK(fi_mr_bind(mr.mr, &n.ep->fid, 0),  "fi_mr_bind");
+  // MR enable via generic fid control (fi_enable only accepts fid_ep*).
+  OFI_CHECK(mr.mr->fid.ops->control(&mr.mr->fid, FI_ENABLE, nullptr), "fi_enable MR");
+
+  mr.key = fi_mr_key(mr.mr);
+  if (mr.key == FI_KEY_NOTAVAIL)
+    throw std::runtime_error("fi_mr_key returned FI_KEY_NOTAVAIL");
+  MORI_IO_INFO("RegisterMr: nic={} buf=0x{:x} sz={} key=0x{:x} device={}",
+               nic, (uintptr_t)buf, size, mr.key, isDevice);
+  return mr;
+}
+
+void OfiManager::DeregisterMr(OfiMemRegion& mr) {
+  if (mr.mr) { fi_close(&mr.mr->fid); mr.mr = nullptr; }
+  mr.key = FI_KEY_NOTAVAIL;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ *  OfiControlPlane — in-memory AV/address registry
+ *  Peer endpoint addresses (EngineDesc) and MR keys (MemoryDesc) are carried
+ *  inline in backendDescs, so no out-of-band TCP exchange is needed. This class
+ *  only inserts advertised peer addrs into the local AVs and returns fi_addr_t.
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+OfiControlPlane::OfiControlPlane(OfiManager* ofi) : ofi_(ofi) {}
+
+OfiControlPlane::~OfiControlPlane() = default;
+
+bool OfiControlPlane::InsertRemoteNicAddrs(const EngineKey& key,
+                                           const std::vector<NicAddr>& nicAddrs) {
+  if (nicAddrs.empty()) return false;
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    // Already seeded for local NIC 0 → treat the whole engine as known.
+    if (remoteAddrs_.count(0) && remoteAddrs_.at(0).count(key)) return false;
+  }
+
+  // Each remote addr must be inserted into every local NIC's AV, since the
+  // fi_addr_t an AV returns is only usable for sends from that NIC.
+  const size_t localNics = ofi_->NumNics();
+  std::unordered_map<uint32_t, std::unordered_map<uint32_t, fi_addr_t>> perLocal;
+  for (uint32_t localNic = 0; localNic < localNics; ++localNic) {
+    for (const auto& [remoteNic, addr] : nicAddrs) {
+      perLocal[localNic][remoteNic] = ofi_->InsertAddr(localNic, addr);
+    }
+  }
+
+  std::lock_guard<std::mutex> lk(mu_);
+  if (remoteAddrs_.count(0) && remoteAddrs_.at(0).count(key)) return false;
+  for (auto& [localNic, byRemote] : perLocal) {
+    remoteAddrs_[localNic][key] = std::move(byRemote);
+  }
+  return true;
+}
+
+bool OfiControlPlane::SeedRemoteAddrs(const EngineKey& key, const std::vector<NicAddr>& nicAddrs) {
+  return InsertRemoteNicAddrs(key, nicAddrs);
+}
+
+void OfiControlPlane::DisconnectRemote(const EngineKey& key) {
+  std::lock_guard<std::mutex> lk(mu_);
+  for (auto& [localNic, byEngine] : remoteAddrs_) byEngine.erase(key);
+}
+
+fi_addr_t OfiControlPlane::GetRemoteAddr(uint32_t localNic, const EngineKey& key,
+                                         uint32_t remoteNic) const {
+  std::lock_guard<std::mutex> lk(mu_);
+  auto lIt = remoteAddrs_.find(localNic);
+  if (lIt == remoteAddrs_.end())
+    throw std::runtime_error("OfiCP: no addrs for local nic " + std::to_string(localNic));
+  auto eIt = lIt->second.find(key);
+  if (eIt == lIt->second.end())
+    throw std::runtime_error("OfiCP: no addr for remote engine " + key);
+  auto rIt = eIt->second.find(remoteNic);
+  if (rIt == eIt->second.end())
+    throw std::runtime_error("OfiCP: no addr for remote engine " + key + " nic " +
+                             std::to_string(remoteNic));
+  return rIt->second;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ *  OfiPoller — background CQ drain
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+OfiPoller::OfiPoller(OfiManager* ofi, int batchSize)
+    : ofi_(ofi), batchSize_(batchSize) {}
+
+OfiPoller::~OfiPoller() { Shutdown(); }
+
+void OfiPoller::Start() {
+  running_ = true;
+  thread_  = std::thread([this] { PollLoop(); });
+}
+
+void OfiPoller::Shutdown() {
+  if (!running_.exchange(false)) return;
+  if (thread_.joinable()) thread_.join();
+}
+
+void OfiPoller::PollLoop() {
+  std::vector<struct fi_cq_data_entry> buf(static_cast<size_t>(batchSize_));
+  const size_t numNics = ofi_->NumNics();
+  while (running_) {
+    for (size_t nic = 0; nic < numNics; ++nic) {
+      struct fid_cq* cq = ofi_->Cq(static_cast<uint32_t>(nic));
+      ssize_t n = fi_cq_read(cq, buf.data(), static_cast<size_t>(batchSize_));
+      if (n > 0) {
+        for (ssize_t i = 0; i < n; i++) {
+          auto* ctx = reinterpret_cast<OfiOpCtx*>(buf[i].op_context);
+          if (!ctx) continue;
+          // Batch counter: if remaining != nullptr, decrement; signal on 0.
+          if (ctx->remaining) {
+            if (ctx->remaining->fetch_sub(1, std::memory_order_acq_rel) == 1) {
+              ctx->status->SetCode(StatusCode::SUCCESS);
+            }
+          } else {
+            ctx->status->SetCode(StatusCode::SUCCESS);
+          }
+          delete ctx;
+        }
+      } else if (n == -FI_EAVAIL) {
+        struct fi_cq_err_entry err{};
+        fi_cq_readerr(cq, &err, 0);
+        const char* errStr = fi_cq_strerror(cq, err.prov_errno, err.err_data, nullptr, 0);
+        MORI_IO_WARN("OfiPoller CQ error: {} (prov_errno={})", errStr, err.prov_errno);
+        auto* ctx = reinterpret_cast<OfiOpCtx*>(err.op_context);
+        if (ctx) {
+          ctx->status->Update(StatusCode::ERR_RDMA_OP, std::string(errStr));
+          delete ctx;
+        }
+      } else if (n != -FI_EAGAIN) {
+        MORI_IO_WARN("OfiPoller: fi_cq_read unexpected rc={}", (int)n);
+      }
+    }
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ *  Helpers: post fi_writemsg / fi_readmsg
+ * ═══════════════════════════════════════════════════════════════════════════ */
+static void PostOfiRw(struct fid_ep* ep, struct fid_cq* cq,
+                      void* localBuf, size_t size, void* localDesc,
+                      fi_addr_t peer, uint64_t remoteOffset,
+                      uint64_t remoteKey, bool isRead,
+                      OfiOpCtx* ctx) {
+  MORI_IO_DEBUG("{}: peer=0x{:x} rma.addr={} key=0x{:x} len={} desc={}", isRead?"READ":"WRITE",
+                (uint64_t)peer, remoteOffset, remoteKey, size, (void*)localDesc);
+
+  ctx->status->SetCode(StatusCode::IN_PROGRESS);
+
+  // Use fi_writemsg with FI_DELIVERY_COMPLETE for writes, fi_read for reads.
+  ssize_t ret;
+  if (isRead) {
+    ret = fi_read(ep, localBuf, size, localDesc, peer, remoteOffset, remoteKey, ctx);
+  } else {
+    struct iovec iov = { .iov_base = localBuf, .iov_len = size };
+    struct fi_rma_iov rma = { .addr = remoteOffset, .key = remoteKey, .len = size };
+    struct fi_msg_rma msg{};
+    msg.msg_iov       = &iov;
+    msg.desc          = &localDesc;
+    msg.iov_count     = 1;
+    msg.addr          = peer;
+    msg.rma_iov       = &rma;
+    msg.rma_iov_count = 1;
+    msg.context       = ctx;
+    ret = fi_writemsg(ep, &msg, FI_DELIVERY_COMPLETE);
+  }
+
+  MORI_IO_DEBUG("PostOfiRw: {} buf={} len={} peer=0x{:x} raddr={} key=0x{:x} ret={}",
+              isRead?"read":"write", (void*)localBuf, size, (uint64_t)peer, remoteOffset, remoteKey, ret);
+
+  if (ret) {
+    ctx->status->Update(StatusCode::ERR_RDMA_OP,
+                        std::string("fi_write/read: ") + fi_strerror((int)-ret));
+    delete ctx;
+    return;
+  }
+
+  // Synchronous inline CQ drain.
+  struct fi_cq_data_entry comp{};
+  ssize_t n;
+  while ((n = fi_cq_read(cq, &comp, 1)) == -FI_EAGAIN) {}
+  if (n < 0) {
+    struct fi_cq_err_entry err{};
+    fi_cq_readerr(cq, &err, 0);
+    const char* es = fi_cq_strerror(cq, err.prov_errno, err.err_data, nullptr, 0);
+    MORI_IO_WARN("PostOfiRw CQ error: {} (prov_errno={})", es, err.prov_errno);
+    ctx->status->Update(StatusCode::ERR_RDMA_OP, std::string(es));
+  } else {
+    MORI_IO_DEBUG("PostOfiRw CQ done: n={} flags=0x{:x}", n, (uint64_t)comp.flags);
+    // For batch ops, remaining tracks how many sub-ops are still in flight.
+    // Set SUCCESS only when the last sub-op completes; always free the counter
+    // when it reaches zero.
+    if (ctx->remaining) {
+      if (ctx->remaining->fetch_sub(1, std::memory_order_acq_rel) == 1) {
+        delete ctx->remaining;
+        ctx->status->SetCode(StatusCode::SUCCESS);
+      }
+    } else {
+      ctx->status->SetCode(StatusCode::SUCCESS);
+    }
+  }
+  delete ctx;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ *  OfiBackendSession
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+OfiBackendSession::OfiBackendSession(OfiManager* ofi, OfiPoller* poller,
+                                     OfiMemRegion localMr, uint64_t remoteMrKey,
+                                     fi_addr_t remoteAddr, uintptr_t remoteBufBase,
+                                     size_t remoteSize)
+    : ofi_(ofi), poller_(poller), localMr_(localMr), remoteMrKey_(remoteMrKey),
+      remoteAddr_(remoteAddr), remoteBufBase_(remoteBufBase), remoteSize_(remoteSize) {}
+
+OfiBackendSession::~OfiBackendSession() {
+  // The session borrows all fabric state: ofi_/poller_ are owned by OfiBackend,
+  // localMr_ aliases the backend's registered MR (freed by DeregisterMemory),
+  // and remoteAddr_ is an AV index owned by the control plane — so none of it is
+  // released here (closing the MR would double-free the backend's registration).
+  // Transfers use synchronous inline CQ drain, so no op outlives the session.
+  alive_ = false;
+  ofi_ = nullptr;
+  poller_ = nullptr;
+  MORI_APP_INFO("Destroying OFI backend session: remoteAddr={} remoteBufBase={} remoteSize={}",
+                remoteAddr_, remoteBufBase_, remoteSize_);
+}
+
+void OfiBackendSession::ReadWrite(size_t localOffset, size_t remoteOffset, size_t size,
+                                  TransferStatus* status, TransferUniqueId id, bool isRead) {
+  status->SetCode(StatusCode::IN_PROGRESS);
+
+  const uint32_t nic = localMr_.nicId;
+  auto* ctx  = new OfiOpCtx{{}, status, id, nullptr};
+  void* lBuf = reinterpret_cast<void*>(localMr_.bufBase + localOffset);
+  void* lDesc = fi_mr_desc(localMr_.mr);
+
+  PostOfiRw(ofi_->Ep(nic), ofi_->Cq(nic), lBuf, size, lDesc,
+            remoteAddr_, remoteOffset, remoteMrKey_, isRead, ctx);
+}
+
+void OfiBackendSession::BatchReadWrite(const SizeVec& localOffsets, const SizeVec& remoteOffsets,
+                                       const SizeVec& sizes, TransferStatus* status,
+                                       TransferUniqueId id, bool isRead) {
+  const size_t n = sizes.size();
+  if (n == 0) { status->SetCode(StatusCode::SUCCESS); return; }
+
+  status->SetCode(StatusCode::IN_PROGRESS);
+
+  // Shared counter; last completion signals status.
+  const uint32_t nic = localMr_.nicId;
+  auto* remaining = new std::atomic<int>(static_cast<int>(n));
+  void* lDesc     = fi_mr_desc(localMr_.mr);
+
+  for (size_t i = 0; i < n; i++) {
+    auto* ctx  = new OfiOpCtx{{}, status, id, remaining};
+    void* lBuf = reinterpret_cast<void*>(localMr_.bufBase + localOffsets[i]);
+    PostOfiRw(ofi_->Ep(nic), ofi_->Cq(nic), lBuf, sizes[i], lDesc,
+              remoteAddr_, remoteOffsets[i], remoteMrKey_, isRead, ctx);
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ *  OfiBackend
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+OfiBackend::OfiBackend(EngineKey key, const IOEngineConfig& cfg,
+                       const OfiBackendConfig& ofiCfg)
+    : myKey_(key), cfg_(ofiCfg) {
+  mori::io::SetLogLevel("debug");
+  (void)cfg;  // OFI needs no control-plane host/port; addrs travel inline.
+  ofi_    = std::make_unique<OfiManager>(ofiCfg);
+  cp_     = std::make_unique<OfiControlPlane>(ofi_.get());
+  poller_ = std::make_unique<OfiPoller>(ofi_.get(), ofiCfg.cqReadBatch);
+
+  // poller thread disabled: inline sync CQ polling used instead
+  // poller_->Start();
+
+  MORI_IO_INFO("OfiBackend: key={} nics={}", key, ofi_->NumNics());
+}
+
+OfiBackend::~OfiBackend() {
+  poller_.reset();
+  cp_.reset();
+  // deregister all MRs
+  std::lock_guard<std::mutex> lk(mrMu_);
+  for (auto& [id, mr] : localMrs_) ofi_->DeregisterMr(mr);
+  localMrs_.clear();
+}
+
+void OfiBackend::RegisterRemoteEngine(const EngineDesc& desc) {
+  // Peer endpoint addresses travel inline in EngineDesc.backendDescs[OFI]; seed
+  // the local AVs directly. There is no TCP fallback.
+  auto it = desc.backendDescs.find(BackendType::OFI);
+  if (it == desc.backendDescs.end() || it->second.empty()) {
+    throw std::runtime_error(
+        "OFI: remote EngineDesc for " + desc.key +
+        " has no inline OFI descriptor (backendDescs[OFI]); cannot seed addresses");
+  }
+  auto nicAddrs = ParseOfiEngineBlob(it->second.data(), it->second.size());
+  MORI_IO_INFO("OfiBackend: seeding remote {} from EngineDesc ({} nics, {} bytes)", desc.key,
+               nicAddrs.size(), it->second.size());
+  cp_->SeedRemoteAddrs(desc.key, nicAddrs);
+}
+
+void OfiBackend::DeregisterRemoteEngine(const EngineDesc& desc) {
+  cp_->DisconnectRemote(desc.key);
+  // Drop this peer's cached remote MR info. Within a single remote engine's
+  // lifetime its memory ids are monotonically increasing, so an entry can never
+  // go stale in place — a purge is only needed when the remote engine restarts
+  // and reuses the same engineKey with ids restarting from 0, which would
+  // otherwise alias a dead registration's key/base/size.
+  std::lock_guard<std::mutex> lk(remoteMrMu_);
+  remoteMrCache_.erase(desc.key);
+}
+
+void OfiBackend::RegisterMemory(MemoryDesc& desc) {
+  auto* buf = reinterpret_cast<void*>(desc.data);
+  const bool isDevice = (desc.loc == MemoryLocationType::GPU);
+  // Pick the local NIC/endpoint by GPU/NUMA affinity; the MR is bound to it.
+  const uint32_t nic = ofi_->SelectLocalNic(desc.deviceId, desc.numaNode);
+  MORI_IO_INFO("Registering memory: id={} size={} loc={} deviceId={}, deviceBusId={} nic={}",
+               desc.id, desc.size, static_cast<int>(desc.loc), desc.deviceId, desc.deviceBusId,
+               nic);
+  OfiMemRegion mr = ofi_->RegisterMr(nic, buf, desc.size, cfg_.mrAccessFlags, isDevice,
+                                     desc.deviceId);
+
+  {
+    std::lock_guard<std::mutex> lk(mrMu_);
+    localMrs_[desc.id] = mr;
+  }
+
+  // Publish the MR key + owning NIC inline so peers resolve them from the
+  // transported MemoryDesc. Base/size are desc.data/desc.size.
+  OfiMrBlob blob{mr.key, mr.nicId};
+  msgpack::sbuffer sb;
+  msgpack::pack(sb, blob);
+  auto& out = desc.backendDescs[BackendType::OFI];
+  out.assign(reinterpret_cast<const uint8_t*>(sb.data()),
+             reinterpret_cast<const uint8_t*>(sb.data()) + sb.size());
+
+  MORI_IO_DEBUG("OfiBackend: registered mem id={} key=0x{:x} size={} nic={}", desc.id, mr.key,
+                desc.size, mr.nicId);
+}
+
+void OfiBackend::DeregisterMemory(const MemoryDesc& desc) {
+  std::lock_guard<std::mutex> lk(mrMu_);
+  auto it = localMrs_.find(desc.id);
+  if (it != localMrs_.end()) {
+    ofi_->DeregisterMr(it->second);
+    localMrs_.erase(it);
+  }
+}
+
+OfiMemRegion* OfiBackend::GetLocalMr(MemoryUniqueId id) {
+  auto it = localMrs_.find(id);
+  if (it == localMrs_.end()) return nullptr;
+  return &it->second;
+}
+
+OfiBackend::RemoteMrInfo OfiBackend::GetRemoteMrInfo(const MemoryDesc& remote) {
+  {
+    std::lock_guard<std::mutex> lk(remoteMrMu_);
+    auto eIt = remoteMrCache_.find(remote.engineKey);
+    if (eIt != remoteMrCache_.end()) {
+      auto mIt = eIt->second.find(remote.id);
+      if (mIt != eIt->second.end()) return mIt->second;
+    }
+  }
+
+  MORI_IO_INFO("Fetching remote MR info for engine={} id={}", remote.engineKey, remote.id);
+  RemoteMrInfo info{};
+  auto it = remote.backendDescs.find(BackendType::OFI);
+  if (it != remote.backendDescs.end() && !it->second.empty()) {
+    // MR key + owning NIC advertised inline; base/size come from the desc.
+    auto oh = msgpack::unpack(reinterpret_cast<const char*>(it->second.data()), it->second.size());
+    OfiMrBlob blob = oh.get().as<OfiMrBlob>();
+    info = RemoteMrInfo{blob.key, static_cast<uintptr_t>(remote.data), remote.size, blob.nicId};
+  } else {
+    throw std::runtime_error(
+        "OFI: remote MemoryDesc for engine " + remote.engineKey + " id " +
+        std::to_string(remote.id) + " has no inline OFI descriptor (backendDescs[OFI])");
+  }
+
+  {
+    std::lock_guard<std::mutex> lk(remoteMrMu_);
+    remoteMrCache_[remote.engineKey][remote.id] = info;
+  }
+  return info;
+}
+
+void OfiBackend::ReadWrite(const MemoryDesc& local, size_t localOffset,
+                           const MemoryDesc& remote, size_t remoteOffset,
+                           size_t size, TransferStatus* status,
+                           TransferUniqueId id, bool isRead) {
+  std::lock_guard<std::mutex> lk(mrMu_);
+  auto* lmr = GetLocalMr(local.id);
+  if (!lmr) {
+    status->Update(StatusCode::ERR_NOT_FOUND, "OFI: local MR not found id=" + std::to_string(local.id));
+    return;
+  }
+
+  auto rInfo  = GetRemoteMrInfo(remote);
+  const uint32_t localNic = lmr->nicId;
+  fi_addr_t   rAddr = cp_->GetRemoteAddr(localNic, remote.engineKey, rInfo.nicId);
+  MORI_IO_DEBUG("ReadWrite: eng={} id={} key=0x{:x} base=0x{:x} lnic={} rnic={} fa=0x{:x}",
+                remote.engineKey, (unsigned)remote.id, rInfo.key, (unsigned long)rInfo.base,
+                localNic, rInfo.nicId, (uint64_t)rAddr);
+
+  auto* ctx  = new OfiOpCtx{{}, status, id, nullptr};
+  void* lBuf = reinterpret_cast<void*>(lmr->bufBase + localOffset);
+  void* lDesc = fi_mr_desc(lmr->mr);
+
+  PostOfiRw(ofi_->Ep(localNic), ofi_->Cq(localNic), lBuf, size, lDesc,
+            rAddr, remoteOffset, rInfo.key, isRead, ctx);
+}
+
+void OfiBackend::BatchReadWrite(const MemoryDesc& local, const SizeVec& localOffsets,
+                                const MemoryDesc& remote, const SizeVec& remoteOffsets,
+                                const SizeVec& sizes, TransferStatus* status,
+                                TransferUniqueId id, bool isRead) {
+  const size_t n = sizes.size();
+  if (n == 0) { status->SetCode(StatusCode::SUCCESS); return; }
+
+  std::lock_guard<std::mutex> lk(mrMu_);
+  auto* lmr = GetLocalMr(local.id);
+  if (!lmr) {
+    status->Update(StatusCode::ERR_NOT_FOUND, "OFI: local MR not found");
+    return;
+  }
+
+  auto      rInfo = GetRemoteMrInfo(remote);
+  const uint32_t localNic = lmr->nicId;
+  fi_addr_t rAddr = cp_->GetRemoteAddr(localNic, remote.engineKey, rInfo.nicId);
+  auto*     rem   = new std::atomic<int>(static_cast<int>(n));
+  void*     lDesc = fi_mr_desc(lmr->mr);
+
+  status->SetCode(StatusCode::IN_PROGRESS);
+  for (size_t i = 0; i < n; i++) {
+    auto* ctx  = new OfiOpCtx{{}, status, id, rem};
+    void* lBuf = reinterpret_cast<void*>(lmr->bufBase + localOffsets[i]);
+    PostOfiRw(ofi_->Ep(localNic), ofi_->Cq(localNic), lBuf, sizes[i], lDesc,
+              rAddr, remoteOffsets[i], rInfo.key, isRead, ctx);
+  }
+}
+
+BackendSession* OfiBackend::CreateSession(const MemoryDesc& local,
+                                          const MemoryDesc& remote) {
+  MORI_APP_INFO("Creating OFI backend session for local engine={} id={} remote engine={} id={}",
+                local.engineKey, local.id, remote.engineKey, remote.id);
+  std::lock_guard<std::mutex> lk(mrMu_);
+  auto* lmr = GetLocalMr(local.id);
+  if (!lmr) throw std::runtime_error("OFI: local MR not found for session");
+
+  auto      rInfo = GetRemoteMrInfo(remote);
+  fi_addr_t rAddr = cp_->GetRemoteAddr(lmr->nicId, remote.engineKey, rInfo.nicId);
+
+  return new OfiBackendSession(ofi_.get(), poller_.get(), *lmr,
+                               rInfo.key, rAddr, rInfo.base, rInfo.size);
+}
+
+bool OfiBackend::PopInboundTransferStatus(EngineKey /*remote*/, TransferUniqueId /*id*/,
+                                          TransferStatus* /*status*/) {
+  // fi_write/fi_read are initiator-side completions only; no inbound tracking needed.
+  return false;
+}
+
+DescBlob OfiBackend::GetEngineDescBlob() const {
+  // Publish every local endpoint's addr_name (per-NIC list) so peers can seed
+  // their AVs pre-handshake and target the right endpoint per remote MR.
+  return ofi_ ? ofi_->BuildEngineBlob() : DescBlob{};
+}
+
+}  // namespace io
+}  // namespace mori

--- a/src/io/ofi/backend_impl.hpp
+++ b/src/io/ofi/backend_impl.hpp
@@ -1,0 +1,254 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+// MIT License — see root LICENSE file.
+//
+// MORI-IO OFI (libfabric) backend — Slingshot / CXI compatible.
+// Capabilities: FI_EP_RDM, FI_MR_ENDPOINT (no FI_MR_VIRT_ADDR), fi_write / fi_read.
+#pragma once
+
+#include <rdma/fabric.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_rma.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_errno.h>
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "mori/io/backend.hpp"
+#include "mori/io/common.hpp"
+#include "mori/io/engine.hpp"
+#include "mori/io/logging.hpp"
+
+namespace mori {
+namespace application {
+class TopoSystem;  // fwd-decl: GPU↔NIC affinity for local NIC selection
+}  // namespace application
+
+namespace io {
+
+/* ── helpers ──────────────────────────────────────────────────────────────── */
+#define OFI_CHECK(call, msg)                                           \
+  do {                                                                 \
+    int _rc = (call);                                                  \
+    if (_rc < 0) {                                                     \
+      throw std::runtime_error(std::string(msg) + ": " +              \
+                               fi_strerror(-_rc));                     \
+    }                                                                  \
+  } while (0)
+
+/* ── per-registered-memory info ───────────────────────────────────────────── */
+struct OfiMemRegion {
+  struct fid_mr* mr{nullptr};
+  uint64_t       key{FI_KEY_NOTAVAIL};
+  uintptr_t      bufBase{0};  // virtual address of registered buffer start
+  size_t         size{0};
+  uint32_t       nicId{0};    // local NIC/endpoint this MR is bound to
+};
+
+/* ── per-in-flight operation context ─────────────────────────────────────── */
+struct OfiOpCtx {
+  // Must be first: when FI_CONTEXT|FI_CONTEXT2 mode is set, the provider
+  // uses the first sizeof(fi_context2)=64 bytes at msg.context for internal
+  // bookkeeping.  Placing fi_ctx first keeps our fields safe.
+  struct fi_context2 fi_ctx{};
+  TransferStatus*   status{nullptr};
+  TransferUniqueId  id{0};
+  // back-link to the parent counter (for batches)
+  std::atomic<int>* remaining{nullptr};
+};
+
+/* ── OFI fabric / domain / endpoint manager ──────────────────────────────── */
+// Per-local-NIC endpoint resources. One is opened per unique provider domain
+// returned by fi_getinfo, so each physical NIC gets its own fabric/domain/av/
+// cq/ep. fi_info is aliased into the owned info_ list and must not be freed here.
+struct OfiNic {
+  uint32_t           nicId{0};
+  std::string        domainName;  // libfabric domain name (e.g. cxi0)
+  struct fi_info*    info{nullptr};
+  struct fid_fabric* fabric{nullptr};
+  struct fid_domain* domain{nullptr};
+  struct fid_av*     av{nullptr};
+  struct fid_ep*     ep{nullptr};
+  struct fid_cq*     cq{nullptr};
+};
+
+class OfiManager {
+ public:
+  explicit OfiManager(const OfiBackendConfig& cfg);
+  ~OfiManager();
+
+  size_t NumNics() const { return nics_.size(); }
+  const std::vector<OfiNic>& Nics() const { return nics_; }
+
+  // Local endpoint address bytes for a given NIC (variable-length, ≤64 B CXI).
+  std::vector<uint8_t> GetAddrName(uint32_t nic) const;
+
+  // msgpack OfiEngineBlob: {nicId, addrName} for every local endpoint.
+  std::vector<uint8_t> BuildEngineBlob() const;
+
+  // Insert a remote endpoint address into a specific local NIC's AV. The
+  // returned fi_addr_t is only valid for fi_write/fi_read from that same NIC.
+  fi_addr_t InsertAddr(uint32_t localNic, const std::vector<uint8_t>& addrBytes);
+
+  // Register a memory region on NIC `nic` and bind it to that endpoint.
+  // isDevice selects FI_HMEM_ROCR (GPU) vs FI_HMEM_SYSTEM (host).
+  OfiMemRegion RegisterMr(uint32_t nic, void* buf, size_t size, uint64_t accessFlags,
+                          bool isDevice = false, int deviceId = 0);
+  void DeregisterMr(OfiMemRegion& mr);
+
+  // Pick the local NIC/endpoint index for a buffer by GPU/NUMA affinity.
+  // deviceId < 0 selects by numaNode (host memory); falls back to NIC 0.
+  uint32_t SelectLocalNic(int deviceId, int numaNode);
+
+  struct fid_ep* Ep(uint32_t nic) const { return nics_[nic].ep; }
+  struct fid_cq* Cq(uint32_t nic) const { return nics_[nic].cq; }
+  bool VirtAddr() const { return virtAddr_; }
+  bool HmemEnabled() const { return hmemEnabled_; }
+
+ private:
+  void OpenNic(struct fi_info* info, uint32_t nicId);
+
+  struct fi_info* info_{nullptr};  // owns the fi_getinfo linked list
+  std::vector<OfiNic> nics_;
+  std::unordered_map<std::string, uint32_t> domainToNic_;  // domainName → index
+  bool virtAddr_{false};
+  bool hmemEnabled_{false};
+  std::unique_ptr<application::TopoSystem> topo_;
+};
+
+/* ── OFI address registry (no out-of-band control plane) ─────────────────── */
+// Peer endpoint addresses (EngineDesc) and MR keys (MemoryDesc) are carried
+// inline in backendDescs, so no TCP exchange is needed. This class just inserts
+// advertised peer addrs into the local AVs and returns fi_addr_t per transfer.
+class OfiControlPlane {
+ public:
+  explicit OfiControlPlane(OfiManager* ofi);
+  ~OfiControlPlane();
+
+  // Seed a remote engine's per-NIC fi_addr_t values from its advertised
+  // (nicId, addrName) list. Each remote addr is inserted into every local NIC's
+  // AV. Returns true if a new engine entry was inserted.
+  using NicAddr = std::pair<uint32_t, std::vector<uint8_t>>;
+  bool SeedRemoteAddrs(const EngineKey& key, const std::vector<NicAddr>& nicAddrs);
+  void DisconnectRemote(const EngineKey& key);
+
+  // Cached fi_addr_t for sending from localNic to (remote engine, remoteNic).
+  fi_addr_t GetRemoteAddr(uint32_t localNic, const EngineKey& key, uint32_t remoteNic) const;
+
+ private:
+  // Insert a remote engine's per-NIC addrs into every local NIC's AV.
+  bool InsertRemoteNicAddrs(const EngineKey& key, const std::vector<NicAddr>& nicAddrs);
+
+  OfiManager*  ofi_{nullptr};
+
+  mutable std::mutex mu_;
+  // localNic → engineKey → remoteNic → fi_addr_t (AV index is per local NIC).
+  std::unordered_map<uint32_t,
+      std::unordered_map<EngineKey, std::unordered_map<uint32_t, fi_addr_t>>> remoteAddrs_;
+};
+
+/* ── OFI completion poller (background thread) ────────────────────────────── */
+class OfiPoller {
+ public:
+  explicit OfiPoller(OfiManager* ofi, int batchSize = 64);
+  ~OfiPoller();
+
+  void Start();
+  void Shutdown();
+
+ private:
+  void PollLoop();
+
+  OfiManager* ofi_;
+  int         batchSize_;
+  std::atomic<bool> running_{false};
+  std::thread  thread_;
+};
+
+/* ── BackendSession ───────────────────────────────────────────────────────── */
+class OfiBackendSession : public BackendSession {
+ public:
+  OfiBackendSession() = default;
+  OfiBackendSession(OfiManager* ofi, OfiPoller* poller,
+                    OfiMemRegion localMr, uint64_t remoteMrKey,
+                    fi_addr_t remoteAddr, uintptr_t remoteBufBase, size_t remoteSize);
+  ~OfiBackendSession() override;
+
+  void ReadWrite(size_t localOffset, size_t remoteOffset, size_t size,
+                 TransferStatus* status, TransferUniqueId id, bool isRead) override;
+
+  void BatchReadWrite(const SizeVec& localOffsets, const SizeVec& remoteOffsets,
+                      const SizeVec& sizes, TransferStatus* status,
+                      TransferUniqueId id, bool isRead) override;
+
+  bool Alive() const override { return alive_; }
+
+ private:
+  OfiManager*  ofi_{nullptr};
+  OfiPoller*   poller_{nullptr};
+  OfiMemRegion localMr_;
+  uint64_t     remoteMrKey_{FI_KEY_NOTAVAIL};
+  fi_addr_t    remoteAddr_{FI_ADDR_UNSPEC};
+  uintptr_t    remoteBufBase_{0};
+  size_t       remoteSize_{0};
+  bool         alive_{true};
+};
+
+/* ── OfiBackend : public Backend ─────────────────────────────────────────── */
+class OfiBackend : public Backend {
+ public:
+  OfiBackend(EngineKey key, const IOEngineConfig& cfg, const OfiBackendConfig& ofiCfg);
+  ~OfiBackend() override;
+
+  void RegisterRemoteEngine(const EngineDesc& desc) override;
+  void DeregisterRemoteEngine(const EngineDesc& desc) override;
+  void RegisterMemory(MemoryDesc& desc) override;
+  void DeregisterMemory(const MemoryDesc& desc) override;
+
+  void ReadWrite(const MemoryDesc& local, size_t localOffset,
+                 const MemoryDesc& remote, size_t remoteOffset,
+                 size_t size, TransferStatus* status,
+                 TransferUniqueId id, bool isRead) override;
+
+  void BatchReadWrite(const MemoryDesc& local, const SizeVec& localOffsets,
+                      const MemoryDesc& remote, const SizeVec& remoteOffsets,
+                      const SizeVec& sizes, TransferStatus* status,
+                      TransferUniqueId id, bool isRead) override;
+
+  BackendSession* CreateSession(const MemoryDesc& local,
+                                const MemoryDesc& remote) override;
+
+  bool PopInboundTransferStatus(EngineKey remote, TransferUniqueId id,
+                                TransferStatus* status) override;
+
+  DescBlob GetEngineDescBlob() const override;
+
+ private:
+  OfiMemRegion* GetLocalMr(MemoryUniqueId id);
+  // Fetch or cache remote MR info: key + buf base + owning remote NIC.
+  struct RemoteMrInfo { uint64_t key; uintptr_t base; size_t size; uint32_t nicId; };
+  RemoteMrInfo GetRemoteMrInfo(const MemoryDesc& remote);
+
+  EngineKey         myKey_;
+  OfiBackendConfig  cfg_;
+  std::unique_ptr<OfiManager>      ofi_;
+  std::unique_ptr<OfiControlPlane> cp_;
+  std::unique_ptr<OfiPoller>       poller_;
+
+  mutable std::mutex mrMu_;
+  std::unordered_map<MemoryUniqueId, OfiMemRegion> localMrs_;
+  // Cache of remote MR info: engineKey → memId → RemoteMrInfo
+  mutable std::mutex remoteMrMu_;
+  std::unordered_map<EngineKey,
+    std::unordered_map<MemoryUniqueId, RemoteMrInfo>> remoteMrCache_;
+};
+
+}  // namespace io
+}  // namespace mori

--- a/src/pybind/pybind_io.cpp
+++ b/src/pybind/pybind_io.cpp
@@ -45,6 +45,7 @@ void RegisterMoriIo(pybind11::module_& m) {
       .value("RDMA", mori::io::BackendType::RDMA)
       .value("TCP", mori::io::BackendType::TCP)
       .value("FABRIC", mori::io::BackendType::FABRIC)
+      .value("OFI", mori::io::BackendType::OFI)
       .export_values();
 
   py::enum_<mori::io::MemoryLocationType>(m, "MemoryLocationType")
@@ -103,6 +104,14 @@ void RegisterMoriIo(pybind11::module_& m) {
       .def_readwrite("num_streams", &mori::io::FabricBackendConfig::numStreams)
       .def_readwrite("num_events", &mori::io::FabricBackendConfig::numEvents);
 
+  py::class_<mori::io::OfiBackendConfig, mori::io::BackendConfig>(m, "OfiBackendConfig")
+      .def(py::init<>())
+      .def(py::init<const std::string&, int>(), py::arg("provider"), py::arg("cq_batch") = 64)
+      .def_readwrite("provider_hint", &mori::io::OfiBackendConfig::providerHint)
+      .def_readwrite("cq_read_batch", &mori::io::OfiBackendConfig::cqReadBatch)
+      .def_readwrite("mr_access_flags", &mori::io::OfiBackendConfig::mrAccessFlags)
+      .def_readwrite("threading_model", &mori::io::OfiBackendConfig::threadingModel);
+
   // Allocate/free GPU memory that is exportable over a UALink super-node fabric.
   // Returns the device pointer as an integer, suitable for register_memory().
   m.def(
@@ -142,6 +151,15 @@ void RegisterMoriIo(pybind11::module_& m) {
       .def_readonly("host", &mori::io::EngineDesc::host)
       .def_readonly("port", &mori::io::EngineDesc::port)
       .def_readonly("pid", &mori::io::EngineDesc::pid)
+      .def_property_readonly("backend_descs",
+                             [](const mori::io::EngineDesc& d) {
+                               py::dict out;
+                               for (const auto& [type, blob] : d.backendDescs) {
+                                 out[py::int_(static_cast<uint32_t>(type))] = py::bytes(
+                                     reinterpret_cast<const char*>(blob.data()), blob.size());
+                               }
+                               return out;
+                             })
       .def(pybind11::self == pybind11::self)
       .def("pack",
            [](const mori::io::EngineDesc& d) {

--- a/tests/cpp/io/ofi_slingshot_test.cpp
+++ b/tests/cpp/io/ofi_slingshot_test.cpp
@@ -1,0 +1,212 @@
+#include <unistd.h>
+#include <immintrin.h>
+// MORI-IO OFI/Slingshot correctness test.
+//
+// Root cause of CXI cache visibility issue:
+//   CXI RDMA writes (fi_write) land in target's physical DRAM but do NOT
+//   automatically invalidate dirty CPU cache lines on the target node.
+//   Fix: pre-flush the receive buffer BEFORE incoming fi_writes arrive.
+//   This evicts all cache lines so the first CPU read after fi_write is a
+//   cache miss that reloads from DRAM, which has the NIC-written data.
+//
+// Design: separate send/receive buffers per rank to avoid the problem where
+//   rank0's own fi_write (DMA read of sendBuf) would re-load the cache lines
+//   of recvBuf, staling them before rank1's remote write arrives.
+//
+// Build: see tests/scripts/build_ofi_test.sh
+// Run:   srun -N 2 --ntasks-per-node=1 ./ofi_slingshot_test
+#include <mpi.h>
+#include <cstring>
+#include <string>
+#include <vector>
+#include <cstdio>
+#include <cstdlib>
+#include <signal.h>
+
+#include "mori/io/engine.hpp"
+#include "mori/io/backend.hpp"
+#include "mori/io/common.hpp"
+#include "mori/io/enum.hpp"
+#include "mori/io/logging.hpp"
+
+using namespace mori::io;
+static void die(const char* msg) { fprintf(stderr, "FATAL: %s\n", msg); MPI_Abort(MPI_COMM_WORLD, 1); }
+
+// Flush all cache lines covering [ptr, ptr+size). Must be called on the
+// RECEIVE buffer before incoming fi_write transfers, since CXI RDMA writes
+// go to DRAM without invalidating dirty CPU cache lines.
+static void FlushCacheLines(void* ptr, size_t size) {
+  char* p = reinterpret_cast<char*>(ptr);
+  for (size_t i = 0; i < size; i += 64) _mm_clflush(p + i);
+  _mm_mfence();
+}
+
+// Force exit if OFI/MPI cleanup hangs.
+static void SigalrmHandler(int) { _exit(0); }
+
+static int RunTest(int rank, int nranks) {
+  if (nranks < 2) die("need at least 2 ranks");
+
+  // ── Engine & backend setup ────────────────────────────────────────────────
+  char hostname[256]; gethostname(hostname, sizeof(hostname));
+  IOEngineConfig cfg; cfg.host = hostname; cfg.port = 0;
+  IOEngine engine("rank" + std::to_string(rank), cfg);
+  engine.CreateBackend(BackendType::OFI, OfiBackendConfig("cxi"));
+
+  // ── Exchange EngineDescs ──────────────────────────────────────────────────
+  struct PackedDesc { char key[64]; char host[256]; int port; int pid; };
+  PackedDesc myPacked{};
+  auto myDesc = engine.GetEngineDesc();
+  snprintf(myPacked.key,  64,  "%s", myDesc.key.c_str());
+  snprintf(myPacked.host, 256, "%s", myDesc.host.c_str());
+  myPacked.port = myDesc.port; myPacked.pid = myDesc.pid;
+  std::vector<PackedDesc> allDescs(nranks);
+  MPI_Allgather(&myPacked, sizeof(PackedDesc), MPI_BYTE,
+                allDescs.data(), sizeof(PackedDesc), MPI_BYTE, MPI_COMM_WORLD);
+  for (int i = 0; i < nranks; i++) {
+    if (i == rank) continue;
+    EngineDesc r; r.key = allDescs[i].key; r.host = allDescs[i].host;
+    r.port = allDescs[i].port; r.pid = allDescs[i].pid;
+    engine.RegisterRemoteEngine(r);
+  }
+
+  // ── Allocate separate send/recv buffers ───────────────────────────────────
+  // sendBuf: local data to push to neighbour (written by CPU, read by local NIC)
+  // recvBuf: pre-flushed before writes; incoming fi_writes land here
+  constexpr size_t BUF_SIZE = 4UL * 1024 * 1024;  // 4 MB
+  void *sendBuf = nullptr, *recvBuf = nullptr;
+  if (posix_memalign(&sendBuf, 4096, BUF_SIZE)) die("posix_memalign sendBuf");
+  if (posix_memalign(&recvBuf, 4096, BUF_SIZE)) die("posix_memalign recvBuf");
+
+  // Each rank fills sendBuf with its pattern (rank+1), recvBuf with sentinel.
+  memset(sendBuf, static_cast<unsigned char>(rank + 1), BUF_SIZE);
+  memset(recvBuf, 0x00, BUF_SIZE);
+
+  // Register both with MORI.
+  MemoryDesc sendMem = engine.RegisterMemory(sendBuf, BUF_SIZE, -1, MemoryLocationType::CPU);
+  MemoryDesc recvMem = engine.RegisterMemory(recvBuf, BUF_SIZE, -1, MemoryLocationType::CPU);
+
+  // ── Exchange MemoryDescs ──────────────────────────────────────────────────
+  struct PackedMem { char engineKey[64]; uint32_t id; uint64_t data; uint64_t size; };
+  // We need to exchange BOTH sendMem and recvMem for each rank.
+  struct PackedMemPair { PackedMem send; PackedMem recv; };
+  PackedMemPair myMems{};
+  auto pack = [](PackedMem& pm, const MemoryDesc& m) {
+    snprintf(pm.engineKey, 64, "%s", m.engineKey.c_str());
+    pm.id = m.id; pm.data = m.data; pm.size = m.size;
+  };
+  pack(myMems.send, sendMem); pack(myMems.recv, recvMem);
+  std::vector<PackedMemPair> allMems(nranks);
+  MPI_Allgather(&myMems, sizeof(PackedMemPair), MPI_BYTE,
+                allMems.data(), sizeof(PackedMemPair), MPI_BYTE, MPI_COMM_WORLD);
+
+  int right = (rank + 1) % nranks;          // where we write to
+  int left  = (rank + nranks - 1) % nranks; // who writes to us
+
+  // Build remote recvMem descriptor for the right neighbour.
+  MemoryDesc rightRecvMem;
+  rightRecvMem.engineKey = allMems[right].recv.engineKey;
+  rightRecvMem.id   = allMems[right].recv.id;
+  rightRecvMem.data = allMems[right].recv.data;
+  rightRecvMem.size = allMems[right].recv.size;
+  rightRecvMem.loc  = MemoryLocationType::CPU;
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // ── Test 1: fi_read (pull) sanity check ──────────────────────────────────
+  // rank0 reads rank1's sendBuf via fi_read → confirms basic connectivity.
+  if (rank == 0) {
+    MemoryDesc rank1SendMem;
+    rank1SendMem.engineKey = allMems[1].send.engineKey;
+    rank1SendMem.id   = allMems[1].send.id;
+    rank1SendMem.data = allMems[1].send.data;
+    rank1SendMem.size = allMems[1].send.size;
+    rank1SendMem.loc  = MemoryLocationType::CPU;
+
+    TransferStatus s; TransferUniqueId u = engine.AllocateTransferUniqueId();
+    engine.Read(recvMem, 0, rank1SendMem, 0, BUF_SIZE, &s, u);
+    s.Wait();
+    if (s.Failed()) die("fi_read Test1 failed");
+    size_t errs = 0;
+    for (size_t i = 0; i < BUF_SIZE; i++) if (((unsigned char*)recvBuf)[i] != 0x02) errs++;
+    if (errs == 0) printf("Rank 0: Test1 fi_read (pull) PASS\n");
+    else { fprintf(stderr, "Rank 0: Test1 fi_read FAIL %zu errs\n", errs); MPI_Abort(MPI_COMM_WORLD, 1); }
+    // Reset recvBuf sentinel for Test 2.
+    memset(recvBuf, 0x00, BUF_SIZE);
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // ── Test 2: Session ring-write (push, bidirectional) ─────────────────────
+  // Each rank writes its sendBuf to the right neighbour's recvBuf.
+  // CRITICAL: pre-flush recvBuf on EVERY rank before any writes start so that
+  // the incoming fi_write lands in clean DRAM, visible on next CPU load.
+  FlushCacheLines(recvBuf, BUF_SIZE);
+  fprintf(stderr, "Rank %d: recvBuf pre-flushed\n", rank);
+  MPI_Barrier(MPI_COMM_WORLD);  // all ranks flushed before any writes start
+
+  // Create session: we write from our sendBuf to the right neighbour's recvBuf.
+  auto sessOpt = engine.CreateSession(sendMem, rightRecvMem);
+  if (!sessOpt) die("CreateSession failed");
+  auto& sess = *sessOpt;
+
+  // Each rank pushes its sendBuf (rank+1 pattern) to the right neighbour's recvBuf.
+  constexpr int N_ITERS = 5;
+  for (int iter = 0; iter < N_ITERS; iter++) {
+    TransferStatus s; TransferUniqueId u = sess.AllocateTransferUniqueId();
+    sess.Write(0, 0, BUF_SIZE, &s, u);
+    s.Wait();
+    if (s.Failed()) {
+      fprintf(stderr, "Rank %d: Write iter %d FAILED\n", rank, iter);
+      MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+  }
+  fprintf(stderr, "Rank %d: %d writes done\n", rank, N_ITERS);
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // ── Verify: each rank checks its recvBuf for the left neighbour's pattern ─
+  // No post-write clflush needed: recvBuf cache lines were evicted in pre-flush
+  // and rank0's sendBuf DMA read doesn't touch recvBuf (separate buffers).
+  // First CPU access to recvBuf here is a cache miss → loads from DRAM.
+  unsigned char expected = static_cast<unsigned char>(left + 1);
+  size_t errors = 0;
+  for (size_t i = 0; i < BUF_SIZE; i++)
+    if (((unsigned char*)recvBuf)[i] != expected) errors++;
+  if (errors == 0) {
+    printf("Rank %d: Test2 ring-write PASS (got 0x%02x from rank%d)\n",
+           rank, expected, left);
+    fflush(stdout);
+  } else {
+    fprintf(stderr, "Rank %d: Test2 ring-write FAIL %zu/%zu bytes wrong "
+            "(expected 0x%02x got 0x%02x)\n",
+            rank, errors, BUF_SIZE, expected, ((unsigned char*)recvBuf)[0]);
+    MPI_Abort(MPI_COMM_WORLD, 1);
+  }
+
+  // ── Cleanup ───────────────────────────────────────────────────────────────
+  engine.DeregisterMemory(sendMem);
+  engine.DeregisterMemory(recvMem);
+  free(sendBuf);
+  free(recvBuf);
+  fflush(stdout); fflush(stderr);
+  // Set alarm before IOEngine/OFI destructor in case fi_close hangs on CXI.
+  // engine destructor runs at scope exit (closing OFI fabric) — may take >10 s.
+  signal(SIGALRM, SigalrmHandler);
+  alarm(15);
+  // engine destroyed here; if OFI cleanup hangs, SIGALRM fires _exit(0).
+  return 0;
+}
+
+int main(int argc, char** argv) {
+  MPI_Init(&argc, &argv);
+  int rank, nranks;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &nranks);
+  int rc = RunTest(rank, nranks);
+  // RunTest destroys IOEngine (OFI cleanup) before returning.
+  // If OFI cleanup hung, SIGALRM already fired _exit(0) inside RunTest.
+  // If cleanup succeeded, alarm is still armed; cancel it before MPI_Finalize.
+  alarm(0);
+  fflush(stdout); fflush(stderr);
+  MPI_Finalize();
+  return rc;
+}

--- a/tests/scripts/build_ofi_portage.sh
+++ b/tests/scripts/build_ofi_portage.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Run from ~/mori-ofi on the login node to configure+build.
+set -e
+
+module purge
+module load rocm/6.4.1
+module load libfabric/2.2.0rc1
+module load cray-mpich/8.1.30
+module load cmake/3.25.1
+
+MORI_ROOT=${HOME}/mori-ofi
+BUILD_DIR=${MORI_ROOT}/build-ofi
+
+# pkg-config path for libfabric
+export PKG_CONFIG_PATH=/opt/cray/libfabric/2.2.0rc1/lib64/pkgconfig:${PKG_CONFIG_PATH}
+
+mkdir -p ${BUILD_DIR}
+cd ${BUILD_DIR}
+
+cmake ${MORI_ROOT} \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DMORI_USE_LIBFABRIC=ON \
+  -DCMAKE_PREFIX_PATH="/opt/rocm-6.4.1;/opt/cray/libfabric/2.2.0rc1" \
+  -DCMAKE_C_COMPILER=$(which mpicc) \
+  -DCMAKE_CXX_COMPILER=$(which mpicxx) \
+  -DMORI_BUILD_TESTS=ON \
+  2>&1 | tee cmake_configure.log
+
+make -j$(nproc) mori_io 2>&1 | tee build_mori_io.log
+
+# Build the standalone OFI test
+mpicxx -std=c++17 -O2 \
+  -I${MORI_ROOT}/include \
+  -I/opt/cray/libfabric/2.2.0rc1/include \
+  -I${MORI_ROOT}/src \
+  -L${BUILD_DIR} -lmori_io \
+  -L/opt/cray/libfabric/2.2.0rc1/lib64 -lfabric \
+  -Wl,-rpath,${BUILD_DIR} \
+  -Wl,-rpath,/opt/cray/libfabric/2.2.0rc1/lib64 \
+  ${MORI_ROOT}/tests/cpp/io/ofi_slingshot_test.cpp \
+  -o ${BUILD_DIR}/tests/ofi_slingshot_test \
+  2>&1 | tee build_test.log
+
+echo "Build complete: ${BUILD_DIR}/tests/ofi_slingshot_test"

--- a/tests/scripts/run_fi_write_basic.sh
+++ b/tests/scripts/run_fi_write_basic.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#SBATCH --job-name=fi-write-basic
+#SBATCH --output=%x_%j.out
+#SBATCH --error=%x_%j.err
+#SBATCH --nodes=2
+#SBATCH --ntasks=2
+#SBATCH --ntasks-per-node=1
+#SBATCH --partition=parry
+#SBATCH --time=00:05:00
+#SBATCH --account=datascience_collab
+
+echo "=== fi_write basic test === $(date)"
+echo "Nodes: $SLURM_JOB_NODELIST"
+srun --mpi=cray_shasta $HOME/mori-ofi/build-ofi/tests/fi_write_basic_test
+echo "=== Done $(date) ==="

--- a/tests/scripts/run_ofi_portage.sh
+++ b/tests/scripts/run_ofi_portage.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#SBATCH --job-name=mori-ofi-test
+#SBATCH --nodes=2
+#SBATCH --ntasks-per-node=1
+#SBATCH --time=00:15:00
+#SBATCH --partition=parry
+#SBATCH --output=%x_%j.out
+#SBATCH --error=%x_%j.err
+
+BUILD=${HOME}/mori-ofi/build-ofi
+export FI_CXI_DEFAULT_VNI=$(od -vAn -N4 -tu4 < /dev/urandom | tr -d ' ')
+export MORI_IO_LOG_LEVEL=debug
+
+echo "=== MORI OFI Slingshot test === $(date)"
+echo "Nodes: $SLURM_NODELIST"
+srun --ntasks=2 --nodes=2 --ntasks-per-node=1 --mpi=cray_shasta ${BUILD}/tests/ofi_slingshot_test
+echo "=== Done $(date) ==="


### PR DESCRIPTION
Add a libfabric (OFI) transport for MORI-IO targeting HPE Slingshot / CXI
fabrics, with per-NIC endpoint management, GPU→NIC affinity selection, and
inline descriptor-based address/MR exchange.

--- OFI backend (new) ---
* src/io/ofi/backend_impl.{hpp,cpp}: FI_EP_RDM + FI_MR_ENDPOINT + FI_MR_PROV_KEY data plane (fi_read / fi_writemsg with offset-based RMA), HMEM (FI_HMEM_ROCR)
  registration for GPU buffers with host-only fallback, inline synchronous CQ
  drain, and a background multi-CQ poller.
* Wire up the backend: src/io/engine.cpp (OFI create branch), src/io/CMakeLists.txt, include/mori/io/{backend.hpp (OfiBackendConfig), engine.hpp, enum.hpp, common.hpp},
  src/pybind/pybind_io.cpp, python/mori/io/{__init__.py, engine.py}.

--- Multi-NIC endpoints + affinity ---
* OfiManager opens one fabric/domain/AV/CQ/endpoint per unique provider domain (per physical NIC) from fi_getinfo, and selects the local NIC per registration
  by GPU/NUMA affinity via TopoSystem (SelectLocalNic), binding each MR to its
  chosen endpoint.
* Per-transfer destination fabric address is resolved from the remote MR's owning NIC: OfiMrBlob carries {key, nicId}; EngineDesc advertises a per-NIC
  address list (OfiEngineBlob); addresses are keyed (localNic, engineKey,
  remoteNic) since each AV is endpoint-scoped.

--- Topology: CXI NIC enumeration ---
* src/application/topology/net.cpp: enumerate HPE Slingshot (CXI) NICs from /sys/class/cxi when ibverbs finds no NICs, parsing the PCI BDF and the link
  speed from device/port/0/link/speed (e.g. ck400G → 400 Gbps). ibverbs enumeration is now fault-tolerant. (include/.../topology/net.hpp)

--- Robustness ---
* src/application/topology/system.cpp: guard null GPU / PCI-node lookups in CollectAndSortCandidates (previously segfaulted when the GPU BDF was missing
  from the PCI tree) and skip NICs absent from the tree before sorting.
* src/application/topology/gpu.cpp: minor topology load hardening.
* OfiManager::SelectLocalNic wraps affinity lookup in try/catch and falls back to a stable NIC on any topology error.

--- Tests / scripts ---
* tests/cpp/io/ofi_slingshot_test.cpp: OFI backend test.
* tests/scripts/{build_ofi_portage.sh, run_ofi_portage.sh, run_fi_write_basic.sh}: build/run harness for the OFI path.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
