### PR TITLE
fix(EPv2): honor the 128B TDM row invariant on gfx1250 metadata trans…

### DIFF
--- a/src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp
+++ b/src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp
@@ -50,12 +50,21 @@
 #include "mori/core/transport/p2p/device_primitives.hpp"
 #include "mori/ops/dispatch_combine_v2/ep_cfg.hpp"
 #include "src/ops/dispatch_combine_v2/ep_intranode_kernel.hpp"
+#include "src/ops/dispatch_combine_v2/tdm_align.hpp"
 
 namespace mori {
 namespace ops {
 namespace v2 {
 
 using index_t = int32_t;
+
+using tdm::kTdmRowBytes;
+using tdm::TdmAddrOnRow;
+using tdm::TdmPlanXfer4B;
+using tdm::TdmSplit128;
+using tdm::TdmSplitDim0;
+using tdm::TdmSplitDim1;
+using tdm::TdmXferOk;
 
 #define MORI_COMB_TDM 2
 #define MORI_COMB_QUAD 2
@@ -120,9 +129,25 @@ __device__ __forceinline__ gfx1250_TDM_GROUP1 TdmShape(int hiddenDim) {
   g1.tileDim1(1);
   return g1;
 }
+#if defined(MORI_TDM_STRICT)
+#define MORI_TDM_CHECK_ADDR(p)                                 \
+  do {                                                         \
+    if (!::mori::tdm::TdmAddrOnRow((const void*)(p))) __trap(); \
+  } while (0)
+#define MORI_TDM_CHECK_XFER(src, dst, n, sp)                                       \
+  do {                                                                             \
+    if (!::mori::tdm::TdmXferOk((const void*)(src), (const void*)(dst), (n), (sp))) \
+      __trap();                                                                    \
+  } while (0)
+#else
+#define MORI_TDM_CHECK_ADDR(p) ((void)0)
+#define MORI_TDM_CHECK_XFER(src, dst, n, sp) ((void)0)
+#endif
+
 template <typename T, int TH = 0, int SCOPE = 0>
 __device__ __forceinline__ void TdmIssueLoad(T* ldsTile, const T* src,
                                              const gfx1250_TDM_GROUP1& g1) {
+  MORI_TDM_CHECK_ADDR(src);
   typedef int _tdm_v4i __attribute__((ext_vector_type(4)));
   typedef int _tdm_v8i __attribute__((ext_vector_type(8)));
   gfx1250_TDM_GROUP0 g0;
@@ -149,6 +174,7 @@ __device__ __forceinline__ gfx1250_TDM_GROUP1 TdmShapeGather(int rowElems, int n
 }
 template <typename T, int TH = 0, int SCOPE = 0>
 __device__ __forceinline__ void TdmIssueStore(T* dst, T* ldsTile, const gfx1250_TDM_GROUP1& g1) {
+  MORI_TDM_CHECK_ADDR(dst);
   typedef int _tdm_v4i __attribute__((ext_vector_type(4)));
   typedef int _tdm_v8i __attribute__((ext_vector_type(8)));
   gfx1250_TDM_GROUP0 g0;
@@ -171,49 +197,17 @@ __device__ __forceinline__ gfx1250_TDM_GROUP1 TdmShape2D(int dim0, int dim1) {
   g1.tileDim1(dim1);
   return g1;
 }
-struct TdmSplit128 {
-  int head;
-  int body;
-  int rows;
-};
-__device__ __forceinline__ TdmSplit128 TdmAlignSplit128(size_t phase, int nElems) {
-  constexpr int P = 32;
-  int head = (int)((P - (phase & (size_t)(P - 1))) & (size_t)(P - 1));
-  if (head > nElems) head = nElems;
-  int rows = (nElems - head) / P;
-  if (rows < 2) return TdmSplit128{nElems, 0, 0};
-  return TdmSplit128{head, rows * P, rows};
-}
-__device__ __forceinline__ int TdmCheapDim1(int nElems) {
-  if ((nElems & 7) == 0 && (nElems >> 3) >= 32) return 8;
-  if ((nElems & 3) == 0 && (nElems >> 2) >= 32) return 4;
-  if ((nElems & 1) == 0 && (nElems >> 1) >= 32) return 2;
-  return 0;
-}
-__device__ __forceinline__ TdmSplit128 TdmWholeOrSplit128(size_t phase, int nElems) {
-  const TdmSplit128 sp = TdmAlignSplit128(phase, nElems);
-  if (sp.head == 0 && sp.body == nElems) return sp;
-  if (TdmCheapDim1(nElems)) return TdmSplit128{0, nElems, 0};
-  if (nElems >= 4 && (nElems & 1) == 0) return TdmSplit128{0, nElems, 0};
-  return sp;
-}
-__device__ __forceinline__ gfx1250_TDM_GROUP1 TdmSplitShape(const TdmSplit128& sp, int nElems) {
-  if (sp.rows == 0) {
-    const int d1 = TdmCheapDim1(nElems);
-    if (d1 > 0) return TdmShape2D(nElems / d1, d1);
-    if (nElems >= 4 && (nElems & 1) == 0) return TdmShape2D(nElems / 2, 2);
-    return TdmShape2D(32, 2);
-  }
-  return TdmShape2D(32, sp.rows);
+__device__ __forceinline__ gfx1250_TDM_GROUP1 TdmSplitShape(const TdmSplit128& sp) {
+  return TdmShape2D(TdmSplitDim0(sp), TdmSplitDim1(sp));
 }
 
 #define CUSPLIT_POOL_SLOTS (MORI_EP_WORLD_SIZE * MORI_EP_MAX_RECV)
 #define CUSPLIT_MAX_BLOCKS 512
 #define CUSPLIT_MAX_TOPK 16
 
-__device__ index_t _cusplit_stgIdx[CUSPLIT_POOL_SLOTS * CUSPLIT_MAX_TOPK];
-__device__ float _cusplit_stgWt[CUSPLIT_POOL_SLOTS * CUSPLIT_MAX_TOPK];
-__device__ index_t _cusplit_stgSrc[CUSPLIT_POOL_SLOTS];
+alignas(kTdmRowBytes) __device__ index_t _cusplit_stgIdx[CUSPLIT_POOL_SLOTS * CUSPLIT_MAX_TOPK];
+alignas(kTdmRowBytes) __device__ float _cusplit_stgWt[CUSPLIT_POOL_SLOTS * CUSPLIT_MAX_TOPK];
+alignas(kTdmRowBytes) __device__ index_t _cusplit_stgSrc[CUSPLIT_POOL_SLOTS];
 __device__ index_t _cusplit_blkBase[CUSPLIT_MAX_BLOCKS * MORI_EP_WORLD_SIZE];
 __device__ index_t _cusplit_blkCount[CUSPLIT_MAX_BLOCKS * MORI_EP_WORLD_SIZE];
 // Per-token scale rows, staged like the other meta fields so they ship to a peer as
@@ -262,8 +256,8 @@ static_assert(kEpScaleStride == 0 || (size_t)kEpScaleSlots * kEpScaleStride <= (
               "EP scale staging exceeds 1 GiB per compiled variant -- it grows as "
               "world_size^2 * maxTokPerRank * EpScaleStride; re-index it block-locally "
               "before going wider");
-// Rows are already a multiple of 128 apart; __align__ makes the BASE match, which
-// TdmWholeOrSplit128 needs for the same split it uses on the peer side.
+static_assert(EpScaleAlign % kTdmRowBytes == 0,
+              "the scale staging base must sit on a TDM row for the metadata tile to reach it");
 constexpr size_t kEpScaleStgBytes = kEpScaleSlots * (kEpScaleStride > 0 ? kEpScaleStride : 1);
 __device__ __align__(EpScaleAlign) unsigned char _cusplit_stgScale[kEpScaleStgBytes];
 
@@ -533,9 +527,10 @@ __device__ void EpDispatch1250xBody(EpArgs args) {
                           ? (EpPeer<float>(win, peer, args.offOutWts) + (size_t)ab * tkM)
                           : nullptr;
           index_t* dR = EpPeer<index_t>(win, peer, args.offRecvToSrc) + (size_t)ab;
-          const TdmSplit128 spI = TdmWholeOrSplit128((size_t)ab * tkM, nIdxB);
-          const TdmSplit128 spW = (dW != nullptr) ? spI : TdmSplit128{0, 0, 0};
-          const TdmSplit128 spR = TdmWholeOrSplit128((size_t)ab, cc);
+          const TdmSplit128 spI = TdmPlanXfer4B(sI, dI, nIdxB);
+          const TdmSplit128 spW =
+              (dW != nullptr) ? TdmPlanXfer4B(sW, dW, nWtB) : TdmSplit128{0, 0, 0};
+          const TdmSplit128 spR = TdmPlanXfer4B(sR, dR, cc);
           // Scale rides as a fourth field: same run, same tile, one more descriptor.
           // The stride, not the caller's row: it is what puts `ab * kSdw` on a
           // 128 B boundary, so this run gets a body instead of a scalar tail.
@@ -548,7 +543,7 @@ __device__ void EpDispatch1250xBody(EpArgs args) {
                   ? (EpPeer<unsigned int>(win, peer, args.offOutScales) + (size_t)ab * kSdw)
                   : nullptr;
           const TdmSplit128 spS =
-              (dS != nullptr) ? TdmWholeOrSplit128((size_t)ab * kSdw, nScB) : TdmSplit128{0, 0, 0};
+              (dS != nullptr) ? TdmPlanXfer4B(sS, dS, nScB) : TdmSplit128{0, 0, 0};
           int* tI = reinterpret_cast<int*>(_m4);
           int* tW = tI + ((spI.body + 31) & ~31);
           int* tR = tW + ((spW.body + 31) & ~31);
@@ -558,10 +553,14 @@ __device__ void EpDispatch1250xBody(EpArgs args) {
             __builtin_amdgcn_s_wait_tensorcnt(0);
             _mPend = false;
           }
-          if (spI.body) gI = TdmSplitShape(spI, spI.body);
-          if (spW.body) gW = TdmSplitShape(spW, spW.body);
-          if (spR.body) gR = TdmSplitShape(spR, spR.body);
-          if (spS.body) gS = TdmSplitShape(spS, spS.body);
+          MORI_TDM_CHECK_XFER(sI, dI, nIdxB, spI);
+          MORI_TDM_CHECK_XFER(sW, dW, nWtB, spW);
+          MORI_TDM_CHECK_XFER(sR, dR, cc, spR);
+          MORI_TDM_CHECK_XFER(sS, dS, nScB, spS);
+          if (spI.body) gI = TdmSplitShape(spI);
+          if (spW.body) gW = TdmSplitShape(spW);
+          if (spR.body) gR = TdmSplitShape(spR);
+          if (spS.body) gS = TdmSplitShape(spS);
           if (spI.body) TdmIssueLoad<int>(tI, reinterpret_cast<int*>(sI + spI.head), gI);
           if (spW.body) TdmIssueLoad<int>(tW, reinterpret_cast<int*>(sW + spW.head), gW);
           if (spR.body) TdmIssueLoad<int>(tR, reinterpret_cast<int*>(sR + spR.head), gR);

--- a/src/ops/dispatch_combine_v2/tdm_align.hpp
+++ b/src/ops/dispatch_combine_v2/tdm_align.hpp
@@ -1,0 +1,101 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#if defined(__HIPCC__) || defined(__CUDACC__)
+#define MORI_TDM_FN __host__ __device__ __forceinline__
+#else
+#define MORI_TDM_FN inline
+#endif
+
+namespace mori {
+namespace tdm {
+
+constexpr int kTdmRowBytes = 128;
+constexpr int kTdmRowElems4B = kTdmRowBytes / 4;
+
+struct TdmSplit128 {
+  int head;
+  int body;
+  int rows;
+};
+
+MORI_TDM_FN TdmSplit128 TdmPlanRun(size_t phase, int nElems) {
+  constexpr int P = kTdmRowElems4B;
+  if (nElems <= 0) return TdmSplit128{0, 0, 0};
+  int head = (int)((P - (phase & (size_t)(P - 1))) & (size_t)(P - 1));
+  if (head > nElems) head = nElems;
+  const int rows = (nElems - head) / P;
+  if (rows < 2) return TdmSplit128{nElems, 0, 0};
+  return TdmSplit128{head, rows * P, rows};
+}
+
+MORI_TDM_FN int TdmSplitDim0(const TdmSplit128& sp) {
+  return (sp.rows > 0) ? kTdmRowElems4B : 0;
+}
+
+MORI_TDM_FN int TdmSplitDim1(const TdmSplit128& sp) { return (sp.rows > 0) ? sp.rows : 0; }
+
+MORI_TDM_FN bool TdmSplitOk(size_t phase, int nElems, const TdmSplit128& sp) {
+  if (sp.head < 0 || sp.body < 0 || sp.rows < 0) return false;
+  if (sp.head + sp.body > nElems) return false;
+  if (sp.body == 0) return sp.rows == 0 && sp.head == (nElems > 0 ? nElems : 0);
+  if (((phase + (size_t)sp.head) & (size_t)(kTdmRowElems4B - 1)) != 0) return false;
+  if ((sp.body % kTdmRowElems4B) != 0) return false;
+  if (sp.rows != sp.body / kTdmRowElems4B) return false;
+  const int d0 = TdmSplitDim0(sp), d1 = TdmSplitDim1(sp);
+  if (d0 <= 0 || d1 <= 0) return false;
+  if ((d0 % kTdmRowElems4B) != 0) return false;
+  if (d0 * d1 != sp.body) return false;
+  if (sp.head >= kTdmRowElems4B) return false;
+  if (nElems - sp.head - sp.body >= kTdmRowElems4B) return false;
+  return true;
+}
+
+MORI_TDM_FN bool TdmAddrOnRow(const void* p) {
+  return ((uintptr_t)p & (uintptr_t)(kTdmRowBytes - 1)) == 0;
+}
+
+MORI_TDM_FN TdmSplit128 TdmPlanXfer4B(const void* src, const void* dst, int nElems) {
+  const int allScalar = (nElems > 0) ? nElems : 0;
+  if (nElems <= 0) return TdmSplit128{0, 0, 0};
+  const uintptr_t s = (uintptr_t)src, d = (uintptr_t)dst;
+  if (((s | d) & (uintptr_t)3) != 0) return TdmSplit128{allScalar, 0, 0};
+  if (((s ^ d) & (uintptr_t)(kTdmRowBytes - 1)) != 0) return TdmSplit128{allScalar, 0, 0};
+  return TdmPlanRun((size_t)((s & (uintptr_t)(kTdmRowBytes - 1)) >> 2), nElems);
+}
+
+MORI_TDM_FN bool TdmXferOk(const void* src, const void* dst, int nElems, const TdmSplit128& sp) {
+  if (src == nullptr || dst == nullptr) return sp.head == 0 && sp.body == 0;
+  const uintptr_t s = (uintptr_t)src, d = (uintptr_t)dst;
+  if (sp.body != 0) {
+    if (((s | d) & (uintptr_t)3) != 0) return false;
+    if (((s ^ d) & (uintptr_t)(kTdmRowBytes - 1)) != 0) return false;
+  }
+  return TdmSplitOk((size_t)((s & (uintptr_t)(kTdmRowBytes - 1)) >> 2), nElems, sp);
+}
+
+}  // namespace tdm
+}  // namespace mori

--- a/tests/python/ops/dispatch_combine_v2/test_op.py
+++ b/tests/python/ops/dispatch_combine_v2/test_op.py
@@ -177,7 +177,7 @@ def main():
                 sync()
                 comm.barrier()
             sc_in = scales[:ct] if SCALE_DIM else None
-            recv_x, _out_w, out_s, _out_i, total_recv_t, routing = op.dispatch(
+            recv_x, disp_w, out_s, disp_i, total_recv_t, routing = op.dispatch(
                 inp[:ct], wts[:ct], sc_in, idx[:ct], return_routing=True
             )
             total_recv = int(total_recv_t.cpu().item())
@@ -225,8 +225,48 @@ def main():
                 if rank == 0:
                     print(
                         f"# OP-SCALES ct={ct}: {'PASS' if errs == 0 else 'FAIL'} "
-                        f"(recv={total_recv}, scale_dim={SCALE_DIM}, {sc_n_i32} dwords/tok, "
-                        f"reverse-map ok)",
+                        f"(recv={total_recv}, scale_dim={SCALE_DIM}, "
+                        f"{sc_n_i32} dwords/tok)",
+                        flush=True,
+                    )
+            if not STDMOE:
+                # The two metadata arrays dispatch forwards next to the payload.
+                # Unlike the scales, their contents cannot be derived from the recv
+                # slot, so every rank's inputs get gathered to know what each slot
+                # should hold. Checking them here rather than through combine is
+                # the point: combine only folds the weights, and reads no indices
+                # at all, so a kernel can corrupt both while payload and combine
+                # still pass.
+                srcs_i = [torch.empty_like(idx[:ct]) for _ in range(npes)]
+                srcs_w = [torch.empty_like(wts[:ct]) for _ in range(npes)]
+                dist.all_gather(srcs_i, idx[:ct].contiguous())
+                dist.all_gather(srcs_w, wts[:ct].contiguous())
+                all_i = torch.zeros(npes * M, K, dtype=torch.int32)
+                all_w = torch.zeros(npes * M, K, dtype=torch.float32)
+                for r in range(npes):
+                    all_i[r * M : r * M + ct] = srcs_i[r].cpu()
+                    all_w[r * M : r * M + ct] = srcs_w[r].cpu()
+                tim = routing.disp_tok_id_to_src_tok_id_local[:total_recv].cpu().long()
+                # The reverse map indexes the expected values, here and in the scale
+                # check above, so it is range-checked before being used as an index.
+                # An out-of-range entry is a failure in its own right, and indexing
+                # with it raises IndexError, which would kill this rank and leave the
+                # others in all_reduce -- a product bug reported as a harness crash.
+                ok_map = bool(((tim >= 0) & (tim < npes * M)).all())
+                if ok_map:
+                    ok_i = torch.equal(disp_i[:total_recv].cpu(), all_i[tim])
+                    ok_dw = torch.allclose(
+                        disp_w[:total_recv].cpu(), all_w[tim], atol=2e-3, rtol=2e-3
+                    )
+                else:
+                    ok_i = ok_dw = False
+                errs = d.allreduce_sum(0 if (ok_map and ok_i and ok_dw) else 1)
+                if rank == 0:
+                    print(
+                        f"# OP-META ct={ct}: {'PASS' if errs == 0 else 'FAIL'} "
+                        f"(recv={total_recv}, topk={K}, map="
+                        f"{'ok' if ok_map else 'BAD'}, idx={'ok' if ok_i else 'BAD'}, "
+                        f"wts={'ok' if ok_dw else 'BAD'})",
                         flush=True,
                     )
             if cap is not None:


### PR DESCRIPTION
## Root cause

`TdmWholeOrSplit128` decided head/body from the element count alone, skipping the
address check: any transfer of at least one row's worth of elements was declared
row-aligned and issued with `head=0`.

The TDM engine writes global memory in atomic 128B blocks, so a body that does not
start on a 128B boundary makes it read-modify-write the block at each end, and two
transfers sharing an end block clobber each other. With `split=4` the per-warp
segment boundaries at `cntAll/split` bear no relation to 128B alignment, so the
four warps serving one peer overwrite each other's metadata.

## Fix

- Plan each metadata field from its own source and destination pointers.
- Give the staging buffers `alignas(128)`.
- Move the planner to `dispatch_combine_v2/tdm_align.hpp` as plain integer arithmetic.

## Test coverage

Dispatch's expert indices and weights had no assertion at all. The payload and
scale checks derive their expected values from `recv_to_src_token`, so a wrong
index is invisible to them, and they use that map without range-checking it. The
new `OP-META` check in `test_op.py` `all_gather`s each rank's routing arrays for
ground truth, and validates the map's range before indexing with it -- an
out-of-range entry raises `IndexError` and takes the rank down, which reports a
product bug as a harness crash.

## Test plan

gfx1250, 4 ranks, `topk=9 epr=65 ct=16384 scale_dim=224 blocks=64`, 3 alternating
rounds of 8 dispatches per arm:

| arm | OP-META | other checks |
| --- | --- | --- |
| the two shortcut lines | 24 FAIL / 24 checks | 24 FAIL |
| the planner | 0 FAIL / 24 checks | 0 FAIL |

The failing arm is included to show the new check actually catches the bug rather
than passing vacuously.