### PR TITLE
register Ionic CQ/SQ/RQ rings and atomic ibuf via dmabuf

### DIFF
--- a/include/mori/application/transport/rdma/providers/dv_loader.hpp
+++ b/include/mori/application/transport/rdma/providers/dv_loader.hpp
@@ -27,6 +27,7 @@
 
 #include <dlfcn.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 
@@ -183,6 +184,12 @@ struct IonicDvApi {
   using pd_set_udma_mask_t = int (*)(struct ibv_pd*, uint32_t);
   using create_cq_ex_t = struct ibv_cq_ex* (*)(struct ibv_context*, struct ibv_cq_init_attr_ex*,
                                                struct ionic_cq_init_attr_ex*);
+  // Spelled out structurally rather than via ionic_dmabuf_{alloc,free}_fn so this
+  // header stays independent of ionic_dv.h.
+  using dmabuf_alloc_cb_t = int (*)(struct ibv_pd*, void*, size_t, uint64_t,
+                                    struct ionic_dmabuf_alloc_result*);
+  using dmabuf_free_cb_t = void (*)(struct ibv_pd*, void*, int, uint64_t, uint64_t);
+  using pd_set_dmabuf_alloc_t = int (*)(struct ibv_pd*, dmabuf_alloc_cb_t, dmabuf_free_cb_t, void*);
 
   get_ctx_t get_ctx = nullptr;
   qp_get_udma_idx_t qp_get_udma_idx = nullptr;
@@ -192,6 +199,7 @@ struct IonicDvApi {
   pd_set_rqcmb_t pd_set_rqcmb = nullptr;
   pd_set_udma_mask_t pd_set_udma_mask = nullptr;
   create_cq_ex_t create_cq_ex = nullptr;
+  pd_set_dmabuf_alloc_t pd_set_dmabuf_alloc = nullptr;
 
   void* handle = nullptr;
 
@@ -207,8 +215,11 @@ struct IonicDvApi {
     pd_set_rqcmb = (pd_set_rqcmb_t)DvLoadSymbol(handle, "ionic_dv_pd_set_rqcmb");
     pd_set_udma_mask = (pd_set_udma_mask_t)DvLoadSymbol(handle, "ionic_dv_pd_set_udma_mask");
     create_cq_ex = (create_cq_ex_t)DvLoadSymbol(handle, "ionic_dv_create_cq_ex");
+    pd_set_dmabuf_alloc =
+        (pd_set_dmabuf_alloc_t)DvLoadSymbol(handle, "ionic_dv_pd_set_dmabuf_alloc");
 
-    // create_cq_ex is optional: nullptr means CCQE not supported by this driver version
+    // create_cq_ex and pd_set_dmabuf_alloc are optional: nullptr means CCQE resp. dmabuf
+    // descriptor rings are not supported by this driver version
     return get_ctx && qp_get_udma_idx && get_cq && get_qp && pd_set_sqcmb && pd_set_rqcmb &&
            pd_set_udma_mask;
   }

--- a/include/mori/application/transport/rdma/providers/ionic/ionic.hpp
+++ b/include/mori/application/transport/rdma/providers/ionic/ionic.hpp
@@ -25,6 +25,9 @@
 #include <hsa/hsa.h>
 #include <hsa/hsa_ext_amd.h>
 
+#include <mutex>
+#include <unordered_map>
+
 #include "mori/application/transport/rdma/providers/dv_loader.hpp"
 #include "mori/application/transport/rdma/providers/ionic/ionic_dv.h"
 #include "mori/application/transport/rdma/rdma.hpp"
@@ -151,9 +154,24 @@ class IonicDeviceContext : public RdmaDeviceContext {
   static void pd_release(ibv_pd* pd, void* pd_context, void* ptr, uint64_t resource_type);
   static void* pd_alloc_device_uncached(ibv_pd* pd, void* pd_context, size_t size, size_t alignment,
                                         uint64_t resource_type);
+  // Descriptor-ring allocators handing the provider a dmabuf fd instead of a bare VA, so the
+  // CQ/SQ/RQ rings are registered the same way the data path registers user buffers.
+  static int pd_alloc_dmabuf(ibv_pd* pd, void* pd_context, size_t size, uint64_t resource_type,
+                             struct ionic_dmabuf_alloc_result* result);
+  static void pd_free_dmabuf(ibv_pd* pd, void* pd_context, int fd, uint64_t offset,
+                             uint64_t resource_type);
   void create_parent_domain(ibv_context* context, struct ibv_pd* pd_orig);
 
  private:
+  // Backing device allocation for a ring handed out through pd_alloc_dmabuf, keyed by the
+  // dmabuf fd since that plus the offset is all pd_free_dmabuf gets back.
+  struct DmabufRing {
+    void* devPtr;
+    uint64_t offset;
+  };
+  std::mutex dmabufRingsMutex;
+  std::unordered_map<int, DmabufRing> dmabufRings;
+
   uint32_t pdn;
   struct ibv_pd* pd_uxdma[2];
 

--- a/include/mori/application/transport/rdma/providers/ionic/ionic_dv.h
+++ b/include/mori/application/transport/rdma/providers/ionic/ionic_dv.h
@@ -21,14 +21,15 @@
 // SOFTWARE.
 /* SPDX-License-Identifier: GPL-2.0 OR Linux-OpenIB */
 /*
- * Copyright (c) 2023 Advanced Micro Devices, Inc.  All rights reserved.
+ * Copyright (c) 2018-2026 Advanced Micro Devices, Inc.  All rights reserved.
  */
 
 #ifndef IONIC_DV_H
 #define IONIC_DV_H
 
-#include <infiniband/verbs.h>
 #include <stdbool.h>
+#include <infiniband/verbs.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -36,101 +37,167 @@ extern "C" {
 struct ibv_cq;
 struct ibv_qp;
 
+#define RDMA_DRIVER_IONIC	21
+
 /** IONIC_PD_TAG - tag used for parent domain resource allocation. */
-#define IONIC_PD_TAG ((uint64_t)RDMA_DRIVER_IONIC << 32)
-#define IONIC_PD_TAG_CQ (IONIC_PD_TAG | 1)
-#define IONIC_PD_TAG_SQ (IONIC_PD_TAG | 2)
-#define IONIC_PD_TAG_RQ (IONIC_PD_TAG | 3)
-#define IONIC_PD_TAG_RCQ (IONIC_PD_TAG | 4)
+#define IONIC_PD_TAG		((uint64_t)RDMA_DRIVER_IONIC << 32)
+#define IONIC_PD_TAG_CQ		(IONIC_PD_TAG | 1)
+#define IONIC_PD_TAG_SQ		(IONIC_PD_TAG | 2)
+#define IONIC_PD_TAG_RQ		(IONIC_PD_TAG | 3)
+#define IONIC_PD_TAG_RCQ	(IONIC_PD_TAG | 4)
 
 /* deprecated */
-#define IONIC_SQ_SIG_ALL 1
+#define IONIC_SQ_SIG_ALL	1
 /* deprecated */
-#define IONIC_SQ_SIG_HACK_HIGH 2
+#define IONIC_SQ_SIG_HACK_HIGH	2
 
 /** IONIC_UDMA_MASK_LOW - flag represents the udma0 pipeline in the udma mask. */
-#define IONIC_UDMA_MASK_LOW 1
+#define IONIC_UDMA_MASK_LOW	1
 /** IONIC_UDMA_MASK_HIGH - flag represents the udma1 pipeline in the udma mask. */
-#define IONIC_UDMA_MASK_HIGH 2
+#define IONIC_UDMA_MASK_HIGH	2
 
-#define IONIC_DV_PUEC_NPORTS_MAX 8
+#define IONIC_DV_MULTIPLANE_NPORTS_MAX	8
+#define IONIC_DV_PUEC_NPORTS_MAX	IONIC_DV_MULTIPLANE_NPORTS_MAX
 
 /** struct ionic_dv_ctx - Context information for gpu-initiated rdma. */
 struct ionic_dv_ctx {
-  void* db_page;
-  uint64_t* db_ptr;
-  uint8_t sq_qtype;
-  uint8_t rq_qtype;
-  uint8_t cq_qtype;
+	void			*db_page;
+	uint64_t		*db_ptr;
+	uint8_t			sq_qtype;
+	uint8_t			rq_qtype;
+	uint8_t			cq_qtype;
 };
 
 /** struct ionic_dv_ctx - Queue information for gpu-initiated rdma. */
 struct ionic_dv_queue {
-  void* ptr;
-  size_t size;
-  uint64_t db_val;
-  uint16_t mask;
-  uint8_t depth_log2;
-  uint8_t stride_log2;
+	void			*ptr;
+	size_t			size;
+	uint64_t		db_val;
+	uint16_t		mask;
+	uint8_t			depth_log2;
+	uint8_t			stride_log2;
 };
 
 /** struct ionic_dv_ctx - CQ information for gpu-initiated rdma. */
 struct ionic_dv_cq {
-  struct ionic_dv_queue q;
+	struct ionic_dv_queue	q;
 };
 
 /** struct ionic_dv_ctx - QP information for gpu-initiated rdma. */
 struct ionic_dv_qp {
-  struct ionic_dv_queue rq;
-  struct ionic_dv_queue sq;
+	struct ionic_dv_queue	rq;
+	struct ionic_dv_queue	sq;
 };
 
-/** struct ionic_puec_route - Info needed to setup a PUEC plane route. */
-struct ionic_dv_puec_route {
-  union ibv_gid dgid;
-  union ibv_gid sgid;
-  uint32_t flow_label;
-  uint8_t hop_limit;
-  uint8_t traffic_class;
-  uint8_t sl;
-  uint8_t rsvd[5];
-  uint32_t flags;
+/** struct ionic_dv_multiplane_route - Info needed to setup a multiplane route. */
+struct ionic_dv_multiplane_route {
+	union ibv_gid	dgid;
+	union ibv_gid	sgid;
+	uint32_t	flow_label;
+	uint8_t		hop_limit;
+	uint8_t		traffic_class;
+	uint8_t		sl;
+	uint8_t		rsvd[5];
+	uint32_t	flags;
 };
+
+/** struct ionic_dv_multiplane_conn_info - Multiplane connection information. */
+struct ionic_dv_multiplane_conn_info {
+	uint16_t	num_planes;
+	struct ionic_dv_multiplane_route *mp_routes;
+	union ibv_gid	src_gid;
+	union ibv_gid	dest_gid;
+};
+
+/** Deprecated: use struct ionic_dv_multiplane_route instead */
+struct ionic_dv_puec_route {
+        union ibv_gid	dgid;
+        union ibv_gid	sgid;
+        uint32_t	flow_label;
+        uint8_t		hop_limit;
+        uint8_t		traffic_class;
+	uint8_t		sl;
+	uint8_t		rsvd[5];
+	uint32_t	flags;
+};
+
+/**
+ * struct ionic_dmabuf_alloc_result - Result of a DMABUF ring allocation.
+ * @fd:		DMABUF file descriptor.
+ * @offset:	Byte offset within the DMABUF at which the ring starts.
+ * @ptr:	Optional CPU mapping of the ring.  If non-NULL, the provider
+ *		will use this address for ibv_post_send(), ibv_post_recv(), and
+ *		ibv_poll_cq().  If NULL, those functions must not be called.
+ */
+struct ionic_dmabuf_alloc_result {
+	int		fd;
+	uint64_t	offset;
+	void		*ptr;
+};
+
+/**
+ * ionic_dmabuf_alloc_fn - Allocate a DMABUF on behalf of the provider.
+ *
+ * @pd:			Parent domain of the allocation.
+ * @pd_context:		Context set by ionic_dv_pd_set_dmabuf_alloc().
+ * @size:		Size in bytes of the buffer to allocate.
+ * @resource_type:	IONIC_PD_TAG_* identifying the buffer type.
+ * @result:		Output: fd and offset of the allocated buffer.
+ *
+ * Return: 0 on success, errno on failure.
+ */
+typedef int ionic_dmabuf_alloc_fn(struct ibv_pd *pd, void *pd_context,
+				  size_t size, uint64_t resource_type,
+				  struct ionic_dmabuf_alloc_result *result);
+
+/**
+ * ionic_dmabuf_free_fn - Free a DMABUF allocated by ionic_dmabuf_alloc_fn.
+ *
+ * @pd:			Parent domain of the allocation.
+ * @pd_context:		Context set by ionic_dv_pd_set_dmabuf_alloc().
+ * @fd:			DMABUF fd from the alloc callback.
+ * @offset:		Offset from the alloc callback.
+ * @resource_type:	IONIC_PD_TAG_* identifying the buffer type.
+ */
+typedef void ionic_dmabuf_free_fn(struct ibv_pd *pd, void *pd_context,
+				  int fd, uint64_t offset,
+				  uint64_t resource_type);
 
 /**
  * ionic_dv_is_ionic_ctx - Test if context belongs to ionic provider.
  */
-bool ionic_dv_is_ionic_ctx(struct ibv_context* ibctx);
+bool ionic_dv_is_ionic_ctx(struct ibv_context *ibctx);
 
 /**
  * ionic_dv_is_ionic_pd - Test if pd belongs to ionic provider.
  */
-bool ionic_dv_is_ionic_pd(struct ibv_pd* ibpd);
+bool ionic_dv_is_ionic_pd(struct ibv_pd *ibpd);
 
 /**
  * ionic_dv_is_ionic_cq - Test if cq belongs to ionic provider.
  */
-bool ionic_dv_is_ionic_cq(struct ibv_cq* ibcq);
+bool ionic_dv_is_ionic_cq(struct ibv_cq *ibcq);
 
 /**
  * ionic_dv_is_ionic_qp - Test if qp belongs to ionic provider.
  */
-bool ionic_dv_is_ionic_qp(struct ibv_qp* ibqp);
+bool ionic_dv_is_ionic_qp(struct ibv_qp *ibqp);
+
 
 /**
  * ionic_dv_ctx_get_udma_count - Get number of udma pipelines.
  */
-uint8_t ionic_dv_ctx_get_udma_count(struct ibv_context* ibctx);
+uint8_t ionic_dv_ctx_get_udma_count(struct ibv_context *ibctx);
 
 /**
  * ionic_dv_ctx_get_udma_mask - Get mask of udma pipeline ids.
  */
-uint8_t ionic_dv_ctx_get_udma_mask(struct ibv_context* ibctx);
+uint8_t ionic_dv_ctx_get_udma_mask(struct ibv_context *ibctx);
 
 /**
  * ionic_dv_pd_get_udma_mask - Get mask of udma pipeline ids of pd or parent domain.
  */
-uint8_t ionic_dv_pd_get_udma_mask(struct ibv_pd* ibpd);
+uint8_t ionic_dv_pd_get_udma_mask(struct ibv_pd *ibpd);
 
 /**
  * ionic_dv_pd_set_udma_mask - Restrict pipeline ids of pd or parent domain.
@@ -146,17 +213,35 @@ uint8_t ionic_dv_pd_get_udma_mask(struct ibv_pd* ibpd);
  * each queue.  Changing the udma mask of the pd has no effect on previously created
  * queues.
  */
-int ionic_dv_pd_set_udma_mask(struct ibv_pd* ibpd, uint8_t udma_mask);
+int ionic_dv_pd_set_udma_mask(struct ibv_pd *ibpd, uint8_t udma_mask);
 
 /**
  * ionic_dv_cq_get_udma_mask - Get mask of udma pipeline ids of completion queueue.
  */
-uint8_t ionic_dv_cq_get_udma_mask(struct ibv_cq* ibcq);
+uint8_t ionic_dv_cq_get_udma_mask(struct ibv_cq *ibcq);
 
 /**
  * ionic_dv_qp_get_udma_idx - Get udma pipeline id of queueue pair.
  */
-uint8_t ionic_dv_qp_get_udma_idx(struct ibv_qp* ibqp);
+uint8_t ionic_dv_qp_get_udma_idx(struct ibv_qp *ibqp);
+
+
+/**
+ * ionic_dv_pd_set_dmabuf_alloc - Register DMABUF ring allocation callbacks on a pd.
+ *
+ * When set, the provider calls @alloc instead of the standard parent domain
+ * alloc callback to obtain descriptor ring memory.  The callback returns a
+ * dmabuf fd, byte offset and optional virtual address.
+ *
+ * @ibpd:       Protection domain to configure.
+ * @alloc:      Callback to allocate a descriptor ring, or NULL.
+ * @free:       Callback to free a descriptor ring, or NULL.
+ * @pd_context: Opaque pointer passed to both callbacks.
+ */
+int ionic_dv_pd_set_dmabuf_alloc(struct ibv_pd *ibpd,
+				 ionic_dmabuf_alloc_fn *alloc,
+				 ionic_dmabuf_free_fn *free,
+				 void *pd_context);
 
 /**
  * ionic_dv_pd_set_sqcmb - Specify send queue preference for controller memory bar.
@@ -168,14 +253,19 @@ uint8_t ionic_dv_qp_get_udma_idx(struct ibv_qp* ibqp);
  * @expdb - Allow the use of express doorbell optimizations.
  * @require - Require preferences to be met, no fallback.
  */
-int ionic_dv_pd_set_sqcmb(struct ibv_pd* ibpd, bool enable, bool expdb, bool require);
+int ionic_dv_pd_set_sqcmb(struct ibv_pd *ibpd, bool enable, bool expdb, bool require);
 
 /**
  * ionic_dv_pd_set_rqcmb - Specify receive queue preference for controller memory bar.
  *
- * See ionic_dv_pd_set_sqcmb().
+ * Receive queues associated with this pd will use the controller memory bar according to
+ * this preference at the time of queue creation.
+ *
+ * @enable - Allow the use of the controller memory bar.
+ * @expdb - Allow the use of express doorbell optimizations.
+ * @require - Require preferences to be met, no fallback.
  */
-int ionic_dv_pd_set_rqcmb(struct ibv_pd* ibpd, bool enable, bool expdb, bool require);
+int ionic_dv_pd_set_rqcmb(struct ibv_pd *ibpd, bool enable, bool expdb, bool require);
 
 /**
  * ionic_dv_pd_set_expdb_mask - Specify expdb mask.
@@ -185,7 +275,7 @@ int ionic_dv_pd_set_rqcmb(struct ibv_pd* ibpd, bool enable, bool expdb, bool req
  *
  * @mask - IONIC_EPXDB_* bitmap
  */
-int ionic_dv_pd_set_expdb_mask(struct ibv_pd* ibpd, uint8_t mask);
+int ionic_dv_pd_set_expdb_mask(struct ibv_pd *ibpd, uint8_t mask);
 
 /**
  * ionic_dv_qp_set_gda - Enable or disable GPU-Direct Async (GDA) mode.
@@ -204,7 +294,7 @@ int ionic_dv_pd_set_expdb_mask(struct ibv_pd* ibpd, uint8_t mask);
  * @enable_send - Enable GDA mode for the send queue.
  * @enable_recv - Enable GDA mode for the recv queue.
  */
-int ionic_dv_qp_set_gda(struct ibv_qp* ibqp, bool enable_send, bool enable_recv);
+int ionic_dv_qp_set_gda(struct ibv_qp *ibqp, bool enable_send, bool enable_recv);
 
 /**
  * ionic_dv_qp_get_send_dbell_data - Get send queue doorbell data.
@@ -226,7 +316,7 @@ int ionic_dv_qp_set_gda(struct ibv_qp* ibqp, bool enable_send, bool enable_recv)
  * @ibqp - Get send doorbell data for this queue pair.
  * @dbdata - Output parameter for doorbell data.
  */
-int ionic_dv_qp_get_send_dbell_data(struct ibv_qp* ibqp, uint64_t* dbdata);
+int ionic_dv_qp_get_send_dbell_data(struct ibv_qp *ibqp, uint64_t *dbdata);
 
 /**
  * ionic_dv_qp_get_recv_dbell_data - Get recv queue doorbell data.
@@ -249,21 +339,22 @@ int ionic_dv_qp_get_send_dbell_data(struct ibv_qp* ibqp, uint64_t* dbdata);
  * @ibqp - Get recv doorbell data for this queue pair.
  * @dbdata - Output parameter for doorbell data.
  */
-int ionic_dv_qp_get_recv_dbell_data(struct ibv_qp* ibqp, uint64_t* dbdata);
+int ionic_dv_qp_get_recv_dbell_data(struct ibv_qp *ibqp, uint64_t *dbdata);
+
 
 enum ionic_cq_init_attr_mask {
-  IONIC_CQ_INIT_ATTR_MASK_FLAGS = 1 << 0,
+	IONIC_CQ_INIT_ATTR_MASK_FLAGS	= 1 << 0,
 };
 
 enum ionic_cq_init_attr_flags {
-  IONIC_CQ_INIT_ATTR_CCQE = 1 << 0,
+	IONIC_CQ_INIT_ATTR_CCQE		= 1 << 0,
 };
 
 struct ionic_cq_init_attr_ex {
-  /* One or more flags of enum ionic_cq_init_attr_mask */
-  uint32_t comp_mask;
-  /* One or more flags of enum ionic_cq_init_attr_flags */
-  uint32_t flags;
+	/* One or more flags of enum ionic_cq_init_attr_mask */
+	uint32_t	    comp_mask;
+	/* One or more flags of enum ionic_cq_init_attr_flags */
+	uint32_t	    flags;
 };
 
 /**
@@ -273,30 +364,46 @@ struct ionic_cq_init_attr_ex {
  * @ex - IBV attributes to create the CQ with.
  * @ionic_ex - Vendor-specific attributes to create the CQ with.
  */
-struct ibv_cq_ex* ionic_dv_create_cq_ex(struct ibv_context* ibctx, struct ibv_cq_init_attr_ex* ex,
-                                        struct ionic_cq_init_attr_ex* ionic_ex);
+struct ibv_cq_ex *ionic_dv_create_cq_ex(struct ibv_context *ibctx,
+					struct ibv_cq_init_attr_ex *ex,
+					struct ionic_cq_init_attr_ex *ionic_ex);
 
 /**
  * ionic_dv_get_ctx - Extract context information for gpu-initiated rdma.
  */
-int ionic_dv_get_ctx(struct ionic_dv_ctx* dvctx, struct ibv_context* ibctx);
+int ionic_dv_get_ctx(struct ionic_dv_ctx *dvctx, struct ibv_context *ibctx);
 
 /**
  * ionic_dv_get_cq - Extract cq information for gpu-initiated rdma.
  */
-int ionic_dv_get_cq(struct ionic_dv_cq* dvcq, struct ibv_cq* ibcq, uint8_t udma_idx);
+int ionic_dv_get_cq(struct ionic_dv_cq *dvcq, struct ibv_cq *ibcq, uint8_t udma_idx);
 
 /**
  * ionic_dv_get_qp - Extract qp information for gpu-initiated rdma.
  */
-int ionic_dv_get_qp(struct ionic_dv_qp* dvqp, struct ibv_qp* ibqp);
+int ionic_dv_get_qp(struct ionic_dv_qp *dvqp, struct ibv_qp *ibqp);
+
+/**
+ * ionic_dv_qp_set_multiplane_conn_info - Set multiplane connection information for a QP.
+ * This is used in multiplane environments to configure both routing information
+ * and GIDs used for routing that may differ from the real port GIDs.
+ * @ibqp: Queue pair to configure
+ * @conn_info: Multiplane connection information including routes and GIDs
+ *
+ * Returns 0 on success, error code on failure.
+ */
+int ionic_dv_qp_set_multiplane_conn_info(struct ibv_qp *ibqp,
+					 const struct ionic_dv_multiplane_conn_info *conn_info);
 
 /**
  * ionic_dv_qp_set_puec_plane_route - set route info for a PUEC plane.
+ * Deprecated: use ionic_dv_qp_set_multiplane_conn_info instead.
  */
-int ionic_dv_qp_set_puec_plane_route(struct ibv_qp* ibqp, uint8_t plane_idx,
-                                     struct ionic_dv_puec_route* ipr);
+int ionic_dv_qp_set_puec_plane_route(struct ibv_qp *ibqp, uint8_t plane_idx,
+				     struct ionic_dv_puec_route *ipr);
+
 #ifdef __cplusplus
 }
 #endif
+
 #endif /* IONIC_DV_H */

--- a/include/mori/application/transport/rdma/rdma.hpp
+++ b/include/mori/application/transport/rdma/rdma.hpp
@@ -201,6 +201,11 @@ bool ReadIoTrafficClassDisableEnv();
 bool ReadIbEnableRelaxedOrderingEnv();
 int MaybeAddRelaxedOrderingFlag(int accessFlag);
 
+// Export a dmabuf fd for the GPU buffer at `ptr`, reporting the byte offset of
+// `ptr` within the exported dmabuf via `*offset`. Returns -1 if unsupported.
+// Callers own the returned fd and must close() it.
+int TryExportDmabufFd(void* ptr, size_t size, uint64_t* offset);
+
 /* -------------------------------------------------------------------------- */
 /*                              RdmaDeviceContext                             */
 /* -------------------------------------------------------------------------- */

--- a/include/mori/application/transport/rdma/rdma.hpp
+++ b/include/mori/application/transport/rdma/rdma.hpp
@@ -221,8 +221,8 @@ class RdmaDeviceContext {
   // dmabuf registration with iova=0 (CCO symmetric flat-VA path; BNXT GDA).
   virtual RdmaMemoryRegion RegisterRdmaMemoryRegionDmabufIova0(
       void* ptr, size_t size, int dmabuf_fd, int accessFlag = MR_DEFAULT_ACCESS_FLAG);
-  // ibv_reg_mr-first registration; falls back to dmabuf. Set MORI_ENABLE_DMABUF_REG to try
-  // dmabuf first instead (falling back to ibv_reg_mr).
+  // ibv_reg_mr-first registration; falls back to dmabuf. Set MORI_ENABLE_DMABUF_REG=1
+  // to try dmabuf first for payload MRs and Ionic CQ/SQ/RQ rings.
   virtual RdmaMemoryRegion RegisterRdmaMemoryRegionAuto(void* ptr, size_t size,
                                                         int accessFlag = MR_DEFAULT_ACCESS_FLAG);
   virtual void DeregisterRdmaMemoryRegion(void* ptr);

--- a/src/application/transport/rdma/providers/ionic/ionic.cpp
+++ b/src/application/transport/rdma/providers/ionic/ionic.cpp
@@ -316,12 +316,51 @@ IonicQpContainer::IonicQpContainer(ibv_context* context, const RdmaEndpointConfi
     assert(!err);
   }
 
-  // Register atomic ibuf as independent memory region
+  // Register atomic ibuf as independent memory region.
+  //
+  // A device-resident ibuf is GPU memory just like the CQ/SQ/RQ rings, so a bare
+  // VA only resolves if a peer memory client is registered with the RDMA stack.
+  // That is not guaranteed: amdgpu's PeerDirect client is optional and resolves
+  // ib_register_peer_memory_client via symbol_get at load time, so on a host
+  // without it ibv_reg_mr returns NULL here while the dma-buf path works fine.
+  // Try both, ordered the same way payload MRs are in RegisterRdmaMemoryRegionAuto.
   int atomicIbufAccessFlag =
       MaybeAddRelaxedOrderingFlag(IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
                                   IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC);
-  atomicIbufMr = ibv_reg_mr(pd_uxdma, atomicIbufAddr, atomicIbufSize, atomicIbufAccessFlag);
-  assert(atomicIbufMr);
+
+  auto tryIbufDmabuf = [&]() -> ibv_mr* {
+    if (!config.onGpu) return nullptr;
+    uint64_t dmabufOffset = 0;
+    int dmabufFd = TryExportDmabufFd(atomicIbufAddr, atomicIbufSize, &dmabufOffset);
+    if (dmabufFd < 0) return nullptr;
+    ibv_mr* mr = ibv_reg_dmabuf_mr(pd_uxdma, dmabufOffset, atomicIbufSize,
+                                   reinterpret_cast<uint64_t>(atomicIbufAddr), dmabufFd,
+                                   atomicIbufAccessFlag);
+    close(dmabufFd);
+    return mr;
+  };
+  auto tryIbufPlain = [&]() -> ibv_mr* {
+    return ibv_reg_mr(pd_uxdma, atomicIbufAddr, atomicIbufSize, atomicIbufAccessFlag);
+  };
+
+  bool preferDmabuf = env::IsEnvVarEnabled("MORI_ENABLE_DMABUF_REG");
+  for (int attempt = 0; attempt < 2 && (atomicIbufMr == nullptr); ++attempt) {
+    bool useDmabuf = (attempt == 0) ? preferDmabuf : !preferDmabuf;
+    atomicIbufMr = useDmabuf ? tryIbufDmabuf() : tryIbufPlain();
+    if (atomicIbufMr) {
+      MORI_APP_TRACE("IONIC atomic ibuf registered via {}, addr:{}, size:{}",
+                     useDmabuf ? "dmabuf" : "ibv_reg_mr", atomicIbufAddr, atomicIbufSize);
+    }
+  }
+
+  if (atomicIbufMr == nullptr) {
+    MORI_APP_ERROR(
+        "IONIC atomic ibuf registration failed: dmabuf and ibv_reg_mr both failed (addr:{}, "
+        "size:{}, onGpu:{}, errno:{} ({})). Device memory needs either a dma-buf capable "
+        "libionic/driver or a registered peer memory client.",
+        atomicIbufAddr, atomicIbufSize, config.onGpu, errno, strerror(errno));
+    std::abort();
+  }
 
   MORI_APP_TRACE(
       "IONIC Atomic ibuf allocated: addr=0x{:x}, slots={}, size={}, lkey=0x{:x}, rkey=0x{:x}",
@@ -370,6 +409,10 @@ void IonicQpContainer::ModifyRst2Init() {
 
   attr_mask = IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS;
   err = ibv_modify_qp(qp, &attr, attr_mask);
+  if (err != 0) {
+    MORI_APP_ERROR("ionic ModifyRst2Init failed: err:{} ({}), qpn:{}, portId:{}", err,
+                   strerror(err), qp ? qp->qp_num : 0, config.portId);
+  }
   assert(err == 0);
 }
 
@@ -415,6 +458,18 @@ void IonicQpContainer::ModifyInit2Rtr(const RdmaEndpointHandle& local_handle,
   printf("\n");
 #endif
   err = ibv_modify_qp(qp, &attr, attr_mask);
+  if (err != 0) {
+    char dgidStr[48] = {0};
+    for (int i = 0; i < 16; i++) {
+      snprintf(dgidStr + i * 2, sizeof(dgidStr) - i * 2, "%02x", remote_handle.eth.gid[i]);
+    }
+    MORI_APP_ERROR(
+        "ionic ModifyInit2Rtr failed: err:{} ({}), local_qpn:{}, dest_qpn:{}, rq_psn:{}, "
+        "sgid_index:{}, portId:{}, path_mtu:{}, max_dest_rd_atomic:{}, sl:{}, tc:{}, dgid:{}",
+        err, strerror(err), qp ? qp->qp_num : 0, attr.dest_qp_num, attr.rq_psn,
+        attr.ah_attr.grh.sgid_index, config.portId, static_cast<int>(attr.path_mtu),
+        attr.max_dest_rd_atomic, attr.ah_attr.sl, attr.ah_attr.grh.traffic_class, dgidStr);
+  }
   assert(err == 0);
 }
 
@@ -436,6 +491,10 @@ void IonicQpContainer::ModifyRtr2Rts(const RdmaEndpointHandle& local_handle,
               IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY;
 
   err = ibv_modify_qp(qp, &attr, attr_mask);
+  if (err != 0) {
+    MORI_APP_ERROR("ionic ModifyRtr2Rts failed: err:{} ({}), local_qpn:{}, sq_psn:{}", err,
+                   strerror(err), qp ? qp->qp_num : 0, attr.sq_psn);
+  }
   assert(!err);
 }
 
@@ -531,10 +590,11 @@ void IonicDeviceContext::create_parent_domain(ibv_context* context, struct ibv_p
   pattr.pd_context = nullptr;
   pattr.alloc = IonicDeviceContext::pd_alloc_device_uncached;
 
-  // Prefer handing the provider dmabuf-backed rings. Needs libionic >= the release that
-  // exports ionic_dv_pd_set_dmabuf_alloc; older ones keep the bare-VA alloc above.
+  // Same switch as payload MRs: MORI_ENABLE_DMABUF_REG=1 enables dma-buf CQ/SQ/RQ
+  // rings. Needs libionic >= the release that exports ionic_dv_pd_set_dmabuf_alloc;
+  // older libs keep the bare-VA alloc above.
   bool useDmabufRings = IonicDvApi::Instance().pd_set_dmabuf_alloc != nullptr &&
-                        !env::IsEnvVarEnabled("MORI_DISABLE_IONIC_DMABUF_RINGS");
+                        env::IsEnvVarEnabled("MORI_ENABLE_DMABUF_REG");
   if (IonicDvApi::Instance().pd_set_dmabuf_alloc == nullptr) {
     MORI_APP_WARN(
         "libionic has no ionic_dv_pd_set_dmabuf_alloc; CQ/SQ/RQ rings fall back to bare-VA "

--- a/src/application/transport/rdma/providers/ionic/ionic.cpp
+++ b/src/application/transport/rdma/providers/ionic/ionic.cpp
@@ -24,12 +24,15 @@
 
 #include <hip/hip_runtime_api.h>
 #include <infiniband/verbs.h>
+#include <unistd.h>
 
 #include <cctype>
+#include <cerrno>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <mutex>
 #include <optional>
 #include <tuple>
 
@@ -37,6 +40,7 @@
 #include "mori/application/utils/check.hpp"
 #include "mori/application/utils/math.hpp"
 #include "mori/core/transport/rdma/providers/ionic/ionic_fw.h"
+#include "mori/utils/env_utils.hpp"
 #include "mori/utils/mori_log.hpp"
 
 namespace mori {
@@ -452,6 +456,71 @@ void* IonicDeviceContext::pd_alloc_device_uncached(struct ibv_pd* pd, void* pd_c
   return dev_ptr;
 }
 
+int IonicDeviceContext::pd_alloc_dmabuf(struct ibv_pd* pd, void* pd_context, size_t size,
+                                        uint64_t resource_type,
+                                        struct ionic_dmabuf_alloc_result* result) {
+  auto* self = static_cast<IonicDeviceContext*>(pd_context);
+  if ((self == nullptr) || (result == nullptr)) return EINVAL;
+
+  void* devPtr{nullptr};
+  hipError_t err =
+      hipExtMallocWithFlags(reinterpret_cast<void**>(&devPtr), size, hipDeviceMallocUncached);
+  if (err != hipSuccess) {
+    (void)hipGetLastError();
+    MORI_APP_ERROR("pd_alloc_dmabuf: hipExtMallocWithFlags failed, size:{}, resource_type:{:#x}",
+                   size, resource_type);
+    return ENOMEM;
+  }
+  memset(devPtr, 0, size);
+
+  uint64_t offset = 0;
+  int fd = TryExportDmabufFd(devPtr, size, &offset);
+  if (fd < 0) {
+    MORI_APP_ERROR("pd_alloc_dmabuf: dmabuf export failed, size:{}, resource_type:{:#x}", size,
+                   resource_type);
+    HIP_RUNTIME_CHECK(hipFree(devPtr));
+    return EOPNOTSUPP;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(self->dmabufRingsMutex);
+    self->dmabufRings[fd] = DmabufRing{devPtr, offset};
+  }
+
+  result->fd = fd;
+  result->offset = offset;
+  // Hand back the VA too so the provider can still drive ibv_post_send/recv and ibv_poll_cq.
+  result->ptr = devPtr;
+
+  MORI_APP_TRACE("pd_alloc_dmabuf, addr:{}, size:{}, fd:{}, offset:{}, resource_type:{:#x}", devPtr,
+                 size, fd, offset, resource_type);
+  return 0;
+}
+
+void IonicDeviceContext::pd_free_dmabuf(struct ibv_pd* pd, void* pd_context, int fd,
+                                        uint64_t offset, uint64_t resource_type) {
+  auto* self = static_cast<IonicDeviceContext*>(pd_context);
+  if (self == nullptr) return;
+
+  void* devPtr{nullptr};
+  {
+    std::lock_guard<std::mutex> lock(self->dmabufRingsMutex);
+    auto it = self->dmabufRings.find(fd);
+    if (it == self->dmabufRings.end()) {
+      MORI_APP_WARN("pd_free_dmabuf: unknown fd:{}, offset:{}, resource_type:{:#x}", fd, offset,
+                    resource_type);
+      return;
+    }
+    devPtr = it->second.devPtr;
+    self->dmabufRings.erase(it);
+  }
+
+  close(fd);
+  HIP_RUNTIME_CHECK(hipFree(devPtr));
+  MORI_APP_TRACE("pd_free_dmabuf, addr:{}, fd:{}, offset:{}, resource_type:{:#x}", devPtr, fd,
+                 offset, resource_type);
+}
+
 void IonicDeviceContext::create_parent_domain(ibv_context* context, struct ibv_pd* pd_orig) {
   struct ibv_parent_domain_init_attr pattr;
 
@@ -461,6 +530,16 @@ void IonicDeviceContext::create_parent_domain(ibv_context* context, struct ibv_p
   pattr.free = IonicDeviceContext::pd_release;
   pattr.pd_context = nullptr;
   pattr.alloc = IonicDeviceContext::pd_alloc_device_uncached;
+
+  // Prefer handing the provider dmabuf-backed rings. Needs libionic >= the release that
+  // exports ionic_dv_pd_set_dmabuf_alloc; older ones keep the bare-VA alloc above.
+  bool useDmabufRings = IonicDvApi::Instance().pd_set_dmabuf_alloc != nullptr &&
+                        !env::IsEnvVarEnabled("MORI_DISABLE_IONIC_DMABUF_RINGS");
+  if (IonicDvApi::Instance().pd_set_dmabuf_alloc == nullptr) {
+    MORI_APP_WARN(
+        "libionic has no ionic_dv_pd_set_dmabuf_alloc; CQ/SQ/RQ rings fall back to bare-VA "
+        "allocation");
+  }
 #if 0
   pd_parent = ibv_alloc_parent_domain(defaultContext, &pattr);
   assert(pd_parent);
@@ -472,6 +551,19 @@ void IonicDeviceContext::create_parent_domain(ibv_context* context, struct ibv_p
     pd_uxdma[i] = ibv_alloc_parent_domain(context, &pattr);
     assert(pd_uxdma[i]);
     // printf("create_parent_domain, pd_uxdma:%p\n", pd_uxdma[i]);
+    if (useDmabufRings) {
+      int err = IonicDvApi::Instance().pd_set_dmabuf_alloc(
+          pd_uxdma[i], IonicDeviceContext::pd_alloc_dmabuf, IonicDeviceContext::pd_free_dmabuf,
+          this);
+      if (err) {
+        MORI_APP_WARN(
+            "ionic_dv_pd_set_dmabuf_alloc failed on pd_uxdma[{}] (err:{}); falling back to bare-VA "
+            "rings",
+            i, err);
+      } else {
+        MORI_APP_TRACE("dmabuf descriptor rings enabled on pd_uxdma[{}]", i);
+      }
+    }
     IonicDvApi::Instance().pd_set_sqcmb(pd_uxdma[i], false, false, false);
     IonicDvApi::Instance().pd_set_rqcmb(pd_uxdma[i], false, false, false);
     IonicDvApi::Instance().pd_set_udma_mask(pd_uxdma[i], 1u << i);

--- a/src/application/transport/rdma/rdma.cpp
+++ b/src/application/transport/rdma/rdma.cpp
@@ -496,7 +496,8 @@ application::RdmaMemoryRegion RdmaDeviceContext::RegisterRdmaMemoryRegionAuto(vo
   };
 
   // Default: ibv_reg_mr first, dmabuf fallback (fast on bnxt). Set
-  // MORI_ENABLE_DMABUF_REG to prefer dmabuf first, falling back to ibv_reg_mr.
+  // MORI_ENABLE_DMABUF_REG=1 to prefer dmabuf first (payload MRs and, on Ionic,
+  // CQ/SQ/RQ rings), falling back to ibv_reg_mr for payload.
   for (int attempt = 0; attempt < 2; ++attempt) {
     bool useDmabuf = (attempt == 0) ? preferDmabufReg : !preferDmabufReg;
     const char* name = useDmabuf ? "dmabuf" : "ibv_reg_mr";

--- a/src/application/transport/rdma/rdma.cpp
+++ b/src/application/transport/rdma/rdma.cpp
@@ -452,7 +452,7 @@ application::RdmaMemoryRegion RdmaDeviceContext::RegisterRdmaMemoryRegionDmabufI
 // silent writes to the wrong address). hsa_amd_portable_export_dmabuf reports the
 // true byte offset, so prefer it and fall back to the hip path (offset 0, correct
 // only for whole-allocation exports) when HSA export is unavailable.
-static int TryExportDmabufFd(void* ptr, size_t size, uint64_t* offset) {
+int TryExportDmabufFd(void* ptr, size_t size, uint64_t* offset) {
   int fd = -1;
   uint64_t off = 0;
   hsa_status_t hs = hsa_amd_portable_export_dmabuf(ptr, size, &fd, &off);


### PR DESCRIPTION
## Summary
On Ionic, CQ/SQ/RQ descriptor rings and the per-QP atomic ibuf were allocated as
plain device VAs and registered with `ibv_reg_mr`. That only resolves when a
peer memory client is registered with the RDMA stack, and amdgpu's PeerDirect
client is optional — it resolves `ib_register_peer_memory_client` via
`symbol_get` at load time. On a host without it, `ibv_reg_mr` returns `NULL`;
the `assert` that was supposed to catch this compiles away under `NDEBUG`, so
the next line dereferences the null MR and release builds segfault with no
diagnostic.
This PR registers both the rings and the atomic ibuf through dma-buf, the same
way payload MRs already can, behind the existing `MORI_ENABLE_DMABUF_REG`
switch. One env var covers payload buffers, Ionic CQ/SQ/RQ rings, and the
atomic ibuf. Default (`unset`) is unchanged: `ibv_reg_mr` first for payload,
bare-VA rings.

## Performance
Two-node Ionic, 8 GPU/node, 16 PE, kernel v1, 2 QP on MI300, bfloat16. Rank-0 tables
from `examples/ops/dispatch_combine --cmd bench`, `MORI_ENABLE_DMABUF_REG=0`
vs `=1`.
dma-buf rings are inside run-to-run noise of the bare-VA path (~1–2%). Neither
side wins consistently.

### `max-tokens=4096` 
| Op | Metric | dma-buf off | dma-buf on | Δ on vs off |
|---|---|---:|---:|---:|
| Dispatch | avg RDMA BW (GB/s) | 62.40 | 63.35 | +1.5% |
| Combine | avg RDMA BW (GB/s) | 65.96 | 66.05 | +0.1% |

