### PR TITLE
feat(ep/v2): make the internode dispatch/combine a v2-native kernel

### DIFF
--- a/docs/EP_INTERNODE_V2_TAIL.md
+++ b/docs/EP_INTERNODE_V2_TAIL.md
@@ -29,8 +29,42 @@ two levels, so a run that stepped early reports ~2.3x while the same binary that
 did not step reports ~1.2x. Chasing "the tail" as if it were a few bad rounds is
 chasing the wrong shape.
 
-IT IS ENVIRONMENTAL, AND WE AMPLIFY IT
---------------------------------------
+RE-RUN AGAINST #625 WITH BOTH SIDES BOUND
+-----------------------------------------
+The comparison below ("we amplify it ~3x") was made with #625 bound and this
+branch unbound, and is superseded. Re-run after the CCO bind fix, eight
+interleaved pairs, ours matched to #625's environment (OMP_NUM_THREADS=4, the
+same 30-round loop):
+
+    pair   #625 disp  comb   total  |  ours disp  comb   total  |  diff
+      1      39.51  50.87   90.38   |   37.2   46.0    83.2   |   -7.2
+      2      39.50  52.41   91.91   |   38.2   47.4    85.6   |   -6.3
+      3      39.54  51.63   91.17   |   50.7   59.4   110.1   |  +18.9
+      4      39.52  54.93   94.45   |   37.2   49.8    87.0   |   -7.5
+      5      39.32  51.52   90.84   |   37.5   46.1    83.6   |   -7.2
+      6      38.72  54.40   93.12   |   39.2   47.7    86.9   |   -6.2
+      7      43.08  64.44  107.52   |   37.0   46.0    83.0   |  -24.5
+      8      48.82  62.90  111.72   |   39.1   46.7    85.8   |  -25.9
+
+              #625 median   ours median   paired median   ours wins
+    dispatch     39.52         37.85       -2.06us (-5.2%)    6/8
+    combine      53.41         47.05       -5.28us (-9.9%)    7/8
+    TOTAL        92.52         85.70       -7.21us (-7.8%)    7/8
+
+    spread   #625 max/med 1.21     ours max/med 1.28
+
+So with both sides bound this branch is faster on BOTH legs, and the spread is
+comparable rather than 2x worse. The "3x more sensitive" result was an artifact
+of the bind difference and is withdrawn.
+
+Caveats: #625's harness reports only per-rank means, so only means are compared
+(its own run-to-run variance is visible -- two of its eight runs are elevated).
+n=8. And one of our eight was elevated (110.1) with NO host doubling and max
+per-rank hwal 86 -- so a smaller residual mechanism survives the bind; it is not
+the 2x one.
+
+IT IS ENVIRONMENTAL, AND WE AMPLIFY IT (SUPERSEDED -- see above)
+----------------------------------------------------------------
 Interleaved against the #625 baseline (v1 host + the same v2 CCO kernels, so the
 same transport on the same wire), four pairs back to back:
 

--- a/docs/EP_INTERNODE_V2_TAIL.md
+++ b/docs/EP_INTERNODE_V2_TAIL.md
@@ -204,12 +204,54 @@ METHOD
     all eight `MORI_EP_INTERNODE_CCO_ENTRY*` entries reports every template error
     at once; finding them one per cluster run costs an afternoon.
 
+DEVICE TIMESTAMPS: NEITHER KERNEL GETS SLOWER
+---------------------------------------------
+`MORI_EP_DEV_TS=1` stamps `wall_clock64()` (fixed 100.008 MHz on this gfx942,
+10 ns; NOT `clock64()`, which is the shader clock and moves with DVFS) at twelve
+points and reports per-round spans per rank. Comparing slow rounds against fast
+rounds WITHIN one run and one rank:
+
+    span                        fast     slow    delta
+    d_stag  copystaging kernel   2.6      2.6     +0.0
+    d_kern  whole dispatch_ll   21.1     21.6     +0.5
+      d_post  WQE + doorbell     5.6      5.4     -0.2
+      d_spin  wait for peer     17.7     18.2     +0.5
+      d_recv  unpack + XGMI      1.0      1.1     +0.1
+      d_sync  grid barrier       1.0      1.0     +0.0
+    residual (phase - kernels)  33.0     78.8    +45.9   <-- all of it
+    disp    the phase           55.5    103.0    +47.5
+
+Reproduced on every run that had slow rounds (+45.9 and +64.8 in two runs).
+**Both kernels in the dispatch phase are flat to under 1 microsecond.** The
+excess is entirely in the launch/scheduling path: host enqueue plus GPU-side gap
+between the two kernels. Splitting that residual further, the mix varies by run
+-- one run had the host flat (+1.0) with a +35 GPU-side gap, another had the
+host itself +24 -- but the kernels are flat in both.
+
+This REVERSES the per-pass split's attribution above. Under
+`MORI_EP_SPLIT_PASSES` the excess appeared to be in `dispatch_ll`, but split
+mode launches each pass separately and the spin passes absorb every other
+launch's skew -- which is exactly the effect being measured here. Trust the
+in-kernel timestamps in batched mode over the split.
+
+Combine is different and simpler: `c_spin`, its cross-node barrier wait, takes
+the whole regime shift (0.7 -> 28.5 against `comb` 48 -> 77) and its spikes
+(+63, +110 on single rounds), while `c_post` is flat. Combine does no extra
+work; it waits longer for peers. It is a victim of dispatch's skew, not a
+source.
+
+So the send/recv question is answered, and the answer is neither: it is not the
+local GPU->NIC post (`d_post` flat) and not waiting for the peer's write
+(`d_spin` flat). Nothing inside either kernel moves.
+
 NEXT
 ----
 Everything outside the GPU has been eliminated, and the per-pass split puts the
 excess inside `dispatch_ll` and inside `combinesyncbarrier` -- both of which mix
 posting with waiting, so the split cannot go further from the host side. The next
-step is device-side timestamps inside `dispatch_ll` separating the send-post from
-the receive spin, which would say whether the extra time is spent getting the
-data out or waiting for a peer's. The step attribution above says the target is
-right: whatever it is, it is on the remote-access path and not in local work.
+step is to decompose the residual: the phase window holds only two kernels, both
+now proven flat, so what remains is the enqueue path and the GPU-side gaps
+around them. Stamping the host at each individual pass launch (rather than
+around the whole `op.dispatch()` call) would split "the host was late" from "the
+command processor was late", which is the last division available from outside
+the kernels.

--- a/docs/EP_INTERNODE_V2_TAIL.md
+++ b/docs/EP_INTERNODE_V2_TAIL.md
@@ -1,0 +1,97 @@
+# EP internode v2: where the CCO tail comes from
+
+Notes from investigating why the v2 CCO/GDA internode path has a latency tail
+that the shmem/IBGDA path does not. Kept out of the test's module docstring so
+that file stays close in shape to the examples harness it mirrors,
+`examples/ops/dispatch_combine/test_dispatch_combine_internode.py`.
+
+CCO's TAIL IS NOT THE FABRIC'S: WHAT SHMEM DOES ON THE SAME WIRE
+----------------------------------------------------------------
+Run the v1 harness in the same session for a reference. It drives the shmem/IBGDA
+transport over the SAME NICs, rails, switch and QoS, at the same shape, so it
+isolates what is specific to the CCO path. Note it spawns its own 8 workers per
+node, so it takes --nproc_per_node=1, not 8:
+
+    GPU_PER_NODE=8 MORI_EP_LAUNCH_CONFIG_MODE=AUTO MORI_RDMA_TC=160 MORI_RDMA_SL=5 \\
+    torchrun --nnodes=2 --node_rank=N --nproc_per_node=1 --master_addr=... \\
+      examples/ops/dispatch_combine/test_dispatch_combine_internode.py \\
+      --cmd bench --kernel-type v1_ll --num-qp 1 --max-tokens 4 \\
+      --hidden-dim 6144 --dtype fp8_e4m3_fnuz --combine-dtype bf16 --quant-type none
+
+Measured, 29 kept rounds x 16 ranks = 464 samples per phase:
+
+                       shmem/IBGDA          CCO/GDA (here)
+    dispatch mean         47.4us              40-47us
+    combine  mean         59.1us              46-52us
+    max/mean              1.19x / 1.18x       2-6x
+    rounds >1.8x base     0 of 29             11 of ~260
+    cross-rank spread     median 9-13us       up to 207us (34 -> 241)
+
+Two things follow. CCO is FASTER in the mean -- combine by ~20% -- so the port is
+not simply worse. And the tail belongs to the CCO path, not to the fabric: shmem
+shares every wire and shows no spiked round at all, which rules out the rail and
+switch explanations that the {i, i+8} pattern below otherwise suggests.
+
+Both harnesses do have a huge round 0 (shmem's spans 83-614us) and both drop 1.
+
+READING THE PER-RANK SERIES (MORI_EP_ROUND_SERIES)
+--------------------------------------------------
+Every rank prints its own per-round series. These are spin-wait collectives, so
+the rank that arrives LAST waits LEAST: on a slow round the straggler is the
+MINIMUM, not the maximum, and the other fifteen are just showing what they waited
+for. Threshold per NODE, not globally -- the two nodes routinely sit at different
+levels in the same round (151 vs 237us was measured), and a global threshold then
+misses a rank that is low within its own node.
+
+The shape of the low set says what happened, and they are not all the same:
+
+  {i, i+8}          one RAIL. Local rank i selects bnxt_re_bond<i> ("rank 1
+                    rankInNode 1 select device [1] bnxt_re_bond1"), so the same
+                    local index on both nodes is one NIC-to-NIC path.
+  {i}               one rank.
+  all of one node    a node-level event; the other node's eight ranks all wait.
+  empty             every rank waited, including the fastest -- no straggler
+                    exists and no single card can explain it.
+
+Measured over 11 spiked rounds in 9 runs: 5 empty, 3 rail pairs (rails 1, 5 and 7,
+once each), 2 single ranks, 1 other. So no one card is at fault; when there is a
+straggler its identity rotates.
+
+## Eliminated by direct measurement
+
+Each of these was tested and came back negative, rather than argued away:
+garbage collection (traced per round -- zero collections during the timed loop),
+GPU clocks (identical 1650-1780MHz in fast and slow runs), host launch-queue
+saturation (~50us of headroom, and the slow regime has more), RoCE traffic class
+(interleaved A/B over four pairs, within noise), host load average (six runs
+across loadavg 11.5-15.3, no ordering), a single bad GPU, a single bad rail, QP
+count, window cacheability, and process topology (`--spawn` reproduces the
+examples harness's process tree; interleaved A/B is equal in the mean and keeps
+the tail under both).
+
+## Where the time actually goes
+
+`MORI_EP_SPLIT_PASSES=1` launches the pass sequence one plan at a time with a
+timing event after each -- the only way to attribute a slow round to a kernel,
+since the launch group crosses the ABI once and runs the passes back to back.
+Worst round against the median round of the same phase, three runs at 4 tokens:
+
+    copystaging          median   7.0   worst   7.1   delta  +0.1
+    dispatch_ll          median  49.2   worst 109.3   delta +60.1
+    combinesync          median   6.4   worst   6.5   delta  +0.1
+    combinesyncbarrier   median  24.3   worst  34.9   delta +10.6
+    combine_ll           median  47.4   worst  69.5   delta +22.1
+    combineall           median   7.1   worst   6.5   delta  -0.6
+
+Every microsecond of the excess is in the passes that wait on remote data; the
+three purely local passes are constant to within 0.2us.
+
+It is also not the fabric erroring. Summing the bnxt RoCE hardware counters over
+all eight devices before and after each run -- packet_seq_err, out_of_sequence,
+implied_nak_seq_err, local_ack_timeout_err, max_retry_exceeded,
+rnr_nak_retry_err, roce_adp_retrans, roce_slow_restart, rx/tx_roce_discards,
+out_of_buffer, np_ecn_marked_roce_packets, np_cnp_sent, rp_cnp_handled,
+duplicate_request -- every delta was zero across four runs including the slowest
+(139.1us total, worst 155/163).
+
+Not root-caused.

--- a/docs/EP_INTERNODE_V2_TAIL.md
+++ b/docs/EP_INTERNODE_V2_TAIL.md
@@ -240,10 +240,18 @@ METHOD
 
 DEVICE TIMESTAMPS: NEITHER KERNEL GETS SLOWER
 ---------------------------------------------
-`MORI_EP_DEV_TS=1` stamps `wall_clock64()` (fixed 100.008 MHz on this gfx942,
-10 ns; NOT `clock64()`, which is the shader clock and moves with DVFS) at twelve
-points and reports per-round spans per rank. Comparing slow rounds against fast
-rounds WITHIN one run and one rank:
+The instrumentation behind this section has been REMOVED (it was `MORI_EP_DEV_TS`,
+twelve `wall_clock64()` stamp sites carried on an `EpInterNodeArgs` pointer). Its
+switch was a runtime null check, so instrumented and uninstrumented shared one
+binary and the +2 VGPR / +4 SGPR-spill cost sat on the default path forever. An
+interleaved A/B put any time cost below this rig's noise, but the findings were
+already banked and a diagnostic that has served its purpose should not be a
+permanent tax. Recover it from git history (`[EP] Device timestamps splitting
+send-post from recv-spin`) if the residual is picked up again; note that
+`wall_clock64()` is the only correct source -- `clock64()` is the shader clock
+and moves with DVFS, which is exactly what such a comparison must not do.
+
+Comparing slow rounds against fast rounds WITHIN one run and one rank:
 
     span                        fast     slow    delta
     d_stag  copystaging kernel   2.6      2.6     +0.0

--- a/docs/EP_INTERNODE_V2_TAIL.md
+++ b/docs/EP_INTERNODE_V2_TAIL.md
@@ -57,6 +57,59 @@ Measured over 11 spiked rounds in 9 runs: 5 empty, 3 rail pairs (rails 1, 5 and 
 once each), 2 single ranks, 1 other. So no one card is at fault; when there is a
 straggler its identity rotates.
 
+## CORRECTION: the tail is not the transport's alone
+
+An earlier revision of this file concluded "the tail belongs to the CCO path, not
+the fabric", from shmem-vs-CCO. That compared two transports AND two kernels at
+once. Adding the missing arm -- the #625 baseline, which is v1's host code with
+its `_launch_multi` redirected to the v2 CCO plans, so same transport and
+effectively the same kernels -- splits it in two. Interleaved, six pairs at 4
+tokens, max/mean:
+
+                        dispatch      combine
+    shmem / IBGDA        1.16          1.23
+    CCO/GDA, #625 base   1.27-1.31     1.46-1.56
+    CCO/GDA, this branch 2.31          1.75
+
+So there are two separate effects:
+
+  * COMBINE's tail is mostly the transport's: CCO adds +27% over shmem, this
+    branch adds only +12% on top.
+  * DISPATCH's tail is mostly OURS: CCO adds +13% over shmem, this branch adds
+    +76% on top. The #625 baseline never exceeded 1.44 in six runs and had zero
+    spiked rounds; this branch reaches 2.1-3.3 in five of six.
+
+Note also that this branch is FASTER in the mean than the baseline it replaces --
+dispatch -7%, combine -14% over those same six pairs -- so the trade is mean for
+tail, not a plain regression.
+
+## Ruled out for the dispatch tail
+
+The architectural difference is host-side: #625 keeps v1's op (its buffers, its
+argument building, its geometry from v1's JSON tuning tables) and only redirects
+the launch, whereas this branch is v2-native (SymmArena, LaunchGroup, its own
+tuning table). Checked and NOT the cause:
+
+  * Kernel logic. A normalised diff over the 27 functions present in both leaves
+    only renames, `if constexpr` for the quant branch, and two guards that REMOVE
+    work (the local-node skip, required because ccoGda has no P2P path).
+  * Region packing. SymmArena packs regions 256B-aligned in one window where v1
+    allocates separately, but the per-region sizes are identical, so the
+    cache-line sharing a peer's RDMA writes contend on is the same.
+  * Counter zeroing. total_recv is a local tensor cleared in-stream by
+    copystaging; node_recv_token_num is zeroed in the combine path of BOTH.
+  * Launch geometry. The two run different geometries -- v1's table gives
+    dispatch 16/10/4 at 4 tokens against our 32/16/4 -- but running ours at v1's
+    geometry does not move the tail: 1.67/2.31/1.21 against 1.22/1.22/2.00.
+
+## Not resolved
+
+The dispatch tail is bimodal in itself: the same geometry has produced 1.22 and
+2.31 in the same afternoon. That is why three-run comparisons cannot separate
+mechanisms here, and why the numbers above are six interleaved pairs rather than
+two batches. Whatever it is, it is host-side and intermittent, and it was not
+found by reading.
+
 ## Eliminated by direct measurement
 
 Each of these was tested and came back negative, rather than argued away:

--- a/docs/EP_INTERNODE_V2_TAIL.md
+++ b/docs/EP_INTERNODE_V2_TAIL.md
@@ -60,11 +60,51 @@ The step is NOT caused by, all eliminated by direct measurement:
     pri5 transition counters are all +0, fast runs and slow runs alike
   * GPU clocks -- sampling pp_dpm_{sclk,fclk,socclk} across the loop window puts
     sclk within 4% and fclk, if anything, HIGHER on the slow runs
+  * xGMI per-link power down -- `~/harness/_plpd.sh 0` (plpd_disallow on all 16
+    GPUs) against stock, four interleaved pairs: slow runs appear under both
+  * PCIe -- `~/harness/_pcie_snap.sh` before and after: no link speed or width
+    change on any GPU or NIC, and TOTAL_ERR_COR/NONFATAL/FATAL all +0, on slow
+    runs as much as fast ones
+  * the VMM/dma-buf placement problem in `.claude/skills/known-issues`
+    (Issue 1) -- both nodes have CONFIG_DMABUF_MOVE_NOTIFY=y and
+    CONFIG_PCI_P2PDMA=y on the running 6.8.12 kernel, and `vmm_peer_probe`
+    returns `VERDICT: OK` on both. Its *family* is right (see the pass split
+    below) but its specific compile-time cause is absent here
   * the host -- see below
+
+A note on the counter probes: `_nic_snap.sh` now reads tx_pkts/tx_bytes/
+rx_pkts/tx_write_req alongside the error counters, as a check on the probe
+itself. A 60-round run moves +20111 packets / +49.6 MB / +12960 write requests
+on each node, so the zeroes above are measured zeroes and not an unwired probe.
+That check was added after noticing that a table of zeroes reads identically
+either way.
 
 `--per-round-sync` cannot be used to test any of this: its gloo barrier costs
 ~1.3ms a round here and injects far more rank skew than it removes (dispatch
 reads ~1370us under it). `--per-round-drain` is the usable version.
+
+ONLY THE PASSES THAT TOUCH REMOTE MEMORY DEGRADE
+------------------------------------------------
+The split also attributes the STEP, by first-k rounds against last-k (a
+different question from which pass owns the worst round, and it need not have
+the same answer). Three runs:
+
+              copystaging   dispatch_ll   combinesync  combine_ll  combineall
+    rep1        +0.0          +33.1         +0.1        -0.3        +0.2
+    rep2        +0.0          +45.8         +0.1       +47.3        -0.0
+    rep3        +0.0          +67.0         +0.0       +66.0        +0.0
+
+`dispatch_ll` and `combine_ll` are the passes that read and write PEER memory.
+`copystaging` (7.0us, local staging copy), `combinesync` and `combineall` touch
+only local memory. The local passes are flat to under 1% in every run; the
+remote ones roughly double.
+
+So the degradation is confined to the remote-access path, and is not a general
+slowdown of the GPU. That is the same family as known-issues Issue 1 -- peer
+traffic getting more expensive than it should -- even though Issue 1's own
+compile-time cause is ruled out here. The remaining candidates all live in that
+family: NIC address-translation/MTT cache pressure, or page placement of the
+symmetric window.
 
 WHERE THE EXCESS LANDS: THE PER-PASS SPLIT
 ------------------------------------------
@@ -171,4 +211,5 @@ excess inside `dispatch_ll` and inside `combinesyncbarrier` -- both of which mix
 posting with waiting, so the split cannot go further from the host side. The next
 step is device-side timestamps inside `dispatch_ll` separating the send-post from
 the receive spin, which would say whether the extra time is spent getting the
-data out or waiting for a peer's.
+data out or waiting for a peer's. The step attribution above says the target is
+right: whatever it is, it is on the remote-access path and not in local work.

--- a/docs/EP_INTERNODE_V2_TAIL.md
+++ b/docs/EP_INTERNODE_V2_TAIL.md
@@ -1,150 +1,174 @@
-# EP internode v2: where the CCO tail comes from
+# EP internode v2: the "tail" is a bistable whole-run regime
 
-Notes from investigating why the v2 CCO/GDA internode path has a latency tail
-that the shmem/IBGDA path does not. Kept out of the test's module docstring so
-that file stays close in shape to the examples harness it mirrors,
+Notes from investigating why the v2 CCO/GDA internode bench reports a large
+worst/mean ratio at small token counts. Kept out of the test's module docstring
+so that file stays close in shape to the examples harness it mirrors,
 `examples/ops/dispatch_combine/test_dispatch_combine_internode.py`.
 
-CCO's TAIL IS NOT THE FABRIC'S: WHAT SHMEM DOES ON THE SAME WIRE
-----------------------------------------------------------------
-Run the v1 harness in the same session for a reference. It drives the shmem/IBGDA
-transport over the SAME NICs, rails, switch and QoS, at the same shape, so it
-isolates what is specific to the CCO path. Note it spawns its own 8 workers per
-node, so it takes --nproc_per_node=1, not 8:
+Read this before running another A/B on this path. The single most expensive
+mistake available here is to compare two configurations across runs that landed
+in different regimes and believe the difference.
 
-    GPU_PER_NODE=8 MORI_EP_LAUNCH_CONFIG_MODE=AUTO MORI_RDMA_TC=160 MORI_RDMA_SL=5 \\
-    torchrun --nnodes=2 --node_rank=N --nproc_per_node=1 --master_addr=... \\
-      examples/ops/dispatch_combine/test_dispatch_combine_internode.py \\
-      --cmd bench --kernel-type v1_ll --num-qp 1 --max-tokens 4 \\
-      --hidden-dim 6144 --dtype fp8_e4m3_fnuz --combine-dtype bf16 --quant-type none
+WHAT IT ACTUALLY IS
+-------------------
+Not a tail. Every run of the 4-token EP16 bench lands in one of two regimes and
+stays there:
 
-Measured, 29 kept rounds x 16 ranks = 464 samples per phase:
+                     fast regime        slow regime
+    dispatch mean      37-40us            50-70us
+    combine  mean      45-48us            72-79us
+    host wall/round    ~105us             ~150us
 
-                       shmem/IBGDA          CCO/GDA (here)
-    dispatch mean         47.4us              40-47us
-    combine  mean         59.1us              46-52us
-    max/mean              1.19x / 1.18x       2-6x
-    rounds >1.8x base     0 of 29             11 of ~260
-    cross-rank spread     median 9-13us       up to 207us (34 -> 241)
+Per-round series (`MORI_EP_ROUND_SERIES=1`) show the transition directly: a run
+that is going to be slow runs 4-8 rounds at fast-regime numbers, steps up over a
+single round, and holds the higher level for every remaining round. A fast run
+never steps. Within a regime the per-round scatter is small.
 
-Two things follow. CCO is FASTER in the mean -- combine by ~20% -- so the port is
-not simply worse. And the tail belongs to the CCO path, not to the fabric: shmem
-shares every wire and shows no spiked round at all, which rules out the rail and
-switch explanations that the {i, i+8} pattern below otherwise suggests.
+The reported worst/mean ratio is an artifact of this: the mean is a blend of the
+two levels, so a run that stepped early reports ~2.3x while the same binary that
+did not step reports ~1.2x. Chasing "the tail" as if it were a few bad rounds is
+chasing the wrong shape.
 
-Both harnesses do have a huge round 0 (shmem's spans 83-614us) and both drop 1.
+IT IS ENVIRONMENTAL, AND WE AMPLIFY IT
+--------------------------------------
+Interleaved against the #625 baseline (v1 host + the same v2 CCO kernels, so the
+same transport on the same wire), four pairs back to back:
 
-READING THE PER-RANK SERIES (MORI_EP_ROUND_SERIES)
---------------------------------------------------
-Every rank prints its own per-round series. These are spin-wait collectives, so
-the rank that arrives LAST waits LEAST: on a slow round the straggler is the
-MINIMUM, not the maximum, and the other fifteen are just showing what they waited
-for. Threshold per NODE, not globally -- the two nodes routinely sit at different
-levels in the same round (151 vs 237us was measured), and a global threshold then
-misses a rank that is low within its own node.
+                    #625 dispatch   #625 combine   ours dispatch   ours combine
+    fast pair 1        39.8            41.8           40.3            48.1
+    fast pair 2        38.4            40.3           38.0            47.4
+    slow pair 3        41.1            51.0           52.8            78.7
+    slow pair 4        40.7            50.6           69.9            72.0
 
-The shape of the low set says what happened, and they are not all the same:
+Both implementations step into the slow regime on the same runs -- so the trigger
+is environmental, not ours -- but ours degrades about three times as far
+(combine +60% against #625's +22%, dispatch +32% against +2%). Whatever the
+trigger is, our path is more sensitive to it. That sensitivity is the thing worth
+fixing; the trigger itself is not in our code.
 
-  {i, i+8}          one RAIL. Local rank i selects bnxt_re_bond<i> ("rank 1
-                    rankInNode 1 select device [1] bnxt_re_bond1"), so the same
-                    local index on both nodes is one NIC-to-NIC path.
-  {i}               one rank.
-  all of one node    a node-level event; the other node's eight ranks all wait.
-  empty             every rank waited, including the fastest -- no straggler
-                    exists and no single card can explain it.
+The step is NOT caused by, all eliminated by direct measurement:
 
-Measured over 11 spiked rounds in 9 runs: 5 empty, 3 rail pairs (rails 1, 5 and 7,
-once each), 2 single ranks, 1 other. So no one card is at fault; when there is a
-straggler its identity rotates.
+  * the caching allocator -- `segment.all.allocated`, `num_device_alloc` and
+    `num_alloc_retries` are all +0 across the timed loop, in every run
+  * launch-queue depth -- `--per-round-drain` (a bare `cuda.synchronize()` each
+    round, no barrier) does not remove the step
+  * warm-up -- `--warmup 200` steps at the same place as `--warmup 20`
+  * RoCE congestion or loss -- `~/harness/_nic_snap.sh` before and after: 0 for
+    np_ecn_marked_roce_packets, np_cnp_sent, rp_cnp_handled, out_of_sequence,
+    packet_seq_err, roce_adp_retrans, rx/tx_roce_discards, out_of_buffer
+  * PFC pause -- `~/harness/_pfc_snap.sh`: rx/tx_pfc_ena_frames_pri5 and the
+    pri5 transition counters are all +0, fast runs and slow runs alike
+  * GPU clocks -- sampling pp_dpm_{sclk,fclk,socclk} across the loop window puts
+    sclk within 4% and fclk, if anything, HIGHER on the slow runs
+  * the host -- see below
 
-## CORRECTION: the tail is not the transport's alone
+`--per-round-sync` cannot be used to test any of this: its gloo barrier costs
+~1.3ms a round here and injects far more rank skew than it removes (dispatch
+reads ~1370us under it). `--per-round-drain` is the usable version.
 
-An earlier revision of this file concluded "the tail belongs to the CCO path, not
-the fabric", from shmem-vs-CCO. That compared two transports AND two kernels at
-once. Adding the missing arm -- the #625 baseline, which is v1's host code with
-its `_launch_multi` redirected to the v2 CCO plans, so same transport and
-effectively the same kernels -- splits it in two. Interleaved, six pairs at 4
-tokens, max/mean:
+WHERE THE EXCESS LANDS: THE PER-PASS SPLIT
+------------------------------------------
+`MORI_EP_SPLIT_PASSES=1` launches the eight passes individually instead of as one
+`LaunchGroup` and stamps an event after each, then prints, per rank, the round
+series and the three worst rounds broken down against the median round. Splitting
+roughly triples the absolute numbers -- eight ABI crossings instead of one, and
+every rank's spin-wait pass absorbs the others' launch skew -- so read the
+deltas, not the levels.
 
-                        dispatch      combine
-    shmem / IBGDA        1.16          1.23
-    CCO/GDA, #625 base   1.27-1.31     1.46-1.56
-    CCO/GDA, this branch 2.31          1.75
+Dispatch, worst round against median (three ranks agreeing):
 
-So there are two separate effects:
+    copystaging     7.0us     median 7.0us      +0.0
+    dispatch_ll   304-307us   median 114us    +190us
 
-  * COMBINE's tail is mostly the transport's: CCO adds +27% over shmem, this
-    branch adds only +12% on top.
-  * DISPATCH's tail is mostly OURS: CCO adds +13% over shmem, this branch adds
-    +76% on top. The #625 baseline never exceeded 1.44 in six runs and had zero
-    spiked rounds; this branch reaches 2.1-3.3 in five of six.
+Combine:
 
-Note also that this branch is FASTER in the mean than the baseline it replaces --
-dispatch -7%, combine -14% over those same six pairs -- so the trade is mean for
-tail, not a plain regression.
+    combinesync           6.4us    median 6.4us     +0.0
+    combine_ll           29.6us    median 29.4us    +0.2
+    combinesyncbarrier  152.3us    median 79.0us   +73.4
+    combineall            6.1us    median 7.0us     -0.8
 
-## Ruled out for the dispatch tail
+So on both legs the entire excess is in the one pass that waits on peers, and
+none of it is in the passes that do local work. `combine_ll` -- combine's actual
+data movement -- is flat to 1% even on the worst round: combine has no tail of
+its own, it inherits one through its barrier. Any fix aimed at combine's
+data path is aimed at the wrong pass.
 
-The architectural difference is host-side: #625 keeps v1's op (its buffers, its
-argument building, its geometry from v1's JSON tuning tables) and only redirects
-the launch, whereas this branch is v2-native (SymmArena, LaunchGroup, its own
-tuning table). Checked and NOT the cause:
+THE HOST IS NOT THE PACER (and how that was settled)
+----------------------------------------------------
+`MORI_EP_ROUND_SERIES=1` prints, per rank, five aligned series: `disp`, `conv`,
+`comb` (GPU, from the events), `hdis`/`hcom` (host time inside the two calls) and
+`hwal` (host wall per round).
 
-  * Kernel logic. A normalised diff over the 27 functions present in both leaves
-    only renames, `if constexpr` for the quant branch, and two guards that REMOVE
-    work (the local-node skip, required because ccoGda has no P2P path).
-  * Region packing. SymmArena packs regions 256B-aligned in one window where v1
-    allocates separately, but the per-region sizes are identical, so the
-    cache-line sharing a peer's RDMA writes contend on is the same.
-  * Counter zeroing. total_recv is a local tensor cleared in-stream by
-    copystaging; node_recv_token_num is zeroed in the combine path of BOTH.
-  * Launch geometry. The two run different geometries -- v1's table gives
-    dispatch 16/10/4 at 4 tokens against our 32/16/4 -- but running ours at v1's
-    geometry does not move the tail: 1.67/2.31/1.21 against 1.22/1.22/2.00.
+The host cost inside the measured windows is real and large -- ~15us in dispatch
+and ~25us in combine, i.e. roughly 40 of the ~85us "kernel" total is the Python
+wrapper. But it is not what moves:
 
-## Not resolved
+  * rounds where `hdis` or `hcom` spike to 50-60us show completely normal `disp`
+    and `comb`. The GPU is behind, so it absorbs a host hiccup entirely.
+  * rounds where `disp` or `comb` spike to 150-300us show completely normal
+    `hdis`/`hcom`/`hwal`.
+  * summed over a 60-round loop, `hwal` (~86us/round) is far below
+    disp+conv+comb (~141us/round) and `wall` -- which is measured after the final
+    `cuda.synchronize()` -- matches the GPU sum. The host runs ahead and the GPU
+    is the bottleneck.
 
-The dispatch tail is bimodal in itself: the same geometry has produced 1.22 and
-2.31 in the same afternoon. That is why three-run comparisons cannot separate
-mechanisms here, and why the numbers above are six interleaved pairs rather than
-two batches. Whatever it is, it is host-side and intermittent, and it was not
-found by reading.
+Over a long run (5000 rounds) the two converge exactly: wall 94.5us/round against
+disp+conv+comb 94.3us/round.
 
-## Eliminated by direct measurement
+READING THE PER-RANK SERIES
+---------------------------
+These are spin-wait collectives, so a stall on one rank appears as a long phase
+on every OTHER rank; the culprit is the rank reporting the SHORTEST time. Both
+nodes must be read together (`/tmp/v2n_rank0.log` and `/tmp/v2n_rank1.log`).
 
-Each of these was tested and came back negative, rather than argued away:
-garbage collection (traced per round -- zero collections during the timed loop),
-GPU clocks (identical 1650-1780MHz in fast and slow runs), host launch-queue
-saturation (~50us of headroom, and the slow regime has more), RoCE traffic class
-(interleaved A/B over four pairs, within noise), host load average (six runs
-across loadavg 11.5-15.3, no ordering), a single bad GPU, a single bad rail, QP
-count, window cacheability, and process topology (`--spawn` reproduces the
-examples harness's process tree; interleaved A/B is equal in the mean and keeps
-the tail under both).
+Two shapes seen, and they mean different things:
 
-## Where the time actually goes
+  * both nodes long in the same phase on the same round -- one ~120us delivery
+    delay that everyone waited out.
+  * node 0 long in combine while node 1 is long in dispatch on the same round --
+    the same single event, seen from the two sides of a phase-offset pipeline.
+    Do not read this as two separate problems.
 
-`MORI_EP_SPLIT_PASSES=1` launches the pass sequence one plan at a time with a
-timing event after each -- the only way to attribute a slow round to a kernel,
-since the launch group crosses the ABI once and runs the passes back to back.
-Worst round against the median round of the same phase, three runs at 4 tokens:
+A step that appears on one node only (node 0's ranks step, node 1's stay flat for
+the whole run) is also seen. In that case node 1 is not waiting at all: its
+time lands outside the measured windows.
 
-    copystaging          median   7.0   worst   7.1   delta  +0.1
-    dispatch_ll          median  49.2   worst 109.3   delta +60.1
-    combinesync          median   6.4   worst   6.5   delta  +0.1
-    combinesyncbarrier   median  24.3   worst  34.9   delta +10.6
-    combine_ll           median  47.4   worst  69.5   delta +22.1
-    combineall           median   7.1   worst   6.5   delta  -0.6
+RIG RECIPE
+----------
+Ours, and the #625 baseline for comparison:
 
-Every microsecond of the excess is in the passes that wait on remote data; the
-three purely local passes are constant to within 0.2us.
+    EXTRA_ENV="-e MORI_EP_ROUND_SERIES=1" bash ~/harness/_run_v2native.sh PORT \\
+      --cmd bench --kernel-type v1_ll --num-qp 1 --max-tokens 4 --rounds 60 \\
+      --dtype fp8_e4m3_fnuz --combine-dtype bf16 --hidden-dim 6144 --topk 8 \\
+      --experts-per-rank 16 --scale-dim 32
 
-It is also not the fabric erroring. Summing the bnxt RoCE hardware counters over
-all eight devices before and after each run -- packet_seq_err, out_of_sequence,
-implied_nak_seq_err, local_ack_timeout_err, max_retry_exceeded,
-rnr_nak_retry_err, roce_adp_retrans, roce_slow_restart, rx/tx_roce_discards,
-out_of_buffer, np_ecn_marked_roce_packets, np_cnp_sent, rp_cnp_handled,
-duplicate_request -- every delta was zero across four runs including the slowest
-(139.1us total, worst 155/163).
+    bash ~/harness/_run_cust.sh PORT --cmd bench --kernel-type v1_ll --num-qp 1 \\
+      --max-tokens 4 --dtype fp8_e4m3_fnuz --combine-dtype bf16 \\
+      --hidden-dim 6144 --topk 8
 
-Not root-caused.
+Both need `--nproc_per_node=1` (the runners set it): each spawns its own 8
+workers per node. `MORI_RDMA_TC=160 MORI_RDMA_SL=5` are set by the runners.
+
+METHOD
+------
+  * Always interleave A/B. Because of the regime, the same configuration back to
+    back has read 85us and 134us total. A non-interleaved sweep will hand you a
+    winner that is really just a run that did not step.
+  * Judge a candidate by a PAIRED comparison against a FIXED incumbent, never by
+    a chain in which each winner becomes the next incumbent -- five repeats of
+    the greedy shape returned five different winners. See `_tune`.
+  * Prefer max/mean over the mean when comparing across sessions: the mean drifts
+    with the regime, the ratio is more stable. But now that the regime is known,
+    reporting which regime each run landed in is better than either.
+  * Compile the kernel offline before going to the cluster. A TU instantiating
+    all eight `MORI_EP_INTERNODE_CCO_ENTRY*` entries reports every template error
+    at once; finding them one per cluster run costs an afternoon.
+
+NEXT
+----
+Everything outside the GPU has been eliminated, and the per-pass split puts the
+excess inside `dispatch_ll` and inside `combinesyncbarrier` -- both of which mix
+posting with waiting, so the split cannot go further from the host side. The next
+step is device-side timestamps inside `dispatch_ll` separating the send-post from
+the receive spin, which would say whether the extra time is spent getting the
+data out or waiting for a peer's.

--- a/docs/EP_INTERNODE_V2_TAIL.md
+++ b/docs/EP_INTERNODE_V2_TAIL.md
@@ -303,13 +303,63 @@ the two mori calls that holds the torch convert and the launch path (+44.9,
 +17.1, +51.1 on spiked rounds), with `hdis` moving in step on some runs and not
 others. The convert kernel itself is flat at 9us.
 
+THE LOOP HAS NO SLACK: HOST JITTER CONVERTS 1:1 INTO PEER WAIT
+--------------------------------------------------------------
+`MORI_EP_INJECT_HOST_US` busy-waits the host between dispatch and combine, on
+every rank, by a known amount. Summing each node's two cross-node waits
+(`c_spin` + `cs_bar`):
+
+    injected    node0 wait   node1 wait   ratio
+        0us         11.9         4.1        --
+       20us         20.1        18.7       1.01
+       60us         61.5        56.9       1.02
+      120us        119.3       129.7       1.08
+
+**Every microsecond of host delay inserted between the two calls comes back as a
+microsecond of cross-node wait.** The round has no slack to absorb it. (An
+earlier single run read ~1.6x; the four-point curve says 1:1 and supersedes it.)
+
+That closes the causal chain and unifies the two mechanisms above: a host hiccup
+in `d2sync` is a perturbation, the loop converts it one-for-one into peer wait,
+and nothing damps it, so it becomes a standing offset that persists for the rest
+of the run.
+
+It also predicts the production case. In a real MoE the expert compute sits
+exactly in that window, so this is not a benchmark artifact -- it is the same
+window, only larger.
+
+Periodic re-alignment does NOT fix it. `--realign-every 20` (a full
+synchronize + gloo barrier every 20 rounds) still ended one of two runs in the
+offset state (node0 c_spin 21.7, node1 cs_bar 32.0): the offset re-forms inside
+20 rounds. Re-aligning treats the symptom and the loop walks straight back.
+
 WHAT WOULD ACTUALLY HELP
 ------------------------
 Not geometry tuning: no kernel is slower, so no schedule can win the time back.
-The lever is the number of serialised cross-node rendezvous per round. There are
-at least two (`combine_ll`'s `c_spin` and `combinesyncbarrier`), and each one
-converts the standing offset into wait time again. Removing one, or making one of
-them absorb skew instead of preserving it, is what changes the fixed point.
+Not periodic re-alignment: measured, it does not hold. Three things follow from
+the 1:1 transfer, in the order I would try them:
+
+1. **Cut the host wrapper on the critical path.** It is ~42us a round (hdis 16 +
+   hcom 26) inside the measured window, and by the transfer above every
+   microsecond removed is a microsecond of peer wait removed. This is the
+   highest-confidence lever because the transfer function is measured, not
+   assumed, and it needs no semantic change. It also plausibly explains why this
+   branch degrades ~3x further than #625 on the same runs -- worth checking
+   whether v1's host path per round is lighter or steadier than ours.
+
+2. **Give the round slack: decouple consecutive rounds.** The benchmark reuses
+   one set of buffers every round, so round i+1 cannot start until the peer has
+   drained round i -- a false dependency. Double-buffering the arena by round
+   parity lets a node that is ahead keep going instead of converting its lead
+   into a wait. This is the structural fix; it changes the fixed point rather
+   than the symptom.
+
+3. **Reduce the number of serialised cross-node rendezvous.** There are at least
+   three a round (`d_spin`, `cs_bar`, `c_spin`), and each is another place the
+   standing offset is re-converted into wait. `combine_ll` already waits on peer
+   data, so whether the separate `combinesyncbarrier` in front of it is
+   redundant is the first thing to read. Expect this alone to move the offset
+   rather than remove it -- it is worth doing together with (2), not instead.
 
 NEXT
 ----

--- a/docs/EP_INTERNODE_V2_TAIL.md
+++ b/docs/EP_INTERNODE_V2_TAIL.md
@@ -244,6 +244,73 @@ So the send/recv question is answered, and the answer is neither: it is not the
 local GPU->NIC post (`d_post` flat) and not waiting for the peer's write
 (`d_spin` flat). Nothing inside either kernel moves.
 
+THE ANSWER: A STABLE INTER-NODE PHASE OFFSET
+--------------------------------------------
+The slow regime is not slower work. It is the two nodes running a fixed number
+of microseconds out of phase, with the cross-node rendezvous converting that
+offset into wait time, every round, forever.
+
+Closed per-round GPU accounting (all spans from wall_clock64, and the four terms
+sum to the CUDA-event round to within 1us -- 94.2 against 94.0, 107.2 against
+106.5, so nothing is unaccounted):
+
+    d_gpu    dispatch's two kernels            22-26us
+    d2sync   dispatch end -> combinesync       25-35us  (holds the torch convert)
+    cs_sync  combinesync kernel                   2.3us  flat always
+    cs_bar   cross-device barrier              see below
+    c_gpu    combine_ll + combineall           29-34us
+    gap_cd   combine end -> next dispatch         4.2us  flat always
+
+Per node, median over rounds, four runs of the same binary:
+
+    run     total   n0 c_spin  n0 cs_bar   n1 c_spin  n1 cs_bar
+    rep1    135.6      31.9        5.3         0.4       39.7
+    rep2    104.0       0.4       11.9        11.9        6.2
+    rep3     96.6       2.3        5.8         5.5        6.3
+    rep4     90.8       4.2        6.4         3.8        6.7
+
+`c_spin` is combine_ll's cross-node wait; `cs_bar` is the cross-device barrier
+that opens the combine phase. Read the table as a phase offset:
+
+- rep1: node 0 is ~35us BEHIND. It pays the offset inside `c_spin` (31.9us,
+  and all eight of its ranks read 31-37us); node 1 pays it one rendezvous later
+  at `cs_bar` (39.7us, all eight ranks). Two waits, opposite sides of the round,
+  same offset.
+- rep2 is the MIRROR IMAGE at smaller magnitude -- node 1 behind by ~12us, so
+  node 1 waits in `c_spin` and node 0 waits in `cs_bar`. The sign flips.
+- rep3 and rep4 are aligned: every wait is 2-7us.
+- The total tracks the offset: 90.8 aligned, 104.0 at ~12us, 135.6 at ~35us.
+
+Everything else is flat across all four: `d_post`, `c_post`, `cs_sync`,
+`gap_cd`, `post_bar`, and both hosts (hwal 75us, hdis 16us, hcom 25-27us on BOTH
+nodes in BOTH regimes). No kernel does more work in the slow regime. The host is
+not the pacer and is not asymmetric.
+
+Why it is bistable and why it never recovers: a rendezvous makes everyone wait
+for the last arrival, which PRESERVES an offset rather than removing it. Aligned
+and offset are both fixed points of the round loop. Which one a run falls into is
+decided in the first handful of rounds and then locked -- exactly the step seen
+in the per-round series.
+
+That also explains the rest of the file: both #625 and this branch step on the
+same runs because both run the same rendezvous structure, and nothing in the
+fabric, the clocks, the allocator, PCIe or PFC has to move for the offset to
+exist.
+
+Two mechanisms, not one. The whole-run REGIME is the offset above. The isolated
+single-round SPIKES are something else: they land in `d2sync`, the window between
+the two mori calls that holds the torch convert and the launch path (+44.9,
++17.1, +51.1 on spiked rounds), with `hdis` moving in step on some runs and not
+others. The convert kernel itself is flat at 9us.
+
+WHAT WOULD ACTUALLY HELP
+------------------------
+Not geometry tuning: no kernel is slower, so no schedule can win the time back.
+The lever is the number of serialised cross-node rendezvous per round. There are
+at least two (`combine_ll`'s `c_spin` and `combinesyncbarrier`), and each one
+converts the standing offset into wait time again. Removing one, or making one of
+them absorb skew instead of preserving it, is what changes the fixed point.
+
 NEXT
 ----
 Everything outside the GPU has been eliminated, and the per-pass split puts the

--- a/docs/EP_INTERNODE_V2_TAIL.md
+++ b/docs/EP_INTERNODE_V2_TAIL.md
@@ -333,6 +333,57 @@ synchronize + gloo barrier every 20 rounds) still ended one of two runs in the
 offset state (node0 c_spin 21.7, node1 cs_bar 32.0): the offset re-forms inside
 20 rounds. Re-aligning treats the symptom and the loop walks straight back.
 
+ROOT CAUSE FOUND: THE CCO PATH NEVER BOUND ITS THREAD
+-----------------------------------------------------
+The per-rank host loop is the whole story. In every run that landed in the slow
+regime, a few ranks show an EXACT 2x on their host loop and the rest show
+nothing:
+
+    slow run, hwal per rank (us)
+      node0  r0..r7    75 76 77 77 77 78 77 76
+      node1  r8 r9 r10 75 77 75 | r11 r12 r13 r14 = 146 149 146 146 | r15 78
+
+    fast run: all sixteen ranks 74-78, no rank doubled
+
+`hdis` goes 16 -> 30 and `hcom` 27 -> 50 on exactly those ranks. The extra
+~36us of host time per round IS the phase offset (measured 35-40us), and it
+reaches the peer through the transfer function above: the affected ranks arrive
+late, their node's INTRA-node barrier (`cs_bar`) makes the other seven wait, and
+the peer node then waits at the cross-node rendezvous (`c_spin`).
+
+The 2x is the giveaway. The box is 2 sockets x 96 cores with SMT (sibling of
+physical core c is c+192), so two unbound processes can land on the two
+hyperthreads of ONE physical core and each runs at about half speed.
+
+**The fix already existed in the tree and was wired to the wrong path.**
+`application::BindCallingThreadToGpuNumaOnce()`
+(`include/mori/application/utils/cpu_affinity.hpp`) binds a thread to the CPUs
+local to its GPU's NUMA node, from the same sysfs `local_cpulist` NCCL uses,
+intersected with the existing cpuset. Its ONLY caller was `src/shmem/init.cpp:746`
+-- "the single bind site for the shmem/EP path". A job that used CCO instead of
+shmem ran completely unbound. `ccoCommCreateImpl` now calls it too.
+
+This also means every EP v2 measurement against v1/shmem was unfair in v1's
+favour: the v1 harness calls `shmem_torch_process_group_init`
+(`examples/ops/dispatch_combine/test_dispatch_combine_internode.py:606`) and was
+bound; ours was not. The "we degrade ~3x further than #625" result above was
+measured across that difference and needs re-running before it means anything.
+
+Measured, eight runs each, `MORI_IGNORE_CPU_AFFINITY=1` as the control:
+
+                       unbound            bound
+    median total       88.0us             84.8us
+    worst total        126.0us            97.4us
+    runs with a
+      doubled rank     1 of 4 (and ~1 in  0 of 8
+                       3 across the day)
+
+Eight clean runs do not prove the residual rate is zero: the bind confines four
+ranks to one socket's 192 CPUs, which makes an SMT collision much less likely
+but not impossible. Strict per-rank disjoint pinning also gave 4 of 4 clean. If
+the regime ever reappears, check the per-rank `hwal` series first -- the
+correlation with a doubled rank has been perfect in every run so far.
+
 WHAT WOULD ACTUALLY HELP
 ------------------------
 Not geometry tuning: no kernel is slower, so no schedule can win the time back.

--- a/docs/MORI_JIT_V2_DESIGN.md
+++ b/docs/MORI_JIT_V2_DESIGN.md
@@ -151,6 +151,16 @@ mori_ep_dispatch_bf16_ws8_h2048_k8_64x16(EpArgs args) { EpDispatchBody<kCfg, Tok
 hash = sha256(name $$ hipcc签名 $$ nic $$ flags $$ include哈希 $$ 源码文本)
 ```
 
+> **⚠️ 开发期陷阱：JIT 默认不编译你的 `src/`。** `DetectSourceRoot()`
+> （`src/jit/v2/toolchain.cpp`）按 `MORI_SOURCE_ROOT` → **`.so` 旁边的 `_jit-sources`** →
+> `MORI_JIT_SOURCE_DIR` 的顺序解析。`python/mori/_jit-sources/` 是 `setup.py` 在
+> pip-install 时做的一份**实拷贝**，editable 安装下它优先命中——于是改
+> `src/ops/**/*.hpp` 或 `include/**` 对 JIT **无效，且静默**：include 哈希也是对那份陈旧
+> 拷贝算的，连缓存目录名都不变。诊断办法是往头文件末尾加 `#error`、清掉
+> `~/.mori/jit/<arch>_<nic>`、重编，若仍然成功就说明编的不是你的树。
+> 开发时导出 `MORI_SOURCE_ROOT=<repo root>`；`pip install -e .` 也能刷新那份拷贝，
+> 但下次编辑又会过期，环境变量不会。
+
 `include 哈希`是对 `SourceDeps()` 列出的目录做一次排序递归遍历，把每个头文件的**相对路径和内容**
 都摘进去。粗粒度是刻意的：它可能过度失效，但不会漏失效。EP 的依赖集是
 `include/mori`、`src/ops/dispatch_combine_v2`、`src/cco`。
@@ -325,13 +335,24 @@ dispatch 的 dtype**——它只归约 bf16/fp32 的暂存区，不管前面搬�
 
 ## 6. Python 绑定
 
-C ABI 是**十个符号，对所有 kernel 永久有效**：
+C ABI 是**十一个符号，对所有 kernel 永久有效**：
 
 ```
-mori_jit_plan_create / _launch / _destroy / _info
+mori_jit_plan_create / _launch / _launch_multi / _destroy / _info
 mori_jit_plan_args_schema / _args_size / _request_schema
 mori_jit_precompile / mori_jit_registered_plans / mori_jit_last_error
 ```
+
+`_launch_multi` 是批量发射：N 个共享同一 args 布局的 plan，填一次参数结构、穿一次 ABI，
+然后按序发射（C++ 侧就是对同一个 `argBuf` 循环 `vt->launch`，不认识任何具体 kernel）。
+EP 的 internode 序列一次 dispatch 是 2 个 pass、一次 combine 是 4 个，本来要穿 6 次。
+
+Python 侧对应 `plan_api.LaunchGroup`：**plan 集合固定时把校验和 handle 数组挪到构建期**，
+发射路径只剩填参数和那一次 ABI 调用。「共享同一 args 布局」按完整的
+`(name, offset, size)` 序列比对，不是只比 `sizeof`——理由见 §3.2：八个裸指针字段，
+调换两个同类型的所有尺寸校验都过，然后按 `plans[0]` 的 schema 填、发给其余 plan，
+静默读错 buffer。代价是 group 缓存了 handle：显式 `close()` 一个 plan 会让它失效，
+而发射路径不再逐次检查——这正是省下来的那部分。
 
 | | 机制 |
 |---|---|

--- a/include/mori/application/utils/cpu_affinity.hpp
+++ b/include/mori/application/utils/cpu_affinity.hpp
@@ -31,6 +31,7 @@
 #include <optional>
 #include <sstream>
 #include <string>
+#include <set>
 #include <vector>
 
 #include "mori/utils/env_utils.hpp"
@@ -81,6 +82,48 @@ inline std::optional<std::string> GpuLocalCpuList(int deviceId, int& numaNode) {
   return line;
 }
 
+// Every device id whose GPU sits on `numaNode`, ascending. One rank per GPU is
+// mori's layout, and under SPMT one thread per GPU, so this doubles as "the
+// ranks that will contend for this NUMA node's CPUs".
+inline std::vector<int> DevicesOnNumaNode(int numaNode) {
+  int count = 0;
+  std::vector<int> out;
+  if (hipGetDeviceCount(&count) != hipSuccess) return out;
+  for (int d = 0; d < count; ++d) {
+    int nn = -1;
+    if (GpuLocalCpuList(d, nn).has_value() && nn == numaNode) out.push_back(d);
+  }
+  return out;
+}
+
+// Group `cpus` into physical cores using the kernel's own sibling list, so SMT
+// siblings always stay together. Grouping by anything else -- a contiguous slice
+// of the cpu list, say -- would happily hand cpu 5 to one rank and cpu 197 to
+// another, and those are the two hyperthreads of one core.
+inline std::vector<std::vector<int>> GroupBySiblings(const std::vector<int>& cpus) {
+  std::set<int> pool(cpus.begin(), cpus.end());
+  std::vector<std::vector<int>> cores;
+  while (!pool.empty()) {
+    const int c = *pool.begin();
+    std::vector<int> core;
+    std::ifstream f("/sys/devices/system/cpu/cpu" + std::to_string(c) +
+                    "/topology/thread_siblings_list");
+    std::string line;
+    if (f && std::getline(f, line)) {
+      for (int s : ParseCpuList(line))
+        if (pool.erase(s)) core.push_back(s);
+    }
+    if (core.empty()) {  // unreadable topology: treat the cpu as its own core
+      pool.erase(c);
+      core.push_back(c);
+    }
+    std::sort(core.begin(), core.end());
+    cores.push_back(std::move(core));
+  }
+  std::sort(cores.begin(), cores.end());
+  return cores;
+}
+
 }  // namespace detail
 
 // Bind the CALLING thread to the CPUs local to its current HIP device's NUMA node,
@@ -111,14 +154,58 @@ inline void BindCallingThreadToGpuNumaOnce() {
   CPU_ZERO(&allowed);
   if (sched_getaffinity(0, sizeof(allowed), &allowed) != 0) return;
 
+  std::vector<int> usable;
+  for (int c : localCpus)
+    if (c >= 0 && c < CPU_SETSIZE && CPU_ISSET(c, &allowed)) usable.push_back(c);
+
+  // Give this rank its OWN physical cores rather than the whole NUMA node.
+  //
+  // Binding to the node alone stops cross-socket placement but leaves the eight
+  // per-node ranks sharing 96 physical cores, and the scheduler does put two of
+  // them on the two SMT siblings of one core. Measured with sched_getcpu: in six
+  // runs of an EP bench, every colliding PAIR -- and only the colliding pair --
+  // ran its host loop at exactly 2x (74us -> 136us a round), and each such run
+  // dragged the whole 16-rank collective from ~89us to 116-124us. Ranks never
+  // migrated mid-run, so the placement is a startup lottery that then sticks.
+  //
+  // Slot = this device's index among the devices on the same NUMA node, which
+  // is stable, needs no bootstrap (this runs before it) and no launcher
+  // environment. When the device count is 1 -- HIP_VISIBLE_DEVICES pinned per
+  // process -- there is nothing to partition and this degrades to the old
+  // whole-node bind. MORI_CPU_AFFINITY_NO_SPLIT forces that too.
+  const std::vector<int> peers = detail::DevicesOnNumaNode(numaNode);
+  const auto self = std::find(peers.begin(), peers.end(), deviceId);
+  if (!env::IsEnvVarEnabled("MORI_CPU_AFFINITY_NO_SPLIT") && peers.size() > 1 &&
+      self != peers.end()) {
+    const std::vector<std::vector<int>> cores = detail::GroupBySiblings(usable);
+    const size_t nslots = peers.size();
+    if (cores.size() >= nslots) {
+      const size_t slot = static_cast<size_t>(self - peers.begin());
+      // Contiguous, remainder to the low slots; every core lands in exactly one.
+      const size_t base = cores.size() / nslots, extra = cores.size() % nslots;
+      const size_t lo = slot * base + std::min(slot, extra);
+      const size_t hi = lo + base + (slot < extra ? 1 : 0);
+      std::vector<int> mine;
+      for (size_t i = lo; i < hi; ++i)
+        mine.insert(mine.end(), cores[i].begin(), cores[i].end());
+      if (!mine.empty()) {
+        usable.swap(mine);
+        MORI_APP_INFO("CPU affinity: GPU {} takes slot {}/{} of numa node {} ({} cores)",
+                      deviceId, slot, nslots, numaNode, hi - lo);
+      }
+    } else {
+      MORI_APP_WARN(
+          "CPU affinity: numa node {} has {} cores for {} GPUs; binding to the whole node",
+          numaNode, cores.size(), nslots);
+    }
+  }
+
   cpu_set_t target;
   CPU_ZERO(&target);
   int count = 0;
-  for (int c : localCpus) {
-    if (c >= 0 && c < CPU_SETSIZE && CPU_ISSET(c, &allowed)) {
-      CPU_SET(c, &target);
-      ++count;
-    }
+  for (int c : usable) {
+    CPU_SET(c, &target);
+    ++count;
   }
   if (count == 0) {
     MORI_APP_WARN(

--- a/include/mori/cco/cco_scale_out.hpp
+++ b/include/mori/cco/cco_scale_out.hpp
@@ -111,6 +111,32 @@ struct ccoGda_SignalAdd {
   __device__ inline ccoGda_SignalAdd(ccoGdaSignal_t id, uint64_t val) : signalId(id), value(val) {}
 };
 
+// Atomic add at an arbitrary offset in a caller-owned window, rather than at a
+// signal slot in the DevComm's resource window.
+//
+// ccoGda_SignalInc / ccoGda_SignalAdd address the resource window's signal pool:
+// gdaSignalCount fixed slots, at signalId * sizeof(uint64_t), read back through
+// waitSignal's consume-on-read shadow. That fits a caller whose flags are the
+// signals; it does not fit one whose flags are a data structure of its own --
+// EP's internode chunk-flag protocol, for instance, keeps one slot per (node,
+// chunk) in its own arena, scaling with token capacity, and polls and clears
+// them itself.
+//
+// The remote op is identical (a NIC atomic add); only the target resolution
+// differs, so this rides the same single-reservation path as ccoGda_SignalAdd --
+// fused into `put`'s own doorbell when passed to put, no extra WQE. `offset` is
+// window-relative with iova=0, the same convention as put's dstOffset.
+//
+// waitSignal/readSignal/resetSignal do NOT see these: the target is the caller's
+// window, so the caller polls it directly.
+struct ccoGda_WindowSignalAdd {
+  ccoWindow_t win;
+  size_t offset;
+  uint64_t value;
+  __device__ inline ccoGda_WindowSignalAdd(ccoWindow_t w, size_t off, uint64_t val)
+      : win(w), offset(off), value(val) {}
+};
+
 struct ccoGda_CounterInc {
   ccoGdaCounter_t counterId;
   __device__ inline ccoGda_CounterInc(ccoGdaCounter_t id) : counterId(id) {}
@@ -1091,6 +1117,14 @@ __device__ inline void ccoGda<PrvdType>::put(int peer, ccoWindow_t dstWin, size_
       signalRkey = comm.resourceWindow_inlined.ibgdaWin.peerRkeys[worldPeer];
       signalOp = ccoGdaSignalAdd;
       signalOpArg = remoteAction.value;
+    } else if constexpr (std::is_same_v<RemoteAction, ccoGda_WindowSignalAdd>) {
+      // Caller's window, not the resource window: the offset is already
+      // window-relative (iova=0), so it is the raddr as-is.
+      signalRaddr = remoteAction.offset;
+      signalRkey =
+          reinterpret_cast<ccoWindowDevice*>(remoteAction.win)->ibgdaWin.peerRkeys[worldPeer];
+      signalOp = ccoGdaSignalAdd;
+      signalOpArg = remoteAction.value;
     }
 
     // Only mixed-peer thread scope needs per-peer grouping; ThreadAggregate and
@@ -1154,6 +1188,14 @@ __device__ inline void ccoGda<PrvdType>::putValue(int peer, ccoWindow_t dstWin, 
     } else if constexpr (std::is_same_v<RemoteAction, ccoGda_SignalAdd>) {
       signalRaddr = remoteAction.signalId * sizeof(uint64_t);
       signalRkey = comm.resourceWindow_inlined.ibgdaWin.peerRkeys[worldPeer];
+      signalOp = ccoGdaSignalAdd;
+      signalOpArg = remoteAction.value;
+    } else if constexpr (std::is_same_v<RemoteAction, ccoGda_WindowSignalAdd>) {
+      // Caller's window, not the resource window: the offset is already
+      // window-relative (iova=0), so it is the raddr as-is.
+      signalRaddr = remoteAction.offset;
+      signalRkey =
+          reinterpret_cast<ccoWindowDevice*>(remoteAction.win)->ibgdaWin.peerRkeys[worldPeer];
       signalOp = ccoGdaSignalAdd;
       signalOpArg = remoteAction.value;
     }
@@ -1249,6 +1291,14 @@ __device__ inline void ccoGda<PrvdType>::signal(int peer, RemoteAction remoteAct
     } else if constexpr (std::is_same_v<RemoteAction, ccoGda_SignalAdd>) {
       signalRaddr = remoteAction.signalId * sizeof(uint64_t);
       signalRkey = comm.resourceWindow_inlined.ibgdaWin.peerRkeys[worldPeer];
+      signalOp = ccoGdaSignalAdd;
+      signalOpArg = remoteAction.value;
+    } else if constexpr (std::is_same_v<RemoteAction, ccoGda_WindowSignalAdd>) {
+      // Caller's window, not the resource window: the offset is already
+      // window-relative (iova=0), so it is the raddr as-is.
+      signalRaddr = remoteAction.offset;
+      signalRkey =
+          reinterpret_cast<ccoWindowDevice*>(remoteAction.win)->ibgdaWin.peerRkeys[worldPeer];
       signalOp = ccoGdaSignalAdd;
       signalOpArg = remoteAction.value;
     }

--- a/include/mori/cco/cco_scale_out.hpp
+++ b/include/mori/cco/cco_scale_out.hpp
@@ -111,32 +111,6 @@ struct ccoGda_SignalAdd {
   __device__ inline ccoGda_SignalAdd(ccoGdaSignal_t id, uint64_t val) : signalId(id), value(val) {}
 };
 
-// Atomic add at an arbitrary offset in a caller-owned window, rather than at a
-// signal slot in the DevComm's resource window.
-//
-// ccoGda_SignalInc / ccoGda_SignalAdd address the resource window's signal pool:
-// gdaSignalCount fixed slots, at signalId * sizeof(uint64_t), read back through
-// waitSignal's consume-on-read shadow. That fits a caller whose flags are the
-// signals; it does not fit one whose flags are a data structure of its own --
-// EP's internode chunk-flag protocol, for instance, keeps one slot per (node,
-// chunk) in its own arena, scaling with token capacity, and polls and clears
-// them itself.
-//
-// The remote op is identical (a NIC atomic add); only the target resolution
-// differs, so this rides the same single-reservation path as ccoGda_SignalAdd --
-// fused into `put`'s own doorbell when passed to put, no extra WQE. `offset` is
-// window-relative with iova=0, the same convention as put's dstOffset.
-//
-// waitSignal/readSignal/resetSignal do NOT see these: the target is the caller's
-// window, so the caller polls it directly.
-struct ccoGda_WindowSignalAdd {
-  ccoWindow_t win;
-  size_t offset;
-  uint64_t value;
-  __device__ inline ccoGda_WindowSignalAdd(ccoWindow_t w, size_t off, uint64_t val)
-      : win(w), offset(off), value(val) {}
-};
-
 struct ccoGda_CounterInc {
   ccoGdaCounter_t counterId;
   __device__ inline ccoGda_CounterInc(ccoGdaCounter_t id) : counterId(id) {}
@@ -1117,14 +1091,6 @@ __device__ inline void ccoGda<PrvdType>::put(int peer, ccoWindow_t dstWin, size_
       signalRkey = comm.resourceWindow_inlined.ibgdaWin.peerRkeys[worldPeer];
       signalOp = ccoGdaSignalAdd;
       signalOpArg = remoteAction.value;
-    } else if constexpr (std::is_same_v<RemoteAction, ccoGda_WindowSignalAdd>) {
-      // Caller's window, not the resource window: the offset is already
-      // window-relative (iova=0), so it is the raddr as-is.
-      signalRaddr = remoteAction.offset;
-      signalRkey =
-          reinterpret_cast<ccoWindowDevice*>(remoteAction.win)->ibgdaWin.peerRkeys[worldPeer];
-      signalOp = ccoGdaSignalAdd;
-      signalOpArg = remoteAction.value;
     }
 
     // Only mixed-peer thread scope needs per-peer grouping; ThreadAggregate and
@@ -1188,14 +1154,6 @@ __device__ inline void ccoGda<PrvdType>::putValue(int peer, ccoWindow_t dstWin, 
     } else if constexpr (std::is_same_v<RemoteAction, ccoGda_SignalAdd>) {
       signalRaddr = remoteAction.signalId * sizeof(uint64_t);
       signalRkey = comm.resourceWindow_inlined.ibgdaWin.peerRkeys[worldPeer];
-      signalOp = ccoGdaSignalAdd;
-      signalOpArg = remoteAction.value;
-    } else if constexpr (std::is_same_v<RemoteAction, ccoGda_WindowSignalAdd>) {
-      // Caller's window, not the resource window: the offset is already
-      // window-relative (iova=0), so it is the raddr as-is.
-      signalRaddr = remoteAction.offset;
-      signalRkey =
-          reinterpret_cast<ccoWindowDevice*>(remoteAction.win)->ibgdaWin.peerRkeys[worldPeer];
       signalOp = ccoGdaSignalAdd;
       signalOpArg = remoteAction.value;
     }
@@ -1291,14 +1249,6 @@ __device__ inline void ccoGda<PrvdType>::signal(int peer, RemoteAction remoteAct
     } else if constexpr (std::is_same_v<RemoteAction, ccoGda_SignalAdd>) {
       signalRaddr = remoteAction.signalId * sizeof(uint64_t);
       signalRkey = comm.resourceWindow_inlined.ibgdaWin.peerRkeys[worldPeer];
-      signalOp = ccoGdaSignalAdd;
-      signalOpArg = remoteAction.value;
-    } else if constexpr (std::is_same_v<RemoteAction, ccoGda_WindowSignalAdd>) {
-      // Caller's window, not the resource window: the offset is already
-      // window-relative (iova=0), so it is the raddr as-is.
-      signalRaddr = remoteAction.offset;
-      signalRkey =
-          reinterpret_cast<ccoWindowDevice*>(remoteAction.win)->ibgdaWin.peerRkeys[worldPeer];
       signalOp = ccoGdaSignalAdd;
       signalOpArg = remoteAction.value;
     }

--- a/include/mori/ops/dispatch_combine_v2/ep_internode_args.hpp
+++ b/include/mori/ops/dispatch_combine_v2/ep_internode_args.hpp
@@ -138,7 +138,12 @@ struct EpInterNodeRegion {
 // over one shared arena.
 // ---------------------------------------------------------------------------
 struct EpInterNodeDeviceCfg {
-  int rank{0};
+  // No `rank`. Every field here is a compiled-in shape constant, so the whole
+  // struct is constexpr and each read folds to a literal. Carrying the rank
+  // would make it a runtime object the compiler has to keep live in scalar
+  // registers across every inlined helper -- measured as dispatch_ll's SGPR
+  // spill count going 1 -> 15 against the pre-refactor kernel. The rank is
+  // `myPe` in DEF_COMMON_VARS, straight off args.
   int worldSize{8};
   int hiddenDim{4096};
   int scaleDim{0};

--- a/include/mori/ops/dispatch_combine_v2/ep_internode_args.hpp
+++ b/include/mori/ops/dispatch_combine_v2/ep_internode_args.hpp
@@ -285,8 +285,8 @@ __device__ inline int NullSendBufSlotOffset(const EpInterNodeDeviceCfg& config) 
   X(combineGridBarrier, "p")             \
   X(interNodeBlocksBarrier, "p")         \
   X(crossDeviceBarrierFlag, "p")         \
-  X(dbgTsBuf, "p")                       \
-  X(dbgRound, "i32")
+  X(dbgRound, "i32")                     \
+  X(dbgTsBuf, "p")
 
 #define MORI_EP_INTERNODE_ARGS_SCHEMA_ENTRY(name, tag) #name ":" tag ","
 // Trailing comma: the binding skips empty items, so there is no last-element
@@ -360,11 +360,13 @@ struct EpInterNodeArgs {
   // host -- the null is what turns every stamp site in the kernel off. The
   // round index has to come from the host: the kernel has no notion of which
   // benchmark round it is in, and deriving one from a device atomic would put
-  // a global atomic inside the region being measured. Pointer first so the
-  // offsets stay ascending with the rest of the pointer block and the trailing
-  // int32 becomes tail padding, which is what EpInterNodeCcoArgs needs.
-  uint64_t* dbgTsBuf{nullptr};
+  // a global atomic inside the region being measured.
+  //
+  // ORDER MATTERS, and not for the reason it looks like. The int32 goes FIRST
+  // so the pointer is last and this struct ends with no tail padding; see the
+  // no-tail-padding static_assert below for what happens otherwise.
   int32_t dbgRound{0};
+  uint64_t* dbgTsBuf{nullptr};
 
   // An offset as something addressable. Built per access; the three members are
   // all the accessors need, so this costs nothing at -O2.
@@ -398,6 +400,22 @@ static_assert(detail::kEpInterNodeArgsFieldCount == 41,
 static_assert(detail::EpInterNodeArgsOffsetsAscend(),
               "MORI_EP_INTERNODE_ARGS_FIELDS is not in declaration order -- the binding "
               "would write each argument into the wrong slot");
+
+// The last field must end exactly at sizeof, i.e. no tail padding.
+//
+// This is not pedantry, it cost a run of eight GPU memory faults. The binding
+// builds a ctypes struct from the schema and appends devComm as a BYTE RANGE,
+// whose alignment is 1 -- so ctypes places it immediately after the last field,
+// while C++ places it at sizeof(EpInterNodeArgs), after any tail padding. End
+// the struct with an int32 and the two disagree by 4 bytes: every launch then
+// writes the communicator 4 bytes low and the kernel dereferences garbage QP
+// state. Nothing else catches it -- both layouts have the SAME sizeof, so the
+// binding's size check passes, and the ascending-offset assert above is about
+// the fields, not about what follows them.
+static_assert(offsetof(EpInterNodeArgs, dbgTsBuf) + sizeof(EpInterNodeArgs::dbgTsBuf) ==
+                  sizeof(EpInterNodeArgs),
+              "EpInterNodeArgs has tail padding -- the binding would place devComm before "
+              "C++ does. Keep an 8-byte member last (update the name here if it changes)");
 
 // What crosses into a JIT module: the arguments plus the communicator. Passing
 // the comm by value is the point of the CCO port; mori-shmem needed a device

--- a/include/mori/ops/dispatch_combine_v2/ep_internode_args.hpp
+++ b/include/mori/ops/dispatch_combine_v2/ep_internode_args.hpp
@@ -284,9 +284,7 @@ __device__ inline int NullSendBufSlotOffset(const EpInterNodeDeviceCfg& config) 
   X(dispatchGridBarrier, "p")            \
   X(combineGridBarrier, "p")             \
   X(interNodeBlocksBarrier, "p")         \
-  X(crossDeviceBarrierFlag, "p")         \
-  X(dbgRound, "i32")                     \
-  X(dbgTsBuf, "p")
+  X(crossDeviceBarrierFlag, "p")
 
 #define MORI_EP_INTERNODE_ARGS_SCHEMA_ENTRY(name, tag) #name ":" tag ","
 // Trailing comma: the binding skips empty items, so there is no last-element
@@ -356,17 +354,6 @@ struct EpInterNodeArgs {
   uint32_t* interNodeBlocksBarrier{nullptr};
   uint64_t* crossDeviceBarrierFlag{nullptr};
 
-  // Device timestamps, opt-in and NULL unless MORI_EP_DEV_TS is set on the
-  // host -- the null is what turns every stamp site in the kernel off. The
-  // round index has to come from the host: the kernel has no notion of which
-  // benchmark round it is in, and deriving one from a device atomic would put
-  // a global atomic inside the region being measured.
-  //
-  // ORDER MATTERS, and not for the reason it looks like. The int32 goes FIRST
-  // so the pointer is last and this struct ends with no tail padding; see the
-  // no-tail-padding static_assert below for what happens otherwise.
-  int32_t dbgRound{0};
-  uint64_t* dbgTsBuf{nullptr};
 
   // An offset as something addressable. Built per access; the three members are
   // all the accessors need, so this costs nothing at -O2.
@@ -394,7 +381,7 @@ constexpr bool EpInterNodeArgsOffsetsAscend() {
 
 }  // namespace detail
 
-static_assert(detail::kEpInterNodeArgsFieldCount == 41,
+static_assert(detail::kEpInterNodeArgsFieldCount == 39,
               "added an EpInterNodeArgs field -- add it to MORI_EP_INTERNODE_ARGS_FIELDS in "
               "the same position and bump this count");
 static_assert(detail::EpInterNodeArgsOffsetsAscend(),
@@ -412,7 +399,8 @@ static_assert(detail::EpInterNodeArgsOffsetsAscend(),
 // state. Nothing else catches it -- both layouts have the SAME sizeof, so the
 // binding's size check passes, and the ascending-offset assert above is about
 // the fields, not about what follows them.
-static_assert(offsetof(EpInterNodeArgs, dbgTsBuf) + sizeof(EpInterNodeArgs::dbgTsBuf) ==
+static_assert(offsetof(EpInterNodeArgs, crossDeviceBarrierFlag) +
+                      sizeof(EpInterNodeArgs::crossDeviceBarrierFlag) ==
                   sizeof(EpInterNodeArgs),
               "EpInterNodeArgs has tail padding -- the binding would place devComm before "
               "C++ does. Keep an 8-byte member last (update the name here if it changes)");

--- a/include/mori/ops/dispatch_combine_v2/ep_internode_args.hpp
+++ b/include/mori/ops/dispatch_combine_v2/ep_internode_args.hpp
@@ -284,7 +284,9 @@ __device__ inline int NullSendBufSlotOffset(const EpInterNodeDeviceCfg& config) 
   X(dispatchGridBarrier, "p")            \
   X(combineGridBarrier, "p")             \
   X(interNodeBlocksBarrier, "p")         \
-  X(crossDeviceBarrierFlag, "p")
+  X(crossDeviceBarrierFlag, "p")         \
+  X(dbgTsBuf, "p")                       \
+  X(dbgRound, "i32")
 
 #define MORI_EP_INTERNODE_ARGS_SCHEMA_ENTRY(name, tag) #name ":" tag ","
 // Trailing comma: the binding skips empty items, so there is no last-element
@@ -354,6 +356,16 @@ struct EpInterNodeArgs {
   uint32_t* interNodeBlocksBarrier{nullptr};
   uint64_t* crossDeviceBarrierFlag{nullptr};
 
+  // Device timestamps, opt-in and NULL unless MORI_EP_DEV_TS is set on the
+  // host -- the null is what turns every stamp site in the kernel off. The
+  // round index has to come from the host: the kernel has no notion of which
+  // benchmark round it is in, and deriving one from a device atomic would put
+  // a global atomic inside the region being measured. Pointer first so the
+  // offsets stay ascending with the rest of the pointer block and the trailing
+  // int32 becomes tail padding, which is what EpInterNodeCcoArgs needs.
+  uint64_t* dbgTsBuf{nullptr};
+  int32_t dbgRound{0};
+
   // An offset as something addressable. Built per access; the three members are
   // all the accessors need, so this costs nothing at -O2.
   __device__ __host__ EpInterNodeRegion reg(uint64_t off) const {
@@ -380,7 +392,7 @@ constexpr bool EpInterNodeArgsOffsetsAscend() {
 
 }  // namespace detail
 
-static_assert(detail::kEpInterNodeArgsFieldCount == 39,
+static_assert(detail::kEpInterNodeArgsFieldCount == 41,
               "added an EpInterNodeArgs field -- add it to MORI_EP_INTERNODE_ARGS_FIELDS in "
               "the same position and bump this count");
 static_assert(detail::EpInterNodeArgsOffsetsAscend(),

--- a/include/mori/ops/dispatch_combine_v2/ep_internode_args.hpp
+++ b/include/mori/ops/dispatch_combine_v2/ep_internode_args.hpp
@@ -292,7 +292,6 @@ __device__ inline int NullSendBufSlotOffset(const EpInterNodeDeviceCfg& config) 
 #define MORI_EP_INTERNODE_ARGS_SCHEMA \
   MORI_EP_INTERNODE_ARGS_FIELDS(MORI_EP_INTERNODE_ARGS_SCHEMA_ENTRY)
 
-template <typename T>
 struct EpInterNodeArgs {
   uint64_t window{0};
 
@@ -329,7 +328,10 @@ struct EpInterNodeArgs {
   int32_t curRankNumToken{0};
 
   ep_index_t* tokenIndices{nullptr};
-  T* inpTokenBuf{nullptr};
+  // void*, like the intranode EpArgs: callers cast at the use site. Keeping it
+  // T* made this struct a template for one member, which then needed an
+  // untyped alias, layout asserts across T, and a memcpy to pun between them.
+  const void* inpTokenBuf{nullptr};
   float* weightsBuf{nullptr};
   uint8_t* scalesBuf{nullptr};
 
@@ -359,20 +361,10 @@ struct EpInterNodeArgs {
   }
 };
 
-// The untyped spelling. T appears in one member, so every instantiation has the
-// same layout -- which is what lets the host, the schema and the plan
-// registration name one non-template type while each kernel reads its own T.
-using EpInterNodeArgsRaw = EpInterNodeArgs<void>;
-
-static_assert(sizeof(EpInterNodeArgs<float>) == sizeof(EpInterNodeArgsRaw),
-              "EpInterNodeArgs must be layout-identical across T");
-static_assert(alignof(EpInterNodeArgs<float>) == alignof(EpInterNodeArgsRaw),
-              "EpInterNodeArgs alignment must not depend on T");
-
 namespace detail {
 
 #define MORI_EP_INTERNODE_ARGS_OFFSET(name, tag) \
-  offsetof(::mori::ops::v2::EpInterNodeArgsRaw, name),
+  offsetof(::mori::ops::v2::EpInterNodeArgs, name),
 inline constexpr size_t kEpInterNodeArgsOffsets[] = {
     MORI_EP_INTERNODE_ARGS_FIELDS(MORI_EP_INTERNODE_ARGS_OFFSET)};
 #undef MORI_EP_INTERNODE_ARGS_OFFSET
@@ -400,12 +392,12 @@ static_assert(detail::EpInterNodeArgsOffsetsAscend(),
 // global filled by the host after every hipModuleLoad. It is the one opaque
 // member, because it is cco's struct and not EP's to name.
 struct EpInterNodeCcoArgs {
-  EpInterNodeArgsRaw args;
+  EpInterNodeArgs args;
   ::mori::cco::ccoDevComm devComm;
 };
 
 static_assert(sizeof(EpInterNodeCcoArgs) ==
-                  sizeof(EpInterNodeArgsRaw) + sizeof(::mori::cco::ccoDevComm),
+                  sizeof(EpInterNodeArgs) + sizeof(::mori::cco::ccoDevComm),
               "EpInterNodeCcoArgs has interior padding -- the schema describes it as the "
               "argument fields followed by one byte range and would place devComm wrong");
 

--- a/include/mori/ops/dispatch_combine_v2/ep_internode_args.hpp
+++ b/include/mori/ops/dispatch_combine_v2/ep_internode_args.hpp
@@ -1,0 +1,442 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+// ---------------------------------------------------------------------------
+// The internode EP kernels' argument surface.
+//
+// Same shape as EpArgs (ep_cfg.hpp), for the same reasons: one arena window
+// handle, one byte offset per region, the local buffers as plain pointers, and a
+// `name:tag` schema published from the field list so the Python binding builds
+// its struct from what C++ declares instead of keeping a parallel copy. Nothing
+// here crosses as an opaque blob except the device communicator, which is cco's
+// struct rather than EP's.
+//
+// Offsets are runtime fields, not Cfg constants. EpArgs records why, and it
+// applies unchanged here: as constants they make every arena layout its own
+// binary, and they measured SLOWER on gfx942 (VGPR 9 -> 22) because the compiler
+// stops treating the base as uniform and rematerialises the address per lane.
+//
+// Nothing in this file names anything from v1. That is the point: this header
+// and the kernel that includes it used to reach dispatch_combine.hpp for the
+// argument struct, the config, the index helpers and index_t, which cost 219
+// transitive headers on every JIT compile and carried a struct whose tail is
+// #ifdef'd on build macros the JIT toolchain never defines -- so the host library
+// and the device module could disagree about its size with nothing to catch it.
+// ---------------------------------------------------------------------------
+
+#include <hip/hip_runtime.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+
+// mori/core/utils/utils.hpp defines `warpSize` as an object-like macro, while
+// cco.hpp declares mori::cco::impl::warpSize(). Whichever lands first wins, so
+// including cco from EP code is otherwise include-order dependent. Hide the
+// macro across the cco header and restore it after.
+#pragma push_macro("warpSize")
+#undef warpSize
+#include "mori/cco/cco.hpp"
+#pragma pop_macro("warpSize")
+
+namespace mori {
+namespace ops {
+namespace v2 {
+
+// v1 spells these index_t and QuantType. Declared here so this header owns them.
+using ep_index_t = int32_t;
+
+enum class EpQuantType {
+  None = 0,
+  Fp8DirectCast = 1,
+  Fp8BlockwiseQuant = 2,
+  Fp4BlockwiseQuant = 3,
+};
+
+// ---------------------------------------------------------------------------
+// A region view: (arena window, byte offset) plus what turns a world rank into
+// an LSA one. Built on the fly from the flat args below, never stored -- which
+// is why it carries no size and why the three members are the three things an
+// access actually needs.
+// ---------------------------------------------------------------------------
+struct EpInterNodeRegion {
+  uint64_t win{0};
+  uint64_t off{0};
+  // World rank of LSA rank 0 on this node (myWorldRank - myLsaRank).
+  //
+  // GetAs(pe) takes a WORLD rank because that is what the kernel computes and
+  // what v1's peer table was indexed by; ccoGetLsaPeerPtr takes an LSA rank. On
+  // one node the two coincide and the difference is invisible. At two nodes
+  // world rank 12 is LSA rank 4, and using it unconverted reads eight slots past
+  // this rank's window -- silently, because that VA belongs to another region.
+  int32_t lsaBase{0};
+
+  __device__ __host__ const EpInterNodeRegion* operator->() const { return this; }
+  __device__ __host__ bool IsValid() const { return win != 0; }
+
+// Device-only: ccoGetLocalPtr / ccoGetLsaPeerPtr are themselves declared inside
+// cco.hpp's `#if defined(__HIPCC__)`, so a plain C++ TU cannot name them. Host
+// code only ever fills offsets, never dereferences through them.
+#if defined(__HIPCC__) || defined(__CUDACC__)
+  template <typename T>
+  __device__ __forceinline__ T GetAs() const {
+    return reinterpret_cast<T>(::mori::cco::ccoGetLocalPtr(
+        reinterpret_cast<::mori::cco::ccoWindow_t>(win), static_cast<size_t>(off)));
+  }
+
+  // The caller must already have established that `worldPe` is on this node --
+  // every call site in the kernel sits behind a `destNode != myNode` skip, and
+  // cross-node traffic goes out as (window, offset) through the RDMA path
+  // instead. A cross-node rank here does not fault, it lands somewhere else in
+  // the flat window, which is why that skip is load-bearing.
+  template <typename T>
+  __device__ __forceinline__ T GetAs(int worldPe) const {
+    return reinterpret_cast<T>(
+        ::mori::cco::ccoGetLsaPeerPtr(reinterpret_cast<::mori::cco::ccoWindow_t>(win),
+                                      worldPe - lsaBase, static_cast<size_t>(off)));
+  }
+
+  __device__ __forceinline__ void* Get() const { return GetAs<void*>(); }
+  __device__ __forceinline__ void* Get(int worldPe) const { return GetAs<void*>(worldPe); }
+#endif
+};
+
+// ---------------------------------------------------------------------------
+// The shape the kernel reads as `args.config`.
+//
+// Thirteen scalars and the derived counts the bodies call: exactly what the
+// `config.` sites touch. EpDispatchCombineConfig has 21 fields and a dozen more
+// helpers; carrying them would re-import the coupling this file removes.
+//
+// Geometry is deliberately NOT here. blockNum and warpNumPerBlock come from
+// gridDim/blockDim, and rdmaBlockNum is a per-launch field of the args below --
+// not for tidiness, but because dispatch and combine are tuned to DIFFERENT
+// values for the same op (internode_tuning_configs: at <=8 tokens dispatch runs
+// rdma=32/warp=8 while combine runs rdma=21/warp=6, and the table comment
+// records that the coupling is deliberate). Folding geometry into the config,
+// and thus later into the NTTP, would give the two phases disagreeing configs
+// over one shared arena.
+// ---------------------------------------------------------------------------
+struct EpInterNodeDeviceCfg {
+  int rank{0};
+  int worldSize{8};
+  int hiddenDim{4096};
+  int scaleDim{0};
+  int scaleTypeSize{0};
+  int maxTokenTypeSize{4};
+  int maxNumInpTokenPerRank{128};
+  int numExpertPerRank{1};
+  int numExpertPerToken{2};
+  int maxTotalRecvTokens{0};
+  int gpuPerNode{8};
+  int numQpPerPe{1};
+  EpQuantType quantType{EpQuantType::None};
+
+  __host__ __device__ int MaxNumTokensToSendPerRank() const { return maxNumInpTokenPerRank; }
+
+  __host__ __device__ int MaxNumTokensToSend() const {
+    return worldSize * MaxNumTokensToSendPerRank();
+  }
+
+  __host__ __device__ int MaxNumTokensToRecvPerRank() const {
+    if (maxTotalRecvTokens > 0) {
+      int perRank = (maxTotalRecvTokens + worldSize - 1) / worldSize;
+      return perRank < maxNumInpTokenPerRank ? perRank : maxNumInpTokenPerRank;
+    }
+    return maxNumInpTokenPerRank;
+  }
+
+  __host__ __device__ int MaxNumTokensToRecv() const {
+    return worldSize * MaxNumTokensToRecvPerRank();
+  }
+
+  // Byte accounting for one transported token. size_t on purpose: these are
+  // multiplied by token counts and the int forms overflow at shapes this kernel
+  // is expected to run.
+  __host__ __device__ size_t HiddenDimSz() const { return static_cast<size_t>(hiddenDim); }
+  __host__ __device__ size_t HiddenBytes(size_t tokenTypeSize) const {
+    return tokenTypeSize * static_cast<size_t>(hiddenDim);
+  }
+  __host__ __device__ size_t IndexBytes() const {
+    return static_cast<size_t>(numExpertPerToken) * sizeof(ep_index_t);
+  }
+  __host__ __device__ size_t WeightBytes() const {
+    return static_cast<size_t>(numExpertPerToken) * sizeof(float);
+  }
+  __host__ __device__ size_t SrcTokenIdBytes() const { return sizeof(ep_index_t); }
+  __host__ __device__ size_t ScaleBytes() const {
+    return static_cast<size_t>(scaleDim) * static_cast<size_t>(scaleTypeSize);
+  }
+  __host__ __device__ size_t XferBytesPerToken(size_t tokenTypeSize) const {
+    return HiddenBytes(tokenTypeSize) + IndexBytes() + WeightBytes() + SrcTokenIdBytes() +
+           ScaleBytes();
+  }
+  __host__ __device__ size_t MaxXferBytesPerToken() const {
+    return XferBytesPerToken(static_cast<size_t>(maxTokenTypeSize));
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Flat token indices and send-slot offsets. Pure index arithmetic over config
+// fields; ported from v1's common.hpp with only the config type changed.
+// ---------------------------------------------------------------------------
+__device__ inline int FlatTokenIndex(const EpInterNodeDeviceCfg& config, int pe, int localTokId) {
+  return pe * config.MaxNumTokensToSend() + localTokId;
+}
+__device__ inline int PeFromFlatTokenIndex(const EpInterNodeDeviceCfg& config, int flatIdx) {
+  return flatIdx / config.MaxNumTokensToSend();
+}
+__device__ inline int LocalTokIdFromFlatTokenIndex(const EpInterNodeDeviceCfg& config,
+                                                   int flatIdx) {
+  return flatIdx % config.MaxNumTokensToSend();
+}
+__device__ inline int NullFlatTokenIndex(const EpInterNodeDeviceCfg& config) {
+  return config.worldSize * config.MaxNumTokensToSend();
+}
+
+// Offset into a per-PE send staging buffer; stride is MaxNumTokensToSendPerRank,
+// which is what the host allocated per PE.
+__device__ inline int SendBufSlotOffset(const EpInterNodeDeviceCfg& config, int pe, int slotId) {
+  return pe * config.MaxNumTokensToSendPerRank() + slotId;
+}
+__device__ inline int PeFromSendBufSlotOffset(const EpInterNodeDeviceCfg& config, int flatIdx) {
+  return flatIdx / config.MaxNumTokensToSendPerRank();
+}
+__device__ inline int SlotIdFromSendBufSlotOffset(const EpInterNodeDeviceCfg& config, int flatIdx) {
+  return flatIdx % config.MaxNumTokensToSendPerRank();
+}
+__device__ inline int NullSendBufSlotOffset(const EpInterNodeDeviceCfg& config) {
+  return config.worldSize * config.MaxNumTokensToSendPerRank();
+}
+
+// ---------------------------------------------------------------------------
+// The by-value kernel argument.
+//
+// One `window`, seventeen offsets into it, the local (non-symmetric) buffers as
+// pointers, and the per-launch scalars. `reg(off)` is how a body turns an offset
+// into something addressable; it is built per access and optimises away.
+//
+// The field list is an X-macro so the schema cannot drift from the declaration:
+// the schema string, the offsetof table and the ascending-order assert below are
+// all generated from this one list.
+// ---------------------------------------------------------------------------
+#define MORI_EP_INTERNODE_ARGS_FIELDS(X) \
+  X(window, "u64")                       \
+  X(offDispatchInp, "u64")               \
+  X(offCombineInp, "u64")                \
+  X(offStaging, "u64")                   \
+  X(offDispatchOut, "u64")               \
+  X(offCombineOut, "u64")                \
+  X(offDispatchStaging, "u64")           \
+  X(offInpWeights, "u64")                \
+  X(offDispatchOutWeights, "u64")        \
+  X(offCombineOutWeights, "u64")         \
+  X(offOutIndices, "u64")                \
+  X(offRecvTokenNum, "u64")              \
+  X(offNodeRecvTokenNum, "u64")          \
+  X(offDispTokOffset, "u64")             \
+  X(offDispTokIdToSrcTokId, "u64")       \
+  X(offCrossDeviceBarrier, "u64")        \
+  X(offChunkFlag, "u64")                 \
+  X(offOutScales, "u64")                 \
+  X(rank, "i32")                         \
+  X(lsaBase, "i32")                      \
+  X(rdmaBlockNum, "i32")                 \
+  X(replayMode, "i32")                   \
+  X(curRankNumToken, "i32")              \
+  X(tokenIndices, "p")                   \
+  X(inpTokenBuf, "p")                    \
+  X(weightsBuf, "p")                     \
+  X(scalesBuf, "p")                      \
+  X(dispDestTokIdMap, "p")               \
+  X(interNodeDispDestTokIdMap, "p")      \
+  X(interNodeDispSendMap, "p")           \
+  X(interNodeChunkFlagCombine, "p")      \
+  X(destPeTokenCounter, "p")             \
+  X(blockFlagCounter, "p")               \
+  X(totalRecvTokenNum, "p")              \
+  X(dispTokIdToSrcTokIdLocal, "p")       \
+  X(dispatchGridBarrier, "p")            \
+  X(combineGridBarrier, "p")             \
+  X(interNodeBlocksBarrier, "p")         \
+  X(crossDeviceBarrierFlag, "p")
+
+#define MORI_EP_INTERNODE_ARGS_SCHEMA_ENTRY(name, tag) #name ":" tag ","
+// Trailing comma: the binding skips empty items, so there is no last-element
+// special case to get wrong.
+#define MORI_EP_INTERNODE_ARGS_SCHEMA \
+  MORI_EP_INTERNODE_ARGS_FIELDS(MORI_EP_INTERNODE_ARGS_SCHEMA_ENTRY)
+
+template <typename T>
+struct EpInterNodeArgs {
+  uint64_t window{0};
+
+  uint64_t offDispatchInp{0};
+  uint64_t offCombineInp{0};
+  uint64_t offStaging{0};
+  uint64_t offDispatchOut{0};
+  uint64_t offCombineOut{0};
+  uint64_t offDispatchStaging{0};
+  uint64_t offInpWeights{0};
+  uint64_t offDispatchOutWeights{0};
+  uint64_t offCombineOutWeights{0};
+  uint64_t offOutIndices{0};
+  uint64_t offRecvTokenNum{0};
+  uint64_t offNodeRecvTokenNum{0};
+  uint64_t offDispTokOffset{0};
+  uint64_t offDispTokIdToSrcTokId{0};
+  uint64_t offCrossDeviceBarrier{0};
+  uint64_t offChunkFlag{0};
+  // Only read when config.scaleDim > 0; the arena does not carry the region
+  // otherwise, so this stays 0 and nothing dereferences it.
+  uint64_t offOutScales{0};
+
+  // Which world rank this is. Runtime, not Cfg, for the reason EpArgs gives:
+  // as a compiled-in constant every rank on a node builds its own copy of an
+  // identical kernel.
+  int32_t rank{0};
+  int32_t lsaBase{0};
+  int32_t rdmaBlockNum{-1};
+  // i32 rather than bool: the schema's scalar tags are fixed-width, and a
+  // one-byte field would put every pointer after it at a different offset than
+  // the binding computes.
+  int32_t replayMode{0};
+  int32_t curRankNumToken{0};
+
+  ep_index_t* tokenIndices{nullptr};
+  T* inpTokenBuf{nullptr};
+  float* weightsBuf{nullptr};
+  uint8_t* scalesBuf{nullptr};
+
+  // Local, non-symmetric. interNodeChunkFlagCombine is NOT the local half of
+  // offChunkFlag despite the name: the symmetric one is written by dispatch and
+  // read+cleared by combine (combine enumerates its work from dispatch's
+  // leftover flags and has no producer of its own), while this one counts
+  // completions. Different types, different lifetimes; pairing them by name
+  // leaves combine with an all-zero work list and a hang.
+  ep_index_t* dispDestTokIdMap{nullptr};
+  ep_index_t* interNodeDispDestTokIdMap{nullptr};
+  ep_index_t* interNodeDispSendMap{nullptr};
+  ep_index_t* interNodeChunkFlagCombine{nullptr};
+  ep_index_t* destPeTokenCounter{nullptr};
+  ep_index_t* blockFlagCounter{nullptr};
+  ep_index_t* totalRecvTokenNum{nullptr};
+  ep_index_t* dispTokIdToSrcTokIdLocal{nullptr};
+  uint32_t* dispatchGridBarrier{nullptr};
+  uint32_t* combineGridBarrier{nullptr};
+  uint32_t* interNodeBlocksBarrier{nullptr};
+  uint64_t* crossDeviceBarrierFlag{nullptr};
+
+  // An offset as something addressable. Built per access; the three members are
+  // all the accessors need, so this costs nothing at -O2.
+  __device__ __host__ EpInterNodeRegion reg(uint64_t off) const {
+    return EpInterNodeRegion{window, off, lsaBase};
+  }
+};
+
+// The untyped spelling. T appears in one member, so every instantiation has the
+// same layout -- which is what lets the host, the schema and the plan
+// registration name one non-template type while each kernel reads its own T.
+using EpInterNodeArgsRaw = EpInterNodeArgs<void>;
+
+static_assert(sizeof(EpInterNodeArgs<float>) == sizeof(EpInterNodeArgsRaw),
+              "EpInterNodeArgs must be layout-identical across T");
+static_assert(alignof(EpInterNodeArgs<float>) == alignof(EpInterNodeArgsRaw),
+              "EpInterNodeArgs alignment must not depend on T");
+
+namespace detail {
+
+#define MORI_EP_INTERNODE_ARGS_OFFSET(name, tag) \
+  offsetof(::mori::ops::v2::EpInterNodeArgsRaw, name),
+inline constexpr size_t kEpInterNodeArgsOffsets[] = {
+    MORI_EP_INTERNODE_ARGS_FIELDS(MORI_EP_INTERNODE_ARGS_OFFSET)};
+#undef MORI_EP_INTERNODE_ARGS_OFFSET
+
+constexpr size_t kEpInterNodeArgsFieldCount =
+    sizeof(kEpInterNodeArgsOffsets) / sizeof(kEpInterNodeArgsOffsets[0]);
+
+constexpr bool EpInterNodeArgsOffsetsAscend() {
+  for (size_t i = 1; i < kEpInterNodeArgsFieldCount; ++i)
+    if (kEpInterNodeArgsOffsets[i] <= kEpInterNodeArgsOffsets[i - 1]) return false;
+  return true;
+}
+
+}  // namespace detail
+
+static_assert(detail::kEpInterNodeArgsFieldCount == 39,
+              "added an EpInterNodeArgs field -- add it to MORI_EP_INTERNODE_ARGS_FIELDS in "
+              "the same position and bump this count");
+static_assert(detail::EpInterNodeArgsOffsetsAscend(),
+              "MORI_EP_INTERNODE_ARGS_FIELDS is not in declaration order -- the binding "
+              "would write each argument into the wrong slot");
+
+// What crosses into a JIT module: the arguments plus the communicator. Passing
+// the comm by value is the point of the CCO port; mori-shmem needed a device
+// global filled by the host after every hipModuleLoad. It is the one opaque
+// member, because it is cco's struct and not EP's to name.
+struct EpInterNodeCcoArgs {
+  EpInterNodeArgsRaw args;
+  ::mori::cco::ccoDevComm devComm;
+};
+
+static_assert(sizeof(EpInterNodeCcoArgs) ==
+                  sizeof(EpInterNodeArgsRaw) + sizeof(::mori::cco::ccoDevComm),
+              "EpInterNodeCcoArgs has interior padding -- the schema describes it as the "
+              "argument fields followed by one byte range and would place devComm wrong");
+
+// Partitions a loop over (numItems x dimSize) work across globalWarpNum warps.
+// When there are more warps than items, multiple warps collaborate on a single item
+// by splitting dimSize; when there are fewer warps, each warp handles multiple items.
+struct MultiWarpIter {
+  int warpsPerItem;
+  size_t dimPerWarp;
+  size_t dimSize;
+
+  // dimGranularity rounds dimPerWarp up to a multiple of itself, so callers doing
+  // vectorized loads get every warp's slice starting on a vector boundary and
+  // sized in whole vector steps.
+  inline __device__ MultiWarpIter(int globalWarpNum, int numItems, size_t dimSize_,
+                                  size_t dimGranularity = 1)
+      : dimSize(dimSize_) {
+    warpsPerItem = (globalWarpNum + numItems - 1) / numItems;
+    dimPerWarp = (dimSize + warpsPerItem - 1) / warpsPerItem;
+    if (dimGranularity > 1) {
+      dimPerWarp = ((dimPerWarp + dimGranularity - 1) / dimGranularity) * dimGranularity;
+      // A coarser slice means fewer warps are actually needed; keep warpsPerItem
+      // consistent with dimPerWarp or the tail warps decode to empty ranges.
+      warpsPerItem = static_cast<int>((dimSize + dimPerWarp - 1) / dimPerWarp);
+    }
+  }
+
+  inline __device__ void Decode(int i, int& itemId, int& inItemPartId, size_t& dimOffset,
+                                size_t& dimChunk) const {
+    itemId = i / warpsPerItem;
+    inItemPartId = i % warpsPerItem;
+    dimOffset = (size_t)inItemPartId * dimPerWarp;
+    dimChunk = (dimOffset < dimSize) ? std::min(dimSize - dimOffset, dimPerWarp) : size_t{0};
+  }
+};
+
+}  // namespace v2
+}  // namespace ops
+}  // namespace mori

--- a/include/mori/ops/dispatch_combine_v2/ep_internode_cfg.hpp
+++ b/include/mori/ops/dispatch_combine_v2/ep_internode_cfg.hpp
@@ -169,17 +169,16 @@ struct EpInterNodeKernelCfg {
   EpQuantType quantType{EpQuantType::None};
 };
 
-// The device-side config the bodies read, built from the compiled-in shape plus
-// the one value that is genuinely per-rank.
+// The device-side config the bodies read: purely the compiled-in shape, so the
+// result is constexpr and every field folds to a literal at its use.
 //
 // This replaces EpInterNodeBindConfig, which used to copy the same twelve fields
 // over a by-value args member at kernel entry so the optimiser could constant-
 // fold them. Constructing it from kConfig directly says the same thing without
 // carrying 56 bytes of kernarg that the host fills and the kernel immediately
 // overwrites -- a duplication that had to agree and had nothing checking it.
-constexpr EpInterNodeDeviceCfg EpInterNodeDeviceCfgOf(const EpInterNodeKernelCfg& k, int rank) {
+constexpr EpInterNodeDeviceCfg EpInterNodeDeviceCfgOf(const EpInterNodeKernelCfg& k) {
   EpInterNodeDeviceCfg d{};
-  d.rank = rank;
   d.worldSize = k.worldSize;
   d.hiddenDim = k.hiddenDim;
   d.scaleDim = k.scaleDim;

--- a/include/mori/ops/dispatch_combine_v2/ep_internode_cfg.hpp
+++ b/include/mori/ops/dispatch_combine_v2/ep_internode_cfg.hpp
@@ -30,10 +30,11 @@
 // either. Attribute-free and standard C++ -- no __host__/__device__ here, or
 // every host TU that touches a Cfg would need hipcc.
 //
-// Kept separate from ep_cfg.hpp rather than merged: dispatch_combine.hpp below
-// costs ~200 headers (`hipcc -E -H`: 14 for ep_cfg.hpp, 219 here), and merging
-// would charge that, and the warpSize dance, to the intranode kernels on every
-// JIT compile.
+// Kept separate from ep_cfg.hpp rather than merged: this one pulls cco.hpp (and
+// the warpSize dance around it) for the device communicator, and merging would
+// charge that to the intranode kernels on every JIT compile. It no longer pulls
+// v1 -- ep_internode_args.hpp owns the argument struct, the config the bodies
+// read, index_t and QuantType.
 // ---------------------------------------------------------------------------
 #pragma once
 
@@ -41,7 +42,7 @@
 #include <string>
 
 #include "mori/jit/v2/render.hpp"
-#include "mori/ops/dispatch_combine/dispatch_combine.hpp"
+#include "mori/ops/dispatch_combine_v2/ep_internode_args.hpp"
 
 // cco.hpp declares mori::cco::impl::warpSize(); mori/core/utils/utils.hpp may
 // already have defined `warpSize` as a macro. See ep_internode_kernel.hpp.
@@ -51,27 +52,24 @@
 #pragma pop_macro("warpSize")
 
 namespace mori {
-namespace moe {
-
-// jit::v2::Fields calls RenderValue unqualified, so the overload for a config
-// enum has to live in the enum's own namespace for ADL to find it.
-inline std::string RenderValue(QuantType q) {
-  switch (q) {
-    case QuantType::Fp8DirectCast:
-      return "::mori::moe::QuantType::Fp8DirectCast";
-    case QuantType::Fp8BlockwiseQuant:
-      return "::mori::moe::QuantType::Fp8BlockwiseQuant";
-    case QuantType::Fp4BlockwiseQuant:
-      return "::mori::moe::QuantType::Fp4BlockwiseQuant";
-    default:
-      return "::mori::moe::QuantType::None";
-  }
-}
-
-}  // namespace moe
-
 namespace ops {
 namespace v2 {
+
+// jit::v2::Fields calls RenderValue unqualified, so the overload for a config
+// enum has to live in the enum's own namespace for ADL to find it. That is
+// mori::ops::v2 now that EpQuantType is v2's own enum rather than v1's.
+inline std::string RenderValue(EpQuantType q) {
+  switch (q) {
+    case EpQuantType::Fp8DirectCast:
+      return "::mori::ops::v2::EpQuantType::Fp8DirectCast";
+    case EpQuantType::Fp8BlockwiseQuant:
+      return "::mori::ops::v2::EpQuantType::Fp8BlockwiseQuant";
+    case EpQuantType::Fp4BlockwiseQuant:
+      return "::mori::ops::v2::EpQuantType::Fp4BlockwiseQuant";
+    default:
+      return "::mori::ops::v2::EpQuantType::None";
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Transported element type. v1 keeps the two fp8 encodings and fp4 apart, which
@@ -168,8 +166,34 @@ struct EpInterNodeKernelCfg {
   int maxTotalRecvTokens{0};
   int gpuPerNode{8};
   int numQpPerPe{1};
-  mori::moe::QuantType quantType{mori::moe::QuantType::None};
+  EpQuantType quantType{EpQuantType::None};
 };
+
+// The device-side config the bodies read, built from the compiled-in shape plus
+// the one value that is genuinely per-rank.
+//
+// This replaces EpInterNodeBindConfig, which used to copy the same twelve fields
+// over a by-value args member at kernel entry so the optimiser could constant-
+// fold them. Constructing it from kConfig directly says the same thing without
+// carrying 56 bytes of kernarg that the host fills and the kernel immediately
+// overwrites -- a duplication that had to agree and had nothing checking it.
+constexpr EpInterNodeDeviceCfg EpInterNodeDeviceCfgOf(const EpInterNodeKernelCfg& k, int rank) {
+  EpInterNodeDeviceCfg d{};
+  d.rank = rank;
+  d.worldSize = k.worldSize;
+  d.hiddenDim = k.hiddenDim;
+  d.scaleDim = k.scaleDim;
+  d.scaleTypeSize = k.scaleTypeSize;
+  d.maxTokenTypeSize = k.maxTokenTypeSize;
+  d.maxNumInpTokenPerRank = k.maxNumInpTokenPerRank;
+  d.numExpertPerRank = k.numExpertPerRank;
+  d.numExpertPerToken = k.numExpertPerToken;
+  d.maxTotalRecvTokens = k.maxTotalRecvTokens;
+  d.gpuPerNode = k.gpuPerNode;
+  d.numQpPerPe = k.numQpPerPe;
+  d.quantType = k.quantType;
+  return d;
+}
 
 template <typename Self, typename Visit>
 inline void VisitFields(Self& c, const EpInterNodeKernelCfg& d, Visit&& v) {
@@ -227,22 +251,6 @@ inline bool operator==(const EpInterNodeKernelCfg& a, const EpInterNodeKernelCfg
 // those two disagree the moment a caller passes hidden_dim -- and since the
 // kernel's EpInterNodeBindConfig OVERWRITES args.config with the NTTP, sourcing the
 // constants from the stale one silently runs the kernel against other numbers.
-inline EpInterNodeKernelCfg MakeEpInterNodeKernelCfg(const mori::moe::EpDispatchCombineConfig& c) {
-  EpInterNodeKernelCfg s;
-  s.worldSize = c.worldSize;
-  s.hiddenDim = c.hiddenDim;
-  s.scaleDim = c.scaleDim;
-  s.scaleTypeSize = c.scaleTypeSize;
-  s.maxTokenTypeSize = c.maxTokenTypeSize;
-  s.maxNumInpTokenPerRank = c.maxNumInpTokenPerRank;
-  s.numExpertPerRank = c.numExpertPerRank;
-  s.numExpertPerToken = c.numExpertPerToken;
-  s.maxTotalRecvTokens = c.maxTotalRecvTokens;
-  s.gpuPerNode = c.gpuPerNode;
-  s.numQpPerPe = c.numQpPerPe;
-  s.quantType = c.quantType;
-  return s;
-}
 
 // A zero in any divisor is a division by a literal zero once the cfg is an
 // NTTP -- hipcc either rejects the TU or emits a poison value, and neither
@@ -258,35 +266,21 @@ inline bool EpInterNodeKernelCfgIsValid(const EpInterNodeKernelCfg& s) {
 // ep_internode_kernel.hpp includes this header rather than redeclaring it, so
 // the two cannot disagree about the layout.
 //
-// EpDispatchCombineArgsRaw is what the AOT launcher already passes, and it is
-// static_asserted to share a layout with EpDispatchCombineArgs<T>. The device
-// communicator rides alongside it because that is how a JIT module gets its
-// endpoints.
+// EpInterNodeCcoArgs itself now lives in ep_internode_args.hpp, next to the
+// argument struct it wraps: it is device-side shape, and keeping it there is
+// what lets this header stop including v1 entirely.
 // ---------------------------------------------------------------------------
-struct EpInterNodeCcoArgs {
-  mori::moe::EpDispatchCombineArgsRaw raw;
-  ::mori::cco::ccoDevComm devComm;
-};
-
-static_assert(
-    sizeof(EpInterNodeCcoArgs) ==
-        sizeof(mori::moe::EpDispatchCombineArgsRaw) + sizeof(::mori::cco::ccoDevComm),
-    "EpInterNodeCcoArgs has interior padding -- EpInterNodeArgsSchema() describes it as two "
-    "back-to-back byte ranges and would place devComm at the wrong offset");
 
 // The args schema, in the form plan_api publishes.
 //
-// EpArgs crosses as 22 named scalars because it was designed for this boundary.
-// These args cannot: every value in them is produced by EpDispatchCombineHandle
-// (53 fields, 15 of them SymmMemObjPtr, 3 nested ShmemBufs*), and a caller on
-// the far side of the ABI holds them only as the opaque buffer BuildArgs hands
-// back. So they cross as byte ranges -- named, sized, and size-checked against
-// C++'s own sizeof like any other schema, but copied wholesale rather than
-// filled field by field.
+// Named fields, exactly like EpArgs: the field list, this string and the
+// offset-order assert are all generated from MORI_EP_INTERNODE_ARGS_FIELDS in
+// ep_internode_args.hpp, so the binding builds its ctypes struct from what C++
+// declares rather than from a parallel copy. The one byte range is devComm,
+// which is cco's struct and not EP's to name.
 inline const char* EpInterNodeArgsSchema() {
-  static const std::string s = "raw:b" +
-                               std::to_string(sizeof(mori::moe::EpDispatchCombineArgsRaw)) +
-                               ",devComm:b" + std::to_string(sizeof(::mori::cco::ccoDevComm)) + ",";
+  static const std::string s = std::string(MORI_EP_INTERNODE_ARGS_SCHEMA) + "devComm:b" +
+                               std::to_string(sizeof(::mori::cco::ccoDevComm)) + ",";
   return s.c_str();
 }
 

--- a/include/mori/ops/dispatch_combine_v2/ep_internode_spec.hpp
+++ b/include/mori/ops/dispatch_combine_v2/ep_internode_spec.hpp
@@ -62,7 +62,6 @@ struct EpInterNodeCfg {
   EpInterNodeDType dtype{EpInterNodeDType::Bf16};
   // Only meaningful for the LL dispatch/combine pair, which the standard-MoE
   // adapter specialises on; the other six entries ignore it.
-  bool enableStdMoE{false};
 
   // ---- launch geometry (host-derived; see MakeEpInterNodeCfg). NOT rendered. ----
   int blockNum{64};
@@ -82,7 +81,6 @@ inline void VisitFields(Self& c, const EpInterNodeCfg& d, Visit&& v) {
 #define MORI_FIELD(x) v(#x, c.x, d.x)
   MORI_FIELD(kernelCfg);
   MORI_FIELD(dtype);
-  MORI_FIELD(enableStdMoE);
   MORI_FIELD(blockNum);
   MORI_FIELD(warpPerBlock);
   MORI_FIELD(rdmaBlockNum);
@@ -92,7 +90,7 @@ inline void VisitFields(Self& c, const EpInterNodeCfg& d, Visit&& v) {
 }
 
 MORI_JIT_ASSERT_FIELD_COUNT(
-    EpInterNodeCfg, 8, "added an EpInterNodeCfg field -- update VisitFields(EpInterNodeCfg) too");
+    EpInterNodeCfg, 7, "added an EpInterNodeCfg field -- update VisitFields(EpInterNodeCfg) too");
 
 // The whole Cfg as text, for the plan's `info` and for logs. NOT the source
 // text: RenderSource renders kernelCfg alone, because geometry must not enter
@@ -149,15 +147,15 @@ constexpr int EpInterNodeDispatchSharedBytes(const EpInterNodeCfg& c) {
   const int wpb = c.warpPerBlock;
   return (c.kernelCfg.worldSize * wpb + c.kernelCfg.numExpertPerRank * wpb +
           c.kernelCfg.numExpertPerRank) *
-         static_cast<int>(sizeof(mori::moe::index_t));
+         static_cast<int>(sizeof(ep_index_t));
 }
 
 // Combine's pointer arrays: one per warp for the topk sources, a second for the
 // weights, a third for the scales when the quant type is blockwise. Mirrors
 // combine_shared_mem() in launch.cpp with use_weight_ptrs=true.
 constexpr int EpInterNodeCombineSharedBytes(const EpInterNodeCfg& c) {
-  const bool blockwise = c.kernelCfg.quantType == mori::moe::QuantType::Fp8BlockwiseQuant ||
-                         c.kernelCfg.quantType == mori::moe::QuantType::Fp4BlockwiseQuant;
+  const bool blockwise = c.kernelCfg.quantType == EpQuantType::Fp8BlockwiseQuant ||
+                         c.kernelCfg.quantType == EpQuantType::Fp4BlockwiseQuant;
   const int ptrArrays = 2 + (blockwise ? 1 : 0);
   return c.warpPerBlock * c.kernelCfg.numExpertPerToken * ptrArrays * 8;
 }
@@ -180,10 +178,9 @@ struct EpInterNodeRequest {
   int maxTotalRecvTokens = 0;
   int gpuPerNode = 8;
   int numQpPerPe = 1;
-  mori::moe::QuantType quantType = mori::moe::QuantType::None;
+  EpQuantType quantType = EpQuantType::None;
   // specialisation
   EpInterNodeDType dtype = EpInterNodeDType::Bf16;
-  bool enableStdMoE = false;
   // geometry; 0 = the placeholder MakeEpInterNodeCfg picks
   int blockNum = 0;
   int warpPerBlock = 0;
@@ -207,7 +204,6 @@ inline void VisitFields(Self& r, const EpInterNodeRequest& d, Visit&& v) {
   MORI_FIELD(numQpPerPe);
   MORI_FIELD(quantType);
   MORI_FIELD(dtype);
-  MORI_FIELD(enableStdMoE);
   MORI_FIELD(blockNum);
   MORI_FIELD(warpPerBlock);
   MORI_FIELD(rdmaBlockNum);
@@ -216,7 +212,7 @@ inline void VisitFields(Self& r, const EpInterNodeRequest& d, Visit&& v) {
 }
 
 MORI_JIT_ASSERT_FIELD_COUNT(
-    EpInterNodeRequest, 18,
+    EpInterNodeRequest, 17,
     "added an EpInterNodeRequest field -- update VisitFields(EpInterNodeRequest) too");
 
 std::string EpInterNodeRequestSchema();

--- a/python/mori/jit/v2/plan_api.py
+++ b/python/mori/jit/v2/plan_api.py
@@ -732,16 +732,16 @@ class LaunchGroup:
     def launch(self, stream=0, **args) -> None:
         """Fill the shared argument struct once, then launch every plan in order."""
         buf = self._lead._launch_buf(args)
+        # The stream parameter is declared c_void_p in argtypes, so ctypes does
+        # the conversion at the boundary and an int passes straight through.
+        # Wrapping it in a c_void_p here built a Python object per launch only for
+        # ctypes to unwrap it again. Only a non-int still needs _as_ptr.
         rc = self._fn(
             self._handles,
             self._n,
             ctypes.byref(buf),
             self._argsize,
-            (
-                ctypes.c_void_p(stream)
-                if isinstance(stream, int)
-                else ctypes.c_void_p(_as_ptr(stream))
-            ),
+            stream if type(stream) is int else _as_ptr(stream),
         )
         if rc != 0:
             raise RuntimeError(f"mori jit launch_multi: {_error()}")

--- a/python/mori/jit/v2/plan_api.py
+++ b/python/mori/jit/v2/plan_api.py
@@ -674,6 +674,79 @@ def make_plan(kernel: str, enums: dict | None = None) -> type:
     return Plan
 
 
+def _args_layout(plan):
+    """The plan's args layout as (name, offset, size) per field.
+
+    Not `sizeof`. Eight of the fields are bare pointers, so two schemas that swap
+    a pair of same-typed fields have identical size and a caller filling one and
+    launching the other reads the wrong buffer in silence -- the exact failure the
+    ascending-offset static_assert exists to catch on the C++ side.
+    """
+    t = plan._args_t
+    return tuple((n, getattr(t, n).offset, getattr(t, n).size) for n in plan._arg_names)
+
+
+class LaunchGroup:
+    """A fixed set of plans over one args layout, validated once.
+
+    `launch_multi` redoes per call what depends only on the set: copying the plan
+    list, checking every handle, comparing every args layout, building the ctypes
+    handle array. A serving loop holds the set fixed -- one per (phase, geometry)
+    -- so it belongs here, leaving the launch path with the argument fill and the
+    one ABI crossing. Measured on the EP internode sequence, that per-call work
+    was ~17us against kernels of ~40us.
+
+    The group keeps its plans alive, so a handle cannot dangle by garbage
+    collection. Explicitly `close()`ing a plan still invalidates every group over
+    it; there is no per-launch check for that, which is the point.
+    """
+
+    __slots__ = ("_plans", "_lead", "_handles", "_n", "_argsize")
+
+    def __init__(self, plans):
+        plans = list(plans)
+        if not plans:
+            raise ValueError("launch group needs at least one plan")
+        for i, p in enumerate(plans):
+            if p._handle is None:
+                raise RuntimeError(f"launch group over a closed plan at index {i}")
+        lead = plans[0]
+        want = _args_layout(lead)
+        for i, p in enumerate(plans[1:], 1):
+            got = _args_layout(p)
+            if got != want:
+                diff = [a for a, b in zip(want, got) if a != b] or ["field count"]
+                raise ValueError(
+                    f"launch group: plan {i} ({p._kernel}) does not share "
+                    f"{lead._kernel}'s args layout; first difference at {diff[0]}"
+                )
+        self._plans = plans
+        self._lead = lead
+        self._n = len(plans)
+        self._handles = (ctypes.c_void_p * self._n)(*[p._handle.value for p in plans])
+        self._argsize = ctypes.sizeof(lead._args_t)
+
+    def launch(self, stream=0, **args) -> None:
+        """Fill the shared argument struct once, then launch every plan in order."""
+        buf = self._lead._launch_buf(args)
+        rc = _load().mori_jit_plan_launch_multi(
+            self._handles,
+            self._n,
+            ctypes.byref(buf),
+            self._argsize,
+            ctypes.c_void_p(_as_ptr(stream)),
+        )
+        if rc != 0:
+            raise RuntimeError(f"mori jit launch_multi: {_error()}")
+
+    __call__ = launch
+
+
+def make_launch_group(plans) -> LaunchGroup:
+    """Bind a fixed plan sequence for repeated launching. See LaunchGroup."""
+    return LaunchGroup(plans)
+
+
 def launch_multi(plans, stream=0, **args) -> None:
     """Launch several plans that share one args schema, with a single ABI crossing.
 
@@ -691,25 +764,7 @@ def launch_multi(plans, stream=0, **args) -> None:
     plans = list(plans)
     if not plans:
         return
-    lead = plans[0]
-    if any(p._handle is None for p in plans):
-        raise RuntimeError("launch_multi on a closed plan")
-    lead_size = ctypes.sizeof(lead._args_t)
-    if any(ctypes.sizeof(p._args_t) != lead_size for p in plans):
-        raise ValueError("launch_multi: plans do not share one args layout")
-
-    buf = lead._launch_buf(args)
-    n = len(plans)
-    handles = (ctypes.c_void_p * n)(*[p._handle.value for p in plans])
-    rc = _load().mori_jit_plan_launch_multi(
-        handles,
-        n,
-        ctypes.byref(buf),
-        ctypes.sizeof(buf),
-        ctypes.c_void_p(_as_ptr(stream)),
-    )
-    if rc != 0:
-        raise RuntimeError(f"mori jit launch_multi: {_error()}")
+    LaunchGroup(plans).launch(stream, **args)
 
 
 def precompile(kernel: str, arch: str | None = None) -> int:

--- a/python/mori/jit/v2/plan_api.py
+++ b/python/mori/jit/v2/plan_api.py
@@ -492,6 +492,7 @@ def make_plan(kernel: str, enums: dict | None = None) -> type:
             # bind(), so pinned arguments are never served from a stale cache.
             self._buf = None
             self._buf_shape = None
+            self._last = {}
             self._dyn_args = ()
             self._dyn_defs = ()
             # Known at construction, so the caller need not repeat them per launch.
@@ -593,10 +594,34 @@ def make_plan(kernel: str, enums: dict | None = None) -> type:
                     for w, v in self._defaults.items()
                     if w in arg_names and (not isinstance(v, int) or w in arg_blobs)
                 )
+                self._last = {}
             else:
                 buf = self._buf
+                last = self._last
                 for k, wire in self._dyn_args:
-                    _set_arg(buf, wire, args[k])
+                    v = args[k]
+                    # Skip a field whose INT value is what is already in the
+                    # buffer. Same reasoning as the _dyn_defs filter above: the
+                    # struct persists between launches, so re-writing an
+                    # unchanged int is pure cost. A caller that hands over
+                    # tensor addresses (every EP one does -- hip_backend passes
+                    # .data_ptr() results) repeats them every round, and each
+                    # write costs a Python call, a dict lookup, a hasattr and a
+                    # setattr. A moved allocation changes the int, misses here,
+                    # and is written.
+                    #
+                    # NOT for a blob: it crosses by value, and an unchanged
+                    # address is no evidence the bytes behind it held still.
+                    # NOT for a non-int either -- resolving it is the only way to
+                    # know its address, and `!=` on a tensor does not even return
+                    # a bool.
+                    if type(v) is int and wire not in arg_blobs:
+                        if last.get(wire) == v:
+                            continue
+                        _set_arg(buf, wire, v)
+                        last[wire] = v
+                    else:
+                        _set_arg(buf, wire, v)
                 for wire in self._dyn_defs:
                     _set_arg(buf, wire, self._defaults[wire])
             return buf

--- a/python/mori/jit/v2/plan_api.py
+++ b/python/mori/jit/v2/plan_api.py
@@ -701,7 +701,7 @@ class LaunchGroup:
     it; there is no per-launch check for that, which is the point.
     """
 
-    __slots__ = ("_plans", "_lead", "_handles", "_n", "_argsize")
+    __slots__ = ("_plans", "_lead", "_handles", "_n", "_argsize", "_fn")
 
     def __init__(self, plans):
         plans = list(plans)
@@ -725,16 +725,23 @@ class LaunchGroup:
         self._n = len(plans)
         self._handles = (ctypes.c_void_p * self._n)(*[p._handle.value for p in plans])
         self._argsize = ctypes.sizeof(lead._args_t)
+        # Bind the entry point too. `_load()` is memoised but still a call and a
+        # lookup per launch, on a path measured at ~14us a call.
+        self._fn = _load().mori_jit_plan_launch_multi
 
     def launch(self, stream=0, **args) -> None:
         """Fill the shared argument struct once, then launch every plan in order."""
         buf = self._lead._launch_buf(args)
-        rc = _load().mori_jit_plan_launch_multi(
+        rc = self._fn(
             self._handles,
             self._n,
             ctypes.byref(buf),
             self._argsize,
-            ctypes.c_void_p(_as_ptr(stream)),
+            (
+                ctypes.c_void_p(stream)
+                if isinstance(stream, int)
+                else ctypes.c_void_p(_as_ptr(stream))
+            ),
         )
         if rc != 0:
             raise RuntimeError(f"mori jit launch_multi: {_error()}")

--- a/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
+++ b/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
@@ -844,12 +844,17 @@ class EpDispatchCombineOp:
 
         # A live arena view: the reverse map is cloned lazily on first access,
         # which must happen after the caller's post-dispatch barrier (see
-        # EpDispatchRoutingHandle).
-        reverse = from_gpu_ptr(
-            self.arena.local_ptr(self._region("recv_to_src_token")),
-            (self._recv_cap,),
-            torch.int32,
-        )
+        # EpDispatchRoutingHandle). Built once -- the pointer and the shape are
+        # fixed for the op's lifetime, and rebuilding it per dispatch is pure
+        # host cost on a path where the host already paces the GPU.
+        reverse = getattr(self, "_reverse_view", None)
+        if reverse is None:
+            reverse = from_gpu_ptr(
+                self.arena.local_ptr(self._region("recv_to_src_token")),
+                (self._recv_cap,),
+                torch.int32,
+            )
+            self._reverse_view = reverse
         handle = EpDispatchRoutingHandle(
             disp_dest_tok_id_map=dest_map,
             inter_node_disp_dest_tok_id_map=self._empty_i32,

--- a/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
+++ b/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
@@ -162,7 +162,14 @@ class EpDispatchCombineConfig:
             raise ValueError(
                 f"combine_mode must be gather|scatter, got {self.combine_mode!r}"
             )
-        if self.quant_type != "none":
+        # Intranode only. There, a quantised combine scatters: each destination
+        # writes its own partial back. The internode fp8_direct_cast combine does
+        # not -- fp8 is the *staging* format, the accumulation is still a gather
+        # (EpCombineAllInternalFp8 reduces nNodes slots into one bf16 output), and
+        # its T stays the combine dtype. Forcing scatter here made
+        # quant_type='fp8_direct_cast' unreachable on the internode path: the
+        # backend accepts it, then rejects the scatter this rule had just set.
+        if self.quant_type != "none" and not self.is_internode:
             self.combine_mode = "scatter"
         # Token copy moves whole 16 B (vec4) chunks; a non-16 B-aligned per-token
         # size would over-read/write a few dwords past the token.

--- a/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
+++ b/python/mori/ops/dispatch_combine_v2/dispatch_combine_op.py
@@ -105,6 +105,25 @@ class EpDispatchCombineConfig:
     schedule: tuple = None
     enable_std_moe: bool = False
     max_total_recv_tokens: int = 0  # mori maxTotalRecvTokens; 0 = worst-case ws*M
+    # --- internode -----------------------------------------------------------
+    # GPUs per physical node. None => one node (== world_size), which is what
+    # every intranode config is and keeps their behaviour unchanged. Setting it
+    # smaller is what selects the internode path: it is EP's own idea of a node
+    # and must agree with the communicator's LSA team, which the op checks at
+    # construction rather than assuming.
+    gpu_per_node: int = None
+    # QPs per peer on the RDMA leg. Only read on the internode path; the default
+    # of 1 starves it (~1.5x) but is the safe value for a config that never
+    # reaches RDMA.
+    num_qp_per_pe: int = 1
+    # Widest transported element, which is what sizes the staging buffers. None
+    # => max over the two legs, which is what the buffers actually have to hold.
+    max_token_type_size: int = None
+    # RDMA-block split of the grid, per phase. Runtime, never compiled in:
+    # dispatch and combine are deliberately tuned to DIFFERENT values (see
+    # internode_tuning_configs), so one compiled-in value cannot serve both.
+    dispatch_rdma_block_num: int = None
+    combine_rdma_block_num: int = None
     # Which kernel backend serves this op: "flydsl" (default, full feature set)
     # or "hip" (HIP/JIT, bf16/fp32 gather only). None = MORI_V2_KERNEL_BACKEND,
     # else the default. Only consulted when constructing the BASE class; naming a
@@ -112,6 +131,20 @@ class EpDispatchCombineConfig:
     kernel_backend: str = None
 
     def __post_init__(self):
+        # Node grouping first: is_internode gates checks further down, and the
+        # derived defaults below are cheaper to reason about once it is fixed.
+        if self.gpu_per_node is None:
+            self.gpu_per_node = self.world_size
+        if self.gpu_per_node <= 0 or self.world_size % self.gpu_per_node:
+            raise ValueError(
+                f"world_size ({self.world_size}) must be a positive multiple of "
+                f"gpu_per_node ({self.gpu_per_node}); EP addresses a peer as "
+                "node * gpu_per_node + local rank and a partial node has no such "
+                "encoding"
+            )
+        if self.num_qp_per_pe < 1:
+            raise ValueError(f"num_qp_per_pe must be >= 1, got {self.num_qp_per_pe}")
+
         # all-or-none: setting only one silently defaults the other to data_type.
         if (self.dispatch_data_type is None) != (self.combine_data_type is None):
             raise ValueError(
@@ -164,6 +197,12 @@ class EpDispatchCombineConfig:
                     f"combine per-token bytes must be 16 B aligned; combine_data_type="
                     f"{self.combine_data_type} -> {self.combine_token_nbytes}"
                 )
+        # The staging buffers hold whichever leg is wider, so that is the default.
+        # Left settable because v1 configs pass it explicitly and the two must
+        # agree for the arena sizes to match.
+        if self.max_token_type_size is None:
+            self.max_token_type_size = max(self.elem_size, self.combine_elem_size)
+
         self._resolve_geometry()
 
     def _resolve_geometry(self):
@@ -186,6 +225,27 @@ class EpDispatchCombineConfig:
                 self.combine_warp_num_per_block,
             )
         )
+        if self.is_internode:
+            # The intranode tables are keyed on a single node's geometry and
+            # carry no rdma_block_num, so they have nothing to say about this
+            # config. Internode geometry comes from internode_tuning_configs,
+            # which the backend applies per phase and per token count -- and
+            # which keeps dispatch and combine on DIFFERENT rdma/warp values,
+            # something a single `schedule` tuple cannot express.
+            self.schedule = None
+            if self.dispatch_block_num is None:
+                self.dispatch_block_num = 96
+            if self.combine_block_num is None:
+                self.combine_block_num = 96
+            if self.warp_num_per_block is None:
+                self.warp_num_per_block = 8
+            if self.combine_warp_num_per_block is None:
+                self.combine_warp_num_per_block = 8
+            if self.dispatch_rdma_block_num is None:
+                self.dispatch_rdma_block_num = 64
+            if self.combine_rdma_block_num is None:
+                self.combine_rdma_block_num = 64
+            return
         if not pinned:
             backend = (
                 self.kernel_backend
@@ -245,6 +305,21 @@ class EpDispatchCombineConfig:
                 f"wave = {max_peers} threads); the `tid < npes` barrier requires "
                 f"world_size <= blockDim"
             )
+
+    @property
+    def nodes(self):
+        """Physical nodes this op spans. 1 for every intranode config."""
+        return self.world_size // self.gpu_per_node
+
+    @property
+    def is_internode(self):
+        """True when some peer is not reachable over the flat LSA VA.
+
+        This is the whole selector: there is no kernel_type enum on the v2 side.
+        A config whose world fits in one node takes the intranode kernels even if
+        gpu_per_node was passed explicitly.
+        """
+        return self.nodes > 1
 
     @property
     def is_scatter(self):
@@ -575,6 +650,16 @@ class EpDispatchCombineOp:
         """Reasons this backend cannot serve `cfg`. Empty = it can."""
         return ()
 
+    def _region(self, name):
+        """Arena region a shared view should read.
+
+        Identity by default -- one layout, one set of names. A backend that
+        serves more than one layout (the HIP one does: intranode and internode
+        arenas hold the same things under different names) overrides this so the
+        views stay a single contract instead of branching at every call site.
+        """
+        return name
+
     # -- shared: capability gate -------------------------------------------
 
     def _gate(self, kernels: KernelSet) -> None:
@@ -754,7 +839,9 @@ class EpDispatchCombineOp:
         # which must happen after the caller's post-dispatch barrier (see
         # EpDispatchRoutingHandle).
         reverse = from_gpu_ptr(
-            self.arena.local_ptr("recv_to_src_token"), (self._recv_cap,), torch.int32
+            self.arena.local_ptr(self._region("recv_to_src_token")),
+            (self._recv_cap,),
+            torch.int32,
         )
         handle = EpDispatchRoutingHandle(
             disp_dest_tok_id_map=dest_map,
@@ -783,7 +870,7 @@ class EpDispatchCombineOp:
         if not self._kernels.stages_in_kernel and not self.cfg.enable_std_moe:
             # StdMoE has already written the weighted-reduced tokens into out_tok;
             # copying `input` over them would clobber that result.
-            out_tok_ptr = self.arena.local_ptr("out_tok")
+            out_tok_ptr = self.arena.local_ptr(self._region("out_tok"))
             if input.data_ptr() != out_tok_ptr:
                 dst = self.combine_in_view().view(-1)[: input.numel()]
                 dst.copy_(input.reshape(-1))

--- a/python/mori/ops/dispatch_combine_v2/ep_plans.py
+++ b/python/mori/ops/dispatch_combine_v2/ep_plans.py
@@ -56,10 +56,10 @@ plan_api.load_library(_LIB_NAME, extra_dirs=_extra_dirs())
 EpDispatchPlan = make_plan("ep_dispatch")
 EpCombinePlan = make_plan("ep_combine")
 
-# The v1 internode sequence. Eight plans rather than two: v1's dispatch and
-# combine are several passes each, and each pass is its own module. The two name
-# tables must match the C++ enums -- EpInterNodeDType in ep_internode_cfg.hpp and
-# QuantType in dispatch_combine.hpp.
+# The internode sequence. Eight plans rather than two: its dispatch and combine
+# are several passes each, and each pass is its own module. Both name tables must
+# match the C++ enums, which are now v2's own -- EpInterNodeDType and
+# EpQuantType, both in ep_internode_cfg.hpp.
 INTERNODE_DTYPES = {"bf16": 0, "f32": 1, "fp8_fnuz": 2, "fp8_ocp": 3, "fp4": 4}
 INTERNODE_QUANT_TYPES = {
     "none": 0,

--- a/python/mori/ops/dispatch_combine_v2/hip_backend.py
+++ b/python/mori/ops/dispatch_combine_v2/hip_backend.py
@@ -291,20 +291,6 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
                 f"quant_type={cfg.quant_type!r} "
                 "(the internode combine implements none and fp8_direct_cast)"
             )
-        # The internode kernel is single-T: EpDispatchCombineArgs<T> carries one
-        # element type, and `hiddenBytes = hiddenDim * sizeof(T)` sizes both the
-        # dispatch payload and the combine output. A dispatch dtype narrower than
-        # the combine dtype does not fault -- the kernel writes hidden*sizeof(fp8)
-        # bytes and the combine_out view reads hidden*sizeof(bf16), so half the
-        # output is whatever was already there. Reject it: on this path an fp8
-        # transport is spelled quant_type='fp8_direct_cast', which keeps T at the
-        # combine dtype and uses fp8 for the staging slots only.
-        if cfg.is_asymmetric_dtype:
-            bad.append(
-                f"asymmetric dtype (dispatch {cfg.dispatch_dtype} -> combine "
-                f"{cfg.combine_dtype}): the internode kernel has a single element "
-                "type; use quant_type='fp8_direct_cast' for an fp8 transport"
-            )
         # The same-destination dedup is a ballot with one lane per expert.
         from .dispatch_combine_op import WAVE
 
@@ -423,6 +409,24 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
         torch.float32: "f32",
         torch.float8_e4m3fnuz: "fp8_fnuz",
         torch.float8_e4m3fn: "fp8_ocp",
+    }
+
+    # Which leg each pass belongs to. The two legs are separate Plans and carry
+    # DIFFERENT element types, exactly as the intranode path does: the kernel's
+    # `T` is "elements of this leg's dtype", and `hiddenBytes = hiddenDim *
+    # sizeof(T)` sizes the dispatch payload in one and the combine output in the
+    # other. Compiling all eight with the dispatch dtype is what made an fp8
+    # dispatch write hidden*sizeof(fp8) bytes where the bf16 combine_out view
+    # reads hidden*sizeof(bf16) -- half the output left as whatever was there.
+    _INTERNODE_LEG = {
+        "copystaging": "dispatch",
+        "dispatch": "dispatch",
+        "dispatch_ll": "dispatch",
+        "combinesync": "combine",
+        "combinesyncbarrier": "combine",
+        "combine": "combine",
+        "combine_ll": "combine",
+        "combineall": "combine",
     }
 
     # (phase, low_latency) -> the pass sequence, in launch order. Two for
@@ -579,14 +583,22 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
         return out
 
     def _build_internode_kernels(self, cfg) -> KernelSet:
-        dtype_tag = self._INTERNODE_DTYPE.get(cfg.dispatch_dtype)
-        if dtype_tag is None:
+        # One tag per leg, not one for the op: see _INTERNODE_LEG.
+        leg_dtype = {
+            "dispatch": self._INTERNODE_DTYPE.get(cfg.dispatch_dtype),
+            "combine": self._INTERNODE_DTYPE.get(cfg.combine_dtype),
+        }
+        missing = [
+            f"{leg} dtype "
+            f"{cfg.dispatch_dtype if leg == 'dispatch' else cfg.combine_dtype}"
+            for leg, tag in leg_dtype.items()
+            if tag is None
+        ]
+        if missing:
             return KernelSet(
                 dispatch={},
                 combine={},
-                unsupported=(
-                    f"dispatch dtype {cfg.dispatch_dtype} has no internode entry",
-                ),
+                unsupported=tuple(f"{m} has no internode entry" for m in missing),
             )
 
         self._internode_buckets = self._internode_geometry_buckets(cfg)
@@ -619,8 +631,12 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
                 needed.setdefault(geom, set()).update(names)
         for geom, names in needed.items():
             block, rdma, warp = geom
-            req = self._internode_request(cfg, dtype_tag, block, warp, rdma)
-            built = {n: cb.EP_INTERNODE_PLANS[n](**req) for n in sorted(names)}
+            built = {}
+            for n in sorted(names):
+                req = self._internode_request(
+                    cfg, leg_dtype[self._INTERNODE_LEG[n]], block, warp, rdma
+                )
+                built[n] = cb.EP_INTERNODE_PLANS[n](**req)
             self._internode_plans[geom] = built
             self._plans.extend(built.values())
 

--- a/python/mori/ops/dispatch_combine_v2/hip_backend.py
+++ b/python/mori/ops/dispatch_combine_v2/hip_backend.py
@@ -80,6 +80,20 @@ _SCALE_ALIGN = 128
 _FP8_TUNING_DTYPES = (torch.float8_e4m3fnuz, torch.float8_e4m3fn)
 
 
+def _raw_stream() -> int:
+    """The current stream as a raw pointer.
+
+    `torch.cuda.current_stream().cuda_stream` builds a Python Stream wrapper on
+    every call -- ~14us a launch in the host profile, on a path where the host
+    already paces the GPU. The private entry returns the pointer directly; it is
+    what torch.compile's generated code uses. Fall back if it is ever renamed.
+    """
+    try:
+        return torch._C._cuda_getCurrentRawStream(torch.cuda.current_device())
+    except AttributeError:
+        return torch.cuda.current_stream().cuda_stream
+
+
 def scale_stride_bytes(scale_bytes: int) -> int:
     """What a DESTINATION scale row is laid down at: EpScaleStride in ep_cfg.hpp.
 
@@ -686,7 +700,10 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
             combine={comb_spec: self._wrap_internode("combine")},
             dispatch_replay=None,
             stages_in_kernel=True,
-            self_resets_counters=False,
+            # copystaging zeroes total_recv as its first act, so the host does not
+            # have to -- that zero_() was a fill kernel enqueued ahead of the
+            # dispatch sequence, delaying the kernels it protected.
+            self_resets_counters=True,
             capabilities=frozenset({"gather", "scales", "internode"}),
         )
 
@@ -780,7 +797,7 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
                     f"rdma={args['rdmaBlockNum']} passes={names}",
                     flush=True,
                 )
-            group.launch(torch.cuda.current_stream().cuda_stream, **args)
+            group.launch(_raw_stream(), **args)
 
         return run
 

--- a/python/mori/ops/dispatch_combine_v2/hip_backend.py
+++ b/python/mori/ops/dispatch_combine_v2/hip_backend.py
@@ -88,6 +88,22 @@ _DEBUG_GEOM = bool(os.environ.get("MORI_EP_DEBUG_GEOM"))
 _TRACE_ARGS = bool(os.environ.get("MORI_INTERNODE_TRACE_ARGS"))
 
 
+def _geom_env(name):
+    """``"block,rdma,warp"`` from the environment, or None.
+
+    Sweep-only. Read at build time (see _internode_geometry_buckets): the
+    internode plans are compiled per geometry, so a geometry cannot be chosen at
+    launch and a sweep has to pin it before the op is constructed.
+    """
+    raw = os.environ.get(name)
+    if not raw:
+        return None
+    parts = tuple(int(x) for x in raw.replace(" ", "").split(","))
+    if len(parts) != 3:
+        raise ValueError(f"{name}={raw!r}: want three ints, block,rdma,warp")
+    return parts
+
+
 def _raw_stream(dev_index: int) -> int:
     """The current stream on `dev_index`, as a raw pointer.
 
@@ -598,6 +614,25 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
         is why a bucket carries two triples rather than one.
         """
         from .internode_tuning_configs import _TABLE, _device_key, lookup
+
+        # Sweep hook: pin one geometry for every token count, bypassing the table.
+        # A geometry is a compile-time identity here, so a sweep cannot select one
+        # at launch the way the intranode path can -- it has to be fixed before
+        # the plans are built, which is before the op exists. Hence an env var
+        # rather than a CLI flag threaded through the config.
+        pin = _geom_env("MORI_EP_DISP_GEOM"), _geom_env("MORI_EP_COMB_GEOM")
+        if pin[0] or pin[1]:
+            base_d = (
+                cfg.dispatch_block_num,
+                cfg.dispatch_rdma_block_num,
+                cfg.warp_num_per_block,
+            )
+            base_c = (
+                cfg.combine_block_num,
+                cfg.combine_rdma_block_num,
+                cfg.combine_warp_num_per_block,
+            )
+            return [(None, pin[0] or base_d, pin[1] or base_c)]
 
         dtype = "fp8" if cfg.dispatch_dtype in _FP8_TUNING_DTYPES else "bf16"
         key = (_device_key(), cfg.world_size, cfg.hidden_dim, cfg.num_experts_per_token)

--- a/python/mori/ops/dispatch_combine_v2/hip_backend.py
+++ b/python/mori/ops/dispatch_combine_v2/hip_backend.py
@@ -110,6 +110,11 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
         self.dev = dev
         self._recv_cap = cfg.effective_max_recv
         self._closed = False
+        # Arena views, built once. Every one below is a pure function of cfg and
+        # of an arena pointer that never moves, yet dispatch() rebuilt five of
+        # them per call -- torch.as_tensor + view showed up in the host profile at
+        # ~27us a round, on a path where the host already paces the GPU.
+        self._views = {}
         # gfx125x routes to the TDM kernel, which needs a superset arena (plan A).
         _arch = getattr(torch.cuda.get_device_properties(dev), "gcnArchName", "") or ""
         self._is1250 = _arch.split(":")[0].startswith("gfx125")
@@ -863,34 +868,51 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
         return inter if self.cfg.is_internode else intra
 
     def recv_tokens(self):
+        v = self._views.get("recv_tokens")
+        if v is not None:
+            return v
         # fp4 packs 2 e2m1 per element of the torch dtype -> last dim is hidden/2.
         cols = self.cfg.hidden_dim // 2 if self.cfg.is_fp4 else self.cfg.hidden_dim
-        return from_gpu_ptr(
+        v = from_gpu_ptr(
             self.arena.local_ptr(self._region("disp_out")),
             (self._recv_cap, cols),
             self.cfg.dispatch_dtype,
         )
+        self._views["recv_tokens"] = v
+        return v
 
     def combine_in_view(self):
-        return from_gpu_ptr(
-            self.arena.local_ptr(self._region("out_tok")),
-            (self._recv_cap, self.cfg.hidden_dim),
-            self.cfg.combine_dtype,
-        )
+        v = self._views.get("combine_in")
+        if v is None:
+            v = from_gpu_ptr(
+                self.arena.local_ptr(self._region("out_tok")),
+                (self._recv_cap, self.cfg.hidden_dim),
+                self.cfg.combine_dtype,
+            )
+            self._views["combine_in"] = v
+        return v
 
     def recv_weights(self):
-        return from_gpu_ptr(
-            self.arena.local_ptr(self._region("out_wts")),
-            (self._recv_cap, self.cfg.num_experts_per_token),
-            torch.float32,
-        )
+        v = self._views.get("recv_weights")
+        if v is None:
+            v = from_gpu_ptr(
+                self.arena.local_ptr(self._region("out_wts")),
+                (self._recv_cap, self.cfg.num_experts_per_token),
+                torch.float32,
+            )
+            self._views["recv_weights"] = v
+        return v
 
     def recv_indices(self):
-        return from_gpu_ptr(
-            self.arena.local_ptr(self._region("out_idx")),
-            (self._recv_cap, self.cfg.num_experts_per_token),
-            torch.int32,
-        )
+        v = self._views.get("recv_indices")
+        if v is None:
+            v = from_gpu_ptr(
+                self.arena.local_ptr(self._region("out_idx")),
+                (self._recv_cap, self.cfg.num_experts_per_token),
+                torch.int32,
+            )
+            self._views["recv_indices"] = v
+        return v
 
     def recv_scales(self):
         """The forwarded scale rows, or None when the transport is off -- the same
@@ -900,6 +922,9 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
         Strided, not packed: the rows sit scale_stride_bytes() apart. Anything
         reading the region by pointer needs that pitch, not this shape.
         """
+        v = self._views.get("recv_scales")
+        if v is not None:
+            return v
         n_i32 = self._scale_i32(self.cfg)
         if not n_i32:
             return None
@@ -909,7 +934,9 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
             (self._recv_cap, stride_i32),
             torch.int32,
         )
-        return rows[:, :n_i32]
+        v = rows[:, :n_i32]
+        self._views["recv_scales"] = v
+        return v
 
     def local_expert_count(self):
         raise NotImplementedError(

--- a/python/mori/ops/dispatch_combine_v2/hip_backend.py
+++ b/python/mori/ops/dispatch_combine_v2/hip_backend.py
@@ -80,6 +80,7 @@ _SCALE_ALIGN = 128
 _FP8_TUNING_DTYPES = (torch.float8_e4m3fnuz, torch.float8_e4m3fn)
 
 
+
 def scale_stride_bytes(scale_bytes: int) -> int:
     """What a DESTINATION scale row is laid down at: EpScaleStride in ep_cfg.hpp.
 
@@ -480,8 +481,14 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
         """The window handle, the seventeen offsets and the local pointers.
 
         Everything here is fixed for the life of the op, so it is built once and
-        merged with the per-launch values at each call.
+        merged with the per-launch values at each call. Memoised because it is
+        NOT free at launch scale: thirty-odd arena lookups and data_ptr() calls
+        per pass sequence, on a path where the host is already the thing the GPU
+        waits for.
         """
+        cached = getattr(self, "_internode_static_args", None)
+        if cached is not None:
+            return cached
         a = self.arena
         off = a.offset
         has_scales = a.has("out_scales")
@@ -489,7 +496,7 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
         def ptr(t):
             return 0 if t is None else t.data_ptr()
 
-        return dict(
+        self._internode_static_args = dict(
             window=a.handle,
             offDispatchInp=off("inter_dispatch_inp"),
             offCombineInp=off("inter_combine_inp"),
@@ -528,6 +535,7 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
             # embed a ccoDevComm by value, so the binding memcpys from host memory.
             devComm=self._dev_comm._dev_comm.host_ptr,
         )
+        return self._internode_static_args
 
     # Below this token count the LL variants win; above it the plain ones do.
     # The same split v1's bench selects at, and both variants are compiled either
@@ -671,7 +679,17 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
         from mori.jit.v2 import plan_api
 
         def run(*, input, num_tokens, dest_map, **kw):
-            ll = num_tokens <= self._INTERNODE_LL_MAX_TOKENS
+            # The low-latency pair is chosen by token count. `_internode_force_ll`
+            # overrides it (True/False) so a benchmark can name the variant it is
+            # reporting instead of inferring it from the shape -- the two are
+            # separate compiled entries, and a number is only comparable to
+            # another harness's if both ran the same one.
+            forced = getattr(self, "_internode_force_ll", None)
+            ll = (
+                (num_tokens <= self._INTERNODE_LL_MAX_TOKENS)
+                if forced is None
+                else forced
+            )
             names = self._INTERNODE_SEQ[(phase, ll)]
             geom = self._internode_geom_for(phase, num_tokens)
             plans = [self._internode_plans[geom][n] for n in names]

--- a/python/mori/ops/dispatch_combine_v2/hip_backend.py
+++ b/python/mori/ops/dispatch_combine_v2/hip_backend.py
@@ -98,17 +98,6 @@ _DEBUG_GEOM = bool(os.environ.get("MORI_EP_DEBUG_GEOM"))
 _SPLIT_PASSES = bool(os.environ.get("MORI_EP_SPLIT_PASSES"))
 _TRACE_ARGS = bool(os.environ.get("MORI_INTERNODE_TRACE_ARGS"))
 
-# Device timestamps inside dispatch_ll and combine_ll, opt-in. Read once here for
-# the same reason as the two above. When off the buffer is not allocated and the
-# args pointer stays null, and the null is what turns off every stamp site in the
-# kernel -- there is one binary either way, so the JIT cache key does not depend
-# on this. The kernel cannot know which benchmark round it is in, so the host
-# supplies the row index; that is only correct because dispatch and combine are
-# each called exactly once per round.
-_DEV_TS = bool(os.environ.get("MORI_EP_DEV_TS"))
-_TS_SLOTS = 24  # must equal kEpDbgTsSlots in ep_internode_kernel.hpp
-_TS_ROUNDS = 4096
-
 
 def _geom_env(name):
     """``"block,rdma,warp"`` from the environment, or None.
@@ -183,11 +172,6 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
         self._views = {}
         # (pass_name, event) appended per launch when MORI_EP_SPLIT_PASSES is on.
         self._pass_marks = []
-        # Set here rather than only on the internode path so run() can test it
-        # unconditionally; the buffer itself is allocated with the other
-        # internode buffers, and stays None for an intranode config.
-        self.dbg_ts = None
-        self.dbg_round = {"dispatch": 0, "combine": 0}
         # gfx125x routes to the TDM kernel, which needs a superset arena (plan A).
         _arch = getattr(torch.cuda.get_device_properties(dev), "gcnArchName", "") or ""
         self._is1250 = _arch.split(":")[0].startswith("gfx125")
@@ -342,16 +326,6 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
         # Zero, not one: the internode kernels start their cross-device epoch at
         # 0 (v1 seeds it that way for exactly these kernel types).
         self.cross_device_flag = torch.zeros(1, dtype=torch.int64, device=dev)
-
-        # Plain local device memory, deliberately NOT an arena region: nothing
-        # reads these remotely, and the arena is the uncached symmetric window
-        # whose behaviour is what the timestamps are measuring -- storing into it
-        # would perturb the thing under test.
-        self.dbg_ts = (
-            torch.zeros(_TS_ROUNDS * _TS_SLOTS, dtype=torch.int64, device=dev)
-            if _DEV_TS
-            else None
-        )
 
         # Views onto the arena, NOT fresh tensors: EpCombineAll writes the
         # symmetric regions, so a local buffer here would be returned to the
@@ -629,7 +603,6 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
             combineGridBarrier=ptr(self.combine_barrier),
             interNodeBlocksBarrier=ptr(self.inter_blocks_barrier),
             crossDeviceBarrierFlag=ptr(self.cross_device_flag),
-            dbgTsBuf=ptr(self.dbg_ts) if self.dbg_ts is not None else 0,
             # The HOST struct, not DevCommHandle.ptr (the device-side copy): the args
             # embed a ccoDevComm by value, so the binding memcpys from host memory.
             devComm=self._dev_comm._dev_comm.host_ptr,
@@ -909,14 +882,6 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
                     kw["scales"].data_ptr() if kw.get("scales") is not None else 0
                 ),
             )
-            if self.dbg_ts is not None:
-                # Which row of the timestamp buffer this launch writes. The key
-                # is present on every launch when on and absent on every launch
-                # when off, so the per-launch arg-buffer cache key is stable
-                # either way and this costs one _set_arg, not a cache miss.
-                r = self.dbg_round[phase]
-                args["dbgRound"] = min(r, _TS_ROUNDS - 1)
-                self.dbg_round[phase] = r + 1
             if _TRACE_ARGS and self.cfg.rank == 0:
                 print(
                     f"[trace] {phase} ll={ll} tokens={num_tokens} "

--- a/python/mori/ops/dispatch_combine_v2/hip_backend.py
+++ b/python/mori/ops/dispatch_combine_v2/hip_backend.py
@@ -98,6 +98,17 @@ _DEBUG_GEOM = bool(os.environ.get("MORI_EP_DEBUG_GEOM"))
 _SPLIT_PASSES = bool(os.environ.get("MORI_EP_SPLIT_PASSES"))
 _TRACE_ARGS = bool(os.environ.get("MORI_INTERNODE_TRACE_ARGS"))
 
+# Device timestamps inside dispatch_ll and combine_ll, opt-in. Read once here for
+# the same reason as the two above. When off the buffer is not allocated and the
+# args pointer stays null, and the null is what turns off every stamp site in the
+# kernel -- there is one binary either way, so the JIT cache key does not depend
+# on this. The kernel cannot know which benchmark round it is in, so the host
+# supplies the row index; that is only correct because dispatch and combine are
+# each called exactly once per round.
+_DEV_TS = bool(os.environ.get("MORI_EP_DEV_TS"))
+_TS_SLOTS = 16  # must equal kEpDbgTsSlots in ep_internode_kernel.hpp
+_TS_ROUNDS = 4096
+
 
 def _geom_env(name):
     """``"block,rdma,warp"`` from the environment, or None.
@@ -172,6 +183,11 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
         self._views = {}
         # (pass_name, event) appended per launch when MORI_EP_SPLIT_PASSES is on.
         self._pass_marks = []
+        # Set here rather than only on the internode path so run() can test it
+        # unconditionally; the buffer itself is allocated with the other
+        # internode buffers, and stays None for an intranode config.
+        self.dbg_ts = None
+        self.dbg_round = {"dispatch": 0, "combine": 0}
         # gfx125x routes to the TDM kernel, which needs a superset arena (plan A).
         _arch = getattr(torch.cuda.get_device_properties(dev), "gcnArchName", "") or ""
         self._is1250 = _arch.split(":")[0].startswith("gfx125")
@@ -326,6 +342,16 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
         # Zero, not one: the internode kernels start their cross-device epoch at
         # 0 (v1 seeds it that way for exactly these kernel types).
         self.cross_device_flag = torch.zeros(1, dtype=torch.int64, device=dev)
+
+        # Plain local device memory, deliberately NOT an arena region: nothing
+        # reads these remotely, and the arena is the uncached symmetric window
+        # whose behaviour is what the timestamps are measuring -- storing into it
+        # would perturb the thing under test.
+        self.dbg_ts = (
+            torch.zeros(_TS_ROUNDS * _TS_SLOTS, dtype=torch.int64, device=dev)
+            if _DEV_TS
+            else None
+        )
 
         # Views onto the arena, NOT fresh tensors: EpCombineAll writes the
         # symmetric regions, so a local buffer here would be returned to the
@@ -603,6 +629,7 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
             combineGridBarrier=ptr(self.combine_barrier),
             interNodeBlocksBarrier=ptr(self.inter_blocks_barrier),
             crossDeviceBarrierFlag=ptr(self.cross_device_flag),
+            dbgTsBuf=ptr(self.dbg_ts) if self.dbg_ts is not None else 0,
             # The HOST struct, not DevCommHandle.ptr (the device-side copy): the args
             # embed a ccoDevComm by value, so the binding memcpys from host memory.
             devComm=self._dev_comm._dev_comm.host_ptr,
@@ -882,6 +909,14 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
                     kw["scales"].data_ptr() if kw.get("scales") is not None else 0
                 ),
             )
+            if self.dbg_ts is not None:
+                # Which row of the timestamp buffer this launch writes. The key
+                # is present on every launch when on and absent on every launch
+                # when off, so the per-launch arg-buffer cache key is stable
+                # either way and this costs one _set_arg, not a cache miss.
+                r = self.dbg_round[phase]
+                args["dbgRound"] = min(r, _TS_ROUNDS - 1)
+                self.dbg_round[phase] = r + 1
             if _TRACE_ARGS and self.cfg.rank == 0:
                 print(
                     f"[trace] {phase} ll={ll} tokens={num_tokens} "

--- a/python/mori/ops/dispatch_combine_v2/hip_backend.py
+++ b/python/mori/ops/dispatch_combine_v2/hip_backend.py
@@ -34,12 +34,15 @@ FlyDSL is not installed.
 
 from __future__ import annotations
 
+import os
+
 import torch
 
 from mori.tensor_utils import from_gpu_ptr
 
 from . import ep_plans as cb
 from .dispatch_combine_op import EpDispatchCombineOp, KernelSet
+from .internode_regions import internode_regions
 from .symm_arena import SymmArena
 
 # C++ offset-argument stem -> arena region name. The C++ side names the offsets
@@ -72,6 +75,9 @@ _DISPATCH_DTYPES = {
 _COMBINE_DTYPES = {torch.bfloat16: 2, torch.float32: 4}
 # Must match EpScaleAlign in include/mori/ops/dispatch_combine_v2/ep_cfg.hpp.
 _SCALE_ALIGN = 128
+
+# Which tuning-table dtype column a dispatch dtype reads.
+_FP8_TUNING_DTYPES = (torch.float8_e4m3fnuz, torch.float8_e4m3fn)
 
 
 def scale_stride_bytes(scale_bytes: int) -> int:
@@ -107,6 +113,7 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
         # gfx125x routes to the TDM kernel, which needs a superset arena (plan A).
         _arch = getattr(torch.cuda.get_device_properties(dev), "gcnArchName", "") or ""
         self._is1250 = _arch.split(":")[0].startswith("gfx125")
+        self._mp_count = torch.cuda.get_device_properties(dev).multi_processor_count
 
         # Gate FIRST: rejecting a config after taking a symmetric window would
         # leak it (the arena is registered with the communicator), and the whole
@@ -119,7 +126,14 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
         self.arena.zero()
 
         self._dispatch_specs, self._combine_specs = self._specs_from(cfg)
+        # The internode passes need a device communicator, and it has to exist
+        # before the kernels are bound: the plans take it by value.
+        self._dev_comm = self._make_dev_comm(cfg, comm) if cfg.is_internode else None
         self._kernels = self._build_kernels(cfg, self.arena)
+
+        if cfg.is_internode:
+            self._alloc_internode_buffers(cfg)
+            return
 
         topk = cfg.num_experts_per_token
         max_tok = cfg.max_num_inp_token_per_rank
@@ -157,6 +171,147 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
                 )
             self.combine_barrier_fan = torch.zeros(max_comb_blocks * 16, **i32)
 
+    # -- internode -------------------------------------------------------
+    #
+    # Multi-node configs run eight passes over a seventeen-region arena with a
+    # device communicator, instead of two kernels over nine regions. Everything
+    # else -- the arena, the plan API, the library -- is the same, which is why
+    # this lives here rather than in a backend of its own.
+
+    @staticmethod
+    def _make_dev_comm(cfg, comm):
+        """The communicator the internode kernels take by value.
+
+        Two requirements the defaults do not meet, made here so no caller has to
+        know them:
+
+        * RAIL rather than the CROSSNODE default. The kernels talk only to their
+          own local rank on other nodes, so that is the only connection set they
+          need, and asking for more costs QPs that never carry traffic.
+        * a context count of num_qp_per_pe. ccoGda picks its QP as
+          ``contextId % numQpPerPe``, so fewer contexts than QPs silently
+          collapses the stripes onto a subset of them -- no error, just less
+          bandwidth than the config asked for.
+        """
+        from mori.cco import cco as _cco
+        from mori.cco.communicator import DevCommHandle
+
+        reqs = _cco.DevCommRequirements()
+        reqs.gda_connection_type = _cco.GDA_CONNECTION_RAIL
+        reqs.gda_context_count = max(1, cfg.num_qp_per_pe)
+        handle = DevCommHandle(comm, requirements=reqs)
+
+        # EP derives "which ranks share a node" from cfg.gpu_per_node; CCO derives
+        # its LSA team from the physical topology. Nothing forces the two to
+        # agree, and the kernel resolves a same-node peer as `worldPe - lsaBase`,
+        # which is only an LSA rank if they do. A mismatch does not fault -- it
+        # reads the wrong rank's copy -- so it is checked once, here, where both
+        # numbers are visible.
+        if handle.lsa_size != cfg.gpu_per_node:
+            raise ValueError(
+                f"EP's gpu_per_node ({cfg.gpu_per_node}) != CCO's lsa_size "
+                f"({handle.lsa_size}): EP's idea of a node and the flat-VA team "
+                "are different sets, so a peer-indexed access would resolve to "
+                "the wrong rank"
+            )
+        expected = cfg.rank % cfg.gpu_per_node
+        if handle.lsa_rank != expected:
+            raise ValueError(
+                f"rank {cfg.rank} has CCO lsa_rank {handle.lsa_rank} but EP's node "
+                f"layout implies {expected}: world ranks are not laid out "
+                "node-major, so worldPe - lsaBase is not an LSA rank"
+            )
+        return handle
+
+    def _alloc_internode_buffers(self, cfg):
+        """The local (non-symmetric) buffers the internode passes write.
+
+        Sizes transcribed from EpDispatchCombineHandle's hipMallocs for the same
+        config; the kernel indexes them with arithmetic derived from the same
+        numbers, so a formula that is merely close overruns silently.
+        """
+        dev = self.dev
+        i32 = dict(dtype=torch.int32, device=dev)
+        ws, gpn = cfg.world_size, cfg.gpu_per_node
+        n_nodes = cfg.nodes
+        m = cfg.max_num_inp_token_per_rank
+        topk = cfg.num_experts_per_token
+
+        self.lsa_base = (cfg.rank // gpn) * gpn
+
+        # The base hands one of these to every dispatch as `dest_map` -- which one
+        # depends on whether the caller asked for a routing handle -- and it is
+        # what the kernel reads as dispDestTokIdMap. Sized the way v1 sizes that
+        # buffer: the kernel indexes it by (token, expert), but v1 allocates the
+        # worst case and the region test does not cover it, so this stays
+        # conservative rather than clever.
+        self.token_dest_map = torch.zeros(ws * m * cfg.num_experts_per_rank, **i32)
+        self._null_flat = ws * cfg.effective_max_recv
+        self.routing_dest_map = torch.full_like(self.token_dest_map, self._null_flat)
+
+        self.inter_disp_dest_tok_id_map = torch.zeros(n_nodes * m * topk, **i32)
+        self.inter_disp_send_map = torch.zeros(n_nodes * m, **i32)
+        # Counts completions. NOT the local half of the symmetric chunk-flag
+        # region despite the name: that one is written by dispatch and read+
+        # cleared by combine, which enumerates its work from dispatch's leftovers.
+        self.inter_chunk_flag_combine = torch.zeros(n_nodes * m * 2, **i32)
+        self.dest_pe_counter = torch.zeros(ws, **i32)
+        self.block_flag_counter = torch.zeros(n_nodes, **i32)
+        self.total_recv = torch.zeros(1, **i32)
+        self.dispatch_barrier = torch.zeros(ws, dtype=torch.uint32, device=dev)
+        self.combine_barrier = torch.zeros(ws, dtype=torch.uint32, device=dev)
+        self.inter_blocks_barrier = torch.zeros(4, dtype=torch.uint32, device=dev)
+        # Zero, not one: the internode kernels start their cross-device epoch at
+        # 0 (v1 seeds it that way for exactly these kernel types).
+        self.cross_device_flag = torch.zeros(1, dtype=torch.int64, device=dev)
+
+        # Views onto the arena, NOT fresh tensors: EpCombineAll writes the
+        # symmetric regions, so a local buffer here would be returned to the
+        # caller unwritten. The base slices these to (ct, hidden) / (ct, topk)
+        # and never learns which layout it is looking at.
+        self.combine_out = from_gpu_ptr(
+            self.arena.local_ptr("inter_combine_out"),
+            (m * cfg.hidden_dim,),
+            cfg.combine_dtype,
+        )
+        self.combine_out_weights = from_gpu_ptr(
+            self.arena.local_ptr("combine_out_weights"),
+            (m * topk,),
+            torch.float32,
+        )
+
+    def _internode_unsupported(self, cfg) -> tuple[str, ...]:
+        bad = []
+        if cfg.is_scatter:
+            bad.append("combine_mode='scatter' (the internode kernels gather)")
+        if cfg.enable_std_moe:
+            bad.append("enable_std_moe (not implemented on the internode path)")
+        if cfg.quant_type not in ("none", "fp8_direct_cast"):
+            bad.append(
+                f"quant_type={cfg.quant_type!r} "
+                "(the internode combine implements none and fp8_direct_cast)"
+            )
+        # The same-destination dedup is a ballot with one lane per expert.
+        from .dispatch_combine_op import WAVE
+
+        if cfg.num_experts_per_token >= WAVE:
+            bad.append(
+                f"num_experts_per_token ({cfg.num_experts_per_token}) must be "
+                f"smaller than the {WAVE}-wide wavefront"
+            )
+        # EpCombineAll's per-warp shared pointer arrays are sized topk wide
+        # (EpInterNodeCombineSharedBytes) but indexed 0..nNodes -- it clears and
+        # fills one slot per node. With topk < nodes a warp writes into its
+        # neighbour's slot and the last warp runs off the array, so the fold
+        # silently reads the wrong sources. Reject instead of corrupting.
+        if cfg.num_experts_per_token < cfg.nodes:
+            bad.append(
+                f"num_experts_per_token ({cfg.num_experts_per_token}) must be at "
+                f"least the node count ({cfg.nodes}): the combine fold indexes "
+                "its topk-wide shared pointer arrays by node"
+            )
+        return tuple(bad)
+
     # -- backend hooks -----------------------------------------------------
 
     @staticmethod
@@ -176,6 +331,13 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
         return scale_stride_bytes(cls._scale_i32(cfg) * 4) // 4
 
     def _regions(self, cfg):
+        if cfg.is_internode:
+            # Seventeen regions, sized exactly. v1 sizes its arena with a 256 MB
+            # slack term on a rough estimate; this is the exact sum, which is both
+            # the point (an overrun fails instead of landing in the slack) and the
+            # risk (a wrong formula corrupts a neighbour). test_internode_regions
+            # compares every entry against what v1 allocates for the same config.
+            return internode_regions(cfg)
         # token_nbytes / combine_token_nbytes rather than elem*hidden: they are the
         # only forms that are right for fp4, where 2 values share a byte.
         cap = cfg.effective_max_recv
@@ -205,6 +367,8 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
 
     def _unsupported(self, cfg) -> tuple[str, ...]:
         """Everything this backend cannot do, checked before anything is built."""
+        if cfg.is_internode:
+            return self._internode_unsupported(cfg)
         bad = []
         if cfg.dispatch_dtype not in _DISPATCH_DTYPES:
             bad.append(
@@ -240,8 +404,314 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
             )
         return tuple(bad)
 
+    _INTERNODE_DTYPE = {
+        torch.bfloat16: "bf16",
+        torch.float32: "f32",
+        torch.float8_e4m3fnuz: "fp8_fnuz",
+        torch.float8_e4m3fn: "fp8_ocp",
+    }
+
+    # (phase, low_latency) -> the pass sequence, in launch order. Two for
+    # dispatch, four for combine; the LL and non-LL members of each pair are
+    # separate compiled entries rather than a runtime branch.
+    _INTERNODE_SEQ = {
+        ("dispatch", False): ("copystaging", "dispatch"),
+        ("dispatch", True): ("copystaging", "dispatch_ll"),
+        ("combine", False): (
+            "combinesync",
+            "combinesyncbarrier",
+            "combine",
+            "combineall",
+        ),
+        ("combine", True): (
+            "combinesync",
+            "combinesyncbarrier",
+            "combine_ll",
+            "combineall",
+        ),
+    }
+
+    def _internode_request(
+        self, cfg, dtype_tag, block_num, warp_per_block, rdma_block_num
+    ):
+        return dict(
+            worldSize=cfg.world_size,
+            hiddenDim=cfg.hidden_dim,
+            scaleDim=cfg.scale_dim,
+            scaleTypeSize=cfg.scale_type_size,
+            maxTokenTypeSize=cfg.max_token_type_size,
+            maxNumInpTokenPerRank=cfg.max_num_inp_token_per_rank,
+            numExpertPerRank=cfg.num_experts_per_rank,
+            numExpertPerToken=cfg.num_experts_per_token,
+            maxTotalRecvTokens=cfg.max_total_recv_tokens,
+            gpuPerNode=cfg.gpu_per_node,
+            numQpPerPe=cfg.num_qp_per_pe,
+            quantType=(
+                cfg.quant_type.replace("_", "").lower()
+                if cfg.quant_type != "none"
+                else "none"
+            ),
+            dtype=dtype_tag,
+            blockNum=block_num,
+            warpPerBlock=warp_per_block,
+            rdmaBlockNum=rdma_block_num,
+            mpCount=self._mp_count,
+        )
+
+    def _internode_arena_args(self):
+        """The window handle, the seventeen offsets and the local pointers.
+
+        Everything here is fixed for the life of the op, so it is built once and
+        merged with the per-launch values at each call.
+        """
+        a = self.arena
+        off = a.offset
+        has_scales = a.has("out_scales")
+
+        def ptr(t):
+            return 0 if t is None else t.data_ptr()
+
+        return dict(
+            window=a.handle,
+            offDispatchInp=off("inter_dispatch_inp"),
+            offCombineInp=off("inter_combine_inp"),
+            offStaging=off("inter_staging"),
+            offDispatchOut=off("inter_dispatch_out"),
+            offCombineOut=off("inter_combine_out"),
+            offDispatchStaging=off("inter_dispatch_staging"),
+            offInpWeights=off("inp_weights"),
+            offDispatchOutWeights=off("dispatch_out_weights"),
+            offCombineOutWeights=off("combine_out_weights"),
+            offOutIndices=off("out_indices"),
+            offRecvTokenNum=off("recv_token_num"),
+            offNodeRecvTokenNum=off("node_recv_token_num"),
+            offDispTokOffset=off("disp_tok_offset"),
+            offDispTokIdToSrcTokId=off("disp_tok_id_to_src_tok_id"),
+            offCrossDeviceBarrier=off("cross_device_barrier"),
+            offChunkFlag=off("inter_node_chunk_flag"),
+            # Absent, not zero-sized, when the transport is off; the kernel gates
+            # on cfg.scaleDim and never dereferences it.
+            offOutScales=off("out_scales") if has_scales else 0,
+            rank=self.cfg.rank,
+            lsaBase=self.lsa_base,
+            dispDestTokIdMap=0,  # per-launch: the base passes token_dest_map or routing_dest_map
+            interNodeDispDestTokIdMap=ptr(self.inter_disp_dest_tok_id_map),
+            interNodeDispSendMap=ptr(self.inter_disp_send_map),
+            interNodeChunkFlagCombine=ptr(self.inter_chunk_flag_combine),
+            destPeTokenCounter=ptr(self.dest_pe_counter),
+            blockFlagCounter=ptr(self.block_flag_counter),
+            totalRecvTokenNum=ptr(self.total_recv),
+            dispTokIdToSrcTokIdLocal=0,
+            dispatchGridBarrier=ptr(self.dispatch_barrier),
+            combineGridBarrier=ptr(self.combine_barrier),
+            interNodeBlocksBarrier=ptr(self.inter_blocks_barrier),
+            crossDeviceBarrierFlag=ptr(self.cross_device_flag),
+            # The HOST struct, not DevCommHandle.ptr (the device-side copy): the args
+            # embed a ccoDevComm by value, so the binding memcpys from host memory.
+            devComm=self._dev_comm._dev_comm.host_ptr,
+        )
+
+    # Below this token count the LL variants win; above it the plain ones do.
+    # The same split v1's bench selects at, and both variants are compiled either
+    # way, so this only chooses which of eight already-built plans a launch uses.
+    _INTERNODE_LL_MAX_TOKENS = 2048
+
+    def _internode_geometry_buckets(self, cfg):
+        """``[(max_tok | None, disp_geom, comb_geom)]``, coarsest last.
+
+        Compilation happens at build time, so every geometry a launch could pick
+        has to be known now -- which is why this returns the whole schedule and
+        not just the one for the current token count. Same rule as the intranode
+        schedule: `_pick` must never be able to trigger a compile.
+
+        The table keeps dispatch and combine on DIFFERENT rdma/warp values for the
+        same token count, which a single geometry per bucket cannot express; that
+        is why a bucket carries two triples rather than one.
+        """
+        from .internode_tuning_configs import _TABLE, _device_key, lookup
+
+        dtype = "fp8" if cfg.dispatch_dtype in _FP8_TUNING_DTYPES else "bf16"
+        key = (_device_key(), cfg.world_size, cfg.hidden_dim, cfg.num_experts_per_token)
+        entry = _TABLE.get(key)
+        if not entry:
+            # Untuned shape: one bucket, whatever the config resolved to.
+            return [
+                (
+                    None,
+                    (
+                        cfg.dispatch_block_num,
+                        cfg.dispatch_rdma_block_num,
+                        cfg.warp_num_per_block,
+                    ),
+                    (
+                        cfg.combine_block_num,
+                        cfg.combine_rdma_block_num,
+                        cfg.combine_warp_num_per_block,
+                    ),
+                )
+            ]
+        sched = entry.get(dtype) or entry.get("fp8")
+        out = []
+        for row in sched:
+            max_tok = row[0]
+            g = lookup(
+                cfg.world_size,
+                cfg.hidden_dim,
+                cfg.num_experts_per_token,
+                max_tok if max_tok is not None else 1 << 30,
+                dtype=dtype,
+            )
+            out.append((max_tok, g["dispatch"], g["combine"]))
+        return out
+
+    def _build_internode_kernels(self, cfg) -> KernelSet:
+        dtype_tag = self._INTERNODE_DTYPE.get(cfg.dispatch_dtype)
+        if dtype_tag is None:
+            return KernelSet(
+                dispatch={},
+                combine={},
+                unsupported=(
+                    f"dispatch dtype {cfg.dispatch_dtype} has no internode entry",
+                ),
+            )
+
+        self._internode_buckets = self._internode_geometry_buckets(cfg)
+        self._plans = []
+        # Keyed by the geometry triple so two buckets that resolve to the same
+        # geometry share one compile -- the shipped table does exactly that for
+        # tokens 4 and 8.
+        self._internode_plans = {}
+        # Collect the passes each geometry has to serve BEFORE building any, and
+        # union them: a geometry is not owned by one phase. The shipped table
+        # gives tokens 16 the same triple for dispatch and combine, so keying on
+        # the triple alone and skipping an already-present one leaves that
+        # geometry holding only whichever phase was seen first -- a KeyError on
+        # the other phase's first launch, at run time, not build time.
+        needed = {}
+        for _, disp_geom, comb_geom in self._internode_buckets:
+            for geom, names in (
+                (disp_geom, ("copystaging", "dispatch", "dispatch_ll")),
+                (
+                    comb_geom,
+                    (
+                        "combinesync",
+                        "combinesyncbarrier",
+                        "combine",
+                        "combine_ll",
+                        "combineall",
+                    ),
+                ),
+            ):
+                needed.setdefault(geom, set()).update(names)
+        for geom, names in needed.items():
+            block, rdma, warp = geom
+            req = self._internode_request(cfg, dtype_tag, block, warp, rdma)
+            built = {n: cb.EP_INTERNODE_PLANS[n](**req) for n in sorted(names)}
+            self._internode_plans[geom] = built
+            self._plans.extend(built.values())
+
+        disp_spec = (cfg.dispatch_block_num, cfg.warp_num_per_block)
+        comb_spec = (cfg.combine_block_num, cfg.combine_warp_num_per_block)
+        return KernelSet(
+            dispatch={disp_spec: self._wrap_internode("dispatch")},
+            combine={comb_spec: self._wrap_internode("combine")},
+            dispatch_replay=None,
+            stages_in_kernel=True,
+            self_resets_counters=False,
+            capabilities=frozenset({"gather", "scales", "internode"}),
+        )
+
+    def _internode_geom_for(self, phase, num_tokens):
+        """The tuned geometry for this token count. Buckets are ordered, coarsest
+        last, exactly as `_pick` walks the intranode schedule."""
+        for max_tok, disp_geom, comb_geom in self._internode_buckets:
+            if max_tok is None or num_tokens <= max_tok:
+                return disp_geom if phase == "dispatch" else comb_geom
+        _, disp_geom, comb_geom = self._internode_buckets[-1]
+        return disp_geom if phase == "dispatch" else comb_geom
+
+    def _wrap_internode(self, phase):
+        """One ABI crossing for the whole pass sequence.
+
+        Every pass shares the schema and the same filled struct, so the arguments
+        are written once and each plan launches against them in order -- six
+        crossings become one, and a JIT-compile failure on a later pass aborts
+        before any earlier one is enqueued.
+        """
+        from mori.jit.v2 import plan_api
+
+        def run(*, input, num_tokens, dest_map, **kw):
+            ll = num_tokens <= self._INTERNODE_LL_MAX_TOKENS
+            names = self._INTERNODE_SEQ[(phase, ll)]
+            geom = self._internode_geom_for(phase, num_tokens)
+            plans = [self._internode_plans[geom][n] for n in names]
+
+            # Two of the kernel's arguments are set by dispatch and READ AGAIN by
+            # combine, but the base only hands them to dispatch -- combine's
+            # signature carries no indices and treats `weights` as a request
+            # rather than an input. v1 does not notice because its handle keeps
+            # both across the pair; here they have to be remembered explicitly.
+            #
+            #   tokenIndices  EpCombineAll dereferences it unconditionally
+            #                 (args.tokenIndices[tokenId * topk + laneId]), so a
+            #                 null is a fault, not a skipped branch.
+            #   weightsBuf    it is a DIFFERENT tensor in each phase, and its
+            #                 NULLNESS additionally sets the staging slot stride
+            #                 (`combXferBytes = hidden + (weights ? wt : 0)`),
+            #                 which both phases index -- so the two must agree on
+            #                 null-ness while disagreeing on the buffer.
+            #
+            # Dispatch's weightsBuf is the caller's per-input-token weights and is
+            # indexed by source token id. Combine's is indexed by RECEIVED token
+            # id (`CombineSync` stages `weightsBuf + tokenId * topk` for tokenId in
+            # [0, totalRecvTokenNum)), so it must be the weights dispatch just
+            # delivered -- the `dispatch_out_weights` region, which is exactly the
+            # `dispatch_weights` output v1's callers hand back to `combine()`.
+            # Passing the input weights here does not fault: it folds the right
+            # number of node slots holding other tokens' weights.
+            if phase == "dispatch":
+                w, ix = kw.get("weights"), kw.get("indices")
+                self._internode_has_weights = w is not None
+                self._internode_indices_ptr = 0 if ix is None else ix.data_ptr()
+                weights_ptr = 0 if w is None else w.data_ptr()
+            elif getattr(self, "_internode_has_weights", False):
+                weights_ptr = self.arena.local_ptr("dispatch_out_weights")
+            else:
+                weights_ptr = 0
+            indices_ptr = getattr(self, "_internode_indices_ptr", 0)
+
+            args = dict(self._internode_arena_args())
+            args.update(
+                curRankNumToken=num_tokens,
+                replayMode=0,
+                dispDestTokIdMap=dest_map.data_ptr(),
+                tokenIndices=indices_ptr,
+                inpTokenBuf=input.data_ptr(),
+                weightsBuf=weights_ptr,
+                scalesBuf=(
+                    kw["scales"].data_ptr() if kw.get("scales") is not None else 0
+                ),
+                rdmaBlockNum=geom[1],
+            )
+            if os.environ.get("MORI_INTERNODE_TRACE_ARGS") and self.cfg.rank == 0:
+                print(
+                    f"[trace] {phase} ll={ll} tokens={num_tokens} "
+                    f"weightsBuf={weights_ptr:#x} tokenIndices={indices_ptr:#x} "
+                    f"dispDestTokIdMap={args['dispDestTokIdMap']:#x} "
+                    f"offCombineOutWeights={args['offCombineOutWeights']} "
+                    f"rdma={args['rdmaBlockNum']} passes={names}",
+                    flush=True,
+                )
+            plan_api.launch_multi(
+                plans, stream=torch.cuda.current_stream().cuda_stream, **args
+            )
+
+        return run
+
     def _build_kernels(self, cfg, arena) -> KernelSet:
         bad = self._unsupported(cfg)
+        if not bad and cfg.is_internode:
+            return self._build_internode_kernels(cfg)
         if bad:
             # Build nothing when the config is out of range: constructing a Plan
             # compiles, and compiling a kernel we are about to reject is both
@@ -306,32 +776,47 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
 
     # -- views (same contract as the FlyDSL backend) -----------------------
 
+    # Region names for the two arena layouts. The views below are one contract
+    # over both, so the only thing that varies is which name each maps to.
+    _VIEW_REGION = {
+        "disp_out": ("disp_out", "inter_dispatch_out"),
+        "out_tok": ("out_tok", "inter_combine_inp"),
+        "out_wts": ("out_wts", "dispatch_out_weights"),
+        "out_idx": ("out_idx", "out_indices"),
+        "out_scales": ("out_scales", "out_scales"),
+        "recv_to_src_token": ("recv_to_src_token", "disp_tok_id_to_src_tok_id"),
+    }
+
+    def _region(self, name):
+        intra, inter = self._VIEW_REGION[name]
+        return inter if self.cfg.is_internode else intra
+
     def recv_tokens(self):
         # fp4 packs 2 e2m1 per element of the torch dtype -> last dim is hidden/2.
         cols = self.cfg.hidden_dim // 2 if self.cfg.is_fp4 else self.cfg.hidden_dim
         return from_gpu_ptr(
-            self.arena.local_ptr("disp_out"),
+            self.arena.local_ptr(self._region("disp_out")),
             (self._recv_cap, cols),
             self.cfg.dispatch_dtype,
         )
 
     def combine_in_view(self):
         return from_gpu_ptr(
-            self.arena.local_ptr("out_tok"),
+            self.arena.local_ptr(self._region("out_tok")),
             (self._recv_cap, self.cfg.hidden_dim),
             self.cfg.combine_dtype,
         )
 
     def recv_weights(self):
         return from_gpu_ptr(
-            self.arena.local_ptr("out_wts"),
+            self.arena.local_ptr(self._region("out_wts")),
             (self._recv_cap, self.cfg.num_experts_per_token),
             torch.float32,
         )
 
     def recv_indices(self):
         return from_gpu_ptr(
-            self.arena.local_ptr("out_idx"),
+            self.arena.local_ptr(self._region("out_idx")),
             (self._recv_cap, self.cfg.num_experts_per_token),
             torch.int32,
         )
@@ -349,7 +834,7 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
             return None
         stride_i32 = self._scale_stride_i32(self.cfg)
         rows = from_gpu_ptr(
-            self.arena.local_ptr("out_scales"),
+            self.arena.local_ptr(self._region("out_scales")),
             (self._recv_cap, stride_i32),
             torch.int32,
         )

--- a/python/mori/ops/dispatch_combine_v2/hip_backend.py
+++ b/python/mori/ops/dispatch_combine_v2/hip_backend.py
@@ -79,17 +79,30 @@ _SCALE_ALIGN = 128
 # Which tuning-table dtype column a dispatch dtype reads.
 _FP8_TUNING_DTYPES = (torch.float8_e4m3fnuz, torch.float8_e4m3fn)
 
+# Read once. Both of these gate diagnostics inside the per-launch path, and
+# `os.environ.get` is a C-level dict lookup wrapped in encode/decode: the host
+# profile charged the two of them 5us per round (4 lookups: two diagnostics x
+# two launches) on a path where the host already paces the GPU. Reading them at
+# import costs nothing and cannot be forgotten at a third call site.
+_DEBUG_GEOM = bool(os.environ.get("MORI_EP_DEBUG_GEOM"))
+_TRACE_ARGS = bool(os.environ.get("MORI_INTERNODE_TRACE_ARGS"))
 
-def _raw_stream() -> int:
-    """The current stream as a raw pointer.
+
+def _raw_stream(dev_index: int) -> int:
+    """The current stream on `dev_index`, as a raw pointer.
 
     `torch.cuda.current_stream().cuda_stream` builds a Python Stream wrapper on
     every call -- ~14us a launch in the host profile, on a path where the host
     already paces the GPU. The private entry returns the pointer directly; it is
     what torch.compile's generated code uses. Fall back if it is ever renamed.
+
+    The device index is passed in rather than queried: `torch.cuda.current_device()`
+    is a lazy-init check plus a C call (~1.5us a launch in the same profile) for a
+    value the op fixes at construction. The STREAM still has to be read every call
+    -- a caller may run us under a different one.
     """
     try:
-        return torch._C._cuda_getCurrentRawStream(torch.cuda.current_device())
+        return torch._C._cuda_getCurrentRawStream(dev_index)
     except AttributeError:
         return torch.cuda.current_stream().cuda_stream
 
@@ -120,7 +133,8 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
     def __init__(self, cfg, comm):
         self.cfg = cfg
         self.comm = comm
-        dev = torch.device("cuda", torch.cuda.current_device())
+        self._dev_index = torch.cuda.current_device()
+        dev = torch.device("cuda", self._dev_index)
         self.dev = dev
         self._recv_cap = cfg.effective_max_recv
         self._closed = False
@@ -674,6 +688,19 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
                     cfg, leg_dtype[self._INTERNODE_LEG[n]], block, warp, rdma
                 )
                 built[n] = cb.EP_INTERNODE_PLANS[n](**req)
+                # Two launch arguments that never vary for THIS plan, so they
+                # belong on the plan rather than in every launch's dict:
+                #   rdmaBlockNum  a plan is compiled per geometry and lives in
+                #                 exactly one `_internode_plans[geom]`, so the
+                #                 value a launch could pass is always geom[1].
+                #   replayMode    this backend has no replay path (KernelSet
+                #                 carries dispatch_replay=None); it is always 0.
+                # bind() stores ints in the plan's cached struct, and _launch_buf
+                # re-writes only the per-call names and the non-int defaults --
+                # so a bound int is written once at bind time and never again,
+                # while a passed one costs a _set_arg every launch (~1.2us each,
+                # x2 args x2 launches per round).
+                built[n].bind(rdmaBlockNum=rdma, replayMode=0)
             self._internode_plans[geom] = built
             self._plans.extend(built.values())
 
@@ -741,6 +768,24 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
             geom = self._internode_geom_for(phase, num_tokens)
             group = self._internode_groups[(geom, (phase, ll))]
 
+            # Opt-in: what actually reached the launch. The tuning table resolving
+            # correctly when called offline does not prove the geometry a launch
+            # runs at -- the bucket walk, the CU clamp and the rdma clamp all sit
+            # between them, and a plan is compiled per geometry, so a wrong pick
+            # is a silently different kernel rather than an error. Printed once
+            # per distinct (phase, ll, geom, tokens) so it cannot pace the loop.
+            if _DEBUG_GEOM:
+                seen = self.__dict__.setdefault("_geom_logged", set())
+                k = (phase, ll, geom, int(num_tokens))
+                if k not in seen:
+                    seen.add(k)
+                    print(
+                        f"# GEOM rank={self.cfg.rank} {phase} ll={ll} "
+                        f"tok={int(num_tokens)} -> block/rdma/warp={geom} "
+                        f"buckets={self._internode_buckets}",
+                        flush=True,
+                    )
+
             # Two of the kernel's arguments are set by dispatch and READ AGAIN by
             # combine, but the base only hands them to dispatch -- combine's
             # signature carries no indices and treats `weights` as a request
@@ -776,10 +821,11 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
             indices_ptr = getattr(self, "_internode_indices_ptr", 0)
 
             # Only what varies. The rest is bound on the plan; see
-            # _build_internode_kernels.
+            # _build_internode_kernels -- rdmaBlockNum and replayMode used to be
+            # passed here and are bound there now, since neither can differ
+            # between two launches that reach the same plan.
             args = dict(
                 curRankNumToken=num_tokens,
-                replayMode=0,
                 dispDestTokIdMap=dest_map.data_ptr(),
                 tokenIndices=indices_ptr,
                 inpTokenBuf=input.data_ptr(),
@@ -787,17 +833,16 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
                 scalesBuf=(
                     kw["scales"].data_ptr() if kw.get("scales") is not None else 0
                 ),
-                rdmaBlockNum=geom[1],
             )
-            if os.environ.get("MORI_INTERNODE_TRACE_ARGS") and self.cfg.rank == 0:
+            if _TRACE_ARGS and self.cfg.rank == 0:
                 print(
                     f"[trace] {phase} ll={ll} tokens={num_tokens} "
                     f"weightsBuf={weights_ptr:#x} tokenIndices={indices_ptr:#x} "
                     f"dispDestTokIdMap={args['dispDestTokIdMap']:#x} "
-                    f"rdma={args['rdmaBlockNum']} passes={names}",
+                    f"rdma={geom[1]} passes={names}",
                     flush=True,
                 )
-            group.launch(_raw_stream(), **args)
+            group.launch(_raw_stream(self._dev_index), **args)
 
         return run
 

--- a/python/mori/ops/dispatch_combine_v2/hip_backend.py
+++ b/python/mori/ops/dispatch_combine_v2/hip_backend.py
@@ -106,7 +106,7 @@ _TRACE_ARGS = bool(os.environ.get("MORI_INTERNODE_TRACE_ARGS"))
 # supplies the row index; that is only correct because dispatch and combine are
 # each called exactly once per round.
 _DEV_TS = bool(os.environ.get("MORI_EP_DEV_TS"))
-_TS_SLOTS = 16  # must equal kEpDbgTsSlots in ep_internode_kernel.hpp
+_TS_SLOTS = 24  # must equal kEpDbgTsSlots in ep_internode_kernel.hpp
 _TS_ROUNDS = 4096
 
 

--- a/python/mori/ops/dispatch_combine_v2/hip_backend.py
+++ b/python/mori/ops/dispatch_combine_v2/hip_backend.py
@@ -80,7 +80,6 @@ _SCALE_ALIGN = 128
 _FP8_TUNING_DTYPES = (torch.float8_e4m3fnuz, torch.float8_e4m3fn)
 
 
-
 def scale_stride_bytes(scale_bytes: int) -> int:
     """What a DESTINATION scale row is laid down at: EpScaleStride in ep_cfg.hpp.
 
@@ -281,6 +280,17 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
             torch.float32,
         )
 
+        # Pin everything fixed for the op's lifetime, now that every buffer it
+        # names exists. The launch path re-fills every field passed through
+        # `args` on every call -- only bound values reach the plan's cached
+        # struct -- so passing the whole 36-field schema each time cost ~40
+        # ctypes field writes per phase, measured as the largest single item in
+        # the host profile (80 _set_arg calls per round). Binding leaves eight.
+        static = self._internode_static_args()
+        for built in self._internode_plans.values():
+            for plan in built.values():
+                plan.bind(**static)
+
     def _internode_unsupported(self, cfg) -> tuple[str, ...]:
         bad = []
         if cfg.is_scatter:
@@ -477,7 +487,7 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
             mpCount=self._mp_count,
         )
 
-    def _internode_arena_args(self):
+    def _internode_static_args(self):
         """The window handle, the seventeen offsets and the local pointers.
 
         Everything here is fixed for the life of the op, so it is built once and
@@ -486,7 +496,7 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
         per pass sequence, on a path where the host is already the thing the GPU
         waits for.
         """
-        cached = getattr(self, "_internode_static_args", None)
+        cached = getattr(self, "_internode_static_cache", None)
         if cached is not None:
             return cached
         a = self.arena
@@ -496,7 +506,7 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
         def ptr(t):
             return 0 if t is None else t.data_ptr()
 
-        self._internode_static_args = dict(
+        self._internode_static_cache = dict(
             window=a.handle,
             offDispatchInp=off("inter_dispatch_inp"),
             offCombineInp=off("inter_combine_inp"),
@@ -535,7 +545,7 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
             # embed a ccoDevComm by value, so the binding memcpys from host memory.
             devComm=self._dev_comm._dev_comm.host_ptr,
         )
-        return self._internode_static_args
+        return self._internode_static_cache
 
     # Below this token count the LL variants win; above it the plain ones do.
     # The same split v1's bench selects at, and both variants are compiled either
@@ -728,8 +738,9 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
                 weights_ptr = 0
             indices_ptr = getattr(self, "_internode_indices_ptr", 0)
 
-            args = dict(self._internode_arena_args())
-            args.update(
+            # Only what varies. The rest is bound on the plan; see
+            # _build_internode_kernels.
+            args = dict(
                 curRankNumToken=num_tokens,
                 replayMode=0,
                 dispDestTokIdMap=dest_map.data_ptr(),
@@ -746,7 +757,6 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
                     f"[trace] {phase} ll={ll} tokens={num_tokens} "
                     f"weightsBuf={weights_ptr:#x} tokenIndices={indices_ptr:#x} "
                     f"dispDestTokIdMap={args['dispDestTokIdMap']:#x} "
-                    f"offCombineOutWeights={args['offCombineOutWeights']} "
                     f"rdma={args['rdmaBlockNum']} passes={names}",
                     flush=True,
                 )

--- a/python/mori/ops/dispatch_combine_v2/hip_backend.py
+++ b/python/mori/ops/dispatch_combine_v2/hip_backend.py
@@ -85,6 +85,17 @@ _FP8_TUNING_DTYPES = (torch.float8_e4m3fnuz, torch.float8_e4m3fn)
 # two launches) on a path where the host already paces the GPU. Reading them at
 # import costs nothing and cannot be forgotten at a third call site.
 _DEBUG_GEOM = bool(os.environ.get("MORI_EP_DEBUG_GEOM"))
+# Diagnostic: launch the pass sequence one plan at a time with a timing event
+# after each, instead of as one launch group. This is the only way to see which
+# KERNEL owns a slow round -- the group crosses the ABI once and the passes run
+# back to back, so no event can be placed between them from outside.
+#
+# It costs host time (one extra ABI crossing and one event per pass, ~5 of each
+# per round), and host time converts to measured time roughly 1:1 on this path,
+# so the ABSOLUTE numbers under it read high. The decomposition is still valid:
+# the spike being hunted is ~120us against ~25us of added overhead, and what is
+# wanted is which pass grew, not what it costs.
+_SPLIT_PASSES = bool(os.environ.get("MORI_EP_SPLIT_PASSES"))
 _TRACE_ARGS = bool(os.environ.get("MORI_INTERNODE_TRACE_ARGS"))
 
 
@@ -159,6 +170,8 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
         # them per call -- torch.as_tensor + view showed up in the host profile at
         # ~27us a round, on a path where the host already paces the GPU.
         self._views = {}
+        # (pass_name, event) appended per launch when MORI_EP_SPLIT_PASSES is on.
+        self._pass_marks = []
         # gfx125x routes to the TDM kernel, which needs a superset arena (plan A).
         _arch = getattr(torch.cuda.get_device_properties(dev), "gcnArchName", "") or ""
         self._is1250 = _arch.split(":")[0].startswith("gfx125")
@@ -877,7 +890,20 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
                     f"rdma={geom[1]} passes={names}",
                     flush=True,
                 )
-            group.launch(_raw_stream(self._dev_index), **args)
+            if _SPLIT_PASSES:
+                stream = _raw_stream(self._dev_index)
+                built = self._internode_plans[geom]
+                marks = self._pass_marks
+                e = torch.cuda.Event(enable_timing=True)
+                e.record()
+                marks.append((phase + ":start", e))
+                for nm in names:
+                    built[nm].launch(stream, **args)
+                    e = torch.cuda.Event(enable_timing=True)
+                    e.record()
+                    marks.append((nm, e))
+            else:
+                group.launch(_raw_stream(self._dev_index), **args)
 
         return run
 

--- a/python/mori/ops/dispatch_combine_v2/hip_backend.py
+++ b/python/mori/ops/dispatch_combine_v2/hip_backend.py
@@ -658,6 +658,22 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
             self._internode_plans[geom] = built
             self._plans.extend(built.values())
 
+        # One bound launch group per (geometry, phase, low-latency). The set of
+        # plans a launch fires is fixed by that triple, so the validation and the
+        # ctypes handle array belong here rather than on the launch path. A
+        # geometry only carries the passes it actually serves, hence the subset
+        # test -- the shipped table gives dispatch and combine the same triple at
+        # 16 tokens but different ones elsewhere.
+        from mori.jit.v2 import plan_api
+
+        self._internode_groups = {}
+        for geom, built in self._internode_plans.items():
+            for key, names in self._INTERNODE_SEQ.items():
+                if all(n in built for n in names):
+                    self._internode_groups[(geom, key)] = plan_api.make_launch_group(
+                        [built[n] for n in names]
+                    )
+
         disp_spec = (cfg.dispatch_block_num, cfg.warp_num_per_block)
         comb_spec = (cfg.combine_block_num, cfg.combine_warp_num_per_block)
         return KernelSet(
@@ -686,7 +702,6 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
         crossings become one, and a JIT-compile failure on a later pass aborts
         before any earlier one is enqueued.
         """
-        from mori.jit.v2 import plan_api
 
         def run(*, input, num_tokens, dest_map, **kw):
             # The low-latency pair is chosen by token count. `_internode_force_ll`
@@ -702,7 +717,7 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
             )
             names = self._INTERNODE_SEQ[(phase, ll)]
             geom = self._internode_geom_for(phase, num_tokens)
-            plans = [self._internode_plans[geom][n] for n in names]
+            group = self._internode_groups[(geom, (phase, ll))]
 
             # Two of the kernel's arguments are set by dispatch and READ AGAIN by
             # combine, but the base only hands them to dispatch -- combine's
@@ -760,9 +775,7 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
                     f"rdma={args['rdmaBlockNum']} passes={names}",
                     flush=True,
                 )
-            plan_api.launch_multi(
-                plans, stream=torch.cuda.current_stream().cuda_stream, **args
-            )
+            group.launch(torch.cuda.current_stream().cuda_stream, **args)
 
         return run
 

--- a/python/mori/ops/dispatch_combine_v2/hip_backend.py
+++ b/python/mori/ops/dispatch_combine_v2/hip_backend.py
@@ -291,6 +291,20 @@ class EpDispatchCombineOpHip(EpDispatchCombineOp, backend="hip"):
                 f"quant_type={cfg.quant_type!r} "
                 "(the internode combine implements none and fp8_direct_cast)"
             )
+        # The internode kernel is single-T: EpDispatchCombineArgs<T> carries one
+        # element type, and `hiddenBytes = hiddenDim * sizeof(T)` sizes both the
+        # dispatch payload and the combine output. A dispatch dtype narrower than
+        # the combine dtype does not fault -- the kernel writes hidden*sizeof(fp8)
+        # bytes and the combine_out view reads hidden*sizeof(bf16), so half the
+        # output is whatever was already there. Reject it: on this path an fp8
+        # transport is spelled quant_type='fp8_direct_cast', which keeps T at the
+        # combine dtype and uses fp8 for the staging slots only.
+        if cfg.is_asymmetric_dtype:
+            bad.append(
+                f"asymmetric dtype (dispatch {cfg.dispatch_dtype} -> combine "
+                f"{cfg.combine_dtype}): the internode kernel has a single element "
+                "type; use quant_type='fp8_direct_cast' for an fp8 transport"
+            )
         # The same-destination dedup is a ballot with one lane per expert.
         from .dispatch_combine_op import WAVE
 

--- a/python/mori/ops/dispatch_combine_v2/internode_regions.py
+++ b/python/mori/ops/dispatch_combine_v2/internode_regions.py
@@ -1,0 +1,126 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""The internode op's symmetric arena: 17 named regions and their sizes.
+
+Every size here is transcribed from what ``EpDispatchCombineHandle`` allocates on
+the CCO path (``src/ops/dispatch_combine/dispatch_combine.cpp``,
+``InitializeShmemBuf`` / ``InitializeTokenNumSignalBuf`` / ``InitializeOrderMapBuf``
+/ ``InitializeBarrier``), because that is what the kernel was written against and
+what it is still validated against. Transcribed, not re-derived: a formula that
+merely resembles the original is the one bug class this file cannot afford.
+
+Two things about the v1 allocator are worth carrying over as intent rather than
+as code:
+
+* It already carves every buffer out of ONE registered CCO window with 256 B
+  alignment -- its own comment says it mirrors FlyDSL's SymmArena. So this is not
+  a new memory model, it is the same one with names.
+* It sizes that window as ``6 * MaxNumTokensToRecv * hiddenDim * maxTokenTypeSize
+  + 256 MB``. The 256 MB is slack, and slack is what has been absorbing any
+  discrepancy between these formulas and what the kernel actually indexes. Sizing
+  the arena exactly, as SymmArena does, removes that cushion -- which is the point
+  (an overrun should fail loudly) but also means a wrong formula here shows up as
+  corruption rather than as nothing at all.
+
+`interNodeChunkFlagCombine` is deliberately NOT here. Despite the name it is not
+the local half of ``inter_node_chunk_flag``: the symmetric one is written by
+dispatch and read+cleared by combine (combine enumerates its work from dispatch's
+leftover flags), while that one counts completions and is plain device memory.
+They have different types and different lifetimes; pairing them by name gives
+combine an all-zero work list and a hang.
+"""
+
+from __future__ import annotations
+
+_I32 = 4
+_U64 = 8
+_F32 = 4
+
+
+def internode_regions(cfg):
+    """``[(name, nbytes)]`` for :class:`SymmArena`, in v1's allocation order.
+
+    Order matters only for reproducing v1's offsets when comparing the two side
+    by side; the kernel addresses everything by name.
+
+    ``cfg`` needs: world_size, gpu_per_node, hidden_dim, max_num_inp_token_per_rank,
+    num_experts_per_rank, num_experts_per_token, max_token_type_size, scale_dim,
+    scale_type_size, num_qp_per_pe, max_total_recv_tokens.
+    """
+    ws = cfg.world_size
+    gpn = cfg.gpu_per_node
+    if gpn <= 0 or ws % gpn:
+        raise ValueError(f"world_size {ws} must be a multiple of gpu_per_node {gpn}")
+    n_nodes = ws // gpn
+
+    m = cfg.max_num_inp_token_per_rank  # MaxNumTokensToSendPerRank
+    topk = cfg.num_experts_per_token
+    tsz = cfg.max_token_type_size
+    hidden = cfg.hidden_dim
+
+    # MaxNumTokensToRecvPerRank clamps by max_total_recv_tokens when set.
+    if cfg.max_total_recv_tokens > 0:
+        per_rank = min((cfg.max_total_recv_tokens + ws - 1) // ws, m)
+    else:
+        per_rank = m
+    recv = ws * per_rank  # MaxNumTokensToRecv
+
+    # MaxXferBytesPerToken: hidden + index + weight + srcTokenId + scale.
+    scale_bytes = cfg.scale_dim * cfg.scale_type_size
+    xfer = hidden * tsz + topk * _I32 + topk * _F32 + _I32 + scale_bytes
+
+    # maxNumOutToken, the stride of the order maps.
+    max_out_token = ws * m * cfg.num_experts_per_rank
+    barrier_bytes = ws * _I32
+
+    regions = [
+        # --- ShmemBufsInterNodeV1, in InitializeShmemBuf's order --------------
+        ("inter_dispatch_inp", n_nodes * m * xfer),
+        ("inter_combine_inp", recv * xfer),  # v1's maxStagingSize
+        ("inter_staging", 2 * n_nodes * m * xfer),
+        ("inter_dispatch_out", recv * hidden * tsz),
+        ("inter_combine_out", m * hidden * tsz),
+        ("inter_dispatch_staging", m * xfer),
+        # --- weights ---------------------------------------------------------
+        ("inp_weights", recv * topk * _F32),
+        ("dispatch_out_weights", recv * topk * _F32),
+        ("combine_out_weights", recv * topk * _F32),
+        # --- indices ---------------------------------------------------------
+        ("out_indices", recv * topk * _I32),
+        # --- token-count signals ---------------------------------------------
+        ("recv_token_num", ws * _I32 * 2 * cfg.num_qp_per_pe),
+        ("node_recv_token_num", n_nodes * _U64),
+        # --- order maps ------------------------------------------------------
+        ("disp_tok_offset", _I32),
+        ("disp_tok_id_to_src_tok_id", max_out_token * _I32),
+        # --- barriers and flags ----------------------------------------------
+        ("cross_device_barrier", barrier_bytes * 2 * _U64),
+        ("inter_node_chunk_flag", n_nodes * m * _U64),
+    ]
+
+    # Scales are absent, not zero-sized, when the transport is off: the kernel
+    # gates on the region being unbound exactly as v1 gated on an invalid
+    # SymmMemObjPtr.
+    if scale_bytes:
+        regions.append(("out_scales", recv * scale_bytes))
+
+    return regions

--- a/python/mori/ops/dispatch_combine_v2/internode_tuning_configs.py
+++ b/python/mori/ops/dispatch_combine_v2/internode_tuning_configs.py
@@ -23,14 +23,19 @@
 """Per-device launch geometry for the v2 CCO internode (InterNodeV1LL)
 dispatch/combine kernels.
 
-The internode kernels reach their grid a different way than the intranode ones:
-the launch redirect (see the v2 internode test) inherits geometry from
-``dispatch_combine.py`` -- the shmem resolve -- rather than a per-token schedule
-the kernel selects at runtime. So the *host* picks a per-token bucket here and
-pins the resulting block/rdma/warp on ``op.dispatch`` / ``op.combine``. That is
-why this table, unlike ``tuning_configs.py`` (flydsl intranode) and
-``hip_tuning_configs.py``, carries an ``rdma_block_num`` per phase and is looked
-up with the live ``num_tokens`` rather than compiled into a schedule.
+The internode kernels reach their grid a different way than the intranode ones.
+An intranode kernel is compiled once per (block, warp) the schedule can name and
+picks among those at launch; an internode *pass sequence* is compiled per
+geometry, because ``rdma_block_num`` splits the grid between the RDMA blocks and
+the intra-node ones and the kernel branches on it. So the host resolves a bucket
+here from the live ``num_tokens`` and launches the plan set built for it --
+``HipBackend._internode_geometry_buckets`` walks this whole table at build time
+so that resolution can never trigger a compile.
+
+That is also why this table, unlike ``tuning_configs.py`` (flydsl intranode) and
+``hip_tuning_configs.py``, carries an ``rdma_block_num`` per phase: dispatch and
+combine are tuned to different values at the same token count over one shared
+arena, which a single geometry per bucket cannot express.
 
 Devices are told apart the same way as ``tuning_configs.py`` -- PCI DID first
 (MI300X and MI308X are both gfx942, differing only in CU count), then arch. The
@@ -117,4 +122,9 @@ def lookup(world_size, hidden_dim, topk, num_tokens, dtype="fp8"):
 
     cu = gpu_utils.cu_count() or 80
     db, cb = min(db, cu), min(cb, cu)  # never over-subscribe the CUs
+    # rdma_block_num partitions the SAME grid: blocks below it talk to the
+    # network, the rest do the intra-node half. Clamping block without clamping
+    # rdma can leave rdma >= block, which is not slow but wrong -- no block is
+    # left for the intra-node side and the dispatch barrier never completes.
+    dr, cr = min(dr, max(1, db - 1)), min(cr, max(1, cb - 1))
     return {"dispatch": (db, dr, dw), "combine": (cb, cr, cw)}

--- a/python/mori/ops/dispatch_combine_v2/internode_tuning_configs.py
+++ b/python/mori/ops/dispatch_combine_v2/internode_tuning_configs.py
@@ -111,10 +111,20 @@ from mori.ops import utils as gpu_utils
 # a multiple-comparison problem and the sweep alone cannot tell a real effect
 # from the best of 165 draws. The bar applied here is: the tuned phase's median
 # must be better in all three head-to-heads.
-#   4. A plain interleaved bench A/B of the resulting TABLE. Stage 3 runs two ops
-#      at once -- incumbent and candidate each holding a symmetric window, run
-#      alternately -- which is not the shipping condition, so its verdict does
-#      not transfer on its own.
+#   4. A plain interleaved bench A/B of the resulting TABLE. This stage cannot be
+#      replaced by a better statistic inside the tuner, and that was measured
+#      rather than assumed. Two things differ, both verified on (32,12,6):
+#        * the ESTIMATOR -- the tuner takes the median over 21 paired passes,
+#          the bench the mean over 30 rounds of ONE pass. The two geometries have
+#          the SAME median round (42.0 against 41-42); the candidate spikes to
+#          4-5x on one round in thirty, which moves a bench mean and which a
+#          median over passes discards.
+#        * the ENVIRONMENT -- the tuner holds two ops alive, each with its own
+#          symmetric window, alternating. That makes BOTH arms spike: worst round
+#          124/127, 127/127, 127/133 over three runs, against 79 and 65 for the
+#          incumbent and 162 and 205 for the candidate in a plain bench. The
+#          candidate's own spike is invisible because the environment supplies
+#          one to both arms.
 #
 # Stage 4 rejected 8-token dispatch (32,12,6), which had passed stage 3 on both
 # the median (39.0/39.2/40.2 against 40.9/41.0/41.3) and the worst. In a plain

--- a/python/mori/ops/dispatch_combine_v2/internode_tuning_configs.py
+++ b/python/mori/ops/dispatch_combine_v2/internode_tuning_configs.py
@@ -92,6 +92,47 @@ from mori.ops import utils as gpu_utils
 # tokens has gone with it. The note is left standing for the 8-token row, whose
 # sweep found nothing better and which still carries rdma 32.
 #
+# Re-tune (2026-09-09) after the CCO NUMA-binding fix. EVERY number above this
+# line was tuned with the ranks unbound, i.e. every A/B in it raced a +-40us
+# random term from CPU placement, so the table had to be re-derived rather than
+# trusted. ONE row moved: 32-token combine 80/40/8 -> 64/48/6.
+#
+# Method, FOUR stages. The fourth is not optional and I learned that the hard way:
+#   1. Full sweep, 165 candidates (the rdma grid was widened from three points to
+#      eighths -- the old one could not even reach the shipped 32-token rdma=48),
+#      three repeats per (token, phase).
+#   2. Keep only candidates that won in at least two of the three repeats. At 4
+#      tokens the three sweeps returned 15 winners and NONE repeated, which is
+#      the whole argument for this stage.
+#   3. Head-to-head against the shipped row, 21 paired reps, three times.
+#
+# Stage 3 is not a formality. 16-token combine (64,40,6) won all THREE sweeps and
+# then lost all three head-to-heads -- picking a winner out of 165 candidates is
+# a multiple-comparison problem and the sweep alone cannot tell a real effect
+# from the best of 165 draws. The bar applied here is: the tuned phase's median
+# must be better in all three head-to-heads.
+#   4. A plain interleaved bench A/B of the resulting TABLE. Stage 3 runs two ops
+#      at once -- incumbent and candidate each holding a symmetric window, run
+#      alternately -- which is not the shipping condition, so its verdict does
+#      not transfer on its own.
+#
+# Stage 4 rejected 8-token dispatch (32,12,6), which had passed stage 3 on both
+# the median (39.0/39.2/40.2 against 40.9/41.0/41.3) and the worst. In a plain
+# bench it read 118.1/118.8/115.9 against the shipped row's 92.0/94.3, with one
+# dispatch worst of 374us -- best-in-class once and much worse three times. That
+# geometry leaves only 20 of 32 blocks for the intra-node half and is bimodal;
+# 8-token dispatch is therefore UNCHANGED.
+#
+# 32-token combine (64,48,6) passed stage 4: interleaved against the shipped row,
+# three pairs, 113.6/114.6/114.3 against 116.1/116.1/118.3, with combine itself
+# 65.0/64.9/64.9 against 66.7/66.8/67.3. That is the one row this re-tune moved.
+# 4- and 32-token dispatch had no candidate reproduce at all and are unchanged.
+#
+# Two candidates cleared the tail bar but not the median one and are NOT applied,
+# recorded so they are not re-derived: 4-token combine (64,16,8) and 8-token
+# combine (80,50,4). Both tie on the median and cut the worst of the paired reps
+# by 15-25us. They are a real trade, not noise; they want their own decision.
+#
 # Methodology, because a sweep on this path is easy to get wrong: candidates are
 # judged by a PAIRED comparison against a FIXED incumbent, not by a chain. v1's
 # greedy shape (a winner becomes the incumbent) is unusable at this noise level
@@ -102,7 +143,7 @@ _MI308X_EP16_H6144 = (
     (4, 32, 16, 4, 32, 21, 6),
     (8, 64, 32, 8, 32, 21, 6),
     (16, 80, 40, 4, 80, 40, 4),
-    (None, 80, 48, 8, 80, 40, 8),
+    (None, 80, 48, 8, 64, 48, 6),
 )
 
 # (device_key, world_size, hidden_dim, topk) -> {dtype: schedule}

--- a/python/mori/ops/dispatch_combine_v2/internode_tuning_configs.py
+++ b/python/mori/ops/dispatch_combine_v2/internode_tuning_configs.py
@@ -71,9 +71,35 @@ from mori.ops import utils as gpu_utils
 # moved: a single shared 80/rdma40/warp4 geometry for both phases beat the old
 # 80/48/8 + 80/40/8 by ~4us total (disp 41.3 vs 43.6, comb 51.1 vs 53.1),
 # reproducible across two A/B batches.
+#
+# Re-tune (2026-09-08, v2 CCO path, `--cmd tuning` in the v2 harness): only the
+# 4-token DISPATCH moved, 64/32/8 -> 32/16/4. Everything else in this table was
+# re-swept and held: 4-token combine, both phases at 8, 16 and 32 tokens -- 0
+# reproducible wins over 3 repeats each (16 and 32 gave 0 wins in all 6 runs).
+#
+# That row is the one change because it is the only one that reproduced. Three
+# independent 29-candidate sweeps ranked 32/16/4 first every time (-2.4, -2.6,
+# -2.8us paired against the fixed incumbent), and eight 51-rep head-to-heads gave
+# a median of -2.3us with 6 of 8 clearing the margin. The per-phase split is
+# consistent across all eight: dispatch 36.9-38.4us against 39.2-40.9us, combine
+# 46.2-46.9 against 45.8-46.6 -- so the gain is ~6% of dispatch and the combine
+# after it is unchanged.
+#
+# That last part matters, because the coupling note above predicts the opposite:
+# it records rdma 16 costing ~+18us on the paired combine at 4/8 tokens, which is
+# why this row held rdma at 32. On the v2 CCO path that penalty does not appear
+# (46.5 vs 46.5 in the validation runs), so the reason for keeping rdma high at 4
+# tokens has gone with it. The note is left standing for the 8-token row, whose
+# sweep found nothing better and which still carries rdma 32.
+#
+# Methodology, because a sweep on this path is easy to get wrong: candidates are
+# judged by a PAIRED comparison against a FIXED incumbent, not by a chain. v1's
+# greedy shape (a winner becomes the incumbent) is unusable at this noise level
+# -- five repeats of one sweep returned five different winners. See _tune in
+# tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py.
 _MI308X_EP16_H6144 = (
     # max_tok, disp_block, disp_rdma, disp_warp, comb_block, comb_rdma, comb_warp
-    (4, 64, 32, 8, 32, 21, 6),
+    (4, 32, 16, 4, 32, 21, 6),
     (8, 64, 32, 8, 32, 21, 6),
     (16, 80, 40, 4, 80, 40, 4),
     (None, 80, 48, 8, 80, 40, 8),

--- a/python/mori/ops/dispatch_combine_v2/symm_arena.py
+++ b/python/mori/ops/dispatch_combine_v2/symm_arena.py
@@ -66,6 +66,15 @@ class SymmArena:
     def total_bytes(self):
         return self._total
 
+    def has(self, name):
+        """Whether this arena carries `name`.
+
+        Regions that are absent are absent, not zero-sized -- the scale transport
+        is the case that matters -- so a caller binding an offset needs to ask
+        rather than index.
+        """
+        return name in self._offsets
+
     def offset(self, name):
         return self._offsets[name]
 

--- a/src/cco/cco_init.cpp
+++ b/src/cco/cco_init.cpp
@@ -34,6 +34,7 @@
 #include <vector>
 
 #include "hip/hip_runtime_api.h"
+#include "mori/application/utils/cpu_affinity.hpp"
 #include "mori/application/application.hpp"  // Context, BootstrapNetwork
 #include "mori/application/bootstrap/local_bootstrap.hpp"
 #include "mori/application/bootstrap/socket_bootstrap.hpp"
@@ -422,6 +423,26 @@ static hipError_t CcoZeroWindowMem(void* ptr, size_t bytes) {
 
 static int ccoCommCreateImpl(application::BootstrapNetwork* bootNet, size_t perRankVmmSize,
                              ccoComm** outComm) {
+  // Pin this thread to its GPU's NUMA-local CPUs before the bootstrap, the
+  // Context and any worker thread below (new threads inherit the affinity).
+  // This is the single bind site for the CCO path, mirroring shmem's in
+  // src/shmem/init.cpp -- which was, until now, the ONLY caller of this helper,
+  // so a job that used CCO instead of shmem ran unbound.
+  //
+  // It is not a tuning knob. Unbound, the scheduler is free to place two of the
+  // eight per-node ranks on the two SMT siblings of one physical core; both then
+  // run at about half speed, measured as an exact 2x on the EP host loop
+  // (~43 -> ~80us a round) for the affected ranks and no change for the others.
+  // Those ranks arrive ~36us late, their node's intra-node barrier makes the
+  // other seven wait, and the peer node then waits at the cross-node rendezvous
+  // -- which is the whole of the bistable slow regime documented in
+  // docs/EP_INTERNODE_V2_TAIL.md. It also made every EP v2 measurement against
+  // the v1/shmem path unfair in v1's favour, since v1 bound and v2 did not.
+  //
+  // The caller has already hipSetDevice()'d -- the same contract step 2 below
+  // relies on when it caches comm->hipDev. MORI_IGNORE_CPU_AFFINITY=1 disables.
+  application::BindCallingThreadToGpuNumaOnce();
+
   auto* comm = new ccoComm();
   *outComm = comm;
 

--- a/src/ops/dispatch_combine_v2/ep_internode_kernel.hpp
+++ b/src/ops/dispatch_combine_v2/ep_internode_kernel.hpp
@@ -54,19 +54,22 @@
 
 #include <type_traits>
 
-#include "mori/application/application_device_types.hpp"
 #include "mori/core/core.hpp"
 #include "mori/core/profiler/constants.hpp"
 #include "mori/core/profiler/kernel_profiler.hpp"
-#include "mori/ops/dispatch_combine/dispatch_combine.hpp"
 #ifdef ENABLE_PROFILER
 #include "mori/profiler/profiler.hpp"
 #endif
 // The cfg half only. ep_internode_spec.hpp is host-only -- it pulls in the
 // Compiler, which this TU is the OUTPUT of and must not depend on.
 #include "mori/ops/dispatch_combine_v2/ep_internode_cfg.hpp"
-#include "src/ops/dispatch_combine/common.hpp"
-#include "src/ops/dispatch_combine/convert.hpp"
+// The argument surface, the config the bodies read, the flat-index helpers and
+// MultiWarpIter -- everything this TU used to take from v1's dispatch_combine.hpp,
+// common.hpp and application_device_types.hpp. Those three are gone: they cost 219
+// transitive headers per JIT compile against 14 here, and dispatch_combine.hpp is
+// where the ENABLE_PROFILER / ENABLE_STANDARD_MOE_ADAPT conditional struct tail
+// lives that the JIT toolchain never defines and nothing was checking.
+#include "mori/ops/dispatch_combine_v2/ep_internode_args.hpp"
 
 // mori/core/utils/utils.hpp defines `warpSize` as an object-like macro, while
 // cco.hpp declares mori::cco::impl::warpSize(). Whichever lands first wins, so
@@ -80,7 +83,59 @@
 #pragma pop_macro("warpSize")
 
 namespace mori {
-namespace moe {
+namespace ops {
+namespace v2 {
+
+// ---------------------------------------------------------------------------
+// v2 spellings, under the names the bodies below already use.
+//
+// The bodies live in this namespace and say `index_t`, `QuantType::...`,
+// `EpDispatchCombineArgs<T>` and the flat-index helpers unqualified. Introducing
+// the v2 types under those names is what lets the argument surface change
+// without touching the ~250 `args.` sites, the 39 index-helper calls or the 29
+// signatures -- the surface moves, the algorithm does not, and the two want to
+// be separately reviewable.
+//
+// Scaffolding with a definite end: moving these bodies out of mori::moe deletes
+// this block and makes v1's namespace unreachable from the v2 tree. Nothing
+// else belongs here.
+// ---------------------------------------------------------------------------
+using index_t = ep_index_t;
+using QuantType = EpQuantType;
+
+template <typename T>
+using EpDispatchCombineArgs = EpInterNodeArgs<T>;
+
+// v1's common.hpp macro, with the config type swapped. Everything else is
+// verbatim, including the assert: numExpertPerToken must fit in a ballot.
+#define DEF_COMMON_VARS                                                           \
+  const EpInterNodeDeviceCfg config = EpInterNodeDeviceCfgOf(kConfig, args.rank); \
+  int thdId = threadIdx.x;                                                        \
+  int thdNum = blockDim.x;                                                        \
+  int laneId = threadIdx.x & (warpSize - 1);                                      \
+  int warpId = thdId / warpSize;                                                  \
+  int warpNum = blockDim.x / warpSize;                                            \
+  int blockNum = gridDim.x;                                                       \
+  int blockId = blockIdx.x;                                                       \
+  int globalThdId = blockIdx.x * blockDim.x + threadIdx.x;                        \
+  int globalThdNum = gridDim.x * blockDim.x;                                      \
+  int globalWarpId = blockIdx.x * warpNum + warpId;                               \
+  int globalWarpNum = gridDim.x * warpNum;                                        \
+  int nullTokenId = NullFlatTokenIndex(config);                                   \
+  int myPe = config.rank;                                                         \
+  int npes = config.worldSize;                                                    \
+  int myNode = myPe / config.gpuPerNode;                                          \
+  int nNodes = npes / config.gpuPerNode;                                          \
+  int numExpertPerToken = config.numExpertPerToken;                               \
+  assert(numExpertPerToken < warpSize);                                           \
+  size_t hiddenDim = config.HiddenDimSz();                                        \
+  size_t hiddenBytes = config.HiddenBytes(sizeof(T));                             \
+  size_t indexBytes = config.IndexBytes();                                        \
+  size_t weightBytes = config.WeightBytes();                                      \
+  size_t srcTokenIdBytes = config.SrcTokenIdBytes();                              \
+  size_t scaleBytes = config.ScaleBytes();                                        \
+  size_t xferBytes = config.XferBytesPerToken(sizeof(T));                         \
+  size_t combXferBytes = (args.weightsBuf == nullptr) ? hiddenBytes : hiddenBytes + weightBytes;
 
 /* ---------------------------------------------------------------------------------------------- */
 /*                                    Transport shim (cco-GDA)                                    */
@@ -89,7 +144,7 @@ namespace moe {
 // identical to the shmem calls they replaced, so the call sites read the same.
 //
 // Only cross-node traffic is here. Intra-node peer access is untouched: it was
-// always a direct store through SymmMemObj::p2pPeerPtrs, and MallocSymm fills
+// always a direct store through the flat LSA VA, and the arena window covers
 // those from ccoGetPeerPtr on the cco backend, so GetAs<T*>(pe) keeps working.
 //
 // Scope, matching what the replaced shmem calls actually did:
@@ -115,15 +170,13 @@ inline constexpr ::mori::core::ProviderType kEpInterNodeProvider = CCO_GDA_BUILD
 // A buffer's position in the arena window. Every EP buffer is a sub-region of
 // one registered window (EpDispatchCombineHandle::MallocSymm), and RDMA names a
 // remote buffer as (window, byte offset) with iova=0 -- there is no peer VA to
-// hand the NIC, which is why SymmMemObj carries these two fields.
-__device__ __forceinline__ ::mori::cco::ccoWindow_t EpInterNodeWin(
-    const application::SymmMemObjPtr obj) {
-  return reinterpret_cast<::mori::cco::ccoWindow_t>(obj->ccoWin);
+// hand the NIC, which is why a region is (window, offset).
+__device__ __forceinline__ ::mori::cco::ccoWindow_t EpInterNodeWin(const EpInterNodeRegion obj) {
+  return reinterpret_cast<::mori::cco::ccoWindow_t>(obj->win);
 }
 
-__device__ __forceinline__ size_t EpInterNodeOff(const application::SymmMemObjPtr obj,
-                                                 size_t byteOffset) {
-  return obj->ccoWinOffset + byteOffset;
+__device__ __forceinline__ size_t EpInterNodeOff(const EpInterNodeRegion obj, size_t byteOffset) {
+  return obj->off + byteOffset;
 }
 
 // ── the one primitive ccoGda does not expose ─────────────────────────────────
@@ -135,13 +188,27 @@ __device__ __forceinline__ size_t EpInterNodeOff(const application::SymmMemObjPt
 // signal pool -- a fixed gdaSignalCount slots read through waitSignal's
 // consume-on-read shadow -- so neither the address nor the semantics fit.
 //
-// Rather than grow the facade with a remote action that only this op wants, the
-// two lookups the facade would do -- (window, offset) -> (rkey, raddr) and
-// (pe, qpId) -> endpoint -- happen here and the WQE is posted through
-// mori::cco::impl. That is the level ccoGdaBarrierSession composes at, and
-// cco.hpp spells out the same lkey/rkey/raddr triple for kernels that do it.
-// No warp protocol is duplicated: signalImpl posts one WQE for its caller, and
-// putImpl runs the same warp aggregation the facade would have run.
+// So the two lookups the facade would do -- (window, offset) -> (rkey, raddr)
+// and (pe, qpId) -> endpoint -- happen here and the WQE is posted through
+// mori::cco::impl. No warp protocol is duplicated: signalImpl posts one WQE for
+// its caller, and putImpl runs the same warp aggregation the facade would have
+// run.
+//
+// THIS IS A LAYERING VIOLATION AND SHOULD NOT BE COPIED. cco_scale_out.hpp says
+// of that namespace: "Device kernels use the public ccoGda<> facade ... never
+// these directly", and EP is its only caller outside cco. It is here because the
+// facade cannot currently express the operation, not because reaching past it is
+// acceptable: the resolver pins a remote action to
+// `signalId * sizeof(uint64_t)` in comm.resourceWindow, and EP's chunk flags are
+// at an arbitrary offset in EP's own window.
+//
+// The fix belongs in cco, and is small: a remote-action type carrying
+// (window, offset, value) alongside ccoGda_SignalInc / ccoGda_SignalAdd, plus one
+// `else if constexpr` per resolver site. `put` and `signal` are already templated
+// on RemoteAction, so both of the calls below would then go through the facade
+// unchanged and this block would delete. Until then, folding the flag atomic into
+// the put's own reservation is worth keeping -- the facade route costs one extra
+// doorbell and CQE per chunk, on the critical path of a latency-bound kernel.
 
 __device__ __forceinline__ ::mori::core::RdmaEndpointDevice* EpInterNodeEndpoint(
     const ::mori::cco::ccoDevComm& comm, int pe, int qpId) {
@@ -151,14 +218,13 @@ __device__ __forceinline__ ::mori::core::RdmaEndpointDevice* EpInterNodeEndpoint
   return &ibgda->endpoints[pe * ibgda->numQpPerPe + (qpId % ibgda->numQpPerPe)];
 }
 
-__device__ __forceinline__ uint32_t EpInterNodeRkey(const application::SymmMemObjPtr obj, int pe) {
+__device__ __forceinline__ uint32_t EpInterNodeRkey(const EpInterNodeRegion obj, int pe) {
   return EpInterNodeWin(obj)->ibgdaWin.peerRkeys[pe];
 }
 
 __device__ __forceinline__ void EpInterNodeAtomicAdd(const ::mori::cco::ccoDevComm& comm,
-                                                     const application::SymmMemObjPtr dst,
-                                                     size_t dstOffset, uint64_t value, int pe,
-                                                     int qpId = 0) {
+                                                     const EpInterNodeRegion dst, size_t dstOffset,
+                                                     uint64_t value, int pe, int qpId = 0) {
   ::mori::core::RdmaEndpointDevice* ep = EpInterNodeEndpoint(comm, pe, qpId);
   ::mori::cco::impl::signalImpl<kEpInterNodeProvider>(ep, ep->qpn, EpInterNodeOff(dst, dstOffset),
                                                       EpInterNodeRkey(dst, pe),
@@ -188,11 +254,12 @@ __device__ __forceinline__ void EpInterNodeAtomicAdd(const ::mori::cco::ccoDevCo
 // putImpl directly skips the facade's group-by-peer ballot, and all three call
 // sites are warp-uniform in both (proxyPe follows the warp's node, and
 // startTokenIdx is a multiple of warpSize so tokenId / warpSize is too).
-__device__ __forceinline__ void EpInterNodePutSignal(
-    const ::mori::cco::ccoDevComm& comm, const application::SymmMemObjPtr dst, size_t dstOffset,
-    const application::SymmMemObjPtr src, size_t srcOffset, size_t bytes,
-    const application::SymmMemObjPtr signal, size_t signalOffset, uint64_t signalValue, int pe,
-    int qpId) {
+__device__ __forceinline__ void EpInterNodePutSignal(const ::mori::cco::ccoDevComm& comm,
+                                                     const EpInterNodeRegion dst, size_t dstOffset,
+                                                     const EpInterNodeRegion src, size_t srcOffset,
+                                                     size_t bytes, const EpInterNodeRegion signal,
+                                                     size_t signalOffset, uint64_t signalValue,
+                                                     int pe, int qpId) {
   ::mori::core::RdmaEndpointDevice* ep = EpInterNodeEndpoint(comm, pe, qpId);
   ::mori::cco::impl::putImpl<kEpInterNodeProvider>(
       ep, ep->qpn, EpInterNodeOff(src, srcOffset), EpInterNodeWin(src)->ibgdaWin.lkey,
@@ -202,10 +269,9 @@ __device__ __forceinline__ void EpInterNodePutSignal(
 }
 
 __device__ __forceinline__ void EpInterNodePut(const ::mori::cco::ccoDevComm& comm,
-                                               const application::SymmMemObjPtr dst,
-                                               size_t dstOffset,
-                                               const application::SymmMemObjPtr src,
-                                               size_t srcOffset, size_t bytes, int pe, int qpId) {
+                                               const EpInterNodeRegion dst, size_t dstOffset,
+                                               const EpInterNodeRegion src, size_t srcOffset,
+                                               size_t bytes, int pe, int qpId) {
   if ((threadIdx.x & (warpSize - 1)) != 0) return;
   ::mori::cco::ccoGda<kEpInterNodeProvider> gda{comm, qpId};
   gda.template put<::mori::cco::CCO_TEAM_WORLD, ::mori::cco::ccoGdaThreadIndependent>(
@@ -239,64 +305,27 @@ __device__ __forceinline__ int32_t EpInterNodeWaitGt(int32_t* addr, int32_t val)
   return observed;
 }
 
-// ── compile-time configuration ───────────────────────────────────────────────
-//
-// v1 reads its whole configuration out of args.config, so
-// `flat / config.MaxNumTokensToRecv()` and friends are a scalar load feeding a
-// full integer division, repeated in every inner loop. EpInterNodeKernelCfg carries the
-// fields that cannot change on a live handle as an NTTP -- the same
-// `template <EpCfg kCfg, typename T>` shape ep_intranode_kernel.hpp uses.
-//
-// The last mile differs from intranode, because the code does. There the body is
-// self-contained and `constexpr int kNpes = kCfg.worldSize;` is the whole story.
-// Here the body is only the entry: the work is spread over forty-odd helpers
-// that all read `config.xxx` (77 sites for numExpertPerToken alone), plus free
-// functions like SendBufSlotOffset that take a `const EpDispatchCombineConfig&`.
-// So the entry writes the constants over its BY-VALUE copy of args instead, and
-// DEF_COMMON_VARS binds `config` to that. Every helper takes `args` by reference
-// from the entry, so after inlining these stores are the only definitions their
-// loads can see: constant propagation reaches all of them and not one signature
-// changes.
-//
-// The fields left alone -- rank, blockNum, warpNumPerBlock -- keep the values
-// the host launched with; see EpInterNodeKernelCfg for why they are not specialised.
-template <::mori::ops::v2::EpInterNodeKernelCfg kConfig>
-__device__ __forceinline__ void EpInterNodeBindConfig(EpDispatchCombineConfig& config) {
-  config.worldSize = kConfig.worldSize;
-  config.hiddenDim = kConfig.hiddenDim;
-  config.scaleDim = kConfig.scaleDim;
-  config.scaleTypeSize = kConfig.scaleTypeSize;
-  config.maxTokenTypeSize = kConfig.maxTokenTypeSize;
-  config.maxNumInpTokenPerRank = kConfig.maxNumInpTokenPerRank;
-  config.numExpertPerRank = kConfig.numExpertPerRank;
-  config.numExpertPerToken = kConfig.numExpertPerToken;
-  config.maxTotalRecvTokens = kConfig.maxTotalRecvTokens;
-  config.gpuPerNode = kConfig.gpuPerNode;
-  config.numQpPerPe = kConfig.numQpPerPe;
-  config.quantType = kConfig.quantType;
-}
-
 /* ---------------------------------------------------------------------------------------------- */
 /*                                   EpDispatchInterNodeV1Kernel                                  */
 /* ---------------------------------------------------------------------------------------------- */
-namespace v1 {
-template <typename T>
+namespace internode {
+template <EpInterNodeKernelCfg kConfig, typename T>
 inline __device__ void DispatchIntraNodeBlock(EpDispatchCombineArgs<T>& args, int tokenId,
                                               int expId, int destPe, int& localPeTokenCounter) {
   DEF_COMMON_VARS;
 
-  index_t tokenExpertId = tokenId * args.config.numExpertPerToken + expId;
+  index_t tokenExpertId = tokenId * config.numExpertPerToken + expId;
   index_t destTokId = 0;
   if (!args.replayMode) {
     if (laneId == 0) {
       // decide token id in dest pe
-      destTokId = atomicAdd(args.dispTokOffsetMemObj->template GetAs<index_t*>(destPe), 1);
+      destTokId = atomicAdd(args.reg(args.offDispTokOffset)->template GetAs<index_t*>(destPe), 1);
       assert(destTokId < config.MaxNumTokensToRecv() &&
              "Total recv token overflow: increase maxTotalRecvTokens");
       args.dispDestTokIdMap[tokenExpertId] = FlatTokenIndex(config, destPe, destTokId);
 
       core::AtomicStoreRelaxedSystem(
-          args.dispTokIdToSrcTokIdMemObj->template GetAs<index_t*>(destPe) + destTokId,
+          args.reg(args.offDispTokIdToSrcTokId)->template GetAs<index_t*>(destPe) + destTokId,
           static_cast<index_t>(FlatTokenIndex(config, config.rank, tokenId)));
     }
     destTokId = __shfl(destTokId, 0);
@@ -310,28 +339,28 @@ inline __device__ void DispatchIntraNodeBlock(EpDispatchCombineArgs<T>& args, in
   size_t srcTokOffset = tokenId * hiddenDim;
   size_t destTokOffset = destTokId * hiddenDim;
 
-  T* remoteTokenPtr = args.interNodeV1TokBufs.dispatchOut->template GetAs<T*>(destPe);
+  T* remoteTokenPtr = args.reg(args.offDispatchOut)->template GetAs<T*>(destPe);
   const T* localTokenPtr = args.inpTokenBuf;
   core::WarpCopy(remoteTokenPtr + destTokOffset, localTokenPtr + srcTokOffset, hiddenDim);
 
-  index_t* remoteIndexPtr = args.shmemOutIndicesMemObj->template GetAs<index_t*>(destPe);
+  index_t* remoteIndexPtr = args.reg(args.offOutIndices)->template GetAs<index_t*>(destPe);
   const index_t* localIndexPtr = args.tokenIndices;
   core::WarpCopy(remoteIndexPtr + destTokId * config.numExpertPerToken,
                  localIndexPtr + tokenId * config.numExpertPerToken, config.numExpertPerToken);
 
-  float* remoteWeightPtr = args.shmemDispatchOutWeightsMemObj->template GetAs<float*>(destPe);
+  float* remoteWeightPtr = args.reg(args.offDispatchOutWeights)->template GetAs<float*>(destPe);
   const float* localWeightPtr = args.weightsBuf;
   core::WarpCopy(remoteWeightPtr + destTokId * config.numExpertPerToken,
                  localWeightPtr + tokenId * config.numExpertPerToken, config.numExpertPerToken);
 
   if (args.scalesBuf && (scaleBytes > 0)) {
     core::WarpCopy(
-        args.shmemOutScalesMemObj->template GetAs<uint8_t*>(destPe) + destTokId * scaleBytes,
+        args.reg(args.offOutScales)->template GetAs<uint8_t*>(destPe) + destTokId * scaleBytes,
         args.scalesBuf + tokenId * scaleBytes, scaleBytes);
   }
 }
 
-template <typename T>
+template <EpInterNodeKernelCfg kConfig, typename T>
 inline __device__ void DispatchIntraNode(EpDispatchCombineArgs<T>& args) {
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
@@ -375,7 +404,7 @@ inline __device__ void DispatchIntraNode(EpDispatchCombineArgs<T>& args) {
           args.dispDestTokIdMap[expertOffset] = NullFlatTokenIndex(config);
         continue;
       }
-      DispatchIntraNodeBlock(args, tokenId, inTokenExpertId, destPe, localPeTokenCounter);
+      DispatchIntraNodeBlock<kConfig>(args, tokenId, inTokenExpertId, destPe, localPeTokenCounter);
     }
   }
 
@@ -385,7 +414,7 @@ inline __device__ void DispatchIntraNode(EpDispatchCombineArgs<T>& args) {
   }
 }
 
-template <typename T, bool DEDUP>
+template <EpInterNodeKernelCfg kConfig, typename T, bool DEDUP>
 inline __device__ void DispatchInterNodeSend(EpDispatchCombineArgs<T>& args,
                                              const ::mori::cco::ccoDevComm& comm) {
   DEF_COMMON_VARS;
@@ -462,9 +491,9 @@ inline __device__ void DispatchInterNodeSend(EpDispatchCombineArgs<T>& args,
           if (count > 0) {
             size_t stagingTokOffset = tokenId * xferBytes;
             int qpId = (tokenId / warpSize) % config.numQpPerPe;
-            EpInterNodePutSignal(comm, args.interNodeV1TokBufs.dispatchInp, remoteIdx * xferBytes,
-                                 args.interNodeV1TokBufs.dispatchStaging, stagingTokOffset,
-                                 count * xferBytes, args.interNodeChunkFlagMemObj,
+            EpInterNodePutSignal(comm, args.reg(args.offDispatchInp), remoteIdx * xferBytes,
+                                 args.reg(args.offDispatchStaging), stagingTokOffset,
+                                 count * xferBytes, args.reg(args.offChunkFlag),
                                  (myNode * maxChunkNum + flagSlotId) * sizeof(uint64_t), flag,
                                  proxyPe, qpId);
           }
@@ -498,9 +527,9 @@ inline __device__ void DispatchInterNodeSend(EpDispatchCombineArgs<T>& args,
           index_t tokenNum = std::min(tokenId + warpSize, endTokenIdx) - tokenId;
           size_t stagingTokOffset = tokenId * xferBytes;
           int qpId = (tokenId / warpSize) % config.numQpPerPe;
-          EpInterNodePutSignal(comm, args.interNodeV1TokBufs.dispatchInp, remoteIdx * xferBytes,
-                               args.interNodeV1TokBufs.dispatchStaging, stagingTokOffset,
-                               tokenNum * xferBytes, args.interNodeChunkFlagMemObj,
+          EpInterNodePutSignal(comm, args.reg(args.offDispatchInp), remoteIdx * xferBytes,
+                               args.reg(args.offDispatchStaging), stagingTokOffset,
+                               tokenNum * xferBytes, args.reg(args.offChunkFlag),
                                (myNode * maxChunkNum + flagSlotId) * sizeof(uint64_t), tokenNum + 1,
                                proxyPe, qpId);
         }
@@ -523,14 +552,14 @@ inline __device__ void DispatchInterNodeSend(EpDispatchCombineArgs<T>& args,
       int proxyPe = laneId * config.gpuPerNode + (config.rank % config.gpuPerNode);
       index_t numTokenSignal =
           core::AtomicLoadRelaxed(args.blockFlagCounter + laneId) * warpSize + 1;
-      EpInterNodeAtomicAdd(comm, args.nodeRecvTokenNumMemObj, myNode * sizeof(uint64_t),
+      EpInterNodeAtomicAdd(comm, args.reg(args.offNodeRecvTokenNum), myNode * sizeof(uint64_t),
                            numTokenSignal, proxyPe);
     }
     if (laneId == 0) args.interNodeBlocksBarrier[0] = 0;
   }
 }
 
-template <typename T>
+template <EpInterNodeKernelCfg kConfig, typename T>
 inline __device__ void DispatchInterNodeLLSend(EpDispatchCombineArgs<T>& args,
                                                const ::mori::cco::ccoDevComm& comm) {
   DEF_COMMON_VARS;
@@ -576,9 +605,9 @@ inline __device__ void DispatchInterNodeLLSend(EpDispatchCombineArgs<T>& args,
         size_t stagingTokOffset = tokenId * xferBytes;
         int qpId = (tokenId / warpSize) % config.numQpPerPe;
 
-        EpInterNodePutSignal(comm, args.interNodeV1TokBufs.dispatchInp, remoteIdx * xferBytes,
-                             args.interNodeV1TokBufs.dispatchStaging, stagingTokOffset,
-                             tokenNum * xferBytes, args.interNodeChunkFlagMemObj,
+        EpInterNodePutSignal(comm, args.reg(args.offDispatchInp), remoteIdx * xferBytes,
+                             args.reg(args.offDispatchStaging), stagingTokOffset,
+                             tokenNum * xferBytes, args.reg(args.offChunkFlag),
                              (myNode * maxChunkNum + flagSlotId) * sizeof(uint64_t), tokenNum + 1,
                              proxyPe, qpId);
       }
@@ -595,14 +624,14 @@ inline __device__ void DispatchInterNodeLLSend(EpDispatchCombineArgs<T>& args,
       int proxyPe = laneId * config.gpuPerNode + (config.rank % config.gpuPerNode);
       index_t numTokenSignal =
           core::AtomicLoadRelaxed(args.blockFlagCounter + laneId) * warpSize + 1;
-      EpInterNodeAtomicAdd(comm, args.nodeRecvTokenNumMemObj, myNode * sizeof(uint64_t),
+      EpInterNodeAtomicAdd(comm, args.reg(args.offNodeRecvTokenNum), myNode * sizeof(uint64_t),
                            numTokenSignal, proxyPe);
     }
     if (laneId == 0) args.interNodeBlocksBarrier[1] = 0;
   }
 }
 
-template <typename T>
+template <EpInterNodeKernelCfg kConfig, typename T>
 inline __device__ void DispatchInterNodeRecv(EpDispatchCombineArgs<T>& args) {
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
@@ -612,9 +641,9 @@ inline __device__ void DispatchInterNodeRecv(EpDispatchCombineArgs<T>& args) {
   constexpr int numRecvBlock = 8;
   int maxChunkNum = core::CeilDiv(config.MaxNumTokensToSendPerRank(), warpSize);
 
-  uint64_t* chunkFlag = args.interNodeChunkFlagMemObj->template GetAs<uint64_t*>();
-  uint64_t* nodeRecvTokenNum = args.nodeRecvTokenNumMemObj->template GetAs<uint64_t*>();
-  uint8_t* stagingPtr = args.interNodeV1TokBufs.dispatchInp->template GetAs<uint8_t*>();
+  uint64_t* chunkFlag = args.reg(args.offChunkFlag)->template GetAs<uint64_t*>();
+  uint64_t* nodeRecvTokenNum = args.reg(args.offNodeRecvTokenNum)->template GetAs<uint64_t*>();
+  uint8_t* stagingPtr = args.reg(args.offDispatchInp)->template GetAs<uint8_t*>();
 
   int localPeTokenCounter = 0;
   int totalChunkNum = 0;
@@ -684,12 +713,14 @@ inline __device__ void DispatchInterNodeRecv(EpDispatchCombineArgs<T>& args) {
         int destTokId = 0;
         if (!args.replayMode) {
           if (laneId == 0) {
-            destTokId = atomicAdd(args.dispTokOffsetMemObj->template GetAs<index_t*>(destPe), 1);
+            destTokId =
+                atomicAdd(args.reg(args.offDispTokOffset)->template GetAs<index_t*>(destPe), 1);
             assert(destTokId < config.MaxNumTokensToRecv() &&
                    "Total recv token overflow: increase maxTotalRecvTokens");
             args.interNodeDispDestTokIdMap[tokIdx * config.numExpertPerToken + e] =
                 FlatTokenIndex(config, destPe, destTokId);
-            args.dispTokIdToSrcTokIdMemObj->template GetAs<index_t*>(destPe)[destTokId] = srcTokId;
+            args.reg(args.offDispTokIdToSrcTokId)->template GetAs<index_t*>(destPe)[destTokId] =
+                srcTokId;
           }
           destTokId = __shfl(destTokId, 0);
         } else {
@@ -698,20 +729,20 @@ inline __device__ void DispatchInterNodeRecv(EpDispatchCombineArgs<T>& args) {
           destTokId = LocalTokIdFromFlatTokenIndex(config, flat);
         }
         if (!args.replayMode && (destPe % config.gpuPerNode) == laneId) localPeTokenCounter++;
+        core::WarpCopy<uint8_t, 4>(args.reg(args.offDispatchOut)->template GetAs<uint8_t*>(destPe) +
+                                       destTokId * hiddenBytes,
+                                   stagingPtr + tokIdx * xferBytes, hiddenBytes);
         core::WarpCopy<uint8_t, 4>(
-            args.interNodeV1TokBufs.dispatchOut->template GetAs<uint8_t*>(destPe) +
-                destTokId * hiddenBytes,
-            stagingPtr + tokIdx * xferBytes, hiddenBytes);
-        core::WarpCopy<uint8_t, 4>(
-            args.shmemOutIndicesMemObj->template GetAs<uint8_t*>(destPe) + destTokId * indexBytes,
+            args.reg(args.offOutIndices)->template GetAs<uint8_t*>(destPe) + destTokId * indexBytes,
             stagingPtr + tokIdx * xferBytes + hiddenBytes, indexBytes);
         core::WarpCopy<uint8_t, 4>(
-            args.shmemDispatchOutWeightsMemObj->template GetAs<uint8_t*>(destPe) +
+            args.reg(args.offDispatchOutWeights)->template GetAs<uint8_t*>(destPe) +
                 destTokId * weightBytes,
             stagingPtr + tokIdx * xferBytes + hiddenBytes + indexBytes, weightBytes);
         if ((scaleBytes > 0)) {
           core::WarpCopy<uint8_t, 4>(
-              args.shmemOutScalesMemObj->template GetAs<uint8_t*>(destPe) + destTokId * scaleBytes,
+              args.reg(args.offOutScales)->template GetAs<uint8_t*>(destPe) +
+                  destTokId * scaleBytes,
               stagingPtr + tokIdx * xferBytes + hiddenBytes + indexBytes + weightBytes, scaleBytes);
         }
       }
@@ -724,7 +755,7 @@ inline __device__ void DispatchInterNodeRecv(EpDispatchCombineArgs<T>& args) {
   }
 }
 
-template <typename T>
+template <EpInterNodeKernelCfg kConfig, typename T>
 inline __device__ void DispatchInterNodeLLRecv(EpDispatchCombineArgs<T>& args) {
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
@@ -733,9 +764,9 @@ inline __device__ void DispatchInterNodeLLRecv(EpDispatchCombineArgs<T>& args) {
 
   int maxChunkNum = core::CeilDiv(config.MaxNumTokensToSendPerRank(), warpSize);
 
-  uint64_t* chunkFlag = args.interNodeChunkFlagMemObj->template GetAs<uint64_t*>();
-  uint64_t* nodeRecvTokenNum = args.nodeRecvTokenNumMemObj->template GetAs<uint64_t*>();
-  uint8_t* stagingPtr = args.interNodeV1TokBufs.dispatchInp->template GetAs<uint8_t*>();
+  uint64_t* chunkFlag = args.reg(args.offChunkFlag)->template GetAs<uint64_t*>();
+  uint64_t* nodeRecvTokenNum = args.reg(args.offNodeRecvTokenNum)->template GetAs<uint64_t*>();
+  uint8_t* stagingPtr = args.reg(args.offDispatchInp)->template GetAs<uint8_t*>();
 
   int localPeTokenCounter = 0;
 
@@ -799,29 +830,28 @@ inline __device__ void DispatchInterNodeLLRecv(EpDispatchCombineArgs<T>& args) {
 
     int destTokId = 0;
     if (laneId == 0) {
-      destTokId = atomicAdd(args.dispTokOffsetMemObj->template GetAs<index_t*>(destPe), 1);
+      destTokId = atomicAdd(args.reg(args.offDispTokOffset)->template GetAs<index_t*>(destPe), 1);
       assert(destTokId < config.MaxNumTokensToRecv() &&
              "Total recv token overflow: increase maxTotalRecvTokens");
       args.interNodeDispDestTokIdMap[globalTokenId * config.numExpertPerToken + expertId] =
           FlatTokenIndex(config, destPe, destTokId);
-      args.dispTokIdToSrcTokIdMemObj->template GetAs<index_t*>(destPe)[destTokId] = srcTokId;
+      args.reg(args.offDispTokIdToSrcTokId)->template GetAs<index_t*>(destPe)[destTokId] = srcTokId;
     }
     if ((destPe % config.gpuPerNode) == laneId) localPeTokenCounter++;
     destTokId = __shfl(destTokId, 0);
     core::WarpCopy<uint8_t, 4>(
-        args.interNodeV1TokBufs.dispatchOut->template GetAs<uint8_t*>(destPe) +
-            destTokId * hiddenBytes,
+        args.reg(args.offDispatchOut)->template GetAs<uint8_t*>(destPe) + destTokId * hiddenBytes,
         stagingPtr + globalTokenId * xferBytes, hiddenBytes);
     core::WarpCopy<uint8_t, 4>(
-        args.shmemOutIndicesMemObj->template GetAs<uint8_t*>(destPe) + destTokId * indexBytes,
+        args.reg(args.offOutIndices)->template GetAs<uint8_t*>(destPe) + destTokId * indexBytes,
         stagingPtr + globalTokenId * xferBytes + hiddenBytes, indexBytes);
     core::WarpCopy<uint8_t, 4>(
-        args.shmemDispatchOutWeightsMemObj->template GetAs<uint8_t*>(destPe) +
+        args.reg(args.offDispatchOutWeights)->template GetAs<uint8_t*>(destPe) +
             destTokId * weightBytes,
         stagingPtr + globalTokenId * xferBytes + hiddenBytes + indexBytes, weightBytes);
     if ((scaleBytes > 0)) {
       core::WarpCopy<uint8_t, 4>(
-          args.shmemOutScalesMemObj->template GetAs<uint8_t*>(destPe) + destTokId * scaleBytes,
+          args.reg(args.offOutScales)->template GetAs<uint8_t*>(destPe) + destTokId * scaleBytes,
           stagingPtr + globalTokenId * xferBytes + hiddenBytes + indexBytes + weightBytes,
           scaleBytes);
     }
@@ -833,7 +863,7 @@ inline __device__ void DispatchInterNodeLLRecv(EpDispatchCombineArgs<T>& args) {
   }
 }
 
-template <typename T>
+template <EpInterNodeKernelCfg kConfig, typename T>
 inline __device__ void DispatchSync(EpDispatchCombineArgs<T>& args,
                                     const ::mori::cco::ccoDevComm& comm) {
   DEF_COMMON_VARS;
@@ -849,13 +879,13 @@ inline __device__ void DispatchSync(EpDispatchCombineArgs<T>& args,
     if (laneId < config.gpuPerNode) {
       int destPe = myNode * config.gpuPerNode + laneId;
       index_t numTokenSignal = core::AtomicLoadSeqCstSystem(args.destPeTokenCounter + destPe) + 1;
-      index_t* signal = args.recvTokenNumMemObj->template GetAs<index_t*>(destPe) + myPe;
+      index_t* signal = args.reg(args.offRecvTokenNum)->template GetAs<index_t*>(destPe) + myPe;
       core::AtomicStoreSeqCstSystem(signal, numTokenSignal);
     }
     if (laneId == 0)
       __hip_atomic_store(args.dispatchGridBarrier, 0u, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
 
-    index_t* recvTokenNums = args.recvTokenNumMemObj->template GetAs<index_t*>();
+    index_t* recvTokenNums = args.reg(args.offRecvTokenNum)->template GetAs<index_t*>();
     for (int destPe = nodePeOffset + laneId; destPe < (nodePeOffset + config.gpuPerNode);
          destPe += warpSize) {
       index_t* signal = recvTokenNums + destPe;
@@ -868,7 +898,7 @@ inline __device__ void DispatchSync(EpDispatchCombineArgs<T>& args,
     }
 
     if (laneId == 0) {
-      args.dispTokOffsetMemObj->template GetAs<index_t*>()[0] = 0;
+      args.reg(args.offDispTokOffset)->template GetAs<index_t*>()[0] = 0;
       atomicAdd(args.crossDeviceBarrierFlag, 1);
       __hip_atomic_store(args.combineGridBarrier + 1, 0u, __ATOMIC_RELAXED,
                          __HIP_MEMORY_SCOPE_AGENT);
@@ -890,25 +920,23 @@ inline __device__ void DispatchSync(EpDispatchCombineArgs<T>& args,
   }
 }
 
-}  // namespace v1
+}  // namespace internode
 
-template <::mori::ops::v2::EpInterNodeKernelCfg kConfig, typename T>
+template <EpInterNodeKernelCfg kConfig, typename T>
 __device__ void EpDispatchInterNodeV1Kernel_body(EpDispatchCombineArgs<T> args,
                                                  const ::mori::cco::ccoDevComm& comm) {
-  EpInterNodeBindConfig<kConfig>(args.config);
   DEF_COMMON_VARS;
   if (blockId < args.rdmaBlockNum) {
-    v1::DispatchInterNodeSend<T, true>(args, comm);
-    v1::DispatchInterNodeRecv(args);
+    internode::DispatchInterNodeSend<kConfig, T, true>(args, comm);
+    internode::DispatchInterNodeRecv<kConfig>(args);
   } else {
-    v1::DispatchIntraNode(args);
+    internode::DispatchIntraNode<kConfig>(args);
   }
-  v1::DispatchSync(args, comm);
+  internode::DispatchSync<kConfig>(args, comm);
 }
 
-template <::mori::ops::v2::EpInterNodeKernelCfg kConfig, typename T>
+template <EpInterNodeKernelCfg kConfig, typename T>
 __device__ void EpDispatchCopyToStaging_body(EpDispatchCombineArgs<T> args) {
-  EpInterNodeBindConfig<kConfig>(args.config);
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
       INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
@@ -923,7 +951,7 @@ __device__ void EpDispatchCopyToStaging_body(EpDispatchCombineArgs<T> args) {
     size_t hiddenDimOffset, hiddenDimSize;
     mwIter.Decode(i, tokenId, inTokenPartId, hiddenDimOffset, hiddenDimSize);
 
-    uint8_t* stagingPtr = args.interNodeV1TokBufs.dispatchStaging->template GetAs<uint8_t*>();
+    uint8_t* stagingPtr = args.reg(args.offDispatchStaging)->template GetAs<uint8_t*>();
     size_t stagingTokOffset = tokenId * xferBytes;
     core::WarpCopy<uint8_t, 4>(stagingPtr + stagingTokOffset + hiddenDimOffset * sizeof(T),
                                reinterpret_cast<uint8_t*>(args.inpTokenBuf) +
@@ -947,32 +975,25 @@ __device__ void EpDispatchCopyToStaging_body(EpDispatchCombineArgs<T> args) {
   }
 }
 
-template <::mori::ops::v2::EpInterNodeKernelCfg kConfig, typename T, bool EnableStdMoE>
+template <EpInterNodeKernelCfg kConfig, typename T>
 __device__ void EpDispatchInterNodeV1KernelLowLatency_body(EpDispatchCombineArgs<T> args,
                                                            const ::mori::cco::ccoDevComm& comm) {
-  EpInterNodeBindConfig<kConfig>(args.config);
   DEF_COMMON_VARS;
   if (blockId < args.rdmaBlockNum) {
-    v1::DispatchInterNodeLLSend<T>(args, comm);
-    v1::DispatchInterNodeLLRecv(args);
+    internode::DispatchInterNodeLLSend<kConfig, T>(args, comm);
+    internode::DispatchInterNodeLLRecv<kConfig>(args);
   } else {
-    v1::DispatchIntraNode(args);
+    internode::DispatchIntraNode<kConfig>(args);
   }
-  v1::DispatchSync(args, comm);
-
-#ifdef ENABLE_STANDARD_MOE_ADAPT
-  if constexpr (EnableStdMoE) {
-    InvokeConvertDispatchOutput<T>(args, myPe);
-  }
-#endif
+  internode::DispatchSync<kConfig>(args, comm);
 }
 
 /* ---------------------------------------------------------------------------------------------- */
 /*                                   EpCombineInterNodeV1Kernel                                   */
 /* ---------------------------------------------------------------------------------------------- */
-namespace v1 {
+namespace internode {
 
-template <typename T>
+template <EpInterNodeKernelCfg kConfig, typename T>
 inline __device__ void CombineSync(EpDispatchCombineArgs<T>& args) {
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
@@ -983,25 +1004,24 @@ inline __device__ void CombineSync(EpDispatchCombineArgs<T>& args) {
   int tokenPerBlock = core::CeilDiv(totalRecvTokenNum, blockNum);
   int startTokenIdx = blockId * tokenPerBlock;
   int endTokenIdx = std::min(startTokenIdx + tokenPerBlock, totalRecvTokenNum);
-#ifndef ENABLE_STANDARD_MOE_ADAPT
   for (int tokenId = startTokenIdx + warpId; tokenId < endTokenIdx; tokenId += warpNum) {
-    if (args.config.quantType == QuantType::Fp8DirectCast) {
+    if constexpr (kConfig.quantType == QuantType::Fp8DirectCast) {
       using Fp8T = core::CombineInternalFp8;
-      Fp8T* dst = args.interNodeV1TokBufs.combineInp->template GetAs<Fp8T*>();
+      Fp8T* dst = args.reg(args.offCombineInp)->template GetAs<Fp8T*>();
       const T* src = args.inpTokenBuf;
       const size_t base = tokenId * hiddenDim;
       core::WarpCastBf16ToCombineInternalFp8<T>(dst + base, src + base, hiddenDim, laneId);
     } else {
-      core::WarpCopy(args.interNodeV1TokBufs.combineInp->template GetAs<T*>() + tokenId * hiddenDim,
+      core::WarpCopy(args.reg(args.offCombineInp)->template GetAs<T*>() + tokenId * hiddenDim,
                      args.inpTokenBuf + tokenId * hiddenDim, hiddenDim);
     }
   }
-#endif
   if (args.weightsBuf) {
     for (int tokenId = startTokenIdx + warpId; tokenId < endTokenIdx; tokenId += warpNum) {
-      core::WarpCopy(
-          args.shmemInpWeightsMemObj->template GetAs<float*>() + tokenId * config.numExpertPerToken,
-          args.weightsBuf + tokenId * config.numExpertPerToken, config.numExpertPerToken);
+      core::WarpCopy(args.reg(args.offInpWeights)->template GetAs<float*>() +
+                         tokenId * config.numExpertPerToken,
+                     args.weightsBuf + tokenId * config.numExpertPerToken,
+                     config.numExpertPerToken);
     }
   }
 }
@@ -1058,7 +1078,7 @@ inline __device__ void CombineGather(TokT* dest, TokT** srcPtrs, int accumNum, s
   }
 }
 
-template <typename TokT, typename T>
+template <EpInterNodeKernelCfg kConfig, typename TokT, typename T>
 __forceinline__ __device__ void CombineIntraNodeTyped(EpDispatchCombineArgs<T>& args,
                                                       size_t tokHiddenBytes,
                                                       size_t tokCombXferBytes) {
@@ -1071,7 +1091,7 @@ __forceinline__ __device__ void CombineIntraNodeTyped(EpDispatchCombineArgs<T>& 
   TokT** srcPtrs = reinterpret_cast<TokT**>(sharedMem) + warpId * config.numExpertPerToken;
   float** srcWeightsPtr = reinterpret_cast<float**>(sharedMem) +
                           warpNum * config.numExpertPerToken + warpId * config.numExpertPerToken;
-  uint8_t* stagingPtr = args.interNodeV1TokBufs.staging->template GetAs<uint8_t*>() +
+  uint8_t* stagingPtr = args.reg(args.offStaging)->template GetAs<uint8_t*>() +
                         SendBufSlotOffset(config, nNodes + myNode, 0) * tokCombXferBytes;
 
   int tokenPerBlock = (args.curRankNumToken + xgmiBlockNum - 1) / xgmiBlockNum;
@@ -1087,9 +1107,9 @@ __forceinline__ __device__ void CombineIntraNodeTyped(EpDispatchCombineArgs<T>& 
       index_t destNode = destPe / config.gpuPerNode;
       if (destNode == myNode) {
         index_t destLocalTokId = LocalTokIdFromFlatTokenIndex(config, destTokId);
-        srcPtrs[laneId] = args.interNodeV1TokBufs.combineInp->template GetAs<TokT*>(destPe) +
+        srcPtrs[laneId] = args.reg(args.offCombineInp)->template GetAs<TokT*>(destPe) +
                           destLocalTokId * hiddenDim;
-        srcWeightsPtr[laneId] = args.shmemInpWeightsMemObj->template GetAs<float*>(destPe) +
+        srcWeightsPtr[laneId] = args.reg(args.offInpWeights)->template GetAs<float*>(destPe) +
                                 destLocalTokId * config.numExpertPerToken;
       }
     }
@@ -1103,7 +1123,7 @@ __forceinline__ __device__ void CombineIntraNodeTyped(EpDispatchCombineArgs<T>& 
   }
 }
 
-template <typename TokT, typename T>
+template <EpInterNodeKernelCfg kConfig, typename TokT, typename T>
 __forceinline__ __device__ void CombineIntraNodeLLTyped(EpDispatchCombineArgs<T>& args,
                                                         size_t tokHiddenBytes,
                                                         size_t tokCombXferBytes) {
@@ -1118,7 +1138,7 @@ __forceinline__ __device__ void CombineIntraNodeLLTyped(EpDispatchCombineArgs<T>
   TokT** srcPtrs = reinterpret_cast<TokT**>(sharedMem) + warpId * config.numExpertPerToken;
   float** srcWeightsPtr = reinterpret_cast<float**>(sharedMem) +
                           warpNum * config.numExpertPerToken + warpId * config.numExpertPerToken;
-  uint8_t* stagingPtr = args.interNodeV1TokBufs.staging->template GetAs<uint8_t*>() +
+  uint8_t* stagingPtr = args.reg(args.offStaging)->template GetAs<uint8_t*>() +
                         SendBufSlotOffset(config, nNodes + myNode, 0) * tokCombXferBytes;
 
   // Slices are snapped to a whole vector step so the gather below stays on
@@ -1141,9 +1161,9 @@ __forceinline__ __device__ void CombineIntraNodeLLTyped(EpDispatchCombineArgs<T>
       index_t destNode = destPe / config.gpuPerNode;
       if (destNode == myNode) {
         index_t destLocalTokId = LocalTokIdFromFlatTokenIndex(config, destTokId);
-        srcPtrs[laneId] = args.interNodeV1TokBufs.combineInp->template GetAs<TokT*>(destPe) +
+        srcPtrs[laneId] = args.reg(args.offCombineInp)->template GetAs<TokT*>(destPe) +
                           destLocalTokId * hiddenDim + hiddenDimOffset;
-        srcWeightsPtr[laneId] = args.shmemInpWeightsMemObj->template GetAs<float*>(destPe) +
+        srcWeightsPtr[laneId] = args.reg(args.offInpWeights)->template GetAs<float*>(destPe) +
                                 destLocalTokId * config.numExpertPerToken;
       }
     }
@@ -1158,7 +1178,7 @@ __forceinline__ __device__ void CombineIntraNodeLLTyped(EpDispatchCombineArgs<T>
   }
 }
 
-template <typename TokT, typename T>
+template <EpInterNodeKernelCfg kConfig, typename TokT, typename T>
 __forceinline__ __device__ void CombineInterNodeTyped(EpDispatchCombineArgs<T>& args,
                                                       size_t tokHiddenBytes,
                                                       size_t tokCombXferBytes,
@@ -1168,14 +1188,14 @@ __forceinline__ __device__ void CombineInterNodeTyped(EpDispatchCombineArgs<T>& 
   constexpr int numRecvBlock = 8;
   int maxChunkNum = core::CeilDiv(config.MaxNumTokensToSendPerRank(), warpSize);
 
-  uint64_t* chunkFlag = args.interNodeChunkFlagMemObj->template GetAs<uint64_t*>();
-  index_t* nodeRecvTokenNum = args.nodeRecvTokenNumMemObj->template GetAs<index_t*>();
+  uint64_t* chunkFlag = args.reg(args.offChunkFlag)->template GetAs<uint64_t*>();
+  index_t* nodeRecvTokenNum = args.reg(args.offNodeRecvTokenNum)->template GetAs<index_t*>();
 
   extern __shared__ char sharedMem[];
   TokT** srcPtrs = reinterpret_cast<TokT**>(sharedMem) + warpId * config.numExpertPerToken;
   float** srcWeightsPtr = reinterpret_cast<float**>(sharedMem) +
                           warpNum * config.numExpertPerToken + warpId * config.numExpertPerToken;
-  uint8_t* stagingPtr = args.interNodeV1TokBufs.staging->template GetAs<uint8_t*>();
+  uint8_t* stagingPtr = args.reg(args.offStaging)->template GetAs<uint8_t*>();
 
   int totalBids = 0;
   for (int bid = blockId; bid < numRecvBlock * maxChunkNum * (nNodes - 1);
@@ -1237,11 +1257,10 @@ __forceinline__ __device__ void CombineInterNodeTyped(EpDispatchCombineArgs<T>& 
                 index_t destNode = destPe / config.gpuPerNode;
                 if (destNode == myNode) {
                   index_t destLocalTokId = LocalTokIdFromFlatTokenIndex(config, destTokId);
-                  srcPtrs[laneId] =
-                      args.interNodeV1TokBufs.combineInp->template GetAs<TokT*>(destPe) +
-                      destLocalTokId * hiddenDim;
+                  srcPtrs[laneId] = args.reg(args.offCombineInp)->template GetAs<TokT*>(destPe) +
+                                    destLocalTokId * hiddenDim;
                   srcWeightsPtr[laneId] =
-                      args.shmemInpWeightsMemObj->template GetAs<float*>(destPe) +
+                      args.reg(args.offInpWeights)->template GetAs<float*>(destPe) +
                       destLocalTokId * config.numExpertPerToken;
                 }
                 // routing-handle callers own this tensor, hence no need to reset.
@@ -1269,8 +1288,8 @@ __forceinline__ __device__ void CombineInterNodeTyped(EpDispatchCombineArgs<T>& 
             if ((finished + 1) >= (numRecvBlock * warpNum)) {
               if (laneId == 0) {
                 core::AtomicStoreSeqCstSystem(
-                    args.interNodeChunkFlagMemObj->template GetAs<uint64_t*>() +
-                        node * maxChunkNum + k,
+                    args.reg(args.offChunkFlag)->template GetAs<uint64_t*>() + node * maxChunkNum +
+                        k,
                     uint64_t{0});
                 core::AtomicStoreRelaxedSystem(
                     args.interNodeChunkFlagCombine + node * maxChunkNum + k, index_t{0});
@@ -1278,9 +1297,9 @@ __forceinline__ __device__ void CombineInterNodeTyped(EpDispatchCombineArgs<T>& 
               int proxyPe = node * config.gpuPerNode + (config.rank % config.gpuPerNode);
               int qpId = k % config.numQpPerPe;
               EpInterNodePut(
-                  comm, args.interNodeV1TokBufs.staging,
+                  comm, args.reg(args.offStaging),
                   SendBufSlotOffset(config, myNode + nNodes, startTokenIdx) * tokCombXferBytes,
-                  args.interNodeV1TokBufs.staging,
+                  args.reg(args.offStaging),
                   SendBufSlotOffset(config, node, startTokenIdx) * tokCombXferBytes,
                   thisChunkTokenNum * tokCombXferBytes, proxyPe, qpId);
             }
@@ -1294,7 +1313,7 @@ __forceinline__ __device__ void CombineInterNodeTyped(EpDispatchCombineArgs<T>& 
     batchStart += currentBatchSize;
   }
 
-  // Ensure all prior writes (in particular zeroing interNodeChunkFlagMemObj) are visible
+  // Ensure all prior writes (in particular zeroing the chunk-flag region) are visible
   // to other nodes before participating in the cross-device barrier, so a remote node
   // never observes a non-zero flag that is subsequently overwritten with zero
   __threadfence_system();
@@ -1311,19 +1330,19 @@ __forceinline__ __device__ void CombineInterNodeTyped(EpDispatchCombineArgs<T>& 
   if ((finishedWarp + 1) == (args.rdmaBlockNum * warpNum)) {
     if (laneId < nNodes) {
       core::AtomicStoreSeqCstSystem(
-          args.nodeRecvTokenNumMemObj->template GetAs<uint64_t*>() + laneId, uint64_t{0});
+          args.reg(args.offNodeRecvTokenNum)->template GetAs<uint64_t*>() + laneId, uint64_t{0});
     }
     if ((laneId < nNodes) &&
         (laneId != myNode)) {  // avoid setting myNode, it will be set in intra node branch
       int proxyPe = laneId * config.gpuPerNode + (config.rank % config.gpuPerNode);
       for (int i = 0; i < config.numQpPerPe; i++) {
-        EpInterNodeAtomicAdd(comm, args.crossDeviceBarrierMemObj,
-                             args.config.rank * sizeof(uint64_t), 1, proxyPe, i);
+        EpInterNodeAtomicAdd(comm, args.reg(args.offCrossDeviceBarrier),
+                             args.rank * sizeof(uint64_t), 1, proxyPe, i);
       }
     }
     if (laneId == 0) args.interNodeBlocksBarrier[0] = 0;
 
-    uint64_t* localBarrierPtr = args.crossDeviceBarrierMemObj->template GetAs<uint64_t*>();
+    uint64_t* localBarrierPtr = args.reg(args.offCrossDeviceBarrier)->template GetAs<uint64_t*>();
     if ((laneId < nNodes) && (laneId != myNode)) {
       int proxyPe = laneId * config.gpuPerNode + (config.rank % config.gpuPerNode);
       while (core::AtomicLoadRelaxedSystem(localBarrierPtr + proxyPe) !=
@@ -1333,7 +1352,7 @@ __forceinline__ __device__ void CombineInterNodeTyped(EpDispatchCombineArgs<T>& 
   }
 }
 
-template <typename TokT, typename T>
+template <EpInterNodeKernelCfg kConfig, typename TokT, typename T>
 __forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs<T>& args,
                                                         size_t tokHiddenBytes,
                                                         size_t tokCombXferBytes,
@@ -1343,14 +1362,14 @@ __forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs<T>
   constexpr int numRecvBlock = 8;
   int maxChunkNum = core::CeilDiv(config.MaxNumTokensToSendPerRank(), warpSize);
 
-  uint64_t* chunkFlag = args.interNodeChunkFlagMemObj->template GetAs<uint64_t*>();
-  uint64_t* nodeRecvTokenNum = args.nodeRecvTokenNumMemObj->template GetAs<uint64_t*>();
+  uint64_t* chunkFlag = args.reg(args.offChunkFlag)->template GetAs<uint64_t*>();
+  uint64_t* nodeRecvTokenNum = args.reg(args.offNodeRecvTokenNum)->template GetAs<uint64_t*>();
 
   extern __shared__ char sharedMem[];
   TokT** srcPtrs = reinterpret_cast<TokT**>(sharedMem) + warpId * config.numExpertPerToken;
   float** srcWeightsPtr = reinterpret_cast<float**>(sharedMem) +
                           warpNum * config.numExpertPerToken + warpId * config.numExpertPerToken;
-  uint8_t* stagingPtr = args.interNodeV1TokBufs.staging->template GetAs<uint8_t*>();
+  uint8_t* stagingPtr = args.reg(args.offStaging)->template GetAs<uint8_t*>();
 
   int rdmaWarpNum = args.rdmaBlockNum * warpNum;
   for (int n = 0; n < (nNodes - 1); n++) {
@@ -1398,9 +1417,9 @@ __forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs<T>
           index_t destNode = destPe / config.gpuPerNode;
           if (destNode == myNode) {
             index_t destLocalTokId = LocalTokIdFromFlatTokenIndex(config, destTokId);
-            srcPtrs[laneId] = args.interNodeV1TokBufs.combineInp->template GetAs<TokT*>(destPe) +
+            srcPtrs[laneId] = args.reg(args.offCombineInp)->template GetAs<TokT*>(destPe) +
                               destLocalTokId * hiddenDim + hiddenDimOffset;
-            srcWeightsPtr[laneId] = args.shmemInpWeightsMemObj->template GetAs<float*>(destPe) +
+            srcWeightsPtr[laneId] = args.reg(args.offInpWeights)->template GetAs<float*>(destPe) +
                                     destLocalTokId * config.numExpertPerToken;
           }
         }
@@ -1422,23 +1441,23 @@ __forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs<T>
       if ((finished + 1) >= (warpsPerToken * warpSize)) {
         if (laneId == 0) {
           core::AtomicStoreSeqCstSystem(
-              args.interNodeChunkFlagMemObj->template GetAs<uint64_t*>() + node * maxChunkNum + k,
+              args.reg(args.offChunkFlag)->template GetAs<uint64_t*>() + node * maxChunkNum + k,
               uint64_t{0});
           core::AtomicStoreRelaxedSystem(args.interNodeChunkFlagCombine + node * maxChunkNum + k,
                                          index_t{0});
         }
         int proxyPe = node * config.gpuPerNode + (config.rank % config.gpuPerNode);
         int qpId = k % config.numQpPerPe;
-        EpInterNodePut(comm, args.interNodeV1TokBufs.staging,
+        EpInterNodePut(comm, args.reg(args.offStaging),
                        SendBufSlotOffset(config, myNode + nNodes, startTokenIdx) * tokCombXferBytes,
-                       args.interNodeV1TokBufs.staging,
+                       args.reg(args.offStaging),
                        SendBufSlotOffset(config, node, startTokenIdx) * tokCombXferBytes,
                        thisChunkTokenNum * tokCombXferBytes, proxyPe, qpId);
       }
     }
   }
 
-  // Ensure all prior writes (in particular zeroing interNodeChunkFlagMemObj) are visible
+  // Ensure all prior writes (in particular zeroing the chunk-flag region) are visible
   // to other nodes before participating in the cross-device barrier, so a remote node
   // never observes a non-zero flag that is subsequently overwritten with zero
   __threadfence_system();
@@ -1454,21 +1473,21 @@ __forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs<T>
   if ((finishedWarp + 1) == (args.rdmaBlockNum * warpNum)) {
     if (laneId < nNodes) {
       core::AtomicStoreSeqCstSystem(
-          args.nodeRecvTokenNumMemObj->template GetAs<uint64_t*>() + laneId, uint64_t{0});
+          args.reg(args.offNodeRecvTokenNum)->template GetAs<uint64_t*>() + laneId, uint64_t{0});
     }
     if ((laneId < nNodes) &&
         (laneId != myNode)) {  // avoid setting myNode, it will be set in intra node branch
       int proxyPe = laneId * config.gpuPerNode + (config.rank % config.gpuPerNode);
       for (int i = 0; i < config.numQpPerPe; i++) {
-        EpInterNodeAtomicAdd(comm, args.crossDeviceBarrierMemObj,
-                             args.config.rank * sizeof(uint64_t), 1, proxyPe, i);
+        EpInterNodeAtomicAdd(comm, args.reg(args.offCrossDeviceBarrier),
+                             args.rank * sizeof(uint64_t), 1, proxyPe, i);
       }
       __threadfence_system();
     }
     if (laneId == 0) args.interNodeBlocksBarrier[0] = 0;
 
     // Wait other nodes
-    uint64_t* localBarrierPtr = args.crossDeviceBarrierMemObj->template GetAs<uint64_t*>();
+    uint64_t* localBarrierPtr = args.reg(args.offCrossDeviceBarrier)->template GetAs<uint64_t*>();
     if ((laneId < nNodes) && (laneId != myNode)) {
       int proxyPe = laneId * config.gpuPerNode + (config.rank % config.gpuPerNode);
       while (core::AtomicLoadRelaxedSystem(localBarrierPtr + proxyPe) !=
@@ -1480,25 +1499,25 @@ __forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs<T>
 
 }  // namespace combine_impl
 
-template <typename T>
+template <EpInterNodeKernelCfg kConfig, typename T>
 inline __device__ void CombineIntraNode(EpDispatchCombineArgs<T>& args) {
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
       INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::CombineIntraNode);
-  if (args.config.quantType == QuantType::Fp8DirectCast) {
+  if constexpr (kConfig.quantType == QuantType::Fp8DirectCast) {
     using TokT = core::CombineInternalFp8;
     const size_t tokHiddenBytes = hiddenDim * sizeof(TokT);
     const size_t tokCombXferBytes =
         (args.weightsBuf == nullptr) ? tokHiddenBytes : tokHiddenBytes + weightBytes;
-    combine_impl::CombineIntraNodeTyped<TokT>(args, tokHiddenBytes, tokCombXferBytes);
+    combine_impl::CombineIntraNodeTyped<kConfig, TokT>(args, tokHiddenBytes, tokCombXferBytes);
     return;
   }
 
-  combine_impl::CombineIntraNodeTyped<T>(args, hiddenBytes, combXferBytes);
+  combine_impl::CombineIntraNodeTyped<kConfig, T>(args, hiddenBytes, combXferBytes);
 }
 
-template <typename T>
+template <EpInterNodeKernelCfg kConfig, typename T>
 inline __device__ void CombineIntraNodeLL(EpDispatchCombineArgs<T>& args) {
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
@@ -1506,18 +1525,18 @@ inline __device__ void CombineIntraNodeLL(EpDispatchCombineArgs<T>& args) {
   MORI_TRACE_SPAN(profiler, Slot::CombineIntraNodeLL);
 
   if (args.curRankNumToken == 0) return;
-  if (args.config.quantType == QuantType::Fp8DirectCast) {
+  if constexpr (kConfig.quantType == QuantType::Fp8DirectCast) {
     using TokT = core::CombineInternalFp8;
     const size_t tokHiddenBytes = hiddenDim * sizeof(TokT);
     const size_t tokCombXferBytes =
         (args.weightsBuf == nullptr) ? tokHiddenBytes : tokHiddenBytes + weightBytes;
-    combine_impl::CombineIntraNodeLLTyped<TokT>(args, tokHiddenBytes, tokCombXferBytes);
+    combine_impl::CombineIntraNodeLLTyped<kConfig, TokT>(args, tokHiddenBytes, tokCombXferBytes);
     return;
   }
-  combine_impl::CombineIntraNodeLLTyped<T>(args, hiddenBytes, combXferBytes);
+  combine_impl::CombineIntraNodeLLTyped<kConfig, T>(args, hiddenBytes, combXferBytes);
 }
 
-template <typename T>
+template <EpInterNodeKernelCfg kConfig, typename T>
 inline __device__ void CombineInterNode(EpDispatchCombineArgs<T>& args,
                                         const ::mori::cco::ccoDevComm& comm) {
   DEF_COMMON_VARS;
@@ -1525,52 +1544,53 @@ inline __device__ void CombineInterNode(EpDispatchCombineArgs<T>& args,
       INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::CombineInterNode);
 
-  if (args.config.quantType == QuantType::Fp8DirectCast) {
+  if constexpr (kConfig.quantType == QuantType::Fp8DirectCast) {
     using TokT = core::CombineInternalFp8;
     const size_t tokHiddenBytes = hiddenDim * sizeof(TokT);
     const size_t tokCombXferBytes =
         (args.weightsBuf == nullptr) ? tokHiddenBytes : tokHiddenBytes + weightBytes;
-    combine_impl::CombineInterNodeTyped<TokT>(args, tokHiddenBytes, tokCombXferBytes, comm);
+    combine_impl::CombineInterNodeTyped<kConfig, TokT>(args, tokHiddenBytes, tokCombXferBytes,
+                                                       comm);
     return;
   }
-  combine_impl::CombineInterNodeTyped<T>(args, hiddenBytes, combXferBytes, comm);
+  combine_impl::CombineInterNodeTyped<kConfig, T>(args, hiddenBytes, combXferBytes, comm);
 }
 
-template <typename T>
+template <EpInterNodeKernelCfg kConfig, typename T>
 inline __device__ void CombineInterNodeLL(EpDispatchCombineArgs<T>& args,
                                           const ::mori::cco::ccoDevComm& comm) {
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
       INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::CombineInterNodeLL);
-  if (args.config.quantType == QuantType::Fp8DirectCast) {
+  if constexpr (kConfig.quantType == QuantType::Fp8DirectCast) {
     using TokT = core::CombineInternalFp8;
     const size_t tokHiddenBytes = hiddenDim * sizeof(TokT);
     const size_t tokCombXferBytes =
         (args.weightsBuf == nullptr) ? tokHiddenBytes : tokHiddenBytes + weightBytes;
-    combine_impl::CombineInterNodeLLTyped<TokT>(args, tokHiddenBytes, tokCombXferBytes, comm);
+    combine_impl::CombineInterNodeLLTyped<kConfig, TokT>(args, tokHiddenBytes, tokCombXferBytes,
+                                                         comm);
     return;
   }
-  combine_impl::CombineInterNodeLLTyped<T>(args, hiddenBytes, combXferBytes, comm);
+  combine_impl::CombineInterNodeLLTyped<kConfig, T>(args, hiddenBytes, combXferBytes, comm);
 }
-}  // namespace v1
+}  // namespace internode
 
-template <::mori::ops::v2::EpInterNodeKernelCfg kConfig, typename T>
+template <EpInterNodeKernelCfg kConfig, typename T>
 __device__ void EpCombineInterNodeV1Kernel_body(EpDispatchCombineArgs<T> args,
                                                 const ::mori::cco::ccoDevComm& comm) {
-  EpInterNodeBindConfig<kConfig>(args.config);
   DEF_COMMON_VARS;
 
   if (blockId < args.rdmaBlockNum) {
-    v1::CombineInterNode(args, comm);
+    internode::CombineInterNode<kConfig>(args, comm);
   } else {
-    v1::CombineIntraNode(args);
+    internode::CombineIntraNode<kConfig>(args);
   }
 }
 
 namespace combine_all_impl {
 
-template <typename T>
+template <EpInterNodeKernelCfg kConfig, typename T>
 __forceinline__ __device__ void EpCombineAllInternalFp8(EpDispatchCombineArgs<T>& args,
                                                         size_t fp8HiddenBytes,
                                                         size_t fp8CombXferBytes) {
@@ -1581,7 +1601,7 @@ __forceinline__ __device__ void EpCombineAllInternalFp8(EpDispatchCombineArgs<T>
   Fp8T** srcPtrs = reinterpret_cast<Fp8T**>(sharedMem) + warpId * config.numExpertPerToken;
   float** srcWeightsPtrs = reinterpret_cast<float**>(sharedMem) +
                            warpNum * config.numExpertPerToken + warpId * config.numExpertPerToken;
-  uint8_t* stagingPtr = args.interNodeV1TokBufs.staging->template GetAs<uint8_t*>() +
+  uint8_t* stagingPtr = args.reg(args.offStaging)->template GetAs<uint8_t*>() +
                         SendBufSlotOffset(config, nNodes, 0) * fp8CombXferBytes;
 
   MultiWarpIter mwIter(globalWarpNum, args.curRankNumToken, hiddenDim);
@@ -1614,20 +1634,20 @@ __forceinline__ __device__ void EpCombineAllInternalFp8(EpDispatchCombineArgs<T>
       }
     }
 
-    T* out = args.interNodeV1TokBufs.combineOut->template GetAs<T*>() + tokenId * hiddenDim +
-             hiddenDimOffset;
+    T* out =
+        args.reg(args.offCombineOut)->template GetAs<T*>() + tokenId * hiddenDim + hiddenDimOffset;
     core::WarpAccumCombineInternalFp8ToBf16(out, reinterpret_cast<const Fp8T* const*>(srcPtrs),
                                             nNodes, laneId, hiddenDimSize);
 
     if (args.weightsBuf && (inTokenPartId == mwIter.warpsPerItem - 1)) {
-      core::WarpAccum<float, 4>(args.shmemCombineOutWeightsMemObj->template GetAs<float*>() +
+      core::WarpAccum<float, 4>(args.reg(args.offCombineOutWeights)->template GetAs<float*>() +
                                     tokenId * config.numExpertPerToken,
                                 srcWeightsPtrs, nullptr, nNodes, config.numExpertPerToken);
     }
   }
 }
 
-template <typename T>
+template <EpInterNodeKernelCfg kConfig, typename T>
 __forceinline__ __device__ void EpCombineAllGeneric(EpDispatchCombineArgs<T>& args) {
   DEF_COMMON_VARS;
 
@@ -1635,7 +1655,7 @@ __forceinline__ __device__ void EpCombineAllGeneric(EpDispatchCombineArgs<T>& ar
   T** srcPtrs = reinterpret_cast<T**>(sharedMem) + warpId * config.numExpertPerToken;
   float** srcWeightsPtrs = reinterpret_cast<float**>(sharedMem) +
                            warpNum * config.numExpertPerToken + warpId * config.numExpertPerToken;
-  uint8_t* stagingPtr = args.interNodeV1TokBufs.staging->template GetAs<uint8_t*>() +
+  uint8_t* stagingPtr = args.reg(args.offStaging)->template GetAs<uint8_t*>() +
                         SendBufSlotOffset(config, nNodes, 0) * combXferBytes;
 
   MultiWarpIter mwIter(globalWarpNum, args.curRankNumToken, hiddenDim);
@@ -1667,11 +1687,11 @@ __forceinline__ __device__ void EpCombineAllGeneric(EpDispatchCombineArgs<T>& ar
         srcWeightsPtrs[n] = reinterpret_cast<float*>(base + hiddenBytes);
       }
     }
-    core::WarpAccum<T, 4>(args.interNodeV1TokBufs.combineOut->template GetAs<T*>() +
-                              tokenId * hiddenDim + hiddenDimOffset,
-                          srcPtrs, nullptr, nNodes, hiddenDimSize);
+    core::WarpAccum<T, 4>(
+        args.reg(args.offCombineOut)->template GetAs<T*>() + tokenId * hiddenDim + hiddenDimOffset,
+        srcPtrs, nullptr, nNodes, hiddenDimSize);
     if (args.weightsBuf && (inTokenPartId == mwIter.warpsPerItem - 1)) {
-      core::WarpAccum<float, 4>(args.shmemCombineOutWeightsMemObj->template GetAs<float*>() +
+      core::WarpAccum<float, 4>(args.reg(args.offCombineOutWeights)->template GetAs<float*>() +
                                     tokenId * config.numExpertPerToken,
                                 srcWeightsPtrs, nullptr, nNodes, config.numExpertPerToken);
     }
@@ -1680,9 +1700,8 @@ __forceinline__ __device__ void EpCombineAllGeneric(EpDispatchCombineArgs<T>& ar
 
 }  // namespace combine_all_impl
 
-template <::mori::ops::v2::EpInterNodeKernelCfg kConfig, typename T>
+template <EpInterNodeKernelCfg kConfig, typename T>
 __device__ void EpCombineAll_body(EpDispatchCombineArgs<T> args) {
-  EpInterNodeBindConfig<kConfig>(args.config);
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
       INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
@@ -1694,47 +1713,37 @@ __device__ void EpCombineAll_body(EpDispatchCombineArgs<T> args) {
     if (laneId < nNodes) args.blockFlagCounter[laneId] = 0;
   }
   if (args.curRankNumToken == 0) return;
-  if (args.config.quantType == QuantType::Fp8DirectCast) {
+  if constexpr (kConfig.quantType == QuantType::Fp8DirectCast) {
     using Fp8T = core::CombineInternalFp8;
     const size_t fp8HiddenBytes = hiddenDim * sizeof(Fp8T);
     const size_t fp8CombXferBytes =
         (args.weightsBuf == nullptr) ? fp8HiddenBytes : fp8HiddenBytes + weightBytes;
-    combine_all_impl::EpCombineAllInternalFp8(args, fp8HiddenBytes, fp8CombXferBytes);
+    combine_all_impl::EpCombineAllInternalFp8<kConfig>(args, fp8HiddenBytes, fp8CombXferBytes);
     return;
   }
-  combine_all_impl::EpCombineAllGeneric(args);
+  combine_all_impl::EpCombineAllGeneric<kConfig>(args);
 }
 
-template <::mori::ops::v2::EpInterNodeKernelCfg kConfig, typename T, bool EnableStdMoE>
+template <EpInterNodeKernelCfg kConfig, typename T>
 __device__ void EpCombineInterNodeV1KernelLowLatency_body(EpDispatchCombineArgs<T> args,
                                                           const ::mori::cco::ccoDevComm& comm) {
-  EpInterNodeBindConfig<kConfig>(args.config);
   DEF_COMMON_VARS;
-
-  // If EnableStdMoE, call ConvertCombineInputDevice first to convert standard MoE format
-#ifdef ENABLE_STANDARD_MOE_ADAPT
-  if constexpr (EnableStdMoE) {
-    InvokeConvertCombineInput<T>(args, myPe);
-  }
-#endif
 
   if (blockId < args.rdmaBlockNum) {
-    v1::CombineInterNodeLL(args, comm);
+    internode::CombineInterNodeLL<kConfig>(args, comm);
   } else {
-    v1::CombineIntraNodeLL(args);
+    internode::CombineIntraNodeLL<kConfig>(args);
   }
 }
 
-template <::mori::ops::v2::EpInterNodeKernelCfg kConfig, typename T>
+template <EpInterNodeKernelCfg kConfig, typename T>
 __device__ void EpCombineSync_body(EpDispatchCombineArgs<T> args) {
-  EpInterNodeBindConfig<kConfig>(args.config);
   DEF_COMMON_VARS;
-  v1::CombineSync(args);
+  internode::CombineSync<kConfig>(args);
 }
 
-template <::mori::ops::v2::EpInterNodeKernelCfg kConfig, typename T>
+template <EpInterNodeKernelCfg kConfig, typename T>
 __device__ void EpCombineSyncBarrier_body(EpDispatchCombineArgs<T> args) {
-  EpInterNodeBindConfig<kConfig>(args.config);
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
       INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
@@ -1744,18 +1753,19 @@ __device__ void EpCombineSyncBarrier_body(EpDispatchCombineArgs<T> args) {
     barrierFlag = core::AtomicLoadRelaxed(args.crossDeviceBarrierFlag);
   }
   barrierFlag = __shfl(barrierFlag, 0);
-  uint64_t* localBarrierPtr = args.crossDeviceBarrierMemObj->template GetAs<uint64_t*>();
+  uint64_t* localBarrierPtr = args.reg(args.offCrossDeviceBarrier)->template GetAs<uint64_t*>();
   if (laneId < config.gpuPerNode) {
     int destPe = myNode * config.gpuPerNode + laneId;
     core::AtomicStoreRelaxedSystem(
-        args.crossDeviceBarrierMemObj->template GetAs<uint64_t*>(destPe) + args.config.rank,
+        args.reg(args.offCrossDeviceBarrier)->template GetAs<uint64_t*>(destPe) + args.rank,
         barrierFlag);
     while (core::AtomicLoadRelaxedSystem(localBarrierPtr + destPe) != barrierFlag) {
     }
   }
 }
 
-}  // namespace moe
+}  // namespace v2
+}  // namespace ops
 }  // namespace mori
 
 // ---------------------------------------------------------------------------
@@ -1771,20 +1781,23 @@ __device__ void EpCombineSyncBarrier_body(EpDispatchCombineArgs<T> args) {
 // ---------------------------------------------------------------------------
 
 namespace mori {
-namespace moe {
+namespace ops {
+namespace v2 {
 
-// EpDispatchCombineArgsRaw is static_asserted to share a layout with
-// EpDispatchCombineArgs<T> (dispatch_combine.hpp), which is how the AOT launcher
-// already passes it.
+// EpInterNodeArgsRaw is EpInterNodeArgs<void>: the same struct with the single
+// T-dependent member spelled void*, static_asserted in ep_internode_args.hpp to
+// have identical size and alignment for every T. So the host fills one untyped
+// struct and each kernel reads it as its own T at the same addresses.
 template <typename T>
 __device__ __forceinline__ EpDispatchCombineArgs<T> EpInterNodeAsArgs(
     const ::mori::ops::v2::EpInterNodeCcoArgs& a) {
   EpDispatchCombineArgs<T> typed;
-  __builtin_memcpy(&typed, &a.raw, sizeof(EpDispatchCombineArgsRaw));
+  __builtin_memcpy(&typed, &a.args, sizeof(::mori::ops::v2::EpInterNodeArgsRaw));
   return typed;
 }
 
-}  // namespace moe
+}  // namespace v2
+}  // namespace ops
 }  // namespace mori
 
 // `kConfig` and `TokT` are not macro arguments. The generated TU defines both
@@ -1794,21 +1807,15 @@ __device__ __forceinline__ EpDispatchCombineArgs<T> EpInterNodeAsArgs(
 // the commas inside its brace initialiser would be taken as argument separators.
 
 // Kernels that reach the network.
-#define MORI_EP_INTERNODE_CCO_ENTRY(entry, body)                                          \
-  extern "C" __global__ void entry(::mori::ops::v2::EpInterNodeCcoArgs a) {               \
-    ::mori::moe::body<kConfig, TokT>(::mori::moe::EpInterNodeAsArgs<TokT>(a), a.devComm); \
-  }
-
-// The LL pair, additionally specialised on the standard-MoE adapter.
-#define MORI_EP_INTERNODE_CCO_ENTRY_STDMOE(entry, body, StdMoE)                                   \
+#define MORI_EP_INTERNODE_CCO_ENTRY(entry, body)                                                  \
   extern "C" __global__ void entry(::mori::ops::v2::EpInterNodeCcoArgs a) {                       \
-    ::mori::moe::body<kConfig, TokT, StdMoE>(::mori::moe::EpInterNodeAsArgs<TokT>(a), a.devComm); \
+    ::mori::ops::v2::body<kConfig, TokT>(::mori::ops::v2::EpInterNodeAsArgs<TokT>(a), a.devComm); \
   }
 
 // Staging, sync and the final reduction: local or intra-node only, so they take
 // no communicator. They still take the same argument struct, so the host has one
 // launch path for the whole sequence.
-#define MORI_EP_INTERNODE_CCO_ENTRY_LOCAL(entry, body)                         \
-  extern "C" __global__ void entry(::mori::ops::v2::EpInterNodeCcoArgs a) {    \
-    ::mori::moe::body<kConfig, TokT>(::mori::moe::EpInterNodeAsArgs<TokT>(a)); \
+#define MORI_EP_INTERNODE_CCO_ENTRY_LOCAL(entry, body)                                 \
+  extern "C" __global__ void entry(::mori::ops::v2::EpInterNodeCcoArgs a) {            \
+    ::mori::ops::v2::body<kConfig, TokT>(::mori::ops::v2::EpInterNodeAsArgs<TokT>(a)); \
   }

--- a/src/ops/dispatch_combine_v2/ep_internode_kernel.hpp
+++ b/src/ops/dispatch_combine_v2/ep_internode_kernel.hpp
@@ -128,7 +128,8 @@ using EpDispatchCombineArgs = EpInterNodeArgs;
   int myNode = myPe / config.gpuPerNode;                                   \
   int nNodes = npes / config.gpuPerNode;                                   \
   int numExpertPerToken = config.numExpertPerToken;                        \
-  assert(numExpertPerToken < warpSize);                                    \
+  static_assert(kConfig.numExpertPerToken < warpSize,                       \
+                "numExpertPerToken must fit in a ballot");                   \
   size_t hiddenDim = config.HiddenDimSz();                                 \
   size_t hiddenBytes = config.HiddenBytes(sizeof(T));                      \
   size_t indexBytes = config.IndexBytes();                                 \

--- a/src/ops/dispatch_combine_v2/ep_internode_kernel.hpp
+++ b/src/ops/dispatch_combine_v2/ep_internode_kernel.hpp
@@ -522,8 +522,12 @@ inline __device__ void DispatchInterNodeSend(EpDispatchCombineArgs& args,
     // and DispatchInterNodeRecv only ever polls slots of remote nodes, so that
     // write is dead. It is also unroutable: RAIL connects cross-node same-rail
     // peers only, so a local peer has no QP and EpInterNodeAtomicAdd would fault.
-    // shmem's atomic resolved a local peer to a plain store, hence no guard here
-    // originally.
+    // v1 needed no guard because shmem dispatches per peer on
+    // globalGpuStates->transportTypes[pe] (shmem_device_api.hpp): a same-node
+    // peer is TransportType::P2P, so the atomic became a local XGMI atomic and
+    // never touched a NIC. ccoGda has no such dispatch -- cco_scale_out.hpp
+    // mentions neither P2P nor locality -- so scale-out is the only path it can
+    // take, and it has nowhere to send this.
     if ((laneId < nNodes) && (laneId != myNode)) {
       int proxyPe = laneId * config.gpuPerNode + (myPe % config.gpuPerNode);
       index_t numTokenSignal =

--- a/src/ops/dispatch_combine_v2/ep_internode_kernel.hpp
+++ b/src/ops/dispatch_combine_v2/ep_internode_kernel.hpp
@@ -281,24 +281,6 @@ __device__ __forceinline__ int32_t EpInterNodeWaitGt(int32_t* addr, int32_t val)
   return observed;
 }
 
-// Device timestamps, opt-in. args.dbgTsBuf is null unless MORI_EP_DEV_TS is set
-// on the host, so each site below is one wave-uniform scalar compare against a
-// kernarg. EVERY site sits OUTSIDE a spin loop: the whole point is to time the
-// loops, and an instruction added inside one would change what is measured.
-//
-// wall_clock64() and not mori::cco::clock64(): the latter is
-// __builtin_readcyclecounter(), the SHADER clock, which moves with DVFS. This
-// measurement compares a slow round against a fast one on a box where the
-// shader clock has been observed to vary by several percent, so a shader-clock
-// timer cannot tell "waited longer" from "clocked lower". wall_clock64 is the
-// fixed reference counter; measured on this gfx942 rig at 100.008 MHz.
-constexpr int kEpDbgTsSlots = 24;
-
-__device__ __forceinline__ void EpDbgTs(const EpDispatchCombineArgs& args, int slot) {
-  if (args.dbgTsBuf == nullptr) return;
-  args.dbgTsBuf[args.dbgRound * kEpDbgTsSlots + slot] = static_cast<uint64_t>(wall_clock64());
-}
-
 /* ---------------------------------------------------------------------------------------------- */
 /*                                   EpDispatchInterNodeV1Kernel                                  */
 /* ---------------------------------------------------------------------------------------------- */
@@ -603,17 +585,11 @@ inline __device__ void DispatchInterNodeLLSend(EpDispatchCombineArgs& args,
         size_t stagingTokOffset = tokenId * xferBytes;
         int qpId = (tokenId / warpSize) % config.numQpPerPe;
 
-        // Slots 1/2 bracket the ONE thing that is purely local on the send
-        // side: building the WQE and ringing the doorbell. At 4 tokens there is
-        // exactly one post per pass so this is exact; above 64 tokens it is
-        // last-write-wins and reports the final chunk.
-        EpDbgTs(args, 1);
         EpInterNodePutSignal(comm, args.reg(args.offDispatchInp), remoteIdx * xferBytes,
                              args.reg(args.offDispatchStaging), stagingTokOffset,
                              tokenNum * xferBytes, args.reg(args.offChunkFlag),
                              (myNode * maxChunkNum + flagSlotId) * sizeof(uint64_t), tokenNum + 1,
                              proxyPe, qpId);
-        EpDbgTs(args, 2);
       }
       if (shouldSend) args.interNodeDispSendMap[nNodes * tokenId + i] = destTokId;
     }
@@ -633,10 +609,6 @@ inline __device__ void DispatchInterNodeLLSend(EpDispatchCombineArgs& args,
     }
     if (laneId == 0) args.interNodeBlocksBarrier[1] = 0;
   }
-  // End of the send half. This is a fan-in (atomicAdd), not a barrier -- nobody
-  // blocks -- so slot 3 measures warp-arrival skew plus the tail atomic, and
-  // must not be read as "barrier time".
-  if ((globalWarpId == 0) && (laneId == 0)) EpDbgTs(args, 3);
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
@@ -795,11 +767,6 @@ inline __device__ void DispatchInterNodeLLRecv(EpDispatchCombineArgs& args) {
     index_t nodeFlag = 0;
     if (laneId == 0) {
       uint64_t barrierFlag = args.crossDeviceBarrierFlag[0];
-      // Slots 4/5 bracket the wait for the peer's write to land. Guarded to one
-      // warp so the 32 spinning lanes do not all write the same slot; at 4
-      // tokens globalWarp 0 runs the outer loop exactly once, so it is
-      // unambiguous which wait this is.
-      if (globalWarpId == 0) EpDbgTs(args, 4);
       while (1) {
         thisChunkTokenNum = core::AtomicLoadRelaxedSystem(&chunkFlag[node * maxChunkNum + k]);
         if (thisChunkTokenNum > 0) break;
@@ -810,7 +777,6 @@ inline __device__ void DispatchInterNodeLLRecv(EpDispatchCombineArgs& args) {
           break;
         }
       }
-      if (globalWarpId == 0) EpDbgTs(args, 5);
     }
     thisChunkTokenNum = __shfl(thisChunkTokenNum, 0) - 1;
     int endTokenIdx = startTokenIdx + thisChunkTokenNum;
@@ -875,12 +841,6 @@ inline __device__ void DispatchInterNodeLLRecv(EpDispatchCombineArgs& args) {
     int destPe = myNode * config.gpuPerNode + laneId;
     int counter = atomicAdd(args.destPeTokenCounter + destPe, localPeTokenCounter);
   }
-  // Slot 6 closes the recv half. 5->6 is everything AFTER the peer data has
-  // landed: unpacking the staging slots and WarpCopy-ing each token into the
-  // destination rank's buffer, which for a same-node destPe is an XGMI peer
-  // write. The 4-token measurement put the whole regime delta in this span,
-  // with the post and the spin both flat, so it needs its own bracket.
-  if ((globalWarpId == 0) && (laneId == 0)) EpDbgTs(args, 6);
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
@@ -962,16 +922,6 @@ __device__ void EpDispatchCopyToStaging_body(EpDispatchCombineArgs args) {
       INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::EpDispatchCopyToStaging);
 
-  // Zero the receive counter here rather than from the host. DispatchSync
-  // accumulates into it with atomicAdd, so it has to start at 0 every dispatch;
-  // EpCombineAll clears it at the end of the pair, but that only covers a caller
-  // that always combines. The host's `total_recv.zero_()` covered the rest at the
-  // cost of a whole fill kernel enqueued AHEAD of the dispatch sequence on the
-  // same stream -- it delayed the kernels it was protecting. This is the first
-  // pass of that sequence and runs entirely before dispatch_ll, so stream order
-  // is the ordering guarantee. Before the empty-input return: zero tokens still
-  // needs the counter cleared.
-  if ((blockId == 0) && (thdId == 0)) EpDbgTs(args, 12);
   if (globalThdId == 0) args.totalRecvTokenNum[0] = 0;
   if (args.curRankNumToken == 0) return;
 
@@ -1005,18 +955,12 @@ __device__ void EpDispatchCopyToStaging_body(EpDispatchCombineArgs args) {
                                  weightBytes + scaleBytes)[0] =
           static_cast<index_t>(FlatTokenIndex(config, myPe, tokenId));
   }
-  // Slots 12/13 bracket copystaging. It is the ONLY other kernel in the
-  // dispatch phase, and the phase's whole regime delta sits outside
-  // dispatch_ll, so this is what separates 'the staging copy got slower' from
-  // 'the gap between the two launches grew'.
-  if ((blockId == 0) && (thdId == 0)) EpDbgTs(args, 13);
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
 __device__ void EpDispatchInterNodeV1KernelLowLatency_body(EpDispatchCombineArgs args,
                                                            const ::mori::cco::ccoDevComm& comm) {
   DEF_COMMON_VARS;
-  if ((blockId == 0) && (thdId == 0)) EpDbgTs(args, 0);
   if (blockId < args.rdmaBlockNum) {
     internode::DispatchInterNodeLLSend<kConfig, T>(args, comm);
     internode::DispatchInterNodeLLRecv<kConfig, T>(args);
@@ -1024,8 +968,6 @@ __device__ void EpDispatchInterNodeV1KernelLowLatency_body(EpDispatchCombineArgs
     internode::DispatchIntraNode<kConfig, T>(args);
   }
   internode::DispatchSync<kConfig, T>(args, comm);
-  // 6->7 is DispatchSync, the grid-wide barrier that ends the kernel.
-  if ((blockId == 0) && (thdId == 0)) EpDbgTs(args, 7);
 }
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -1489,7 +1431,6 @@ __forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs& a
         }
         int proxyPe = node * config.gpuPerNode + (myPe % config.gpuPerNode);
         int qpId = k % config.numQpPerPe;
-        EpDbgTs(args, 9);
         EpInterNodePut(comm, args.reg(args.offStaging),
                        SendBufSlotOffset(config, myNode + nNodes, startTokenIdx) * tokCombXferBytes,
                        args.reg(args.offStaging),
@@ -1532,12 +1473,9 @@ __forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs& a
     uint64_t* localBarrierPtr = args.reg(args.offCrossDeviceBarrier)->template GetAs<uint64_t*>();
     if ((laneId < nNodes) && (laneId != myNode)) {
       int proxyPe = laneId * config.gpuPerNode + (myPe % config.gpuPerNode);
-      // Slots 10/11: combine's only cross-node wait.
-      EpDbgTs(args, 10);
       while (core::AtomicLoadRelaxedSystem(localBarrierPtr + proxyPe) !=
              (barrierFlag * config.numQpPerPe)) {
       }
-      EpDbgTs(args, 11);
     }
   }
 }
@@ -1764,22 +1702,15 @@ __device__ void EpCombineAll_body(EpDispatchCombineArgs args) {
     const size_t fp8CombXferBytes =
         (args.weightsBuf == nullptr) ? fp8HiddenBytes : fp8HiddenBytes + weightBytes;
     combine_all_impl::EpCombineAllInternalFp8<kConfig, T>(args, fp8HiddenBytes, fp8CombXferBytes);
-    // Slot 14 marks the end of the LAST pass of the combine phase, on both
-    // exits. Paired with slot 12 of the NEXT round's dispatch it gives the true
-    // GPU-timeline gap between the two phases -- the quantity that the phase
-    // events cannot separate from host time.
-    if ((blockId == 0) && (thdId == 0)) EpDbgTs(args, 14);
     return;
   }
   combine_all_impl::EpCombineAllGeneric<kConfig, T>(args);
-  if ((blockId == 0) && (thdId == 0)) EpDbgTs(args, 14);
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
 __device__ void EpCombineInterNodeV1KernelLowLatency_body(EpDispatchCombineArgs args,
                                                           const ::mori::cco::ccoDevComm& comm) {
   DEF_COMMON_VARS;
-  if ((blockId == 0) && (thdId == 0)) EpDbgTs(args, 8);
 
   if (blockId < args.rdmaBlockNum) {
     internode::CombineInterNodeLL<kConfig, T>(args, comm);
@@ -1791,22 +1722,12 @@ __device__ void EpCombineInterNodeV1KernelLowLatency_body(EpDispatchCombineArgs 
 template <EpInterNodeKernelCfg kConfig, typename T>
 __device__ void EpCombineSync_body(EpDispatchCombineArgs args) {
   DEF_COMMON_VARS;
-  // 18/19 bracket combinesync, the FIRST pass of the combine phase. With 7->18
-  // this splits pre_bar into "everything between the two mori calls" -- the
-  // torch convert and the launch path -- and the kernel itself.
-  if ((blockId == 0) && (thdId == 0)) EpDbgTs(args, 18);
   internode::CombineSync<kConfig, T>(args);
-  if ((blockId == 0) && (thdId == 0)) EpDbgTs(args, 19);
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
 __device__ void EpCombineSyncBarrier_body(EpDispatchCombineArgs args) {
   DEF_COMMON_VARS;
-  // 16/17 bracket the cross-device barrier that OPENS the combine phase. It
-  // sits between dispatch_ll ending and combine_ll starting, so the phase
-  // events charge it to neither -- and the closed per-round accounting put both
-  // the largest term and the whole regime delta in exactly that window.
-  if ((blockId == 0) && (thdId == 0)) EpDbgTs(args, 16);
   IF_ENABLE_PROFILER(
       INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::EpCombineSyncBarrier);
@@ -1824,7 +1745,6 @@ __device__ void EpCombineSyncBarrier_body(EpDispatchCombineArgs args) {
     while (core::AtomicLoadRelaxedSystem(localBarrierPtr + destPe) != barrierFlag) {
     }
   }
-  if ((blockId == 0) && (thdId == 0)) EpDbgTs(args, 17);
 }
 
 }  // namespace v2

--- a/src/ops/dispatch_combine_v2/ep_internode_kernel.hpp
+++ b/src/ops/dispatch_combine_v2/ep_internode_kernel.hpp
@@ -179,56 +179,34 @@ __device__ __forceinline__ size_t EpInterNodeOff(const EpInterNodeRegion obj, si
   return obj->off + byteOffset;
 }
 
-// ── the one primitive ccoGda does not expose ─────────────────────────────────
+// ── the remote actions ───────────────────────────────────────────────────────
 //
 // v1's chunk-flag protocol needs a remote atomic add at an *arbitrary* window
 // offset: one slot per (node, chunk) in EP's own arena, count scaling with the
-// token capacity, polled and cleared by the receiver. ccoGda's remote actions
-// (ccoGda_SignalInc / ccoGda_SignalAdd) address only the resource window's
-// signal pool -- a fixed gdaSignalCount slots read through waitSignal's
-// consume-on-read shadow -- so neither the address nor the semantics fit.
+// token capacity, polled and cleared by the receiver. ccoGda_SignalInc /
+// ccoGda_SignalAdd cannot name that target -- they resolve to
+// `signalId * sizeof(uint64_t)` in the DevComm's own resourceWindow -- so EP
+// passes ccoGda_WindowSignalAdd, which carries (window, offset, value) instead
+// of a slot id. Same NIC atomic, same single reservation; only the raddr/rkey
+// lookup differs.
 //
-// So the two lookups the facade would do -- (window, offset) -> (rkey, raddr)
-// and (pe, qpId) -> endpoint -- happen here and the WQE is posted through
-// mori::cco::impl. No warp protocol is duplicated: signalImpl posts one WQE for
-// its caller, and putImpl runs the same warp aggregation the facade would have
-// run.
-//
-// THIS IS A LAYERING VIOLATION AND SHOULD NOT BE COPIED. cco_scale_out.hpp says
-// of that namespace: "Device kernels use the public ccoGda<> facade ... never
-// these directly", and EP is its only caller outside cco. It is here because the
-// facade cannot currently express the operation, not because reaching past it is
-// acceptable: the resolver pins a remote action to
-// `signalId * sizeof(uint64_t)` in comm.resourceWindow, and EP's chunk flags are
-// at an arbitrary offset in EP's own window.
-//
-// The fix belongs in cco, and is small: a remote-action type carrying
-// (window, offset, value) alongside ccoGda_SignalInc / ccoGda_SignalAdd, plus one
-// `else if constexpr` per resolver site. `put` and `signal` are already templated
-// on RemoteAction, so both of the calls below would then go through the facade
-// unchanged and this block would delete. Until then, folding the flag atomic into
-// the put's own reservation is worth keeping -- the facade route costs one extra
-// doorbell and CQE per chunk, on the critical path of a latency-bound kernel.
+// The tradeoff that comes with naming your own window: waitSignal / readSignal /
+// resetSignal do not see these, because they are written against the resource
+// window's signal pool and its consume-on-read shadow. EP polls and clears the
+// flags itself, which is what its protocol did anyway.
 
-__device__ __forceinline__ ::mori::core::RdmaEndpointDevice* EpInterNodeEndpoint(
-    const ::mori::cco::ccoDevComm& comm, int pe, int qpId) {
-  auto* ibgda = const_cast<::mori::cco::ccoIbgdaContext*>(&comm.ibgda);
-  // endpoints and peerRkeys are world-indexed; v1 always passes a world rank,
-  // which is what CCO_TEAM_WORLD means at the ccoGda calls below.
-  return &ibgda->endpoints[pe * ibgda->numQpPerPe + (qpId % ibgda->numQpPerPe)];
-}
-
-__device__ __forceinline__ uint32_t EpInterNodeRkey(const EpInterNodeRegion obj, int pe) {
-  return EpInterNodeWin(obj)->ibgdaWin.peerRkeys[pe];
+__device__ __forceinline__ ::mori::cco::ccoGda_WindowSignalAdd EpInterNodeFlagAdd(
+    const EpInterNodeRegion flag, size_t flagOffset, uint64_t value) {
+  return ::mori::cco::ccoGda_WindowSignalAdd{EpInterNodeWin(flag), EpInterNodeOff(flag, flagOffset),
+                                             value};
 }
 
 __device__ __forceinline__ void EpInterNodeAtomicAdd(const ::mori::cco::ccoDevComm& comm,
                                                      const EpInterNodeRegion dst, size_t dstOffset,
                                                      uint64_t value, int pe, int qpId = 0) {
-  ::mori::core::RdmaEndpointDevice* ep = EpInterNodeEndpoint(comm, pe, qpId);
-  ::mori::cco::impl::signalImpl<kEpInterNodeProvider>(ep, ep->qpn, EpInterNodeOff(dst, dstOffset),
-                                                      EpInterNodeRkey(dst, pe),
-                                                      ::mori::cco::ccoGdaSignalAdd, value);
+  ::mori::cco::ccoGda<kEpInterNodeProvider> gda{comm, qpId};
+  gda.template signal<::mori::cco::CCO_TEAM_WORLD>(pe, EpInterNodeFlagAdd(dst, dstOffset, value),
+                                                   ::mori::cco::ccoCoopThread{});
 }
 
 // RDMA write with the flag atomic fused into the same reservation. The ordering
@@ -238,34 +216,30 @@ __device__ __forceinline__ void EpInterNodeAtomicAdd(const ::mori::cco::ccoDevCo
 // write, with the slot index doubling as the PSN (BNXT reserves its signal PSN
 // behind the data PSNs for the same reason).
 //
-// This is the signalled put shmem had. Going through ccoGda's facade cannot
-// express it: ccoGda_SignalAdd resolves its target as
-// signalId * sizeof(uint64_t) in the resource window, and v1's chunk flags live
-// at an arbitrary offset in EP's own arena, so the facade would have to issue a
-// bare put and leave us to post the atomic as a second reservation -- one extra
-// doorbell and CQE per chunk. impl::putImpl takes the signal as a raw
-// (raddr, rkey, op, arg), which is exactly the triple EpInterNodeAtomicAdd already
-// hands to impl::signalImpl, so the flag buffer drops straight in.
+// This is the signalled put shmem had, and it stays ONE reservation: issuing a
+// bare put and posting the atomic separately would cost an extra doorbell and
+// CQE per chunk, on the critical path of a latency-bound kernel.
 //
-// One atomic per warp group, posted by putImpl's leader lane. That is the shape
-// shmem had and the dedup call site depends on it: its active lanes carry the
-// same flag slot and the same value, so a single add per group is the protocol,
-// not a saving. Every active lane must also agree on pe and qpId -- calling
-// putImpl directly skips the facade's group-by-peer ballot, and all three call
-// sites are warp-uniform in both (proxyPe follows the warp's node, and
-// startTokenIdx is a multiple of warpSize so tokenId / warpSize is too).
+// ccoGdaThreadAggregate, not ThreadIndependent: the latter runs a group-by-peer
+// ballot before posting, which every call site here would resolve in a single
+// iteration anyway -- all three are warp-uniform in pe and qpId (proxyPe follows
+// the warp's node, and startTokenIdx is a multiple of warpSize so
+// tokenId / warpSize is too). Aggregate skips the ballot and posts directly,
+// which is the shape shmem had. The warp aggregation itself is unaffected: it
+// lives in putImpl, below the ThreadMode branch, so one atomic per warp group
+// from the leader lane either way -- the shape the dedup call site depends on,
+// since its active lanes carry the same flag slot and the same value.
 __device__ __forceinline__ void EpInterNodePutSignal(const ::mori::cco::ccoDevComm& comm,
                                                      const EpInterNodeRegion dst, size_t dstOffset,
                                                      const EpInterNodeRegion src, size_t srcOffset,
                                                      size_t bytes, const EpInterNodeRegion signal,
                                                      size_t signalOffset, uint64_t signalValue,
                                                      int pe, int qpId) {
-  ::mori::core::RdmaEndpointDevice* ep = EpInterNodeEndpoint(comm, pe, qpId);
-  ::mori::cco::impl::putImpl<kEpInterNodeProvider>(
-      ep, ep->qpn, EpInterNodeOff(src, srcOffset), EpInterNodeWin(src)->ibgdaWin.lkey,
-      EpInterNodeOff(dst, dstOffset), EpInterNodeRkey(dst, pe), bytes, /*hasSignal=*/true,
-      EpInterNodeOff(signal, signalOffset), EpInterNodeRkey(signal, pe),
-      ::mori::cco::ccoGdaSignalAdd, signalValue);
+  ::mori::cco::ccoGda<kEpInterNodeProvider> gda{comm, qpId};
+  gda.template put<::mori::cco::CCO_TEAM_WORLD, ::mori::cco::ccoGdaThreadAggregate>(
+      pe, EpInterNodeWin(dst), EpInterNodeOff(dst, dstOffset), EpInterNodeWin(src),
+      EpInterNodeOff(src, srcOffset), bytes, EpInterNodeFlagAdd(signal, signalOffset, signalValue),
+      ::mori::cco::ccoCoopThread{});
 }
 
 __device__ __forceinline__ void EpInterNodePut(const ::mori::cco::ccoDevComm& comm,

--- a/src/ops/dispatch_combine_v2/ep_internode_kernel.hpp
+++ b/src/ops/dispatch_combine_v2/ep_internode_kernel.hpp
@@ -109,7 +109,7 @@ using EpDispatchCombineArgs = EpInterNodeArgs<T>;
 // v1's common.hpp macro, with the config type swapped. Everything else is
 // verbatim, including the assert: numExpertPerToken must fit in a ballot.
 #define DEF_COMMON_VARS                                                           \
-  const EpInterNodeDeviceCfg config = EpInterNodeDeviceCfgOf(kConfig, args.rank); \
+  constexpr EpInterNodeDeviceCfg config = EpInterNodeDeviceCfgOf(kConfig);        \
   int thdId = threadIdx.x;                                                        \
   int thdNum = blockDim.x;                                                        \
   int laneId = threadIdx.x & (warpSize - 1);                                      \
@@ -122,7 +122,7 @@ using EpDispatchCombineArgs = EpInterNodeArgs<T>;
   int globalWarpId = blockIdx.x * warpNum + warpId;                               \
   int globalWarpNum = gridDim.x * warpNum;                                        \
   int nullTokenId = NullFlatTokenIndex(config);                                   \
-  int myPe = config.rank;                                                         \
+  int myPe = args.rank;                                                           \
   int npes = config.worldSize;                                                    \
   int myNode = myPe / config.gpuPerNode;                                          \
   int nNodes = npes / config.gpuPerNode;                                          \
@@ -300,7 +300,7 @@ inline __device__ void DispatchIntraNodeBlock(EpDispatchCombineArgs<T>& args, in
 
       core::AtomicStoreRelaxedSystem(
           args.reg(args.offDispTokIdToSrcTokId)->template GetAs<index_t*>(destPe) + destTokId,
-          static_cast<index_t>(FlatTokenIndex(config, config.rank, tokenId)));
+          static_cast<index_t>(FlatTokenIndex(config, myPe, tokenId)));
     }
     destTokId = __shfl(destTokId, 0);
   } else {
@@ -406,7 +406,7 @@ inline __device__ void DispatchInterNodeSend(EpDispatchCombineArgs<T>& args,
   // Then send to other nodes
   for (int i = warpId; i < nNodes; i += warpNum) {
     if (i == myNode) continue;
-    int proxyPe = i * config.gpuPerNode + (config.rank % config.gpuPerNode);
+    int proxyPe = i * config.gpuPerNode + (myPe % config.gpuPerNode);
     if (DEDUP) {
       for (int tokenId = startTokenIdx + laneId; tokenId < endTokenIdx; tokenId += warpSize) {
         bool shouldSend = false;
@@ -523,7 +523,7 @@ inline __device__ void DispatchInterNodeSend(EpDispatchCombineArgs<T>& args,
     // shmem's atomic resolved a local peer to a plain store, hence no guard here
     // originally.
     if ((laneId < nNodes) && (laneId != myNode)) {
-      int proxyPe = laneId * config.gpuPerNode + (config.rank % config.gpuPerNode);
+      int proxyPe = laneId * config.gpuPerNode + (myPe % config.gpuPerNode);
       index_t numTokenSignal =
           core::AtomicLoadRelaxed(args.blockFlagCounter + laneId) * warpSize + 1;
       EpInterNodeAtomicAdd(comm, args.reg(args.offNodeRecvTokenNum), myNode * sizeof(uint64_t),
@@ -550,7 +550,7 @@ inline __device__ void DispatchInterNodeLLSend(EpDispatchCombineArgs<T>& args,
       std::min(chunkStartTokenIdx + blockChunkNum * warpSize, args.curRankNumToken);
   for (int i = warpId; i < nNodes; i += warpNum) {
     if (i == myNode) continue;
-    int proxyPe = i * config.gpuPerNode + (config.rank % config.gpuPerNode);
+    int proxyPe = i * config.gpuPerNode + (myPe % config.gpuPerNode);
 
     for (int tokenId = chunkStartTokenIdx + laneId; tokenId < chunkEndTokenIdx;
          tokenId += warpSize) {
@@ -595,7 +595,7 @@ inline __device__ void DispatchInterNodeLLSend(EpDispatchCombineArgs<T>& args,
   if ((finishedWarp + 1) == (args.rdmaBlockNum * warpNum)) {
     // Skips the local node for the same reason as DispatchInterNodeSend above.
     if ((laneId < nNodes) && (laneId != myNode)) {
-      int proxyPe = laneId * config.gpuPerNode + (config.rank % config.gpuPerNode);
+      int proxyPe = laneId * config.gpuPerNode + (myPe % config.gpuPerNode);
       index_t numTokenSignal =
           core::AtomicLoadRelaxed(args.blockFlagCounter + laneId) * warpSize + 1;
       EpInterNodeAtomicAdd(comm, args.reg(args.offNodeRecvTokenNum), myNode * sizeof(uint64_t),
@@ -889,7 +889,7 @@ inline __device__ void DispatchSync(EpDispatchCombineArgs<T>& args,
     // node faults. shmem's ShmemQuietThread tolerated the self peer, which is
     // why the original loop covered every node.
     if (i == myNode) continue;
-    int proxyPe = i * config.gpuPerNode + (config.rank % config.gpuPerNode);
+    int proxyPe = i * config.gpuPerNode + (myPe % config.gpuPerNode);
     EpInterNodeQuiet(comm, proxyPe, config.numQpPerPe);
   }
 }
@@ -945,7 +945,7 @@ __device__ void EpDispatchCopyToStaging_body(EpDispatchCombineArgs<T> args) {
     if (laneId == 0)
       reinterpret_cast<index_t*>(stagingPtr + stagingTokOffset + hiddenBytes + indexBytes +
                                  weightBytes + scaleBytes)[0] =
-          static_cast<index_t>(FlatTokenIndex(config, config.rank, tokenId));
+          static_cast<index_t>(FlatTokenIndex(config, myPe, tokenId));
   }
 }
 
@@ -1268,7 +1268,7 @@ __forceinline__ __device__ void CombineInterNodeTyped(EpDispatchCombineArgs<T>& 
                 core::AtomicStoreRelaxedSystem(
                     args.interNodeChunkFlagCombine + node * maxChunkNum + k, index_t{0});
               }
-              int proxyPe = node * config.gpuPerNode + (config.rank % config.gpuPerNode);
+              int proxyPe = node * config.gpuPerNode + (myPe % config.gpuPerNode);
               int qpId = k % config.numQpPerPe;
               EpInterNodePut(
                   comm, args.reg(args.offStaging),
@@ -1308,7 +1308,7 @@ __forceinline__ __device__ void CombineInterNodeTyped(EpDispatchCombineArgs<T>& 
     }
     if ((laneId < nNodes) &&
         (laneId != myNode)) {  // avoid setting myNode, it will be set in intra node branch
-      int proxyPe = laneId * config.gpuPerNode + (config.rank % config.gpuPerNode);
+      int proxyPe = laneId * config.gpuPerNode + (myPe % config.gpuPerNode);
       for (int i = 0; i < config.numQpPerPe; i++) {
         EpInterNodeAtomicAdd(comm, args.reg(args.offCrossDeviceBarrier),
                              args.rank * sizeof(uint64_t), 1, proxyPe, i);
@@ -1318,7 +1318,7 @@ __forceinline__ __device__ void CombineInterNodeTyped(EpDispatchCombineArgs<T>& 
 
     uint64_t* localBarrierPtr = args.reg(args.offCrossDeviceBarrier)->template GetAs<uint64_t*>();
     if ((laneId < nNodes) && (laneId != myNode)) {
-      int proxyPe = laneId * config.gpuPerNode + (config.rank % config.gpuPerNode);
+      int proxyPe = laneId * config.gpuPerNode + (myPe % config.gpuPerNode);
       while (core::AtomicLoadRelaxedSystem(localBarrierPtr + proxyPe) !=
              (barrierFlag * config.numQpPerPe)) {
       }
@@ -1420,7 +1420,7 @@ __forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs<T>
           core::AtomicStoreRelaxedSystem(args.interNodeChunkFlagCombine + node * maxChunkNum + k,
                                          index_t{0});
         }
-        int proxyPe = node * config.gpuPerNode + (config.rank % config.gpuPerNode);
+        int proxyPe = node * config.gpuPerNode + (myPe % config.gpuPerNode);
         int qpId = k % config.numQpPerPe;
         EpInterNodePut(comm, args.reg(args.offStaging),
                        SendBufSlotOffset(config, myNode + nNodes, startTokenIdx) * tokCombXferBytes,
@@ -1451,7 +1451,7 @@ __forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs<T>
     }
     if ((laneId < nNodes) &&
         (laneId != myNode)) {  // avoid setting myNode, it will be set in intra node branch
-      int proxyPe = laneId * config.gpuPerNode + (config.rank % config.gpuPerNode);
+      int proxyPe = laneId * config.gpuPerNode + (myPe % config.gpuPerNode);
       for (int i = 0; i < config.numQpPerPe; i++) {
         EpInterNodeAtomicAdd(comm, args.reg(args.offCrossDeviceBarrier),
                              args.rank * sizeof(uint64_t), 1, proxyPe, i);
@@ -1463,7 +1463,7 @@ __forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs<T>
     // Wait other nodes
     uint64_t* localBarrierPtr = args.reg(args.offCrossDeviceBarrier)->template GetAs<uint64_t*>();
     if ((laneId < nNodes) && (laneId != myNode)) {
-      int proxyPe = laneId * config.gpuPerNode + (config.rank % config.gpuPerNode);
+      int proxyPe = laneId * config.gpuPerNode + (myPe % config.gpuPerNode);
       while (core::AtomicLoadRelaxedSystem(localBarrierPtr + proxyPe) !=
              (barrierFlag * config.numQpPerPe)) {
       }

--- a/src/ops/dispatch_combine_v2/ep_internode_kernel.hpp
+++ b/src/ops/dispatch_combine_v2/ep_internode_kernel.hpp
@@ -875,6 +875,12 @@ inline __device__ void DispatchInterNodeLLRecv(EpDispatchCombineArgs& args) {
     int destPe = myNode * config.gpuPerNode + laneId;
     int counter = atomicAdd(args.destPeTokenCounter + destPe, localPeTokenCounter);
   }
+  // Slot 6 closes the recv half. 5->6 is everything AFTER the peer data has
+  // landed: unpacking the staging slots and WarpCopy-ing each token into the
+  // destination rank's buffer, which for a same-node destPe is an XGMI peer
+  // write. The 4-token measurement put the whole regime delta in this span,
+  // with the post and the spin both flat, so it needs its own bracket.
+  if ((globalWarpId == 0) && (laneId == 0)) EpDbgTs(args, 6);
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
@@ -965,6 +971,7 @@ __device__ void EpDispatchCopyToStaging_body(EpDispatchCombineArgs args) {
   // pass of that sequence and runs entirely before dispatch_ll, so stream order
   // is the ordering guarantee. Before the empty-input return: zero tokens still
   // needs the counter cleared.
+  if ((blockId == 0) && (thdId == 0)) EpDbgTs(args, 12);
   if (globalThdId == 0) args.totalRecvTokenNum[0] = 0;
   if (args.curRankNumToken == 0) return;
 
@@ -998,6 +1005,11 @@ __device__ void EpDispatchCopyToStaging_body(EpDispatchCombineArgs args) {
                                  weightBytes + scaleBytes)[0] =
           static_cast<index_t>(FlatTokenIndex(config, myPe, tokenId));
   }
+  // Slots 12/13 bracket copystaging. It is the ONLY other kernel in the
+  // dispatch phase, and the phase's whole regime delta sits outside
+  // dispatch_ll, so this is what separates 'the staging copy got slower' from
+  // 'the gap between the two launches grew'.
+  if ((blockId == 0) && (thdId == 0)) EpDbgTs(args, 13);
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
@@ -1012,6 +1024,8 @@ __device__ void EpDispatchInterNodeV1KernelLowLatency_body(EpDispatchCombineArgs
     internode::DispatchIntraNode<kConfig, T>(args);
   }
   internode::DispatchSync<kConfig, T>(args, comm);
+  // 6->7 is DispatchSync, the grid-wide barrier that ends the kernel.
+  if ((blockId == 0) && (thdId == 0)) EpDbgTs(args, 7);
 }
 
 /* ---------------------------------------------------------------------------------------------- */

--- a/src/ops/dispatch_combine_v2/ep_internode_kernel.hpp
+++ b/src/ops/dispatch_combine_v2/ep_internode_kernel.hpp
@@ -108,33 +108,33 @@ using EpDispatchCombineArgs = EpInterNodeArgs<T>;
 
 // v1's common.hpp macro, with the config type swapped. Everything else is
 // verbatim, including the assert: numExpertPerToken must fit in a ballot.
-#define DEF_COMMON_VARS                                                           \
-  constexpr EpInterNodeDeviceCfg config = EpInterNodeDeviceCfgOf(kConfig);        \
-  int thdId = threadIdx.x;                                                        \
-  int thdNum = blockDim.x;                                                        \
-  int laneId = threadIdx.x & (warpSize - 1);                                      \
-  int warpId = thdId / warpSize;                                                  \
-  int warpNum = blockDim.x / warpSize;                                            \
-  int blockNum = gridDim.x;                                                       \
-  int blockId = blockIdx.x;                                                       \
-  int globalThdId = blockIdx.x * blockDim.x + threadIdx.x;                        \
-  int globalThdNum = gridDim.x * blockDim.x;                                      \
-  int globalWarpId = blockIdx.x * warpNum + warpId;                               \
-  int globalWarpNum = gridDim.x * warpNum;                                        \
-  int nullTokenId = NullFlatTokenIndex(config);                                   \
-  int myPe = args.rank;                                                           \
-  int npes = config.worldSize;                                                    \
-  int myNode = myPe / config.gpuPerNode;                                          \
-  int nNodes = npes / config.gpuPerNode;                                          \
-  int numExpertPerToken = config.numExpertPerToken;                               \
-  assert(numExpertPerToken < warpSize);                                           \
-  size_t hiddenDim = config.HiddenDimSz();                                        \
-  size_t hiddenBytes = config.HiddenBytes(sizeof(T));                             \
-  size_t indexBytes = config.IndexBytes();                                        \
-  size_t weightBytes = config.WeightBytes();                                      \
-  size_t srcTokenIdBytes = config.SrcTokenIdBytes();                              \
-  size_t scaleBytes = config.ScaleBytes();                                        \
-  size_t xferBytes = config.XferBytesPerToken(sizeof(T));                         \
+#define DEF_COMMON_VARS                                                    \
+  constexpr EpInterNodeDeviceCfg config = EpInterNodeDeviceCfgOf(kConfig); \
+  int thdId = threadIdx.x;                                                 \
+  int thdNum = blockDim.x;                                                 \
+  int laneId = threadIdx.x & (warpSize - 1);                               \
+  int warpId = thdId / warpSize;                                           \
+  int warpNum = blockDim.x / warpSize;                                     \
+  int blockNum = gridDim.x;                                                \
+  int blockId = blockIdx.x;                                                \
+  int globalThdId = blockIdx.x * blockDim.x + threadIdx.x;                 \
+  int globalThdNum = gridDim.x * blockDim.x;                               \
+  int globalWarpId = blockIdx.x * warpNum + warpId;                        \
+  int globalWarpNum = gridDim.x * warpNum;                                 \
+  int nullTokenId = NullFlatTokenIndex(config);                            \
+  int myPe = args.rank;                                                    \
+  int npes = config.worldSize;                                             \
+  int myNode = myPe / config.gpuPerNode;                                   \
+  int nNodes = npes / config.gpuPerNode;                                   \
+  int numExpertPerToken = config.numExpertPerToken;                        \
+  assert(numExpertPerToken < warpSize);                                    \
+  size_t hiddenDim = config.HiddenDimSz();                                 \
+  size_t hiddenBytes = config.HiddenBytes(sizeof(T));                      \
+  size_t indexBytes = config.IndexBytes();                                 \
+  size_t weightBytes = config.WeightBytes();                               \
+  size_t srcTokenIdBytes = config.SrcTokenIdBytes();                       \
+  size_t scaleBytes = config.ScaleBytes();                                 \
+  size_t xferBytes = config.XferBytesPerToken(sizeof(T));                  \
   size_t combXferBytes = (args.weightsBuf == nullptr) ? hiddenBytes : hiddenBytes + weightBytes;
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -915,6 +915,17 @@ __device__ void EpDispatchCopyToStaging_body(EpDispatchCombineArgs<T> args) {
   IF_ENABLE_PROFILER(
       INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::EpDispatchCopyToStaging);
+
+  // Zero the receive counter here rather than from the host. DispatchSync
+  // accumulates into it with atomicAdd, so it has to start at 0 every dispatch;
+  // EpCombineAll clears it at the end of the pair, but that only covers a caller
+  // that always combines. The host's `total_recv.zero_()` covered the rest at the
+  // cost of a whole fill kernel enqueued AHEAD of the dispatch sequence on the
+  // same stream -- it delayed the kernels it was protecting. This is the first
+  // pass of that sequence and runs entirely before dispatch_ll, so stream order
+  // is the ordering guarantee. Before the empty-input return: zero tokens still
+  // needs the counter cleared.
+  if (globalThdId == 0) args.totalRecvTokenNum[0] = 0;
   if (args.curRankNumToken == 0) return;
 
   MultiWarpIter mwIter(globalWarpNum, args.curRankNumToken, hiddenDim);

--- a/src/ops/dispatch_combine_v2/ep_internode_kernel.hpp
+++ b/src/ops/dispatch_combine_v2/ep_internode_kernel.hpp
@@ -90,7 +90,7 @@ namespace v2 {
 // v2 spellings, under the names the bodies below already use.
 //
 // The bodies live in this namespace and say `index_t`, `QuantType::...`,
-// `EpDispatchCombineArgs<T>` and the flat-index helpers unqualified. Introducing
+// `EpDispatchCombineArgs` and the flat-index helpers unqualified. Introducing
 // the v2 types under those names is what lets the argument surface change
 // without touching the ~250 `args.` sites, the 39 index-helper calls or the 29
 // signatures -- the surface moves, the algorithm does not, and the two want to
@@ -103,8 +103,9 @@ namespace v2 {
 using index_t = ep_index_t;
 using QuantType = EpQuantType;
 
-template <typename T>
-using EpDispatchCombineArgs = EpInterNodeArgs<T>;
+// v1's spelling, now a plain alias: the struct stopped depending on T when
+// inpTokenBuf became void*, matching the intranode EpArgs.
+using EpDispatchCombineArgs = EpInterNodeArgs;
 
 // v1's common.hpp macro, with the config type swapped. Everything else is
 // verbatim, including the assert: numExpertPerToken must fit in a ballot.
@@ -284,7 +285,7 @@ __device__ __forceinline__ int32_t EpInterNodeWaitGt(int32_t* addr, int32_t val)
 /* ---------------------------------------------------------------------------------------------- */
 namespace internode {
 template <EpInterNodeKernelCfg kConfig, typename T>
-inline __device__ void DispatchIntraNodeBlock(EpDispatchCombineArgs<T>& args, int tokenId,
+inline __device__ void DispatchIntraNodeBlock(EpDispatchCombineArgs& args, int tokenId,
                                               int expId, int destPe, int& localPeTokenCounter) {
   DEF_COMMON_VARS;
 
@@ -314,7 +315,7 @@ inline __device__ void DispatchIntraNodeBlock(EpDispatchCombineArgs<T>& args, in
   size_t destTokOffset = destTokId * hiddenDim;
 
   T* remoteTokenPtr = args.reg(args.offDispatchOut)->template GetAs<T*>(destPe);
-  const T* localTokenPtr = args.inpTokenBuf;
+  const T* localTokenPtr = static_cast<const T*>(args.inpTokenBuf);
   core::WarpCopy(remoteTokenPtr + destTokOffset, localTokenPtr + srcTokOffset, hiddenDim);
 
   index_t* remoteIndexPtr = args.reg(args.offOutIndices)->template GetAs<index_t*>(destPe);
@@ -335,7 +336,7 @@ inline __device__ void DispatchIntraNodeBlock(EpDispatchCombineArgs<T>& args, in
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
-inline __device__ void DispatchIntraNode(EpDispatchCombineArgs<T>& args) {
+inline __device__ void DispatchIntraNode(EpDispatchCombineArgs& args) {
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
       INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
@@ -378,7 +379,7 @@ inline __device__ void DispatchIntraNode(EpDispatchCombineArgs<T>& args) {
           args.dispDestTokIdMap[expertOffset] = NullFlatTokenIndex(config);
         continue;
       }
-      DispatchIntraNodeBlock<kConfig>(args, tokenId, inTokenExpertId, destPe, localPeTokenCounter);
+      DispatchIntraNodeBlock<kConfig, T>(args, tokenId, inTokenExpertId, destPe, localPeTokenCounter);
     }
   }
 
@@ -389,7 +390,7 @@ inline __device__ void DispatchIntraNode(EpDispatchCombineArgs<T>& args) {
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T, bool DEDUP>
-inline __device__ void DispatchInterNodeSend(EpDispatchCombineArgs<T>& args,
+inline __device__ void DispatchInterNodeSend(EpDispatchCombineArgs& args,
                                              const ::mori::cco::ccoDevComm& comm) {
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
@@ -534,7 +535,7 @@ inline __device__ void DispatchInterNodeSend(EpDispatchCombineArgs<T>& args,
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
-inline __device__ void DispatchInterNodeLLSend(EpDispatchCombineArgs<T>& args,
+inline __device__ void DispatchInterNodeLLSend(EpDispatchCombineArgs& args,
                                                const ::mori::cco::ccoDevComm& comm) {
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
@@ -606,7 +607,7 @@ inline __device__ void DispatchInterNodeLLSend(EpDispatchCombineArgs<T>& args,
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
-inline __device__ void DispatchInterNodeRecv(EpDispatchCombineArgs<T>& args) {
+inline __device__ void DispatchInterNodeRecv(EpDispatchCombineArgs& args) {
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
       INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
@@ -730,7 +731,7 @@ inline __device__ void DispatchInterNodeRecv(EpDispatchCombineArgs<T>& args) {
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
-inline __device__ void DispatchInterNodeLLRecv(EpDispatchCombineArgs<T>& args) {
+inline __device__ void DispatchInterNodeLLRecv(EpDispatchCombineArgs& args) {
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
       INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
@@ -838,7 +839,7 @@ inline __device__ void DispatchInterNodeLLRecv(EpDispatchCombineArgs<T>& args) {
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
-inline __device__ void DispatchSync(EpDispatchCombineArgs<T>& args,
+inline __device__ void DispatchSync(EpDispatchCombineArgs& args,
                                     const ::mori::cco::ccoDevComm& comm) {
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
@@ -897,20 +898,20 @@ inline __device__ void DispatchSync(EpDispatchCombineArgs<T>& args,
 }  // namespace internode
 
 template <EpInterNodeKernelCfg kConfig, typename T>
-__device__ void EpDispatchInterNodeV1Kernel_body(EpDispatchCombineArgs<T> args,
+__device__ void EpDispatchInterNodeV1Kernel_body(EpDispatchCombineArgs args,
                                                  const ::mori::cco::ccoDevComm& comm) {
   DEF_COMMON_VARS;
   if (blockId < args.rdmaBlockNum) {
     internode::DispatchInterNodeSend<kConfig, T, true>(args, comm);
-    internode::DispatchInterNodeRecv<kConfig>(args);
+    internode::DispatchInterNodeRecv<kConfig, T>(args);
   } else {
-    internode::DispatchIntraNode<kConfig>(args);
+    internode::DispatchIntraNode<kConfig, T>(args);
   }
-  internode::DispatchSync<kConfig>(args, comm);
+  internode::DispatchSync<kConfig, T>(args, comm);
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
-__device__ void EpDispatchCopyToStaging_body(EpDispatchCombineArgs<T> args) {
+__device__ void EpDispatchCopyToStaging_body(EpDispatchCombineArgs args) {
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
       INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
@@ -939,7 +940,7 @@ __device__ void EpDispatchCopyToStaging_body(EpDispatchCombineArgs<T> args) {
     uint8_t* stagingPtr = args.reg(args.offDispatchStaging)->template GetAs<uint8_t*>();
     size_t stagingTokOffset = tokenId * xferBytes;
     core::WarpCopy<uint8_t, 4>(stagingPtr + stagingTokOffset + hiddenDimOffset * sizeof(T),
-                               reinterpret_cast<uint8_t*>(args.inpTokenBuf) +
+                               static_cast<const uint8_t*>(args.inpTokenBuf) +
                                    tokenId * hiddenBytes + hiddenDimOffset * sizeof(T),
                                hiddenDimSize * sizeof(T));
     if (inTokenPartId != 0) continue;
@@ -961,16 +962,16 @@ __device__ void EpDispatchCopyToStaging_body(EpDispatchCombineArgs<T> args) {
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
-__device__ void EpDispatchInterNodeV1KernelLowLatency_body(EpDispatchCombineArgs<T> args,
+__device__ void EpDispatchInterNodeV1KernelLowLatency_body(EpDispatchCombineArgs args,
                                                            const ::mori::cco::ccoDevComm& comm) {
   DEF_COMMON_VARS;
   if (blockId < args.rdmaBlockNum) {
     internode::DispatchInterNodeLLSend<kConfig, T>(args, comm);
-    internode::DispatchInterNodeLLRecv<kConfig>(args);
+    internode::DispatchInterNodeLLRecv<kConfig, T>(args);
   } else {
-    internode::DispatchIntraNode<kConfig>(args);
+    internode::DispatchIntraNode<kConfig, T>(args);
   }
-  internode::DispatchSync<kConfig>(args, comm);
+  internode::DispatchSync<kConfig, T>(args, comm);
 }
 
 /* ---------------------------------------------------------------------------------------------- */
@@ -979,7 +980,7 @@ __device__ void EpDispatchInterNodeV1KernelLowLatency_body(EpDispatchCombineArgs
 namespace internode {
 
 template <EpInterNodeKernelCfg kConfig, typename T>
-inline __device__ void CombineSync(EpDispatchCombineArgs<T>& args) {
+inline __device__ void CombineSync(EpDispatchCombineArgs& args) {
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
       INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
@@ -993,12 +994,13 @@ inline __device__ void CombineSync(EpDispatchCombineArgs<T>& args) {
     if constexpr (kConfig.quantType == QuantType::Fp8DirectCast) {
       using Fp8T = core::CombineInternalFp8;
       Fp8T* dst = args.reg(args.offCombineInp)->template GetAs<Fp8T*>();
-      const T* src = args.inpTokenBuf;
+      const T* src = static_cast<const T*>(args.inpTokenBuf);
       const size_t base = tokenId * hiddenDim;
       core::WarpCastBf16ToCombineInternalFp8<T>(dst + base, src + base, hiddenDim, laneId);
     } else {
       core::WarpCopy(args.reg(args.offCombineInp)->template GetAs<T*>() + tokenId * hiddenDim,
-                     args.inpTokenBuf + tokenId * hiddenDim, hiddenDim);
+                     static_cast<const T*>(args.inpTokenBuf) + tokenId * hiddenDim,
+                     hiddenDim);
     }
   }
   if (args.weightsBuf) {
@@ -1064,7 +1066,7 @@ inline __device__ void CombineGather(TokT* dest, TokT** srcPtrs, int accumNum, s
 }
 
 template <EpInterNodeKernelCfg kConfig, typename TokT, typename T>
-__forceinline__ __device__ void CombineIntraNodeTyped(EpDispatchCombineArgs<T>& args,
+__forceinline__ __device__ void CombineIntraNodeTyped(EpDispatchCombineArgs& args,
                                                       size_t tokHiddenBytes,
                                                       size_t tokCombXferBytes) {
   DEF_COMMON_VARS;
@@ -1109,7 +1111,7 @@ __forceinline__ __device__ void CombineIntraNodeTyped(EpDispatchCombineArgs<T>& 
 }
 
 template <EpInterNodeKernelCfg kConfig, typename TokT, typename T>
-__forceinline__ __device__ void CombineIntraNodeLLTyped(EpDispatchCombineArgs<T>& args,
+__forceinline__ __device__ void CombineIntraNodeLLTyped(EpDispatchCombineArgs& args,
                                                         size_t tokHiddenBytes,
                                                         size_t tokCombXferBytes) {
   DEF_COMMON_VARS;
@@ -1164,7 +1166,7 @@ __forceinline__ __device__ void CombineIntraNodeLLTyped(EpDispatchCombineArgs<T>
 }
 
 template <EpInterNodeKernelCfg kConfig, typename TokT, typename T>
-__forceinline__ __device__ void CombineInterNodeTyped(EpDispatchCombineArgs<T>& args,
+__forceinline__ __device__ void CombineInterNodeTyped(EpDispatchCombineArgs& args,
                                                       size_t tokHiddenBytes,
                                                       size_t tokCombXferBytes,
                                                       const ::mori::cco::ccoDevComm& comm) {
@@ -1338,7 +1340,7 @@ __forceinline__ __device__ void CombineInterNodeTyped(EpDispatchCombineArgs<T>& 
 }
 
 template <EpInterNodeKernelCfg kConfig, typename TokT, typename T>
-__forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs<T>& args,
+__forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs& args,
                                                         size_t tokHiddenBytes,
                                                         size_t tokCombXferBytes,
                                                         const ::mori::cco::ccoDevComm& comm) {
@@ -1485,7 +1487,7 @@ __forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs<T>
 }  // namespace combine_impl
 
 template <EpInterNodeKernelCfg kConfig, typename T>
-inline __device__ void CombineIntraNode(EpDispatchCombineArgs<T>& args) {
+inline __device__ void CombineIntraNode(EpDispatchCombineArgs& args) {
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
       INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
@@ -1495,15 +1497,15 @@ inline __device__ void CombineIntraNode(EpDispatchCombineArgs<T>& args) {
     const size_t tokHiddenBytes = hiddenDim * sizeof(TokT);
     const size_t tokCombXferBytes =
         (args.weightsBuf == nullptr) ? tokHiddenBytes : tokHiddenBytes + weightBytes;
-    combine_impl::CombineIntraNodeTyped<kConfig, TokT>(args, tokHiddenBytes, tokCombXferBytes);
+    combine_impl::CombineIntraNodeTyped<kConfig, TokT, T>(args, tokHiddenBytes, tokCombXferBytes);
     return;
   }
 
-  combine_impl::CombineIntraNodeTyped<kConfig, T>(args, hiddenBytes, combXferBytes);
+  combine_impl::CombineIntraNodeTyped<kConfig, T, T>(args, hiddenBytes, combXferBytes);
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
-inline __device__ void CombineIntraNodeLL(EpDispatchCombineArgs<T>& args) {
+inline __device__ void CombineIntraNodeLL(EpDispatchCombineArgs& args) {
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
       INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
@@ -1515,14 +1517,14 @@ inline __device__ void CombineIntraNodeLL(EpDispatchCombineArgs<T>& args) {
     const size_t tokHiddenBytes = hiddenDim * sizeof(TokT);
     const size_t tokCombXferBytes =
         (args.weightsBuf == nullptr) ? tokHiddenBytes : tokHiddenBytes + weightBytes;
-    combine_impl::CombineIntraNodeLLTyped<kConfig, TokT>(args, tokHiddenBytes, tokCombXferBytes);
+    combine_impl::CombineIntraNodeLLTyped<kConfig, TokT, T>(args, tokHiddenBytes, tokCombXferBytes);
     return;
   }
-  combine_impl::CombineIntraNodeLLTyped<kConfig, T>(args, hiddenBytes, combXferBytes);
+  combine_impl::CombineIntraNodeLLTyped<kConfig, T, T>(args, hiddenBytes, combXferBytes);
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
-inline __device__ void CombineInterNode(EpDispatchCombineArgs<T>& args,
+inline __device__ void CombineInterNode(EpDispatchCombineArgs& args,
                                         const ::mori::cco::ccoDevComm& comm) {
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
@@ -1534,15 +1536,15 @@ inline __device__ void CombineInterNode(EpDispatchCombineArgs<T>& args,
     const size_t tokHiddenBytes = hiddenDim * sizeof(TokT);
     const size_t tokCombXferBytes =
         (args.weightsBuf == nullptr) ? tokHiddenBytes : tokHiddenBytes + weightBytes;
-    combine_impl::CombineInterNodeTyped<kConfig, TokT>(args, tokHiddenBytes, tokCombXferBytes,
+    combine_impl::CombineInterNodeTyped<kConfig, TokT, T>(args, tokHiddenBytes, tokCombXferBytes,
                                                        comm);
     return;
   }
-  combine_impl::CombineInterNodeTyped<kConfig, T>(args, hiddenBytes, combXferBytes, comm);
+  combine_impl::CombineInterNodeTyped<kConfig, T, T>(args, hiddenBytes, combXferBytes, comm);
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
-inline __device__ void CombineInterNodeLL(EpDispatchCombineArgs<T>& args,
+inline __device__ void CombineInterNodeLL(EpDispatchCombineArgs& args,
                                           const ::mori::cco::ccoDevComm& comm) {
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
@@ -1553,30 +1555,30 @@ inline __device__ void CombineInterNodeLL(EpDispatchCombineArgs<T>& args,
     const size_t tokHiddenBytes = hiddenDim * sizeof(TokT);
     const size_t tokCombXferBytes =
         (args.weightsBuf == nullptr) ? tokHiddenBytes : tokHiddenBytes + weightBytes;
-    combine_impl::CombineInterNodeLLTyped<kConfig, TokT>(args, tokHiddenBytes, tokCombXferBytes,
+    combine_impl::CombineInterNodeLLTyped<kConfig, TokT, T>(args, tokHiddenBytes, tokCombXferBytes,
                                                          comm);
     return;
   }
-  combine_impl::CombineInterNodeLLTyped<kConfig, T>(args, hiddenBytes, combXferBytes, comm);
+  combine_impl::CombineInterNodeLLTyped<kConfig, T, T>(args, hiddenBytes, combXferBytes, comm);
 }
 }  // namespace internode
 
 template <EpInterNodeKernelCfg kConfig, typename T>
-__device__ void EpCombineInterNodeV1Kernel_body(EpDispatchCombineArgs<T> args,
+__device__ void EpCombineInterNodeV1Kernel_body(EpDispatchCombineArgs args,
                                                 const ::mori::cco::ccoDevComm& comm) {
   DEF_COMMON_VARS;
 
   if (blockId < args.rdmaBlockNum) {
-    internode::CombineInterNode<kConfig>(args, comm);
+    internode::CombineInterNode<kConfig, T>(args, comm);
   } else {
-    internode::CombineIntraNode<kConfig>(args);
+    internode::CombineIntraNode<kConfig, T>(args);
   }
 }
 
 namespace combine_all_impl {
 
 template <EpInterNodeKernelCfg kConfig, typename T>
-__forceinline__ __device__ void EpCombineAllInternalFp8(EpDispatchCombineArgs<T>& args,
+__forceinline__ __device__ void EpCombineAllInternalFp8(EpDispatchCombineArgs& args,
                                                         size_t fp8HiddenBytes,
                                                         size_t fp8CombXferBytes) {
   DEF_COMMON_VARS;
@@ -1633,7 +1635,7 @@ __forceinline__ __device__ void EpCombineAllInternalFp8(EpDispatchCombineArgs<T>
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
-__forceinline__ __device__ void EpCombineAllGeneric(EpDispatchCombineArgs<T>& args) {
+__forceinline__ __device__ void EpCombineAllGeneric(EpDispatchCombineArgs& args) {
   DEF_COMMON_VARS;
 
   extern __shared__ char sharedMem[];
@@ -1686,7 +1688,7 @@ __forceinline__ __device__ void EpCombineAllGeneric(EpDispatchCombineArgs<T>& ar
 }  // namespace combine_all_impl
 
 template <EpInterNodeKernelCfg kConfig, typename T>
-__device__ void EpCombineAll_body(EpDispatchCombineArgs<T> args) {
+__device__ void EpCombineAll_body(EpDispatchCombineArgs args) {
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
       INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
@@ -1703,32 +1705,32 @@ __device__ void EpCombineAll_body(EpDispatchCombineArgs<T> args) {
     const size_t fp8HiddenBytes = hiddenDim * sizeof(Fp8T);
     const size_t fp8CombXferBytes =
         (args.weightsBuf == nullptr) ? fp8HiddenBytes : fp8HiddenBytes + weightBytes;
-    combine_all_impl::EpCombineAllInternalFp8<kConfig>(args, fp8HiddenBytes, fp8CombXferBytes);
+    combine_all_impl::EpCombineAllInternalFp8<kConfig, T>(args, fp8HiddenBytes, fp8CombXferBytes);
     return;
   }
-  combine_all_impl::EpCombineAllGeneric<kConfig>(args);
+  combine_all_impl::EpCombineAllGeneric<kConfig, T>(args);
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
-__device__ void EpCombineInterNodeV1KernelLowLatency_body(EpDispatchCombineArgs<T> args,
+__device__ void EpCombineInterNodeV1KernelLowLatency_body(EpDispatchCombineArgs args,
                                                           const ::mori::cco::ccoDevComm& comm) {
   DEF_COMMON_VARS;
 
   if (blockId < args.rdmaBlockNum) {
-    internode::CombineInterNodeLL<kConfig>(args, comm);
+    internode::CombineInterNodeLL<kConfig, T>(args, comm);
   } else {
-    internode::CombineIntraNodeLL<kConfig>(args);
+    internode::CombineIntraNodeLL<kConfig, T>(args);
   }
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
-__device__ void EpCombineSync_body(EpDispatchCombineArgs<T> args) {
+__device__ void EpCombineSync_body(EpDispatchCombineArgs args) {
   DEF_COMMON_VARS;
-  internode::CombineSync<kConfig>(args);
+  internode::CombineSync<kConfig, T>(args);
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
-__device__ void EpCombineSyncBarrier_body(EpDispatchCombineArgs<T> args) {
+__device__ void EpCombineSyncBarrier_body(EpDispatchCombineArgs args) {
   DEF_COMMON_VARS;
   IF_ENABLE_PROFILER(
       INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
@@ -1769,18 +1771,6 @@ namespace mori {
 namespace ops {
 namespace v2 {
 
-// EpInterNodeArgsRaw is EpInterNodeArgs<void>: the same struct with the single
-// T-dependent member spelled void*, static_asserted in ep_internode_args.hpp to
-// have identical size and alignment for every T. So the host fills one untyped
-// struct and each kernel reads it as its own T at the same addresses.
-template <typename T>
-__device__ __forceinline__ EpDispatchCombineArgs<T> EpInterNodeAsArgs(
-    const ::mori::ops::v2::EpInterNodeCcoArgs& a) {
-  EpDispatchCombineArgs<T> typed;
-  __builtin_memcpy(&typed, &a.args, sizeof(::mori::ops::v2::EpInterNodeArgsRaw));
-  return typed;
-}
-
 }  // namespace v2
 }  // namespace ops
 }  // namespace mori
@@ -1794,7 +1784,7 @@ __device__ __forceinline__ EpDispatchCombineArgs<T> EpInterNodeAsArgs(
 // Kernels that reach the network.
 #define MORI_EP_INTERNODE_CCO_ENTRY(entry, body)                                                  \
   extern "C" __global__ void entry(::mori::ops::v2::EpInterNodeCcoArgs a) {                       \
-    ::mori::ops::v2::body<kConfig, TokT>(::mori::ops::v2::EpInterNodeAsArgs<TokT>(a), a.devComm); \
+    ::mori::ops::v2::body<kConfig, TokT>(a.args, a.devComm); \
   }
 
 // Staging, sync and the final reduction: local or intra-node only, so they take
@@ -1802,5 +1792,5 @@ __device__ __forceinline__ EpDispatchCombineArgs<T> EpInterNodeAsArgs(
 // launch path for the whole sequence.
 #define MORI_EP_INTERNODE_CCO_ENTRY_LOCAL(entry, body)                                 \
   extern "C" __global__ void entry(::mori::ops::v2::EpInterNodeCcoArgs a) {            \
-    ::mori::ops::v2::body<kConfig, TokT>(::mori::ops::v2::EpInterNodeAsArgs<TokT>(a)); \
+    ::mori::ops::v2::body<kConfig, TokT>(a.args); \
   }

--- a/src/ops/dispatch_combine_v2/ep_internode_kernel.hpp
+++ b/src/ops/dispatch_combine_v2/ep_internode_kernel.hpp
@@ -292,7 +292,7 @@ __device__ __forceinline__ int32_t EpInterNodeWaitGt(int32_t* addr, int32_t val)
 // shader clock has been observed to vary by several percent, so a shader-clock
 // timer cannot tell "waited longer" from "clocked lower". wall_clock64 is the
 // fixed reference counter; measured on this gfx942 rig at 100.008 MHz.
-constexpr int kEpDbgTsSlots = 16;
+constexpr int kEpDbgTsSlots = 24;
 
 __device__ __forceinline__ void EpDbgTs(const EpDispatchCombineArgs& args, int slot) {
   if (args.dbgTsBuf == nullptr) return;
@@ -1764,9 +1764,15 @@ __device__ void EpCombineAll_body(EpDispatchCombineArgs args) {
     const size_t fp8CombXferBytes =
         (args.weightsBuf == nullptr) ? fp8HiddenBytes : fp8HiddenBytes + weightBytes;
     combine_all_impl::EpCombineAllInternalFp8<kConfig, T>(args, fp8HiddenBytes, fp8CombXferBytes);
+    // Slot 14 marks the end of the LAST pass of the combine phase, on both
+    // exits. Paired with slot 12 of the NEXT round's dispatch it gives the true
+    // GPU-timeline gap between the two phases -- the quantity that the phase
+    // events cannot separate from host time.
+    if ((blockId == 0) && (thdId == 0)) EpDbgTs(args, 14);
     return;
   }
   combine_all_impl::EpCombineAllGeneric<kConfig, T>(args);
+  if ((blockId == 0) && (thdId == 0)) EpDbgTs(args, 14);
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
@@ -1785,12 +1791,22 @@ __device__ void EpCombineInterNodeV1KernelLowLatency_body(EpDispatchCombineArgs 
 template <EpInterNodeKernelCfg kConfig, typename T>
 __device__ void EpCombineSync_body(EpDispatchCombineArgs args) {
   DEF_COMMON_VARS;
+  // 18/19 bracket combinesync, the FIRST pass of the combine phase. With 7->18
+  // this splits pre_bar into "everything between the two mori calls" -- the
+  // torch convert and the launch path -- and the kernel itself.
+  if ((blockId == 0) && (thdId == 0)) EpDbgTs(args, 18);
   internode::CombineSync<kConfig, T>(args);
+  if ((blockId == 0) && (thdId == 0)) EpDbgTs(args, 19);
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
 __device__ void EpCombineSyncBarrier_body(EpDispatchCombineArgs args) {
   DEF_COMMON_VARS;
+  // 16/17 bracket the cross-device barrier that OPENS the combine phase. It
+  // sits between dispatch_ll ending and combine_ll starting, so the phase
+  // events charge it to neither -- and the closed per-round accounting put both
+  // the largest term and the whole regime delta in exactly that window.
+  if ((blockId == 0) && (thdId == 0)) EpDbgTs(args, 16);
   IF_ENABLE_PROFILER(
       INTERNODE_V1_PROFILER_INIT_CONTEXT(profiler, args.profilerConfig, globalWarpId, laneId));
   MORI_TRACE_SPAN(profiler, Slot::EpCombineSyncBarrier);
@@ -1808,6 +1824,7 @@ __device__ void EpCombineSyncBarrier_body(EpDispatchCombineArgs args) {
     while (core::AtomicLoadRelaxedSystem(localBarrierPtr + destPe) != barrierFlag) {
     }
   }
+  if ((blockId == 0) && (thdId == 0)) EpDbgTs(args, 17);
 }
 
 }  // namespace v2

--- a/src/ops/dispatch_combine_v2/ep_internode_kernel.hpp
+++ b/src/ops/dispatch_combine_v2/ep_internode_kernel.hpp
@@ -281,6 +281,24 @@ __device__ __forceinline__ int32_t EpInterNodeWaitGt(int32_t* addr, int32_t val)
   return observed;
 }
 
+// Device timestamps, opt-in. args.dbgTsBuf is null unless MORI_EP_DEV_TS is set
+// on the host, so each site below is one wave-uniform scalar compare against a
+// kernarg. EVERY site sits OUTSIDE a spin loop: the whole point is to time the
+// loops, and an instruction added inside one would change what is measured.
+//
+// wall_clock64() and not mori::cco::clock64(): the latter is
+// __builtin_readcyclecounter(), the SHADER clock, which moves with DVFS. This
+// measurement compares a slow round against a fast one on a box where the
+// shader clock has been observed to vary by several percent, so a shader-clock
+// timer cannot tell "waited longer" from "clocked lower". wall_clock64 is the
+// fixed reference counter; measured on this gfx942 rig at 100.008 MHz.
+constexpr int kEpDbgTsSlots = 16;
+
+__device__ __forceinline__ void EpDbgTs(const EpDispatchCombineArgs& args, int slot) {
+  if (args.dbgTsBuf == nullptr) return;
+  args.dbgTsBuf[args.dbgRound * kEpDbgTsSlots + slot] = static_cast<uint64_t>(wall_clock64());
+}
+
 /* ---------------------------------------------------------------------------------------------- */
 /*                                   EpDispatchInterNodeV1Kernel                                  */
 /* ---------------------------------------------------------------------------------------------- */
@@ -585,11 +603,17 @@ inline __device__ void DispatchInterNodeLLSend(EpDispatchCombineArgs& args,
         size_t stagingTokOffset = tokenId * xferBytes;
         int qpId = (tokenId / warpSize) % config.numQpPerPe;
 
+        // Slots 1/2 bracket the ONE thing that is purely local on the send
+        // side: building the WQE and ringing the doorbell. At 4 tokens there is
+        // exactly one post per pass so this is exact; above 64 tokens it is
+        // last-write-wins and reports the final chunk.
+        EpDbgTs(args, 1);
         EpInterNodePutSignal(comm, args.reg(args.offDispatchInp), remoteIdx * xferBytes,
                              args.reg(args.offDispatchStaging), stagingTokOffset,
                              tokenNum * xferBytes, args.reg(args.offChunkFlag),
                              (myNode * maxChunkNum + flagSlotId) * sizeof(uint64_t), tokenNum + 1,
                              proxyPe, qpId);
+        EpDbgTs(args, 2);
       }
       if (shouldSend) args.interNodeDispSendMap[nNodes * tokenId + i] = destTokId;
     }
@@ -609,6 +633,10 @@ inline __device__ void DispatchInterNodeLLSend(EpDispatchCombineArgs& args,
     }
     if (laneId == 0) args.interNodeBlocksBarrier[1] = 0;
   }
+  // End of the send half. This is a fan-in (atomicAdd), not a barrier -- nobody
+  // blocks -- so slot 3 measures warp-arrival skew plus the tail atomic, and
+  // must not be read as "barrier time".
+  if ((globalWarpId == 0) && (laneId == 0)) EpDbgTs(args, 3);
 }
 
 template <EpInterNodeKernelCfg kConfig, typename T>
@@ -767,6 +795,11 @@ inline __device__ void DispatchInterNodeLLRecv(EpDispatchCombineArgs& args) {
     index_t nodeFlag = 0;
     if (laneId == 0) {
       uint64_t barrierFlag = args.crossDeviceBarrierFlag[0];
+      // Slots 4/5 bracket the wait for the peer's write to land. Guarded to one
+      // warp so the 32 spinning lanes do not all write the same slot; at 4
+      // tokens globalWarp 0 runs the outer loop exactly once, so it is
+      // unambiguous which wait this is.
+      if (globalWarpId == 0) EpDbgTs(args, 4);
       while (1) {
         thisChunkTokenNum = core::AtomicLoadRelaxedSystem(&chunkFlag[node * maxChunkNum + k]);
         if (thisChunkTokenNum > 0) break;
@@ -777,6 +810,7 @@ inline __device__ void DispatchInterNodeLLRecv(EpDispatchCombineArgs& args) {
           break;
         }
       }
+      if (globalWarpId == 0) EpDbgTs(args, 5);
     }
     thisChunkTokenNum = __shfl(thisChunkTokenNum, 0) - 1;
     int endTokenIdx = startTokenIdx + thisChunkTokenNum;
@@ -970,6 +1004,7 @@ template <EpInterNodeKernelCfg kConfig, typename T>
 __device__ void EpDispatchInterNodeV1KernelLowLatency_body(EpDispatchCombineArgs args,
                                                            const ::mori::cco::ccoDevComm& comm) {
   DEF_COMMON_VARS;
+  if ((blockId == 0) && (thdId == 0)) EpDbgTs(args, 0);
   if (blockId < args.rdmaBlockNum) {
     internode::DispatchInterNodeLLSend<kConfig, T>(args, comm);
     internode::DispatchInterNodeLLRecv<kConfig, T>(args);
@@ -1440,6 +1475,7 @@ __forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs& a
         }
         int proxyPe = node * config.gpuPerNode + (myPe % config.gpuPerNode);
         int qpId = k % config.numQpPerPe;
+        EpDbgTs(args, 9);
         EpInterNodePut(comm, args.reg(args.offStaging),
                        SendBufSlotOffset(config, myNode + nNodes, startTokenIdx) * tokCombXferBytes,
                        args.reg(args.offStaging),
@@ -1482,9 +1518,12 @@ __forceinline__ __device__ void CombineInterNodeLLTyped(EpDispatchCombineArgs& a
     uint64_t* localBarrierPtr = args.reg(args.offCrossDeviceBarrier)->template GetAs<uint64_t*>();
     if ((laneId < nNodes) && (laneId != myNode)) {
       int proxyPe = laneId * config.gpuPerNode + (myPe % config.gpuPerNode);
+      // Slots 10/11: combine's only cross-node wait.
+      EpDbgTs(args, 10);
       while (core::AtomicLoadRelaxedSystem(localBarrierPtr + proxyPe) !=
              (barrierFlag * config.numQpPerPe)) {
       }
+      EpDbgTs(args, 11);
     }
   }
 }
@@ -1720,6 +1759,7 @@ template <EpInterNodeKernelCfg kConfig, typename T>
 __device__ void EpCombineInterNodeV1KernelLowLatency_body(EpDispatchCombineArgs args,
                                                           const ::mori::cco::ccoDevComm& comm) {
   DEF_COMMON_VARS;
+  if ((blockId == 0) && (thdId == 0)) EpDbgTs(args, 8);
 
   if (blockId < args.rdmaBlockNum) {
     internode::CombineInterNodeLL<kConfig, T>(args, comm);

--- a/src/ops/dispatch_combine_v2/ep_internode_spec.cpp
+++ b/src/ops/dispatch_combine_v2/ep_internode_spec.cpp
@@ -40,27 +40,26 @@ struct KernelDesc {
   const char* tag;   // goes in the entry name
   const char* body;  // the *_body function in ep_internode_kernel.hpp
   bool takesComm;    // false for the passes with no cross-node traffic
-  bool takesStdMoE;  // the LL pair is additionally specialised on it
 };
 
 KernelDesc DescFor(EpInterNodeKernel k) {
   switch (k) {
     case EpInterNodeKernel::CopyToStaging:
-      return {"copystaging", "EpDispatchCopyToStaging_body", false, false};
+      return {"copystaging", "EpDispatchCopyToStaging_body", false};
     case EpInterNodeKernel::Dispatch:
-      return {"dispatch", "EpDispatchInterNodeV1Kernel_body", true, false};
+      return {"dispatch", "EpDispatchInterNodeV1Kernel_body", true};
     case EpInterNodeKernel::DispatchLL:
-      return {"dispatch_ll", "EpDispatchInterNodeV1KernelLowLatency_body", true, true};
+      return {"dispatch_ll", "EpDispatchInterNodeV1KernelLowLatency_body", true};
     case EpInterNodeKernel::CombineSync:
-      return {"combinesync", "EpCombineSync_body", false, false};
+      return {"combinesync", "EpCombineSync_body", false};
     case EpInterNodeKernel::CombineSyncBarrier:
-      return {"combinesyncbarrier", "EpCombineSyncBarrier_body", false, false};
+      return {"combinesyncbarrier", "EpCombineSyncBarrier_body", false};
     case EpInterNodeKernel::Combine:
-      return {"combine", "EpCombineInterNodeV1Kernel_body", true, false};
+      return {"combine", "EpCombineInterNodeV1Kernel_body", true};
     case EpInterNodeKernel::CombineLL:
-      return {"combine_ll", "EpCombineInterNodeV1KernelLowLatency_body", true, true};
+      return {"combine_ll", "EpCombineInterNodeV1KernelLowLatency_body", true};
     case EpInterNodeKernel::CombineAll:
-      return {"combineall", "EpCombineAll_body", false, false};
+      return {"combineall", "EpCombineAll_body", false};
   }
   throw std::runtime_error("mori ep v1 jit: unknown kernel");
 }
@@ -98,7 +97,6 @@ EpInterNodeCfg MakeEpInterNodeCfg(const std::string& arch, const EpInterNodeRequ
   c.kernelCfg.quantType = req.quantType;
 
   c.dtype = req.dtype;
-  c.enableStdMoE = req.enableStdMoE;
 
   c.waveSize = mori::jit::v2::WaveSizeForArch(arch);
 
@@ -155,7 +153,6 @@ std::string EpInterNodeEntryName(const EpInterNodeCfg& cfg, EpInterNodeKernel ki
   s += d.tag;
   s += '_';
   s += EpInterNodeDTypeTag(cfg.dtype);
-  if (d.takesStdMoE && cfg.enableStdMoE) s += "_stdmoe";
   return s;
 }
 
@@ -188,14 +185,6 @@ std::string EpInterNodeRenderSource(const EpInterNodeCfg& cfg, EpInterNodeKernel
     src += entry;
     src += ", ";
     src += d.body;
-    src += ")\n";
-  } else if (d.takesStdMoE) {
-    src += "MORI_EP_INTERNODE_CCO_ENTRY_STDMOE(";
-    src += entry;
-    src += ", ";
-    src += d.body;
-    src += ", ";
-    src += cfg.enableStdMoE ? "true" : "false";
     src += ")\n";
   } else {
     src += "MORI_EP_INTERNODE_CCO_ENTRY(";

--- a/tests/python/ops/dispatch_combine_test_utils.py
+++ b/tests/python/ops/dispatch_combine_test_utils.py
@@ -19,6 +19,10 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import os
+import queue
+import time
+
 import pytest
 from tests.python.utils import TorchDistProcessManager, data_type_supported
 import mori
@@ -389,10 +393,49 @@ def start_torch_dist_process_manager(world_size=8, disable_p2p=False):
     return manager
 
 
-def assert_worker_results(manager, world_size):
+def assert_worker_results(manager, world_size, timeout_s=None):
+    """Collect one result per rank, or fail naming the ranks that never reported.
+
+    The collection is bounded. These kernels are distributed spin-wait protocols
+    with unbounded polling loops and no in-kernel watchdog, so a protocol bug
+    presents as a rank that never returns, not as an exception. An untimed
+    ``get()`` turns that into a hung session that the outer shell ``timeout``
+    eventually kills with no message and no attribution -- the single most
+    expensive failure mode to debug, because it says nothing about WHICH rank
+    stopped.
+
+    Timing out does not rescue the worker pool: the hung ranks still hold their
+    task and the manager is session-scoped, so tests after this one in the same
+    session are expected to fail too. The point is to name the first casualty
+    while the evidence is still legible.
+
+    ``MORI_TEST_WORKER_TIMEOUT`` overrides the budget in seconds; it is
+    deliberately generous, because a slow case must not be reported as a hang.
+    """
+    budget = (
+        float(os.environ.get("MORI_TEST_WORKER_TIMEOUT") or "900")
+        if timeout_s is None
+        else float(timeout_s)
+    )
+    deadline = time.monotonic() + budget
     results = []
     for _ in range(world_size):
-        rank, result = manager.result_queue.get()
+        try:
+            rank, result = manager.result_queue.get(
+                timeout=max(0.0, deadline - time.monotonic())
+            )
+        except queue.Empty:
+            reported = sorted(r for r, _ in results)
+            missing = [r for r in range(world_size) if r not in reported]
+            pytest.fail(
+                f"timed out after {budget:g}s waiting for worker results: "
+                f"{len(missing)} of {world_size} ranks never reported. "
+                f"silent ranks {missing}, reported {reported}. "
+                "A rank that never reports is a hang in the kernel or in the "
+                "collective before it -- not a slow case; raise "
+                "MORI_TEST_WORKER_TIMEOUT only after ruling that out.",
+                pytrace=False,
+            )
         results.append((rank, result))
 
     failures = [

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -181,7 +181,53 @@ def _gen_round(rng, cfg, ct, dev, dtype):
         ]
     ).to(torch.int32)
     wts = torch.rand(ct, cfg.num_experts_per_token, generator=rng, device=dev)
-    return inp, idx, wts
+    # Real scales when the transport is on. The dispatch send path copies
+    # scale_dim * scale_type_size bytes per token whether or not a buffer was
+    # handed in -- only the staging copy is guarded on the pointer -- so passing
+    # None with scale_dim > 0 transports uninitialised staging. Same byte count,
+    # but not something to measure against.
+    scales = (
+        torch.rand(ct, cfg.scale_dim, generator=rng, device=dev)
+        if cfg.scale_dim
+        else None
+    )
+    return inp, idx, wts, scales
+
+
+def _verify_once(op, cfg, d, dev, a, comm, inp, idx, wts, sc):
+    """One dispatch+combine against the analytic golden. True if this rank agrees.
+
+    Same expectation as `--cmd test`: an identity expert makes combine[t] equal
+    U[t] * input[t] over the DISTINCT destination ranks. Weights are always folded
+    here even when the timed loop will not fold them -- an unchecked weight path
+    is how this harness shipped a silent bug twice.
+    """
+    r = op.dispatch(inp, wts, sc, idx, return_routing=True)
+    torch.cuda.synchronize()
+    comm.barrier()
+    x = r[0].to(cfg.combine_dtype) if cfg.is_asymmetric_dtype else r[0]
+    out, out_w = op.combine(x, wts, routing=r[5])
+    torch.cuda.synchronize()
+    comm.barrier()
+
+    ct = inp.shape[0]
+    idx_c = idx.cpu()
+    U = np.array(
+        [
+            len({int(idx_c[t, j]) // cfg.num_experts_per_rank for j in range(a.topk)})
+            for t in range(ct)
+        ]
+    )
+    Ut = torch.from_numpy(U).view(ct, 1).float()
+    got = out.float().cpu()
+    exp = Ut * inp.float().cpu()
+    per_elem = inp.float().cpu().abs()
+    eps = 3e-1 if (a.quant_type != "none" or cfg.dispatch_dtype in _FP8) else 8e-3
+    ok = bool(((got - exp).abs() <= eps * Ut * per_elem.clamp(min=1.0)).all())
+    ok_w = bool(((out_w.cpu() - Ut * wts.float().cpu()).abs() <= 2e-3 * Ut).all())
+    if not (ok and ok_w) and d.rank == 0:
+        print(f"#   pre-bench check: hidden_ok={ok} weights_ok={ok_w}", flush=True)
+    return ok and ok_w
 
 
 def _bench(op, cfg, d, dev, a, comm):
@@ -213,9 +259,28 @@ def _bench(op, cfg, d, dev, a, comm):
     rng = torch.Generator(device=dev)
     rng.manual_seed(4242 + d.rank)
     ct = a.max_tokens
-    inp, idx, wts = _gen_round(rng, cfg, ct, dev, cfg.dispatch_dtype)
+    inp, idx, wts, sc = _gen_round(rng, cfg, ct, dev, cfg.dispatch_dtype)
     if a.kernel_type is not None:
         op._internode_force_ll = a.kernel_type == "v1_ll"
+
+    # Check BEFORE measuring, as bench_dispatch_combine does (it runs
+    # run_test_once and asserts before run_bench_once). A configuration that is
+    # silently wrong still produces timings, and this harness has shipped two of
+    # those -- the weight fold reading the wrong buffer, and both legs compiled
+    # with the dispatch dtype. One round, folding weights whatever --bench-weights
+    # says, because the point is to check them.
+    ok = _verify_once(op, cfg, d, dev, a, comm, inp, idx, wts, sc)
+    bad = d.allreduce_sum(0 if ok else 1)
+    if bad:
+        if d.rank == 0:
+            print(
+                f"# BENCH ABORTED: {bad} of {d.world} ranks failed the "
+                f"pre-bench check; the numbers below would be meaningless",
+                flush=True,
+            )
+        return 1
+    torch.cuda.synchronize()
+    comm.barrier()
 
     # The examples harness's _convert_for_combine: the combine leg reads its
     # input as its own element type, so an asymmetric config has to cast first.
@@ -225,7 +290,7 @@ def _bench(op, cfg, d, dev, a, comm):
     cw = wts if a.bench_weights else None
 
     for _ in range(a.warmup):
-        r = op.dispatch(inp, wts, None, idx, return_routing=True)
+        r = op.dispatch(inp, wts, sc, idx, return_routing=True)
         op.combine(convert(r[0]), cw, routing=r[5])
     torch.cuda.synchronize()
     comm.barrier()
@@ -235,7 +300,7 @@ def _bench(op, cfg, d, dev, a, comm):
     t0 = time.perf_counter()
     ev[0].record()
     for i in range(n):
-        r = op.dispatch(inp, wts, None, idx, return_routing=True)
+        r = op.dispatch(inp, wts, sc, idx, return_routing=True)
         ev[3 * i + 1].record()
         x = convert(r[0])
         ev[3 * i + 2].record()
@@ -263,7 +328,7 @@ def _bench(op, cfg, d, dev, a, comm):
         pr = cProfile.Profile()
         pr.enable()
         for _ in range(n):
-            rp = op.dispatch(inp, wts, None, idx, return_routing=True)
+            rp = op.dispatch(inp, wts, sc, idx, return_routing=True)
             op.combine(convert(rp[0]), cw, routing=rp[5])
         pr.disable()
         torch.cuda.synchronize()
@@ -366,7 +431,7 @@ def main(argv):
         for r in range(a.rounds):
             rng.manual_seed(1234 + r * 977 + rank)
             ct = M
-            inp, idx, wts = _gen_round(rng, cfg, ct, dev, cfg.dispatch_dtype)
+            inp, idx, wts, sc = _gen_round(rng, cfg, ct, dev, cfg.dispatch_dtype)
 
             recv_x, recv_w, recv_s, recv_i, total_recv, routing = op.dispatch(
                 inp, wts, None, idx, return_routing=True

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -44,6 +44,25 @@ without a QP.
 ``tools/run_internode_test.sh`` drives both ranks; the CLI below is the subset of
 the shmem harness's flags that means anything here.
 
+RoCE QoS: SET MORI_RDMA_TC AND MORI_RDMA_SL
+-------------------------------------------
+Unset, ``bnxt.cpp`` takes ``ReadRdmaServiceLevelEnv().value_or(1)`` and leaves
+``grh.traffic_class`` alone, so every transfer goes out on SL 1 / DSCP 0 -- the
+default lossy class -- no matter how the NIC and switch are programmed. The
+values must match the fabric: on the 2-node bnxt rig here the NIC is programmed
+``roce_dscp=0x28`` (40), so ``MORI_RDMA_TC=160`` (40 << 2) and
+``MORI_RDMA_SL=5``. ``tools/env_setup.sh`` derives both from ROCE_DSCP/ROCE_PRIO
+and exports them; its checked-in 26/3 are reference defaults its own comment says
+to align with the switch. Confirm they arrived with ``MORI_APP_LOG_LEVEL=info``:
+``bnxt attr.ah_attr.sl:5 attr.ah_attr.grh.traffic_class:160``.
+
+Measured, it changes nothing HERE -- interleaved A/B over four pairs at 4 tokens
+put 160/5 and 0/1 within noise of each other. That is expected rather than
+contradictory: a lossless priority class buys nothing when the benchmark is the
+only traffic on the fabric. It is worth setting because a number measured in the
+wrong traffic class does not transfer to a shared one, not because it is a
+speedup.
+
 COMPARING AGAINST THE v1 BENCH
 ------------------------------
 The reference numbers come from ``run_bench_once`` in

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -106,6 +106,7 @@ leaves both unaligned is not bounded in either direction.
 """
 
 import argparse
+import ctypes
 import os
 import sys
 import time
@@ -152,6 +153,13 @@ class Dist:
         t = torch.tensor([value], dtype=torch.int64)
         dist.all_reduce(t, op=dist.ReduceOp.SUM)
         return int(t.item())
+
+    def all_gather_rows(self, row):
+        """(world, len(row)) float64 from each rank's `row`. gloo, so CPU."""
+        t = torch.tensor(row, dtype=torch.float64)
+        out = [torch.zeros_like(t) for _ in range(self.world)]
+        dist.all_gather(out, t)
+        return torch.stack(out)
 
     def allreduce_minmax(self, lo, hi):
         """Extremes across ranks, for the same best/worst the v1 harness prints."""
@@ -247,6 +255,10 @@ def _parse_args(argv):
     # which is the question when the host is running ahead -- and adds nothing
     # cross-rank.
     p.add_argument("--per-round-drain", action="store_true")
+    p.add_argument("--no-bench-tables", action="store_true")
+    p.add_argument("--pre-barriers", type=int, default=1)
+    p.add_argument("--pre-sleep-ms", type=float, default=0.0)
+    p.add_argument("--barrier-kind", default="cco", choices=["cco", "gloo", "both"])
     # Re-align the ranks every N rounds. The slow regime is a stable inter-node
     # phase offset, and a rendezvous does not remove one -- this asks whether an
     # explicit re-alignment escapes the offset fixed point or whether the loop
@@ -403,6 +415,184 @@ def _report_loop_alignment(a, rank):
         )
 
 
+def _geom_for_report(op, cfg, a):
+    """The (block, rdma, warp) each phase actually launched with, for the table
+    titles -- the point v1's `_launch_params_str` makes: a table that does not
+    name its launch config cannot be matched back to the run that produced it.
+    Read from the backend rather than from the config, because on the internode
+    path cfg.dispatch_block_num is a dict key and not a grid."""
+    try:
+        # EpDispatchCombineOpHip IS the backend -- it subclasses the op.
+        return (
+            tuple(op._internode_geom_for("dispatch", a.max_tokens)),
+            tuple(op._internode_geom_for("combine", a.max_tokens)),
+        )
+    except Exception:
+        from mori.ops.dispatch_combine_v2.internode_tuning_configs import lookup
+
+        t = lookup(
+            cfg.world_size, cfg.hidden_dim, cfg.num_experts_per_token, a.max_tokens
+        )
+        if t:
+            return tuple(t["dispatch"]), tuple(t["combine"])
+        return (0, 0, 0), (0, 0, 0)
+
+
+def _rdma_algo_token_count(idx, cfg, ll):
+    """(token, destination-node) pairs this rank emits, DeepEP's definition and
+    the numerator of the RDMA bandwidth column.
+
+    Reimplemented rather than imported: this file keeps zero coupling to the v1
+    harness, which is what lets the two be compared without one dragging the
+    other's op in. The formula is v1's `compute_rdma_algo_token_count`.
+
+    The LL kernel does not deduplicate across expert slots, so every token
+    contributes one entry per node unconditionally.
+    """
+    nodes = cfg.world_size // cfg.gpu_per_node
+    if ll:
+        return idx.shape[0] * nodes
+    per_node = cfg.num_experts_per_rank * cfg.gpu_per_node
+    seen = torch.zeros(idx.shape[0], nodes, dtype=torch.bool, device=idx.device)
+    seen.scatter_((idx // per_node).long().clamp_(0, nodes - 1), 1, True)
+    return int(seen.sum().item())
+
+
+def _phase_stats(col):
+    """(worst, best, avg) over a (rounds, ranks) tensor, as v1's _compute_stats:
+    worst/best are extremes over individual samples, avg is the grand mean."""
+    return col.min().item(), col.max().item(), col.mean(dim=1).mean().item()
+
+
+def _print_phase_table(title, rdma, xgmi, ll, lat):
+    from prettytable import PrettyTable
+
+    t = PrettyTable()
+    t.title = title
+    t.field_names = [
+        "Metrics",
+        "RDMA Bandwidth (GB/s)",
+        "XGMI Bandwidth (GB/s)",
+        "LL Bandwidth (GB/s)",
+        "Latency (us)",
+    ]
+    r = lambda v: round(v, 2)
+    # Bandwidth "Best" is the MAX and latency "Best" is the MIN, so the two
+    # columns index the same tuple from opposite ends. v1 does this too; it is
+    # the reason Best/Worst are not simply [1]/[0] throughout.
+    t.add_rows(
+        [
+            ["Best", r(rdma[1]), r(xgmi[1]), r(ll[1]), r(lat[0])],
+            ["Worst", r(rdma[0]), r(xgmi[0]), r(ll[0]), r(lat[1])],
+            ["Average", r(rdma[2]), r(xgmi[2]), r(ll[2]), r(lat[2])],
+        ]
+    )
+    print(t, flush=True)
+
+
+def _report_tables(d, cfg, a, disp, comb, total_recv, idx, ll, geom):
+    """v1's bench output: a per-round dump and the two performance tables.
+
+    Every rank computes its OWN bandwidths from its own byte counts and the
+    numbers are then gathered, which is what v1 does -- gathering durations and
+    applying one rank's byte count to all of them would be wrong the moment the
+    routing is not perfectly balanced.
+    """
+    ct = a.max_tokens
+    d_elem = torch.tensor([], dtype=cfg.dispatch_dtype).element_size()
+    c_elem = torch.tensor([], dtype=cfg.combine_dtype).element_size()
+    d_bytes = total_recv * cfg.hidden_dim * d_elem
+    c_bytes = total_recv * cfg.hidden_dim * c_elem
+    rdma_tok = _rdma_algo_token_count(idx, cfg, ll)
+    d_rdma_bytes = rdma_tok * cfg.hidden_dim * d_elem
+    c_rdma_bytes = rdma_tok * cfg.hidden_dim * c_elem
+    # LL packs a fixed slot per (token, expert) rather than only what routed, so
+    # its wire bytes exceed the payload by this factor. v1 scales the XGMI
+    # column by it to get the LL column.
+    ll_scale = ct * cfg.num_experts_per_token / (total_recv + 1)
+
+    # bw in GB/s from a duration in MICROseconds: bytes/1e9 / (us/1e6).
+    bw = lambda b, us: b / (1000.0 * us) if us > 0 else 0.0
+    row = []
+    for dv, cv in zip(disp, comb):
+        row += [
+            bw(d_rdma_bytes, dv),
+            bw(d_bytes, dv),
+            dv,
+            bw(c_rdma_bytes, cv),
+            bw(c_bytes, cv),
+            cv,
+        ]
+    g = d.all_gather_rows(row).reshape(d.world, len(disp), 6).permute(1, 0, 2)
+    if d.rank != 0:
+        return
+
+    for i in range(g.shape[0]):
+        rd = g[i]
+        print(f"Round {i}", flush=True)
+        for phase, cols in (
+            (
+                "dispatch",
+                (
+                    ("duration", 2, "us"),
+                    ("rdma bandwidth", 0, "GB/s"),
+                    ("bandwidth", 1, "GB/s"),
+                ),
+            ),
+            (
+                "combine",
+                (
+                    ("duration", 5, "us"),
+                    ("rdma bandwidth", 3, "GB/s"),
+                    ("bandwidth", 4, "GB/s"),
+                ),
+            ),
+        ):
+            for name, c, unit in cols:
+                vals = [round(v, 2) for v in rd[:, c].tolist()]
+                print(
+                    f"  {phase} {name} {vals} avg {rd[:, c].mean():.2f} {unit}",
+                    flush=True,
+                )
+
+    # Config header immediately above the tables. The `# BENCH` one-liner is
+    # printed before the per-round dump, which at 30 rounds is 180 lines earlier
+    # -- by the time the tables are on screen it has scrolled away, and a table
+    # whose configuration you have to scroll to find is a table you will
+    # eventually misattribute.
+    nodes = cfg.world_size // cfg.gpu_per_node
+    print(
+        f"\n# CONFIG tok={ct} dtype={str(cfg.dispatch_dtype).split('.')[-1]}"
+        f"->{str(cfg.combine_dtype).split('.')[-1]} hidden={cfg.hidden_dim} "
+        f"topk={cfg.num_experts_per_token} kernel={'v1_ll' if ll else 'v1'} "
+        f"world={cfg.world_size} nodes={nodes}x{cfg.gpu_per_node} "
+        f"experts/rank={cfg.num_experts_per_rank} scale_dim={cfg.scale_dim} "
+        f"qp={cfg.num_qp_per_pe}",
+        flush=True,
+    )
+    print(
+        f"# CONFIG dispatch block/rdma/warp={geom[0]}  combine={geom[1]}  "
+        f"rounds={a.rounds} warmup={a.warmup}  "
+        f"recv_tokens={total_recv} rdma_algo_tokens={rdma_tok}",
+        flush=True,
+    )
+
+    for name, (cr, cx, cl), dt, gm, elem in (
+        ("Dispatch", (0, 1, 2), cfg.dispatch_dtype, geom[0], d_elem),
+        ("Combine", (3, 4, 5), cfg.combine_dtype, geom[1], c_elem),
+    ):
+        xg = _phase_stats(g[:, :, cx])
+        _print_phase_table(
+            f"{name} Performance ({str(dt).split('.')[-1]}) "
+            f"block={gm[0]} warp={gm[2]} rdma={gm[1]} "
+            f"~{ct * cfg.hidden_dim * elem / (1024 ** 2):.1f} MB/rank",
+            _phase_stats(g[:, :, cr]),
+            xg,
+            tuple(v * ll_scale for v in xg),
+            _phase_stats(g[:, :, cl]),
+        )
+
+
 def _bench(op, cfg, d, dev, a, comm):
     """Per-phase latency, structured to match ``run_bench_once`` in
     ``examples/ops/dispatch_combine/test_dispatch_combine_internode.py``.
@@ -466,12 +656,48 @@ def _bench(op, cfg, d, dev, a, comm):
     n = a.rounds
     ev = [torch.cuda.Event(enable_timing=True) for _ in range(3 * n + 1)]
 
-    for _ in range(a.warmup):
+    total_recv = 0
+    for i in range(a.warmup):
         r = op.dispatch(inp, wts, sc, idx, return_routing=True)
+        if i == a.warmup - 1:
+            # Read it here, not in the timed loop: .item() synchronises.
+            torch.cuda.synchronize()
+            total_recv = int(r[4][0].item())
         op.combine(convert(r[0]), cw, routing=r[5])
     torch.cuda.synchronize()
     comm.barrier()
 
+    # Barrier-skew probe. comm.barrier() is ccoBarrierAll, a CPU-side collective
+    # over the bootstrap sockets, and dist.barrier() is gloo -- same family, both
+    # tree/ring shaped, so neither releases its ranks at one instant. Timestamp
+    # after EACH of N barriers so the question "is the first one just ragged, or
+    # is every one ragged" has an answer instead of a guess.
+    _bt = []
+    for _k in range(max(1, a.pre_barriers)):
+        if a.barrier_kind in ("cco", "both"):
+            comm.barrier()
+        if a.barrier_kind in ("gloo", "both"):
+            dist.barrier()
+        _bt.append(time.time())
+    # The control for the barrier-count effect: idle for the same wall time
+    # instead of barriering. If sleeping reproduces the benefit then what helps
+    # is elapsed time, not the collective.
+    if a.pre_sleep_ms:
+        time.sleep(a.pre_sleep_ms / 1000.0)
+        _bt.append(time.time())
+
+    # KEEP THE BARRIER. The first one to three TIMED rounds run 4-5x slow even
+    # though 20 warmup rounds precede them, and the obvious reading -- that the
+    # barrier releases all 16 ranks at one instant and the first rounds are a
+    # maximally synchronised start -- is WRONG. Tested by inserting un-timed,
+    # un-barriered rounds between the barrier and the loop: they do remove the
+    # opening spike (first rounds 42/45/43 instead of 67/38/41), and in three of
+    # four pairs the whole run then sat in the slow regime, 128-134us total
+    # against 89-91. The barrier is what keeps the ranks aligned; extra rounds
+    # after it let the inter-node phase offset re-establish before timing starts.
+    # So the opening rounds are the settling cost of alignment, and warmup cannot
+    # remove them because warmup happens BEFORE the barrier. Drop them from the
+    # statistics (--drop-rounds) rather than trying to warm them away.
     # Causal probe for host pacing, opt-in: busy-wait known host microseconds
     # before the combine enqueue, no GPU work. The slope of measured-combine
     # against injected microseconds is the answer (measured ~1.0 beyond ~30us of
@@ -493,6 +719,19 @@ def _bench(op, cfg, d, dev, a, comm):
         op.dbg_round = dict.fromkeys(op.dbg_round, 0)
 
     _series = bool(os.environ.get("MORI_EP_ROUND_SERIES"))
+
+    # Which physical CPU this rank is actually ON, sampled around the loop.
+    # sched_getaffinity only gives the ALLOWED set, and after the NUMA bind that
+    # is 192 CPUs shared by four ranks -- so it cannot answer whether two ranks
+    # landed on the two SMT siblings of one core, which is the mechanism that
+    # produced the 2x host-loop time earlier. sched_getcpu can.
+    def _cpu():
+        try:
+            return int(ctypes.CDLL("libc.so.6", use_errno=True).sched_getcpu())
+        except Exception:
+            return -1
+
+    _cpu0 = _cpu()
 
     # Caching-allocator segments, opt-in. A cudaMalloc inside the timed loop
     # blocks the host for ~100us and lands on every rank in the same round (the
@@ -777,6 +1016,8 @@ def _bench(op, cfg, d, dev, a, comm):
             "# loop r%d t0=%.4f t1=%.4f" % (d.rank, _ep0, time.time()),
             flush=True,
         )
+        print("# barr r%d: " % d.rank + " ".join("%.6f" % x for x in _bt), flush=True)
+        print("# cpu  r%d: %d %d" % (d.rank, _cpu0, _cpu()), flush=True)
         hwal = [(tr[i + 1] - tr[i]) * 1e6 for i in range(n)][keep]
         print(
             "# rounds r%d hwal: " % d.rank + " ".join("%.0f" % x for x in hwal),
@@ -807,6 +1048,14 @@ def _bench(op, cfg, d, dev, a, comm):
             f"total={dm + cm:.1f}us [conv={vm:.1f}us wall={wall:.1f}us]",
             flush=True,
         )
+
+    # v1's bench output on top of ours: the per-round dump and the two
+    # performance tables. Off with --no-bench-tables; it costs one all_gather
+    # after the timed loop and nothing inside it.
+    if not a.no_bench_tables:
+        ll = bool(getattr(op, "_internode_force_ll", a.max_tokens <= 2048))
+        geom = _geom_for_report(op, cfg, a)
+        _report_tables(d, cfg, a, disp, comb, total_recv, idx, ll, geom)
     return 0
 
 

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -559,10 +559,19 @@ def _bench(op, cfg, d, dev, a, comm):
         if d.rank == 0:
             print("%s wallclock_khz=%d (expect 100000)" % (pfx, khz), flush=True)
         for nm, v in (
+            # 0->7 is the WHOLE dispatch_ll kernel as block 0 sees it, entry to
+            # after DispatchSync. Printed because the sum of the inner spans is
+            # not the kernel: they are stamped by different warps, and anything
+            # the phase spends outside this span belongs to another block, to
+            # copystaging, or to the host.
+            ("d_stag", _us(12, 13)),  # the copystaging kernel itself
+            ("d_kern", _us(0, 7)),
             ("d_head", _us(0, 1)),  # kernel entry -> first post
             ("d_post", _us(1, 2)),  # WQE build + doorbell: LOCAL
             ("d_gap", _us(2, 4)),  # post returns -> spin entry (warp skew)
             ("d_spin", _us(4, 5)),  # waiting for the peer's write: REMOTE
+            ("d_recv", _us(5, 6)),  # unpack + XGMI peer write of each token
+            ("d_sync", _us(6, 7)),  # DispatchSync grid barrier
             ("c_post", _us(8, 9)),  # combine entry -> put
             ("c_spin", _us(10, 11)),  # combine cross-node barrier wait
         ):

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -550,10 +550,18 @@ def _bench(op, cfg, d, dev, a, comm):
         # wrong unit is visible rather than silently scaling every number.
         khz = mori_cpp.get_cur_device_wall_clock_freq_mhz()
         # Rows are launch-indexed, so the same drop the phase series uses.
-        ts = _ts.view(-1, 16)[a.drop_rounds : n].cpu().to(torch.float64)
+        ts = _ts.view(-1, 24)[a.drop_rounds : n].cpu().to(torch.float64)
 
         def _us(b, e):
             return ((ts[:, e] - ts[:, b]) * 1e3 / khz).tolist()
+
+        # GPU-timeline gap between the previous round's LAST combine kernel and
+        # this round's FIRST dispatch kernel. Both are wall_clock64 on the same
+        # device, so this is the real inter-phase idle -- the thing the CUDA
+        # event window folds together with host time. Row 0 has no predecessor.
+        interphase = [float("nan")] + [
+            (ts[j, 12] - ts[j - 1, 14]) * 1e3 / khz for j in range(1, ts.shape[0])
+        ]
 
         pfx = "# DEVTS r%d" % d.rank
         if d.rank == 0:
@@ -564,6 +572,14 @@ def _bench(op, cfg, d, dev, a, comm):
             # not the kernel: they are stamped by different warps, and anything
             # the phase spends outside this span belongs to another block, to
             # copystaging, or to the host.
+            # The whole GPU span of the dispatch phase, and the gap BETWEEN its
+            # two kernels. Both endpoints are wall_clock64 on the same device in
+            # the same row, so their difference is meaningful even though CUDA
+            # event times and wall_clock64 do not share an origin. `disp -
+            # d_gpu` is then what is left outside the kernels entirely: the host
+            # enqueue and the two phase boundaries.
+            ("d_gpu", _us(12, 7)),
+            ("d_k2k", _us(13, 0)),  # copystaging end -> dispatch_ll start
             ("d_stag", _us(12, 13)),  # the copystaging kernel itself
             ("d_kern", _us(0, 7)),
             ("d_head", _us(0, 1)),  # kernel entry -> first post
@@ -574,6 +590,15 @@ def _bench(op, cfg, d, dev, a, comm):
             ("d_sync", _us(6, 7)),  # DispatchSync grid barrier
             ("c_post", _us(8, 9)),  # combine entry -> put
             ("c_spin", _us(10, 11)),  # combine cross-node barrier wait
+            ("d2sync", _us(7, 18)),  # dispatch end -> combinesync start
+            ("cs_sync", _us(18, 19)),  # the combinesync kernel
+            ("sync2bar", _us(19, 16)),  # combinesync end -> barrier start
+            ("cs_bar", _us(16, 17)),  # the cross-device barrier itself
+            ("pre_bar", _us(7, 16)),  # dispatch end -> barrier start (holds conv)
+            ("post_bar", _us(17, 8)),  # barrier end -> combine_ll start
+            ("c_gpu", _us(8, 14)),  # combine's whole GPU span
+            ("gap_dc", _us(7, 8)),  # dispatch end -> combine start (holds conv)
+            ("gap_cd", interphase),  # combine end -> next dispatch start (GPU)
         ):
             print("%s %s: " % (pfx, nm) + " ".join("%.1f" % x for x in v), flush=True)
     # Which PASS owns the slow round. The marks are (name, event) in launch

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -735,13 +735,6 @@ def _bench(op, cfg, d, dev, a, comm):
     if _marks is not None:
         del _marks[:]
 
-    # Same reason as the marks above: the warmup ran the identical path and
-    # burned rounds off the buffer, so only the timed loop's rows are wanted.
-    _ts = getattr(op, "dbg_ts", None)
-    if _ts is not None:
-        _ts.zero_()
-        op.dbg_round = dict.fromkeys(op.dbg_round, 0)
-
     _series = bool(os.environ.get("MORI_EP_ROUND_SERIES"))
 
     # Which physical CPU this rank is actually ON, sampled around the loop.
@@ -810,74 +803,6 @@ def _bench(op, cfg, d, dev, a, comm):
     torch.cuda.synchronize()
     wall = (time.perf_counter() - t0) * 1e6 / n
 
-    # Device timestamps, opt-in (MORI_EP_DEV_TS on the backend). Exactly ONE
-    # device-to-host copy, after the loop's own synchronize, so nothing here is
-    # inside a measured window -- a per-round readback would serialise the loop
-    # and destroy the thing being measured.
-    #
-    # The point of these is the one split the host cannot make: dispatch_ll and
-    # combine_ll each POST to a peer and then WAIT for a peer, and the phase
-    # events bracket both together. d_post is local work (WQE build + doorbell);
-    # d_spin is waiting for the peer's write to land.
-    if _ts is not None:
-        from mori import cpp as mori_cpp
-
-        # Misnamed accessor: hipDeviceAttributeWallClockRate is kHz, which is
-        # why kernel_profiler divides it by 1e6 to get GHz. Printed once so a
-        # wrong unit is visible rather than silently scaling every number.
-        khz = mori_cpp.get_cur_device_wall_clock_freq_mhz()
-        # Rows are launch-indexed, so the same drop the phase series uses.
-        ts = _ts.view(-1, 24)[a.drop_rounds : n].cpu().to(torch.float64)
-
-        def _us(b, e):
-            return ((ts[:, e] - ts[:, b]) * 1e3 / khz).tolist()
-
-        # GPU-timeline gap between the previous round's LAST combine kernel and
-        # this round's FIRST dispatch kernel. Both are wall_clock64 on the same
-        # device, so this is the real inter-phase idle -- the thing the CUDA
-        # event window folds together with host time. Row 0 has no predecessor.
-        interphase = [float("nan")] + [
-            (ts[j, 12] - ts[j - 1, 14]) * 1e3 / khz for j in range(1, ts.shape[0])
-        ]
-
-        pfx = "# DEVTS r%d" % d.rank
-        if d.rank == 0:
-            print("%s wallclock_khz=%d (expect 100000)" % (pfx, khz), flush=True)
-        for nm, v in (
-            # 0->7 is the WHOLE dispatch_ll kernel as block 0 sees it, entry to
-            # after DispatchSync. Printed because the sum of the inner spans is
-            # not the kernel: they are stamped by different warps, and anything
-            # the phase spends outside this span belongs to another block, to
-            # copystaging, or to the host.
-            # The whole GPU span of the dispatch phase, and the gap BETWEEN its
-            # two kernels. Both endpoints are wall_clock64 on the same device in
-            # the same row, so their difference is meaningful even though CUDA
-            # event times and wall_clock64 do not share an origin. `disp -
-            # d_gpu` is then what is left outside the kernels entirely: the host
-            # enqueue and the two phase boundaries.
-            ("d_gpu", _us(12, 7)),
-            ("d_k2k", _us(13, 0)),  # copystaging end -> dispatch_ll start
-            ("d_stag", _us(12, 13)),  # the copystaging kernel itself
-            ("d_kern", _us(0, 7)),
-            ("d_head", _us(0, 1)),  # kernel entry -> first post
-            ("d_post", _us(1, 2)),  # WQE build + doorbell: LOCAL
-            ("d_gap", _us(2, 4)),  # post returns -> spin entry (warp skew)
-            ("d_spin", _us(4, 5)),  # waiting for the peer's write: REMOTE
-            ("d_recv", _us(5, 6)),  # unpack + XGMI peer write of each token
-            ("d_sync", _us(6, 7)),  # DispatchSync grid barrier
-            ("c_post", _us(8, 9)),  # combine entry -> put
-            ("c_spin", _us(10, 11)),  # combine cross-node barrier wait
-            ("d2sync", _us(7, 18)),  # dispatch end -> combinesync start
-            ("cs_sync", _us(18, 19)),  # the combinesync kernel
-            ("sync2bar", _us(19, 16)),  # combinesync end -> barrier start
-            ("cs_bar", _us(16, 17)),  # the cross-device barrier itself
-            ("pre_bar", _us(7, 16)),  # dispatch end -> barrier start (holds conv)
-            ("post_bar", _us(17, 8)),  # barrier end -> combine_ll start
-            ("c_gpu", _us(8, 14)),  # combine's whole GPU span
-            ("gap_dc", _us(7, 8)),  # dispatch end -> combine start (holds conv)
-            ("gap_cd", interphase),  # combine end -> next dispatch start (GPU)
-        ):
-            print("%s %s: " % (pfx, nm) + " ".join("%.1f" % x for x in v), flush=True)
     # Which PASS owns the slow round. The marks are (name, event) in launch
     # order: one "<phase>:start" then one per pass, repeating per phase per round.
     # Consecutive deltas are per-pass GPU durations, so the round with the largest

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -292,10 +292,28 @@ def main(argv):
                     f"(expected U[0]={int(U[0])})",
                     flush=True,
                 )
-                # What KIND of wrong matters more than that it is wrong: all
-                # zeros means the output never landed, a constant factor means
-                # the reduce counted the wrong number of contributions, and
-                # noise means the routing or the staging offsets are off.
+                # The worst violator with everything needed to classify it:
+                # a relative error near the wire dtype's half-ulp is rounding,
+                # one far above it is not, and a `want` at the staging format's
+                # saturation point says the partial sum clipped rather than
+                # rounded.
+                viol = (got - exp).abs() - bound
+                if bool((viol > 0).any()):
+                    fi = int(viol.argmax())
+                    t, d = fi // cfg.hidden_dim, fi % cfg.hidden_dim
+                    g, e, pin = (
+                        float(got[t, d]),
+                        float(exp[t, d]),
+                        float(per_elem[t, d]),
+                    )
+                    print(
+                        f"#   worst: tok={t} dim={d} got={g:.6g} want={e:.6g} "
+                        f"input={pin:.6g} U={int(Ut[t])} "
+                        f"|diff|={abs(g - e):.6g} bound={float(bound[t, d]):.6g} "
+                        f"rel={abs(g - e) / max(abs(e), 1e-9):.4f} "
+                        f"nviol={int((viol > 0).sum())}",
+                        flush=True,
+                    )
                 want = exp
                 print(
                     f"#   hidden: max|diff|={(got - want).abs().max():.4g} "

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -59,11 +59,19 @@ default. Every difference found by reading both, and what to pass to close it:
                                              = 32               at world 16
   scale_dim                32                --scale-dim = 0    --scale-dim 32
   scale_type_size          4                 4 when scale_dim   (aligned)
-  warmup / rounds / drop   20 / 30 / 1       same               (aligned)
+  warmup / rounds / drop   20 / 30 / 1       same, and CHECKED  (aligned)
   routing                  randperm[:topk]   same               (aligned)
   tokens per rank          max on every rank same               (aligned)
   statistic                avg over          same               (aligned)
                            rounds x ranks
+
+Only ONE row of this table is enforced: `_report_loop_alignment` reads the three
+loop constants out of that harness's source and warns, next to the numbers, when
+they differ from ours. Every other row is a claim a reader has to re-check, and
+one of them was wrong for as long as it was written -- `--rounds` sat at 3
+against that harness's 30 while this row said "same", because a table asserting
+three numbers had been checked for two. Prefer extending the check to adding a
+row.
 
 The two that move real work: the weight fold costs an extra peer read per
 (token, destination) plus an accumulate in three kernels and a wider staging slot,
@@ -238,6 +246,84 @@ def _verify_once(op, cfg, d, dev, a, comm, inp, idx, wts, sc):
     return ok and ok_w
 
 
+def _v1_loop_defaults():
+    """The examples harness's rounds/warmup/drop defaults, read from its source.
+
+    The alignment table in this module's docstring used to ASSERT that these
+    matched ours. It was written from intent, not from the file: --rounds sat at
+    3 against that harness's 30 for as long as the row claimed "same", because
+    nothing ever compared the two. A comment cannot notice when the other side
+    moves, and neither can a reader who wrote the comment.
+
+    Read, do not import. Importing that module pulls in the v1 op, and this test
+    depends on v1 nowhere else -- buying a consistency check with a dependency on
+    the thing we are trying to be independent of is a bad trade. Parsing three
+    integer literals out of its AST costs nothing and keeps the coupling at zero.
+
+    Returns ``{"rounds": int, "warmup": int, "drop_rounds": int}``, or ``{}`` if
+    the file is missing or has been restructured -- a missing reference is a
+    reason to skip the check, never to fail the run.
+    """
+    import ast
+
+    path = os.path.join(
+        _ROOT, "examples", "ops", "dispatch_combine", "test_dispatch_combine_internode.py"
+    )
+    names = {
+        "_EP_ROUNDS": "rounds",
+        "_EP_WARMUP": "warmup",
+        "_EP_DROP_ROUNDS": "drop_rounds",
+    }
+    out = {}
+    try:
+        tree = ast.parse(open(path).read())
+    except (OSError, SyntaxError):
+        return {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        tgt = node.targets[0]
+        key = names.get(getattr(tgt, "id", None))
+        if key is None:
+            continue
+        # `int(os.environ.get("MORI_EP_ROUNDS") or "30")` -- the default is the
+        # only digit-string literal in the expression.
+        #
+        # Accept both spellings of a string literal. Python >= 3.8 gives
+        # ast.Constant; 3.6/3.7 give ast.Str, and the host python here is 3.6
+        # while the container's is 3.12. Matching only Constant makes this
+        # silently return {} on the older one -- which would disable the very
+        # check whose absence caused the problem it exists to catch.
+        for sub in ast.walk(node.value):
+            lit = None
+            if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+                lit = sub.value
+            elif sub.__class__.__name__ == "Str":
+                lit = sub.s
+            if lit is not None and lit.isdigit():
+                out[key] = int(lit)
+                break
+    return out
+
+
+def _report_loop_alignment(a, rank):
+    """Say out loud when this harness's timed loop is shaped differently from the
+    reference one. Printed with the numbers, not buried in a docstring, because
+    the numbers are what gets quoted."""
+    ref = _v1_loop_defaults()
+    if not ref or rank != 0:
+        return
+    mine = {"rounds": a.rounds, "warmup": a.warmup, "drop_rounds": a.drop_rounds}
+    off = {k: (mine[k], v) for k, v in ref.items() if mine.get(k) != v}
+    if off:
+        detail = " ".join(f"{k}={m}(ref {r})" for k, (m, r) in sorted(off.items()))
+        print(
+            f"# WARNING: timed loop differs from run_bench_once: {detail} -- "
+            f"these numbers are not directly comparable to that harness's",
+            flush=True,
+        )
+
+
 def _bench(op, cfg, d, dev, a, comm):
     """Per-phase latency, structured to match ``run_bench_once`` in
     ``examples/ops/dispatch_combine/test_dispatch_combine_internode.py``.
@@ -264,6 +350,7 @@ def _bench(op, cfg, d, dev, a, comm):
     ahead only while wall stays at or below dispatch+combine. Above it, the host
     is the pacer and the phase numbers carry host stall.
     """
+    _report_loop_alignment(a, d.rank)
     rng = torch.Generator(device=dev)
     rng.manual_seed(4242 + d.rank)
     ct = a.max_tokens
@@ -311,11 +398,26 @@ def _bench(op, cfg, d, dev, a, comm):
 
     t0 = time.perf_counter()
     ev[0].record()
+    # Causal test for "is the host pacing the GPU", opt-in. Busy-waits a known
+    # number of microseconds on the HOST between the convert-end event and the
+    # combine enqueue -- pure host time, no GPU work, no extra kernel. If the
+    # host is running ahead of the GPU, the GPU still has queued work to chew on
+    # and the measured combine barely moves. If the GPU is already waiting on the
+    # host, the injected delay is added GPU idle inside the combine window and
+    # the measured combine rises by about the injected amount. The slope of
+    # measured-combine against injected microseconds is the answer, and it needs
+    # no assumption about what any window "should" cost.
+    inject = float(os.environ.get("MORI_EP_INJECT_HOST_US") or 0) / 1e6
+
     for i in range(n):
         r = op.dispatch(inp, wts, sc, idx, return_routing=True)
         ev[3 * i + 1].record()
         x = convert(r[0])
         ev[3 * i + 2].record()
+        if inject:
+            t = time.perf_counter()
+            while time.perf_counter() - t < inject:
+                pass
         op.combine(x, cw, routing=r[5])
         ev[3 * i + 3].record()
         if a.per_round_sync:
@@ -366,6 +468,23 @@ def _bench(op, cfg, d, dev, a, comm):
     keep = slice(a.drop_rounds, None)
     disp = [ev[3 * i].elapsed_time(ev[3 * i + 1]) * 1e3 for i in range(n)][keep]
     comb = [ev[3 * i + 2].elapsed_time(ev[3 * i + 3]) * 1e3 for i in range(n)][keep]
+    # The third window, which neither harness reports and which is the honest
+    # host-gap meter.
+    #
+    # The events TILE the timed region: ev[3i+3] ends round i's combine and IS
+    # ev[3(i+1)], the start of round i+1's dispatch window. There is no gap
+    # between windows for host time to hide in -- every microsecond between
+    # ev[0] and ev[3n] is inside exactly one of the three. So if the host falls
+    # behind, the GPU idles at the head of whichever segment it is waiting for
+    # and that idle is charged to that window as if it were kernel time.
+    #
+    # This window contains ONE cast. Its kernel cost is a few microseconds at
+    # these token counts and does not grow with anything we tune, so whatever it
+    # reads above that is GPU idle waiting for the host -- which makes it a
+    # measure of host lag that does not require trusting `wall`. (`wall` cannot
+    # show this: wall - (dispatch + combine) is this window BY CONSTRUCTION, so
+    # quoting that difference as evidence of host pacing assumes the conclusion.)
+    conv = [ev[3 * i + 1].elapsed_time(ev[3 * i + 2]) * 1e3 for i in range(n)][keep]
 
     # Which round stalled, opt-in. EVERY rank prints its own series, because the
     # question the averages cannot answer is whether a spike lands on the same
@@ -403,6 +522,7 @@ def _bench(op, cfg, d, dev, a, comm):
 
     dm, dlo, dhi = _stats(disp)
     cm, clo, chi = _stats(comb)
+    vm, _, _ = _stats(conv)
     if d.rank == 0:
         print(
             f"# BENCH tok={ct} dtype={a.dtype}->{a.combine_dtype or a.dtype} "
@@ -410,7 +530,7 @@ def _bench(op, cfg, d, dev, a, comm):
             f"kernel={a.kernel_type or 'auto'} "
             f"dispatch={dm:.1f}us [{dlo:.1f}/{dhi:.1f}] "
             f"combine={cm:.1f}us [{clo:.1f}/{chi:.1f}] "
-            f"total={dm + cm:.1f}us [wall={wall:.1f}us]",
+            f"total={dm + cm:.1f}us [conv={vm:.1f}us wall={wall:.1f}us]",
             flush=True,
         )
     return 0

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -63,8 +63,9 @@ only traffic on the fabric. It is worth setting because a number measured in the
 wrong traffic class does not transfer to a shared one, not because it is a
 speedup.
 
-Findings from the CCO-vs-shmem investigation -- why the tail is CCO-specific, and
-how to read the per-rank series for straggler attribution -- live in
+What the tail investigation found -- that it is not a tail but a bistable
+whole-run regime, what has been eliminated as its cause, and how to read the
+per-rank series and the per-pass split -- lives in
 ``docs/EP_INTERNODE_V2_TAIL.md`` rather than here, so this file stays close in
 shape to the examples harness it mirrors.
 
@@ -184,7 +185,9 @@ def _parse_args(argv):
     p.add_argument("--tuning-reps", type=int, default=3)
     # Smoke-test / bisect aid: stop after N candidates (0 = sweep all).
     p.add_argument("--tuning-limit", type=int, default=0)
-    p.add_argument("--tuning-phase", default="dispatch", choices=["dispatch", "combine"])
+    p.add_argument(
+        "--tuning-phase", default="dispatch", choices=["dispatch", "combine"]
+    )
     # Validation mode: sweep exactly one named candidate against the shipped
     # geometry. A sweep winner is chosen by a greedy chain of paired tests, each
     # with its own error; before it is written into the table it gets one long
@@ -234,6 +237,12 @@ def _parse_args(argv):
     # than kernel work. It folds the barrier wait into the next round's dispatch
     # window, so dispatch is not clean under it -- combine is.
     p.add_argument("--per-round-sync", action="store_true")
+    # Sync WITHOUT the barrier. --per-round-sync costs ~1.3ms a round here (gloo
+    # over TCP) and injects more rank skew than it removes, so it cannot test the
+    # one thing it was meant to. This keeps the local launch queue drained --
+    # which is the question when the host is running ahead -- and adds nothing
+    # cross-rank.
+    p.add_argument("--per-round-drain", action="store_true")
     # Both members of the LL / non-LL pair are compiled either way; this picks
     # which one runs. Default (None) leaves the backend's token-count rule alone,
     # which selects LL below 2048 tokens. Naming it explicitly is what makes a
@@ -326,7 +335,11 @@ def _v1_loop_defaults():
     import ast
 
     path = os.path.join(
-        _ROOT, "examples", "ops", "dispatch_combine", "test_dispatch_combine_internode.py"
+        _ROOT,
+        "examples",
+        "ops",
+        "dispatch_combine",
+        "test_dispatch_combine_internode.py",
     )
     names = {
         "_EP_ROUNDS": "rounds",
@@ -461,12 +474,35 @@ def _bench(op, cfg, d, dev, a, comm):
     if _marks is not None:
         del _marks[:]
 
+    _series = bool(os.environ.get("MORI_EP_ROUND_SERIES"))
+
+    # Caching-allocator segments, opt-in. A cudaMalloc inside the timed loop
+    # blocks the host for ~100us and lands on every rank in the same round (the
+    # ranks are symmetric), which is exactly what an early-round synchronous
+    # spike looks like. Counting segments before and after says whether any
+    # happened, without having to infer it from the shape of the series.
+    _seg = _series and torch.cuda.memory_stats()
+
+    # Host time INSIDE the two calls, plus a host timestamp per round. The phase
+    # events bracket the call, so whatever the wrapper does on the host before
+    # the launch lands in the reported phase time and is indistinguishable from
+    # kernel time there; this is what separates them. Off unless the series is
+    # asked for -- perf_counter is only ~0.1us, but it would sit inside the
+    # measured window and the default path should carry nothing it does not need.
+    hd = [0.0] * n
+    hc = [0.0] * n
+    tr = [0.0] * (n + 1)
+
+    _ep0 = time.time()
     t0 = time.perf_counter()
     ev[0].record()
 
-
     for i in range(n):
+        if _series:
+            tr[i] = time.perf_counter()
         r = op.dispatch(inp, wts, sc, idx, return_routing=True)
+        if _series:
+            hd[i] = (time.perf_counter() - tr[i]) * 1e6
         ev[3 * i + 1].record()
         x = convert(r[0])
         ev[3 * i + 2].record()
@@ -474,11 +510,19 @@ def _bench(op, cfg, d, dev, a, comm):
             t = time.perf_counter()
             while time.perf_counter() - t < inject:
                 pass
+        if _series:
+            _h = time.perf_counter()
         op.combine(x, cw, routing=r[5])
+        if _series:
+            hc[i] = (time.perf_counter() - _h) * 1e6
         ev[3 * i + 3].record()
         if a.per_round_sync:
             torch.cuda.synchronize()
             comm.barrier()
+        elif a.per_round_drain:
+            torch.cuda.synchronize()
+    if _series:
+        tr[n] = time.perf_counter()
     torch.cuda.synchronize()
     wall = (time.perf_counter() - t0) * 1e6 / n
     # Which PASS owns the slow round. The marks are (name, event) in launch
@@ -486,7 +530,7 @@ def _bench(op, cfg, d, dev, a, comm):
     # Consecutive deltas are per-pass GPU durations, so the round with the largest
     # total can be broken down against the median round of the same phase -- which
     # is the question, since the tail is a few rounds and the median is the rest.
-    if _marks and d.rank == 0:
+    if _marks:
         per_round = []  # [(phase, [(name, us), ...]), ...] in order
         cur_name, cur_ev, cur = None, None, []
         for name, evm in _marks:
@@ -506,23 +550,31 @@ def _bench(op, cfg, d, dev, a, comm):
             if not rounds:
                 continue
             totals = [sum(v for _, v in r) for r in rounds]
-            wi = max(range(len(totals)), key=totals.__getitem__)
             order = sorted(range(len(totals)), key=totals.__getitem__)
             mi = order[len(order) // 2]
-            names = [nm for nm, _ in rounds[wi]]
+            names = [nm for nm, _ in rounds[mi]]
+            # EVERY rank prints. The tail is measured over rounds x ranks and a
+            # spike is usually on one rank, so a rank-0-only breakdown reports the
+            # median round of a quiet rank and says nothing about the tail.
+            pfx = f"# SPLIT[{d.rank}] {phase}"
             print(
-                f"# SPLIT {phase}: worst round {wi} = {totals[wi]:.1f}us, "
-                f"median round = {totals[mi]:.1f}us",
+                f"{pfx}: mean={sum(totals) / len(totals):.1f} "
+                f"max={totals[order[-1]]:.1f} med={totals[mi]:.1f} "
+                f"ratio={totals[order[-1]] / (sum(totals) / len(totals)):.2f}",
                 flush=True,
             )
-            for k, nm in enumerate(names):
-                w, m = rounds[wi][k][1], rounds[mi][k][1]
-                print(
-                    f"#    {nm:<20} worst={w:8.1f}  median={m:7.1f}  "
-                    f"delta={w - m:+8.1f}",
-                    flush=True,
-                )
-
+            print(f"{pfx} rounds: " + " ".join(f"{t:.0f}" for t in totals), flush=True)
+            # Top 3, not just the worst: one round can be an artifact, three
+            # agreeing on the same pass is a mechanism.
+            for wi in reversed(order[-3:]):
+                print(f"{pfx} round {wi} = {totals[wi]:.1f}us vs med {totals[mi]:.1f}")
+                for k, nm in enumerate(names):
+                    w, m = rounds[wi][k][1], rounds[mi][k][1]
+                    print(
+                        f"#    {nm:<20} this={w:8.1f}  median={m:7.1f}  "
+                        f"delta={w - m:+8.1f}",
+                        flush=True,
+                    )
 
     # Host profile, opt-in. Whenever wall exceeds dispatch+combine the loop above
     # is host-paced, and then its phase numbers are wrapper cost rather than
@@ -578,13 +630,50 @@ def _bench(op, cfg, d, dev, a, comm):
     # spin-wait collectives, so one slow rank shows as a slow round on all of
     # them and only the rank-local series separates a straggler from a
     # whole-round event. See docs/EP_INTERNODE_V2_TAIL.md for how to read it.
-    if os.environ.get("MORI_EP_ROUND_SERIES"):
+    if _seg:
+        now = torch.cuda.memory_stats()
+        keys = ("segment.all.allocated", "num_alloc_retries", "num_device_alloc")
+        print(
+            "# alloc r%d: " % d.rank
+            + " ".join(
+                f"{k.split('.')[-1]}+{now.get(k, 0) - _seg.get(k, 0)}" for k in keys
+            ),
+            flush=True,
+        )
+
+    if _series:
         print(
             "# rounds r%d disp: " % d.rank + " ".join("%.0f" % x for x in disp),
             flush=True,
         )
         print(
             "# rounds r%d comb: " % d.rank + " ".join("%.0f" % x for x in comb),
+            flush=True,
+        )
+        print(
+            "# rounds r%d hdis: " % d.rank + " ".join("%.0f" % x for x in hd[keep]),
+            flush=True,
+        )
+        print(
+            "# rounds r%d hcom: " % d.rank + " ".join("%.0f" % x for x in hc[keep]),
+            flush=True,
+        )
+        # Host wall per round and the convert window. With disp/comb/hdis/hcom
+        # above, these close the accounting: a round whose hwal exceeds
+        # disp+conv+comb has a hole somewhere the other series do not cover.
+        print(
+            "# rounds r%d conv: " % d.rank + " ".join("%.0f" % x for x in conv),
+            flush=True,
+        )
+        # Epoch bounds of the timed loop, so an external sampler (clocks, NIC)
+        # can be lined up with it. perf_counter has no epoch; time.time does.
+        print(
+            "# loop r%d t0=%.4f t1=%.4f" % (d.rank, _ep0, time.time()),
+            flush=True,
+        )
+        hwal = [(tr[i + 1] - tr[i]) * 1e6 for i in range(n)][keep]
+        print(
+            "# rounds r%d hwal: " % d.rank + " ".join("%.0f" % x for x in hwal),
             flush=True,
         )
 
@@ -613,7 +702,6 @@ def _bench(op, cfg, d, dev, a, comm):
             flush=True,
         )
     return 0
-
 
 
 def _timed_pass(op, cfg, d, a, inp, idx, wts, sc, cw, convert, n, warm):
@@ -701,7 +789,11 @@ def _tune(cfg, d, dev, a, comm):
     warps = [4, 8, 16] if a.tuning_scope == "quick" else [4, 6, 8, 12, 16]
 
     def rdmas(bn):
-        frac = (bn // 2, bn * 2 // 3) if a.tuning_scope == "quick" else (bn // 4, bn // 2, bn * 2 // 3)
+        frac = (
+            (bn // 2, bn * 2 // 3)
+            if a.tuning_scope == "quick"
+            else (bn // 4, bn // 2, bn * 2 // 3)
+        )
         return sorted({v for v in frac if 1 <= v < bn})
 
     cands = [(b, r, w) for b in sorted(blocks) for w in warps for r in rdmas(b)]
@@ -712,7 +804,9 @@ def _tune(cfg, d, dev, a, comm):
 
     from mori.ops.dispatch_combine_v2.internode_tuning_configs import lookup
 
-    tbl = lookup(cfg.world_size, cfg.hidden_dim, cfg.num_experts_per_token, a.max_tokens)
+    tbl = lookup(
+        cfg.world_size, cfg.hidden_dim, cfg.num_experts_per_token, a.max_tokens
+    )
     # The incumbent is the SHIPPED pair, so a win means "better than what we ship".
     inc_d = tuple(tbl["dispatch"]) if tbl else cands[0]
     inc_c = tuple(tbl["combine"]) if tbl else cands[0]
@@ -732,7 +826,11 @@ def _tune(cfg, d, dev, a, comm):
     rng = torch.Generator(device=dev)
     rng.manual_seed(4242 + d.rank)
     inp, idx, wts, sc = _gen_round(rng, cfg, a.max_tokens, dev, cfg.dispatch_dtype)
-    convert = (lambda x: x.to(cfg.combine_dtype)) if cfg.is_asymmetric_dtype else (lambda x: x)
+    convert = (
+        (lambda x: x.to(cfg.combine_dtype))
+        if cfg.is_asymmetric_dtype
+        else (lambda x: x)
+    )
     cw = wts if a.bench_weights else None
 
     # Only the swept phase varies; the other stays at the shipped value, because
@@ -767,10 +865,14 @@ def _tune(cfg, d, dev, a, comm):
         bt, ct_ = [], []
         bph, cph = [], []  # (dispatch, combine) per rep, to show the coupling
         for _ in range(a.tuning_reps):
-            dv, cv = _timed_pass(best_op, cfg, d, a, inp, idx, wts, sc, cw, convert, a.rounds, a.warmup)
+            dv, cv = _timed_pass(
+                best_op, cfg, d, a, inp, idx, wts, sc, cw, convert, a.rounds, a.warmup
+            )
             bt.append(pick(dv, cv))
             bph.append((dv, cv))
-            dv, cv = _timed_pass(cand_op, cfg, d, a, inp, idx, wts, sc, cw, convert, a.rounds, a.warmup)
+            dv, cv = _timed_pass(
+                cand_op, cfg, d, a, inp, idx, wts, sc, cw, convert, a.rounds, a.warmup
+            )
             ct_.append(pick(dv, cv))
             cph.append((dv, cv))
         bm, cm = sorted(bt)[len(bt) // 2], sorted(ct_)[len(ct_) // 2]

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -196,6 +196,39 @@ def _bench(op, cfg, d, dev, a, comm):
     torch.cuda.synchronize()
     wall = (time.perf_counter() - t0) * 1e6 / n
 
+    # Host profile, opt-in. Whenever wall exceeds dispatch+combine the loop above
+    # is host-paced, and then its phase numbers are wrapper cost rather than
+    # kernel cost. This says which wrapper. It runs its OWN untimed loop so the
+    # profiler's overhead can never land in a reported number.
+    if os.environ.get("MORI_EP_HOST_PROFILE"):
+        import cProfile
+        import pstats
+
+        # EVERY rank runs the loop; only rank 0 prints. dispatch and combine are
+        # collectives -- a rank that enters them alone spins in the kernel's
+        # wait-for-peers loop forever, which reads as one GPU pinned at 100% with
+        # every other idle. Guarding the loop itself on rank 0 (rather than just
+        # the reporting) is exactly that hang.
+        pr = cProfile.Profile()
+        pr.enable()
+        for _ in range(n):
+            rp = op.dispatch(inp, wts, None, idx, return_routing=True)
+            op.combine(convert(rp[0]), wts, routing=rp[5])
+        pr.disable()
+        torch.cuda.synchronize()
+        comm.barrier()
+        if d.rank != 0:
+            return 0
+        st = pstats.Stats(pr)
+        rows = sorted(st.stats.items(), key=lambda kv: -kv[1][2])[:20]
+        print(f"# HOST PROFILE tok={ct}  (us/round, sorted by self time)", flush=True)
+        for (fn, ln, name), (_, nc, tt, _ct, _) in rows:
+            print(
+                f"#   self={tt / n * 1e6:8.1f}  cum={_ct / n * 1e6:8.1f}  "
+                f"n={nc / n:5.1f}  {os.path.basename(fn)}:{ln}({name})",
+                flush=True,
+            )
+
     keep = slice(a.drop_rounds, None)
     disp = [ev[3 * i].elapsed_time(ev[3 * i + 1]) * 1e3 for i in range(n)][keep]
     comb = [ev[3 * i + 2].elapsed_time(ev[3 * i + 3]) * 1e3 for i in range(n)][keep]

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -222,6 +222,10 @@ def _parse_args(argv):
     # over. Whichever of the two is larger. Not 0: see the note in _tune.
     p.add_argument("--tuning-margin-us", type=float, default=1.5)
     p.add_argument("--tuning-margin-frac", type=float, default=0.02)
+    # How much worst-of-reps regression a median win may carry, and how much
+    # worst-of-reps improvement makes a median TIE interesting. Fraction of the
+    # incumbent's median.
+    p.add_argument("--tuning-tail-frac", type=float, default=0.10)
     # The v1 bench calls combine with weights=None, so it does not pay for the
     # weight fold: an extra peer read per (token, destination) plus an accumulate
     # in three kernels, and a wider staging slot (combXferBytes = hidden + weights).
@@ -891,10 +895,24 @@ def _tune(cfg, d, dev, a, comm):
     warps = [4, 8, 16] if a.tuning_scope == "quick" else [4, 6, 8, 12, 16]
 
     def rdmas(bn):
+        # rdma_block_num partitions the SAME grid between the blocks that talk to
+        # the network and the rest, so the optimum is a fraction of block and can
+        # sit anywhere in (0, 1). Three points was too coarse to say anything
+        # about the shape -- and it could not even reach the shipped 32-token row,
+        # whose rdma=48 against block=80 is 0.6 and is not 1/4, 1/2 or 2/3.
+        # Eighths plus 2/3 covers it at a cost of ~70s a sweep against ~31s.
         frac = (
             (bn // 2, bn * 2 // 3)
             if a.tuning_scope == "quick"
-            else (bn // 4, bn // 2, bn * 2 // 3)
+            else (
+                bn // 8,
+                bn // 4,
+                3 * bn // 8,
+                bn // 2,
+                5 * bn // 8,
+                bn * 2 // 3,
+                3 * bn // 4,
+            )
         )
         return sorted({v for v in frac if 1 <= v < bn})
 
@@ -978,6 +996,11 @@ def _tune(cfg, d, dev, a, comm):
             ct_.append(pick(dv, cv))
             cph.append((dv, cv))
         bm, cm = sorted(bt)[len(bt) // 2], sorted(ct_)[len(ct_) // 2]
+        # Worst of the paired reps, as a tail proxy. _timed_pass returns a grand
+        # mean, so this is run-to-run spread rather than a worst ROUND -- which is
+        # the right thing here anyway, since the risk being guarded against is a
+        # geometry that lands in a bad regime more often.
+        bmax, cmax = max(bt), max(ct_)
         # PAIRED, not a difference of medians: the regime moves during a sweep
         # (the same incumbent geometry has read 84.9us on one candidate and
         # 126.0us on the next), and differencing within a rep cancels that. The
@@ -986,12 +1009,23 @@ def _tune(cfg, d, dev, a, comm):
         diffs = sorted(c - b_ for b_, c in zip(bt, ct_))
         lo, hi = diffs[0], diffs[-1]
         dmed = diffs[len(diffs) // 2]
-        win = dmed < -max(a.tuning_margin_us, bm * a.tuning_margin_frac)
+        margin = max(a.tuning_margin_us, bm * a.tuning_margin_frac)
+        tail_room = bm * a.tuning_tail_frac
+        # A median win is not enough on its own. Selecting purely on the median
+        # would accept a geometry that gains 2us at the median and gives back 30
+        # at the worst, and this table is used for a latency-bound collective
+        # where the worst round is what the caller waits for.
+        win = dmed < -margin and (cmax - bmax) <= tail_room
+        # And when the medians TIE, a clearly better worst is worth surfacing --
+        # this is the "same average, better tail" rule, made explicit rather than
+        # applied by hand after the fact.
+        tie = abs(dmed) <= margin and (bmax - cmax) > tail_room
         if d.rank == 0:
             print(
                 f"#   [{k + 1}/{len(cands)}] {cand} med={cm:6.1f}us vs "
                 f"incumbent {best} med={bm:6.1f}us  paired={dmed:+6.1f}us "
-                f"[{lo:+.1f},{hi:+.1f}]  {'WIN' if win else '--'}"
+                f"[{lo:+.1f},{hi:+.1f}] worst {cmax:.0f}/{bmax:.0f}  "
+                f"{'WIN' if win else ('TAIL' if tie else '--')}"
                 f"   d/c cand={_med(x for x, _ in cph):.1f}/{_med(y for _, y in cph):.1f}"
                 f" inc={_med(x for x, _ in bph):.1f}/{_med(y for _, y in bph):.1f}",
                 flush=True,
@@ -1001,8 +1035,23 @@ def _tune(cfg, d, dev, a, comm):
             best_op, best, best_med = cand_op, cand, cm
         else:
             cand_op.close()
-            if not a.tuning_greedy and win:
-                fixed_wins.append((dmed, cand, cm, bm))
+            if not a.tuning_greedy and (win or tie):
+                # Sort key puts real median wins ahead of tail-only ties.
+                # Rank real median wins ahead of tail-only ties: the two keys
+                # are different quantities and must not be sorted against each
+                # other, or a -20us tail tie outranks a -3us median win.
+                fixed_wins.append(
+                    (
+                        0 if win else 1,
+                        dmed if win else (cmax - bmax),
+                        cand,
+                        cm,
+                        bm,
+                        win,
+                        cmax,
+                        bmax,
+                    )
+                )
             best_med = bm
         comm.barrier()
 
@@ -1014,10 +1063,10 @@ def _tune(cfg, d, dev, a, comm):
             f"{len(cands)} candidates beat the fixed incumbent {start}",
             flush=True,
         )
-        for dm, cd, cm2, bm2 in fixed_wins[:5]:
+        for _, dm, cd, cm2, bm2, w, cx, bx in fixed_wins[:5]:
             print(
-                f"#   BEAT {cd} paired={dm:+.1f}us (cand med={cm2:.1f} "
-                f"inc med={bm2:.1f})",
+                f"#   {'BEAT' if w else 'TAIL'} {cd} paired={dm:+.1f}us "
+                f"(cand med={cm2:.1f} inc med={bm2:.1f} worst {cx:.0f}/{bx:.0f})",
                 flush=True,
             )
         if fixed_wins:

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -44,6 +44,29 @@ without a QP.
 ``tools/run_internode_test.sh`` drives both ranks; the CLI below is the subset of
 the shmem harness's flags that means anything here.
 
+READING THE PER-RANK SERIES (MORI_EP_ROUND_SERIES)
+--------------------------------------------------
+Every rank prints its own per-round series. These are spin-wait collectives, so
+the rank that arrives LAST waits LEAST: on a slow round the straggler is the
+MINIMUM, not the maximum, and the other fifteen are just showing what they waited
+for. Threshold per NODE, not globally -- the two nodes routinely sit at different
+levels in the same round (151 vs 237us was measured), and a global threshold then
+misses a rank that is low within its own node.
+
+The shape of the low set says what happened, and they are not all the same:
+
+  {i, i+8}          one RAIL. Local rank i selects bnxt_re_bond<i> ("rank 1
+                    rankInNode 1 select device [1] bnxt_re_bond1"), so the same
+                    local index on both nodes is one NIC-to-NIC path.
+  {i}               one rank.
+  all of one node    a node-level event; the other node's eight ranks all wait.
+  empty             every rank waited, including the fastest -- no straggler
+                    exists and no single card can explain it.
+
+Measured over 11 spiked rounds in 9 runs: 5 empty, 3 rail pairs (rails 1, 5 and 7,
+once each), 2 single ranks, 1 other. So no one card is at fault; when there is a
+straggler its identity rotates.
+
 RoCE QoS: SET MORI_RDMA_TC AND MORI_RDMA_SL
 -------------------------------------------
 Unset, ``bnxt.cpp`` takes ``ReadRdmaServiceLevelEnv().value_or(1)`` and leaves

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -113,6 +113,12 @@ def _parse_args(argv):
     p.add_argument("--scale-dim", type=int, default=0)
     p.add_argument("--warmup", type=int, default=20)
     p.add_argument("--drop-rounds", type=int, default=1)
+    # Diagnostic, matching _EP_PERROUND_SYNC in the examples harness. Re-aligns
+    # the ranks every round. These kernels spin on their peers, so any host skew
+    # shows up as KERNEL time; if this moves the numbers, the gap is skew rather
+    # than kernel work. It folds the barrier wait into the next round's dispatch
+    # window, so dispatch is not clean under it -- combine is.
+    p.add_argument("--per-round-sync", action="store_true")
     # Both members of the LL / non-LL pair are compiled either way; this picks
     # which one runs. Default (None) leaves the backend's token-count rule alone,
     # which selects LL below 2048 tokens. Naming it explicitly is what makes a
@@ -193,6 +199,9 @@ def _bench(op, cfg, d, dev, a, comm):
         ev[3 * i + 2].record()
         op.combine(x, wts, routing=r[5])
         ev[3 * i + 3].record()
+        if a.per_round_sync:
+            torch.cuda.synchronize()
+            comm.barrier()
     torch.cuda.synchronize()
     wall = (time.perf_counter() - t0) * 1e6 / n
 

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -142,7 +142,15 @@ def _parse_args(argv):
     p.add_argument("--combine-dtype", default=None, choices=list(_DTYPES))
     p.add_argument("--quant-type", default="none", choices=["none", "fp8_direct_cast"])
     p.add_argument("--num-qp", type=int, default=2)
-    p.add_argument("--rounds", type=int, default=3)
+    # 30, matching _EP_ROUNDS in the examples harness -- and for the reason its
+    # comment gives, which applies here with full force: the CCO/GDA path reaches
+    # steady state slowly, so at 10 rounds its per-round jitter does not average
+    # out and the mean swings ~20% run to run. This defaulted to 3 while claiming
+    # alignment, which with --drop-rounds 1 keeps rounds 1 and 2 -- precisely the
+    # two that harness documents as still elevated. A single spike then carries
+    # half the average AND is the reported worst, so this side read a wide tail
+    # against a 29-round mean. Not a small-sample caveat: a different estimator.
+    p.add_argument("--rounds", type=int, default=30)
     p.add_argument("--scale-dim", type=int, default=0)
     # The v1 bench calls combine with weights=None, so it does not pay for the
     # weight fold: an extra peer read per (token, destination) plus an accumulate
@@ -339,6 +347,11 @@ def _bench(op, cfg, d, dev, a, comm):
         comm.barrier()
         if d.rank != 0:
             return 0
+        # Rank 0 must leave through here too. The stats below are allreduces, and
+        # every other rank has already returned -- rank 0 entering them alone is a
+        # hang, then a nonzero exit with no BENCH line. Profiling is a diagnostic
+        # mode, so ending the run after the profile is right; ending it on 15 of
+        # 16 ranks is not.
         st = pstats.Stats(pr)
         rows = sorted(st.stats.items(), key=lambda kv: -kv[1][2])[:20]
         print(f"# HOST PROFILE tok={ct}  (us/round, sorted by self time)", flush=True)
@@ -348,17 +361,34 @@ def _bench(op, cfg, d, dev, a, comm):
                 f"n={nc / n:5.1f}  {os.path.basename(fn)}:{ln}({name})",
                 flush=True,
             )
+        return 0
 
     keep = slice(a.drop_rounds, None)
     disp = [ev[3 * i].elapsed_time(ev[3 * i + 1]) * 1e3 for i in range(n)][keep]
     comb = [ev[3 * i + 2].elapsed_time(ev[3 * i + 3]) * 1e3 for i in range(n)][keep]
 
-    # Which round stalled, opt-in. A worst that lands on the same round in both
-    # phases is a whole-round event (host); one that moves between ranks is
-    # fabric. The averages cannot tell those apart.
-    if os.environ.get("MORI_EP_ROUND_SERIES") and d.rank == 0:
-        print("# rounds disp: " + " ".join("%.0f" % x for x in disp), flush=True)
-        print("# rounds comb: " + " ".join("%.0f" % x for x in comb), flush=True)
+    # Which round stalled, opt-in. EVERY rank prints its own series, because the
+    # question the averages cannot answer is whether a spike lands on the same
+    # round index across ranks or on one rank alone:
+    #   same round, all ranks   -> a whole-round event; every rank waits for the
+    #                              same thing, so the cause is host-side (a launch
+    #                              that took longer to build, an allocation, GC)
+    #                              or a fabric stall that stops everyone.
+    #   one rank, one round     -> a straggler; the others are only showing the
+    #                              spin-wait for it. Chasing the peak on the ranks
+    #                              that merely waited leads nowhere.
+    # These are collective kernels, so a single slow rank prints as a slow round
+    # on all of them -- which is why the RANK-LOCAL series is what separates the
+    # two, and rank 0's alone cannot.
+    if os.environ.get("MORI_EP_ROUND_SERIES"):
+        print(
+            "# rounds r%d disp: " % d.rank + " ".join("%.0f" % x for x in disp),
+            flush=True,
+        )
+        print(
+            "# rounds r%d comb: " % d.rank + " ".join("%.0f" % x for x in comb),
+            flush=True,
+        )
 
     # AVERAGE over rounds x ranks, plus BEST and WORST over the same sample set --
     # the three numbers run_bench_once prints, so a reading here can be put beside

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -44,58 +44,6 @@ without a QP.
 ``tools/run_internode_test.sh`` drives both ranks; the CLI below is the subset of
 the shmem harness's flags that means anything here.
 
-CCO's TAIL IS NOT THE FABRIC'S: WHAT SHMEM DOES ON THE SAME WIRE
-----------------------------------------------------------------
-Run the v1 harness in the same session for a reference. It drives the shmem/IBGDA
-transport over the SAME NICs, rails, switch and QoS, at the same shape, so it
-isolates what is specific to the CCO path. Note it spawns its own 8 workers per
-node, so it takes --nproc_per_node=1, not 8:
-
-    GPU_PER_NODE=8 MORI_EP_LAUNCH_CONFIG_MODE=AUTO MORI_RDMA_TC=160 MORI_RDMA_SL=5 \\
-    torchrun --nnodes=2 --node_rank=N --nproc_per_node=1 --master_addr=... \\
-      examples/ops/dispatch_combine/test_dispatch_combine_internode.py \\
-      --cmd bench --kernel-type v1_ll --num-qp 1 --max-tokens 4 \\
-      --hidden-dim 6144 --dtype fp8_e4m3_fnuz --combine-dtype bf16 --quant-type none
-
-Measured, 29 kept rounds x 16 ranks = 464 samples per phase:
-
-                       shmem/IBGDA          CCO/GDA (here)
-    dispatch mean         47.4us              40-47us
-    combine  mean         59.1us              46-52us
-    max/mean              1.19x / 1.18x       2-6x
-    rounds >1.8x base     0 of 29             11 of ~260
-    cross-rank spread     median 9-13us       up to 207us (34 -> 241)
-
-Two things follow. CCO is FASTER in the mean -- combine by ~20% -- so the port is
-not simply worse. And the tail belongs to the CCO path, not to the fabric: shmem
-shares every wire and shows no spiked round at all, which rules out the rail and
-switch explanations that the {i, i+8} pattern below otherwise suggests.
-
-Both harnesses do have a huge round 0 (shmem's spans 83-614us) and both drop 1.
-
-READING THE PER-RANK SERIES (MORI_EP_ROUND_SERIES)
---------------------------------------------------
-Every rank prints its own per-round series. These are spin-wait collectives, so
-the rank that arrives LAST waits LEAST: on a slow round the straggler is the
-MINIMUM, not the maximum, and the other fifteen are just showing what they waited
-for. Threshold per NODE, not globally -- the two nodes routinely sit at different
-levels in the same round (151 vs 237us was measured), and a global threshold then
-misses a rank that is low within its own node.
-
-The shape of the low set says what happened, and they are not all the same:
-
-  {i, i+8}          one RAIL. Local rank i selects bnxt_re_bond<i> ("rank 1
-                    rankInNode 1 select device [1] bnxt_re_bond1"), so the same
-                    local index on both nodes is one NIC-to-NIC path.
-  {i}               one rank.
-  all of one node    a node-level event; the other node's eight ranks all wait.
-  empty             every rank waited, including the fastest -- no straggler
-                    exists and no single card can explain it.
-
-Measured over 11 spiked rounds in 9 runs: 5 empty, 3 rail pairs (rails 1, 5 and 7,
-once each), 2 single ranks, 1 other. So no one card is at fault; when there is a
-straggler its identity rotates.
-
 RoCE QoS: SET MORI_RDMA_TC AND MORI_RDMA_SL
 -------------------------------------------
 Unset, ``bnxt.cpp`` takes ``ReadRdmaServiceLevelEnv().value_or(1)`` and leaves
@@ -114,6 +62,11 @@ contradictory: a lossless priority class buys nothing when the benchmark is the
 only traffic on the fabric. It is worth setting because a number measured in the
 wrong traffic class does not transfer to a shared one, not because it is a
 speedup.
+
+Findings from the CCO-vs-shmem investigation -- why the tail is CCO-specific, and
+how to read the per-rank series for straggler attribution -- live in
+``docs/EP_INTERNODE_V2_TAIL.md`` rather than here, so this file stays close in
+shape to the examples harness it mirrors.
 
 COMPARING AGAINST THE v1 BENCH
 ------------------------------
@@ -356,32 +309,6 @@ def _verify_once(op, cfg, d, dev, a, comm, inp, idx, wts, sc):
     return ok and ok_w
 
 
-def _sclk_levels():
-    """Active DPM shader-clock level of every GPU on this host, as a string.
-
-    The amdgpu driver publishes the level table per card with a `*` on the
-    active one; on this rig that is 88MHz idle / 500MHz / 1850MHz with
-    power_dpm_force_performance_level=auto, so a run that never boosts is
-    several times slower at identical code. Cards are not numbered contiguously
-    (card0, card16, card24...) and the HIP device order does not have to match
-    the DRM order, so this reports ALL of them rather than pretending to know
-    which one is ours -- the question is whether the node boosted, not which
-    card did. A plain sysfs read, microseconds, no subprocess.
-    """
-    import glob
-
-    out = []
-    for path in sorted(glob.glob("/sys/class/drm/card*/device/pp_dpm_sclk")):
-        try:
-            for line in open(path):
-                if "*" in line:
-                    out.append(line.split(":")[1].split("*")[0].strip())
-                    break
-        except OSError:
-            pass
-    return " ".join(out) if out else "n/a"
-
-
 def _v1_loop_defaults():
     """The examples harness's rounds/warmup/drop defaults, read from its source.
 
@@ -543,42 +470,9 @@ def _bench(op, cfg, d, dev, a, comm):
     # no assumption about what any window "should" cost.
     inject = float(os.environ.get("MORI_EP_INJECT_HOST_US") or 0) / 1e6
 
-    # Which round a garbage collection lands in, opt-in. The spikes are GLOBAL --
-    # 12 to 16 of 16 ranks spike in the same round -- so the cause is something
-    # every rank does on its own schedule, not a straggler one rank produces. A
-    # generational GC is exactly that shape: it fires on allocation counts, and
-    # every rank allocates the same objects per round, so they all reach the
-    # threshold on the same round. This records the collections rather than
-    # inferring them from an A/B. (gc.disable() was A/B'd before and read
-    # negative, but that run had 2 kept rounds and a round-8 event was not in the
-    # sample at all -- the test could not have detected what it was testing for.)
-    gc_hits = []
-    gc_cb = None
-    _cur = [-1]
-    if os.environ.get("MORI_EP_GC_TRACE"):
-        import gc
-
-        def gc_cb(phase, info):
-            if phase == "stop":
-                gc_hits.append((_cur[0], info.get("generation"), info.get("collected")))
-
-        gc.callbacks.append(gc_cb)
-
-    # Opt-in counterpart: freeze everything already alive and stop collecting for
-    # the timed loop. gc.freeze() moves the existing objects to a permanent
-    # generation so re-enabling later does not immediately pay for them.
-    _no_gc = bool(os.environ.get("MORI_EP_NO_GC"))
-    if _no_gc:
-        import gc
-
-        gc.collect()
-        gc.freeze()
-        gc.disable()
-
-    _sclk_before = _sclk_levels() if os.environ.get("MORI_EP_SCLK") else None
     # Per-pass marks accumulate inside the backend when MORI_EP_SPLIT_PASSES is
-    # set. Clear them here so only the timed loop's are read; the warmup ran with
-    # the same code path and left its own behind.
+    # set. Cleared here so only the timed loop's are read; the warmup ran the
+    # same code path and left its own behind.
     _marks = getattr(op, "_pass_marks", None)
     if _marks is not None:
         del _marks[:]
@@ -586,30 +480,9 @@ def _bench(op, cfg, d, dev, a, comm):
     t0 = time.perf_counter()
     ev[0].record()
 
-    # Host-side duration of each enqueue, opt-in via the same flag as the round
-    # series. These calls are asynchronous: while the host runs ahead of the GPU
-    # they return as soon as the work is queued, so this reads as pure Python
-    # cost. Once the launch queue is full they BLOCK until the GPU retires
-    # something, and the number jumps. That transition is the thing to look for
-    # -- it says the loop stopped measuring the kernel and started measuring the
-    # host, and it is invisible in the event timings, which report the same
-    # wall-clock either way. perf_counter is ~50ns, far below what it resolves.
-    hdisp = [0.0] * n
-    hcomb = [0.0] * n
-    # WHEN each round started on this rank, relative to the loop start. Durations
-    # cannot see a rank that entered the round late -- only one that took long
-    # once inside -- and a spin-wait collective punishes lateness, not slowness.
-    # All ranks barrier immediately before t0, so these are comparable across
-    # ranks to within the barrier skew even though the two nodes' clocks are not
-    # synchronised (t0 is each rank's own zero).
-    hstart = [0.0] * n
 
     for i in range(n):
-        _cur[0] = i
-        _h = time.perf_counter()
-        hstart[i] = (_h - t0) * 1e6
         r = op.dispatch(inp, wts, sc, idx, return_routing=True)
-        hdisp[i] = (time.perf_counter() - _h) * 1e6
         ev[3 * i + 1].record()
         x = convert(r[0])
         ev[3 * i + 2].record()
@@ -617,9 +490,7 @@ def _bench(op, cfg, d, dev, a, comm):
             t = time.perf_counter()
             while time.perf_counter() - t < inject:
                 pass
-        _h = time.perf_counter()
         op.combine(x, cw, routing=r[5])
-        hcomb[i] = (time.perf_counter() - _h) * 1e6
         ev[3 * i + 3].record()
         if a.per_round_sync:
             torch.cuda.synchronize()
@@ -668,24 +539,6 @@ def _bench(op, cfg, d, dev, a, comm):
                     flush=True,
                 )
 
-    if _sclk_before is not None and d.rank == 0:
-        print(f"# SCLK before: {_sclk_before}", flush=True)
-        print(f"# SCLK after:  {_sclk_levels()}", flush=True)
-    if _no_gc:
-        import gc
-
-        gc.enable()
-        gc.unfreeze()
-    if gc_cb is not None:
-        import gc
-
-        gc.callbacks.remove(gc_cb)
-        if gc_hits:
-            print(
-                "# GC r%d: " % d.rank
-                + " ".join("round%d/gen%s/n%s" % h for h in gc_hits),
-                flush=True,
-            )
 
     # Host profile, opt-in. Whenever wall exceeds dispatch+combine the loop above
     # is host-paced, and then its phase numbers are wrapper cost rather than
@@ -767,20 +620,6 @@ def _bench(op, cfg, d, dev, a, comm):
         )
         print(
             "# rounds r%d comb: " % d.rank + " ".join("%.0f" % x for x in comb),
-            flush=True,
-        )
-        print(
-            "# hostus r%d disp: " % d.rank
-            + " ".join("%.0f" % x for x in hdisp[keep]),
-            flush=True,
-        )
-        print(
-            "# hostus r%d comb: " % d.rank
-            + " ".join("%.0f" % x for x in hcomb[keep]),
-            flush=True,
-        )
-        print(
-            "# entry r%d: " % d.rank + " ".join("%.0f" % x for x in hstart[keep]),
             flush=True,
         )
 

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -243,6 +243,13 @@ def _parse_args(argv):
     # which is the question when the host is running ahead -- and adds nothing
     # cross-rank.
     p.add_argument("--per-round-drain", action="store_true")
+    # Re-align the ranks every N rounds. The slow regime is a stable inter-node
+    # phase offset, and a rendezvous does not remove one -- this asks whether an
+    # explicit re-alignment escapes the offset fixed point or whether the loop
+    # falls straight back into it. N is chosen so the gloo barrier's ~1.3ms is
+    # amortised: at 20 it costs ~65us a round against a ~100us round, which is
+    # far too much for a benchmark number but fine for answering the question.
+    p.add_argument("--realign-every", type=int, default=0)
     # Both members of the LL / non-LL pair are compiled either way; this picks
     # which one runs. Default (None) leaves the backend's token-count rule alone,
     # which selects LL below 2048 tokens. Naming it explicitly is what makes a
@@ -528,6 +535,9 @@ def _bench(op, cfg, d, dev, a, comm):
             comm.barrier()
         elif a.per_round_drain:
             torch.cuda.synchronize()
+        if a.realign_every and (i % a.realign_every) == (a.realign_every - 1):
+            torch.cuda.synchronize()
+            comm.barrier()
     if _series:
         tr[n] = time.perf_counter()
     torch.cuda.synchronize()

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -260,8 +260,12 @@ def _parse_args(argv):
     # independent paired test against the thing it would replace, which is both
     # what we want to know and reproducible across repeats.
     p.add_argument("--tuning-greedy", action="store_true")
-    # Workers to spawn per node (0 = off: one torchrun process per rank).
-    p.add_argument("--spawn", type=int, default=0)
+    # Workers to spawn per node. 8 by default, which means this harness expects
+    # --nproc_per_node=1 and builds the rest of the ranks itself -- the same
+    # process tree the examples harness uses, so the two are comparable without
+    # remembering to pass a flag. --spawn 0 turns it off for the old shape (one
+    # torchrun process per rank).
+    p.add_argument("--spawn", type=int, default=8)
     # How much better a candidate must be, on the paired difference, to take
     # over. Whichever of the two is larger. Not 0: see the note in _tune.
     p.add_argument("--tuning-margin-us", type=float, default=1.5)
@@ -1063,6 +1067,16 @@ def main(argv):
     # able to switch because host time on this path converts to measured "kernel"
     # time about 1:1, so how the ranks are parented is not obviously neutral.
     if a.spawn and not os.environ.get("_MORI_EP_SPAWN_CHILD"):
+        # Both topologies at once would be nprocs x spawn ranks per node, each
+        # claiming a GPU index it does not own. Refuse rather than deadlock in
+        # the rendezvous, and say which of the two to drop.
+        lws = int(os.environ.get("LOCAL_WORLD_SIZE", "1"))
+        if lws > 1:
+            raise SystemExit(
+                f"--spawn {a.spawn} with torchrun --nproc_per_node={lws}: that is "
+                f"{lws * a.spawn} ranks per node. Use --nproc_per_node=1 (spawn "
+                f"builds the ranks), or pass --spawn 0 to let torchrun do it."
+            )
         node_rank = int(os.environ["RANK"])
         nnodes = int(os.environ["WORLD_SIZE"])
         torch.multiprocessing.spawn(

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -289,14 +289,18 @@ def _bench(op, cfg, d, dev, a, comm):
 
     cw = wts if a.bench_weights else None
 
+    # Allocated before the warmup, where run_bench_once allocates them. (Priming
+    # them with a record here was tried and did not move the tail, so it is not
+    # done -- run_bench_once does not either.)
+    n = a.rounds
+    ev = [torch.cuda.Event(enable_timing=True) for _ in range(3 * n + 1)]
+
     for _ in range(a.warmup):
         r = op.dispatch(inp, wts, sc, idx, return_routing=True)
         op.combine(convert(r[0]), cw, routing=r[5])
     torch.cuda.synchronize()
     comm.barrier()
 
-    n = a.rounds
-    ev = [torch.cuda.Event(enable_timing=True) for _ in range(3 * n + 1)]
     t0 = time.perf_counter()
     ev[0].record()
     for i in range(n):
@@ -348,6 +352,13 @@ def _bench(op, cfg, d, dev, a, comm):
     keep = slice(a.drop_rounds, None)
     disp = [ev[3 * i].elapsed_time(ev[3 * i + 1]) * 1e3 for i in range(n)][keep]
     comb = [ev[3 * i + 2].elapsed_time(ev[3 * i + 3]) * 1e3 for i in range(n)][keep]
+
+    # Which round stalled, opt-in. A worst that lands on the same round in both
+    # phases is a whole-round event (host); one that moves between ranks is
+    # fabric. The averages cannot tell those apart.
+    if os.environ.get("MORI_EP_ROUND_SERIES") and d.rank == 0:
+        print("# rounds disp: " + " ".join("%.0f" % x for x in disp), flush=True)
+        print("# rounds comb: " + " ".join("%.0f" % x for x in comb), flush=True)
 
     # AVERAGE over rounds x ranks, plus BEST and WORST over the same sample set --
     # the three numbers run_bench_once prints, so a reading here can be put beside

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -485,6 +485,12 @@ def _bench(op, cfg, d, dev, a, comm):
         gc.disable()
 
     _sclk_before = _sclk_levels() if os.environ.get("MORI_EP_SCLK") else None
+    # Per-pass marks accumulate inside the backend when MORI_EP_SPLIT_PASSES is
+    # set. Clear them here so only the timed loop's are read; the warmup ran with
+    # the same code path and left its own behind.
+    _marks = getattr(op, "_pass_marks", None)
+    if _marks is not None:
+        del _marks[:]
 
     t0 = time.perf_counter()
     ev[0].record()
@@ -499,10 +505,18 @@ def _bench(op, cfg, d, dev, a, comm):
     # wall-clock either way. perf_counter is ~50ns, far below what it resolves.
     hdisp = [0.0] * n
     hcomb = [0.0] * n
+    # WHEN each round started on this rank, relative to the loop start. Durations
+    # cannot see a rank that entered the round late -- only one that took long
+    # once inside -- and a spin-wait collective punishes lateness, not slowness.
+    # All ranks barrier immediately before t0, so these are comparable across
+    # ranks to within the barrier skew even though the two nodes' clocks are not
+    # synchronised (t0 is each rank's own zero).
+    hstart = [0.0] * n
 
     for i in range(n):
         _cur[0] = i
         _h = time.perf_counter()
+        hstart[i] = (_h - t0) * 1e6
         r = op.dispatch(inp, wts, sc, idx, return_routing=True)
         hdisp[i] = (time.perf_counter() - _h) * 1e6
         ev[3 * i + 1].record()
@@ -521,6 +535,48 @@ def _bench(op, cfg, d, dev, a, comm):
             comm.barrier()
     torch.cuda.synchronize()
     wall = (time.perf_counter() - t0) * 1e6 / n
+    # Which PASS owns the slow round. The marks are (name, event) in launch
+    # order: one "<phase>:start" then one per pass, repeating per phase per round.
+    # Consecutive deltas are per-pass GPU durations, so the round with the largest
+    # total can be broken down against the median round of the same phase -- which
+    # is the question, since the tail is a few rounds and the median is the rest.
+    if _marks and d.rank == 0:
+        per_round = []  # [(phase, [(name, us), ...]), ...] in order
+        cur_name, cur_ev, cur = None, None, []
+        for name, evm in _marks:
+            if name.endswith(":start"):
+                if cur:
+                    per_round.append((cur_name, cur))
+                cur_name, cur, cur_ev = name.split(":")[0], [], evm
+                continue
+            if cur_ev is not None:
+                cur.append((name, cur_ev.elapsed_time(evm) * 1e3))
+                cur_ev = evm
+        if cur:
+            per_round.append((cur_name, cur))
+
+        for phase in ("dispatch", "combine"):
+            rounds = [c for ph, c in per_round if ph == phase][a.drop_rounds :]
+            if not rounds:
+                continue
+            totals = [sum(v for _, v in r) for r in rounds]
+            wi = max(range(len(totals)), key=totals.__getitem__)
+            order = sorted(range(len(totals)), key=totals.__getitem__)
+            mi = order[len(order) // 2]
+            names = [nm for nm, _ in rounds[wi]]
+            print(
+                f"# SPLIT {phase}: worst round {wi} = {totals[wi]:.1f}us, "
+                f"median round = {totals[mi]:.1f}us",
+                flush=True,
+            )
+            for k, nm in enumerate(names):
+                w, m = rounds[wi][k][1], rounds[mi][k][1]
+                print(
+                    f"#    {nm:<20} worst={w:8.1f}  median={m:7.1f}  "
+                    f"delta={w - m:+8.1f}",
+                    flush=True,
+                )
+
     if _sclk_before is not None and d.rank == 0:
         print(f"# SCLK before: {_sclk_before}", flush=True)
         print(f"# SCLK after:  {_sclk_levels()}", flush=True)
@@ -630,6 +686,10 @@ def _bench(op, cfg, d, dev, a, comm):
         print(
             "# hostus r%d comb: " % d.rank
             + " ".join("%.0f" % x for x in hcomb[keep]),
+            flush=True,
+        )
+        print(
+            "# entry r%d: " % d.rank + " ".join("%.0f" % x for x in hstart[keep]),
             flush=True,
         )
 

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -93,6 +93,12 @@ class Dist:
         dist.all_reduce(t, op=dist.ReduceOp.SUM)
         return int(t.item())
 
+    def allreduce_minmax(self, lo, hi):
+        """Extremes across ranks, for the same best/worst the v1 harness prints."""
+        t = torch.tensor([lo, -hi], dtype=torch.int64)
+        dist.all_reduce(t, op=dist.ReduceOp.MIN)
+        return int(t[0].item()), -int(t[1].item())
+
     def shutdown(self):
         if dist.is_initialized():
             dist.destroy_process_group()
@@ -241,17 +247,28 @@ def _bench(op, cfg, d, dev, a, comm):
     keep = slice(a.drop_rounds, None)
     disp = [ev[3 * i].elapsed_time(ev[3 * i + 1]) * 1e3 for i in range(n)][keep]
     comb = [ev[3 * i + 2].elapsed_time(ev[3 * i + 3]) * 1e3 for i in range(n)][keep]
-    dm = sum(disp) / len(disp)
-    cm = sum(comb) / len(comb)
-    dm = d.allreduce_sum(int(dm * 1000)) / d.world / 1000
-    cm = d.allreduce_sum(int(cm * 1000)) / d.world / 1000
+
+    # AVERAGE over rounds x ranks, plus BEST and WORST over the same sample set --
+    # the three numbers run_bench_once prints, so a reading here can be put beside
+    # one from the v1 harness without converting estimators. The average is the
+    # robust one; best/worst are extremes and noise-dominated, but they are what
+    # makes a single stalled round visible. Reporting only a minimum hides exactly
+    # that (an earlier version of this comparison did, and buried a 227us outlier).
+    def _stats(v):
+        m = d.allreduce_sum(int(sum(v) / len(v) * 1000)) / d.world / 1000
+        lo, hi = d.allreduce_minmax(int(min(v) * 1000), int(max(v) * 1000))
+        return m, lo / 1000, hi / 1000
+
+    dm, dlo, dhi = _stats(disp)
+    cm, clo, chi = _stats(comb)
     if d.rank == 0:
         print(
             f"# BENCH tok={ct} dtype={a.dtype}->{a.combine_dtype or a.dtype} "
             f"hidden={cfg.hidden_dim} topk={cfg.num_experts_per_token} "
             f"kernel={a.kernel_type or 'auto'} "
-            f"dispatch={dm:.1f}us combine={cm:.1f}us total={dm + cm:.1f}us "
-            f"[wall={wall:.1f}us]",
+            f"dispatch={dm:.1f}us [{dlo:.1f}/{dhi:.1f}] "
+            f"combine={cm:.1f}us [{clo:.1f}/{chi:.1f}] "
+            f"total={dm + cm:.1f}us [wall={wall:.1f}us]",
             flush=True,
         )
     return 0

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -246,6 +246,32 @@ def _verify_once(op, cfg, d, dev, a, comm, inp, idx, wts, sc):
     return ok and ok_w
 
 
+def _sclk_levels():
+    """Active DPM shader-clock level of every GPU on this host, as a string.
+
+    The amdgpu driver publishes the level table per card with a `*` on the
+    active one; on this rig that is 88MHz idle / 500MHz / 1850MHz with
+    power_dpm_force_performance_level=auto, so a run that never boosts is
+    several times slower at identical code. Cards are not numbered contiguously
+    (card0, card16, card24...) and the HIP device order does not have to match
+    the DRM order, so this reports ALL of them rather than pretending to know
+    which one is ours -- the question is whether the node boosted, not which
+    card did. A plain sysfs read, microseconds, no subprocess.
+    """
+    import glob
+
+    out = []
+    for path in sorted(glob.glob("/sys/class/drm/card*/device/pp_dpm_sclk")):
+        try:
+            for line in open(path):
+                if "*" in line:
+                    out.append(line.split(":")[1].split("*")[0].strip())
+                    break
+        except OSError:
+            pass
+    return " ".join(out) if out else "n/a"
+
+
 def _v1_loop_defaults():
     """The examples harness's rounds/warmup/drop defaults, read from its source.
 
@@ -396,8 +422,6 @@ def _bench(op, cfg, d, dev, a, comm):
     torch.cuda.synchronize()
     comm.barrier()
 
-    t0 = time.perf_counter()
-    ev[0].record()
     # Causal test for "is the host pacing the GPU", opt-in. Busy-waits a known
     # number of microseconds on the HOST between the convert-end event and the
     # combine enqueue -- pure host time, no GPU work, no extra kernel. If the
@@ -409,8 +433,59 @@ def _bench(op, cfg, d, dev, a, comm):
     # no assumption about what any window "should" cost.
     inject = float(os.environ.get("MORI_EP_INJECT_HOST_US") or 0) / 1e6
 
+    # Which round a garbage collection lands in, opt-in. The spikes are GLOBAL --
+    # 12 to 16 of 16 ranks spike in the same round -- so the cause is something
+    # every rank does on its own schedule, not a straggler one rank produces. A
+    # generational GC is exactly that shape: it fires on allocation counts, and
+    # every rank allocates the same objects per round, so they all reach the
+    # threshold on the same round. This records the collections rather than
+    # inferring them from an A/B. (gc.disable() was A/B'd before and read
+    # negative, but that run had 2 kept rounds and a round-8 event was not in the
+    # sample at all -- the test could not have detected what it was testing for.)
+    gc_hits = []
+    gc_cb = None
+    _cur = [-1]
+    if os.environ.get("MORI_EP_GC_TRACE"):
+        import gc
+
+        def gc_cb(phase, info):
+            if phase == "stop":
+                gc_hits.append((_cur[0], info.get("generation"), info.get("collected")))
+
+        gc.callbacks.append(gc_cb)
+
+    # Opt-in counterpart: freeze everything already alive and stop collecting for
+    # the timed loop. gc.freeze() moves the existing objects to a permanent
+    # generation so re-enabling later does not immediately pay for them.
+    _no_gc = bool(os.environ.get("MORI_EP_NO_GC"))
+    if _no_gc:
+        import gc
+
+        gc.collect()
+        gc.freeze()
+        gc.disable()
+
+    _sclk_before = _sclk_levels() if os.environ.get("MORI_EP_SCLK") else None
+
+    t0 = time.perf_counter()
+    ev[0].record()
+
+    # Host-side duration of each enqueue, opt-in via the same flag as the round
+    # series. These calls are asynchronous: while the host runs ahead of the GPU
+    # they return as soon as the work is queued, so this reads as pure Python
+    # cost. Once the launch queue is full they BLOCK until the GPU retires
+    # something, and the number jumps. That transition is the thing to look for
+    # -- it says the loop stopped measuring the kernel and started measuring the
+    # host, and it is invisible in the event timings, which report the same
+    # wall-clock either way. perf_counter is ~50ns, far below what it resolves.
+    hdisp = [0.0] * n
+    hcomb = [0.0] * n
+
     for i in range(n):
+        _cur[0] = i
+        _h = time.perf_counter()
         r = op.dispatch(inp, wts, sc, idx, return_routing=True)
+        hdisp[i] = (time.perf_counter() - _h) * 1e6
         ev[3 * i + 1].record()
         x = convert(r[0])
         ev[3 * i + 2].record()
@@ -418,13 +493,33 @@ def _bench(op, cfg, d, dev, a, comm):
             t = time.perf_counter()
             while time.perf_counter() - t < inject:
                 pass
+        _h = time.perf_counter()
         op.combine(x, cw, routing=r[5])
+        hcomb[i] = (time.perf_counter() - _h) * 1e6
         ev[3 * i + 3].record()
         if a.per_round_sync:
             torch.cuda.synchronize()
             comm.barrier()
     torch.cuda.synchronize()
     wall = (time.perf_counter() - t0) * 1e6 / n
+    if _sclk_before is not None and d.rank == 0:
+        print(f"# SCLK before: {_sclk_before}", flush=True)
+        print(f"# SCLK after:  {_sclk_levels()}", flush=True)
+    if _no_gc:
+        import gc
+
+        gc.enable()
+        gc.unfreeze()
+    if gc_cb is not None:
+        import gc
+
+        gc.callbacks.remove(gc_cb)
+        if gc_hits:
+            print(
+                "# GC r%d: " % d.rank
+                + " ".join("round%d/gen%s/n%s" % h for h in gc_hits),
+                flush=True,
+            )
 
     # Host profile, opt-in. Whenever wall exceeds dispatch+combine the loop above
     # is host-paced, and then its phase numbers are wrapper cost rather than
@@ -506,6 +601,16 @@ def _bench(op, cfg, d, dev, a, comm):
         )
         print(
             "# rounds r%d comb: " % d.rank + " ".join("%.0f" % x for x in comb),
+            flush=True,
+        )
+        print(
+            "# hostus r%d disp: " % d.rank
+            + " ".join("%.0f" % x for x in hdisp[keep]),
+            flush=True,
+        )
+        print(
+            "# hostus r%d comb: " % d.rank
+            + " ".join("%.0f" % x for x in hcomb[keep]),
             flush=True,
         )
 

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -19,944 +19,323 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""InterNodeV1 / InterNodeV1LL on the CCO kernels the v2 JIT plans compile.
+"""Internode correctness for the v2 EP op, over CCO/GDA.
 
-The internode counterpart to ``test_dispatch_combine_v2_intranode.py``, and the
-CCO counterpart to ``test_dispatch_combine_internode_v1.py`` -- which covers the
-same two kernels on the shmem AOT path and is the model this file follows: the
-same worker-pool fan-out, the same analytic golden from
-``EpDispatchCombineTestCase``, the same ``_KERNELS`` geometry pairs. Expectations
-are computed analytically, so a pass means "matches the intended semantics",
-not "matches the other backend".
+Identity expert -- the received tokens are combined unchanged -- so
+``combine[t] == U[t] * input[t]`` and ``out_weights[t] == U[t] * wts[t]``, where
+U is the number of DISTINCT destination ranks token t routed to. The expectation
+is analytic: a pass means "matches the intended semantics", not "matches some
+other implementation", which is the property that has to survive the kernel being
+rewritten underneath it.
 
-``backend`` is the axis this file adds. ``cco`` builds the handle on the CCO
-communicator and redirects every InterNodeV1 launch to a v2 JIT plan (see the
-launch-redirect section below); ``shmem`` is the stock AOT path, present as a
-control -- if a case fails on both, suspect the shape or the harness rather than
-the CCO port.
+TWO NODES ARE REQUIRED, and not merely for coverage -- the op refuses to build
+otherwise. ``gpu_per_node < world_size`` is what selects the internode path, and
+the op checks EP's node grouping against the communicator's LSA team; on one host
+CCO reports the whole world as one team, so a config claiming two nodes is
+rejected rather than silently running the intranode half. Lowering gpu_per_node
+on a single host does not emulate this either: RAIL leaves same-host peers
+without a QP.
 
-Three modes, in one file, because they want opposite settings:
+    # rank 0 of 2, 8 GPUs each
+    torchrun --nnodes=2 --node_rank=0 --nproc_per_node=8 \\
+        --master_addr=<ip> --master_port=<port> \\
+        test_dispatch_combine_v2_internode.py --max-tokens 128
 
-``correctness``
-    One checked round per case. Default; this is the mode that gates a merge.
-
-``stress`` (``MORI_INTERNODE_TEST_STRESS=1``)
-    Hundreds of rounds, checked once at the start and then run unchecked. Finds
-    what a single round cannot: chunk flags that are never reset, recv counters
-    that drift, send-slot reuse. The shmem suite does the same thing in
-    ``test_dispatch_combine_internode.py``.
-
-``bench`` (``MORI_INTERNODE_TEST_BENCH=1``)
-    Latency and algorithmic bandwidth for both backends. **Asserts nothing about
-    speed.** This machine's absolute throughput moves ~25% between batches with
-    no code change, so a threshold would be a coin flip; the pair is printed
-    (use ``-s``) and the comparison left to a human. Only same-invocation pairs
-    are meaningful.
-
-One host means one CCO node. CCO derives its node grouping from the physical
-topology, so ``gpu_per_node`` stays at the whole world here: lowering it changes
-only EP's idea of a node, and the RDMA path then issues puts to peers RAIL left
-without a QP. The intra-node half of these kernels is what runs; the network
-path needs two hosts and a driver that is machine-specific glue.
+``tools/run_internode_test.sh`` drives both ranks; the CLI below is the subset of
+the shmem harness's flags that means anything here.
 """
-import os
-import statistics
 
-import pytest
+import argparse
+import os
+import sys
+
+import numpy as np
 import torch
 import torch.distributed as dist
 
-import mori
-from mori.jit.v2 import plan_api as _jit_plan_api
-from mori.ops.dispatch_combine_v2.ep_plans import EP_INTERNODE_PLANS, INTERNODE_DTYPES
-from tests.python.ops.dispatch_combine_test_utils import (
-    EpDispatchCombineTestCase,
-    _all_data_types,
-    assert_worker_results,
-    cross_dtype_hidden_dims,
-    cross_dtype_skip_reason,
-    run_ep_dispatch_combine_test,
-)
+from mori.cco import Communicator
+from mori.ops.dispatch_combine_v2 import EpDispatchCombineConfig, EpDispatchCombineOp
 
-# kernel -> (type, block_num, rdma_block_num, warp_num_per_block). The pairs
-# test_dispatch_combine_internode_v1.py ships: the bandwidth table uses V1, the
-# latency table V1LL, and the two want different grids.
-_KERNELS = {
-    "v1": (mori.ops.EpDispatchCombineKernelType.InterNodeV1, 96, 64, 8),
-    "v1_ll": (mori.ops.EpDispatchCombineKernelType.InterNodeV1LL, 256, 128, 8),
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.abspath(os.path.join(_HERE, "..", "..", "..", ".."))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+_DTYPES = {
+    "bf16": torch.bfloat16,
+    "fp32": torch.float32,
+    "fp8_e4m3_fnuz": torch.float8_e4m3fnuz,
+    "fp8_e4m3": torch.float8_e4m3fn,
 }
-
-# InterNodeV1 is what the reference bench selects at >=4096 tokens and V1LL
-# below it, so each kernel is exercised at a count it actually ships for.
-_BENCH_TOKENS = {"v1": 4096, "v1_ll": 128}
-
-# CCO's LL path needs thousands of rounds to reach steady state where shmem
-# needs under ten; a few hundred reads a transient. V1 at 4096 tokens covers the
-# same cumulative work in far fewer rounds, which is why the two differ.
-_BENCH_WARMUP = {"v1": 20, "v1_ll": 2000}
-
-_WORLD_SIZE = 8
+_FP8 = (torch.float8_e4m3fnuz, torch.float8_e4m3fn)
 
 
-def _enabled(name):
-    return os.environ.get(name, "0").strip().lower() not in ("", "0", "false", "no")
+class Dist:
+    """torchrun/gloo bootstrap. gloo is only the courier for the cco unique id
+    and the pass/fail counts; every byte of payload moves over cco."""
+
+    def __init__(self):
+        self.rank = int(os.environ["RANK"])
+        self.world = int(os.environ["WORLD_SIZE"])
+        self.local_rank = int(os.environ["LOCAL_RANK"])
+        if not dist.is_initialized():
+            dist.init_process_group(backend="gloo")
+        torch.cuda.set_device(self.local_rank)
+
+    def bcast_uid(self, uid):
+        objs = [uid if self.rank == 0 else None]
+        dist.broadcast_object_list(objs, src=0)
+        return objs[0]
+
+    def allreduce_sum(self, value):
+        t = torch.tensor([value], dtype=torch.int64)
+        dist.all_reduce(t, op=dist.ReduceOp.SUM)
+        return int(t.item())
+
+    def shutdown(self):
+        if dist.is_initialized():
+            dist.destroy_process_group()
 
 
-_stress_only = pytest.mark.skipif(
-    not _enabled("MORI_INTERNODE_TEST_STRESS"),
-    reason="stress mode is opt-in: set MORI_INTERNODE_TEST_STRESS=1",
-)
-_bench_only = pytest.mark.skipif(
-    not _enabled("MORI_INTERNODE_TEST_BENCH"),
-    reason="bench mode is opt-in: set MORI_INTERNODE_TEST_BENCH=1",
-)
+def _parse_args(argv):
+    p = argparse.ArgumentParser(description="v2 internode dispatch/combine test")
+    p.add_argument("--cmd", default="test", choices=["test", "bench"])
+    p.add_argument("--max-tokens", type=int, default=128)
+    p.add_argument("--hidden-dim", type=int, default=7168)
+    p.add_argument("--topk", type=int, default=8)
+    p.add_argument("--experts-per-rank", type=int, default=32)
+    p.add_argument("--dtype", default="bf16", choices=list(_DTYPES))
+    p.add_argument("--combine-dtype", default=None, choices=list(_DTYPES))
+    p.add_argument("--quant-type", default="none", choices=["none", "fp8_direct_cast"])
+    p.add_argument("--num-qp", type=int, default=2)
+    p.add_argument("--rounds", type=int, default=3)
+    p.add_argument("--scale-dim", type=int, default=0)
+    p.add_argument("--warmup", type=int, default=20)
+    p.add_argument("--drop-rounds", type=int, default=1)
+    # Accepted and ignored: both members of the LL / non-LL pair are compiled
+    # either way and the launch picks one from the token count. Kept so the
+    # shared runner script can pass identical flags to both harnesses.
+    p.add_argument("--kernel-type", default=None)
+    return p.parse_args(argv)
 
 
-# ---------------------------------------------------------------------------
-# launch redirect: the only caller the CCO internode kernels have
-# ---------------------------------------------------------------------------
-#
-# v1 internode exists twice over, as two implementations sharing only a handle
-# and an args struct:
-#
-#   shmem  src/ops/dispatch_combine/internode_v1.cpp, entries
-#          ``EpDispatchInterNodeV1Kernel_<dt>``, which dispatch_combine.py drives.
-#   cco    src/ops/dispatch_combine_v2/ep_internode_kernel.hpp, entries
-#          ``mori_ep_internode_*`` -- what the JIT v2 plans compile, and what has
-#          no caller anywhere else in the tree.
-#
-# ``EpDispatchCombineOp._launch_multi`` is the single funnel every InterNodeV1
-# launch goes through, so redirecting it to the plans leaves argument building,
-# routing and output tensors on the existing code. It is swapped for the whole
-# process rather than per call: the cco kernels need a cco-backed handle, and the
-# shmem kernels address the shmem heap, so on such a handle they fault.
-
-
-# Read once: these sit on the per-launch path, which runs as often as the kernels
-# do, and an os.environ lookup there is pure overhead in the common case where
-# none of them is set.
-_TRACE_PATH = os.environ.get("MORI_INTERNODE_TRACE")
-_TRACE_CFG = bool(os.environ.get("MORI_INTERNODE_TRACE_CFG"))
-_TRACE_SYNC = bool(os.environ.get("MORI_INTERNODE_TRACE_SYNC"))
-# Batch the N-pass launch through one ABI crossing (launch_multi). On by default;
-# set MORI_INTERNODE_BATCH_LAUNCH=0 to fall back to per-pass plan.launch, which
-# is the A/B control for measuring what the batch saves on the eager host path.
-_BATCH_LAUNCH = os.environ.get(
-    "MORI_INTERNODE_BATCH_LAUNCH", "1"
-).strip().lower() not in (
-    "",
-    "0",
-    "false",
-    "no",
-)
-
-
-def _trace(msg):
-    """Progress markers to a file, enabled by MORI_INTERNODE_TRACE.
-
-    The workers this runs in are spawned by the test's process manager, which
-    keeps no handle on their stdout; when one dies the buffered output goes with
-    it, so a stage that hangs or faults leaves no trace at all on stdout.
-    """
-    if not _TRACE_PATH:
-        return
-    with open(f"{_TRACE_PATH}.{os.environ.get('RANK', os.getpid())}", "a") as f:
-        f.write(msg + "\n")
-
-
-# The AOT entry base name of each pass, mapped to the plan that supplies it.
-_PASS_BY_ENTRY = {
-    "EpDispatchCopyToStaging": "copystaging",
-    "EpDispatchInterNodeV1Kernel": "dispatch",
-    "EpDispatchInterNodeV1KernelLowLatency": "dispatch_ll",
-    "EpCombineSync": "combinesync",
-    "EpCombineSyncBarrier": "combinesyncbarrier",
-    "EpCombineInterNodeV1Kernel": "combine",
-    "EpCombineInterNodeV1KernelLowLatency": "combine_ll",
-    "EpCombineAll": "combineall",
-}
-# Longest-first so "..._fp8_ocp" is not read as dtype "ocp", and so
-# "...V1Kernel" does not swallow "...V1KernelLowLatency".
-_DTYPES_LONGEST_FIRST = sorted(INTERNODE_DTYPES, key=len, reverse=True)
-
-# Cfg field -> the get_handle_info key reporting the same thing, for the
-# consistency dump. Fields the handle does not report are simply absent.
-_HANDLE_INFO_KEY = {
-    "worldSize": "world_size",
-    "scaleDim": "scale_dim",
-    "scaleTypeSize": "scale_type_size",
-    "maxTokenTypeSize": "max_token_type_size",
-    "maxNumInpTokenPerRank": "max_num_inp_token_per_rank",
-    "numExpertPerRank": "num_expert_per_rank",
-    "numExpertPerToken": "num_expert_per_token",
-    "gpuPerNode": "gpu_per_node",
-    "rdmaBlockNum": "rdma_block_num",
-    "quantType": "quant_type",
-}
-
-
-def _split_entry(func_name):
-    """``EpCombineAll_bf16`` -> ``("combineall", "bf16")``; None if not a v1 pass."""
-    for dtype in _DTYPES_LONGEST_FIRST:
-        if not func_name.endswith("_" + dtype):
-            continue
-        base = func_name[: -len(dtype) - 1]
-        if base in _PASS_BY_ENTRY:
-            return _PASS_BY_ENTRY[base], dtype
-    return None
-
-
-def _dev_comm_host_ptr(op):
-    """Address of the host-side ``ccoDevComm``, which the args hold by value.
-
-    ``DevComm.ptr`` is the device-side copy, for kernels taking a pointer; this
-    has to be the host struct, because ``EpInterNodeCcoArgs`` embeds one.
-    """
-    cached = op.__dict__.get("_internode_dev_comm")
-    if cached is not None:
-        return cached
-    if op._cco_comm is None:
-        raise RuntimeError(
-            "the cco v1 internode kernels need a cco-backed handle; "
-            "set MORI_EP_COMM=cco before building the op"
-        )
-    from mori.cco import cco as _cco
-    from mori.cco.communicator import DevCommHandle
-
-    # These requirements are what the kernels are written against, and since the
-    # C++ side has no devComm of its own this is the only place they are chosen.
-    # The defaults are not close enough to work: v1 talks only to its own local
-    # rank on other nodes, so it asks for RAIL rather than the CROSSNODE default,
-    # and ccoGda picks its QP as contextId % numQpPerPe, so a smaller context
-    # count than numQpPerPe silently collapses the stripes onto fewer QPs.
-    # A production path would need to make the same two choices.
-    reqs = _cco.DevCommRequirements()
-    reqs.gda_connection_type = _cco.GDA_CONNECTION_RAIL
-    reqs.gda_context_count = max(1, op.config.num_qp_per_pe)
-
-    handle = DevCommHandle(op._cco_comm, requirements=reqs)
-    op.__dict__["_internode_dev_comm_handle"] = handle  # keep it alive
-    # lsa_size is CCO's own view of how many ranks share a node, which comes from
-    # the physical topology and not from config.gpuPerNode. Under RAIL there are
-    # QPs only to cross-node peers, so lsa_size == world_size means none exist.
-    _trace(
-        f"  devComm world_size={handle.world_size} lsa_size={handle.lsa_size} "
-        f"rank={handle.rank} lsa_rank={handle.lsa_rank}"
-    )
-    ptr = handle._dev_comm.host_ptr
-    op.__dict__["_internode_dev_comm"] = ptr
-    return ptr
-
-
-def _plan_for(op, pass_name, dtype, block_num, warp_per_block, mp_count, want=None):
-    """One plan per (pass, dtype, geometry). Geometry is outside the JIT cache
-    key, so the geometry variants share one compiled binary.
-
-    ``want`` is the (grid, block, smem) dispatch_combine.py computed. It is
-    checked against EpInterNodeGeometry once per plan rather than once per launch:
-    reading ``plan.info`` parses the whole Cfg out of a key=value blob, and the
-    two arithmetics cannot start agreeing or stop agreeing between launches of
-    the same plan.
-    """
-    key = (pass_name, dtype, block_num, warp_per_block, mp_count)
-    cache = op.__dict__.setdefault("_internode_plans", {})
-    plan = cache.get(key)
-    if plan is not None:
-        return plan
-
-    info = op._handle_info
-    cfg = op.config
-    # Shape comes from what C++ resolved on the handle rather than from the
-    # Python config: these become compiled-in constants that the kernel's
-    # EpInterNodeBindConfig writes back over args.config, so a constant disagreeing
-    # with what the launch carries would silently change behaviour. hiddenDim is
-    # the exception, overridden per call by build_args from the input tensor.
-    plan = EP_INTERNODE_PLANS[pass_name](
-        worldSize=info["world_size"],
-        hiddenDim=op.__dict__.get("_internode_hidden_dim") or info["hidden_dim"],
-        scaleDim=info["scale_dim"],
-        scaleTypeSize=info["scale_type_size"],
-        maxTokenTypeSize=info["max_token_type_size"],
-        maxNumInpTokenPerRank=info["max_num_inp_token_per_rank"],
-        numExpertPerRank=info["num_expert_per_rank"],
-        numExpertPerToken=info["num_expert_per_token"],
-        maxTotalRecvTokens=cfg.max_total_recv_tokens,
-        gpuPerNode=info["gpu_per_node"],
-        numQpPerPe=cfg.num_qp_per_pe,
-        quantType=int(info["quant_type"]),  # the handle reports the code, not the name
-        dtype=dtype,
-        blockNum=block_num,
-        warpPerBlock=warp_per_block,
-        rdmaBlockNum=info["rdma_block_num"],
-        mpCount=mp_count,
-    )
-    got = plan.info
-    if _TRACE_CFG:
-        # The kernel's EpInterNodeBindConfig overwrites args.config with the constants
-        # compiled in, so any field where the two disagree is a silent behaviour
-        # change rather than an error.
-        hi = op._handle_info
-        for k, v in sorted(got.items()):
-            mine = hi.get(_HANDLE_INFO_KEY.get(k, ""), "-")
-            flag = "" if str(mine) in ("-", str(v)) else "  <== DIFFERS"
-            _trace(f"    cfg {k}={v} handle={mine}{flag}")
-    # Geometry is arrived at twice -- once by dispatch_combine.py, once by
-    # EpInterNodeGeometry -- so a disagreement means the host arithmetic drifted.
-    if want is not None:
-        have = (got["gridX"], got["blockX"], got["sharedBytes"])
-        if want != have:
-            raise AssertionError(
-                f"{pass_name}: geometry drift, dispatch_combine.py wants "
-                f"grid/block/smem {want}, EpInterNodeGeometry says {have}"
-            )
-    cache[key] = plan
-    return plan
-
-
-def _install_jit_redirect():
-    """Route every InterNodeV1 launch in this process to the JIT v2 plans.
-
-    Pair with _uninstall_jit_redirect(): the patch is on the class, so leaving it
-    in place would have a later shmem case launch cco plans against a shmem
-    handle.
-    """
-    import mori.ops.dispatch_combine as dc
-
-    Op = dc.EpDispatchCombineOp
-    if getattr(Op, "_internode_installed", False):
-        return
-    orig_launch_multi = Op._launch_multi
-    Op._internode_saved = {
-        "_launch_multi": orig_launch_multi,
-        "dispatch": Op.dispatch,
-        "combine": Op.combine,
-    }
-
-    def _launch_multi(self, func_names, grids, blocks, shared_mems, stream, args_ptr):
-        passes = [_split_entry(n) for n in func_names]
-        if any(p is None for p in passes):
-            return orig_launch_multi(
-                self, func_names, grids, blocks, shared_mems, stream, args_ptr
-            )
-        mp_count = self._handle_info["multi_processor_count"]
-        _trace(f"launch_multi enter {[p for p, _ in passes]}")
-        dev_comm = _dev_comm_host_ptr(self)
-        _trace(f"  dev_comm={dev_comm:#x}")
-        plans = []
-        for (pass_name, dtype), grid, block, smem in zip(
-            passes, grids, blocks, shared_mems
-        ):
-            wpb = max(1, block // self._warp_size)
-            plan = _plan_for(
-                self, pass_name, dtype, grid, wpb, mp_count, (grid, block, smem)
-            )
-            _trace(f"  plan ready {pass_name}")
-            plans.append(plan)
-
-        if _TRACE_PATH or _TRACE_SYNC or not _BATCH_LAUNCH:
-            # Per-pass on the debug path, so a fault is attributable: kernel errors
-            # are asynchronous, and a batch launch would report one pass's fault
-            # against whichever call syncs next -- or take the process down with no
-            # attribution at all.
-            for plan, (pass_name, _), grid, block, smem in zip(
-                plans, passes, grids, blocks, shared_mems
-            ):
-                _trace(f"  launching {pass_name} grid={grid} block={block} smem={smem}")
-                plan.launch(raw=args_ptr, devComm=dev_comm, stream=stream)
-                _trace(f"  launched {pass_name}")
-                if _TRACE_SYNC:
-                    try:
-                        torch.cuda.synchronize()
-                        _trace(f"  synced {pass_name} ok")
-                    except Exception as exc:
-                        _trace(
-                            f"  synced {pass_name} FAILED {type(exc).__name__}: {exc}"
-                        )
-                        raise
-        else:
-            # Fast path: one ABI crossing for the whole N-pass sequence. All passes
-            # share the EpInterNodeCcoArgs schema and the same raw/devComm, so the
-            # arg struct is filled once and every plan launches against it in order.
-            _jit_plan_api.launch_multi(
-                plans, raw=args_ptr, devComm=dev_comm, stream=stream
-            )
-
-    Op._launch_multi = _launch_multi
-
-    # build_args takes the hidden dim from the input tensor, and the kernel gets
-    # it as a compiled constant, so the plan must be built for the same value.
-    from mori.ops.dispatch_combine_v2 import internode_tuning_configs as _ep_tuning
-
-    for name in ("dispatch", "combine"):
-        orig = getattr(Op, name)
-
-        def wrapper(self, input, *a, _orig=orig, _phase=name, **kw):
-            self.__dict__["_internode_hidden_dim"] = input.size(1)
-            # The redirect is the internode path's only geometry hook: left alone
-            # it inherits dispatch_combine.py's grid, which is not CU-aware and
-            # over-subscribes MI308 at these token counts. When the caller pinned
-            # nothing, pin the per-device, CU-bounded, per-token geometry instead.
-            if kw.get("block_num", -1) <= 0:
-                geom = _ep_tuning.lookup(
-                    self.config.world_size,
-                    self.config.hidden_dim,
-                    self.config.num_experts_per_token,
-                    int(input.size(0)),
-                )
-                if geom is not None:
-                    b, r, w = geom[_phase]
-                    kw["block_num"], kw["rdma_block_num"], kw["warp_per_block"] = (
-                        b,
-                        r,
-                        w,
-                    )
-            return _orig(self, input, *a, **kw)
-
-        setattr(Op, name, wrapper)
-
-    Op._internode_installed = True
-
-
-def _uninstall_jit_redirect():
-    """Undo _install_jit_redirect(), returning the op to the stock AOT launch path.
-
-    The cached plans and devComm need no cleanup: they hang off the op instance,
-    not the class, so they go when the op does.
-    """
-    import mori.ops.dispatch_combine as dc
-
-    Op = dc.EpDispatchCombineOp
-    saved = getattr(Op, "_internode_saved", None)
-    if not getattr(Op, "_internode_installed", False) or saved is None:
-        return
-    Op._launch_multi = saved["_launch_multi"]
-    Op.dispatch = saved["dispatch"]
-    Op.combine = saved["combine"]
-    Op._internode_installed = False
-    Op._internode_saved = None
-
-
-def _install_backend(backend):
-    """Select the implementation. Must precede the op: the backend decides what
-    the handle can host, and the JIT redirect has to be in place for the first
-    launch. The shmem branch uninstalls rather than merely not installing,
-    because a cco case earlier in the session has already patched the class.
-    """
-    if backend == "cco":
-        os.environ["MORI_EP_COMM"] = "cco"
-        _install_jit_redirect()
-    else:
-        os.environ.pop("MORI_EP_COMM", None)
-        _uninstall_jit_redirect()
-
-
-def _make_config(
-    rank,
-    world_size,
-    kernel,
-    data_type,
-    hidden_dim,
-    max_num_inp_token_per_rank,
-    num_experts_per_rank,
-    num_experts_per_token,
-    scale_dim=0,
-    scale_type_size=1,
-    quant_type="none",
-    combine_data_type=None,
-):
-    kernel_type, block_num, rdma_block_num, warp_num_per_block = _KERNELS[kernel]
-    _, _, config_hidden_dim = cross_dtype_hidden_dims(
-        hidden_dim, data_type, combine_data_type or data_type
-    )
-    return mori.ops.EpDispatchCombineConfig(
-        data_type=data_type,
-        rank=rank,
-        world_size=world_size,
-        hidden_dim=config_hidden_dim,
-        scale_dim=scale_dim,
-        scale_type_size=scale_type_size,
-        max_num_inp_token_per_rank=max_num_inp_token_per_rank,
-        num_experts_per_rank=num_experts_per_rank,
-        num_experts_per_token=num_experts_per_token,
-        max_token_type_size=2,
-        block_num=block_num,
-        rdma_block_num=rdma_block_num,
-        warp_num_per_block=warp_num_per_block,
-        kernel_type=kernel_type,
-        # One node here, and it has to match LOCAL_WORLD_SIZE -- see the module
-        # docstring.
-        gpu_per_node=world_size,
-        # The field defaults to 1, which starves the cross-node path by ~1.5x.
-        # It also sizes the CCO side, where gdaContextCount == numQpPerPe, so
-        # both backends are measured at the value the published bench uses.
-        num_qp_per_pe=2,
-        quant_type=quant_type,
-    )
-
-
-def _fanout(manager, func, args):
-    for _ in range(_WORLD_SIZE):
-        manager.task_queue.put((func, args))
-    assert_worker_results(manager, _WORLD_SIZE)
-
-
-# ---------------------------------------------------------------------------
-# correctness
-# ---------------------------------------------------------------------------
-
-
-def _worker_correctness(
-    rank,
-    backend,
-    kernel,
-    data_type,
-    hidden_dim,
-    max_num_inp_token_per_rank,
-    num_experts_per_rank,
-    num_experts_per_token,
-    scale_dim,
-    scale_type_size,
-):
-    _install_backend(backend)
-    config = _make_config(
-        rank=rank,
-        world_size=_WORLD_SIZE,
-        kernel=kernel,
-        data_type=data_type,
-        hidden_dim=hidden_dim,
-        max_num_inp_token_per_rank=max_num_inp_token_per_rank,
-        num_experts_per_rank=num_experts_per_rank,
-        num_experts_per_token=num_experts_per_token,
-        scale_dim=scale_dim,
-        scale_type_size=scale_type_size,
-    )
-    run_ep_dispatch_combine_test(
-        config, EpDispatchCombineTestCase, use_max_token_num=True
-    )
-
-
-@pytest.mark.parametrize("backend", ("cco", "shmem"))
-@pytest.mark.parametrize("kernel", tuple(_KERNELS))
-@pytest.mark.parametrize("data_type", _all_data_types())
-@pytest.mark.parametrize("hidden_dim", (7168, 4096))
-@pytest.mark.parametrize("max_num_inp_token_per_rank", (32, 128))
-@pytest.mark.parametrize("scale_dim, scale_type_size", ((0, 1), (32, 4)))
-def test_internode_correctness(
-    torch_dist_process_manager,
-    backend,
-    kernel,
-    data_type,
-    hidden_dim,
-    max_num_inp_token_per_rank,
-    scale_dim,
-    scale_type_size,
-):
-    """dispatch + combine must match the analytic golden."""
-    _fanout(
-        torch_dist_process_manager,
-        _worker_correctness,
+def _gen_round(rng, cfg, ct, dev, dtype):
+    """Seeded per-round input, routing and weights, so a failure is reproducible
+    from the round number and the rank alone."""
+    inp = torch.randn(ct, cfg.hidden_dim, generator=rng, device=dev).to(dtype)
+    n_experts = cfg.world_size * cfg.num_experts_per_rank
+    idx = torch.stack(
         [
-            backend,
-            kernel,
-            data_type,
-            hidden_dim,
-            max_num_inp_token_per_rank,
-            32,  # num_experts_per_rank
-            8,  # num_experts_per_token
-            scale_dim,
-            scale_type_size,
-        ],
-    )
+            torch.randperm(n_experts, generator=rng, device=dev)[
+                : cfg.num_experts_per_token
+            ]
+            for _ in range(ct)
+        ]
+    ).to(torch.int32)
+    wts = torch.rand(ct, cfg.num_experts_per_token, generator=rng, device=dev)
+    return inp, idx, wts
 
 
-def _worker_cross_dtype(
-    rank,
-    backend,
-    kernel,
-    data_type,
-    combine_data_type,
-    hidden_dim,
-    max_num_inp_token_per_rank,
-    quant_type,
-):
-    _install_backend(backend)
-    dispatch_hidden_dim, combine_hidden_dim, _ = cross_dtype_hidden_dims(
-        hidden_dim, data_type, combine_data_type
-    )
-    config = _make_config(
-        rank=rank,
-        world_size=_WORLD_SIZE,
-        kernel=kernel,
-        data_type=data_type,
-        hidden_dim=hidden_dim,
-        max_num_inp_token_per_rank=max_num_inp_token_per_rank,
-        num_experts_per_rank=32,
-        num_experts_per_token=8,
-        quant_type=quant_type,
-        combine_data_type=combine_data_type,
-    )
-    run_ep_dispatch_combine_test(
-        config,
-        EpDispatchCombineTestCase,
-        use_max_token_num=True,
-        combine_data_type=combine_data_type,
-        combine_hidden_dim=combine_hidden_dim,
-        dispatch_hidden_dim=dispatch_hidden_dim,
-    )
+def _bench(op, cfg, d, dev, a, comm):
+    """Per-phase latency, measured the way the shmem harness measures it.
 
-
-@pytest.mark.parametrize("backend", ("cco", "shmem"))
-@pytest.mark.parametrize("kernel", tuple(_KERNELS))
-@pytest.mark.parametrize("data_type", _all_data_types())
-@pytest.mark.parametrize("quant_type", ("none", "fp8_direct_cast"))
-def test_internode_cross_dtype(
-    torch_dist_process_manager, backend, kernel, data_type, quant_type
-):
-    """FP8/FP4 dispatch with a BF16 combine -- the pairing the tuning matrix
-    ships, and the one the CCO path's FP8 and LL branches were never exercised
-    on before this port."""
-    combine_data_type = torch.bfloat16
-    skip = cross_dtype_skip_reason(quant_type, data_type, combine_data_type)
-    if skip:
-        pytest.skip(skip)
-
-    _fanout(
-        torch_dist_process_manager,
-        _worker_cross_dtype,
-        [backend, kernel, data_type, combine_data_type, 7168, 128, quant_type],
-    )
-
-
-def _worker_small_shapes(rank, backend, kernel, tokens):
-    _install_backend(backend)
-    config = _make_config(
-        rank=rank,
-        world_size=_WORLD_SIZE,
-        kernel=kernel,
-        data_type=torch.bfloat16,
-        hidden_dim=4096,
-        max_num_inp_token_per_rank=tokens,
-        num_experts_per_rank=32,
-        num_experts_per_token=8,
-    )
-    run_ep_dispatch_combine_test(
-        config, EpDispatchCombineTestCase, use_max_token_num=True
-    )
-
-
-@pytest.mark.parametrize("backend", ("cco", "shmem"))
-@pytest.mark.parametrize("kernel", tuple(_KERNELS))
-@pytest.mark.parametrize("tokens", (1, 32))
-def test_internode_small_shapes(torch_dist_process_manager, backend, kernel, tokens):
-    """One token per rank is where an off-by-one in the chunk count or an empty
-    chunk-flag range shows up; the shipping shapes never produce a single-token
-    chunk."""
-    _fanout(torch_dist_process_manager, _worker_small_shapes, [backend, kernel, tokens])
-
-
-# ---------------------------------------------------------------------------
-# stress
-# ---------------------------------------------------------------------------
-
-
-def _round(case, op, test_data, check=False):
-    """One dispatch+combine, mirroring EpDispatchCombineTestCase.run_test_once
-    but with ``call_reset=True`` so the counters are returned to their initial
-    state -- a loop that leaves them dirty measures the second round against the
-    first round's leftovers."""
-    (_, all_rank_indices, all_rank_input, all_rank_weights, all_rank_scales) = test_data
-    rank = case.config.rank
-    (
-        dispatch_output,
-        dispatch_weights,
-        _,
-        dispatch_indices,
-        dispatch_recv_num_token,
-    ) = op.dispatch(
-        all_rank_input[rank],
-        all_rank_weights[rank],
-        all_rank_scales[rank],
-        all_rank_indices[rank],
-    )
-    # Read it here, between the two calls: combine reuses this counter, so after
-    # combine it reads back as zero.
-    total_recv = dispatch_recv_num_token[0].item()
-    if check:
-        num_experts = case.config.num_experts_per_rank * case.config.world_size
-        max_expert = dispatch_indices[:total_recv].max().item()
-        assert max_expert < num_experts, (
-            f"rank[{rank}] dispatch returned expert id {max_expert} "
-            f">= {num_experts}"
-        )
-    combine_input = case._get_combine_input(op, dispatch_output, num_token=total_recv)
-    op.combine(
-        combine_input,
-        dispatch_weights,
-        all_rank_indices[rank],
-        call_reset=True,
-    )
-    case.sync()
-    return total_recv
-
-
-def _worker_stress(rank, backend, kernel, tokens, reps):
-    _install_backend(backend)
-    config = _make_config(
-        rank=rank,
-        world_size=_WORLD_SIZE,
-        kernel=kernel,
-        data_type=torch.bfloat16,
-        hidden_dim=7168,
-        max_num_inp_token_per_rank=tokens,
-        num_experts_per_rank=32,
-        num_experts_per_token=8,
-    )
-    op = mori.ops.EpDispatchCombineOp(config)
-    case = EpDispatchCombineTestCase(config)
-    test_data = case.gen_test_data(use_max_token_num=True)
-
-    # One fully checked round first, so a path that silently moves nothing
-    # cannot pass this test by being fast.
-    case.run_test_once(op, test_data, check_results=True)
-
-    for i in range(reps):
-        _round(case, op, test_data, check=True)
-        if rank == 0 and (i + 1) % 50 == 0:
-            print(f"[stress] {backend}/{kernel} {i + 1}/{reps}", flush=True)
-
-
-@_stress_only
-@pytest.mark.parametrize("backend", ("cco", "shmem"))
-@pytest.mark.parametrize("kernel", tuple(_KERNELS))
-def test_internode_stress(torch_dist_process_manager, backend, kernel):
-    """Many rounds on one op. What breaks at round 300 and not at round 1 is
-    state that survives a round, and none of it is visible to a single-shot
-    check."""
-    _fanout(
-        torch_dist_process_manager,
-        _worker_stress,
-        [backend, kernel, _BENCH_TOKENS[kernel], 300],
-    )
-
-
-@_stress_only
-@pytest.mark.parametrize("backend", ("cco", "shmem"))
-def test_internode_large_tokens(torch_dist_process_manager, backend):
-    """4096 tokens/rank, the largest shape that completes.
-
-    Deliberately not 8192: cco at 7168/8192 runs past a 1500s timeout while
-    shmem finishes the same config in ~30s, still unexplained. Raise this when
-    that is fixed -- leaving it at 4096 keeps the test from being a slow way to
-    rediscover a known hang. Few rounds, because at this size the one checked
-    round dominates the cost.
+    Warmup then timed rounds, each phase timed on its own events, and the
+    reported number is the mean over ranks of the per-round mean -- the leading
+    rounds are dropped because the first ones after a barrier are dominated by
+    the thundering herd rather than by the kernels.
     """
-    _fanout(torch_dist_process_manager, _worker_stress, [backend, "v1", 4096, 20])
+    rng = torch.Generator(device=dev)
+    rng.manual_seed(4242 + d.rank)
+    ct = a.max_tokens
+    inp, idx, wts = _gen_round(rng, cfg, ct, dev, cfg.dispatch_dtype)
 
+    def one():
+        e = [torch.cuda.Event(enable_timing=True) for _ in range(3)]
+        e[0].record()
+        r = op.dispatch(inp, wts, None, idx, return_routing=True)
+        e[1].record()
+        op.combine(r[0], wts, routing=r[5])
+        e[2].record()
+        torch.cuda.synchronize()
+        return e[0].elapsed_time(e[1]) * 1e3, e[1].elapsed_time(e[2]) * 1e3
 
-# ---------------------------------------------------------------------------
-# bench
-# ---------------------------------------------------------------------------
-
-
-def _worker_bench(rank, backend, kernel, data_type, tokens, warmup, iters):
-    _install_backend(backend)
-    config = _make_config(
-        rank=rank,
-        world_size=_WORLD_SIZE,
-        kernel=kernel,
-        data_type=data_type,
-        hidden_dim=7168,
-        max_num_inp_token_per_rank=tokens,
-        num_experts_per_rank=32,
-        num_experts_per_token=8,
-    )
-    op = mori.ops.EpDispatchCombineOp(config)
-    case = EpDispatchCombineTestCase(config)
-    test_data = case.gen_test_data(use_max_token_num=True)
-
-    # Checked once before timing: a measurement of a path that drops tokens is
-    # worse than no measurement.
-    case.run_test_once(op, test_data, check_results=True)
-
-    (_, all_rank_indices, all_rank_input, all_rank_weights, all_rank_scales) = test_data
-    total_recv = _round(case, op, test_data)
-
-    # Routing is fixed by the test data, so the combine input is resolved once
-    # rather than per round -- in zero-copy mode that call is a device copy, and
-    # timing it would attribute a harness cost to the kernel.
-    d_us, c_us = [], []
-    for i in range(warmup + iters):
-        d0, d1 = torch.cuda.Event(True), torch.cuda.Event(True)
-        c0, c1 = torch.cuda.Event(True), torch.cuda.Event(True)
-
-        d0.record()
-        out, weights, _, _, _ = op.dispatch(
-            all_rank_input[rank],
-            all_rank_weights[rank],
-            all_rank_scales[rank],
-            all_rank_indices[rank],
-        )
-        d1.record()
-        combine_input = case._get_combine_input(op, out, num_token=total_recv)
-        c0.record()
-        op.combine(combine_input, weights, all_rank_indices[rank], call_reset=True)
-        c1.record()
-        case.sync()
-
-        if i >= warmup:
-            d_us.append(d0.elapsed_time(d1) * 1000.0)
-            c_us.append(c0.elapsed_time(c1) * 1000.0)
-
-    elem = torch.tensor([], dtype=data_type).element_size()
-
-    def bw(us):
-        # Algorithmic bandwidth, the bench_dispatch_combine.py definition:
-        # received payload over elapsed time, covering both the XGMI and the
-        # RDMA leg.
-        return total_recv * config.hidden_dim * elem / (us * 1e-6) / 1e9
-
-    mine = {
-        "rank": rank,
-        "d": statistics.mean(d_us),
-        "c": statistics.mean(c_us),
-        "recv": total_recv,
-    }
-    gathered = [None] * _WORLD_SIZE
-    dist.all_gather_object(gathered, mine)
-    if rank == 0:
-        d = statistics.mean(g["d"] for g in gathered)
-        c = statistics.mean(g["c"] for g in gathered)
-        # Mean and worst both matter: these are collective passes, so a round is
-        # not over until the slowest rank finishes.
+    for _ in range(a.warmup):
+        one()
+        comm.barrier()
+    disp, comb = [], []
+    for _ in range(a.rounds):
+        dt, ct_us = one()
+        comm.barrier()
+        disp.append(dt)
+        comb.append(ct_us)
+    keep = slice(a.drop_rounds, None)
+    dm = sum(disp[keep]) / max(1, len(disp[keep]))
+    cm = sum(comb[keep]) / max(1, len(comb[keep]))
+    dm = d.allreduce_sum(int(dm * 1000)) / d.world / 1000
+    cm = d.allreduce_sum(int(cm * 1000)) / d.world / 1000
+    if d.rank == 0:
         print(
-            f"[bench] {backend:5s} {kernel:5s} {str(data_type).split('.')[-1]:14s} "
-            f"tokens={tokens} recv={total_recv} "
-            f"dispatch={d:8.1f}us (worst {max(g['d'] for g in gathered):8.1f}) "
-            f"{bw(d):6.1f} GB/s  "
-            f"combine={c:8.1f}us (worst {max(g['c'] for g in gathered):8.1f}) "
-            f"{bw(c):6.1f} GB/s",
+            f"# BENCH tok={ct} dtype={a.dtype}->{a.combine_dtype or a.dtype} "
+            f"hidden={cfg.hidden_dim} topk={cfg.num_experts_per_token} "
+            f"dispatch={dm:.1f}us combine={cm:.1f}us total={dm + cm:.1f}us",
             flush=True,
         )
+    return 0
 
 
-@_bench_only
-@pytest.mark.parametrize("kernel", tuple(_KERNELS))
-@pytest.mark.parametrize(
-    "data_type",
-    [
-        pytest.param(torch.bfloat16, id="bf16"),
-        pytest.param(
-            torch.float8_e4m3fn,
-            id="fp8",
-            marks=pytest.mark.skipif(
-                not torch.cuda.is_available()
-                or not torch.cuda.get_device_properties(0)
-                .gcnArchName.split(":")[0]
-                .startswith("gfx95"),
-                reason="float8_e4m3fn (OCP) is gfx950-only",
-            ),
-        ),
-    ],
-)
-def test_internode_bench(torch_dist_process_manager, kernel, data_type):
-    """Latency and algorithmic bandwidth for both backends, printed as a pair.
+def main(argv):
+    a = _parse_args(argv)
+    d = Dist()
+    rank, npes = d.rank, d.world
+    dev = torch.device("cuda", d.local_rank)
 
-    No speed assertion, and both backends run inside one test rather than as two
-    parametrized cases: absolute numbers here move ~25% between batches with no
-    code change, so the only defensible comparison is cco against shmem measured
-    close together. Use ``-s`` to see the lines.
-
-    Two things these numbers are not. They are **one host**, so nNodes=1 and no
-    RDMA leg runs -- they do not reproduce, and must not be compared against,
-    the two-node figures. And ``shmem``/``v1_ll``/combine carries a fixed ~1.39ms
-    here (against cco's ~55us) that does not scale with tokens and does not
-    appear on ``v1``; it looks like the local-peer handling these kernels
-    inherited rather than a real cco win, so read that one cell with suspicion.
-    """
-    for backend in ("shmem", "cco"):
-        _fanout(
-            torch_dist_process_manager,
-            _worker_bench,
-            [
-                backend,
-                kernel,
-                data_type,
-                _BENCH_TOKENS[kernel],
-                _BENCH_WARMUP[kernel],
-                50,
-            ],
+    gpu_per_node = int(os.environ.get("LOCAL_WORLD_SIZE", "1"))
+    if npes <= gpu_per_node:
+        raise SystemExit(
+            f"this test needs more than one node: world_size={npes} with "
+            f"{gpu_per_node} GPUs per node is a single node"
         )
 
+    dtype = _DTYPES[a.dtype]
+    combine_dtype = _DTYPES[a.combine_dtype] if a.combine_dtype else None
+    M = a.max_tokens
 
-# ---------------------------------------------------------------------------
-# two-host entry, under torchrun
-# ---------------------------------------------------------------------------
+    uid = Communicator.get_unique_id() if rank == 0 else None
+    uid = d.bcast_uid(uid)
+    # internode_regions sizes the arena exactly; this is the VMM budget it is
+    # carved out of, with room for the communicator's own resource window.
+    win_bytes = npes * M * a.hidden_dim * 4 * 2 + (1 << 24)
+    failures = 0
+    with Communicator.init(
+        npes, rank, uid, per_rank_vmm=2 * win_bytes + (1 << 28)
+    ) as comm:
+        cfg = EpDispatchCombineConfig(
+            rank=rank,
+            world_size=npes,
+            hidden_dim=a.hidden_dim,
+            max_num_inp_token_per_rank=M,
+            num_experts_per_rank=a.experts_per_rank,
+            num_experts_per_token=a.topk,
+            data_type=dtype if combine_dtype is None else torch.bfloat16,
+            dispatch_data_type=dtype if combine_dtype is not None else None,
+            combine_data_type=combine_dtype,
+            scale_dim=a.scale_dim,
+            scale_type_size=1 if a.scale_dim else 0,
+            quant_type=a.quant_type,
+            gpu_per_node=gpu_per_node,
+            num_qp_per_pe=a.num_qp,
+            kernel_backend="hip",
+        )
+        op = EpDispatchCombineOp(cfg, comm)
+        comm.barrier()
 
+        if a.cmd == "bench":
+            rc = _bench(op, cfg, d, dev, a, comm)
+            op.close()
+            d.shutdown()
+            return rc
 
-def _spawn_worker(rank, fn, args):
-    """Install the redirect in the worker, then hand off to the harness.
+        rng = torch.Generator(device=dev)
+        for r in range(a.rounds):
+            rng.manual_seed(1234 + r * 977 + rank)
+            ct = M
+            inp, idx, wts = _gen_round(rng, cfg, ct, dev, cfg.dispatch_dtype)
 
-    The harness fans out with torch.multiprocessing.spawn, and a spawned worker
-    is a fresh interpreter that re-imports mori -- so the class patch the parent
-    made is not there. MORI_EP_COMM travels with the environment and does arrive,
-    which is the dangerous half: the worker would build a cco-backed handle and
-    then launch the shmem AOT entries at it, and those address the shmem heap, so
-    the result is a fault at 0x0 rather than a clean failure.
-    """
-    _install_jit_redirect()
-    return fn(rank, *args)
+            recv_x, recv_w, recv_s, recv_i, total_recv, routing = op.dispatch(
+                inp, wts, None, idx, return_routing=True
+            )
+            torch.cuda.synchronize()
+            comm.barrier()
+
+            # Identity expert: recv_x already holds the dispatched tokens.
+            out, out_w = op.combine(recv_x, wts, routing=routing)
+            torch.cuda.synchronize()
+            comm.barrier()
+
+            idx_c = idx.cpu()
+            U = np.array(
+                [
+                    len(
+                        {
+                            int(idx_c[t, j]) // cfg.num_experts_per_rank
+                            for j in range(a.topk)
+                        }
+                    )
+                    for t in range(ct)
+                ]
+            )
+            Ut = torch.from_numpy(U).view(ct, 1).float()
+            exp_w = Ut * wts.float().cpu()
+            exp = Ut * inp.float().cpu()
+
+            # The bound has to scale with U: combine sums U contributions in the
+            # wire dtype, so the error grows with the number of terms and with the
+            # magnitude being summed -- not with |expected| at that element, which
+            # cancellation can make arbitrarily small. This is the same shape of
+            # bound v1's harness uses (it scales its per-element bound by
+            # unique_pes) rather than a flat allclose.
+            got = out.float().cpu()
+            per_elem = inp.float().cpu().abs()
+            eps = 3e-1 if (a.quant_type != "none" or dtype in _FP8) else 8e-3
+            bound = eps * Ut * per_elem.clamp(min=1.0)
+            ok = bool(((got - exp).abs() <= bound).all())
+            # Weights are transported as f32 and summed the same way, so their
+            # bound is much tighter -- but still proportional to U.
+            gw = out_w.cpu()
+            ok_w = bool(((gw - exp_w).abs() <= 2e-3 * Ut).all())
+
+            if not (ok and ok_w) and rank == 0:
+                print(f"#   hidden_ok={ok} weights_ok={ok_w}", flush=True)
+                ratio = (out_w.cpu() / wts.float().cpu().clamp(min=1e-6))[:4]
+                print(
+                    f"#   effective multiplier got_w/wts[0,:4]={ratio[0, :4].tolist()} "
+                    f"(expected U[0]={int(U[0])})",
+                    flush=True,
+                )
+                # What KIND of wrong matters more than that it is wrong: all
+                # zeros means the output never landed, a constant factor means
+                # the reduce counted the wrong number of contributions, and
+                # noise means the routing or the staging offsets are off.
+                want = exp
+                print(
+                    f"#   hidden: max|diff|={(got - want).abs().max():.4g} "
+                    f"got[0,:4]={got[0, :4].tolist()} want[0,:4]={want[0, :4].tolist()} "
+                    f"got_nonzero={int((got != 0).sum())}/{got.numel()}",
+                    flush=True,
+                )
+                ww = exp_w
+                # Distinguish "the kernel never wrote it" from "the base reads
+                # the wrong place": read the region the kernel targets directly.
+                from mori.tensor_utils import from_gpu_ptr
+
+                for rn in (
+                    "combine_out_weights",
+                    "inp_weights",
+                    "dispatch_out_weights",
+                ):
+                    v = from_gpu_ptr(
+                        op.arena.local_ptr(rn), (min(8, a.topk * 2),), torch.float32
+                    )
+                    print(f"#   region {rn}[:8] = {v.cpu().tolist()}", flush=True)
+                print(
+                    f"#   weights: max|diff|={(gw - ww).abs().max():.4g} "
+                    f"got[0,:4]={gw[0, :4].tolist()} want[0,:4]={ww[0, :4].tolist()} "
+                    f"U[:4]={U[:4].tolist()} total_recv={int(total_recv[0])}",
+                    flush=True,
+                )
+            errs = d.allreduce_sum(0 if (ok and ok_w) else 1)
+            failures += errs
+            if rank == 0:
+                print(
+                    f"# round {r} tokens={ct}: {'PASS' if errs == 0 else 'FAIL'} "
+                    f"({errs} of {npes} ranks disagree)",
+                    flush=True,
+                )
+        op.close()
+
+    d.shutdown()
+    return 1 if failures else 0
 
 
 if __name__ == "__main__":
-    # Everything above is one host: the cases fan out through the process manager
-    # and _WORLD_SIZE is a single node's worth of ranks, so no RDMA leg runs. The
-    # cross-node numbers need two hosts, and the harness that knows how to drive
-    # them is the shmem one in examples/ -- it owns the CLI, the shapes and the
-    # result tables. All this entry adds is the cco redirect.
-    #
-    #   torchrun --nnodes=2 --node_rank=N --nproc_per_node=1 \
-    #     tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py \
-    #     --kernel-type v1 --cmd bench --dtype bf16 --max-tokens 4096
-    #
-    # nproc_per_node is 1 by design: the harness reads WORLD_SIZE as the node
-    # count and spawns gpu_per_node workers of its own on top of it.
-    import runpy
-
-    import torch.multiprocessing
-
-    # Self, under the package name. Anything handed to spawn is pickled as
-    # module + qualname, and this file's __name__ here is "__main__" -- whose
-    # counterpart in the worker is the harness, not this module, so a
-    # "__main__._spawn_worker" reference would not resolve there.
-    from tests.python.ops.dispatch_combine_v2 import (
-        test_dispatch_combine_v2_internode as _self,
-    )
-
-    os.environ["MORI_EP_COMM"] = "cco"
-
-    _real_spawn = torch.multiprocessing.spawn
-
-    def _spawn(fn, args=(), nprocs=1, **kwargs):
-        return _real_spawn(
-            _self._spawn_worker, args=(fn, args), nprocs=nprocs, **kwargs
-        )
-
-    torch.multiprocessing.spawn = _spawn
-
-    _repo_root = os.path.dirname(os.path.abspath(__file__))
-    for _ in range(4):  # dispatch_combine_v2 -> ops -> python -> tests -> root
-        _repo_root = os.path.dirname(_repo_root)
-
-    # run_name="__main__" because the harness keeps its driver under its own
-    # __main__ guard; importing it would only parse argv and define classes. Our
-    # argv is already the harness's argv, and argparse ignores argv[0].
-    runpy.run_path(
-        os.path.join(
-            _repo_root,
-            "examples",
-            "ops",
-            "dispatch_combine",
-            "test_dispatch_combine_internode.py",
-        ),
-        run_name="__main__",
-    )
+    sys.exit(main(sys.argv[1:]))

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -474,6 +474,13 @@ def _bench(op, cfg, d, dev, a, comm):
     if _marks is not None:
         del _marks[:]
 
+    # Same reason as the marks above: the warmup ran the identical path and
+    # burned rounds off the buffer, so only the timed loop's rows are wanted.
+    _ts = getattr(op, "dbg_ts", None)
+    if _ts is not None:
+        _ts.zero_()
+        op.dbg_round = dict.fromkeys(op.dbg_round, 0)
+
     _series = bool(os.environ.get("MORI_EP_ROUND_SERIES"))
 
     # Caching-allocator segments, opt-in. A cudaMalloc inside the timed loop
@@ -525,6 +532,41 @@ def _bench(op, cfg, d, dev, a, comm):
         tr[n] = time.perf_counter()
     torch.cuda.synchronize()
     wall = (time.perf_counter() - t0) * 1e6 / n
+
+    # Device timestamps, opt-in (MORI_EP_DEV_TS on the backend). Exactly ONE
+    # device-to-host copy, after the loop's own synchronize, so nothing here is
+    # inside a measured window -- a per-round readback would serialise the loop
+    # and destroy the thing being measured.
+    #
+    # The point of these is the one split the host cannot make: dispatch_ll and
+    # combine_ll each POST to a peer and then WAIT for a peer, and the phase
+    # events bracket both together. d_post is local work (WQE build + doorbell);
+    # d_spin is waiting for the peer's write to land.
+    if _ts is not None:
+        from mori import cpp as mori_cpp
+
+        # Misnamed accessor: hipDeviceAttributeWallClockRate is kHz, which is
+        # why kernel_profiler divides it by 1e6 to get GHz. Printed once so a
+        # wrong unit is visible rather than silently scaling every number.
+        khz = mori_cpp.get_cur_device_wall_clock_freq_mhz()
+        # Rows are launch-indexed, so the same drop the phase series uses.
+        ts = _ts.view(-1, 16)[a.drop_rounds : n].cpu().to(torch.float64)
+
+        def _us(b, e):
+            return ((ts[:, e] - ts[:, b]) * 1e3 / khz).tolist()
+
+        pfx = "# DEVTS r%d" % d.rank
+        if d.rank == 0:
+            print("%s wallclock_khz=%d (expect 100000)" % (pfx, khz), flush=True)
+        for nm, v in (
+            ("d_head", _us(0, 1)),  # kernel entry -> first post
+            ("d_post", _us(1, 2)),  # WQE build + doorbell: LOCAL
+            ("d_gap", _us(2, 4)),  # post returns -> spin entry (warp skew)
+            ("d_spin", _us(4, 5)),  # waiting for the peer's write: REMOTE
+            ("c_post", _us(8, 9)),  # combine entry -> put
+            ("c_spin", _us(10, 11)),  # combine cross-node barrier wait
+        ):
+            print("%s %s: " % (pfx, nm) + " ".join("%.1f" % x for x in v), flush=True)
     # Which PASS owns the slow round. The marks are (name, event) in launch
     # order: one "<phase>:start" then one per pass, repeating per phase per round.
     # Consecutive deltas are per-pass GPU durations, so the round with the largest
@@ -573,11 +615,11 @@ def _bench(op, cfg, d, dev, a, comm):
             # something quite different from a step in the pass that waits.
             k = max(3, len(rounds) // 12)
             for nm_i, nm in enumerate(names):
-                e = sum(r[nm_i][1] for r in rounds[:k]) / k
-                l = sum(r[nm_i][1] for r in rounds[-k:]) / k
+                first = sum(r[nm_i][1] for r in rounds[:k]) / k
+                last = sum(r[nm_i][1] for r in rounds[-k:]) / k
                 print(
-                    f"{pfx} step {nm:<20} first{k}={e:8.1f}  last{k}={l:8.1f}  "
-                    f"delta={l - e:+8.1f}",
+                    f"{pfx} step {nm:<20} first{k}={first:8.1f}  "
+                    f"last{k}={last:8.1f}  delta={last - first:+8.1f}",
                     flush=True,
                 )
             # Top 3, not just the worst: one round can be an artifact, three

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -248,7 +248,16 @@ def main(argv):
             comm.barrier()
 
             # Identity expert: recv_x already holds the dispatched tokens.
-            out, out_w = op.combine(recv_x, wts, routing=routing)
+            #
+            # Converting it is the CALLER's job when the two legs have different
+            # element types, exactly as v1's harness does it (_get_combine_input
+            # -> _to_combine_dtype). The combine kernel's T is the combine dtype
+            # and it reads inpTokenBuf as T*, so handing it the fp8 dispatch
+            # output unconverted reinterprets fp8 bytes as bf16.
+            combine_in = (
+                recv_x.to(cfg.combine_dtype) if cfg.is_asymmetric_dtype else recv_x
+            )
+            out, out_w = op.combine(combine_in, wts, routing=routing)
             torch.cuda.synchronize()
             comm.barrier()
 
@@ -300,16 +309,17 @@ def main(argv):
                 viol = (got - exp).abs() - bound
                 if bool((viol > 0).any()):
                     fi = int(viol.argmax())
-                    t, d = fi // cfg.hidden_dim, fi % cfg.hidden_dim
+                    # NOT `t, d` -- `d` is the Dist handle in this scope.
+                    vt, vd = fi // cfg.hidden_dim, fi % cfg.hidden_dim
                     g, e, pin = (
-                        float(got[t, d]),
-                        float(exp[t, d]),
-                        float(per_elem[t, d]),
+                        float(got[vt, vd]),
+                        float(exp[vt, vd]),
+                        float(per_elem[vt, vd]),
                     )
                     print(
-                        f"#   worst: tok={t} dim={d} got={g:.6g} want={e:.6g} "
-                        f"input={pin:.6g} U={int(Ut[t])} "
-                        f"|diff|={abs(g - e):.6g} bound={float(bound[t, d]):.6g} "
+                        f"#   worst: tok={vt} dim={vd} got={g:.6g} want={e:.6g} "
+                        f"input={pin:.6g} U={int(Ut[vt])} "
+                        f"|diff|={abs(g - e):.6g} bound={float(bound[vt, vd]):.6g} "
                         f"rel={abs(g - e) / max(abs(e), 1e-9):.4f} "
                         f"nviol={int((viol > 0).sum())}",
                         flush=True,

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -241,6 +241,25 @@ def _parse_args(argv):
     # with its own error; before it is written into the table it gets one long
     # head-to-head against what it would replace.
     p.add_argument("--tuning-candidate", default=None)
+    # What a candidate is selected ON. "total" by default, and deliberately:
+    # internode_tuning_configs.py records that the two phases are COUPLED -- a
+    # dispatch with too few rdma blocks leaves the following combine ~18us slower
+    # at 4/8 tokens -- so the shipped small-token dispatch is NOT the dispatch
+    # argmin, it holds rdma high to keep the paired combine fast. Selecting a
+    # dispatch geometry on dispatch time alone reproduces exactly the mistake
+    # that comment warns about. "phase" is kept for looking at a phase in
+    # isolation, which is a diagnostic, not a way to choose a table row.
+    p.add_argument("--tuning-metric", default="total", choices=["total", "phase"])
+    # Greedy chaining (v1's shape: a winner becomes the incumbent) is OFF by
+    # default here. With a chain, one lucky early win moves the baseline and
+    # every later candidate is judged against it, so the outcome depends on the
+    # order noise arrived in: five repeats of the same 29-candidate sweep at 15
+    # paired reps returned five different winners -- (80,53,4), (16,10,4) twice,
+    # (16,8,4), (8,5,8) -- plus (32,21,8) on two earlier runs. Holding the
+    # incumbent FIXED at the shipped geometry makes every candidate an
+    # independent paired test against the thing it would replace, which is both
+    # what we want to know and reproducible across repeats.
+    p.add_argument("--tuning-greedy", action="store_true")
     # How much better a candidate must be, on the paired difference, to take
     # over. Whichever of the two is larger. Not 0: see the note in _tune.
     p.add_argument("--tuning-margin-us", type=float, default=1.5)
@@ -835,6 +854,11 @@ def _build_op(cfg, comm, dgeom, cgeom):
                 os.environ[k] = v
 
 
+def _med(xs):
+    v = sorted(xs)
+    return v[len(v) // 2]
+
+
 def _tune(cfg, d, dev, a, comm):
     """Sweep launch geometries and report the winner for this token count.
 
@@ -906,7 +930,10 @@ def _tune(cfg, d, dev, a, comm):
     # after it slower) and a per-phase argmin measured against a DIFFERENT other
     # phase does not carry over.
     geoms = lambda g: ((g, inc_c) if phase == "dispatch" else (inc_d, g))
-    pick = (lambda dv, cv: dv) if phase == "dispatch" else (lambda dv, cv: cv)
+    if a.tuning_metric == "total":
+        pick = lambda dv, cv: dv + cv
+    else:
+        pick = (lambda dv, cv: dv) if phase == "dispatch" else (lambda dv, cv: cv)
 
     best_op = _build_op(cfg, comm, *geoms(start))
     if a.kernel_type is not None:
@@ -914,6 +941,7 @@ def _tune(cfg, d, dev, a, comm):
     comm.barrier()
     best = start
     best_med = None
+    fixed_wins = []  # non-greedy: every candidate that beat the fixed incumbent
 
     for k, cand in enumerate(cands):
         try:
@@ -927,11 +955,14 @@ def _tune(cfg, d, dev, a, comm):
         comm.barrier()
 
         bt, ct_ = [], []
+        bph, cph = [], []  # (dispatch, combine) per rep, to show the coupling
         for _ in range(a.tuning_reps):
             dv, cv = _timed_pass(best_op, cfg, d, a, inp, idx, wts, sc, cw, convert, a.rounds, a.warmup)
             bt.append(pick(dv, cv))
+            bph.append((dv, cv))
             dv, cv = _timed_pass(cand_op, cfg, d, a, inp, idx, wts, sc, cw, convert, a.rounds, a.warmup)
             ct_.append(pick(dv, cv))
+            cph.append((dv, cv))
         bm, cm = sorted(bt)[len(bt) // 2], sorted(ct_)[len(ct_) // 2]
         # PAIRED comparison, not a difference of medians. The two arms are
         # measured alternately inside one rep, so both see the same regime -- and
@@ -953,18 +984,38 @@ def _tune(cfg, d, dev, a, comm):
             print(
                 f"#   [{k + 1}/{len(cands)}] {cand} med={cm:6.1f}us vs "
                 f"incumbent {best} med={bm:6.1f}us  paired={dmed:+6.1f}us "
-                f"[{lo:+.1f},{hi:+.1f}]  {'WIN' if win else '--'}",
+                f"[{lo:+.1f},{hi:+.1f}]  {'WIN' if win else '--'}"
+                f"   d/c cand={_med(x for x, _ in cph):.1f}/{_med(y for _, y in cph):.1f}"
+                f" inc={_med(x for x, _ in bph):.1f}/{_med(y for _, y in bph):.1f}",
                 flush=True,
             )
-        if win:
+        if win and a.tuning_greedy:
             best_op.close()
             best_op, best, best_med = cand_op, cand, cm
         else:
             cand_op.close()
+            if not a.tuning_greedy and win:
+                fixed_wins.append((dmed, cand, cm, bm))
             best_med = bm
         comm.barrier()
 
     best_op.close()
+    if d.rank == 0 and not a.tuning_greedy:
+        fixed_wins.sort()
+        print(
+            f"# TUNING tok={a.max_tokens} phase={phase}: {len(fixed_wins)} of "
+            f"{len(cands)} candidates beat the fixed incumbent {start}",
+            flush=True,
+        )
+        for dm, cd, cm2, bm2 in fixed_wins[:5]:
+            print(
+                f"#   BEAT {cd} paired={dm:+.1f}us (cand med={cm2:.1f} "
+                f"inc med={bm2:.1f})",
+                flush=True,
+            )
+        if fixed_wins:
+            best = fixed_wins[0][1]
+            best_med = fixed_wins[0][2]
     if d.rank == 0:
         d_out = best if phase == "dispatch" else inc_d
         c_out = best if phase == "combine" else inc_c

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -48,6 +48,7 @@ the shmem harness's flags that means anything here.
 import argparse
 import os
 import sys
+import time
 
 import numpy as np
 import torch
@@ -112,10 +113,11 @@ def _parse_args(argv):
     p.add_argument("--scale-dim", type=int, default=0)
     p.add_argument("--warmup", type=int, default=20)
     p.add_argument("--drop-rounds", type=int, default=1)
-    # Accepted and ignored: both members of the LL / non-LL pair are compiled
-    # either way and the launch picks one from the token count. Kept so the
-    # shared runner script can pass identical flags to both harnesses.
-    p.add_argument("--kernel-type", default=None)
+    # Both members of the LL / non-LL pair are compiled either way; this picks
+    # which one runs. Default (None) leaves the backend's token-count rule alone,
+    # which selects LL below 2048 tokens. Naming it explicitly is what makes a
+    # benchmark number comparable to another harness's.
+    p.add_argument("--kernel-type", default=None, choices=[None, "v1", "v1_ll"])
     return p.parse_args(argv)
 
 
@@ -137,47 +139,77 @@ def _gen_round(rng, cfg, ct, dev, dtype):
 
 
 def _bench(op, cfg, d, dev, a, comm):
-    """Per-phase latency, measured the way the shmem harness measures it.
+    """Per-phase latency, structured to match ``run_bench_once`` in
+    ``examples/ops/dispatch_combine/test_dispatch_combine_internode.py``.
 
-    Warmup then timed rounds, each phase timed on its own events, and the
-    reported number is the mean over ranks of the per-round mean -- the leading
-    rounds are dropped because the first ones after a barrier are dominated by
-    the thundering herd rather than by the kernels.
+    Apple-to-apple means only the op call differs, so everything around it is
+    copied from there rather than invented here:
+
+    * ONE event before the loop, then three per round. Round i's dispatch window
+      is [end of round i-1's combine, end of this dispatch]; its combine window
+      is [end of the combine-input conversion, end of this combine]. The
+      conversion sits between two events of its own and is charged to neither.
+    * Nothing synchronises or barriers inside the timed loop. Events are stream
+      markers, so a host that has to stop and build the next launch shows up as
+      GPU idle inside the window; free-running lets the host stay ahead. (An
+      earlier version here synced per round and read 460us at 4 tokens against a
+      41us reference -- 11x of host overhead, none of it kernel.)
+    * Warmup is untimed and ends on sync + barrier; the leading `drop_rounds`
+      timed rounds are discarded because the first after a barrier is thundering
+      herd, not kernel.
+    * The reported number is the AVERAGE over rounds and ranks, as there.
+
+    `wall` is reported alongside as an honesty check, not as part of the
+    measurement: it is the whole loop's wall time per round. The host is running
+    ahead only while wall stays at or below dispatch+combine. Above it, the host
+    is the pacer and the phase numbers carry host stall.
     """
     rng = torch.Generator(device=dev)
     rng.manual_seed(4242 + d.rank)
     ct = a.max_tokens
     inp, idx, wts = _gen_round(rng, cfg, ct, dev, cfg.dispatch_dtype)
+    if a.kernel_type is not None:
+        op._internode_force_ll = a.kernel_type == "v1_ll"
 
-    def one():
-        e = [torch.cuda.Event(enable_timing=True) for _ in range(3)]
-        e[0].record()
-        r = op.dispatch(inp, wts, None, idx, return_routing=True)
-        e[1].record()
-        op.combine(r[0], wts, routing=r[5])
-        e[2].record()
-        torch.cuda.synchronize()
-        return e[0].elapsed_time(e[1]) * 1e3, e[1].elapsed_time(e[2]) * 1e3
+    # The examples harness's _convert_for_combine: the combine leg reads its
+    # input as its own element type, so an asymmetric config has to cast first.
+    def convert(x):
+        return x.to(cfg.combine_dtype) if cfg.is_asymmetric_dtype else x
 
     for _ in range(a.warmup):
-        one()
-        comm.barrier()
-    disp, comb = [], []
-    for _ in range(a.rounds):
-        dt, ct_us = one()
-        comm.barrier()
-        disp.append(dt)
-        comb.append(ct_us)
+        r = op.dispatch(inp, wts, None, idx, return_routing=True)
+        op.combine(convert(r[0]), wts, routing=r[5])
+    torch.cuda.synchronize()
+    comm.barrier()
+
+    n = a.rounds
+    ev = [torch.cuda.Event(enable_timing=True) for _ in range(3 * n + 1)]
+    t0 = time.perf_counter()
+    ev[0].record()
+    for i in range(n):
+        r = op.dispatch(inp, wts, None, idx, return_routing=True)
+        ev[3 * i + 1].record()
+        x = convert(r[0])
+        ev[3 * i + 2].record()
+        op.combine(x, wts, routing=r[5])
+        ev[3 * i + 3].record()
+    torch.cuda.synchronize()
+    wall = (time.perf_counter() - t0) * 1e6 / n
+
     keep = slice(a.drop_rounds, None)
-    dm = sum(disp[keep]) / max(1, len(disp[keep]))
-    cm = sum(comb[keep]) / max(1, len(comb[keep]))
+    disp = [ev[3 * i].elapsed_time(ev[3 * i + 1]) * 1e3 for i in range(n)][keep]
+    comb = [ev[3 * i + 2].elapsed_time(ev[3 * i + 3]) * 1e3 for i in range(n)][keep]
+    dm = sum(disp) / len(disp)
+    cm = sum(comb) / len(comb)
     dm = d.allreduce_sum(int(dm * 1000)) / d.world / 1000
     cm = d.allreduce_sum(int(cm * 1000)) / d.world / 1000
     if d.rank == 0:
         print(
             f"# BENCH tok={ct} dtype={a.dtype}->{a.combine_dtype or a.dtype} "
             f"hidden={cfg.hidden_dim} topk={cfg.num_experts_per_token} "
-            f"dispatch={dm:.1f}us combine={cm:.1f}us total={dm + cm:.1f}us",
+            f"kernel={a.kernel_type or 'auto'} "
+            f"dispatch={dm:.1f}us combine={cm:.1f}us total={dm + cm:.1f}us "
+            f"[wall={wall:.1f}us]",
             flush=True,
         )
     return 0

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -80,9 +80,8 @@ default. Every difference found by reading both, and what to pass to close it:
   what                     v1 bench          here (default)     to align
   ----------------------   ---------------   ----------------   ------------------
   combine weights          None (no fold)    None               (aligned)
-  num_experts_per_rank     256 // world      --experts-per-rank --experts-per-rank 16
-                                             = 32               at world 16
-  scale_dim                32                --scale-dim = 0    --scale-dim 32
+  num_experts_per_rank     256 // world      256 // world       (aligned)
+  scale_dim                32                32                 (aligned)
   scale_type_size          4                 4 when scale_dim   (aligned)
   warmup / rounds / drop   20 / 30 / 1       same, and CHECKED  (aligned)
   routing                  randperm[:topk]   same               (aligned)
@@ -98,11 +97,12 @@ against that harness's 30 while this row said "same", because a table asserting
 three numbers had been checked for two. Prefer extending the check to adding a
 row.
 
-The two that move real work: the weight fold costs an extra peer read per
-(token, destination) plus an accumulate in three kernels and a wider staging slot,
-and v1's scale_dim=32 makes ITS dispatch carry 128 more bytes per token than a
---scale-dim 0 run here. They push in opposite directions, so a comparison that
-leaves both unaligned is not bounded in either direction.
+Both of those defaults used to differ and had to be passed by hand, which is a
+bad way to keep a comparison honest: scale_dim=32 makes dispatch carry 128 more
+bytes per token, so forgetting it silently flattered this side. They now default
+to v1's values. The remaining row that moves real work is the weight fold, which
+is off in both by default -- it costs an extra peer read per (token, destination)
+plus an accumulate in three kernels and a wider staging slot.
 """
 
 import argparse
@@ -178,7 +178,10 @@ def _parse_args(argv):
     p.add_argument("--max-tokens", type=int, default=128)
     p.add_argument("--hidden-dim", type=int, default=7168)
     p.add_argument("--topk", type=int, default=8)
-    p.add_argument("--experts-per-rank", type=int, default=32)
+    # None -> 256 // world_size, which is what the v1 harness hardcodes
+    # (examples/.../test_dispatch_combine_internode.py:576). world_size is not
+    # known until the workers start, so the default has to be resolved there.
+    p.add_argument("--experts-per-rank", type=int, default=None)
     p.add_argument("--dtype", default="bf16", choices=list(_DTYPES))
     p.add_argument("--combine-dtype", default=None, choices=list(_DTYPES))
     p.add_argument("--quant-type", default="none", choices=["none", "fp8_direct_cast"])
@@ -188,7 +191,10 @@ def _parse_args(argv):
     # --drop-rounds 1 the two kept rounds are the ones that harness documents as
     # still in the CCO ramp, so one spike carries half the mean AND is the worst.
     p.add_argument("--rounds", type=int, default=30)
-    p.add_argument("--scale-dim", type=int, default=0)
+    # 32 to match v1, which hardcodes scale_dim=32 / scale_type_size=4. It is not
+    # free -- it makes dispatch carry 128 more bytes per token -- which is exactly
+    # why it should not be something a comparison has to remember to pass.
+    p.add_argument("--scale-dim", type=int, default=32)
     p.add_argument("--tuning-scope", default="quick", choices=["quick", "full"])
     p.add_argument("--tuning-reps", type=int, default=3)
     # Smoke-test / bisect aid: stop after N candidates (0 = sweep all).
@@ -258,7 +264,15 @@ def _parse_args(argv):
     p.add_argument("--no-bench-tables", action="store_true")
     p.add_argument("--pre-barriers", type=int, default=1)
     p.add_argument("--pre-sleep-ms", type=float, default=0.0)
-    p.add_argument("--barrier-kind", default="cco", choices=["cco", "gloo", "both"])
+    # gloo by default to match the v1 harness, which uses dist.barrier() at this
+    # same boundary (examples/.../test_dispatch_combine_internode.py:1270) and
+    # nowhere uses mori.shmem's own barrier. Both kinds are host-side socket
+    # collectives, but they are not the same implementation or the same socket
+    # path -- measured exit skew differs (gloo 265-500us typical against cco
+    # 332-2760us) -- and a comparison should not carry that difference at the
+    # measurement boundary. Only THIS barrier changed; the comm.barrier() calls
+    # elsewhere are CCO collectives that may also order the symmetric window.
+    p.add_argument("--barrier-kind", default="gloo", choices=["cco", "gloo", "both"])
     # Re-align the ranks every N rounds. The slow regime is a stable inter-node
     # phase offset, and a rendezvous does not remove one -- this asks whether an
     # explicit re-alignment escapes the offset fixed point or whether the loop
@@ -665,13 +679,23 @@ def _bench(op, cfg, d, dev, a, comm):
             total_recv = int(r[4][0].item())
         op.combine(convert(r[0]), cw, routing=r[5])
     torch.cuda.synchronize()
-    comm.barrier()
 
-    # Barrier-skew probe. comm.barrier() is ccoBarrierAll, a CPU-side collective
-    # over the bootstrap sockets, and dist.barrier() is gloo -- same family, both
-    # tree/ring shaped, so neither releases its ranks at one instant. Timestamp
-    # after EACH of N barriers so the question "is the first one just ragged, or
-    # is every one ragged" has an answer instead of a guess.
+    # THE pre-loop barrier. One site, so the default cannot drift. (It briefly
+    # did: a probe loop with a max(1,..) sat below an unconditional barrier and
+    # silently made the default two.)
+    #
+    # v1 documents the transient this creates and reaches the same conclusion
+    # from the other side (see _EP_DROP_ROUNDS there): the first timed rounds
+    # run elevated, "worse and longer on the CCO/GDA path ... than on shmem",
+    # and it suggests MORI_EP_DROP_ROUNDS=3 to cover it. Its stated mechanism --
+    # all ranks released at once, thundering herd -- does not survive
+    # measurement here: the exit skew is 200-800us, i.e. 2-9 rounds, so they are
+    # NOT released at once, and the skew does not correlate with the run's
+    # outcome. The transient is real; that account of it is not.
+    #
+    # Both kinds are CPU-side collectives over sockets -- comm.barrier() is
+    # ccoBarrierAll, dist.barrier() is gloo -- so neither releases its ranks at
+    # one instant, and the timestamp after each is what measures that.
     _bt = []
     for _k in range(max(1, a.pre_barriers)):
         if a.barrier_kind in ("cco", "both"):
@@ -1431,7 +1455,9 @@ def main(argv):
             world_size=npes,
             hidden_dim=a.hidden_dim,
             max_num_inp_token_per_rank=M,
-            num_experts_per_rank=a.experts_per_rank,
+            num_experts_per_rank=(
+                a.experts_per_rank if a.experts_per_rank else 256 // npes
+            ),
             num_experts_per_token=a.topk,
             data_type=dtype if combine_dtype is None else torch.bfloat16,
             dispatch_data_type=dtype if combine_dtype is not None else None,

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -260,6 +260,8 @@ def _parse_args(argv):
     # independent paired test against the thing it would replace, which is both
     # what we want to know and reproducible across repeats.
     p.add_argument("--tuning-greedy", action="store_true")
+    # Workers to spawn per node (0 = off: one torchrun process per rank).
+    p.add_argument("--spawn", type=int, default=0)
     # How much better a candidate must be, on the paired difference, to take
     # over. Whichever of the two is larger. Not 0: see the note in _tune.
     p.add_argument("--tuning-margin-us", type=float, default=1.5)
@@ -1030,8 +1032,47 @@ def _tune(cfg, d, dev, a, comm):
     return 0
 
 
+def _spawn_entry(local_rank, argv, node_rank, nnodes, per_node):
+    """One spawned worker. Rewrites the rank env, then re-enters main().
+
+    torchrun gives ONE process per node here (RANK = node rank, WORLD_SIZE =
+    node count), and the workers are children of it -- the shape the examples
+    harness uses. Everything downstream reads its identity from the environment,
+    so setting it here is the whole adaptation; no call site changes.
+
+    LOCAL_WORLD_SIZE has to be rewritten too. torchrun sets it to 1 under
+    --nproc_per_node=1, and main() derives gpu_per_node from it, which decides
+    the node grouping the internode path is gated on.
+    """
+    os.environ["_MORI_EP_SPAWN_CHILD"] = "1"
+    os.environ["RANK"] = str(node_rank * per_node + local_rank)
+    os.environ["LOCAL_RANK"] = str(local_rank)
+    os.environ["WORLD_SIZE"] = str(nnodes * per_node)
+    os.environ["LOCAL_WORLD_SIZE"] = str(per_node)
+    rc = main(argv)
+    if rc:
+        raise SystemExit(rc)
+
+
 def main(argv):
     a = _parse_args(argv)
+
+    # --spawn N reproduces the examples harness's process topology: one torchrun
+    # process per node that spawns N workers, instead of N torchrun processes.
+    # Same kernels, same bench, different process tree -- which is worth being
+    # able to switch because host time on this path converts to measured "kernel"
+    # time about 1:1, so how the ranks are parented is not obviously neutral.
+    if a.spawn and not os.environ.get("_MORI_EP_SPAWN_CHILD"):
+        node_rank = int(os.environ["RANK"])
+        nnodes = int(os.environ["WORLD_SIZE"])
+        torch.multiprocessing.spawn(
+            _spawn_entry,
+            args=(argv, node_rank, nnodes, a.spawn),
+            nprocs=a.spawn,
+            join=True,
+        )
+        return 0
+
     d = Dist()
     rank, npes = d.rank, d.world
     dev = torch.device("cuda", d.local_rank)

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -212,7 +212,7 @@ class Dist:
 
 def _parse_args(argv):
     p = argparse.ArgumentParser(description="v2 internode dispatch/combine test")
-    p.add_argument("--cmd", default="test", choices=["test", "bench"])
+    p.add_argument("--cmd", default="test", choices=["test", "bench", "tuning"])
     p.add_argument("--max-tokens", type=int, default=128)
     p.add_argument("--hidden-dim", type=int, default=7168)
     p.add_argument("--topk", type=int, default=8)
@@ -231,6 +231,20 @@ def _parse_args(argv):
     # against a 29-round mean. Not a small-sample caveat: a different estimator.
     p.add_argument("--rounds", type=int, default=30)
     p.add_argument("--scale-dim", type=int, default=0)
+    p.add_argument("--tuning-scope", default="quick", choices=["quick", "full"])
+    p.add_argument("--tuning-reps", type=int, default=3)
+    # Smoke-test / bisect aid: stop after N candidates (0 = sweep all).
+    p.add_argument("--tuning-limit", type=int, default=0)
+    p.add_argument("--tuning-phase", default="dispatch", choices=["dispatch", "combine"])
+    # Validation mode: sweep exactly one named candidate against the shipped
+    # geometry. A sweep winner is chosen by a greedy chain of paired tests, each
+    # with its own error; before it is written into the table it gets one long
+    # head-to-head against what it would replace.
+    p.add_argument("--tuning-candidate", default=None)
+    # How much better a candidate must be, on the paired difference, to take
+    # over. Whichever of the two is larger. Not 0: see the note in _tune.
+    p.add_argument("--tuning-margin-us", type=float, default=1.5)
+    p.add_argument("--tuning-margin-frac", type=float, default=0.02)
     # The v1 bench calls combine with weights=None, so it does not pay for the
     # weight fold: an extra peer read per (token, destination) plus an accumulate
     # in three kernels, and a wider staging slot (combXferBytes = hidden + weights).
@@ -772,6 +786,199 @@ def _bench(op, cfg, d, dev, a, comm):
     return 0
 
 
+
+def _timed_pass(op, cfg, d, a, inp, idx, wts, sc, cw, convert, n, warm):
+    """One warmup+timed block; returns (dispatch_us, combine_us) as grand means
+    over rounds x ranks -- the same statistic _bench and run_bench_once report."""
+    ev = [torch.cuda.Event(enable_timing=True) for _ in range(3 * n + 1)]
+    for _ in range(warm):
+        r = op.dispatch(inp, wts, sc, idx, return_routing=True)
+        op.combine(convert(r[0]), cw, routing=r[5])
+    torch.cuda.synchronize()
+    ev[0].record()
+    for i in range(n):
+        r = op.dispatch(inp, wts, sc, idx, return_routing=True)
+        ev[3 * i + 1].record()
+        x = convert(r[0])
+        ev[3 * i + 2].record()
+        op.combine(x, cw, routing=r[5])
+        ev[3 * i + 3].record()
+    torch.cuda.synchronize()
+    keep = slice(a.drop_rounds, None)
+    dv = [ev[3 * i].elapsed_time(ev[3 * i + 1]) * 1e3 for i in range(n)][keep]
+    cv = [ev[3 * i + 2].elapsed_time(ev[3 * i + 3]) * 1e3 for i in range(n)][keep]
+    gm = lambda v: d.allreduce_sum(int(sum(v) / len(v) * 1000)) / d.world / 1000
+    return gm(dv), gm(cv)
+
+
+def _build_op(cfg, comm, dgeom, cgeom):
+    """An op whose dispatch plans are compiled for `dgeom` and its combine plans
+    for `cgeom`. Goes through the MORI_EP_*_GEOM hook the backend already exposes
+    for sweeps: a geometry is a compile-time identity there, read once at build
+    time, so it cannot be selected per launch the way v1's can.
+
+    The two are SEPARATE because the shipped table gives them separate values
+    (tokens 4: dispatch 64/32/8, combine 32/21/6). Driving both from one geometry
+    means the sweep's incumbent is not the configuration actually shipped, so
+    "beats the incumbent" would not mean "beats what we ship".
+    """
+    old = (os.environ.get("MORI_EP_DISP_GEOM"), os.environ.get("MORI_EP_COMB_GEOM"))
+    os.environ["MORI_EP_DISP_GEOM"] = "%d,%d,%d" % dgeom
+    os.environ["MORI_EP_COMB_GEOM"] = "%d,%d,%d" % cgeom
+    try:
+        return EpDispatchCombineOp(cfg, comm)
+    finally:
+        for k, v in zip(("MORI_EP_DISP_GEOM", "MORI_EP_COMB_GEOM"), old):
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def _tune(cfg, d, dev, a, comm):
+    """Sweep launch geometries and report the winner for this token count.
+
+    Structured after tuning_dispatch_combine in the examples harness -- same
+    candidate construction (block doubling plus 8/16, warp list, rdma as a
+    fraction of block), same selection metric (grand-mean latency) -- with ONE
+    deliberate difference, which the numbers force.
+
+    That harness measures each candidate once and compares the means. It can:
+    its transport's max/mean is 1.19 and its run-to-run spread is a few percent.
+    Ours is not: the same geometry measured back to back has produced 86us and
+    137us total, and a straight sweep here already "found" 64,32,4 beating the
+    shipped 64,32,8 by 5% on the mean and 30% on the worst -- which vanished
+    entirely when the two were run alternately, four pairs. A one-shot sweep on
+    this path selects noise and writes it into the table as if it were tuning.
+
+    So the incumbent stays LIVE and every candidate is measured against it
+    alternately, `reps` times each, comparing medians. Two ops hold symmetric
+    windows at once; the loser is closed immediately. Drift, whatever its cause,
+    then applies to both arms of every comparison instead of to whichever
+    candidate happened to run during it.
+    """
+    sm = torch.cuda.get_device_properties(dev).multi_processor_count
+    blocks = {b for b in (8, 16) if b < sm}
+    p = 32
+    while p <= sm:
+        blocks.add(p)
+        p <<= 1
+    blocks.add(sm)
+    warps = [4, 8, 16] if a.tuning_scope == "quick" else [4, 6, 8, 12, 16]
+
+    def rdmas(bn):
+        frac = (bn // 2, bn * 2 // 3) if a.tuning_scope == "quick" else (bn // 4, bn // 2, bn * 2 // 3)
+        return sorted({v for v in frac if 1 <= v < bn})
+
+    cands = [(b, r, w) for b in sorted(blocks) for w in warps for r in rdmas(b)]
+    if a.tuning_candidate:
+        cands = [tuple(int(x) for x in a.tuning_candidate.split(","))]
+    elif a.tuning_limit:
+        cands = cands[: a.tuning_limit]
+
+    from mori.ops.dispatch_combine_v2.internode_tuning_configs import lookup
+
+    tbl = lookup(cfg.world_size, cfg.hidden_dim, cfg.num_experts_per_token, a.max_tokens)
+    # The incumbent is the SHIPPED pair, so a win means "better than what we ship".
+    inc_d = tuple(tbl["dispatch"]) if tbl else cands[0]
+    inc_c = tuple(tbl["combine"]) if tbl else cands[0]
+    phase = a.tuning_phase
+    start = inc_d if phase == "dispatch" else inc_c
+    if start in cands:
+        cands.remove(start)
+
+    if d.rank == 0:
+        print(
+            f"# TUNING tok={a.max_tokens} phase={phase} scope={a.tuning_scope} "
+            f"reps={a.tuning_reps} sm={sm} candidates={len(cands)} "
+            f"shipped dispatch={inc_d} combine={inc_c}",
+            flush=True,
+        )
+
+    rng = torch.Generator(device=dev)
+    rng.manual_seed(4242 + d.rank)
+    inp, idx, wts, sc = _gen_round(rng, cfg, a.max_tokens, dev, cfg.dispatch_dtype)
+    convert = (lambda x: x.to(cfg.combine_dtype)) if cfg.is_asymmetric_dtype else (lambda x: x)
+    cw = wts if a.bench_weights else None
+
+    # Only the swept phase varies; the other stays at the shipped value, because
+    # the two are coupled (a dispatch with too few rdma blocks leaves the combine
+    # after it slower) and a per-phase argmin measured against a DIFFERENT other
+    # phase does not carry over.
+    geoms = lambda g: ((g, inc_c) if phase == "dispatch" else (inc_d, g))
+    pick = (lambda dv, cv: dv) if phase == "dispatch" else (lambda dv, cv: cv)
+
+    best_op = _build_op(cfg, comm, *geoms(start))
+    if a.kernel_type is not None:
+        best_op._internode_force_ll = a.kernel_type == "v1_ll"
+    comm.barrier()
+    best = start
+    best_med = None
+
+    for k, cand in enumerate(cands):
+        try:
+            cand_op = _build_op(cfg, comm, *geoms(cand))
+        except Exception as exc:  # a geometry the backend rejects is not a failure
+            if d.rank == 0:
+                print(f"#   [{k + 1}/{len(cands)}] {cand} rejected: {exc}", flush=True)
+            continue
+        if a.kernel_type is not None:
+            cand_op._internode_force_ll = a.kernel_type == "v1_ll"
+        comm.barrier()
+
+        bt, ct_ = [], []
+        for _ in range(a.tuning_reps):
+            dv, cv = _timed_pass(best_op, cfg, d, a, inp, idx, wts, sc, cw, convert, a.rounds, a.warmup)
+            bt.append(pick(dv, cv))
+            dv, cv = _timed_pass(cand_op, cfg, d, a, inp, idx, wts, sc, cw, convert, a.rounds, a.warmup)
+            ct_.append(pick(dv, cv))
+        bm, cm = sorted(bt)[len(bt) // 2], sorted(ct_)[len(ct_) // 2]
+        # PAIRED comparison, not a difference of medians. The two arms are
+        # measured alternately inside one rep, so both see the same regime -- and
+        # the regime moves a lot during a sweep: the SAME incumbent geometry has
+        # read 84.9us on one candidate and 126.0us on the next. Differencing
+        # within a rep cancels that; differencing the medians does not, and the
+        # first version of this promoted three candidates on gaps under 1us
+        # (125.7 vs 126.0) that were pure regime noise being written into the
+        # table as if they were tuning results.
+        #
+        # The margin is then a floor on how big the paired improvement has to be.
+        # v1's equivalent (MORI_EP_TUNING_MARGIN) defaults to 0 -- any improvement
+        # wins -- which is safe at its 1.19x max/mean and is not safe here.
+        diffs = sorted(c - b_ for b_, c in zip(bt, ct_))
+        lo, hi = diffs[0], diffs[-1]
+        dmed = diffs[len(diffs) // 2]
+        win = dmed < -max(a.tuning_margin_us, bm * a.tuning_margin_frac)
+        if d.rank == 0:
+            print(
+                f"#   [{k + 1}/{len(cands)}] {cand} med={cm:6.1f}us vs "
+                f"incumbent {best} med={bm:6.1f}us  paired={dmed:+6.1f}us "
+                f"[{lo:+.1f},{hi:+.1f}]  {'WIN' if win else '--'}",
+                flush=True,
+            )
+        if win:
+            best_op.close()
+            best_op, best, best_med = cand_op, cand, cm
+        else:
+            cand_op.close()
+            best_med = bm
+        comm.barrier()
+
+    best_op.close()
+    if d.rank == 0:
+        d_out = best if phase == "dispatch" else inc_d
+        c_out = best if phase == "combine" else inc_c
+        print(
+            f"# TUNING RESULT tok={a.max_tokens} phase={phase}: "
+            f"block/rdma/warp={best} median {phase}={best_med:.1f}us "
+            f"(shipped was {start})\n"
+            f"#   table row: ({a.max_tokens}, {d_out[0]}, {d_out[1]}, {d_out[2]}, "
+            f"{c_out[0]}, {c_out[1]}, {c_out[2]}),",
+            flush=True,
+        )
+    return 0
+
+
 def main(argv):
     a = _parse_args(argv)
     d = Dist()
@@ -821,6 +1028,14 @@ def main(argv):
         if a.cmd == "bench":
             rc = _bench(op, cfg, d, dev, a, comm)
             op.close()
+            d.shutdown()
+            return rc
+
+        if a.cmd == "tuning":
+            # The sweep builds its own ops, one per candidate geometry; this one
+            # only proved the config is constructible.
+            op.close()
+            rc = _tune(cfg, d, dev, a, comm)
             d.shutdown()
             return rc
 

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -174,14 +174,10 @@ def _parse_args(argv):
     p.add_argument("--combine-dtype", default=None, choices=list(_DTYPES))
     p.add_argument("--quant-type", default="none", choices=["none", "fp8_direct_cast"])
     p.add_argument("--num-qp", type=int, default=2)
-    # 30, matching _EP_ROUNDS in the examples harness -- and for the reason its
-    # comment gives, which applies here with full force: the CCO/GDA path reaches
-    # steady state slowly, so at 10 rounds its per-round jitter does not average
-    # out and the mean swings ~20% run to run. This defaulted to 3 while claiming
-    # alignment, which with --drop-rounds 1 keeps rounds 1 and 2 -- precisely the
-    # two that harness documents as still elevated. A single spike then carries
-    # half the average AND is the reported worst, so this side read a wide tail
-    # against a 29-round mean. Not a small-sample caveat: a different estimator.
+    # 30, matching _EP_ROUNDS in the examples harness. Lower is not a
+    # small-sample caveat but a different estimator: at --rounds 3 with
+    # --drop-rounds 1 the two kept rounds are the ones that harness documents as
+    # still in the CCO ramp, so one spike carries half the mean AND is the worst.
     p.add_argument("--rounds", type=int, default=30)
     p.add_argument("--scale-dim", type=int, default=0)
     p.add_argument("--tuning-scope", default="quick", choices=["quick", "full"])
@@ -349,14 +345,10 @@ def _v1_loop_defaults():
         key = names.get(getattr(tgt, "id", None))
         if key is None:
             continue
-        # `int(os.environ.get("MORI_EP_ROUNDS") or "30")` -- the default is the
-        # only digit-string literal in the expression.
-        #
-        # Accept both spellings of a string literal. Python >= 3.8 gives
-        # ast.Constant; 3.6/3.7 give ast.Str, and the host python here is 3.6
-        # while the container's is 3.12. Matching only Constant makes this
-        # silently return {} on the older one -- which would disable the very
-        # check whose absence caused the problem it exists to catch.
+        # The default is the only digit-string literal in the expression. Accept
+        # both spellings: 3.8+ gives ast.Constant, 3.6/3.7 ast.Str, and matching
+        # only Constant silently returns {} on the older one -- disabling the
+        # very check whose absence caused the problem it exists to catch.
         for sub in ast.walk(node.value):
             lit = None
             if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
@@ -421,12 +413,9 @@ def _bench(op, cfg, d, dev, a, comm):
     if a.kernel_type is not None:
         op._internode_force_ll = a.kernel_type == "v1_ll"
 
-    # Check BEFORE measuring, as bench_dispatch_combine does (it runs
-    # run_test_once and asserts before run_bench_once). A configuration that is
-    # silently wrong still produces timings, and this harness has shipped two of
-    # those -- the weight fold reading the wrong buffer, and both legs compiled
-    # with the dispatch dtype. One round, folding weights whatever --bench-weights
-    # says, because the point is to check them.
+    # Check BEFORE measuring, as bench_dispatch_combine does: a silently wrong
+    # configuration still produces timings. Always folds weights, whatever
+    # --bench-weights says, because the point is to check them.
     ok = _verify_once(op, cfg, d, dev, a, comm, inp, idx, wts, sc)
     bad = d.allreduce_sum(0 if ok else 1)
     if bad:
@@ -459,15 +448,10 @@ def _bench(op, cfg, d, dev, a, comm):
     torch.cuda.synchronize()
     comm.barrier()
 
-    # Causal test for "is the host pacing the GPU", opt-in. Busy-waits a known
-    # number of microseconds on the HOST between the convert-end event and the
-    # combine enqueue -- pure host time, no GPU work, no extra kernel. If the
-    # host is running ahead of the GPU, the GPU still has queued work to chew on
-    # and the measured combine barely moves. If the GPU is already waiting on the
-    # host, the injected delay is added GPU idle inside the combine window and
-    # the measured combine rises by about the injected amount. The slope of
-    # measured-combine against injected microseconds is the answer, and it needs
-    # no assumption about what any window "should" cost.
+    # Causal probe for host pacing, opt-in: busy-wait known host microseconds
+    # before the combine enqueue, no GPU work. The slope of measured-combine
+    # against injected microseconds is the answer (measured ~1.0 beyond ~30us of
+    # headroom), and it assumes nothing about what a window "should" cost.
     inject = float(os.environ.get("MORI_EP_INJECT_HOST_US") or 0) / 1e6
 
     # Per-pass marks accumulate inside the backend when MORI_EP_SPLIT_PASSES is
@@ -582,37 +566,18 @@ def _bench(op, cfg, d, dev, a, comm):
     keep = slice(a.drop_rounds, None)
     disp = [ev[3 * i].elapsed_time(ev[3 * i + 1]) * 1e3 for i in range(n)][keep]
     comb = [ev[3 * i + 2].elapsed_time(ev[3 * i + 3]) * 1e3 for i in range(n)][keep]
-    # The third window, which neither harness reports and which is the honest
-    # host-gap meter.
-    #
-    # The events TILE the timed region: ev[3i+3] ends round i's combine and IS
-    # ev[3(i+1)], the start of round i+1's dispatch window. There is no gap
-    # between windows for host time to hide in -- every microsecond between
-    # ev[0] and ev[3n] is inside exactly one of the three. So if the host falls
-    # behind, the GPU idles at the head of whichever segment it is waiting for
-    # and that idle is charged to that window as if it were kernel time.
-    #
-    # This window contains ONE cast. Its kernel cost is a few microseconds at
-    # these token counts and does not grow with anything we tune, so whatever it
-    # reads above that is GPU idle waiting for the host -- which makes it a
-    # measure of host lag that does not require trusting `wall`. (`wall` cannot
-    # show this: wall - (dispatch + combine) is this window BY CONSTRUCTION, so
-    # quoting that difference as evidence of host pacing assumes the conclusion.)
+    # The events TILE the timed region -- ev[3i+3] ends round i's combine and IS
+    # ev[3(i+1)] -- so host time cannot hide between windows: if the host falls
+    # behind, the GPU idles at the head of a segment and that idle is charged to
+    # it as kernel time. This window holds one cast, whose cost is small and
+    # fixed, so what it reads above that is host lag. (wall - (dispatch+combine)
+    # IS this window by construction, so it cannot be used as evidence instead.)
     conv = [ev[3 * i + 1].elapsed_time(ev[3 * i + 2]) * 1e3 for i in range(n)][keep]
 
-    # Which round stalled, opt-in. EVERY rank prints its own series, because the
-    # question the averages cannot answer is whether a spike lands on the same
-    # round index across ranks or on one rank alone:
-    #   same round, all ranks   -> a whole-round event; every rank waits for the
-    #                              same thing, so the cause is host-side (a launch
-    #                              that took longer to build, an allocation, GC)
-    #                              or a fabric stall that stops everyone.
-    #   one rank, one round     -> a straggler; the others are only showing the
-    #                              spin-wait for it. Chasing the peak on the ranks
-    #                              that merely waited leads nowhere.
-    # These are collective kernels, so a single slow rank prints as a slow round
-    # on all of them -- which is why the RANK-LOCAL series is what separates the
-    # two, and rank 0's alone cannot.
+    # Which round stalled, opt-in. EVERY rank prints its own series: these are
+    # spin-wait collectives, so one slow rank shows as a slow round on all of
+    # them and only the rank-local series separates a straggler from a
+    # whole-round event. See docs/EP_INTERNODE_V2_TAIL.md for how to read it.
     if os.environ.get("MORI_EP_ROUND_SERIES"):
         print(
             "# rounds r%d disp: " % d.rank + " ".join("%.0f" % x for x in disp),
@@ -809,18 +774,11 @@ def _tune(cfg, d, dev, a, comm):
             ct_.append(pick(dv, cv))
             cph.append((dv, cv))
         bm, cm = sorted(bt)[len(bt) // 2], sorted(ct_)[len(ct_) // 2]
-        # PAIRED comparison, not a difference of medians. The two arms are
-        # measured alternately inside one rep, so both see the same regime -- and
-        # the regime moves a lot during a sweep: the SAME incumbent geometry has
-        # read 84.9us on one candidate and 126.0us on the next. Differencing
-        # within a rep cancels that; differencing the medians does not, and the
-        # first version of this promoted three candidates on gaps under 1us
-        # (125.7 vs 126.0) that were pure regime noise being written into the
-        # table as if they were tuning results.
-        #
-        # The margin is then a floor on how big the paired improvement has to be.
-        # v1's equivalent (MORI_EP_TUNING_MARGIN) defaults to 0 -- any improvement
-        # wins -- which is safe at its 1.19x max/mean and is not safe here.
+        # PAIRED, not a difference of medians: the regime moves during a sweep
+        # (the same incumbent geometry has read 84.9us on one candidate and
+        # 126.0us on the next), and differencing within a rep cancels that. The
+        # margin then floors the improvement; v1's equivalent defaults to 0,
+        # which is safe at its 1.19x max/mean and not here.
         diffs = sorted(c - b_ for b_, c in zip(bt, ct_))
         lo, hi = diffs[0], diffs[-1]
         dmed = diffs[len(diffs) // 2]

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -43,6 +43,33 @@ without a QP.
 
 ``tools/run_internode_test.sh`` drives both ranks; the CLI below is the subset of
 the shmem harness's flags that means anything here.
+
+COMPARING AGAINST THE v1 BENCH
+------------------------------
+The reference numbers come from ``run_bench_once`` in
+``examples/ops/dispatch_combine/test_dispatch_combine_internode.py``, driven
+through v1's op. The timed loop here is structured the same way and reports the
+same three statistics, but the two harnesses do NOT build the same shape by
+default. Every difference found by reading both, and what to pass to close it:
+
+  what                     v1 bench          here (default)     to align
+  ----------------------   ---------------   ----------------   ------------------
+  combine weights          None (no fold)    None               (aligned)
+  num_experts_per_rank     256 // world      --experts-per-rank --experts-per-rank 16
+                                             = 32               at world 16
+  scale_dim                32                --scale-dim = 0    --scale-dim 32
+  scale_type_size          4                 4 when scale_dim   (aligned)
+  warmup / rounds / drop   20 / 30 / 1       same               (aligned)
+  routing                  randperm[:topk]   same               (aligned)
+  tokens per rank          max on every rank same               (aligned)
+  statistic                avg over          same               (aligned)
+                           rounds x ranks
+
+The two that move real work: the weight fold costs an extra peer read per
+(token, destination) plus an accumulate in three kernels and a wider staging slot,
+and v1's scale_dim=32 makes ITS dispatch carry 128 more bytes per token than a
+--scale-dim 0 run here. They push in opposite directions, so a comparison that
+leaves both unaligned is not bounded in either direction.
 """
 
 import argparse
@@ -117,6 +144,13 @@ def _parse_args(argv):
     p.add_argument("--num-qp", type=int, default=2)
     p.add_argument("--rounds", type=int, default=3)
     p.add_argument("--scale-dim", type=int, default=0)
+    # The v1 bench calls combine with weights=None, so it does not pay for the
+    # weight fold: an extra peer read per (token, destination) plus an accumulate
+    # in three kernels, and a wider staging slot (combXferBytes = hidden + weights).
+    # Off by default so a reading here is comparable to one from that harness;
+    # --bench-weights measures the fold when that is what you want. The
+    # correctness path always folds -- it is checking the weights.
+    p.add_argument("--bench-weights", action="store_true")
     p.add_argument("--warmup", type=int, default=20)
     p.add_argument("--drop-rounds", type=int, default=1)
     # Diagnostic, matching _EP_PERROUND_SYNC in the examples harness. Re-aligns
@@ -188,9 +222,11 @@ def _bench(op, cfg, d, dev, a, comm):
     def convert(x):
         return x.to(cfg.combine_dtype) if cfg.is_asymmetric_dtype else x
 
+    cw = wts if a.bench_weights else None
+
     for _ in range(a.warmup):
         r = op.dispatch(inp, wts, None, idx, return_routing=True)
-        op.combine(convert(r[0]), wts, routing=r[5])
+        op.combine(convert(r[0]), cw, routing=r[5])
     torch.cuda.synchronize()
     comm.barrier()
 
@@ -203,7 +239,7 @@ def _bench(op, cfg, d, dev, a, comm):
         ev[3 * i + 1].record()
         x = convert(r[0])
         ev[3 * i + 2].record()
-        op.combine(x, wts, routing=r[5])
+        op.combine(x, cw, routing=r[5])
         ev[3 * i + 3].record()
         if a.per_round_sync:
             torch.cuda.synchronize()
@@ -228,7 +264,7 @@ def _bench(op, cfg, d, dev, a, comm):
         pr.enable()
         for _ in range(n):
             rp = op.dispatch(inp, wts, None, idx, return_routing=True)
-            op.combine(convert(rp[0]), wts, routing=rp[5])
+            op.combine(convert(rp[0]), cw, routing=rp[5])
         pr.disable()
         torch.cuda.synchronize()
         comm.barrier()
@@ -311,7 +347,7 @@ def main(argv):
             dispatch_data_type=dtype if combine_dtype is not None else None,
             combine_data_type=combine_dtype,
             scale_dim=a.scale_dim,
-            scale_type_size=1 if a.scale_dim else 0,
+            scale_type_size=4 if a.scale_dim else 0,
             quant_type=a.quant_type,
             gpu_per_node=gpu_per_node,
             num_qp_per_pe=a.num_qp,

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -44,6 +44,35 @@ without a QP.
 ``tools/run_internode_test.sh`` drives both ranks; the CLI below is the subset of
 the shmem harness's flags that means anything here.
 
+CCO's TAIL IS NOT THE FABRIC'S: WHAT SHMEM DOES ON THE SAME WIRE
+----------------------------------------------------------------
+Run the v1 harness in the same session for a reference. It drives the shmem/IBGDA
+transport over the SAME NICs, rails, switch and QoS, at the same shape, so it
+isolates what is specific to the CCO path. Note it spawns its own 8 workers per
+node, so it takes --nproc_per_node=1, not 8:
+
+    GPU_PER_NODE=8 MORI_EP_LAUNCH_CONFIG_MODE=AUTO MORI_RDMA_TC=160 MORI_RDMA_SL=5 \\
+    torchrun --nnodes=2 --node_rank=N --nproc_per_node=1 --master_addr=... \\
+      examples/ops/dispatch_combine/test_dispatch_combine_internode.py \\
+      --cmd bench --kernel-type v1_ll --num-qp 1 --max-tokens 4 \\
+      --hidden-dim 6144 --dtype fp8_e4m3_fnuz --combine-dtype bf16 --quant-type none
+
+Measured, 29 kept rounds x 16 ranks = 464 samples per phase:
+
+                       shmem/IBGDA          CCO/GDA (here)
+    dispatch mean         47.4us              40-47us
+    combine  mean         59.1us              46-52us
+    max/mean              1.19x / 1.18x       2-6x
+    rounds >1.8x base     0 of 29             11 of ~260
+    cross-rank spread     median 9-13us       up to 207us (34 -> 241)
+
+Two things follow. CCO is FASTER in the mean -- combine by ~20% -- so the port is
+not simply worse. And the tail belongs to the CCO path, not to the fabric: shmem
+shares every wire and shows no spiked round at all, which rules out the rail and
+switch explanations that the {i, i+8} pattern below otherwise suggests.
+
+Both harnesses do have a huge round 0 (shmem's spans 83-614us) and both drop 1.
+
 READING THE PER-RANK SERIES (MORI_EP_ROUND_SERIES)
 --------------------------------------------------
 Every rank prints its own per-round series. These are spin-wait collectives, so

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -564,6 +564,22 @@ def _bench(op, cfg, d, dev, a, comm):
                 flush=True,
             )
             print(f"{pfx} rounds: " + " ".join(f"{t:.0f}" for t in totals), flush=True)
+            # STEP attribution. A run that lands in the slow regime does a few
+            # rounds at the fast level, steps over one round, and holds -- so the
+            # question "which pass owns the step" is answered by the first rounds
+            # against the last, and is a different question from "which pass owns
+            # the worst round". Both are printed because they need not have the
+            # same answer: a step in a pass that only does local work would mean
+            # something quite different from a step in the pass that waits.
+            k = max(3, len(rounds) // 12)
+            for nm_i, nm in enumerate(names):
+                e = sum(r[nm_i][1] for r in rounds[:k]) / k
+                l = sum(r[nm_i][1] for r in rounds[-k:]) / k
+                print(
+                    f"{pfx} step {nm:<20} first{k}={e:8.1f}  last{k}={l:8.1f}  "
+                    f"delta={l - e:+8.1f}",
+                    flush=True,
+                )
             # Top 3, not just the worst: one round can be an artifact, three
             # agreeing on the same pass is a mechanism.
             for wi in reversed(order[-3:]):

--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -831,7 +831,15 @@ def _timed_pass(op, cfg, d, a, inp, idx, wts, sc, cw, convert, n, warm):
     dv = [ev[3 * i].elapsed_time(ev[3 * i + 1]) * 1e3 for i in range(n)][keep]
     cv = [ev[3 * i + 2].elapsed_time(ev[3 * i + 3]) * 1e3 for i in range(n)][keep]
     gm = lambda v: d.allreduce_sum(int(sum(v) / len(v) * 1000)) / d.world / 1000
-    return gm(dv), gm(cv)
+    # The worst ROUND, across ranks, alongside the grand means. Without it a
+    # sweep cannot see the failure mode that matters here: a geometry whose
+    # median round is identical but which spikes to 4-5x on one round in thirty.
+    # A pass mean hides that (160us over 30 rounds moves the mean by 4us, inside
+    # the noise) and a median over paired passes discards it entirely -- which is
+    # exactly how (32,12,6) won the 8-token sweep and then lost the bench.
+    _, wd = d.allreduce_minmax(0, int(max(dv) * 1000))
+    _, wc = d.allreduce_minmax(0, int(max(cv) * 1000))
+    return gm(dv), gm(cv), wd / 1000, wc / 1000
 
 
 def _build_op(cfg, comm, dgeom, cgeom):
@@ -984,23 +992,31 @@ def _tune(cfg, d, dev, a, comm):
 
         bt, ct_ = [], []
         bph, cph = [], []  # (dispatch, combine) per rep, to show the coupling
+        bw, cw_ = [], []  # worst ROUND per pass, per arm
         for _ in range(a.tuning_reps):
-            dv, cv = _timed_pass(
+            dv, cv, wd, wc = _timed_pass(
                 best_op, cfg, d, a, inp, idx, wts, sc, cw, convert, a.rounds, a.warmup
             )
             bt.append(pick(dv, cv))
             bph.append((dv, cv))
-            dv, cv = _timed_pass(
+            bw.append(pick(wd, wc))
+            dv, cv, wd, wc = _timed_pass(
                 cand_op, cfg, d, a, inp, idx, wts, sc, cw, convert, a.rounds, a.warmup
             )
             ct_.append(pick(dv, cv))
             cph.append((dv, cv))
+            cw_.append(pick(wd, wc))
         bm, cm = sorted(bt)[len(bt) // 2], sorted(ct_)[len(ct_) // 2]
         # Worst of the paired reps, as a tail proxy. _timed_pass returns a grand
         # mean, so this is run-to-run spread rather than a worst ROUND -- which is
         # the right thing here anyway, since the risk being guarded against is a
         # geometry that lands in a bad regime more often.
-        bmax, cmax = max(bt), max(ct_)
+        # MEDIAN of the per-pass worst ROUND, not the worst pass mean. The
+        # median across passes keeps one unlucky pass from vetoing a candidate,
+        # while the per-pass max is what makes a recurring single-round spike
+        # visible at all.
+        bmax = sorted(bw)[len(bw) // 2]
+        cmax = sorted(cw_)[len(cw_) // 2]
         # PAIRED, not a difference of medians: the regime moves during a sweep
         # (the same incumbent geometry has read 84.9us on one candidate and
         # 126.0us on the next), and differencing within a rep cancels that. The

--- a/tests/python/ops/dispatch_combine_v2/test_internode_regions.py
+++ b/tests/python/ops/dispatch_combine_v2/test_internode_regions.py
@@ -1,0 +1,145 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Invariants of the v2 internode arena layout.
+
+``internode_regions()`` is the whole of the op's symmetric memory: SymmArena bump
+-allocates exactly these regions and the kernel addresses them by name, so a
+missing name is an AttributeError at build time but a *wrong size* is silent
+corruption of whichever region follows.
+
+This used to compare the sizes against what v1's ``EpDispatchCombineHandle``
+allocated, via a pybind probe. Both are gone -- the v2 path no longer constructs a
+v1 handle, which was the point of the refactor -- so the oracle is gone with them.
+What is checked here instead are the properties that do not need a second
+implementation to state: the name contract with the backend, and the capacity
+bounds the kernel's own indexing arithmetic implies.
+
+Pure function of the config: no GPU, no process group, no op.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from mori.ops.dispatch_combine_v2.internode_regions import internode_regions
+
+# Every name `HipBackend._internode_arena_args` resolves, transcribed
+# independently. A rename on either side has to be made twice or this fails --
+# which is the only cheap guard left now that the v1 allocator is not around to
+# be compared against.
+_REQUIRED = {
+    "inter_dispatch_inp",
+    "inter_combine_inp",
+    "inter_staging",
+    "inter_dispatch_out",
+    "inter_combine_out",
+    "inter_dispatch_staging",
+    "inp_weights",
+    "dispatch_out_weights",
+    "combine_out_weights",
+    "out_indices",
+    "recv_token_num",
+    "node_recv_token_num",
+    "disp_tok_offset",
+    "disp_tok_id_to_src_tok_id",
+    "cross_device_barrier",
+    "inter_node_chunk_flag",
+}
+_OPTIONAL = {"out_scales"}
+
+
+def _cfg(**over):
+    base = dict(
+        world_size=16,
+        gpu_per_node=8,
+        hidden_dim=7168,
+        max_num_inp_token_per_rank=128,
+        num_experts_per_rank=32,
+        num_experts_per_token=8,
+        max_token_type_size=2,
+        scale_dim=32,
+        scale_type_size=4,
+        num_qp_per_pe=2,
+        max_total_recv_tokens=0,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+# Chosen to exercise the branches the formulas actually have: scales on/off, one
+# node vs many, and the max_total_recv_tokens clamp.
+_CASES = {
+    "base": _cfg(),
+    "single_node": _cfg(world_size=8, gpu_per_node=8),
+    "two_nodes_no_scale": _cfg(
+        world_size=8, gpu_per_node=4, scale_dim=0, scale_type_size=0, num_qp_per_pe=1
+    ),
+    "recv_cap_clamped": _cfg(max_total_recv_tokens=256, num_experts_per_token=4),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_CASES))
+def test_region_names_match_the_backend_contract(name):
+    cfg = _CASES[name]
+    got = {n for n, _ in internode_regions(cfg)}
+    assert _REQUIRED <= got, f"missing: {sorted(_REQUIRED - got)}"
+    assert (
+        got <= _REQUIRED | _OPTIONAL
+    ), f"unexpected: {sorted(got - _REQUIRED - _OPTIONAL)}"
+
+
+@pytest.mark.parametrize("name", sorted(_CASES))
+def test_no_duplicate_or_empty_regions(name):
+    regions = internode_regions(_CASES[name])
+    names = [n for n, _ in regions]
+    assert len(names) == len(set(names)), "SymmArena would silently keep only the last"
+    for n, sz in regions:
+        assert sz > 0, f"{n} is zero-sized; the arena hands out an aliasing pointer"
+
+
+@pytest.mark.parametrize("name", sorted(_CASES))
+def test_scales_absent_rather_than_zero_sized(name):
+    cfg = _CASES[name]
+    present = "out_scales" in dict(internode_regions(cfg))
+    assert present == bool(cfg.scale_dim * cfg.scale_type_size)
+
+
+@pytest.mark.parametrize("name", sorted(_CASES))
+def test_staging_holds_every_slot_the_kernel_indexes(name):
+    """The combine half of ``inter_staging`` starts at slot ``nNodes * m`` and
+    runs to ``2 * nNodes * m`` (``SendBufSlotOffset(cfg, nNodes, 0)`` onward), at
+    a stride of ``combXferBytes = hidden + weights``. Dispatch uses the same
+    region at the larger ``xferBytes`` stride, so the region has to cover the
+    worse of the two."""
+    cfg = _CASES[name]
+    sizes = dict(internode_regions(cfg))
+    n_nodes = cfg.world_size // cfg.gpu_per_node
+    slots = 2 * n_nodes * cfg.max_num_inp_token_per_rank
+    comb_xfer = cfg.hidden_dim * cfg.max_token_type_size + cfg.num_experts_per_token * 4
+    assert sizes["inter_staging"] >= slots * comb_xfer
+
+
+def test_gpu_per_node_must_divide_the_world():
+    with pytest.raises(ValueError):
+        internode_regions(_cfg(world_size=16, gpu_per_node=6))

--- a/tools/run_internode_test.sh
+++ b/tools/run_internode_test.sh
@@ -3,10 +3,19 @@
 #
 # Usage:
 #   run_internode_test.sh --rank <0|1> --master-addr <ip> --ifname <nic> \
-#                         --cmd <bench|stress|test> --max-tokens <N> \
+#                         --cmd <bench|stress|test|test_sentinel> --max-tokens <N> \
 #                         [--master-port <port>] [--kernel-type <v1|v1_ll|async_ll>] \
 #                         [--num-qp <N>] [--quant-type <none|...>] [--dtype <bf16|...>] \
-#                         [--entry <path>]
+#                         [--combine-dtype <bf16|...>] [--hidden-dim <N>] [--topk <N>] \
+#                         [--max-recv-total-tokens <N>] [--sentinel-pattern <p>] \
+#                         [--nproc-per-node <N>] [--entry <path>]
+#
+# The optional shape/dtype flags are pass-throughs to the harness, which already
+# accepts all of them; they are listed here so the cross-node leg can cover the
+# same matrix the single-host pytest file does. Only --nproc-per-node is this
+# script's own: it was pinned at 1, which made every cross-node run EP2 and left
+# EP16 -- the shape that actually ships -- reachable only by hand-written
+# torchrun lines outside this script.
 #
 # --entry selects which driver torchrun runs, defaulting to the shmem AOT harness.
 # The v2 CCO entry takes the same CLI and differs only in installing the JIT
@@ -29,23 +38,33 @@ NUM_QP=2
 MAX_TOKENS=""
 QUANT_TYPE=""
 DTYPE=""
+COMBINE_DTYPE=""
 TOPK=""
+HIDDEN_DIM=""
+MAX_RECV_TOTAL_TOKENS=""
+SENTINEL_PATTERN=""
+NPROC_PER_NODE=1
 ENTRY="examples/ops/dispatch_combine/test_dispatch_combine_internode.py"
 
 while [[ $# -gt 0 ]]; do
   case $1 in
-    --rank)         RANK="$2";         shift 2 ;;
-    --master-addr)  MASTER_ADDR="$2";  shift 2 ;;
-    --master-port)  MASTER_PORT="$2";  shift 2 ;;
-    --ifname)       IFNAME="$2";       shift 2 ;;
-    --cmd)          CMD="$2";          shift 2 ;;
-    --kernel-type)  KERNEL_TYPE="$2";  shift 2 ;;
-    --num-qp)       NUM_QP="$2";       shift 2 ;;
-    --max-tokens)   MAX_TOKENS="$2";   shift 2 ;;
-    --quant-type)   QUANT_TYPE="$2";   shift 2 ;;
-    --dtype)        DTYPE="$2";        shift 2 ;;
-    --topk)         TOPK="$2";         shift 2 ;;
-    --entry)        ENTRY="$2";        shift 2 ;;
+    --rank)             RANK="$2";                  shift 2 ;;
+    --master-addr)      MASTER_ADDR="$2";           shift 2 ;;
+    --master-port)      MASTER_PORT="$2";           shift 2 ;;
+    --ifname)           IFNAME="$2";                shift 2 ;;
+    --cmd)              CMD="$2";                   shift 2 ;;
+    --kernel-type)      KERNEL_TYPE="$2";           shift 2 ;;
+    --num-qp)           NUM_QP="$2";                shift 2 ;;
+    --max-tokens)       MAX_TOKENS="$2";            shift 2 ;;
+    --quant-type)       QUANT_TYPE="$2";            shift 2 ;;
+    --dtype)            DTYPE="$2";                 shift 2 ;;
+    --combine-dtype)    COMBINE_DTYPE="$2";         shift 2 ;;
+    --topk)             TOPK="$2";                  shift 2 ;;
+    --hidden-dim)       HIDDEN_DIM="$2";            shift 2 ;;
+    --max-recv-total-tokens) MAX_RECV_TOTAL_TOKENS="$2"; shift 2 ;;
+    --sentinel-pattern) SENTINEL_PATTERN="$2";      shift 2 ;;
+    --nproc-per-node)   NPROC_PER_NODE="$2";        shift 2 ;;
+    --entry)            ENTRY="$2";                 shift 2 ;;
     *) echo "Unknown option: $1"; exit 1 ;;
   esac
 done
@@ -69,14 +88,19 @@ cd "$REPO_ROOT"
 export PYTHONPATH="$REPO_ROOT${PYTHONPATH:+:$PYTHONPATH}"
 
 EXTRA_ARGS=()
-[[ -n "$QUANT_TYPE" ]] && EXTRA_ARGS+=(--quant-type "$QUANT_TYPE")
-[[ -n "$DTYPE" ]]       && EXTRA_ARGS+=(--dtype "$DTYPE")
-[[ -n "$TOPK" ]]        && EXTRA_ARGS+=(--topk "$TOPK")
+[[ -n "$QUANT_TYPE" ]]     && EXTRA_ARGS+=(--quant-type "$QUANT_TYPE")
+[[ -n "$DTYPE" ]]          && EXTRA_ARGS+=(--dtype "$DTYPE")
+[[ -n "$COMBINE_DTYPE" ]]  && EXTRA_ARGS+=(--combine-dtype "$COMBINE_DTYPE")
+[[ -n "$TOPK" ]]           && EXTRA_ARGS+=(--topk "$TOPK")
+[[ -n "$HIDDEN_DIM" ]]     && EXTRA_ARGS+=(--hidden-dim "$HIDDEN_DIM")
+[[ -n "$MAX_RECV_TOTAL_TOKENS" ]] \
+  && EXTRA_ARGS+=(--max-recv-total-tokens "$MAX_RECV_TOTAL_TOKENS")
+[[ -n "$SENTINEL_PATTERN" ]] && EXTRA_ARGS+=(--sentinel-pattern "$SENTINEL_PATTERN")
 
 exec timeout "${MORI_INTERNODE_TIMEOUT:-120}" torchrun \
   --nnodes=2 \
   --node_rank="$RANK" \
-  --nproc_per_node=1 \
+  --nproc_per_node="$NPROC_PER_NODE" \
   --master_addr="$MASTER_ADDR" \
   --master_port="$MASTER_PORT" \
   "$ENTRY" \


### PR DESCRIPTION
**Stacked on #625** — base is that PR's head branch (`dev/adpat_v1ops_to_cco_api`), not `main`.
Against #625's head this is 21 files / +4381 / −1413, which is the work up for review.
GitHub will retarget to `main` when #625 merges.

## What this does

The internode path reached its kernels through v1's op: v1 built the buffers and the arguments,
and a `_launch_multi` redirect handed them to the v2 CCO kernels. That works, but the v2 op does
not own its internode path — buffer layout, geometry table and launch sequence all live on the
other side, and every v2 change has to be mirrored there.

This makes the path **v2-native**. No v1 op, no v1 buffers, no redirect. Coupling to v1 is zero.

The kernels themselves are shared with v1 and are **not rewritten here**.

## What replaces what

| | |
|---|---|
| **SymmArena** | One registered CCO window carved into 17 named, 256B-aligned regions (`internode_regions.py`), instead of separately registered symmetric buffers. Region offsets are bound once on the plans; the launch path carries six arguments, not the whole schema. |
| **`ccoDevComm`** | Passed **by value** inside the argument struct. mori-shmem needed a device global filled by the host after every `hipModuleLoad`; this is the point of the CCO port. |
| **Geometry** | Compiled per `(block, rdma, warp)` and resolved from a per-device table at launch. `rdma_block_num` splits the grid between network and intra-node blocks and the kernel branches on it, so it cannot be chosen per launch — every bucket the table can name is built at construction. That is also why a geometry can never trigger a compile inside a timed region. |
| **`LaunchGroup`** | One ABI crossing per phase for the two- and four-kernel pass sequences, rather than one per kernel. |

Two guards were added because CCO is not shmem: the local-node peer is skipped in the send loops
(shmem dispatches per peer on `transportTypes[pe]` and uses P2P for a same-node peer; ccoGda has
no such dispatch, and RAIL leaves a local peer without a QP), and the one foldable device assert
became a `static_assert`.

## ⚠️ Three changes outside EP's scope

Flagging these explicitly — a reviewer will not expect them in an EP PR.

- **`src/cco/cco_init.cpp` + `include/mori/application/utils/cpu_affinity.hpp`** —
  `ccoCommCreateImpl` now calls `BindCallingThreadToGpuNumaOnce()`, and that helper now gives each
  rank its own **physical cores** rather than the whole NUMA node. The helper already existed;
  `src/shmem/init.cpp` was its **only** caller, so every job using CCO instead of shmem ran
  completely unbound. **This affects every CCO job, not just EP.**
- **`python/mori/jit/v2/plan_api.py`** — shared JIT infrastructure. The launch buffer persists
  between launches and the code already relied on that for bound ints; this extends it to
  per-launch arguments. Regression: 35 passed / 1 skipped across `test_jit_binding` and the v2
  intranode suite.

Both are clean split points if you would rather they went separately.

## The CPU-affinity finding, since it is the load-bearing one

Unbound, two of the eight per-node ranks can land on the two SMT siblings of one physical core.
Measured with `sched_getcpu`, six runs of the 8-token bench:

| run | total | colliding ranks | ranks whose host loop ran 2× |
|---|---|---|---|
| 1 | 89.5 µs | none | none |
| 2 | **124.1 µs** | **5+6** | **5, 6** |
| 3 | **116.4 µs** | **12+14, 13+15** | **12, 13, 14, 15** |
| 4 | 88.7 µs | none | none |
| 5 | **152.8 µs** | none | **1** |
| 6 | 88.5 µs | none | none |

Every colliding pair — and only the colliding pair — ran at exactly 2× (74 → 136 µs a round), and
any doubled rank dragged the whole 16-rank collective. Ranks never migrate mid-run, so placement
is a startup lottery that then sticks. Run 5 doubles without a collision: a rank can also share
its core with a non-mori process, which this cannot prevent.

Partitioning is by the kernel's own `thread_siblings_list` — cpu 5 and cpu 197 are one core here,
and a contiguous slice of the cpu list would separate them. Eight runs after the fix: no
collision, no doubled rank, max 152.8 → 110.4 µs, median 103 → 90 µs.

## Measurement

Against #625 (v1 host, same v2 kernels, same wire), **both sides NUMA-bound**, eight interleaved
pairs at 4 tokens:

| | #625 median | this branch | paired median | wins |
|---|---|---|---|---|
| dispatch | 39.52 µs | 37.85 µs | **−2.06 µs (−5.2%)** | 6/8 |
| combine | 53.41 µs | 47.05 µs | **−5.28 µs (−9.9%)** | 7/8 |
| **total** | 92.52 µs | 85.70 µs | **−7.21 µs (−7.8%)** | **7/8** |

Spread is comparable, not worse (max/median 1.28 against 1.21).

**Withdrawn:** an earlier reading that this branch was ~3× more sensitive to the slow regime. It
was measured with #625 bound and this branch not — the v1 harness calls
`shmem_torch_process_group_init` and was bound all along.

The internode tuning table was **re-derived** after the bind, since every A/B in it had raced a
±40 µs random term from CPU placement. Four stages — sweep, keep only what reproduces across
repeats, head-to-head against the shipped row, then a plain bench A/B — and each of the last two
rejected something the earlier ones accepted (16-token combine won all three sweeps and lost all
three head-to-heads; 8-token dispatch passed the head-to-head and then read 118 against 92 in a
plain bench). **One row moved:** 32-token combine `80/40/8` → `64/48/6`.

## Suggested review order

1. `internode_regions.py`, `symm_arena.py` — the memory model
2. `ep_internode_args.hpp` — the argument schema, and the no-tail-padding `static_assert` (that
   trap cost eight GPU memory faults: ctypes places the `devComm` blob before C++ does, and both
   layouts have the same `sizeof`, so the size check passes)
3. `hip_backend.py` — construction order, geometry buckets, the launch path
4. `ep_internode_kernel.hpp` — the two guards; the rest is v1's logic
5. `cco_init.cpp` / `cpu_affinity.hpp` — the out-of-scope fix

## Testing

```bash
# correctness — analytic, not differential: identity expert, so
# combine[t] == U[t] * input[t] with U = distinct destination ranks
--cmd test  --kernel-type v1_ll --num-qp 1 --max-tokens 4 \
  --dtype fp8_e4m3_fnuz --combine-dtype bf16 --hidden-dim 6144 --topk 8
```

Green for bf16 and fp8→bf16 at 4/8/16/32 tokens, 0 of 16 ranks disagreeing.

`--cmd bench` now reports what the v1 bench reports — the per-round per-rank dump and the two
performance tables, same formulas — so the two can be read side by side. Defaults match v1 where
they affect the comparison (`scale_dim` 32, `experts_per_rank` `256 // world_size`,
`dist.barrier()` at the measurement boundary).

## Known and unresolved

`docs/EP_INTERNODE_V2_TAIL.md` is the writeup: what the "tail" actually is (a bistable whole-run
regime, not a tail), the full list of what was eliminated and how, and the residual that survives
— a ~10-20 µs inter-node offset in roughly 3 runs in 8, with no host doubling and no identified
mechanism. Everything outside the GPU has been ruled out for it; the next step would be
device-side arrival timestamps.
