### PR TITLE
perf(EPv2): hide the dispatch drain read behind the grid barrier on gfx1250

### DIFF
--- a/src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp
+++ b/src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp
@@ -664,22 +664,35 @@ __device__ void EpDispatch1250xBody(EpArgs args) {
   }
   __syncthreads();
 
-  if (thdId == 0) atomicAdd(args.gridBarrier, 1u);
+  // Tickets on the arrival counter instead of a spin on it: every block draws
+  // one, the first arriver draws a second once its drain read is done, and the
+  // highest draw implies both preconditions of the signal store -- all blocks in
+  // (destPeTokenCounter is a complete sum) and the drain observed.
+  constexpr unsigned kNoTicket = ~0u;
+  unsigned arriveTicket = 0;
+  if (thdId == 0) arriveTicket = atomicAdd(args.gridBarrier, 1u);
   index_t* recvTokenNums = EpLocal<index_t>(win, args.offRecvNum);
-  if (globalWarpId == 0) {
-    // Drain the destination's signal slot BEFORE spinning on the grid barrier.
-    // That read is against uncached peer memory, so it costs a full fabric round
-    // trip even though the slot has long been zero, and its address depends only
-    // on destPe -- nothing about it needs the barrier satisfied. Issuing it while
-    // the barrier is still spinning is what hides the round trip; done after, it
-    // sits fully exposed on the critical path. Same trick as v1's 1250x body.
-    // The wire format is untouched: both are pure spin-waits that write nothing,
-    // and the signal store below still happens after both.
+  if (warpId == 0) arriveTicket = (unsigned)__shfl((int)arriveTicket, 0);
+  const bool isFirstArriver = (warpId == 0) && (arriveTicket == 0u);
+
+  // The drain read belongs to the first arriver because it is uncached peer
+  // memory -- a full fabric round trip even when the slot has long been zero --
+  // and its address depends only on destPe, so it needs nothing the barrier gives.
+  unsigned drainTicket = kNoTicket;
+  if (isFirstArriver) {
     for (int destPe = laneId; destPe < npes; destPe += WS)
       EpWaitEq(EpPeer<index_t>(win, destPe, args.offRecvNum) + myPe, (index_t)0);
-    // Grid barrier hoisted before the peer loop so wide EP (worldSize > waveSize)
-    // multi-iterates safely — the barrier is consumed and reset exactly once.
-    EpWaitEq(args.gridBarrier, static_cast<unsigned int>(gridDim.x));
+    __scoped_atomic_thread_fence(__ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_AGENT);
+    if (laneId == 0) drainTicket = atomicAdd(args.gridBarrier, 1u);
+    drainTicket = (unsigned)__shfl((int)drainTicket, 0);
+  }
+
+  // atomicAdd returns the pre-increment value, so the gridDim.x + 1 draws read
+  // 0 .. gridDim.x: the highest ticket, not the counter's final value.
+  const unsigned kHighestTicket = static_cast<unsigned>(gridDim.x);
+  const bool holdsHighestTicket =
+      (warpId == 0) && (arriveTicket == kHighestTicket || drainTicket == kHighestTicket);
+  if (holdsHighestTicket) {
     __hip_atomic_store(args.gridBarrier, 0u, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
 
     for (int destPe = laneId; destPe < npes; destPe += WS) {
@@ -689,16 +702,23 @@ __device__ void EpDispatch1250xBody(EpArgs args) {
                                1;
       __scoped_atomic_thread_fence(__ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
       __hip_atomic_store(signal, numTokenSignal, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+      // Cleared here, not in the inbound loop: that runs on another block now,
+      // and a peer signalling this rank says nothing about whether this rank has
+      // read its own send counts yet.
+      args.destPeTokenCounter[destPe] = 0;
     }
   }
-  if (globalWarpId == 0) {
+  // Inbound rides the first arriver so it is already parked when the peers'
+  // signals land. It cannot simply move above the outbound store on the same
+  // warp: this rank would wait on a peer that is waiting on this rank, with
+  // neither having sent. Separate tickets are what break that cycle.
+  if (isFirstArriver) {
     index_t myRecv = 0;
     for (int srcPe = laneId; srcPe < npes; srcPe += WS) {
       index_t* signal = recvTokenNums + srcPe;
       index_t recvTokenNum = EpWaitGt(signal, 0) - 1;
       __hip_atomic_store(signal, 0, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
       myRecv += recvTokenNum;
-      args.destPeTokenCounter[srcPe] = 0;
     }
     for (int off = WS / 2; off > 0; off >>= 1) myRecv += __shfl_down(myRecv, off, WS);
     if (laneId == 0) {

--- a/src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp
+++ b/src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp
@@ -130,14 +130,13 @@ __device__ __forceinline__ gfx1250_TDM_GROUP1 TdmShape(int hiddenDim) {
   return g1;
 }
 #if defined(MORI_TDM_STRICT)
-#define MORI_TDM_CHECK_ADDR(p)                                 \
-  do {                                                         \
+#define MORI_TDM_CHECK_ADDR(p)                                  \
+  do {                                                          \
     if (!::mori::tdm::TdmAddrOnRow((const void*)(p))) __trap(); \
   } while (0)
-#define MORI_TDM_CHECK_XFER(src, dst, n, sp)                                       \
-  do {                                                                             \
-    if (!::mori::tdm::TdmXferOk((const void*)(src), (const void*)(dst), (n), (sp))) \
-      __trap();                                                                    \
+#define MORI_TDM_CHECK_XFER(src, dst, n, sp)                                                  \
+  do {                                                                                        \
+    if (!::mori::tdm::TdmXferOk((const void*)(src), (const void*)(dst), (n), (sp))) __trap(); \
   } while (0)
 #else
 #define MORI_TDM_CHECK_ADDR(p) ((void)0)

--- a/src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp
+++ b/src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp
@@ -667,6 +667,16 @@ __device__ void EpDispatch1250xBody(EpArgs args) {
   if (thdId == 0) atomicAdd(args.gridBarrier, 1u);
   index_t* recvTokenNums = EpLocal<index_t>(win, args.offRecvNum);
   if (globalWarpId == 0) {
+    // Drain the destination's signal slot BEFORE spinning on the grid barrier.
+    // That read is against uncached peer memory, so it costs a full fabric round
+    // trip even though the slot has long been zero, and its address depends only
+    // on destPe -- nothing about it needs the barrier satisfied. Issuing it while
+    // the barrier is still spinning is what hides the round trip; done after, it
+    // sits fully exposed on the critical path. Same trick as v1's 1250x body.
+    // The wire format is untouched: both are pure spin-waits that write nothing,
+    // and the signal store below still happens after both.
+    for (int destPe = laneId; destPe < npes; destPe += WS)
+      EpWaitEq(EpPeer<index_t>(win, destPe, args.offRecvNum) + myPe, (index_t)0);
     // Grid barrier hoisted before the peer loop so wide EP (worldSize > waveSize)
     // multi-iterates safely — the barrier is consumed and reset exactly once.
     EpWaitEq(args.gridBarrier, static_cast<unsigned int>(gridDim.x));
@@ -674,7 +684,6 @@ __device__ void EpDispatch1250xBody(EpArgs args) {
 
     for (int destPe = laneId; destPe < npes; destPe += WS) {
       index_t* signal = EpPeer<index_t>(win, destPe, args.offRecvNum) + myPe;
-      EpWaitEq(signal, 0);
       index_t numTokenSignal = __hip_atomic_load(args.destPeTokenCounter + destPe, __ATOMIC_RELAXED,
                                                  __HIP_MEMORY_SCOPE_AGENT) +
                                1;


### PR DESCRIPTION
## Summary

- Hide the dispatch drain read (uncached peer-memory round trip to confirm the previous recv-count was consumed) behind the grid barrier spin on gfx1250, so the fabric latency overlaps the wait instead of sitting on the critical path.
- Replace the grid barrier spin with an arrival-ticket scheme: every block draws one ticket via `atomicAdd`, the first arriver draws a second after its drain read completes, and whoever holds the highest ticket (`gridDim.x`) knows both preconditions for the signal store — all blocks arrived and drain observed — without polling.
- Move the inbound wait to the first arriver so it is already parked when peers' signals land, breaking the deadlock cycle (this rank waits on a peer that waits on this rank) by running inbound and outbound on separate tickets/blocks.
- Move `destPeTokenCounter` clearing from the inbound loop to the outbound loop to avoid a race now that inbound runs on a different block.

## Performance

EP4, hidden 7168, topk 6, bf16, 5 runs each:

| tokens | mode  | base      | branch    | delta  |
|--------|-------|-----------|-----------|--------|
| 512    | graph | 44.0 us   | 39.5 us   | -10.2% |
| 512    | eager | 42.2 us   | 37.7 us   | -10.7% |
| 4096   | graph | 138.1 us  | 134.9 us  | -2.3%  |
| 4096   | eager | 136.6 us  | 133.5 us  | -2.3%  |