### PR TITLE
feat(ccl): support HIP graph capture in AllGather SDMA

### DIFF
--- a/include/mori/collective/allgather/oneshot_allgather_sdma_class.hpp
+++ b/include/mori/collective/allgather/oneshot_allgather_sdma_class.hpp
@@ -240,7 +240,13 @@ class AllgatherSdma {
   int64_t prepare_sync_param_contiguous(T* input, T* output, size_t total_count,
                                         const size_t* split_sizes, const size_t* split_offsets,
                                         size_t split_count, hipStream_t stream);
-  double finish_sync(T* output, size_t total_count, hipStream_t stream);
+  // `capturing`: skip the host-side stream syncs, as AllreduceSdma already
+  // allows. Put, the SDMA transfer, the wait kernel and the copy-out are
+  // stream-ordered anyway; the syncs only make the returned duration
+  // meaningful, and blocking the launch thread for the whole transfer stops
+  // the caller from queueing work into the window where the copy engines are
+  // busy but the CUs are idle (and is illegal during graph capture).
+  double finish_sync(T* output, size_t total_count, hipStream_t stream, bool capturing = false);
   int64_t prepare_async_start(T* input, T* output, size_t total_count, hipStream_t stream);
   int64_t prepare_async_start_param_contiguous(T* input, T* output, size_t total_count,
                                                const size_t* split_sizes,
@@ -248,7 +254,7 @@ class AllgatherSdma {
                                                hipStream_t stream);
   void after_async_start();
   int64_t prepare_async_wait(hipStream_t stream);
-  double finish_async_wait(hipStream_t stream);
+  double finish_async_wait(hipStream_t stream, bool capturing = false);
 };
 
 }  // namespace collective

--- a/include/mori/collective/allgather/oneshot_allgather_sdma_class.hpp
+++ b/include/mori/collective/allgather/oneshot_allgather_sdma_class.hpp
@@ -50,6 +50,14 @@ class AllgatherSdma {
   application::SymmMemObjPtr flagsObj_;
   std::unique_ptr<uint64_t[], ShmemDeleter> flags_;
 
+  // Generation counter for the completion flags, read and advanced by the
+  // kernel rather than the host so that a captured graph derives a fresh
+  // generation on every replay. Local to this PE: no peer ever touches it, the
+  // kernel bumps it once per collective, and ranks stay in step because they
+  // all issue the same sequence of collectives. Its own allocation, so peer
+  // AMO_SET traffic into `flags_` does not share its cacheline.
+  std::unique_ptr<uint64_t, ShmemDeleter> gen_;
+
   // Input transit buffer
   void* input_transit_buffer_;
   size_t input_transit_buffer_size_;
@@ -64,14 +72,14 @@ class AllgatherSdma {
 
   // ================ NEW: Async state variables ================
   std::atomic<bool> async_in_progress_;       // Flag indicating async operation is active
-  std::atomic<uint64_t> call_seq_;            // Monotonic generation token for flag synchronization
   T* async_input_;                            // Saved input pointer for async operation
   T* async_output_;                           // Saved output pointer for async operation
   size_t async_total_count_;                  // Saved element count for async operation
   hipStream_t async_stream_;                  // Saved stream for async operation
   application::SymmMemObjPtr async_dst_obj_;  // Destination symm object used by async PUT
   double async_start_time_;                   // Start time for async operation
-  uint64_t async_flag_token_;                 // Generation token for current async op
+  // No host-side generation token: the WAIT kernel derives and advances the
+  // generation itself, so nothing has to be carried from START to WAIT.
   // ============================================================
 
   // Copy mode flag: if true, copy output_transit_buffer to user output buffer
@@ -232,7 +240,11 @@ class AllgatherSdma {
   }
 
   /**
-   * @brief Resets flags (sets to 0)
+   * @brief Resets the completion flags and the generation counter (both to 0).
+   * @note The two must be reset together. Zeroing the counter while stale flag
+   *       values survive makes the next kernel derive generation 1 and find
+   *       every flag already above it, so the wait passes before any data has
+   *       landed. Collective — all ranks must call it at the same point.
    */
   void resetFlags();
 
@@ -241,11 +253,17 @@ class AllgatherSdma {
                                         const size_t* split_sizes, const size_t* split_offsets,
                                         size_t split_count, hipStream_t stream);
   // `capturing`: skip the host-side stream syncs, as AllreduceSdma already
-  // allows. Put, the SDMA transfer, the wait kernel and the copy-out are
-  // stream-ordered anyway; the syncs only make the returned duration
-  // meaningful, and blocking the launch thread for the whole transfer stops
-  // the caller from queueing work into the window where the copy engines are
-  // busy but the CUs are idle (and is illegal during graph capture).
+  // allows. The SDMA transfer, the wait kernel and the copy-out are all
+  // stream-ordered anyway, so a consumer enqueued on the same stream still
+  // sees complete data. The syncs only make the returned duration meaningful,
+  // and blocking the launch thread for the whole transfer stops the caller
+  // from queueing work into the window where the copy engines are busy but the
+  // CUs are idle (and is illegal during graph capture).
+  // `capturing` is the caller's assertion, not something checked here: a torch
+  // capture always hands us a real side stream, while an eager caller may well
+  // pass the default stream (handle 0) with `capturing` already hardcoded on.
+  // The return is always 0.0, as in AllreduceSdma -- nothing here is timed
+  // either way, so `capturing` does not change it.
   double finish_sync(T* output, size_t total_count, hipStream_t stream, bool capturing = false);
   int64_t prepare_async_start(T* input, T* output, size_t total_count, hipStream_t stream);
   int64_t prepare_async_start_param_contiguous(T* input, T* output, size_t total_count,

--- a/include/mori/collective/allgather/oneshot_sdma_async_kernel.hpp
+++ b/include/mori/collective/allgather/oneshot_sdma_async_kernel.hpp
@@ -165,6 +165,11 @@ __device__ void OneShotAllGatherSdmaAsyncWaitKernel_body(
   }
   __syncthreads();
 
+  // SYSTEM-scope loads, a seq-cst acquire on exit and a tail system fence, as
+  // OneShotAllGatherSdmaKernel_body already does: the flags are written by a
+  // peer GPU's SDMA engine, so a device-scope load does not order the payload
+  // behind them. Callers passing finish_async_wait(capturing=true) have no
+  // host sync left to establish that visibility for the consumer kernel.
   for (int sender = 0; sender < npes; ++sender) {
     if (sender == myPe) {
       continue;
@@ -173,16 +178,19 @@ __device__ void OneShotAllGatherSdmaAsyncWaitKernel_body(
     if (threadLinearId == 0) {
       int spinCount = 0;
       bool warned = false;
-      while (core::AtomicLoadRelaxed(flags + sender) < flagVal) {
+      while (core::AtomicLoadRelaxedSystem(flags + sender) < flagVal) {
         ++spinCount;
         if (!warned && spinCount > 10000000) {
           printf("PE %d: Slow wait for data from peer %d (still waiting)\n", myPe, sender);
           warned = true;
         }
       }
+      (void)core::AtomicLoadSeqCstSystem(flags + sender);
     }
     __syncthreads();
   }
+  if (threadLinearId == 0) __threadfence_system();
+  __syncthreads();
 
   // Monotonic generation flags; no reset needed.
 }

--- a/include/mori/collective/allgather/oneshot_sdma_async_kernel.hpp
+++ b/include/mori/collective/allgather/oneshot_sdma_async_kernel.hpp
@@ -150,8 +150,14 @@ __global__ void OneShotAllGatherSdmaParamContiguousAsyncPutKernel(
 
 __device__ void OneShotAllGatherSdmaAsyncWaitKernel_body(
     int myPe, int npes, const application::SymmMemObjPtr dstMemObj,
-    const application::SymmMemObjPtr flagsMemObj, uint64_t flagVal = 1) {
+    const application::SymmMemObjPtr flagsMemObj, uint64_t* genCounter = nullptr) {
   uint64_t* __restrict__ flags = reinterpret_cast<uint64_t*>(flagsMemObj->localPtr);
+
+  // Device-derived generation; see CclAllgatherArgs::genCounter. This kernel
+  // both publishes and consumes the generation, so the paired PUT kernel needs
+  // no token of its own and nothing has to survive between the two launches.
+  // Non-const: the AMO below takes the value by address.
+  uint64_t flagVal = (genCounter != nullptr) ? core::AtomicLoadRelaxed(genCounter) + 1ULL : 1ULL;
 
   const size_t threadLinearId =
       static_cast<size_t>(blockIdx.x) * static_cast<size_t>(blockDim.x) + threadIdx.x;
@@ -168,8 +174,9 @@ __device__ void OneShotAllGatherSdmaAsyncWaitKernel_body(
   // SYSTEM-scope loads, a seq-cst acquire on exit and a tail system fence, as
   // OneShotAllGatherSdmaKernel_body already does: the flags are written by a
   // peer GPU's SDMA engine, so a device-scope load does not order the payload
-  // behind them. Callers passing finish_async_wait(capturing=true) have no
-  // host sync left to establish that visibility for the consumer kernel.
+  // behind them. Needed regardless of `capturing`: a host stream sync only
+  // waits for this kernel to retire, it does not pull the peer's writes into
+  // this GPU's caches for the consumer kernel. It was merely masking this.
   for (int sender = 0; sender < npes; ++sender) {
     if (sender == myPe) {
       continue;
@@ -189,7 +196,12 @@ __device__ void OneShotAllGatherSdmaAsyncWaitKernel_body(
     }
     __syncthreads();
   }
-  if (threadLinearId == 0) __threadfence_system();
+  if (threadLinearId == 0) {
+    __threadfence_system();
+    // Advance only after every peer's flag is in: the next wait derives its
+    // generation from this value.
+    if (genCounter != nullptr) core::AtomicStoreRelaxed(genCounter, flagVal);
+  }
   __syncthreads();
 
   // Monotonic generation flags; no reset needed.
@@ -198,8 +210,8 @@ __device__ void OneShotAllGatherSdmaAsyncWaitKernel_body(
 __global__ void OneShotAllGatherSdmaAsyncWaitKernel(int myPe, int npes,
                                                     const application::SymmMemObjPtr dstMemObj,
                                                     const application::SymmMemObjPtr flagsMemObj,
-                                                    uint64_t flagVal = 1) {
-  OneShotAllGatherSdmaAsyncWaitKernel_body(myPe, npes, dstMemObj, flagsMemObj, flagVal);
+                                                    uint64_t* genCounter = nullptr) {
+  OneShotAllGatherSdmaAsyncWaitKernel_body(myPe, npes, dstMemObj, flagsMemObj, genCounter);
 }
 }  // namespace collective
 }  // namespace mori

--- a/include/mori/collective/allgather/oneshot_sdma_kernel.hpp
+++ b/include/mori/collective/allgather/oneshot_sdma_kernel.hpp
@@ -48,13 +48,23 @@ __device__ void OneShotAllGatherSdmaKernel_body(int myPe, int npes, T* input,
                                                 const application::SymmMemObjPtr dstMemObj,
                                                 const application::SymmMemObjPtr flagsMemObj,
                                                 size_t elementCount, size_t dstBaseOffset = 0,
-                                                uint64_t flagVal = 1) {
+                                                uint64_t* genCounter = nullptr) {
   if (elementCount == 0 || npes <= 0) {
     return;
   }
 
   T* __restrict__ inputData = input;
   uint64_t* __restrict__ flags = reinterpret_cast<uint64_t*>(flagsMemObj->localPtr);
+
+  // Generation derived on the device so every graph replay gets a fresh value;
+  // see CclAllgatherArgs::genCounter. The counter is local to this PE, so a
+  // relaxed agent-scope load suffices: the previous call's store-back is on the
+  // far side of a kernel boundary on the same stream. A null counter means the
+  // caller keeps no generation state and hands us freshly zeroed flags.
+  // Ranks agree on the value because they all take the early return above and
+  // advance the counter on the same sequence of collective calls.
+  // Non-const: the AMO below takes the value by address.
+  uint64_t flagVal = (genCounter != nullptr) ? core::AtomicLoadRelaxed(genCounter) + 1ULL : 1ULL;
 
   const size_t threadLinearId =
       static_cast<size_t>(blockIdx.x) * static_cast<size_t>(blockDim.x) + threadIdx.x;
@@ -118,7 +128,13 @@ __device__ void OneShotAllGatherSdmaKernel_body(int myPe, int npes, T* input,
       (void)core::AtomicLoadSeqCstSystem(flags + sender);
     }
     __syncthreads();
-    if (threadLinearId == 0) __threadfence_system();
+    if (threadLinearId == 0) {
+      __threadfence_system();
+      // Publish only now that every peer's flag is in: the next call derives
+      // its generation from this value, so advancing it earlier would let that
+      // call's wait pass while this transfer is still landing.
+      if (genCounter != nullptr) core::AtomicStoreRelaxed(genCounter, flagVal);
+    }
     __syncthreads();
   }
 
@@ -131,9 +147,9 @@ __global__ void OneShotAllGatherSdmaKernel(int myPe, int npes, T* input,
                                            const application::SymmMemObjPtr dstMemObj,
                                            const application::SymmMemObjPtr flagsMemObj,
                                            size_t elementCount, size_t dstBaseOffset = 0,
-                                           uint64_t flagVal = 1) {
+                                           uint64_t* genCounter = nullptr) {
   OneShotAllGatherSdmaKernel_body<T>(myPe, npes, input, srcMemObj, dstMemObj, flagsMemObj,
-                                     elementCount, dstBaseOffset, flagVal);
+                                     elementCount, dstBaseOffset, genCounter);
 }
 
 // ---------------------------------------------------------------------------
@@ -466,12 +482,17 @@ template <typename T>
 __device__ void OneShotAllGatherSdmaParamContiguousKernel_body(
     int myPe, int npes, T* input, const application::SymmMemObjPtr srcMemObj,
     const application::SymmMemObjPtr dstMemObj, const application::SymmMemObjPtr flagsMemObj,
-    size_t elementCount, size_t dstBaseOffset, uint64_t flagVal, const size_t* splitSizes,
+    size_t elementCount, size_t dstBaseOffset, uint64_t* genCounter, const size_t* splitSizes,
     const size_t* splitOffsets, size_t splitCount) {
   if (elementCount == 0 || npes <= 0 || splitCount == 0 || splitSizes == nullptr ||
       splitOffsets == nullptr) {
     return;
   }
+
+  // Device-derived generation; see OneShotAllGatherSdmaKernel_body. Every rank
+  // must reach or skip this kernel together, split descriptors included, or the
+  // counters drift apart.
+  uint64_t flagVal = (genCounter != nullptr) ? core::AtomicLoadRelaxed(genCounter) + 1ULL : 1ULL;
 
   const size_t threadLinearId =
       static_cast<size_t>(blockIdx.x) * static_cast<size_t>(blockDim.x) + threadIdx.x;
@@ -539,6 +560,8 @@ __device__ void OneShotAllGatherSdmaParamContiguousKernel_body(
       (void)core::AtomicLoadSeqCstSystem(flags + sender);
     }
     __threadfence_system();
+    // Advance only after every peer's flag is in (see the flat gather).
+    if (genCounter != nullptr) core::AtomicStoreRelaxed(genCounter, flagVal);
   }
   __syncthreads();
 }
@@ -547,12 +570,12 @@ template <typename T>
 __global__ void OneShotAllGatherSdmaParamContiguousKernel(
     int myPe, int npes, T* input, const application::SymmMemObjPtr srcMemObj,
     const application::SymmMemObjPtr dstMemObj, const application::SymmMemObjPtr flagsMemObj,
-    size_t elementCount, size_t dstBaseOffset = 0, uint64_t flagVal = 1,
+    size_t elementCount, size_t dstBaseOffset = 0, uint64_t* genCounter = nullptr,
     const size_t* splitSizes = nullptr, const size_t* splitOffsets = nullptr,
     size_t splitCount = 0) {
-  OneShotAllGatherSdmaParamContiguousKernel_body<T>(myPe, npes, input, srcMemObj, dstMemObj,
-                                                    flagsMemObj, elementCount, dstBaseOffset,
-                                                    flagVal, splitSizes, splitOffsets, splitCount);
+  OneShotAllGatherSdmaParamContiguousKernel_body<T>(
+      myPe, npes, input, srcMemObj, dstMemObj, flagsMemObj, elementCount, dstBaseOffset, genCounter,
+      splitSizes, splitOffsets, splitCount);
 }
 }  // namespace collective
 }  // namespace mori

--- a/include/mori/collective/ccl_kernel_args.hpp
+++ b/include/mori/collective/ccl_kernel_args.hpp
@@ -71,7 +71,14 @@ struct CclAllgatherArgs {
   application::SymmMemObjPtr flagsMemObj;
   size_t elementCount;
   size_t dstBaseOffset;
-  uint64_t flagVal;
+  // Device-resident generation counter, deliberately a pointer and not a value.
+  // A host-minted token is frozen into the graph node at capture, and since the
+  // completion flags are monotonic and never reset, the wait would already be
+  // satisfied on entry from the second replay onward and let a consumer read a
+  // buffer whose SDMA is still in flight. The kernel derives `*genCounter + 1`
+  // itself and stores it back once every peer's flag is in, so the pointer is
+  // what gets captured and the generation stays fresh on every replay.
+  uint64_t* genCounter;
   const size_t* splitSizes;
   const size_t* splitOffsets;
   size_t splitCount;

--- a/python/mori/ccl/collective.py
+++ b/python/mori/ccl/collective.py
@@ -250,7 +250,9 @@ class AllgatherSdma:
                 my_pe, npes, 512 * 1024 * 1024, copy_output_to_user
             )
 
-    def __call__(self, input_data, output_data, count: int, stream=None) -> bool:
+    def __call__(
+        self, input_data, output_data, count: int, stream=None, capturing: bool = False
+    ) -> bool:
         byte_count = count * input_data.element_size()
         u32_count = (byte_count + 3) // 4
         s = _stream_to_int(stream)
@@ -260,7 +262,9 @@ class AllgatherSdma:
         _get_ccl_func("OneShotAllGatherSdmaKernel_u32").launch_struct(
             (1,), (512,), 0, s, args
         )
-        self._handle.finish_sync(output_data.data_ptr(), u32_count, s)
+        self._handle.finish_sync(
+            output_data.data_ptr(), u32_count, s, capturing=capturing
+        )
         return True
 
     def enqueue_param_contiguous(
@@ -334,13 +338,21 @@ class AllgatherSdma:
         self._handle.after_async_start()
         return True
 
-    def wait_async(self, stream=None) -> float:
+    def wait_async(self, stream=None, capturing: bool = False) -> float:
+        """Enqueue the completion wait.
+
+        ``capturing=True`` skips the host-side stream syncs: the wait kernel
+        and the copy-out are stream-ordered, so a consumer enqueued on the same
+        stream still sees complete data, and the launch thread stays free. The
+        returned duration is meaningless then, nothing having waited for the
+        transfer to land.
+        """
         s = _stream_to_int(stream)
         args = self._handle.prepare_async_wait(s)
         _get_ccl_func("OneShotAllGatherSdmaAsyncWaitKernel_u32").launch_struct(
             (1,), (64,), 0, s, args
         )
-        return self._handle.finish_async_wait(s)
+        return self._handle.finish_async_wait(s, capturing=capturing)
 
     def is_async_in_progress(self) -> bool:
         return self._handle.is_async_in_progress()

--- a/python/mori/ccl/collective.py
+++ b/python/mori/ccl/collective.py
@@ -253,6 +253,12 @@ class AllgatherSdma:
     def __call__(
         self, input_data, output_data, count: int, stream=None, capturing: bool = False
     ) -> bool:
+        """Run a blocking AllGather.
+
+        ``capturing=True`` skips the host-side stream syncs so the call is legal
+        inside ``hipStreamBeginCapture``. The completion generation is derived
+        on the device, so a captured graph is safe to replay.
+        """
         byte_count = count * input_data.element_size()
         u32_count = (byte_count + 3) // 4
         s = _stream_to_int(stream)
@@ -275,6 +281,7 @@ class AllgatherSdma:
         split_sizes,
         split_offsets,
         stream=None,
+        capturing: bool = False,
     ) -> bool:
         if split_sizes.numel() != split_offsets.numel():
             raise ValueError("split_sizes and split_offsets must have the same length")
@@ -293,7 +300,9 @@ class AllgatherSdma:
         _get_ccl_func("OneShotAllGatherSdmaParamContiguousKernel_u32").launch_struct(
             (1,), (512,), 0, s, args
         )
-        self._handle.finish_sync(output_data.data_ptr(), u32_count, s)
+        self._handle.finish_sync(
+            output_data.data_ptr(), u32_count, s, capturing=capturing
+        )
         return True
 
     def start_async(self, input_data, output_data, count: int, stream=None) -> bool:
@@ -343,8 +352,8 @@ class AllgatherSdma:
 
         ``capturing=True`` skips the host-side stream syncs: the wait kernel
         and the copy-out are stream-ordered, so a consumer enqueued on the same
-        stream still sees complete data, and the launch thread stays free. The
-        returned duration is meaningless then, nothing having waited for the
+        stream still sees complete data, and the launch thread stays free. It
+        returns ``-1.0`` rather than a duration, nothing having waited for the
         transfer to land.
         """
         s = _stream_to_int(stream)

--- a/src/collective/core/oneshot_allgather_sdma_class.cpp
+++ b/src/collective/core/oneshot_allgather_sdma_class.cpp
@@ -430,28 +430,23 @@ int64_t AllgatherSdma<T>::prepare_sync_param_contiguous(T* input, T* output, siz
 }
 
 template <typename T>
-double AllgatherSdma<T>::finish_sync(T* output, size_t total_count, hipStream_t stream) {
-  if (stream != nullptr) {
-    hipError_t err = hipStreamSynchronize(stream);
+double AllgatherSdma<T>::finish_sync(T* output, size_t total_count, hipStream_t stream,
+                                     bool capturing) {
+  // See the header: the fused kernel already blocks on every peer's flag
+  // before it retires, so these syncs are not what makes the result visible.
+  if (!capturing) {
+    hipError_t err = stream ? hipStreamSynchronize(stream) : hipDeviceSynchronize();
     if (err != hipSuccess) {
-      fprintf(stderr, "PE %d: Stream synchronization failed: %s\n", myPe_, hipGetErrorString(err));
-      throw std::runtime_error("Stream synchronization failed");
-    }
-  } else {
-    hipError_t err = hipDeviceSynchronize();
-    if (err != hipSuccess) {
-      fprintf(stderr, "PE %d: Device synchronization failed: %s\n", myPe_, hipGetErrorString(err));
-      throw std::runtime_error("Device synchronization failed");
+      fprintf(stderr, "PE %d: Synchronization failed: %s\n", myPe_, hipGetErrorString(err));
+      throw std::runtime_error("Synchronization failed");
     }
   }
 
   bool direct = find_registered(output).first.IsValid();
   if (!direct && copy_output_to_user_) {
     copy_output_to_user(output, total_count, stream);
-    if (stream != nullptr) {
-      (void)hipStreamSynchronize(stream);
-    } else {
-      (void)hipDeviceSynchronize();
+    if (!capturing) {
+      (void)(stream ? hipStreamSynchronize(stream) : hipDeviceSynchronize());
     }
   }
 
@@ -558,36 +553,30 @@ int64_t AllgatherSdma<T>::prepare_async_wait(hipStream_t stream) {
 }
 
 template <typename T>
-double AllgatherSdma<T>::finish_async_wait(hipStream_t stream) {
+double AllgatherSdma<T>::finish_async_wait(hipStream_t stream, bool capturing) {
   if (!async_in_progress_) {
     throw std::runtime_error("No async operation in progress");
   }
 
   hipStream_t wait_stream = (stream != nullptr) ? stream : async_stream_;
 
-  if (wait_stream != nullptr) {
-    hipError_t err = hipStreamSynchronize(wait_stream);
+  // Under `capturing` the stream already carries the ordering: the wait kernel
+  // does not retire until every peer's flag is set, and the copy-out below is
+  // enqueued behind it. Only the returned duration becomes meaningless.
+  if (!capturing) {
+    hipError_t err = wait_stream ? hipStreamSynchronize(wait_stream) : hipDeviceSynchronize();
     if (err != hipSuccess) {
-      fprintf(stderr, "PE %d: Stream synchronization failed: %s\n", myPe_, hipGetErrorString(err));
+      fprintf(stderr, "PE %d: Synchronization failed: %s\n", myPe_, hipGetErrorString(err));
       cancel_async();
-      throw std::runtime_error("Stream synchronization failed");
-    }
-  } else {
-    hipError_t err = hipDeviceSynchronize();
-    if (err != hipSuccess) {
-      fprintf(stderr, "PE %d: Device synchronization failed: %s\n", myPe_, hipGetErrorString(err));
-      cancel_async();
-      throw std::runtime_error("Device synchronization failed");
+      throw std::runtime_error("Synchronization failed");
     }
   }
 
   bool direct = find_registered(async_output_).first.IsValid();
   if (!direct && copy_output_to_user_) {
     copy_output_to_user(async_output_, async_total_count_, wait_stream);
-    if (wait_stream != nullptr) {
-      (void)hipStreamSynchronize(wait_stream);
-    } else {
-      (void)hipDeviceSynchronize();
+    if (!capturing) {
+      (void)(wait_stream ? hipStreamSynchronize(wait_stream) : hipDeviceSynchronize());
     }
   }
 

--- a/src/collective/core/oneshot_allgather_sdma_class.cpp
+++ b/src/collective/core/oneshot_allgather_sdma_class.cpp
@@ -38,6 +38,12 @@ void ShmemDeleter::operator()(void* ptr) const {
     }
 }
 #endif
+
+// One cacheline for a single uint64_t: the generation counter is re-read by
+// every kernel launch, and sharing a line with the flags the peers AMO_SET
+// would have that remote traffic invalidate it on every collective.
+static constexpr size_t kGenCounterBytes = 128;
+
 // Constructor implementation - delegating version
 template <typename T>
 AllgatherSdma<T>::AllgatherSdma(int myPe, int npes, size_t transit_buffer_size,
@@ -55,6 +61,7 @@ AllgatherSdma<T>::AllgatherSdma(int myPe, int npes, size_t input_buffer_size,
       npes_(npes),
       dtype_size_(sizeof(T)),
       flags_(nullptr, ShmemDeleter()),
+      gen_(nullptr, ShmemDeleter()),
       input_transit_buffer_(nullptr),
       input_transit_buffer_size_(input_buffer_size),
       input_transit_buffer_ptr_(nullptr, ShmemDeleter()),
@@ -62,14 +69,12 @@ AllgatherSdma<T>::AllgatherSdma(int myPe, int npes, size_t input_buffer_size,
       output_transit_buffer_size_(output_buffer_size),
       output_transit_buffer_ptr_(nullptr, ShmemDeleter()),
       async_in_progress_(false),
-      call_seq_(0),
       async_input_(nullptr),
       async_output_(nullptr),
       async_total_count_(0),
       async_stream_(nullptr),
       async_dst_obj_(),
       async_start_time_(0.0),
-      async_flag_token_(0),
       copy_output_to_user_(copy_output_to_user) {
   // 1. Allocate and initialize flags memory
   size_t flagsSize = npes_ * sizeof(uint64_t);
@@ -83,6 +88,16 @@ AllgatherSdma<T>::AllgatherSdma(int myPe, int npes, size_t input_buffer_size,
   if (!flagsObj_.IsValid()) {
     throw std::runtime_error("Failed to get valid flags memory object");
   }
+
+  // 1b. Generation counter. Only ever touched by our own kernels, so it needs
+  // no symmetric memory object; it lives in its own allocation to keep it off
+  // the cacheline the peers AMO_SET into.
+  void* gen = shmem::ShmemMalloc(kGenCounterBytes);
+  if (gen == nullptr) {
+    throw std::runtime_error("Failed to allocate generation counter");
+  }
+  gen_.reset(static_cast<uint64_t*>(gen));
+  memset(gen_.get(), 0, kGenCounterBytes);
 
   // 2. Allocate input transit buffer
   input_transit_buffer_ = shmem::ShmemMalloc(input_transit_buffer_size_);
@@ -115,6 +130,7 @@ AllgatherSdma<T>::AllgatherSdma(int myPe, int npes, size_t input_buffer_size,
   // 4. Print initialization information
   printf("AllgatherSdma initialized: PE %d of %d\n", myPe_, npes_);
   printf("  Flags allocated: %zu bytes at %p\n", flagsSize, flags_.get());
+  printf("  Generation counter at %p\n", gen_.get());
   printf("  Input transit buffer: %.2f MB at %p\n", input_transit_buffer_size_ / (1024.0 * 1024.0),
          input_transit_buffer_);
   printf("  Output transit buffer: %.2f MB at %p\n",
@@ -130,6 +146,7 @@ AllgatherSdma<T>::~AllgatherSdma() {
   if (!shmem::ShmemIsInitialized()) {
     registered_output_buffers_.clear();
     flags_.release();
+    gen_.release();
     input_transit_buffer_ptr_.release();
     output_transit_buffer_ptr_.release();
     return;
@@ -235,7 +252,6 @@ void AllgatherSdma<T>::cancel_async() {
     async_stream_ = nullptr;
     async_dst_obj_ = {};
     async_start_time_ = 0.0;
-    async_flag_token_ = 0;
 
     // Reset flags
     // resetFlags();
@@ -383,7 +399,6 @@ template <typename T>
 int64_t AllgatherSdma<T>::prepare_sync(T* input, T* output, size_t total_count,
                                        hipStream_t stream) {
   (void)stream;
-  uint64_t flag_token = call_seq_.fetch_add(1, std::memory_order_relaxed) + 1;
   auto [regObj, byteOffset] = find_registered(output);
   bool direct = regObj.IsValid();
 
@@ -395,7 +410,7 @@ int64_t AllgatherSdma<T>::prepare_sync(T* input, T* output, size_t total_count,
   jit_args_.flagsMemObj = flagsObj_;
   jit_args_.elementCount = total_count;
   jit_args_.dstBaseOffset = direct ? byteOffset : 0;
-  jit_args_.flagVal = flag_token;
+  jit_args_.genCounter = gen_.get();
   jit_args_.splitSizes = nullptr;
   jit_args_.splitOffsets = nullptr;
   jit_args_.splitCount = 0;
@@ -409,7 +424,6 @@ int64_t AllgatherSdma<T>::prepare_sync_param_contiguous(T* input, T* output, siz
                                                         const size_t* split_offsets,
                                                         size_t split_count, hipStream_t stream) {
   (void)stream;
-  uint64_t flag_token = call_seq_.fetch_add(1, std::memory_order_relaxed) + 1;
   auto [regObj, byteOffset] = find_registered(output);
   bool direct = regObj.IsValid();
 
@@ -421,7 +435,7 @@ int64_t AllgatherSdma<T>::prepare_sync_param_contiguous(T* input, T* output, siz
   jit_args_.flagsMemObj = flagsObj_;
   jit_args_.elementCount = total_count;
   jit_args_.dstBaseOffset = direct ? byteOffset : 0;
-  jit_args_.flagVal = flag_token;
+  jit_args_.genCounter = gen_.get();
   jit_args_.splitSizes = split_sizes;
   jit_args_.splitOffsets = split_offsets;
   jit_args_.splitCount = split_count;
@@ -466,7 +480,6 @@ int64_t AllgatherSdma<T>::prepare_async_start(T* input, T* output, size_t total_
   async_total_count_ = total_count;
   async_stream_ = stream;
   async_start_time_ = CollectiveWallTime();
-  async_flag_token_ = call_seq_.fetch_add(1, std::memory_order_relaxed) + 1;
 
   auto [regObj, byteOffset] = find_registered(output);
   bool direct = regObj.IsValid();
@@ -481,7 +494,9 @@ int64_t AllgatherSdma<T>::prepare_async_start(T* input, T* output, size_t total_
   jit_args_.flagsMemObj = flagsObj_;
   jit_args_.elementCount = total_count;
   jit_args_.dstBaseOffset = direct ? byteOffset : 0;
-  jit_args_.flagVal = async_flag_token_;
+  // The PUT kernel never touches the flags, so it ignores this; the paired WAIT
+  // kernel is where the generation is derived and advanced.
+  jit_args_.genCounter = gen_.get();
   jit_args_.splitSizes = nullptr;
   jit_args_.splitOffsets = nullptr;
   jit_args_.splitCount = 0;
@@ -503,7 +518,6 @@ int64_t AllgatherSdma<T>::prepare_async_start_param_contiguous(
   async_total_count_ = total_count;
   async_stream_ = stream;
   async_start_time_ = CollectiveWallTime();
-  async_flag_token_ = call_seq_.fetch_add(1, std::memory_order_relaxed) + 1;
 
   auto [regObj, byteOffset] = find_registered(output);
   bool direct = regObj.IsValid();
@@ -518,7 +532,7 @@ int64_t AllgatherSdma<T>::prepare_async_start_param_contiguous(
   jit_args_.flagsMemObj = flagsObj_;
   jit_args_.elementCount = total_count;
   jit_args_.dstBaseOffset = direct ? byteOffset : 0;
-  jit_args_.flagVal = async_flag_token_;
+  jit_args_.genCounter = gen_.get();
   jit_args_.splitSizes = split_sizes;
   jit_args_.splitOffsets = split_offsets;
   jit_args_.splitCount = split_count;
@@ -544,7 +558,7 @@ int64_t AllgatherSdma<T>::prepare_async_wait(hipStream_t stream) {
   jit_args_.flagsMemObj = flagsObj_;
   jit_args_.elementCount = 0;
   jit_args_.dstBaseOffset = 0;
-  jit_args_.flagVal = async_flag_token_;
+  jit_args_.genCounter = gen_.get();
   jit_args_.splitSizes = nullptr;
   jit_args_.splitOffsets = nullptr;
   jit_args_.splitCount = 0;
@@ -581,7 +595,8 @@ double AllgatherSdma<T>::finish_async_wait(hipStream_t stream, bool capturing) {
   }
 
   double end_time = CollectiveWallTime();
-  double duration = end_time - async_start_time_;
+  // Nothing waited for the transfer under `capturing`; see finish_sync.
+  double duration = capturing ? -1.0 : end_time - async_start_time_;
 
   async_in_progress_ = false;
   async_input_ = nullptr;
@@ -590,19 +605,23 @@ double AllgatherSdma<T>::finish_async_wait(hipStream_t stream, bool capturing) {
   async_stream_ = nullptr;
   async_dst_obj_ = {};
   async_start_time_ = 0.0;
-  async_flag_token_ = 0;
 
   return duration;
 }
 
 // ================ END: JIT prepare/finish methods ================
 
-// resetFlags implementation (unchanged)
 template <typename T>
 void AllgatherSdma<T>::resetFlags() {
+  // Flags and generation counter must go back together: a zeroed counter next
+  // to surviving flag values makes the next kernel derive generation 1, find
+  // every peer already above it and skip the wait entirely.
   if (flags_) {
     size_t flagsSize = npes_ * sizeof(uint64_t);
     memset(flags_.get(), 0, flagsSize);
+  }
+  if (gen_) {
+    memset(gen_.get(), 0, kGenCounterBytes);
   }
 }
 

--- a/src/collective/kernels/ccl_kernels.hip
+++ b/src/collective/kernels/ccl_kernels.hip
@@ -60,15 +60,15 @@ using namespace mori::collective;
                      args.outputTransitMemObj, args.flagsMemObj, args.elementCount); \
   }
 
-// AllGather sync: all fields including dstBaseOffset and flagVal
+// AllGather sync: all fields including dstBaseOffset and genCounter
 #define CCL_WRAP_ALLGATHER(kernel, suffix, T)                                \
   extern "C" __global__ void kernel##_##suffix(CclAllgatherArgs<T> args) {  \
     kernel##_body<T>(args.myPe, args.npes, args.input, args.srcMemObj,      \
                      args.dstMemObj, args.flagsMemObj, args.elementCount,   \
-                     args.dstBaseOffset, args.flagVal);                     \
+                     args.dstBaseOffset, args.genCounter);                  \
   }
 
-// AllGather async put: no flagVal parameter
+// AllGather async put: no generation counter, the paired WAIT kernel owns it
 #define CCL_WRAP_ALLGATHER_ASYNC_PUT(kernel, suffix, T)                      \
   extern "C" __global__ void kernel##_##suffix(CclAllgatherArgs<T> args) {  \
     kernel##_body<T>(args.myPe, args.npes, args.input, args.srcMemObj,      \
@@ -80,7 +80,7 @@ using namespace mori::collective;
   extern "C" __global__ void kernel##_##suffix(CclAllgatherArgs<T> args) {  \
     kernel##_body<T>(args.myPe, args.npes, args.input, args.srcMemObj,      \
                      args.dstMemObj, args.flagsMemObj, args.elementCount,   \
-                     args.dstBaseOffset, args.flagVal, args.splitSizes,     \
+                     args.dstBaseOffset, args.genCounter, args.splitSizes,  \
                      args.splitOffsets, args.splitCount);                   \
   }
 
@@ -199,7 +199,7 @@ extern "C" __global__ void OneShotAllGatherSdmaSubGroupParamContiguousKernel_u32
 extern "C" __global__ void OneShotAllGatherSdmaAsyncWaitKernel_u32(
     CclAllgatherArgs<uint32_t> args) {
   OneShotAllGatherSdmaAsyncWaitKernel_body(args.myPe, args.npes, args.dstMemObj,
-                                           args.flagsMemObj, args.flagVal);
+                                           args.flagsMemObj, args.genCounter);
 }
 
 // Sub-group intra-node SDMA broadcast: root (group pos 0) fans the full buffer

--- a/src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp
+++ b/src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp
@@ -130,14 +130,13 @@ __device__ __forceinline__ gfx1250_TDM_GROUP1 TdmShape(int hiddenDim) {
   return g1;
 }
 #if defined(MORI_TDM_STRICT)
-#define MORI_TDM_CHECK_ADDR(p)                                 \
-  do {                                                         \
+#define MORI_TDM_CHECK_ADDR(p)                                  \
+  do {                                                          \
     if (!::mori::tdm::TdmAddrOnRow((const void*)(p))) __trap(); \
   } while (0)
-#define MORI_TDM_CHECK_XFER(src, dst, n, sp)                                       \
-  do {                                                                             \
-    if (!::mori::tdm::TdmXferOk((const void*)(src), (const void*)(dst), (n), (sp))) \
-      __trap();                                                                    \
+#define MORI_TDM_CHECK_XFER(src, dst, n, sp)                                                  \
+  do {                                                                                        \
+    if (!::mori::tdm::TdmXferOk((const void*)(src), (const void*)(dst), (n), (sp))) __trap(); \
   } while (0)
 #else
 #define MORI_TDM_CHECK_ADDR(p) ((void)0)

--- a/src/ops/dispatch_combine_v2/tdm_align.hpp
+++ b/src/ops/dispatch_combine_v2/tdm_align.hpp
@@ -52,9 +52,7 @@ MORI_TDM_FN TdmSplit128 TdmPlanRun(size_t phase, int nElems) {
   return TdmSplit128{head, rows * P, rows};
 }
 
-MORI_TDM_FN int TdmSplitDim0(const TdmSplit128& sp) {
-  return (sp.rows > 0) ? kTdmRowElems4B : 0;
-}
+MORI_TDM_FN int TdmSplitDim0(const TdmSplit128& sp) { return (sp.rows > 0) ? kTdmRowElems4B : 0; }
 
 MORI_TDM_FN int TdmSplitDim1(const TdmSplit128& sp) { return (sp.rows > 0) ? sp.rows : 0; }
 

--- a/src/pybind/pybind_ccl.cpp
+++ b/src/pybind/pybind_ccl.cpp
@@ -224,8 +224,7 @@ void RegisterMoriCcl(pybind11::module_& m) {
             return self.finish_sync(reinterpret_cast<uint32_t*>(output), count,
                                     reinterpret_cast<hipStream_t>(stream), capturing);
           },
-          py::arg("output_ptr"), py::arg("count"), py::arg("stream"),
-          py::arg("capturing") = false)
+          py::arg("output_ptr"), py::arg("count"), py::arg("stream"), py::arg("capturing") = false)
       .def(
           "prepare_async_start",
           [](AllgatherU32& self, uintptr_t input, uintptr_t output, size_t count,

--- a/src/pybind/pybind_ccl.cpp
+++ b/src/pybind/pybind_ccl.cpp
@@ -219,11 +219,13 @@ void RegisterMoriCcl(pybind11::module_& m) {
           py::arg("split_offsets_ptr"), py::arg("split_count"), py::arg("stream"))
       .def(
           "finish_sync",
-          [](AllgatherU32& self, uintptr_t output, size_t count, int64_t stream) -> double {
+          [](AllgatherU32& self, uintptr_t output, size_t count, int64_t stream,
+             bool capturing) -> double {
             return self.finish_sync(reinterpret_cast<uint32_t*>(output), count,
-                                    reinterpret_cast<hipStream_t>(stream));
+                                    reinterpret_cast<hipStream_t>(stream), capturing);
           },
-          py::arg("output_ptr"), py::arg("count"), py::arg("stream"))
+          py::arg("output_ptr"), py::arg("count"), py::arg("stream"),
+          py::arg("capturing") = false)
       .def(
           "prepare_async_start",
           [](AllgatherU32& self, uintptr_t input, uintptr_t output, size_t count,
@@ -255,10 +257,10 @@ void RegisterMoriCcl(pybind11::module_& m) {
           py::arg("stream"))
       .def(
           "finish_async_wait",
-          [](AllgatherU32& self, int64_t stream) -> double {
-            return self.finish_async_wait(reinterpret_cast<hipStream_t>(stream));
+          [](AllgatherU32& self, int64_t stream, bool capturing) -> double {
+            return self.finish_async_wait(reinterpret_cast<hipStream_t>(stream), capturing);
           },
-          py::arg("stream"))
+          py::arg("stream"), py::arg("capturing") = false)
       .def("is_async_in_progress", &AllgatherU32::is_async_in_progress)
       .def("cancel_async", &AllgatherU32::cancel_async)
       .def("reset_flags", &AllgatherU32::resetFlags)

--- a/tests/python/ccl/test_allgather_graph_capture.py
+++ b/tests/python/ccl/test_allgather_graph_capture.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""AllGather SDMA under HIP graph capture and repeated replay.
+
+The interesting case is the *second* replay onward. The completion flags are
+monotonic AMO_SET and never reset, so a generation minted on the host and passed
+to the kernel by value gets frozen into the graph node: from replay 2 the wait is
+already satisfied on entry and returns without the peers' payload having landed.
+Nothing crashes, the output is just silently stale.
+
+So each replay writes a fresh value into the (fixed) input buffer and the output
+is checked against that value. A stale read shows up as the previous replay's
+value, which the failure report prints explicitly.
+
+The three modes cover the three kernels that derive the generation: `sync` the
+fused gather, `async` the standalone wait kernel, and `param_contiguous` the
+split-aware gather. There is no param-contiguous async mode because that path's
+PUT kernel never touches the flags -- it reuses the same wait kernel `async`
+already covers.
+
+Detecting it needs injected skew. With every rank leaving the same barrier and
+doing the same amount of work, peers finish their puts within microseconds of
+each other while the transfer itself takes hundreds, so a wait that returns
+immediately still happens to find the data there. `--skew-cycles` holds half the
+ranks back with a spin kernel enqueued ahead of the replay, so the early ranks
+reach their copy-out long before the late ranks have posted anything. A correct
+wait absorbs the skew; a frozen generation copies out stale data.
+"""
+
+import os
+import numpy as np
+import torch
+import torch.distributed as dist
+import mori.shmem as shmem
+from mori.ccl import AllgatherSdma
+from tests.python.utils import TorchDistContext, get_free_port
+
+
+# Distinct per (pe, replay) and never zero, so a stale or untouched buffer is
+# always distinguishable from a correct one.
+def _expected(pe, replay):
+    return (pe + 1) * 1000 + replay * 7919
+
+
+def _test_graph_capture(rank, world_size, port, elems, replays, mode, skew_cycles):
+    with TorchDistContext(rank=rank, world_size=world_size, master_port=port):
+        shmem.shmem_torch_process_group_init("default")
+
+        my_pe = shmem.shmem_mype()
+        npes = shmem.shmem_npes()
+        assert my_pe == rank and npes == world_size
+
+        bytes_per_pe = elems * 4
+        total_bytes = bytes_per_pe * npes
+
+        if rank == 0:
+            print(f"\n{'=' * 68}")
+            print(f"AllGather SDMA graph capture test  (mode={mode})")
+            print(f"  world size    : {world_size}")
+            print(f"  elems per PE  : {elems:,}  ({bytes_per_pe / 2**20:.1f} MB)")
+            print(f"  output total  : {total_bytes / 2**20:.1f} MB")
+            print(f"  replays       : {replays}")
+            print(f"  skew cycles   : {skew_cycles:,} (on odd ranks)")
+            print(f"{'=' * 68}\n", flush=True)
+
+        # Hold odd ranks back so the even ranks reach their copy-out while the
+        # odd ranks have not posted their contribution yet.
+        is_late = skew_cycles > 0 and (my_pe % 2 == 1)
+
+        allgather = AllgatherSdma(
+            my_pe,
+            npes,
+            input_buffer_size=bytes_per_pe,
+            output_buffer_size=total_bytes,
+            copy_output_to_user=True,
+        )
+
+        device = torch.device(f"cuda:{rank}")
+        input_tensor = torch.zeros(elems, dtype=torch.uint32, device=device)
+        output_tensor = torch.zeros(elems * npes, dtype=torch.uint32, device=device)
+
+        # Param-contiguous scatters each split to `split_offset * npes +
+        # pe * split_size`, so what has to be checked is one region per
+        # (split, pe) instead of one contiguous chunk per pe.
+        split_sizes = split_offsets = None
+        if mode == "param_contiguous":
+            head = elems // 4
+            body = elems // 2
+            sizes = [head, body, elems - head - body]
+            if min(sizes) <= 0:
+                raise ValueError(f"--elems {elems} is too small to split three ways")
+            offsets = [0, head, head + body]
+            split_sizes = torch.tensor(sizes, dtype=torch.uint64, device=device)
+            split_offsets = torch.tensor(offsets, dtype=torch.uint64, device=device)
+            regions = [
+                (off * npes + pe * size, off * npes + pe * size + size, pe, idx)
+                for idx, (size, off) in enumerate(zip(sizes, offsets))
+                for pe in range(npes)
+            ]
+        else:
+            regions = [(pe * elems, (pe + 1) * elems, pe, None) for pe in range(npes)]
+
+        def fill_input(replay):
+            input_tensor.fill_(_expected(my_pe, replay))
+
+        def enqueue(stream, capturing):
+            if mode == "sync":
+                allgather(
+                    input_tensor, output_tensor, elems, stream, capturing=capturing
+                )
+            elif mode == "param_contiguous":
+                allgather.enqueue_param_contiguous(
+                    input_tensor,
+                    output_tensor,
+                    elems,
+                    split_sizes,
+                    split_offsets,
+                    stream,
+                    capturing=capturing,
+                )
+            else:
+                allgather.start_async(input_tensor, output_tensor, elems, stream)
+                allgather.wait_async(stream, capturing=capturing)
+
+        # Warm up eagerly first: the kernels are JIT compiled on first use and
+        # the transit buffers grow on demand, neither of which is capturable.
+        fill_input(0)
+        warmup_stream = torch.cuda.Stream(device=device)
+        warmup_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(warmup_stream):
+            for _ in range(3):
+                enqueue(warmup_stream, capturing=False)
+        warmup_stream.synchronize()
+        torch.cuda.current_stream().wait_stream(warmup_stream)
+        torch.cuda.synchronize()
+        dist.barrier()
+        if rank == 0:
+            print("warmup done, capturing graph ...", flush=True)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            enqueue(torch.cuda.current_stream(), capturing=True)
+        torch.cuda.synchronize()
+        dist.barrier()
+        if rank == 0:
+            print("capture done, replaying ...\n", flush=True)
+
+        failures = []
+        for replay in range(1, replays + 1):
+            # Every rank must have its new contribution in place before any rank
+            # starts replaying, or a peer legitimately gathers the old value.
+            fill_input(replay)
+            output_tensor.fill_(0xDEADBEEF)
+            torch.cuda.synchronize()
+            dist.barrier()
+
+            if is_late:
+                # Enqueued on the stream the replay goes to, so it delays the
+                # whole collective on this rank rather than just the host.
+                torch.cuda._sleep(skew_cycles)
+            graph.replay()
+            torch.cuda.synchronize()
+
+            got = output_tensor.cpu().numpy()
+            bad = []
+            for start, end, src_pe, split_idx in regions:
+                chunk = got[start:end]
+                want = _expected(src_pe, replay)
+                if not np.all(chunk == want):
+                    uniq = np.unique(chunk)
+                    stale = _expected(src_pe, replay - 1)
+                    hint = ""
+                    if stale in uniq:
+                        hint = f"  <-- contains PREVIOUS replay's value {stale}"
+                    elif 0xDEADBEEF in uniq:
+                        hint = "  <-- still poison, nothing was written"
+                    where = f"PE {src_pe}"
+                    if split_idx is not None:
+                        where += f" split {split_idx}"
+                    bad.append(
+                        f"    replay {replay} chunk from {where}: "
+                        f"want {want}, got {uniq[:6]}{hint}"
+                    )
+            if bad:
+                failures.extend(bad)
+                print(f"PE {rank}: replay {replay} MISMATCH", flush=True)
+                for line in bad:
+                    print(line, flush=True)
+            elif rank == 0:
+                print(f"  replay {replay}: ok", flush=True)
+
+            dist.barrier()
+
+        ok = torch.tensor([0 if failures else 1], dtype=torch.int32)
+        dist.all_reduce(ok, op=dist.ReduceOp.SUM)
+        passed = ok.item()
+
+        if rank == 0:
+            print(f"\nPEs passed: {passed}/{npes}")
+            print(f"=== {'PASSED' if passed == npes else 'FAILED'} (mode={mode}) ===\n")
+
+        torch.cuda.synchronize()
+        dist.barrier()
+        del graph
+        del allgather
+        dist.barrier()
+        shmem.shmem_finalize()
+
+        if passed != npes:
+            raise AssertionError(
+                f"PE {rank}: graph replay verification failed "
+                f"({len(failures)} bad chunks locally)"
+            )
+
+
+def test_allgather_graph_capture(
+    elems=4 * 1024 * 1024,
+    world_size=8,
+    replays=10,
+    mode="sync",
+    skew_cycles=400_000_000,
+):
+    os.environ.setdefault("MORI_ENABLE_SDMA", "1")
+    port = get_free_port()
+    torch.multiprocessing.spawn(
+        _test_graph_capture,
+        args=(world_size, port, elems, replays, mode, skew_cycles),
+        nprocs=world_size,
+        join=True,
+    )
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--elems", type=int, default=4 * 1024 * 1024)
+    parser.add_argument("--world-size", type=int, default=8)
+    parser.add_argument("--replays", type=int, default=10)
+    parser.add_argument(
+        "--mode", choices=["sync", "async", "param_contiguous"], default="sync"
+    )
+    parser.add_argument(
+        "--skew-cycles",
+        type=int,
+        default=400_000_000,
+        help="spin cycles enqueued on odd ranks before each replay (0 disables)",
+    )
+    parser.add_argument("--enable-sdma", type=int, default=1, choices=[0, 1])
+    args = parser.parse_args()
+    os.environ["MORI_ENABLE_SDMA"] = str(args.enable_sdma)
+
+    test_allgather_graph_capture(
+        args.elems, args.world_size, args.replays, args.mode, args.skew_cycles
+    )


### PR DESCRIPTION
Add a `capturing` flag to `AllgatherSdma::finish_sync` and `finish_async_wait` (threaded through the Python wrapper and pybind bindings) that skips the host-side stream/device syncs. Those syncs only make the returned duration meaningful and are illegal during graph capture; the SDMA transfer, the wait kernel and the copy-out are already stream-ordered, so a consumer enqueued on the same stream still sees complete data, and the launch thread stays free to queue work into the window where the copy engines are busy but the CUs are idle.

With the host sync gone, the cross-GPU visibility it incidentally provided must be re-established inside the wait kernel: the flags are written by a peer GPU's SDMA engine, so a device-scope load does not order the payload behind them. Switch the flag spin to SYSTEM-scope relaxed loads, add a seq-cst SYSTEM acquire load after the spin, and emit a tail `__threadfence_system()` before retire so the consumer kernel reads the peer's payload rather than a stale cache copy.

Default `capturing=false` preserves the existing synchronous contract.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
