### PR TITLE
perf(EPv2): skip the dispatch completion spin when the peer slot is a…

### DIFF
--- a/src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp
+++ b/src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp
@@ -291,6 +291,10 @@ __device__ void EpDispatch1250xBody(EpArgs args) {
   const int aWarp = globalWarpId;
   const int aWarps = (int)gridDim.x * warpNum;
 
+  constexpr int kPresigCap = 512;
+  constexpr bool _presigOn = ((int)kCfg.maxTokPerRank <= kPresigCap) && (npes <= WS);
+  index_t _preSig = 1;
+
   const int _tpi = (topk > 0 && topk <= WS && (WS % topk) == 0) ? (WS / topk) : 1;
   const int _qTok = (aWarps > 0) ? (int)(((long long)args.numTokens + aWarps - 1) / aWarps) : _tpi;
   const int _etpi = (_tpi > 1 && _qTok >= 1 && _qTok < _tpi) ? _qTok : _tpi;
@@ -380,6 +384,10 @@ __device__ void EpDispatch1250xBody(EpArgs args) {
   const bool _blkMapNeeded = !((_bmPerTok > 0) && (((_bmTileB - 384) / _bmPerTok) > 0));
   for (int p = thdId; p < npes; p += blockDim.x) {
     index_t n = s_N[p];
+    if (_presigOn && globalWarpId == 0 && laneId < npes) {
+      _preSig = __hip_atomic_load(EpPeer<index_t>(win, laneId, args.offRecvNum) + myPe,
+                                  __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+    }
     if (_blkMapNeeded) _cusplit_blkCount[(size_t)blockIdx.x * npes + p] = n;
     if (n > 0) {
       s_base[p] = __hip_atomic_fetch_add(EpPeer<index_t>(win, p, args.offTokOff), n,
@@ -675,7 +683,8 @@ __device__ void EpDispatch1250xBody(EpArgs args) {
 
     for (int destPe = laneId; destPe < npes; destPe += WS) {
       index_t* signal = EpPeer<index_t>(win, destPe, args.offRecvNum) + myPe;
-      EpWaitEq(signal, 0);
+      if constexpr (_presigOn) asm volatile("" : "+v"(_preSig));
+      if (!_presigOn || _preSig != 0) EpWaitEq(signal, 0);
       index_t numTokenSignal = __hip_atomic_load(args.destPeTokenCounter + destPe, __ATOMIC_RELAXED,
                                                  __HIP_MEMORY_SCOPE_AGENT) +
                                1;


### PR DESCRIPTION
…lready clear

The completion phase polls each peer's recv slot with EpWaitEq before storing to it, so this card never overwrites a slot the peer has not consumed yet. A probe found every slot already clear on the first read of all 21 calls it watched: the peer clears it in the previous dispatch and an entire combine runs in between, so nothing is ever waited for. Read the slot once during reserve and skip the spin when it reads zero. A non-zero value falls through to the same spin, so the guarantee is unchanged and the worst case is the behaviour this replaces.

fp4, ct=512, 4 ranks on gfx1250, 6 alternating rounds: dispatch 38.92 -> 31.43 us, -7.48 us (-19%), slower in 0/6 rounds. ct=4096 and ct=16384 measure +0.63 and -0.50 us, opposite signs within run-to-run noise, matching the identical machine code. Correctness checks pass on both arms for fp4 and fp8.

Where that -7.48 us comes from, measured rather than reasoned. Four diagnostic arms, each 6 alternating rounds at ct=512 unless noted:

  - deleting EpWaitEq outright (not shippable, drops the guarantee):  -4.40 us, 0/6
  - keeping the unconditional spin, adding only the early load:       -3.22 / -3.15 us, two runs
  - same, but the load reads THIS card instead of the peer:           -2.98 us, 0/6
  - only the live variable and the empty asm, no load at all:         -0.83 us, 1/6 (noise)

Deleting the spin bounds what skipping it can be worth, so about 3 us of the total is something else: one more memory instruction makes the compiler redo register allocation and scheduling for the whole kernel. That part is not attached to this change. Reading the local address pays it just as well as reading the peer, and moving the load to the kernel entry, to the zeroing loop, or past payload pays -1.63 / -1.93 / -1.93 us (4 rounds each, 0/4 slower) -- it is not attached to a phase either. Occupancy is 10 waves/SIMD in both arms and neither spills, so it is not a resource effect. Ten AMDGPU scheduling strategies were tried through MORI_JIT_EXTRA_FLAGS and none of them reach it; the best, amdgpu-sched-strategy=max-ilp, is -0.15 us over 6 rounds with 3/6 slower.

So roughly -4.4 us is the spin no longer running and will stay; the remaining ~3 us is a scheduling accident that a compiler upgrade or an unrelated edit nearby may take away. The change is worth taking on the -4.4 us alone.

Gated at compile time on maxTokPerRank <= 512 and npes <= waveSize. Wide EP multi-iterates the peer loop while _preSig answers for destPe == laneId only, and an ungated build cost 1.90us in 10/10 rounds at ct=4096 where the payload's register pressure is highest -- a runtime gate still regressed, because the compiler allocates the register under a branch either way. Both conditions are compile-time fields, so configurations outside the range generate instruction-for-instruction the code this replaces: the disassemblies at maxTokPerRank 4096 and 16384 are byte-identical to main, while the 512 one differs by 32 instructions.

The empty volatile asm pins where the loaded value is consumed. _preSig feeds exactly one comparison, and without the asm the compiler folds that comparison back to the definition and waits for the load there.

