### PR TITLE
test(EPv2): emit a JSON result table and per-point clock/power telemetry

### DIFF
--- a/tests/python/ops/dispatch_combine_v2/_report.py
+++ b/tests/python/ops/dispatch_combine_v2/_report.py
@@ -1,0 +1,56 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Machine-readable result rows, in aiter's ``print_json_table`` format.
+
+One single-line JSON object per table, ``{"name": ..., "rows": [...]}``, so a
+parent driver can validate and forward it without parsing a human table. The
+format is aiter's ``aiter/test_common.py``; this is a copy rather than an import,
+and pure Python rather than pandas -- a benchmark should not need a dataframe to
+print its own results, and mori's test env does not ship pandas.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def print_json_table(name, rows) -> None:
+    """Print rows as one JSON object, dropping columns no row ever filled in.
+
+    Column order is first-seen across the rows, matching what pandas builds from
+    a list of dicts. Empty and ``None`` cells are dropped only when the WHOLE
+    column is empty, so a value missing from one row still shows as null there.
+    """
+    rows = [r for r in rows if r is not None]
+    cols: list[str] = []
+    for row in rows:
+        cols += [k for k in row if k not in cols]
+    keep = [c for c in cols if any(r.get(c) not in (None, "") for r in rows)]
+    records = [{c: _plain(row.get(c)) for c in keep} for row in rows]
+    print(json.dumps({"name": name, "rows": records}), flush=True)
+
+
+def _plain(value):
+    """Anything json cannot encode becomes its str(), the way to_json would."""
+    if value is None or isinstance(value, (bool, int, float, str, list, dict)):
+        return value
+    return str(value)

--- a/tests/python/ops/dispatch_combine_v2/_smi.py
+++ b/tests/python/ops/dispatch_combine_v2/_smi.py
@@ -1,0 +1,322 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Clock/power telemetry around a measured window, via amdsmi.
+
+A latency number means little without the clock it was measured at: a
+power-limited part throttles, and the same kernel then reports a different time.
+This samples gfx/soc clock, socket power, hotspot temperature, activity and VRAM
+on a background thread, and summarises only the samples that fall inside a
+caller-supplied window -- so warmup, compilation and input generation stay out of
+the reported clocks.
+
+Names, env vars and the emitted record are aiter's (``op_tests/smi_monitor.py``),
+so ``bench_gfx1250_combo.py`` can consume mori's rows with the collector it
+already has. It is a copy, not an import, for the same reason as ``_data.py``.
+
+ROCm ships the amdsmi binding without a setup.py, so the import falls back to
+``/opt/rocm/share/amd_smi`` without leaving that path on ``sys.path``. When the
+binding is absent ``available()`` is False and the caller skips telemetry rather
+than failing the benchmark.
+"""
+
+from __future__ import annotations
+
+import atexit
+import ctypes
+import glob
+import importlib
+import json
+import os
+import sys
+import threading
+import time
+from functools import cache
+
+SMI_RESULT_PREFIX = "AITER_SMI_RESULT "
+_ROCM_AMDSMI_PATH = "/opt/rocm/share/amd_smi"
+
+
+def _import_amdsmi():
+    try:
+        return importlib.import_module("amdsmi")
+    except ImportError:
+        if not os.path.isdir(_ROCM_AMDSMI_PATH):
+            raise
+    sys.path.insert(0, _ROCM_AMDSMI_PATH)
+    try:
+        return importlib.import_module("amdsmi")
+    finally:
+        sys.path.remove(_ROCM_AMDSMI_PATH)
+
+
+try:
+    amdsmi = _import_amdsmi()
+    _AVAILABLE = True
+except Exception:  # noqa: BLE001 - any import failure just disables telemetry
+    amdsmi = None
+    _AVAILABLE = False
+
+_LOCK = threading.Lock()
+_INITIALIZED = False
+_BY_BDF: dict = {}
+_BY_HIP_DEVICE: dict = {}
+
+
+@cache
+def _hip_runtime():
+    names = ["libamdhip64.so"] + sorted(
+        glob.glob("/opt/rocm/lib/libamdhip64.so.*"), reverse=True
+    )
+    for name in names:
+        try:
+            return ctypes.CDLL(name)
+        except OSError:
+            continue
+    raise RuntimeError("libamdhip64.so not found; is ROCm installed?")
+
+
+@cache
+def _hip_device_bdf(hip_device: int) -> str:
+    """PCIe BDF of a HIP device, the stable key between HIP and amdsmi ordinals.
+
+    amdsmi enumerates every GPU in the box; HIP enumerates what
+    HIP_VISIBLE_DEVICES left it. Indexing amdsmi by the HIP ordinal therefore
+    reads a different GPU as soon as the two lists disagree.
+    """
+    buf = ctypes.create_string_buffer(64)
+    ret = _hip_runtime().hipDeviceGetPCIBusId(
+        buf, ctypes.c_int(64), ctypes.c_int(hip_device)
+    )
+    if ret != 0:
+        raise RuntimeError(f"hipDeviceGetPCIBusId failed: {ret}")
+    return buf.value.decode().lower().strip()
+
+
+def _bdf_str(handle) -> str:
+    raw = amdsmi.amdsmi_get_gpu_device_bdf(handle)
+    if isinstance(raw, str):
+        return raw.lower().strip()
+    return (
+        f"{raw['domain']:04x}:{raw['bus']:02x}:"
+        f"{raw['device']:02x}.{raw['function']:x}"
+    )
+
+
+def _ensure_initialized() -> None:
+    global _INITIALIZED
+    if not _AVAILABLE:
+        raise ImportError("amdsmi is not importable")
+    with _LOCK:
+        if _INITIALIZED:
+            return
+        amdsmi.amdsmi_init()
+        try:
+            _BY_BDF.update(
+                {_bdf_str(h): h for h in amdsmi.amdsmi_get_processor_handles()}
+            )
+        except BaseException:
+            amdsmi.amdsmi_shut_down()
+            raise
+        _INITIALIZED = True
+
+
+def _shutdown() -> None:
+    global _INITIALIZED
+    with _LOCK:
+        if not _INITIALIZED:
+            return
+        try:
+            amdsmi.amdsmi_shut_down()
+        finally:
+            _INITIALIZED = False
+            _BY_BDF.clear()
+            _BY_HIP_DEVICE.clear()
+
+
+atexit.register(_shutdown)
+
+
+def hip_device_to_amdsmi_handle(hip_device: int):
+    """The amdsmi handle for a HIP device ordinal, matched by PCIe BDF."""
+    _ensure_initialized()
+    with _LOCK:
+        cached = _BY_HIP_DEVICE.get(hip_device)
+        if cached is not None:
+            return cached
+    bdf = _hip_device_bdf(hip_device)
+    with _LOCK:
+        handle = _BY_BDF.get(bdf)
+        if handle is None:
+            raise RuntimeError(f"no amdsmi handle with BDF {bdf!r}")
+        _BY_HIP_DEVICE[hip_device] = handle
+        return handle
+
+
+def _collect_sample(handle) -> dict:
+    sample: dict = {"timestamp_s": time.perf_counter()}
+    try:
+        m = amdsmi.amdsmi_get_gpu_metrics_info(handle)
+        sample["gfx_clk_mhz"] = m.get("current_gfxclk")
+        sample["soc_clk_mhz"] = m.get("current_socclk")
+        sample["power_w"] = m.get("current_socket_power")
+        sample["temp_hotspot_c"] = m.get("temperature_hotspot")
+    except Exception:  # noqa: BLE001 - a missing metric must not stop sampling
+        pass
+    try:
+        a = amdsmi.amdsmi_get_gpu_activity(handle)
+        sample["gfx_activity_pct"] = a.get("gfx_activity")
+        sample["umc_activity_pct"] = a.get("umc_activity")
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        used = amdsmi.amdsmi_get_gpu_memory_usage(handle, amdsmi.AmdSmiMemoryType.VRAM)
+        sample["vram_used_mb"] = used / 1024 / 1024
+    except Exception:  # noqa: BLE001
+        pass
+    return sample
+
+
+class GpuMonitor:
+    """Poll one GPU's metrics on a background thread until stopped."""
+
+    def __init__(self, device_index: int = 0, interval_s: float = 0.05) -> None:
+        if not _AVAILABLE:
+            raise ImportError("amdsmi is not importable")
+        self._device_index = device_index
+        self._interval_s = interval_s
+        self._samples: list[dict] = []
+        self._thread: threading.Thread | None = None
+        self._stop = threading.Event()
+        self._ready = threading.Event()
+        self._error: BaseException | None = None
+        self._handle = None
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            raise RuntimeError("GpuMonitor is already running")
+        self._samples = []
+        self._error = None
+        self._stop.clear()
+        self._ready.clear()
+        self._handle = hip_device_to_amdsmi_handle(self._device_index)
+        self._thread = threading.Thread(target=self._poll_loop, daemon=True)
+        self._thread.start()
+        if not self._ready.wait(timeout=10.0):
+            self._stop.set()
+            raise RuntimeError("timed out initializing the amdsmi monitor")
+        if self._error is not None:
+            error = self._error
+            self.stop()
+            raise RuntimeError(f"amdsmi monitor failed to start: {error}")
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join()
+            self._thread = None
+
+    @property
+    def samples(self) -> list[dict]:
+        return list(self._samples)
+
+    def summary(self, *, start_s=None, end_s=None) -> dict:
+        """min/mean/median/max per metric over the samples inside the window.
+
+        Windowing is the whole point: the monitor runs across the replay loop,
+        but only the samples between the two timestamps the caller recorded
+        describe the work that was measured.
+        """
+        rows = [
+            s
+            for s in self._samples
+            if (start_s is None or s["timestamp_s"] >= start_s)
+            and (end_s is None or s["timestamp_s"] <= end_s)
+        ]
+        if not rows:
+            return {}
+        out: dict = {}
+        for key in sorted({k for s in rows for k in s if k != "timestamp_s"}):
+            vals = sorted(
+                s[key] for s in rows if s.get(key) is not None and s[key] != "N/A"
+            )
+            if not vals:
+                continue
+            n, mid = len(vals), len(vals) // 2
+            out[key] = {
+                "min": vals[0],
+                "mean": sum(vals) / n,
+                "median": vals[mid] if n % 2 else (vals[mid - 1] + vals[mid]) / 2,
+                "max": vals[-1],
+                "n": n,
+            }
+        return out
+
+    def __enter__(self) -> GpuMonitor:
+        self.start()
+        return self
+
+    def __exit__(self, *_) -> None:
+        self.stop()
+
+    def _poll_loop(self) -> None:
+        try:
+            self._ready.set()
+            while not self._stop.is_set():
+                t0 = time.perf_counter()
+                self._samples.append(_collect_sample(self._handle))
+                left = self._interval_s - (time.perf_counter() - t0)
+                if left > 0:
+                    self._stop.wait(timeout=left)
+        except BaseException as error:  # noqa: BLE001 - reported via start()
+            self._error = error
+        finally:
+            self._ready.set()
+
+
+def available() -> bool:
+    """Whether telemetry can be collected at all in this process."""
+    return _AVAILABLE
+
+
+def env_config():
+    """(enabled, interval_s, duration_s) from AITER_SMI_MONITOR/INTERVAL/DURATION.
+
+    aiter's spelling, so one driver can turn telemetry on for both harnesses.
+    SMI_MONITOR is accepted as a shorter alias when running this bench directly.
+    """
+    on = os.environ.get("AITER_SMI_MONITOR", os.environ.get("SMI_MONITOR", "0")) == "1"
+    interval = float(os.environ.get("AITER_SMI_INTERVAL", "0.05"))
+    duration = float(os.environ.get("AITER_SMI_DURATION", "1.0"))
+    if on and (interval <= 0 or duration <= 0):
+        raise ValueError("AITER_SMI_INTERVAL and AITER_SMI_DURATION must be positive")
+    return on, interval, duration
+
+
+def emit(record: dict) -> None:
+    """Write one telemetry record to the shared JSONL sink, or to stdout."""
+    line = SMI_RESULT_PREFIX + json.dumps(record, sort_keys=True)
+    path = os.environ.get("AITER_SMI_OUTPUT_PATH")
+    if path:
+        with open(path, "a", encoding="utf-8") as sink:
+            sink.write(line + "\n")
+    else:
+        print(line, flush=True)

--- a/tests/python/ops/dispatch_combine_v2/_smi.py
+++ b/tests/python/ops/dispatch_combine_v2/_smi.py
@@ -28,9 +28,10 @@ on a background thread, and summarises only the samples that fall inside a
 caller-supplied window -- so warmup, compilation and input generation stay out of
 the reported clocks.
 
-Names, env vars and the emitted record are aiter's (``op_tests/smi_monitor.py``),
-so ``bench_gfx1250_combo.py`` can consume mori's rows with the collector it
-already has. It is a copy, not an import, for the same reason as ``_data.py``.
+The emitted record is aiter's (``op_tests/smi_monitor.py``), so
+``bench_gfx1250_combo.py`` can consume mori's rows with the collector it already
+has. It is a copy, not an import, for the same reason as ``_data.py``. Settings
+answer to either spelling, ``MORI_SMI_*`` or ``AITER_SMI_*``.
 
 ROCm ships the amdsmi binding without a setup.py, so the import falls back to
 ``/opt/rocm/share/amd_smi`` without leaving that path on ``sys.path``. When the
@@ -297,24 +298,33 @@ def available() -> bool:
     return _AVAILABLE
 
 
-def env_config():
-    """(enabled, interval_s, duration_s) from AITER_SMI_MONITOR/INTERVAL/DURATION.
+def _env(name, default=None):
+    """MORI_SMI_<name> if set, else AITER_SMI_<name>.
 
-    aiter's spelling, so one driver can turn telemetry on for both harnesses.
-    SMI_MONITOR is accepted as a shorter alias when running this bench directly.
+    Two spellings for one setting: MORI_ is what a mori run should have to know
+    about, AITER_ is the interop contract -- a driver that already exports it for
+    aiter turns mori's telemetry on with no extra plumbing.
     """
-    on = os.environ.get("AITER_SMI_MONITOR", os.environ.get("SMI_MONITOR", "0")) == "1"
-    interval = float(os.environ.get("AITER_SMI_INTERVAL", "0.05"))
-    duration = float(os.environ.get("AITER_SMI_DURATION", "1.0"))
+    value = os.environ.get(f"MORI_SMI_{name}")
+    if value is None:
+        value = os.environ.get(f"AITER_SMI_{name}")
+    return default if value is None else value
+
+
+def env_config():
+    """(enabled, interval_s, duration_s) from {MORI,AITER}_SMI_MONITOR/INTERVAL/DURATION."""
+    on = _env("MONITOR", "0") == "1"
+    interval = float(_env("INTERVAL", "0.05"))
+    duration = float(_env("DURATION", "1.0"))
     if on and (interval <= 0 or duration <= 0):
-        raise ValueError("AITER_SMI_INTERVAL and AITER_SMI_DURATION must be positive")
+        raise ValueError("SMI interval and duration must be positive")
     return on, interval, duration
 
 
 def emit(record: dict) -> None:
     """Write one telemetry record to the shared JSONL sink, or to stdout."""
     line = SMI_RESULT_PREFIX + json.dumps(record, sort_keys=True)
-    path = os.environ.get("AITER_SMI_OUTPUT_PATH")
+    path = _env("OUTPUT_PATH")
     if path:
         with open(path, "a", encoding="utf-8") as sink:
             sink.write(line + "\n")

--- a/tests/python/ops/dispatch_combine_v2/bench_ep.py
+++ b/tests/python/ops/dispatch_combine_v2/bench_ep.py
@@ -46,14 +46,14 @@ scales and recv-cap, across both backends.
 Two machine-readable outputs sit alongside the human table. A final JSON line in
 aiter's print_json_table shape carries every point, one row per (backend, mode,
 m), so a parent driver reads results instead of parsing columns. And with
-AITER_SMI_MONITOR=1 each point also replays under amdsmi: the clocks a number was
+MORI_SMI_MONITOR=1 each point also replays under amdsmi: the clocks a number was
 measured at belong with the number, since a throttled part reports a different
 time for the same kernel. That replay is a window of its own, AFTER warmup and
 graph capture, because ITERS pairs are ~10 ms against a 50 ms sampling tick.
 
     torchrun --standalone --nproc_per_node=8 bench_ep.py
     BACKENDS=flydsl,hip SWEEP=512,4096 ITERS=200 torchrun ... bench_ep.py
-    AITER_SMI_MONITOR=1 AITER_SMI_DURATION=1.0 torchrun ... bench_ep.py
+    MORI_SMI_MONITOR=1 MORI_SMI_DURATION=1.0 torchrun ... bench_ep.py
 """
 
 import math

--- a/tests/python/ops/dispatch_combine_v2/bench_ep.py
+++ b/tests/python/ops/dispatch_combine_v2/bench_ep.py
@@ -43,12 +43,23 @@ that computes garbage never gets a bandwidth number. That check is deliberately
 one invariant, not a matrix -- test_op.py owns dtypes, quant, scatter, StdMoE,
 scales and recv-cap, across both backends.
 
+Two machine-readable outputs sit alongside the human table. A final JSON line in
+aiter's print_json_table shape carries every point, one row per (backend, mode,
+m), so a parent driver reads results instead of parsing columns. And with
+AITER_SMI_MONITOR=1 each point also replays under amdsmi: the clocks a number was
+measured at belong with the number, since a throttled part reports a different
+time for the same kernel. That replay is a window of its own, AFTER warmup and
+graph capture, because ITERS pairs are ~10 ms against a 50 ms sampling tick.
+
     torchrun --standalone --nproc_per_node=8 bench_ep.py
     BACKENDS=flydsl,hip SWEEP=512,4096 ITERS=200 torchrun ... bench_ep.py
+    AITER_SMI_MONITOR=1 AITER_SMI_DURATION=1.0 torchrun ... bench_ep.py
 """
 
+import math
 import os
 import sys
+import time
 
 import torch
 import torch.distributed as dist
@@ -57,6 +68,8 @@ import mori.cco as cco
 from mori.ops.dispatch_combine_v2 import EpDispatchCombineConfig, EpDispatchCombineOp
 
 import _data
+import _report
+import _smi
 
 HIDDEN = int(os.environ.get("HIDDEN", 7168))
 TOPK = int(os.environ.get("TOPK", 8))
@@ -81,12 +94,18 @@ CHECK = int(os.environ.get("CHECK", 1))
 # CONST_VAL. Same names and meanings as aiter's test_common, so the two harnesses
 # describe the same input. Defaults reproduce this file's previous behaviour.
 INIT, SEED, CONST_VAL = _data.env_config()
+# One machine-readable line per run, aiter's print_json_table format. JSON=0 to
+# drop it; the human table above it is unchanged either way.
+JSON = int(os.environ.get("JSON", 1))
+# Clock/power telemetry, off unless asked for: it adds a replay window per point.
+SMI_ON, SMI_INTERVAL, SMI_DURATION = _smi.env_config()
 # What dispatch transports; combine is always bf16, so anything else is asymmetric.
+_DISP = os.environ.get("DISP", "bf16")
 _DISP_DT = {
     "bf16": torch.bfloat16,
     "fp8": torch.float8_e4m3fn,
     "fp4": torch.float4_e2m1fn_x2,
-}[os.environ.get("DISP", "bf16")]
+}[_DISP]
 _DISP_NBYTES = {torch.bfloat16: 2, torch.float8_e4m3fn: 1}.get(_DISP_DT, 0.5)
 _FP4 = _DISP_DT is torch.float4_e2m1fn_x2
 # Geometry, same spelling as tools/ep_test.sh. Unset = the backend's tuned default.
@@ -290,8 +309,128 @@ def main():
         dist.barrier()
         d = sum(ev[0][i].elapsed_time(ev[1][i]) for i in range(ITERS)) / ITERS * 1000
         c = sum(ev[2][i].elapsed_time(ev[3][i]) for i in range(ITERS)) / ITERS * 1000
-        return d, c
+        return d, c, run_d, run_c
 
+    def smi_window(label, pair_us, run_d, run_c):
+        """Replay the pair under the GPU monitor and gather every rank's clocks.
+
+        A window of its own, after the timed loop, because ITERS pairs are ~10 ms
+        against a 50 ms sampling tick -- too short to sample even once. Warmup,
+        graph capture and input generation are already behind us, which is what
+        "do not include init in the telemetry" asks for. Nothing here is timed.
+
+        The replay count must be IDENTICAL on every rank: these kernels barrier
+        across devices, so a per-rank duration loop would leave one rank waiting
+        on a peer that has stopped. It is computed on rank 0 and broadcast.
+        Launches are batched between synchronizations so a 40 us pair still keeps
+        the GPU busy across a tick instead of measuring the sync gap.
+        """
+        if not SMI_ON or pair_us <= 0:
+            return None
+        plan = torch.zeros(2, dtype=torch.int64)
+        if rank == 0:
+            batch = max(1, min(1024, int(SMI_INTERVAL * 1e6 / pair_us)))
+            plan[0] = batch
+            plan[1] = max(1, math.ceil(SMI_DURATION * 1e6 / (pair_us * batch)))
+        dist.broadcast(plan, src=0)
+        batch, rounds = int(plan[0]), int(plan[1])
+
+        mon, err = None, None
+        try:
+            mon = _smi.GpuMonitor(torch.cuda.current_device(), interval_s=SMI_INTERVAL)
+            mon.start()
+        except Exception as e:  # noqa: BLE001 - telemetry never fails the bench
+            err = f"rank {rank}: {type(e).__name__}: {e}"
+        # Every rank must agree on whether the replay happens, or the ranks that
+        # skip it deadlock the ones that do not.
+        bad = torch.tensor([1 if err else 0])
+        dist.all_reduce(bad)
+        if bad.item():
+            if mon is not None:
+                mon.stop()
+            if rank == 0:
+                print(f"  [smi] disabled: {err or 'a peer rank failed'}", flush=True)
+            return None
+
+        lockstep()
+        t0 = time.perf_counter()
+        for _ in range(rounds):
+            for _ in range(batch):
+                run_d()
+                run_c()
+            torch.cuda.synchronize()
+        t1 = time.perf_counter()
+        mon.stop()
+        dist.barrier()
+
+        want = max(1, int(SMI_DURATION / SMI_INTERVAL))
+        metrics = mon.summary(start_s=t0, end_s=t1)
+        n = sum(1 for s in mon.samples if t0 <= s["timestamp_s"] <= t1)
+        local = {
+            "label": label,
+            "device": torch.cuda.current_device(),
+            "rank": rank,
+            "interval_s": SMI_INTERVAL,
+            "duration_s": t1 - t0,
+            "launches": rounds * batch,
+            "samples": n,
+            "sample_status": "ok" if n >= max(2, want // 2) else "insufficient",
+            "metrics": metrics,
+        }
+        every = [None] * world
+        dist.all_gather_object(every, local)
+        if rank != 0:
+            return None
+        for r in every:
+            _smi.emit(r)
+        return every
+
+    def case(ct, name, mode):
+        """The columns that identify a point: the case arguments, aiter's order."""
+        return {
+            "backend": name,
+            "mode": mode,
+            "ep": world,
+            "m": ct,  # tokens per rank, aiter's row key for problem size
+            "hidden": HIDDEN,
+            "topk": TOPK,
+            "experts_per_rank": EPR,
+            "dispatch_dtype": _DISP,
+            "combine_dtype": "bf16",
+            "combine_in": COMBINE_IN,
+            "data_init": INIT,
+            "seed": SEED,
+            "iters": ITERS,
+        }
+
+    def clocks(records):
+        """Cross-rank clock columns. The MIN over ranks is the point of these:
+        one throttled GPU sets the pair time for all of them, and a mean hides it."""
+        med = [
+            r["metrics"]["gfx_clk_mhz"]["median"]
+            for r in records or []
+            if "gfx_clk_mhz" in r["metrics"]
+        ]
+        pwr = [
+            r["metrics"]["power_w"]["median"]
+            for r in records or []
+            if "power_w" in r["metrics"]
+        ]
+        out = {}
+        if med:
+            out["gfx_clk_mhz"] = round(sum(med) / len(med), 1)
+            out["gfx_clk_mhz_min"] = round(min(med), 1)
+        if pwr:
+            out["power_w"] = round(sum(pwr) / len(pwr), 1)
+        if records:
+            out["smi_status"] = (
+                "ok"
+                if all(r["sample_status"] == "ok" for r in records)
+                else "insufficient"
+            )
+        return out
+
+    rows = []
     failures = checked = points = 0
     for ct in SWEEP:
         i_, w_, x_ = inp[:ct], wts[:ct], idx[:ct]
@@ -301,6 +440,12 @@ def main():
             checked += was_checked
             if not ok:
                 failures += 1
+                # A failed point stays in the table as a row with err_msg, so a
+                # gap in the sweep cannot be mistaken for a tier nobody ran.
+                rows += [
+                    dict(case(ct, name, mode), err_msg="correctness check failed")
+                    for mode in MODES
+                ]
                 continue  # never report bandwidth for a kernel computing garbage
 
             def one_pair():
@@ -332,7 +477,7 @@ def main():
                 return eager_d, lambda: op.combine(buf, routing=held[0])
 
             for mode in MODES:
-                d_us, c_us = time_pairs(
+                d_us, c_us, run_d, run_c = time_pairs(
                     mode, one_pair, capture_pair if mode == "graph" else eager_legs
                 )
                 # Bytes off this rank; the legs differ whenever dispatch is narrower.
@@ -340,8 +485,8 @@ def main():
                 c_bw = total * HIDDEN * 2 / (1000**3) / (c_us / 1e6)
                 got = torch.tensor([d_us, c_us, float(total)], dtype=torch.float64)
                 dist.all_reduce(got)
+                n = world
                 if rank == 0:
-                    n = world
                     print(
                         f"  ct={ct:<5d} [{name}/{mode}] "
                         f"dispatch {got[0]/n:7.1f} us ({d_bw:6.1f} GB/s)  "
@@ -350,6 +495,28 @@ def main():
                         flush=True,
                     )
                 lockstep()
+                smi = smi_window(
+                    f"bench_ep/dispatch_combine/backend={name}/mode={mode}"
+                    f"/M={ct}/disp={_DISP}",
+                    float((got[0] + got[1]) / n),
+                    run_d,
+                    run_c,
+                )
+                lockstep()
+                if rank == 0:
+                    rows.append(
+                        dict(
+                            case(ct, name, mode),
+                            recv_tokens=round(float(got[2]) / n),
+                            dispatch_us=round(float(got[0]) / n, 2),
+                            combine_us=round(float(got[1]) / n, 2),
+                            pair_us=round(float(got[0] + got[1]) / n, 2),
+                            dispatch_gbps=round(d_bw, 1),
+                            combine_gbps=round(c_bw, 1),
+                            verified=bool(was_checked),
+                            **clocks(smi),
+                        )
+                    )
 
     if rank == 0:
         # Say how many points were verified, not just that none failed -- with
@@ -369,6 +536,8 @@ def main():
             f"# {'FAIL' if failures else 'PASS'}: {failures} failed, "
             f"{checked}/{points} points verified{why}"
         )
+        if JSON:
+            _report.print_json_table("mori ep dispatch_combine_v2 summary", rows)
     for op in ops.values():
         op.close()
     comm.destroy()

--- a/tests/python/ops/dispatch_combine_v2/bench_ep.py
+++ b/tests/python/ops/dispatch_combine_v2/bench_ep.py
@@ -108,6 +108,19 @@ _DISP_DT = {
 }[_DISP]
 _DISP_NBYTES = {torch.bfloat16: 2, torch.float8_e4m3fn: 1}.get(_DISP_DT, 0.5)
 _FP4 = _DISP_DT is torch.float4_e2m1fn_x2
+# What the correctness gate covers, as one token. A bool cannot say it: fp4 and
+# an all-zero payload verify the dispatch bytes but never compare combine's
+# output, and a row claiming "verified" next to a combine_us nobody checked is
+# the machine-readable half losing what the human summary spells out.
+VERIFY_SCOPE = (
+    "none"
+    if not CHECK
+    else (
+        "dispatch_bytes"
+        if _FP4 or _data.verifies_nothing(INIT)
+        else "dispatch_bytes+combine"
+    )
+)
 # Geometry, same spelling as tools/ep_test.sh. Unset = the backend's tuned default.
 _G = {
     k: (int(os.environ[k]) if os.environ.get(k) else None)
@@ -365,7 +378,19 @@ def main():
 
         want = max(1, int(SMI_DURATION / SMI_INTERVAL))
         metrics = mon.summary(start_s=t0, end_s=t1)
-        n = sum(1 for s in mon.samples if t0 <= s["timestamp_s"] <= t1)
+        inside = [s for s in mon.samples if t0 <= s["timestamp_s"] <= t1]
+        # Count samples that CARRY THE CLOCK, not samples that exist. A metric
+        # query that raises is swallowed so one bad read cannot stop the polling
+        # thread, but the sample is still appended with only its timestamp -- so
+        # counting samples would report a healthy "ok" for a rank whose clock was
+        # never readable at all, which is the rank this telemetry exists to find.
+        n_clk = sum(1 for s in inside if s.get("gfx_clk_mhz") is not None)
+        if n_clk == 0:
+            status = "no_metrics"
+        elif n_clk >= max(2, want // 2):
+            status = "ok"
+        else:
+            status = "insufficient"
         local = {
             "label": label,
             "device": torch.cuda.current_device(),
@@ -373,8 +398,9 @@ def main():
             "interval_s": SMI_INTERVAL,
             "duration_s": t1 - t0,
             "launches": rounds * batch,
-            "samples": n,
-            "sample_status": "ok" if n >= max(2, want // 2) else "insufficient",
+            "samples": len(inside),
+            "clock_samples": n_clk,
+            "sample_status": status,
             "metrics": metrics,
         }
         every = [None] * world
@@ -405,15 +431,22 @@ def main():
 
     def clocks(records):
         """Cross-rank clock columns. The MIN over ranks is the point of these:
-        one throttled GPU sets the pair time for all of them, and a mean hides it."""
+        one throttled GPU sets the pair time for all of them, and a mean hides it.
+
+        A rank whose clock never read is EXCLUDED from that min, so the status
+        column has to say so: silently narrowing the min to the readable ranks
+        would report the healthiest GPUs as if they were all of them.
+        """
+        if not records:
+            return {}
         med = [
             r["metrics"]["gfx_clk_mhz"]["median"]
-            for r in records or []
+            for r in records
             if "gfx_clk_mhz" in r["metrics"]
         ]
         pwr = [
             r["metrics"]["power_w"]["median"]
-            for r in records or []
+            for r in records
             if "power_w" in r["metrics"]
         ]
         out = {}
@@ -422,12 +455,13 @@ def main():
             out["gfx_clk_mhz_min"] = round(min(med), 1)
         if pwr:
             out["power_w"] = round(sum(pwr) / len(pwr), 1)
-        if records:
-            out["smi_status"] = (
-                "ok"
-                if all(r["sample_status"] == "ok" for r in records)
-                else "insufficient"
-            )
+        seen = {r["sample_status"] for r in records}
+        # Worst rank wins, and how many ranks the numbers above came from.
+        for worst in ("no_metrics", "insufficient", "ok"):
+            if worst in seen:
+                break
+        out["smi_status"] = worst
+        out["smi_ranks"] = f"{len(med)}/{len(records)}"
         return out
 
     rows = []
@@ -480,12 +514,19 @@ def main():
                 d_us, c_us, run_d, run_c = time_pairs(
                     mode, one_pair, capture_pair if mode == "graph" else eager_legs
                 )
-                # Bytes off this rank; the legs differ whenever dispatch is narrower.
-                d_bw = total * HIDDEN * _DISP_NBYTES / (1000**3) / (d_us / 1e6)
-                c_bw = total * HIDDEN * 2 / (1000**3) / (c_us / 1e6)
                 got = torch.tensor([d_us, c_us, float(total)], dtype=torch.float64)
                 dist.all_reduce(got)
                 n = world
+                d_us_m, c_us_m = float(got[0]) / n, float(got[1]) / n
+                recv_m = float(got[2]) / n
+                # Bytes off one rank over that leg's time, BOTH cross-rank means,
+                # so the reported bandwidth follows from the recv_tokens and us
+                # this same row reports. Mixing a local byte count with a mean
+                # time gave a row whose columns did not agree with each other,
+                # and recv counts vary between ranks with the routing. The legs
+                # differ whenever dispatch is narrower than combine.
+                d_bw = recv_m * HIDDEN * _DISP_NBYTES / (1000**3) / (d_us_m / 1e6)
+                c_bw = recv_m * HIDDEN * 2 / (1000**3) / (c_us_m / 1e6)
                 if rank == 0:
                     print(
                         f"  ct={ct:<5d} [{name}/{mode}] "
@@ -498,7 +539,7 @@ def main():
                 smi = smi_window(
                     f"bench_ep/dispatch_combine/backend={name}/mode={mode}"
                     f"/M={ct}/disp={_DISP}",
-                    float((got[0] + got[1]) / n),
+                    d_us_m + c_us_m,
                     run_d,
                     run_c,
                 )
@@ -507,13 +548,13 @@ def main():
                     rows.append(
                         dict(
                             case(ct, name, mode),
-                            recv_tokens=round(float(got[2]) / n),
-                            dispatch_us=round(float(got[0]) / n, 2),
-                            combine_us=round(float(got[1]) / n, 2),
-                            pair_us=round(float(got[0] + got[1]) / n, 2),
+                            recv_tokens=round(recv_m),
+                            dispatch_us=round(d_us_m, 2),
+                            combine_us=round(c_us_m, 2),
+                            pair_us=round(d_us_m + c_us_m, 2),
                             dispatch_gbps=round(d_bw, 1),
                             combine_gbps=round(c_bw, 1),
-                            verified=bool(was_checked),
+                            verified=VERIFY_SCOPE,
                             **clocks(smi),
                         )
                     )


### PR DESCRIPTION
Two additions to the EP v2 microbenchmark, both aligned with the cross-framework ubench standardisation (AITER / FlyDSL / perftest / mori reporting comparable numbers). They cover requirement 7 (JSON output) and the clock/power half of requirement 1 (frequency & power reporting).

### JSON result table

`_report.print_json_table` writes one single-line `{"name": ..., "rows": [...]}` object at the end of a run, one row per `(backend, mode, m)`, carrying the case arguments alongside the results:

```json
{"name": "mori ep dispatch_combine_v2 summary", "rows": [{"backend": "hip", "mode": "graph", "ep": 4, "m": 512, "hidden": 7168, "topk": 6, "experts_per_rank": 96, "dispatch_dtype": "bf16", "combine_dtype": "bf16", "combine_in": "inplace", "data_init": "norm", "seed": 1234, "iters": 50, "recv_tokens": 1674, "dispatch_us": 53.9, "combine_us": 32.76, "pair_us": 86.67, "dispatch_gbps": 444.8, "combine_gbps": 719.7, "verified": true, "gfx_clk_mhz": 2333.0, "gfx_clk_mhz_min": 2322, "power_w": 1333.0, "smi_status": "ok"}]}
```

This is aiter's `print_json_table` format (`aiter/test_common.py`), record-oriented and on one line so a parent driver can validate and forward it without parsing a human table. It is a copy rather than an import for the same reason `_data.py` is, and it is pure Python rather than pandas -- a benchmark should not need a dataframe to print its own results. A point that fails its correctness check still gets a row, with `err_msg`, so a gap in the sweep cannot be mistaken for a tier nobody ran. `JSON=0` drops the line; the human table is unchanged either way.

### Clock and power telemetry

A latency number means little without the clock it was measured at: a power-limited part throttles and then reports a different time for the same kernel. With `AITER_SMI_MONITOR=1`, each point is replayed under `amdsmi` and the run reports gfx/soc clock, socket power, hotspot temperature, activity and VRAM.

Three things about that window:

* **It is a replay, after warmup and graph capture -- not the timed loop.** `ITERS` pairs are ~10 ms against a 50 ms sampling tick, too short to sample even once. This is also what keeps input generation, compilation and warmup out of the reported clocks, which is what the requirement asks for.
* **The replay count is computed on rank 0 and broadcast.** These kernels barrier across devices, so a per-rank duration loop would leave one rank waiting on a peer that had already finished.
* **Every rank monitors its own GPU; summaries are gathered to rank 0.** The row keeps the min across ranks as well as the mean, because one throttled GPU sets the pair time for all of them and a mean hides it. HIP ordinals are mapped to amdsmi handles by PCIe BDF, not by index -- amdsmi enumerates every GPU in the box while HIP enumerates what `HIP_VISIBLE_DEVICES` left it.

Telemetry never fails the benchmark. If `amdsmi` is missing, or any rank cannot start its monitor, all ranks agree to skip the window and the sweep continues. ROCm ships the binding without a `setup.py`, so the import falls back to `/opt/rocm/share/amd_smi` without leaving that path on `sys.path`.

Env vars, the emitted `AITER_SMI_RESULT` record and `AITER_SMI_OUTPUT_PATH` are aiter's, so `bench_gfx1250_combo.py` can consume mori's rows with the collector it already has.

### Testing

4x MI4xx, EP4, DSv4 shape (hidden 7168, topk 6, 96 experts/rank):

* JSON table verified against the printed human table for every point.
* SMI: 19-20 samples per 1 s window on **every** rank, `sample_status: ok`, no contention between the four concurrent samplers. Clocks agreed across ranks to within 1% (2322-2345 MHz) and power tracked the token count (1.33 kW at M=512, 1.49 kW at M=4096) -- the window is measuring the replay, not idle.
* Both backends (`flydsl`, `hip`), both modes (`eager`, `graph`), all three dispatch wires (`bf16`, `fp8`, `fp4`), with and without telemetry. All points passed their correctness gate.
* `black==25.1.0` and `ruff==0.12.0` at the repo's pinned config, clean.
