### PR TITLE
fix(umbp): dlopen libhipfile instead of linking it

### DIFF
--- a/src/umbp/CMakeLists.txt
+++ b/src/umbp/CMakeLists.txt
@@ -433,13 +433,30 @@ target_compile_features(umbp_common PUBLIC cxx_std_17)
 
 # ---------- Optional hipfile GDS transfer engine -----------------------------
 # GdsEngine reads an SSD segment's byte range straight into GPU memory via
-# hipFileRead (no host bounce). Auto-enabled when hipfile is installed; a build
-# without it keeps only the memory engines and the host-staged SSD path.
+# hipFileRead (no host bounce). Compiled in when the hipfile headers are
+# installed; a build without them keeps only the memory engines and the
+# host-staged SSD path.
+#
+# HEADERS ONLY, NEVER -lhipfile.  umbp_common is linked into
+# libmori_pybinds.so, so a link-time dependency here becomes a DT_NEEDED on the
+# Python extension and `import mori` fails on any host whose ROCm ships without
+# libhipfile — even for users who never touch UMBP. hipfile_dl.cpp dlopen's the
+# library on first use instead, which keeps GDS working where it exists and
+# costs nothing where it does not.
+# GLOBAL so tests/cpp/umbp/distributed can still gate test_gds_engine on the
+# same target; nothing links it.
 find_package(hipfile QUIET CONFIG GLOBAL)
 if(TARGET hip::hipfile)
-  message(STATUS "[UMBP] hipfile found — GDS transfer engine ENABLED")
-  target_sources(umbp_common PRIVATE distributed/transfer/gds_engine.cpp)
-  target_link_libraries(umbp_common PUBLIC hip::hipfile)
+  message(STATUS "[UMBP] hipfile headers found — GDS transfer engine ENABLED "
+                 "(libhipfile resolved at runtime via dlopen)")
+  target_sources(umbp_common PRIVATE distributed/transfer/gds_engine.cpp
+                                     distributed/transfer/hipfile_dl.cpp)
+  get_target_property(_HIPFILE_INCLUDE_DIRS hip::hipfile
+                      INTERFACE_INCLUDE_DIRECTORIES)
+  if(_HIPFILE_INCLUDE_DIRS)
+    target_include_directories(umbp_common PRIVATE ${_HIPFILE_INCLUDE_DIRS})
+  endif()
+  target_link_libraries(umbp_common PUBLIC ${CMAKE_DL_LIBS})
   target_compile_definitions(umbp_common PUBLIC UMBP_ENABLE_GDS)
 else()
   message(STATUS "[UMBP] hipfile not found — GDS transfer engine disabled")

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -859,8 +859,13 @@ bool PoolClient::Init() {
 #ifdef UMBP_ENABLE_GDS
   // The file->GPU engine for SsdBackend's FileRefs.  It claims only (file,
   // device) pairs, which no memory engine touches, so registration order is
-  // documentation.  Present only when the build found hipfile.
-  composite->AddEngine(std::make_unique<GdsEngine>());
+  // documentation.  Compiled in when the build found the hipfile headers, and
+  // registered only when libhipfile actually dlopen's on this host.
+  if (GdsEngine::Available()) {
+    composite->AddEngine(std::make_unique<GdsEngine>());
+  } else {
+    MORI_UMBP_INFO("[PoolClient] libhipfile unavailable — SSD reads stay host-staged");
+  }
 #endif
   if (!config_.io_engine.host.empty()) {
     mori::io::IOEngineConfig io_cfg;

--- a/src/umbp/distributed/transfer/gds_engine.cpp
+++ b/src/umbp/distributed/transfer/gds_engine.cpp
@@ -21,12 +21,11 @@
 // SOFTWARE.
 #include "umbp/distributed/transfer/gds_engine.h"
 
-#include <hipfile.h>
-
 #include <cerrno>
 #include <string>
 #include <utility>
 
+#include "hipfile_dl.h"
 #include "mori/utils/mori_log.hpp"
 
 namespace mori::umbp {
@@ -57,19 +56,23 @@ class SettledHandle final : public TransferHandle {
 // Turn a hipFileRead return code into a human-readable reason.  >= 0 is a byte
 // count (a short read here); -1 is a POSIX errno; any other negative is the
 // negated hipFileOpError_t.
-std::string ReadFailureReason(ssize_t n, size_t want) {
+std::string ReadFailureReason(const HipFileApi& api, ssize_t n, size_t want) {
   if (n == -1) return std::string("errno=") + std::to_string(errno);
-  if (n < 0) return hipFileGetOpErrorString(static_cast<hipFileOpError_t>(-n));
+  if (n < 0) return api.GetOpErrorString(static_cast<hipFileOpError_t>(-n));
   return std::string("short read ") + std::to_string(n) + "/" + std::to_string(want);
 }
 
 }  // namespace
 
+bool GdsEngine::Available() { return HipFile() != nullptr; }
+
 GdsEngine::~GdsEngine() {
   std::lock_guard<std::mutex> lock(handles_mutex_);
+  // Non-empty handles_ implies a successful register, so the API resolved.
+  const HipFileApi* api = HipFile();
   for (auto& [fd, entry] : handles_) {
-    if (entry.handle != nullptr) {
-      hipFileHandleDeregister(static_cast<hipFileHandle_t>(entry.handle));
+    if (entry.handle != nullptr && api != nullptr) {
+      api->HandleDeregister(static_cast<hipFileHandle_t>(entry.handle));
     }
   }
   handles_.clear();
@@ -77,6 +80,8 @@ GdsEngine::~GdsEngine() {
 
 TransferRef GdsEngine::RegisterFile(int fd, uint64_t offset, uint64_t size) {
   if (fd < 0) return TransferRef{};
+  const HipFileApi* api = HipFile();
+  if (api == nullptr) return TransferRef{};
   std::lock_guard<std::mutex> lock(handles_mutex_);
 
   auto it = handles_.find(fd);
@@ -89,10 +94,10 @@ TransferRef GdsEngine::RegisterFile(int fd, uint64_t offset, uint64_t size) {
   descr.type = hipFileHandleTypeOpaqueFD;
   descr.handle.fd = fd;
   hipFileHandle_t handle = nullptr;
-  hipFileError_t err = hipFileHandleRegister(&handle, &descr);
+  hipFileError_t err = api->HandleRegister(&handle, &descr);
   if (err.err != hipFileSuccess || handle == nullptr) {
     MORI_UMBP_ERROR("[GdsEngine] hipFileHandleRegister(fd={}) failed: {}", fd,
-                    hipFileGetOpErrorString(err.err));
+                    api->GetOpErrorString(err.err));
     return TransferRef{};
   }
   handles_.emplace(fd, HandleEntry{static_cast<void*>(handle), 1});
@@ -101,12 +106,13 @@ TransferRef GdsEngine::RegisterFile(int fd, uint64_t offset, uint64_t size) {
 
 void GdsEngine::Deregister(const TransferRef& ref) {
   if (!ref.IsFile()) return;
+  const HipFileApi* api = HipFile();
   std::lock_guard<std::mutex> lock(handles_mutex_);
   auto it = handles_.find(ref.file_fd);
   if (it == handles_.end()) return;
   if (--it->second.refcount <= 0) {
-    if (it->second.handle != nullptr) {
-      hipFileHandleDeregister(static_cast<hipFileHandle_t>(it->second.handle));
+    if (it->second.handle != nullptr && api != nullptr) {
+      api->HandleDeregister(static_cast<hipFileHandle_t>(it->second.handle));
     }
     handles_.erase(it);
   }
@@ -151,6 +157,17 @@ std::unique_ptr<TransferHandle> GdsEngine::Submit(std::vector<TransferPlan> plan
   if (plans.empty()) return nullptr;
   std::vector<TransferFailure> failures;
 
+  const HipFileApi* api = HipFile();
+  if (api == nullptr) {
+    // Unreachable in practice — a plan can only exist for a ref this engine
+    // registered, which requires the library — but fail the batch rather than
+    // dereference null if the composite ever hands us one.
+    for (const auto& plan : plans) {
+      failures.push_back(TransferFailure{plan.tags, 0, "GdsEngine: libhipfile unavailable", "gds"});
+    }
+    return std::make_unique<SettledHandle>(std::move(failures));
+  }
+
   for (const auto& plan : plans) {
     auto fh = static_cast<hipFileHandle_t>(plan.src.gds_handle);
     if (fh == nullptr) {
@@ -163,10 +180,10 @@ std::unique_ptr<TransferHandle> GdsEngine::Submit(std::vector<TransferPlan> plan
     void* dst_base = plan.dst.host_ptr;
     for (size_t i = 0; i < plan.sizes.size(); ++i) {
       const uint64_t file_off = plan.src.file_offset + plan.src_offsets[i];
-      const ssize_t n = hipFileRead(fh, dst_base, plan.sizes[i], static_cast<hoff_t>(file_off),
-                                    static_cast<hoff_t>(plan.dst_offsets[i]));
+      const ssize_t n = api->Read(fh, dst_base, plan.sizes[i], static_cast<hoff_t>(file_off),
+                                  static_cast<hoff_t>(plan.dst_offsets[i]));
       if (n < 0 || static_cast<size_t>(n) != plan.sizes[i]) {
-        const std::string why = ReadFailureReason(n, plan.sizes[i]);
+        const std::string why = ReadFailureReason(*api, n, plan.sizes[i]);
         MORI_UMBP_ERROR("[GdsEngine] hipFileRead file_off={} size={} failed: {}", file_off,
                         plan.sizes[i], why);
         failures.push_back(TransferFailure{plan.tags, 0, "GdsEngine: hipFileRead: " + why, "gds"});

--- a/src/umbp/distributed/transfer/hipfile_dl.cpp
+++ b/src/umbp/distributed/transfer/hipfile_dl.cpp
@@ -1,0 +1,97 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#include "hipfile_dl.h"
+
+#include <dlfcn.h>
+
+#include <mutex>
+
+#include "mori/utils/mori_log.hpp"
+
+namespace mori::umbp {
+
+namespace {
+
+// SONAME first, then the devel symlink: a runtime-only install ships only the
+// former.
+constexpr const char* kHipFileSonames[] = {"libhipfile.so.0", "libhipfile.so"};
+
+void* OpenHipFile() {
+  for (const char* soname : kHipFileSonames) {
+    // RTLD_LOCAL: hipFile is ours to call, not something to publish into the
+    // process's global namespace.  RTLD_NOW so a partially-resolvable library
+    // fails here rather than at the first read.
+    if (void* h = ::dlopen(soname, RTLD_NOW | RTLD_LOCAL)) return h;
+  }
+  return nullptr;
+}
+
+template <typename Fn>
+bool Bind(void* handle, const char* name, Fn* out) {
+  ::dlerror();
+  void* sym = ::dlsym(handle, name);
+  if (sym == nullptr) {
+    const char* err = ::dlerror();
+    MORI_UMBP_WARN("[hipFile] symbol {} missing from libhipfile: {}", name,
+                   err != nullptr ? err : "unknown");
+    return false;
+  }
+  *out = reinterpret_cast<Fn>(sym);
+  return true;
+}
+
+}  // namespace
+
+const HipFileApi* HipFile() {
+  static HipFileApi api;
+  static const HipFileApi* resolved = nullptr;
+  static std::once_flag once;
+
+  std::call_once(once, [] {
+    void* handle = OpenHipFile();
+    if (handle == nullptr) {
+      // Not an error: a build that found the headers still runs fine on a host
+      // without the library — GDS is just not on offer there.
+      const char* err = ::dlerror();
+      MORI_UMBP_INFO("[hipFile] libhipfile not loadable ({}) — GDS path disabled",
+                     err != nullptr ? err : "no such library");
+      return;
+    }
+    const bool ok = Bind(handle, "hipFileHandleRegister", &api.HandleRegister) &&
+                    Bind(handle, "hipFileHandleDeregister", &api.HandleDeregister) &&
+                    Bind(handle, "hipFileRead", &api.Read) &&
+                    Bind(handle, "hipFileGetOpErrorString", &api.GetOpErrorString);
+    if (!ok) {
+      // Deliberately not dlclose'd: the handle stays alive for the process, and
+      // closing it while another consumer holds symbols would be worse than the
+      // leak.
+      MORI_UMBP_WARN("[hipFile] libhipfile loaded but incomplete — GDS path disabled");
+      return;
+    }
+    MORI_UMBP_INFO("[hipFile] libhipfile loaded — GDS path available");
+    resolved = &api;
+  });
+
+  return resolved;
+}
+
+}  // namespace mori::umbp

--- a/src/umbp/distributed/transfer/hipfile_dl.h
+++ b/src/umbp/distributed/transfer/hipfile_dl.h
@@ -1,0 +1,53 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+#include <hipfile.h>
+
+namespace mori::umbp {
+
+// hipFile resolved at runtime instead of linked.
+//
+// WHY.  GdsEngine is one optional transfer path inside umbp_common, and
+// umbp_common is linked into libmori_pybinds.so — so a `-lhipfile` here becomes
+// a DT_NEEDED on the Python extension, and `import mori` dies with "libhipfile
+// .so.0: cannot open shared object file" on every host whose ROCm ships without
+// hipFile, whether or not UMBP is used at all.  Building against the header but
+// resolving the four entry points with dlopen keeps the capability and makes
+// the library a runtime option: present -> GDS works, absent -> GDS is simply
+// not offered as an engine.
+//
+// The signatures come from <hipfile.h> via decltype, so they cannot drift from
+// the real ones.
+struct HipFileApi {
+  decltype(&::hipFileHandleRegister) HandleRegister = nullptr;
+  decltype(&::hipFileHandleDeregister) HandleDeregister = nullptr;
+  decltype(&::hipFileRead) Read = nullptr;
+  decltype(&::hipFileGetOpErrorString) GetOpErrorString = nullptr;
+};
+
+// Loads libhipfile on the first call and caches the result (including failure).
+// Returns nullptr when the library or any symbol is missing; callers must check
+// before every use.  Thread-safe, never throws.
+const HipFileApi* HipFile();
+
+}  // namespace mori::umbp

--- a/src/umbp/include/umbp/distributed/transfer/gds_engine.h
+++ b/src/umbp/include/umbp/distributed/transfer/gds_engine.h
@@ -52,6 +52,11 @@ namespace mori::umbp {
 // carries no hipfile dependency; only the .cpp includes <hipfile.h>.
 class GdsEngine final : public TransferEngine {
  public:
+  // libhipfile is dlopen'd, not linked (see hipfile_dl.h), so its presence is a
+  // runtime question: ask before registering this engine.  Without it every
+  // RegisterFile returns an invalid ref and the SSD path stays host-staged.
+  static bool Available();
+
   GdsEngine() = default;
   ~GdsEngine() override;
 

--- a/tests/cpp/umbp/distributed/CMakeLists.txt
+++ b/tests/cpp/umbp/distributed/CMakeLists.txt
@@ -468,8 +468,9 @@ add_test(NAME test_component_metrics COMMAND test_component_metrics)
 
 # test_gds_engine — GdsEngine routing/planning (no GPU) plus a GPU + hipFile
 # read round trip (skipped without a device, or on a filesystem that rejects
-# O_DIRECT). Built only when hipfile is available; umbp_common already carries
-# hip::hipfile and the UMBP_ENABLE_GDS definition in that case.
+# O_DIRECT). Built only when the hipfile headers are installed; umbp_common
+# already carries the UMBP_ENABLE_GDS definition in that case and dlopen's
+# libhipfile itself, so this target links no hipfile library.
 if(TARGET hip::hipfile)
   add_executable(test_gds_engine test_gds_engine.cpp)
   target_link_libraries(test_gds_engine PRIVATE umbp_common hip::host GTest::gtest_main)


### PR DESCRIPTION
## Problem

`import mori` fails on any host whose ROCm ships without hipFile:

```
File ".../site-packages/mori/cpp/__init__.py", line 44, in <module>
ImportError: libhipfile.so.0: cannot open shared object file: No such file or directory
```

`GdsEngine` is one optional transfer path inside `umbp_common`, and `umbp_common` is linked into `libmori_pybinds.so` — so `target_link_libraries(umbp_common PUBLIC hip::hipfile)` (added in #540) became a `DT_NEEDED` on the Python extension.

Because the dependency is auto-detected (`find_package(hipfile QUIET)`), whether a wheel carries it depends on what happened to be installed on the build host. A wheel built where hipFile exists cannot be imported anywhere else.

This broke [ROCm/ATOM CI](https://github.com/ROCm/ATOM/actions/runs/34250043097): four accuracy jobs died before the first token — `import mori.shmem` → all 8 DP ranks down → `Engine Core Mgr: Received unexpected SHUTDOWN signal`. None of those jobs use UMBP at all; `rocm/atom-dev:latest` runs ROCm 7.2.4, which has no hipFile.

## Fix

Build against the headers, resolve the library at runtime.

- New `hipfile_dl.{h,cpp}`: `dlopen("libhipfile.so.0")` on first use, `dlsym` the four entry points `GdsEngine` calls, cached under `std::call_once`. Function-pointer types come from `<hipfile.h>` via `decltype`, so they cannot drift from the real signatures.
- `GdsEngine::Available()` reports whether the library loaded. `PoolClient` registers the engine only when it did; without it `RegisterFile` returns an invalid ref and the SSD path stays host-staged — exactly what an hipfile-less build already does.
- CMake takes only `hip::hipfile`'s `INTERFACE_INCLUDE_DIRECTORIES` and links `${CMAKE_DL_LIBS}`. `GLOBAL` is kept so the tests directory can still gate `test_gds_engine` on the same target; nothing links it.

No capability is lost: GDS is still compiled in whenever the headers are present, and it works wherever the library exists.

**Dropping the link alone is not enough.** `patchelf --remove-needed libhipfile.so.0` on a shipped wheel just moves the failure to `undefined symbol: hipFileHandleDeregister` — the calls themselves have to go through `dlsym`. So `PUBLIC` → `PRIVATE` or `--as-needed` would not have fixed this.

## Verification

Reproduced and fixed locally, in a container with a stand-in libhipfile installed at build time:

| check | before | after |
|---|---|---|
| `readelf -d libmori_pybinds.so \| grep hipfile` | `NEEDED libhipfile.so.0` | none |
| `import mori.shmem`, library absent | `ImportError` | **OK** |
| `import mori.shmem`, library present | OK | OK |
| `GdsEngine` symbols compiled in | yes | yes |
| `test_gds_engine` | 2 passed / 1 skipped (no GPU) | 2 passed / 1 skipped |

A probe confirms both directions of the runtime decision:

```
library absent:  Available()=0   RegisterFile -> IsFile=0 handle=(nil)
library present: Available()=1   hipFileHandleRegister(fd=3) called
                 RegisterFile -> IsFile=1 handle=0x7ffff7d6902c
```

Caveats, stated plainly: the library used in verification was a stand-in that implements the four symbols, so symbol resolution and dispatch are covered but a real GDS disk read is not; and the import check ran in a Python 3.10 build container rather than in `rocm/atom-dev` itself (different Python and protobuf/gRPC versions). On `rocm/atom-dev:latest`, `libhipfile.so.0` was confirmed to be the *only* unresolved dependency of the shipped `amd_mori_nightly` wheel.

## Follow-up, not in this PR

`libmori_pybinds.so` still hard-links gRPC / protobuf / abseil / OpenSSL through `umbp_common`. Those happen to resolve in ATOM's image today, but the same class of `ImportError` returns the moment a base image moves to a different protobuf soname. Making `import mori` independent of UMBP's transitive dependencies — e.g. UMBP as a separately-loaded `libmori_umbp.so` — would close the category rather than this one instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
