### PR TITLE
perf(ep): add MI355X IntraNodeLL combine tuning

### DIFF
--- a/python/mori/ops/tuning_configs/gfx950_mi355x_IntraNodeLL_ep8_combine.json
+++ b/python/mori/ops/tuning_configs/gfx950_mi355x_IntraNodeLL_ep8_combine.json
@@ -1,0 +1,170 @@
+{
+  "version": "1.0",
+  "gpu_arch": "gfx950",
+  "gpu_model": "mi355x",
+  "kernel_type": "IntraNodeLL",
+  "ep_size": 8,
+  "phase": "combine",
+  "rules": [
+    {
+      "dtype": "fp4",
+      "num_tokens": 256,
+      "hidden_dim": 3584,
+      "zero_copy": false,
+      "quant_type": "none",
+      "block_num": 256,
+      "rdma_block_num": 0,
+      "warp_per_block": 16
+    },
+    {
+      "dtype": "fp8_e4m3",
+      "num_tokens": 256,
+      "hidden_dim": 7168,
+      "zero_copy": false,
+      "quant_type": "none",
+      "block_num": 64,
+      "rdma_block_num": 0,
+      "warp_per_block": 8
+    },
+    {
+      "dtype": "bf16",
+      "num_tokens": 64,
+      "hidden_dim": 7168,
+      "zero_copy": false,
+      "quant_type": "none",
+      "block_num": 128,
+      "rdma_block_num": 0,
+      "warp_per_block": 8
+    },
+    {
+      "dtype": "bf16",
+      "num_tokens": 128,
+      "hidden_dim": 7168,
+      "zero_copy": false,
+      "quant_type": "none",
+      "block_num": 256,
+      "rdma_block_num": 0,
+      "warp_per_block": 8
+    },
+    {
+      "dtype": "bf16",
+      "num_tokens": 256,
+      "hidden_dim": 7168,
+      "zero_copy": false,
+      "quant_type": "none",
+      "block_num": 248,
+      "rdma_block_num": 0,
+      "warp_per_block": 6
+    },
+    {
+      "dtype": "bf16",
+      "num_tokens": 512,
+      "hidden_dim": 7168,
+      "zero_copy": false,
+      "quant_type": "none",
+      "block_num": 256,
+      "rdma_block_num": 0,
+      "warp_per_block": 16
+    },
+    {
+      "dtype": "bf16",
+      "num_tokens": 1024,
+      "hidden_dim": 7168,
+      "zero_copy": false,
+      "quant_type": "none",
+      "block_num": 256,
+      "rdma_block_num": 0,
+      "warp_per_block": 8
+    },
+    {
+      "dtype": "bf16",
+      "num_tokens": 2048,
+      "hidden_dim": 7168,
+      "zero_copy": false,
+      "quant_type": "none",
+      "block_num": 256,
+      "rdma_block_num": 0,
+      "warp_per_block": 16
+    },
+    {
+      "dtype": "bf16",
+      "num_tokens": 4096,
+      "hidden_dim": 7168,
+      "zero_copy": false,
+      "quant_type": "none",
+      "block_num": 256,
+      "rdma_block_num": 0,
+      "warp_per_block": 16
+    },
+    {
+      "dtype": "bf16",
+      "num_tokens": 64,
+      "hidden_dim": 7168,
+      "zero_copy": true,
+      "quant_type": "none",
+      "block_num": 64,
+      "rdma_block_num": 0,
+      "warp_per_block": 8
+    },
+    {
+      "dtype": "bf16",
+      "num_tokens": 128,
+      "hidden_dim": 7168,
+      "zero_copy": true,
+      "quant_type": "none",
+      "block_num": 64,
+      "rdma_block_num": 0,
+      "warp_per_block": 8
+    },
+    {
+      "dtype": "bf16",
+      "num_tokens": 256,
+      "hidden_dim": 7168,
+      "zero_copy": true,
+      "quant_type": "none",
+      "block_num": 96,
+      "rdma_block_num": 0,
+      "warp_per_block": 12
+    },
+    {
+      "dtype": "bf16",
+      "num_tokens": 512,
+      "hidden_dim": 7168,
+      "zero_copy": true,
+      "quant_type": "none",
+      "block_num": 64,
+      "rdma_block_num": 0,
+      "warp_per_block": 8
+    },
+    {
+      "dtype": "bf16",
+      "num_tokens": 1024,
+      "hidden_dim": 7168,
+      "zero_copy": true,
+      "quant_type": "none",
+      "block_num": 64,
+      "rdma_block_num": 0,
+      "warp_per_block": 8
+    },
+    {
+      "dtype": "bf16",
+      "num_tokens": 2048,
+      "hidden_dim": 7168,
+      "zero_copy": true,
+      "quant_type": "none",
+      "block_num": 64,
+      "rdma_block_num": 0,
+      "warp_per_block": 8
+    },
+    {
+      "dtype": "bf16",
+      "num_tokens": 4096,
+      "hidden_dim": 7168,
+      "zero_copy": true,
+      "quant_type": "none",
+      "block_num": 128,
+      "rdma_block_num": 0,
+      "warp_per_block": 4
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add the canonical MI355X/gfx950 EP8 IntraNodeLL combine tuning table.
- Use 248 blocks x 6 warps for the non-zero-copy BF16, hidden-size 7168, <=256-token bucket.
- Preserve the other deployed tuning buckets. No model configuration is changed.

## Performance

`tools/bench_mori_combine_ab.py` was run on 8x MI355X with BF16 combine, hidden size 7168, top-k 6, 1,000 graph replays per round, and 11 alternating A/B rounds. Timings are the max-rank median.

| Tokens per rank | 160x8 | 248x6 | Delta |
| ---: | ---: | ---: | ---: |
| 186 | 61.761 us | 55.080 us | -6.681 us (-10.8%) |
| 155 | 62.080 us | 60.801 us | -1.279 us (-2.1%) |

All 11 rounds favored 248x6 at both measured sizes.

A 100K/B240 A-B-B-A service run measured 62.91 ms (A1), 62.14 ms and 61.97 ms (B), and 63.58 ms (A2) median ITL. The B arm combined this Mori tuning with a separate AITER fused-MoE configuration, so the service-level difference cannot be attributed to this PR alone. The combined candidate reached 0.949962 strict-match on 5-shot GSM8K. The run verified the original model config and `index_topk=1024` before each server start.

## Validation

- Parsed all 44 tuning JSON files successfully.
- Loaded the new file through the current `TuningConfigManager` schema: 16 valid, unique rules.
- Verified lookup results: N=155, 186, and 256 select 248x6; N=257 selects the existing 256x16 next bucket.
- `pytest tests/python/test_tuning_config_quant_types.py -q`: 15 passed.
- `git diff --check`.
