### PR TITLE
fix(rdma): cco/shmem indicies wraparound (#626)

### DIFF
--- a/examples/dist_rdma_ops/dist_write.cpp
+++ b/examples/dist_rdma_ops/dist_write.cpp
@@ -119,7 +119,7 @@ inline __device__ void QuietSerial(RdmaEndpoint* endpoint) {
     // core::UpdateCqDbrRecord<P>(cq, cq.dbrRecAddr, (uint32_t)(my_cq_consumer + 1), cq.cqeNum);
 
     __atomic_signal_fence(__ATOMIC_SEQ_CST);
-    __hip_atomic_fetch_max(&wq.doneIdx, wqe_id, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    AtomicMaxSerial(&wq.doneIdx, wqe_id);
   }
   ReleaseLock(&cq.pollCqLock);
 }
@@ -194,8 +194,7 @@ __device__ void Quiet(RdmaEndpoint* endpoint) {
       UpdateCqDbrRecord<P>(endpoint->cqHandle, (uint32_t)(warp_cq_consumer + quiet_amount));
 
       uint64_t doneIdx = wqe_broadcast[warp_id];
-      __hip_atomic_fetch_max(&endpoint->wqHandle.doneIdx, doneIdx, __ATOMIC_RELAXED,
-                             __HIP_MEMORY_SCOPE_AGENT);
+      AtomicMaxSerial(&endpoint->wqHandle.doneIdx, static_cast<uint32_t>(doneIdx));
       __hip_atomic_fetch_add(&cqHandle->consIdx, quiet_amount, __ATOMIC_RELAXED,
                              __HIP_MEMORY_SCOPE_AGENT);
     }
@@ -302,8 +301,7 @@ __device__ void Write(RdmaEndpoint* endpoint, RdmaMemoryRegion localMr, RdmaMemo
       core::atomic_add_packed_msn_and_psn(&wqHandle->msnPack, num_wqes, psnCnt * num_wqes,
                                           &warp_msntbl_counter, &warp_psn_counter);
       warp_sq_counter = warp_msntbl_counter;
-      __hip_atomic_fetch_max(&wqHandle->postIdx, warp_sq_counter + num_wqes, __ATOMIC_RELAXED,
-                             __HIP_MEMORY_SCOPE_AGENT);
+      AtomicMaxSerial(&wqHandle->postIdx, warp_sq_counter + num_wqes);
     } else if constexpr (P == core::ProviderType::PSD) {
       warp_sq_counter = __hip_atomic_fetch_add(&wqHandle->postIdx, num_wqes, __ATOMIC_RELAXED,
                                                __HIP_MEMORY_SCOPE_AGENT);
@@ -327,13 +325,13 @@ __device__ void Write(RdmaEndpoint* endpoint, RdmaMemoryRegion localMr, RdmaMemo
   }
 
   while (true) {
-    uint64_t db_touched =
+    uint32_t db_touched =
         __hip_atomic_load(&wqHandle->dbTouchIdx, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_AGENT);
-    uint64_t db_done =
+    uint32_t db_done =
         __hip_atomic_load(&wqHandle->doneIdx, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_AGENT);
-    uint64_t num_active_sq_entries = db_touched - db_done;
-    uint64_t num_free_entries = wqHandle->sqWqeNum - num_active_sq_entries;
-    uint64_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
+    uint32_t num_active_sq_entries = db_touched - db_done;
+    uint32_t num_free_entries = wqHandle->sqWqeNum - num_active_sq_entries;
+    uint32_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
     if (num_free_entries > num_entries_until_warp_last_entry) {
       break;
     }

--- a/include/mori/cco/cco_scale_out.hpp
+++ b/include/mori/cco/cco_scale_out.hpp
@@ -370,12 +370,28 @@ __device__ inline static void quietUntil(core::RdmaEndpointDevice* ep, uint32_t 
           const int highestLane = core::GetLastActiveLaneID(successMask);
           if (highestLane == -1) continue;
           if (myLaneId == highestLane) {
-            cq->cq_consumer = myCqPos + 1;
-            if (((cq->cq_consumer - cq->cq_dbpos) & (cq->cqeNum - 1)) >= CQ_DOORBELL_GRACE) {
-              cq->cq_dbpos = cq->cq_consumer;
-              core::UpdateCqDbrRecord<core::ProviderType::PSD>(*cq, myCqPos + 1);
+            // Widen the 24-bit MSN into doneIdx's 32-bit serial space; see the CCQE
+            // branch above for why the raw store is wrong and why dbTouchIdx caps it.
+            uint32_t dbTouched =
+                __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+            uint32_t cur = wq->doneIdx;
+            uint32_t delta = (wqeCounter - cur) & MSN_MASK;
+
+            // Decide before consuming: ringDoorbellOrdered rings the doorbell before
+            // publishing dbTouchIdx, so a live MSN can be ahead of the cap, and the
+            // color bit is keyed on cq_consumer -- moving it first would drop that
+            // completion for good. Left in place, a later pass takes it.
+            bool aheadOfDoorbell =
+                delta != 0 && static_cast<int32_t>(delta) > static_cast<int32_t>(dbTouched - cur);
+            if (!aheadOfDoorbell) {
+              if (delta != 0) wq->doneIdx = cur + delta;
+
+              cq->cq_consumer = myCqPos + 1;
+              if (((cq->cq_consumer - cq->cq_dbpos) & (cq->cqeNum - 1)) >= CQ_DOORBELL_GRACE) {
+                cq->cq_dbpos = cq->cq_consumer;
+                core::UpdateCqDbrRecord<core::ProviderType::PSD>(*cq, myCqPos + 1);
+              }
             }
-            wq->doneIdx = wqeCounter;
           }
           if (!((wq->doneIdx - targetIdx) & PENDING_WORK_MASK)) {
             if (wq->doneIdx == oldDoneIdx) break;
@@ -449,16 +465,25 @@ __device__ inline static void quietUntil(core::RdmaEndpointDevice* ep, uint32_t 
           assert(false);
           break;
         }
-        // Largest V <= dbTouchIdx with V % sqWqeNum == con_indx % sqWqeNum.
+        // con_indx is the consumed count mod sqWqeNum: rebuild the serial as a
+        // forward delta from doneIdx, as the mlx5 drain does with wqe_counter.
+        // Anchoring on dbTouchIdx instead (largest congruent V <= dbTouchIdx, minus
+        // sqWqeNum when it overshot) went a whole queue depth *backwards* whenever
+        // the CQE ran ahead of dbTouchIdx -- routine, since the doorbell is rung
+        // before dbTouchIdx is published -- and as a raw word that value won the
+        // atomic max this used to be and pinned doneIdx for good. Issue #626.
+        // Flow control never leaves sqWqeNum WQEs outstanding, so delta == 0 is
+        // unambiguously "nothing new" rather than a full queue.
+        uint32_t cur = __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
         uint32_t dbTouch =
             __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-        uint32_t completed = (dbTouch & ~mask) | (wqeCounter & mask);
-        if (completed > dbTouch) completed -= wq->sqWqeNum;
-        // We hold pollCqLock and nothing else writes doneIdx on this path, so a
-        // load + compare + store replaces the atomic max.
-        uint32_t cur = __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-        if (static_cast<int32_t>(completed - cur) > 0) {
-          __hip_atomic_store(&wq->doneIdx, completed, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+        uint32_t delta = (wqeCounter - cur) & mask;
+        // Still capped at what was doorbelled: con_indx alone cannot tell a live
+        // completion from a stale one. Refusing one costs nothing -- PollSingleCqe is
+        // level-triggered for cqeNum == 1, so the next pass re-reads the same value.
+        if (delta != 0 && static_cast<int32_t>(delta) <= static_cast<int32_t>(dbTouch - cur)) {
+          // Sole writer under pollCqLock, and delta > 0 is already an advance.
+          __hip_atomic_store(&wq->doneIdx, cur + delta, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
         }
       }
       __threadfence();

--- a/include/mori/cco/cco_scale_out.hpp
+++ b/include/mori/cco/cco_scale_out.hpp
@@ -275,6 +275,7 @@ __device__ inline static void quietUntil(core::RdmaEndpointDevice* ep, uint32_t 
 
   if constexpr (PrvdType == core::ProviderType::PSD) {
     constexpr uint32_t PENDING_WORK_MASK = 0x800000;
+    constexpr uint32_t MSN_MASK = 0xFFFFFF;  // ionic reports a 24-bit MSN
 #ifdef IONIC_CCQE
     // CCQE: cqeNum==1, NIC overwrites CQE[0] with latest MSN.
     volatile ionic_v1_cqe* cqe = reinterpret_cast<volatile ionic_v1_cqe*>(cq->cqAddr);
@@ -282,7 +283,23 @@ __device__ inline static void quietUntil(core::RdmaEndpointDevice* ep, uint32_t 
       uint32_t msn = BE32TOH(*(volatile uint32_t*)(&cqe->send.msg_msn));
       asm volatile("" ::: "memory");
       if (!((msn - targetIdx) & PENDING_WORK_MASK)) {
-        wq->doneIdx = msn;
+        // Widen the 24-bit MSN into doneIdx's 32-bit serial space: advance by the
+        // masked forward delta instead of storing msn raw, else doneIdx ends up in
+        // a different modulus than dbTouchIdx and the in-flight count goes bad past
+        // 2^24. Never advance beyond what was doorbelled -- a WQE the NIC was never
+        // told about cannot have completed, and skipping over it recycles live SQ
+        // slots.
+        // doneIdx is read once into `cur` and written once, so concurrent pollers
+        // computing off the same CQE all land on the same value, as they did when
+        // this was a bare `doneIdx = msn`. A read-modify-write here could reload
+        // between the two and apply delta twice, running doneIdx past the NIC.
+        uint32_t dbTouched =
+            __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+        uint32_t cur = wq->doneIdx;
+        uint32_t delta = (msn - cur) & MSN_MASK;
+        if (delta != 0 && static_cast<int32_t>(delta) <= static_cast<int32_t>(dbTouched - cur)) {
+          wq->doneIdx = cur + delta;
+        }
       }
     }
 #else
@@ -317,7 +334,15 @@ __device__ inline static void quietUntil(core::RdmaEndpointDevice* ep, uint32_t 
             cq->cq_dbpos = cq->cq_consumer;
             core::UpdateCqDbrRecord<core::ProviderType::PSD>(*cq, myCqPos + 1);
           }
-          wq->doneIdx = wqeCounter;
+          // Widen the 24-bit MSN into doneIdx's 32-bit serial space; see the CCQE
+          // branch above for why the raw store is wrong and why dbTouchIdx caps it.
+          uint32_t dbTouched =
+              __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+          uint32_t cur = wq->doneIdx;
+          uint32_t delta = (wqeCounter - cur) & MSN_MASK;
+          if (delta != 0 && static_cast<int32_t>(delta) <= static_cast<int32_t>(dbTouched - cur)) {
+            wq->doneIdx = cur + delta;
+          }
         }
         if (!((wq->doneIdx - targetIdx) & PENDING_WORK_MASK)) {
           if (wq->doneIdx == oldDoneIdx) break;
@@ -361,7 +386,7 @@ __device__ inline static void quietUntil(core::RdmaEndpointDevice* ep, uint32_t 
       if (delta != 0 && static_cast<int32_t>(delta) <= window) {
         completed = cons + delta;
       }
-      __hip_atomic_fetch_max(&wq->doneIdx, completed, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      core::AtomicMaxSerial(&wq->doneIdx, completed);
       asm volatile("" ::: "memory");
     }
     __threadfence();
@@ -395,7 +420,12 @@ __device__ inline static void quietUntil(core::RdmaEndpointDevice* ep, uint32_t 
             __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
         uint32_t completed = (dbTouch & ~mask) | (wqeCounter & mask);
         if (completed > dbTouch) completed -= wq->sqWqeNum;
-        __hip_atomic_fetch_max(&wq->doneIdx, completed, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+        // We hold pollCqLock and nothing else writes doneIdx on this path, so a
+        // load + compare + store replaces the atomic max.
+        uint32_t cur = __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+        if (static_cast<int32_t>(completed - cur) > 0) {
+          __hip_atomic_store(&wq->doneIdx, completed, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+        }
       }
       __threadfence();
       core::ReleaseLock(&cq->pollCqLock);
@@ -462,12 +492,15 @@ __device__ inline static uint32_t reserveWqeSlots(core::RdmaEndpointDevice* ep,
     if (outPsnBase) *outPsnBase = psnBase;
   }
   while (true) {
-    uint64_t dbTouched =
+    // All uint32_t: widening to uint64_t leaves curPostIdx + numWqesNeeded
+    // wrapping in 32 bits while dbTouched does not, so the difference underflows
+    // and this loop spins forever on an empty SQ. Issue #626.
+    uint32_t dbTouched =
         __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint64_t dbDone = __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint64_t numActiveSqEntries = dbTouched - dbDone;
-    uint64_t numFreeEntries = wq->sqWqeNum - numActiveSqEntries;
-    uint64_t entriesUntilMine = curPostIdx + numWqesNeeded - dbTouched;
+    uint32_t dbDone = __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    uint32_t numActiveSqEntries = dbTouched - dbDone;
+    uint32_t numFreeEntries = wq->sqWqeNum - numActiveSqEntries;
+    uint32_t entriesUntilMine = curPostIdx + numWqesNeeded - dbTouched;
     if (numFreeEntries > entriesUntilMine) {
       break;
     }
@@ -490,12 +523,13 @@ __device__ inline static void waitSqSpace(core::RdmaEndpointDevice* ep, uint32_t
                                           uint32_t totalWqes) {
   core::WorkQueueHandle* wq = &ep->wqHandle;
   while (true) {
-    uint64_t dbTouched =
+    // All uint32_t, same reason as reserveWqeSlots above.
+    uint32_t dbTouched =
         __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint64_t dbDone = __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint64_t numActiveSqEntries = dbTouched - dbDone;
-    uint64_t numFreeEntries = wq->sqWqeNum - numActiveSqEntries;
-    uint64_t entriesUntilBatchLast = base + totalWqes - dbTouched;
+    uint32_t dbDone = __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    uint32_t numActiveSqEntries = dbTouched - dbDone;
+    uint32_t numFreeEntries = wq->sqWqeNum - numActiveSqEntries;
+    uint32_t entriesUntilBatchLast = base + totalWqes - dbTouched;
     if (numFreeEntries > entriesUntilBatchLast) break;
     if constexpr (PrvdType == core::ProviderType::BNXT) {
       quietUntil<PrvdType>(ep, static_cast<uint32_t>(dbTouched));

--- a/include/mori/core/transport/rdma/device_primitives.hpp
+++ b/include/mori/core/transport/rdma/device_primitives.hpp
@@ -28,6 +28,28 @@
 namespace mori {
 namespace core {
 /* ---------------------------------------------------------------------------------------------- */
+/*                                       Serial Number Atomics                                    */
+/* ---------------------------------------------------------------------------------------------- */
+// postIdx / dbTouchIdx / doneIdx are free-running uint32_t serials that wrap at
+// 2^32, so only their order is meaningful, never their magnitude. Issue #626.
+
+// Keep whichever of *addr and value is later in serial order; returns the old
+// value. __hip_atomic_fetch_max compares raw words, so at the wrap it keeps the
+// large pre-wrap value and the counter freezes for good.
+inline __device__ uint32_t AtomicMaxSerial(uint32_t* addr, uint32_t value) {
+  uint32_t old = __hip_atomic_load(addr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+  // A failed CAS refreshes `old`, so the loop also exits if another lane already
+  // stored something further along.
+  while (static_cast<int32_t>(value - old) > 0) {
+    if (__hip_atomic_compare_exchange_strong(addr, &old, value, __ATOMIC_RELAXED, __ATOMIC_RELAXED,
+                                             __HIP_MEMORY_SCOPE_AGENT)) {
+      break;
+    }
+  }
+  return old;
+}
+
+/* ---------------------------------------------------------------------------------------------- */
 /*                                          IBGDA Define                                          */
 /* ---------------------------------------------------------------------------------------------- */
 

--- a/include/mori/core/transport/rdma/providers/bnxt/bnxt_device_primitives.hpp
+++ b/include/mori/core/transport/rdma/providers/bnxt/bnxt_device_primitives.hpp
@@ -674,6 +674,10 @@ inline __device__ void UpdateDbrAndRingDbRecv<ProviderType::BNXT>(void* dbrRecAd
 /* ---------------------------------------------------------------------------------------------- */
 /*                                        Completion Queue                                        */
 /* ---------------------------------------------------------------------------------------------- */
+// Collapsed CQ (cqeNum == 1): a level-triggered read of CQE[0]'s con_indx -- no
+// phase check, nothing consumed, consIdx unused. The collapsed-CQ drains rely on
+// that to re-read a completion they refused for running ahead of dbTouchIdx; a
+// one-shot consume here would drop it and hang them.
 inline __device__ int PollSingleCqe(volatile char* cqe, uint32_t consIdx, uint32_t* wqeIdx) {
   // Extract completion index using HIP atomic load
   const uint32_t con_indx = __hip_atomic_load(

--- a/include/mori/shmem/shmem_ibgda_kernels.hpp
+++ b/include/mori/shmem/shmem_ibgda_kernels.hpp
@@ -198,7 +198,8 @@ inline __device__ void BnxtCollapsedCqDrain(core::WorkQueueHandle& wq,
       DrainToLive ? __hip_atomic_load(&wq.postIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT)
                   : __hip_atomic_load(&wq.dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
   uint32_t cons = __hip_atomic_load(&wq.doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-  if (cons >= exitTarget) return;
+  // Serial-order compare: these wrap at 2^32, a raw >= is wrong there.
+  if (static_cast<int32_t>(cons - exitTarget) >= 0) return;
 
   const uint32_t mask = wq.sqWqeNum - 1;  // sqWqeNum is a power of two
   __threadfence();
@@ -218,12 +219,17 @@ inline __device__ void BnxtCollapsedCqDrain(core::WorkQueueHandle& wq,
     uint32_t completed = (dbTouch & ~mask) | (wqeCounter & mask);
     if (completed > dbTouch) completed -= wq.sqWqeNum;
 
-    __hip_atomic_fetch_max(&wq.doneIdx, completed, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    cons = __hip_atomic_load(&wq.doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    // Caller holds pollCqLock and nothing else writes doneIdx on this path, so a
+    // compare against the value we already hold replaces the atomic max -- and the
+    // reload after it, which could only return what we just stored.
+    if (static_cast<int32_t>(completed - cons) > 0) {
+      __hip_atomic_store(&wq.doneIdx, completed, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      cons = completed;
+    }
     if constexpr (DrainToLive) {
       exitTarget = __hip_atomic_load(&wq.postIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
     }
-  } while (cons < exitTarget);
+  } while (static_cast<int32_t>(cons - exitTarget) < 0);
   __threadfence();
 }
 
@@ -243,7 +249,7 @@ inline __device__ void ShmemQuietThreadKernelSerialImpl(int pe, int qpId) {
     if constexpr (DrainToLive) {
       uint32_t done = __hip_atomic_load(&wq.doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
       uint32_t post = __hip_atomic_load(&wq.postIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      if (done >= post) return;
+      if (static_cast<int32_t>(done - post) >= 0) return;
     }
     if (__hip_atomic_load(&cq.pollCqLock, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT) == 0 &&
         core::AcquireLockOnce(&cq.pollCqLock)) {
@@ -266,6 +272,7 @@ inline __device__ void ShmemQuietThreadKernelPsdImpl(int pe, int qpId) {
   const int myLaneId = core::WarpLaneId();
 
   constexpr uint32_t PENDING_WORK_MASK = 0x800000;  // Bit 23: sign bit for 24-bit counter
+  constexpr uint32_t MSN_MASK = 0xFFFFFF;           // ionic reports a 24-bit MSN
   const uint32_t dbTouchedIdx = wqHandle.dbTouchIdx;
   constexpr uint32_t MAX_GREED = 10;
   constexpr uint32_t CQ_DOORBELL_GRACE = 100;  // IONIC_CQ_GRACE
@@ -311,9 +318,28 @@ inline __device__ void ShmemQuietThreadKernelPsdImpl(int pe, int qpId) {
           core::UpdateCqDbrRecord<core::ProviderType::PSD>(cqHandle, myCqPos + 1);
         }
 
-        wqHandle.doneIdx = wqeCounter;
-        // __hip_atomic_fetch_max(&wqHandle.doneIdx, wqeCounter, __ATOMIC_RELAXED,
-        // __HIP_MEMORY_SCOPE_AGENT);
+        // Widen the 24-bit MSN into doneIdx's 32-bit serial space: advance by the
+        // masked forward delta instead of storing wqeCounter raw, else doneIdx ends
+        // up in a different modulus than dbTouchIdx and the in-flight count goes bad
+        // past 2^24. Cap it at what was doorbelled -- a WQE the NIC was never told
+        // about cannot have completed.
+        //
+        // The cap reads dbTouchIdx live rather than reusing dbTouchedIdx: other
+        // warps keep doorbelling while we poll, so a CQE can legitimately report an
+        // MSN past that snapshot. Capping to the stale value would reject it, leave
+        // doneIdx behind after cq_consumer already moved on, and spin here forever.
+        //
+        // doneIdx is read once into `cur` and written once, so concurrent pollers
+        // computing off the same CQE all land on the same value, as they did when
+        // this was a bare `doneIdx = wqeCounter`. A read-modify-write here could
+        // reload between the two and apply delta twice, running doneIdx past the NIC.
+        uint32_t doorbelled =
+            __hip_atomic_load(&wqHandle.dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+        uint32_t cur = wqHandle.doneIdx;
+        uint32_t delta = (wqeCounter - cur) & MSN_MASK;
+        if (delta != 0 && static_cast<int32_t>(delta) <= static_cast<int32_t>(doorbelled - cur)) {
+          wqHandle.doneIdx = cur + delta;
+        }
       }
 
       if (!((wqHandle.doneIdx - dbTouchedIdx) & PENDING_WORK_MASK)) {
@@ -341,7 +367,8 @@ inline __device__ void Mlx5CollapsedCqDrain(core::WorkQueueHandle& wq,
       DrainToLive ? __hip_atomic_load(&wq.postIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT)
                   : __hip_atomic_load(&wq.dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
   uint32_t cons = __hip_atomic_load(&wq.doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-  if (cons >= exitTarget) return;
+  // Serial-order compare: these wrap at 2^32, a raw >= is wrong there.
+  if (static_cast<int32_t>(cons - exitTarget) >= 0) return;
 
   volatile core::Mlx5Cqe64* cqe = reinterpret_cast<volatile core::Mlx5Cqe64*>(cq.cqAddr);
   __threadfence();
@@ -370,15 +397,18 @@ inline __device__ void Mlx5CollapsedCqDrain(core::WorkQueueHandle& wq,
     // live SQ slots out for reuse and the overwritten writes are silently dropped.
     uint32_t doorbelled =
         __hip_atomic_load(&wq.dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    // Caller holds pollCqLock and nothing else writes doneIdx on this path, so a
+    // plain store replaces the atomic max -- delta > 0 already makes it an advance
+    // -- and the reload after it, which could only return what we just stored.
     if (delta != 0 && static_cast<int32_t>(delta) <= static_cast<int32_t>(doorbelled - cons)) {
-      __hip_atomic_fetch_max(&wq.doneIdx, cons + delta, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      cons += delta;
+      __hip_atomic_store(&wq.doneIdx, cons, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
     }
-    cons = __hip_atomic_load(&wq.doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
     if (cons == prevCons) break;
     if constexpr (DrainToLive) {
       exitTarget = __hip_atomic_load(&wq.postIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
     }
-  } while (cons < exitTarget);
+  } while (static_cast<int32_t>(cons - exitTarget) < 0);
   __threadfence();
 }
 
@@ -397,7 +427,7 @@ inline __device__ void ShmemQuietThreadKernelMlnxImpl(int pe, int qpId) {
     if constexpr (DrainToLive) {
       uint32_t done = __hip_atomic_load(&wq.doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
       uint32_t post = __hip_atomic_load(&wq.postIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      if (done >= post) return;
+      if (static_cast<int32_t>(done - post) >= 0) return;
     }
     if (__hip_atomic_load(&cq.pollCqLock, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT) == 0 &&
         core::AcquireLockOnce(&cq.pollCqLock)) {
@@ -594,8 +624,7 @@ inline __device__ void ShmemPutMemNbiThreadKernelImpl(const application::SymmMem
         core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_active_lanes, warp_total_psn,
                                             &warp_msntbl_counter, &warp_psn_counter);
         warp_sq_counter = warp_msntbl_counter;
-        __hip_atomic_fetch_max(&wq->postIdx, warp_sq_counter + num_active_lanes, __ATOMIC_RELAXED,
-                               __HIP_MEMORY_SCOPE_AGENT);
+        core::AtomicMaxSerial(&wq->postIdx, warp_sq_counter + num_active_lanes);
       } else if constexpr (PrvdType == core::ProviderType::PSD) {
         warp_sq_counter = __hip_atomic_fetch_add(&wq->postIdx, num_active_lanes, __ATOMIC_RELAXED,
                                                  __HIP_MEMORY_SCOPE_AGENT);
@@ -619,13 +648,13 @@ inline __device__ void ShmemPutMemNbiThreadKernelImpl(const application::SymmMem
     }
 
     while (true) {
-      uint64_t db_touched =
+      uint32_t db_touched =
           __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint64_t db_done =
+      uint32_t db_done =
           __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint64_t num_active_sq_entries = db_touched - db_done;
-      uint64_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
-      uint64_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
+      uint32_t num_active_sq_entries = db_touched - db_done;
+      uint32_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
+      uint32_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
       if (num_free_entries > num_entries_until_warp_last_entry) {
         break;
       }
@@ -783,8 +812,7 @@ inline __device__ void ShmemPutSizeImmNbiThreadKernelImpl(const application::Sym
       core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_active_lanes, num_active_lanes,
                                           &warp_msntbl_counter, &warp_psn_counter);
       warp_sq_counter = warp_msntbl_counter;
-      __hip_atomic_fetch_max(&wq->postIdx, warp_sq_counter + num_active_lanes, __ATOMIC_RELAXED,
-                             __HIP_MEMORY_SCOPE_AGENT);
+      core::AtomicMaxSerial(&wq->postIdx, warp_sq_counter + num_active_lanes);
     }
     warp_sq_counter = __shfl(warp_sq_counter, leader_phys_lane_id);
     warp_msntbl_counter = __shfl(warp_msntbl_counter, leader_phys_lane_id);
@@ -804,12 +832,12 @@ inline __device__ void ShmemPutSizeImmNbiThreadKernelImpl(const application::Sym
   }
 
   while (true) {
-    uint64_t db_touched =
+    uint32_t db_touched =
         __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint64_t db_done = __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint64_t num_active_sq_entries = db_touched - db_done;
-    uint64_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
-    uint64_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
+    uint32_t db_done = __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    uint32_t num_active_sq_entries = db_touched - db_done;
+    uint32_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
+    uint32_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
     if (num_free_entries > num_entries_until_warp_last_entry) {
       break;
     }
@@ -984,8 +1012,7 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelImpl(
         core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_wqes, warp_total_psn,
                                             &warp_msntbl_counter, &warp_psn_counter);
         warp_sq_counter = warp_msntbl_counter;
-        __hip_atomic_fetch_max(&wq->postIdx, warp_sq_counter + num_wqes, __ATOMIC_RELAXED,
-                               __HIP_MEMORY_SCOPE_AGENT);
+        core::AtomicMaxSerial(&wq->postIdx, warp_sq_counter + num_wqes);
       } else if constexpr (PrvdType == core::ProviderType::PSD) {
         warp_sq_counter = __hip_atomic_fetch_add(&wq->postIdx, num_wqes, __ATOMIC_RELAXED,
                                                  __HIP_MEMORY_SCOPE_AGENT);
@@ -1014,13 +1041,13 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelImpl(
     }
 
     while (true) {
-      uint64_t db_touched =
+      uint32_t db_touched =
           __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint64_t db_done =
+      uint32_t db_done =
           __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint64_t num_active_sq_entries = db_touched - db_done;
-      uint64_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
-      uint64_t num_entries_until_warp_last_entry = warp_sq_counter + num_wqes - db_touched;
+      uint32_t num_active_sq_entries = db_touched - db_done;
+      uint32_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
+      uint32_t num_entries_until_warp_last_entry = warp_sq_counter + num_wqes - db_touched;
       if (num_free_entries > num_entries_until_warp_last_entry) {
         break;
       }
@@ -1292,8 +1319,7 @@ inline __device__ void ShmemAtomicSizeNonFetchThreadKernelImpl(
       core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_active_lanes, num_active_lanes,
                                           &warp_msntbl_counter, &warp_psn_counter);
       warp_sq_counter = warp_msntbl_counter;
-      __hip_atomic_fetch_max(&wq->postIdx, warp_sq_counter + num_active_lanes, __ATOMIC_RELAXED,
-                             __HIP_MEMORY_SCOPE_AGENT);
+      core::AtomicMaxSerial(&wq->postIdx, warp_sq_counter + num_active_lanes);
     }
     warp_sq_counter = __shfl(warp_sq_counter, leader_phys_lane_id);
     warp_msntbl_counter = __shfl(warp_msntbl_counter, leader_phys_lane_id);
@@ -1313,12 +1339,12 @@ inline __device__ void ShmemAtomicSizeNonFetchThreadKernelImpl(
   }
 
   while (true) {
-    uint64_t db_touched =
+    uint32_t db_touched =
         __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint64_t db_done = __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint64_t num_active_sq_entries = db_touched - db_done;
-    uint64_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
-    uint64_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
+    uint32_t db_done = __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    uint32_t num_active_sq_entries = db_touched - db_done;
+    uint32_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
+    uint32_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
     if (num_free_entries > num_entries_until_warp_last_entry) break;
     ShmemQuietThreadKernelImpl<PrvdType>(pe, qpId);
   }
@@ -1476,8 +1502,7 @@ inline __device__ T ShmemAtomicTypeFetchThreadKernelImpl(const application::Symm
       core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_active_lanes, num_active_lanes,
                                           &warp_msntbl_counter, &warp_psn_counter);
       warp_sq_counter = warp_msntbl_counter;
-      __hip_atomic_fetch_max(&wq->postIdx, warp_sq_counter + num_active_lanes, __ATOMIC_RELAXED,
-                             __HIP_MEMORY_SCOPE_AGENT);
+      core::AtomicMaxSerial(&wq->postIdx, warp_sq_counter + num_active_lanes);
     }
     warp_sq_counter = __shfl(warp_sq_counter, leader_phys_lane_id);
     warp_msntbl_counter = __shfl(warp_msntbl_counter, leader_phys_lane_id);
@@ -1497,12 +1522,12 @@ inline __device__ T ShmemAtomicTypeFetchThreadKernelImpl(const application::Symm
   }
 
   while (true) {
-    uint64_t db_touched =
+    uint32_t db_touched =
         __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint64_t db_done = __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint64_t num_active_sq_entries = db_touched - db_done;
-    uint64_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
-    uint64_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
+    uint32_t db_done = __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    uint32_t num_active_sq_entries = db_touched - db_done;
+    uint32_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
+    uint32_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
     if (num_free_entries > num_entries_until_warp_last_entry) break;
     ShmemQuietThreadKernelImpl<PrvdType>(pe, qpId);
   }
@@ -1729,8 +1754,7 @@ inline __device__ void ShmemPutMemNbiThreadKernelAddrImpl(const void* dest, cons
         core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_active_lanes, warp_total_psn,
                                             &warp_msntbl_counter, &warp_psn_counter);
         warp_sq_counter = warp_msntbl_counter;
-        __hip_atomic_fetch_max(&wq->postIdx, warp_sq_counter + num_active_lanes, __ATOMIC_RELAXED,
-                               __HIP_MEMORY_SCOPE_AGENT);
+        core::AtomicMaxSerial(&wq->postIdx, warp_sq_counter + num_active_lanes);
       } else if constexpr (PrvdType == core::ProviderType::PSD) {
         warp_sq_counter = __hip_atomic_fetch_add(&wq->postIdx, num_active_lanes, __ATOMIC_RELAXED,
                                                  __HIP_MEMORY_SCOPE_AGENT);
@@ -1754,13 +1778,13 @@ inline __device__ void ShmemPutMemNbiThreadKernelAddrImpl(const void* dest, cons
     }
 
     while (true) {
-      uint64_t db_touched =
+      uint32_t db_touched =
           __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint64_t db_done =
+      uint32_t db_done =
           __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint64_t num_active_sq_entries = db_touched - db_done;
-      uint64_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
-      uint64_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
+      uint32_t num_active_sq_entries = db_touched - db_done;
+      uint32_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
+      uint32_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
       if (num_free_entries > num_entries_until_warp_last_entry) {
         break;
       }
@@ -1896,8 +1920,7 @@ inline __device__ void ShmemPutSizeImmNbiThreadKernelAddrImpl(const void* dest, 
       core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_active_lanes, num_active_lanes,
                                           &warp_msntbl_counter, &warp_psn_counter);
       warp_sq_counter = warp_msntbl_counter;
-      __hip_atomic_fetch_max(&wq->postIdx, warp_sq_counter + num_active_lanes, __ATOMIC_RELAXED,
-                             __HIP_MEMORY_SCOPE_AGENT);
+      core::AtomicMaxSerial(&wq->postIdx, warp_sq_counter + num_active_lanes);
     }
     warp_sq_counter = __shfl(warp_sq_counter, leader_phys_lane_id);
     warp_msntbl_counter = __shfl(warp_msntbl_counter, leader_phys_lane_id);
@@ -1917,12 +1940,12 @@ inline __device__ void ShmemPutSizeImmNbiThreadKernelAddrImpl(const void* dest, 
   }
 
   while (true) {
-    uint64_t db_touched =
+    uint32_t db_touched =
         __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint64_t db_done = __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint64_t num_active_sq_entries = db_touched - db_done;
-    uint64_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
-    uint64_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
+    uint32_t db_done = __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    uint32_t num_active_sq_entries = db_touched - db_done;
+    uint32_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
+    uint32_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
     if (num_free_entries > num_entries_until_warp_last_entry) {
       break;
     }
@@ -2095,8 +2118,7 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelAddrImpl(
         core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_wqes, warp_total_psn,
                                             &warp_msntbl_counter, &warp_psn_counter);
         warp_sq_counter = warp_msntbl_counter;
-        __hip_atomic_fetch_max(&wq->postIdx, warp_sq_counter + num_wqes, __ATOMIC_RELAXED,
-                               __HIP_MEMORY_SCOPE_AGENT);
+        core::AtomicMaxSerial(&wq->postIdx, warp_sq_counter + num_wqes);
       } else if constexpr (PrvdType == core::ProviderType::PSD) {
         warp_sq_counter = __hip_atomic_fetch_add(&wq->postIdx, num_wqes, __ATOMIC_RELAXED,
                                                  __HIP_MEMORY_SCOPE_AGENT);
@@ -2125,13 +2147,13 @@ inline __device__ void ShmemPutMemNbiSignalThreadKernelAddrImpl(
     }
 
     while (true) {
-      uint64_t db_touched =
+      uint32_t db_touched =
           __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint64_t db_done =
+      uint32_t db_done =
           __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint64_t num_active_sq_entries = db_touched - db_done;
-      uint64_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
-      uint64_t num_entries_until_warp_last_entry = warp_sq_counter + num_wqes - db_touched;
+      uint32_t num_active_sq_entries = db_touched - db_done;
+      uint32_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
+      uint32_t num_entries_until_warp_last_entry = warp_sq_counter + num_wqes - db_touched;
       if (num_free_entries > num_entries_until_warp_last_entry) {
         break;
       }
@@ -2368,8 +2390,7 @@ inline __device__ void ShmemAtomicSizeNonFetchThreadKernelAddrImpl(const void* d
       core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_active_lanes, num_active_lanes,
                                           &warp_msntbl_counter, &warp_psn_counter);
       warp_sq_counter = warp_msntbl_counter;
-      __hip_atomic_fetch_max(&wq->postIdx, warp_sq_counter + num_active_lanes, __ATOMIC_RELAXED,
-                             __HIP_MEMORY_SCOPE_AGENT);
+      core::AtomicMaxSerial(&wq->postIdx, warp_sq_counter + num_active_lanes);
     }
     warp_sq_counter = __shfl(warp_sq_counter, leader_phys_lane_id);
     warp_msntbl_counter = __shfl(warp_msntbl_counter, leader_phys_lane_id);
@@ -2389,12 +2410,12 @@ inline __device__ void ShmemAtomicSizeNonFetchThreadKernelAddrImpl(const void* d
   }
 
   while (true) {
-    uint64_t db_touched =
+    uint32_t db_touched =
         __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint64_t db_done = __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint64_t num_active_sq_entries = db_touched - db_done;
-    uint64_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
-    uint64_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
+    uint32_t db_done = __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    uint32_t num_active_sq_entries = db_touched - db_done;
+    uint32_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
+    uint32_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
     if (num_free_entries > num_entries_until_warp_last_entry) break;
     ShmemQuietThreadKernelImpl<PrvdType>(pe, qpId);
   }
@@ -2516,8 +2537,7 @@ inline __device__ T ShmemAtomicTypeFetchThreadKernelAddrImpl(const void* dest, v
       core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_active_lanes, num_active_lanes,
                                           &warp_msntbl_counter, &warp_psn_counter);
       warp_sq_counter = warp_msntbl_counter;
-      __hip_atomic_fetch_max(&wq->postIdx, warp_sq_counter + num_active_lanes, __ATOMIC_RELAXED,
-                             __HIP_MEMORY_SCOPE_AGENT);
+      core::AtomicMaxSerial(&wq->postIdx, warp_sq_counter + num_active_lanes);
     }
     warp_sq_counter = __shfl(warp_sq_counter, leader_phys_lane_id);
     warp_msntbl_counter = __shfl(warp_msntbl_counter, leader_phys_lane_id);
@@ -2537,12 +2557,12 @@ inline __device__ T ShmemAtomicTypeFetchThreadKernelAddrImpl(const void* dest, v
   }
 
   while (true) {
-    uint64_t db_touched =
+    uint32_t db_touched =
         __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint64_t db_done = __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint64_t num_active_sq_entries = db_touched - db_done;
-    uint64_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
-    uint64_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
+    uint32_t db_done = __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    uint32_t num_active_sq_entries = db_touched - db_done;
+    uint32_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
+    uint32_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
     if (num_free_entries > num_entries_until_warp_last_entry) break;
     ShmemQuietThreadKernelImpl<PrvdType>(pe, qpId);
   }
@@ -2723,8 +2743,7 @@ inline __device__ void ShmemGetMemNbiThreadKernelImpl(const application::SymmMem
         core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_active_lanes, warp_total_psn,
                                             &warp_msntbl_counter, &warp_psn_counter);
         warp_sq_counter = warp_msntbl_counter;
-        __hip_atomic_fetch_max(&wq->postIdx, warp_sq_counter + num_active_lanes, __ATOMIC_RELAXED,
-                               __HIP_MEMORY_SCOPE_AGENT);
+        core::AtomicMaxSerial(&wq->postIdx, warp_sq_counter + num_active_lanes);
       } else if constexpr (PrvdType == core::ProviderType::PSD) {
         warp_sq_counter = __hip_atomic_fetch_add(&wq->postIdx, num_active_lanes, __ATOMIC_RELAXED,
                                                  __HIP_MEMORY_SCOPE_AGENT);
@@ -2748,13 +2767,13 @@ inline __device__ void ShmemGetMemNbiThreadKernelImpl(const application::SymmMem
     }
 
     while (true) {
-      uint64_t db_touched =
+      uint32_t db_touched =
           __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint64_t db_done =
+      uint32_t db_done =
           __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint64_t num_active_sq_entries = db_touched - db_done;
-      uint64_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
-      uint64_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
+      uint32_t num_active_sq_entries = db_touched - db_done;
+      uint32_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
+      uint32_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
       if (num_free_entries > num_entries_until_warp_last_entry) {
         break;
       }
@@ -2936,8 +2955,7 @@ inline __device__ void ShmemGetMemNbiThreadKernelAddrImpl(void* dest, const void
         core::atomic_add_packed_msn_and_psn(&wq->msnPack, num_active_lanes, warp_total_psn,
                                             &warp_msntbl_counter, &warp_psn_counter);
         warp_sq_counter = warp_msntbl_counter;
-        __hip_atomic_fetch_max(&wq->postIdx, warp_sq_counter + num_active_lanes, __ATOMIC_RELAXED,
-                               __HIP_MEMORY_SCOPE_AGENT);
+        core::AtomicMaxSerial(&wq->postIdx, warp_sq_counter + num_active_lanes);
       } else if constexpr (PrvdType == core::ProviderType::PSD) {
         warp_sq_counter = __hip_atomic_fetch_add(&wq->postIdx, num_active_lanes, __ATOMIC_RELAXED,
                                                  __HIP_MEMORY_SCOPE_AGENT);
@@ -2961,13 +2979,13 @@ inline __device__ void ShmemGetMemNbiThreadKernelAddrImpl(void* dest, const void
     }
 
     while (true) {
-      uint64_t db_touched =
+      uint32_t db_touched =
           __hip_atomic_load(&wq->dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint64_t db_done =
+      uint32_t db_done =
           __hip_atomic_load(&wq->doneIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      uint64_t num_active_sq_entries = db_touched - db_done;
-      uint64_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
-      uint64_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
+      uint32_t num_active_sq_entries = db_touched - db_done;
+      uint32_t num_free_entries = wq->sqWqeNum - num_active_sq_entries;
+      uint32_t num_entries_until_warp_last_entry = warp_sq_counter + num_active_lanes - db_touched;
       if (num_free_entries > num_entries_until_warp_last_entry) {
         break;
       }

--- a/include/mori/shmem/shmem_ibgda_kernels.hpp
+++ b/include/mori/shmem/shmem_ibgda_kernels.hpp
@@ -213,18 +213,21 @@ inline __device__ void BnxtCollapsedCqDrain(core::WorkQueueHandle& wq,
       return;
     }
 
-    // Largest V <= dbTouchIdx with V % sqWqeNum == con_indx % sqWqeNum.
+    // con_indx is the consumed count mod sqWqeNum: rebuild the serial as a forward
+    // delta from doneIdx, as Mlx5CollapsedCqDrain does with wqe_counter. Anchoring on
+    // dbTouchIdx instead went a whole queue depth *backwards* whenever the CQE ran
+    // ahead of it -- routine, since the doorbell is rung before dbTouchIdx is
+    // published -- and as a raw word that pinned doneIdx for good. Issue #626.
     uint32_t dbTouch =
         __hip_atomic_load(&wq.dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-    uint32_t completed = (dbTouch & ~mask) | (wqeCounter & mask);
-    if (completed > dbTouch) completed -= wq.sqWqeNum;
+    uint32_t delta = (wqeCounter - cons) & mask;
 
-    // Caller holds pollCqLock and nothing else writes doneIdx on this path, so a
-    // compare against the value we already hold replaces the atomic max -- and the
-    // reload after it, which could only return what we just stored.
-    if (static_cast<int32_t>(completed - cons) > 0) {
-      __hip_atomic_store(&wq.doneIdx, completed, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-      cons = completed;
+    // Still capped at what was doorbelled: con_indx alone cannot tell a live
+    // completion from a stale one. Refusing one costs nothing -- PollSingleCqe is
+    // level-triggered for cqeNum == 1, so the loop re-reads the same value.
+    if (delta != 0 && static_cast<int32_t>(delta) <= static_cast<int32_t>(dbTouch - cons)) {
+      cons += delta;  // sole writer under pollCqLock, and delta > 0 is already an advance
+      __hip_atomic_store(&wq.doneIdx, cons, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
     }
     if constexpr (DrainToLive) {
       exitTarget = __hip_atomic_load(&wq.postIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
@@ -310,35 +313,34 @@ inline __device__ void ShmemQuietThreadKernelPsdImpl(int pe, int qpId) {
       }
 
       if (myLaneId == highestLane) {
-        cqHandle.cq_consumer = myCqPos + 1;
-
-        if (((cqHandle.cq_consumer - cqHandle.cq_dbpos) & (cqHandle.cqeNum - 1)) >=
-            CQ_DOORBELL_GRACE) {
-          cqHandle.cq_dbpos = cqHandle.cq_consumer;
-          core::UpdateCqDbrRecord<core::ProviderType::PSD>(cqHandle, myCqPos + 1);
-        }
-
         // Widen the 24-bit MSN into doneIdx's 32-bit serial space: advance by the
         // masked forward delta instead of storing wqeCounter raw, else doneIdx ends
         // up in a different modulus than dbTouchIdx and the in-flight count goes bad
         // past 2^24. Cap it at what was doorbelled -- a WQE the NIC was never told
-        // about cannot have completed.
-        //
-        // The cap reads dbTouchIdx live rather than reusing dbTouchedIdx: other
-        // warps keep doorbelling while we poll, so a CQE can legitimately report an
-        // MSN past that snapshot. Capping to the stale value would reject it, leave
-        // doneIdx behind after cq_consumer already moved on, and spin here forever.
-        //
-        // doneIdx is read once into `cur` and written once, so concurrent pollers
-        // computing off the same CQE all land on the same value, as they did when
-        // this was a bare `doneIdx = wqeCounter`. A read-modify-write here could
-        // reload between the two and apply delta twice, running doneIdx past the NIC.
+        // about cannot have completed -- reading dbTouchIdx live, since other warps
+        // keep doorbelling while we poll. Read doneIdx once and write it once so
+        // concurrent pollers off one CQE land on the same value; an RMW could reload
+        // in between and apply delta twice, running doneIdx past the NIC.
         uint32_t doorbelled =
             __hip_atomic_load(&wqHandle.dbTouchIdx, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
         uint32_t cur = wqHandle.doneIdx;
         uint32_t delta = (wqeCounter - cur) & MSN_MASK;
-        if (delta != 0 && static_cast<int32_t>(delta) <= static_cast<int32_t>(doorbelled - cur)) {
-          wqHandle.doneIdx = cur + delta;
+
+        // Decide before consuming: the doorbell is rung before dbTouchIdx is
+        // published, so a live MSN can be ahead of the cap however fresh the load,
+        // and the color bit is keyed on cq_consumer -- moving it first would drop
+        // that completion for good. Left in place, a later pass takes it.
+        bool aheadOfDoorbell =
+            delta != 0 && static_cast<int32_t>(delta) > static_cast<int32_t>(doorbelled - cur);
+        if (!aheadOfDoorbell) {
+          if (delta != 0) wqHandle.doneIdx = cur + delta;
+
+          cqHandle.cq_consumer = myCqPos + 1;
+          if (((cqHandle.cq_consumer - cqHandle.cq_dbpos) & (cqHandle.cqeNum - 1)) >=
+              CQ_DOORBELL_GRACE) {
+            cqHandle.cq_dbpos = cqHandle.cq_consumer;
+            core::UpdateCqDbrRecord<core::ProviderType::PSD>(cqHandle, myCqPos + 1);
+          }
         }
       }
 

--- a/tests/cpp/cco/test_gda_wraparound.cpp
+++ b/tests/cpp/cco/test_gda_wraparound.cpp
@@ -20,38 +20,34 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-// reserveWqeSlots deadlocks when the SQ counters cross 2^32 (ROCm/mori #626).
+// The SQ indices are free-running serial numbers (ROCm/mori #626).
 //
-// wq.postIdx / dbTouchIdx / doneIdx are free-running uint32_t serial numbers. The
-// flow-control gate at cco_scale_out.hpp:464-473 loads them into uint64_t locals:
+// wq.postIdx / dbTouchIdx / doneIdx are uint32_t counters that wrap at 2^32, so
+// only their order is meaningful. Treating them as magnitudes breaks two ways:
 //
-//     uint64_t dbTouched = ...dbTouchIdx;          // widened, does NOT wrap
-//     uint64_t entriesUntilMine = curPostIdx + numWqesNeeded - dbTouched;
-//                                 \_______ still uint32, DOES wrap _______/
+// (A) The serials cross 2^32. The collapsed-CQ drains published completions with an
+//     atomic max over raw words, which across the wrap keeps the stale pre-wrap
+//     value and freezes doneIdx; the flow-control gate mixed a wrapping uint32 sum
+//     into uint64 terms, underflowed, and stopped admitting to an empty SQ; the
+//     shmem drain compared doneIdx to dbTouchIdx unsigned and called a queue with
+//     WQEs still in flight drained.
 //
-// Once a reservation window ends at or past 2^32 the sum folds to a small value
-// while dbTouched stays near 4.29e9, the subtraction underflows to ~1.8e19, no
-// free-entry count can exceed it, and the loop spins forever -- on an empty queue.
+// (B) A completion arrives ahead of dbTouchIdx, no wrap involved. The doorbell is
+//     rung before dbTouchIdx is published, so a bnxt poller can see a con_indx the
+//     NIC has already retired while dbTouchIdx is a batch behind; rebuilding against
+//     dbTouchIdx then lands a whole queue depth behind doneIdx and the atomic max
+//     pins it there. Fires within the first sqWqeNum WQEs of a QP's life -- the
+//     failure actually seen on bnxt_re (#653 review), not a 2^32 event.
 //
-// Reaching 2^32 by actually posting WQEs is not something a test can do, so this
-// seeds the counters to the boundary instead. Seeding to 0xFFFFFFFF makes the very
-// first reservation wrap for any numWqesNeeded >= 1, and no smaller seed does when
-// a put needs a single WQE -- the trigger is curPostIdx + numWqesNeeded >= 2^32.
+// Part 1 drives both classes on a hand-built endpoint: no NIC, no peer, just a GPU.
+// Part 2 is the end-to-end check, a real put on real QPs seeded to the boundary.
 //
-// That seed leaves the QP unusable, and deliberately so: 0xFFFFFFFF % sqWqeNum is
-// sqWqeNum-1, not 0, so the counters no longer agree with the NIC's own SQ indices,
-// which are still at zero. While the bug is present that never matters -- the gate
-// spins before any WQE is written. Once it is fixed the kernel runs on through and
-// posts to a slot the NIC is not expecting, so the QP is scrap by the time the
-// kernel returns and the test exits without unwinding it (see the end of run_test).
-// Only the gate is under test here; delivery is covered elsewhere.
-//
-// WARNING: this wedges a GPU. reserveWqeSlots has no iteration bound, so the only
-// way out is killing the process, which is what the test does after the deadline.
-// Check `rocm-smi --showpids` before running on a shared box.
-//
-// Run:  ./test_gda_wraparound 2      (fork mode, 2 ranks / 2 GPUs)
+// Run:  ./test_gda_wraparound                     part 1, then part 2 on all GPUs
+//       ./test_gda_wraparound 2                   same, 2 ranks
+//       ./test_gda_wraparound --unit-only         part 1 only (no NIC needed)
+//       ./test_gda_wraparound --case bnxt_dbrace  one case, in-process, for rocgdb
 
+#include <signal.h>
 #include <unistd.h>
 
 #include <cstdint>
@@ -59,19 +55,337 @@
 #include <cstring>
 #include <vector>
 
-#include "cco_test_harness.hpp"
+#include "cco_test_harness.hpp"  // HIP_CHECK, g_rank, ccoTestMain (part 2)
 #include "mori/cco/cco_scale_out.hpp"
 #include "mori/core/transport/rdma/core_device_types.hpp"
+// shmem's drains are free functions over the same two handles, so part 1 can drive
+// them too. Via shmem_device_api.hpp: shmem_ibgda_kernels.hpp specializes templates
+// that header declares and does not compile on its own.
+#include "mori/shmem/shmem_device_api.hpp"
+
+using mori::core::Mlx5Cqe64;
+using mori::core::ProviderType;
+using mori::core::RdmaEndpointDevice;
+using mori::core::WorkQueueHandle;
+
+/* ══════════════════════════════════════════════════════════════════════════════ */
+/*  Part 1 — unit cases over a hand-built endpoint                                */
+/* ══════════════════════════════════════════════════════════════════════════════ */
+// The endpoint is a core::RdmaEndpointDevice we fill in ourselves, its CQ a buffer
+// the test writes, so nothing here touches a QP, a doorbell or an SQ. Neither seed
+// is reachable by posting real WQEs, and because the handle lives in coherent host
+// memory the host can play the other half of (B) -- publishing dbTouchIdx mid-kernel
+// -- and hand a wedged kernel its exit condition rather than leave a runaway kernel
+// behind. Each case still runs in its own child process, the parent holding a hard
+// deadline as the backstop.
+
+// A spin: the work under test is a handful of loads on an already-satisfiable
+// condition, so it finishes in microseconds or never.
+static const int kDeadlineMs = 3000;
+// Per-case cap: HIP init + the deadline + the release attempt, with room to spare.
+static const int kChildDeadlineMs = 30000;
+
+enum Site { kQuiet, kGate, kDrain };
+
+// One thread: both drains are single-poller by construction (mlx5's is lock-free,
+// bnxt's runs under pollCqLock) and the gate is per-lane. DrainToLive=false is the
+// dbTouchIdx-snapshot drain, the recycle path shmem's flow control leans on.
+template <ProviderType P, Site S>
+__global__ void SiteKernel(RdmaEndpointDevice* ep, uint32_t target, uint32_t* out) {
+  if constexpr (S == kQuiet) {
+    mori::cco::impl::quietUntil<P>(ep, target);
+  } else if constexpr (S == kGate) {
+    *out = mori::cco::impl::reserveWqeSlots<P>(ep, 1);
+  } else if constexpr (P == ProviderType::MLX5) {
+    mori::shmem::Mlx5CollapsedCqDrain<false>(ep->wqHandle, ep->cqHandle);
+  } else {
+    mori::shmem::BnxtCollapsedCqDrain<false>(ep->wqHandle, ep->cqHandle);
+  }
+}
+
+// doneIdx is where the NIC was last seen. target is postIdx, is what the CQE reports
+// complete, and is what every case must reach. dbTouchLag is how many WQEs
+// dbTouchIdx trails target by: non-zero means the doorbell is rung but dbTouchIdx
+// not yet published, and the host publishes it while the kernel runs.
+struct Case {
+  const char* name;
+  Site site;
+  ProviderType prvd;
+  uint32_t doneIdx;
+  uint32_t target;
+  uint32_t dbTouchLag;
+};
+
+static const Case kCases[] = {
+    // (A) the 2^32 wrap. Each is preceded by the same shape far from the boundary,
+    // so a failure there means the fake endpoint is wrong rather than the code.
+    {"mlx5_plain", kQuiet, ProviderType::MLX5, 0x00001000u, 0x00001010u, 0},
+    {"mlx5_cqe16", kQuiet, ProviderType::MLX5, 0x0001FFF8u, 0x00020008u, 0},  // 16-bit CQE wraps
+    {"mlx5_wrap32", kQuiet, ProviderType::MLX5, 0xFFFFFFF8u, 0x00000008u, 0},
+    {"mlx5_gate32", kGate, ProviderType::MLX5, 0xFFFFFFFFu, 0xFFFFFFFFu, 0},  // empty SQ
+    {"mlx5_shmem", kDrain, ProviderType::MLX5, 0x00001000u, 0x00001010u, 0},
+    {"mlx5_shmem32", kDrain, ProviderType::MLX5, 0xFFFFFFF8u, 0x00000008u, 0},
+    {"bnxt_plain", kQuiet, ProviderType::BNXT, 0x00001000u, 0x00001010u, 0},
+    {"bnxt_wrap32", kQuiet, ProviderType::BNXT, 0xFFFFFFF0u, 0x00000000u, 0},
+
+    // (B) the field case: 103 WQEs doorbelled and retired while dbTouchIdx still
+    // reads 102. Rebuilding against it gives 103 > 102 and so 103 - 4096 =
+    // 0xFFFFF067, the value rocgdb caught on the hung wave. Nothing near 2^32.
+    {"bnxt_dbrace", kQuiet, ProviderType::BNXT, 0u, 103u, 1},
+};
+
+// bnxt's 4096 is the depth the field case was seen on, and the depth is what the bad
+// rebuild subtracts.
+static uint32_t SqWqeNum(const Case& c) { return c.prvd == ProviderType::MLX5 ? 1024 : 4096; }
+static uint32_t DbTouch(const Case& c) { return c.target - c.dbTouchLag; }
+
+static const char* SiteName(const Case& c) {
+  const bool mlx5 = c.prvd == ProviderType::MLX5;
+  switch (c.site) {
+    case kQuiet:
+      return mlx5 ? "quietUntil<MLX5>" : "quietUntil<BNXT>";
+    case kGate:
+      return mlx5 ? "reserveWqeSlots<MLX5>" : "reserveWqeSlots<BNXT>";
+    default:
+      return mlx5 ? "Mlx5CollapsedCqDrain" : "BnxtCollapsedCqDrain";
+  }
+}
+
+// Coherent host memory: device-visible, and unlike device memory writable by the CPU
+// while the kernel spins on it.
+template <typename T>
+static T* AllocShared(size_t bytes) {
+  void* p = nullptr;
+  HIP_CHECK(hipHostMalloc(&p, bytes, hipHostMallocCoherent | hipHostMallocMapped));
+  memset(p, 0, bytes);
+  return reinterpret_cast<T*>(p);
+}
+
+static RdmaEndpointDevice* BuildEndpoint(const Case& c) {
+  auto* ep = AllocShared<RdmaEndpointDevice>(sizeof(RdmaEndpointDevice));
+  void* cqe = AllocShared<void>(sizeof(Mlx5Cqe64));  // the larger of the two layouts
+
+  // Both CQEs report a fully drained queue, in their provider's own units: mlx5's
+  // wqe_counter is the index of the last WQE retired (the drain adds one), bnxt's
+  // con_indx is the count consumed.
+  if (c.prvd == ProviderType::MLX5) {
+    ep->vendorId = mori::core::RdmaDeviceVendorId::Mellanox;
+    auto* mcqe = reinterpret_cast<Mlx5Cqe64*>(cqe);
+    mcqe->wqe_counter = HTOBE16(static_cast<uint16_t>(c.target - 1));
+    mcqe->op_own = 0;  // opcode 0: a plain completion, so not decoded as an error
+  } else {
+    ep->vendorId = mori::core::RdmaDeviceVendorId::Broadcom;
+    // con_indx is read raw (host order, 16 bits valid); the status is bits 8..15 of
+    // the trailing bnxt_re_bcqe flags, where 0 is BNXT_RE_REQ_ST_OK.
+    reinterpret_cast<bnxt_re_req_cqe*>(cqe)->con_indx = c.target & 0xFFFFu;
+    reinterpret_cast<bnxt_re_bcqe*>(reinterpret_cast<char*>(cqe) + sizeof(bnxt_re_req_cqe))
+        ->flg_st_typ_ph = 0;
+  }
+
+  WorkQueueHandle& wq = ep->wqHandle;
+  wq.sqWqeNum = SqWqeNum(c);
+  wq.postIdx = c.target;
+  wq.dbTouchIdx = DbTouch(c);
+  wq.doneIdx = c.doneIdx;
+
+  // Collapsed CQ: one entry the NIC keeps overwriting with its latest completion.
+  // sqAddr / dbrAddr stay null -- no path under test writes a WQE or rings a
+  // doorbell, so a null there faults instead of stomping silently.
+  ep->cqHandle.cqAddr = cqe;
+  ep->cqHandle.cqeNum = 1;
+  ep->cqHandle.cqeSize = sizeof(Mlx5Cqe64);
+  return ep;
+}
+
+// Hand a wedged kernel its exit condition. Seq-cst so the store lands in the coherent
+// mapping the wavefront is polling, not in a store buffer.
+static void Release(RdmaEndpointDevice* ep, const Case& c) {
+  if (c.site == kGate) {
+    // curPostIdx + 1 has already wrapped to 0 in the kernel's registers, so zeroing
+    // both counters makes entriesUntilMine 0 against a free queue either way.
+    __atomic_store_n(&ep->wqHandle.dbTouchIdx, 0u, __ATOMIC_SEQ_CST);
+    __atomic_store_n(&ep->wqHandle.doneIdx, 0u, __ATOMIC_SEQ_CST);
+  } else {
+    __atomic_store_n(&ep->wqHandle.doneIdx, c.target, __ATOMIC_SEQ_CST);
+  }
+}
+
+// A non-null ep re-applies the release on every step: a drain that keeps the counter
+// pinned is issuing back-to-back atomic max on it, so a single host store is likely
+// to be read-modify-written away.
+static bool Wait(hipStream_t stream, RdmaEndpointDevice* ep, const Case& c) {
+  for (int waited = 0; waited < kDeadlineMs; waited += 20) {
+    if (ep) Release(ep, c);
+    if (hipStreamQuery(stream) == hipSuccess) return true;
+    usleep(20 * 1000);
+  }
+  return false;
+}
+
+// Play the posting wave's second half: watch for doneIdx being driven backwards, then
+// publish dbTouchIdx as the post path eventually does. Returns the bad value, or 0.
+static uint32_t PublishLate(RdmaEndpointDevice* ep, const Case& c) {
+  uint32_t bad = 0;
+  for (int waited = 0; waited < 200; waited += 2) {
+    uint32_t done = __atomic_load_n(&ep->wqHandle.doneIdx, __ATOMIC_SEQ_CST);
+    if (static_cast<int32_t>(done - c.doneIdx) < 0) {
+      bad = done;
+      break;
+    }
+    usleep(2 * 1000);
+  }
+  __atomic_store_n(&ep->wqHandle.dbTouchIdx, c.target, __ATOMIC_SEQ_CST);
+  return bad;
+}
+
+template <ProviderType P>
+static void Launch(const Case& c, hipStream_t stream, RdmaEndpointDevice* ep, uint32_t* out) {
+  switch (c.site) {
+    case kQuiet:
+      SiteKernel<P, kQuiet><<<1, 1, 0, stream>>>(ep, c.target, out);
+      break;
+    case kGate:
+      SiteKernel<P, kGate><<<1, 1, 0, stream>>>(ep, c.target, out);
+      break;
+    case kDrain:
+      SiteKernel<P, kDrain><<<1, 1, 0, stream>>>(ep, c.target, out);
+      break;
+  }
+}
+
+// Runs in the child. Returns 0 on pass, 1 on fail.
+static int RunCase(const Case& c) {
+  setvbuf(stdout, nullptr, _IONBF, 0);  // the child leaves via _exit, which skips flushing
+  HIP_CHECK(hipSetDevice(0));
+
+  RdmaEndpointDevice* ep = BuildEndpoint(c);
+  uint32_t* out = AllocShared<uint32_t>(sizeof(uint32_t));
+  printf("%-13s %-22s done=0x%08X db=0x%08X target=0x%08X  ", c.name, SiteName(c), c.doneIdx,
+         DbTouch(c), c.target);
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+  if (c.prvd == ProviderType::MLX5) {
+    Launch<ProviderType::MLX5>(c, stream, ep, out);
+  } else {
+    Launch<ProviderType::BNXT>(c, stream, ep, out);
+  }
+  HIP_CHECK(hipGetLastError());
+
+  const uint32_t bad = c.dbTouchLag ? PublishLate(ep, c) : 0;
+
+  if (!Wait(stream, nullptr, c)) {
+    const uint32_t done = __atomic_load_n(&ep->wqHandle.doneIdx, __ATOMIC_SEQ_CST);
+    printf("FAILED\n  %s still spinning after %d ms: ", SiteName(c), kDeadlineMs);
+    if (c.site == kGate) {
+      printf("empty SQ, %u slots free, entriesUntilMine underflowed to %llu\n", SqWqeNum(c),
+             (unsigned long long)(uint64_t(uint32_t(c.target + 1)) - uint64_t(DbTouch(c))));
+    } else {
+      printf("doneIdx pinned at 0x%08X, %d WQEs short\n", done,
+             -static_cast<int32_t>(done - c.target));
+    }
+    if (bad)
+      printf("  doneIdx had been driven back to 0x%08X (= %u - %u)\n", bad, c.target, SqWqeNum(c));
+    if (!Wait(stream, ep, c)) {
+      printf("  release did not free it; leaving the kernel to the parent\n");
+      _exit(1);
+    }
+    return 1;
+  }
+
+  // Ran to completion -- check it did the right thing, not just that it exited.
+  const uint32_t done = __atomic_load_n(&ep->wqHandle.doneIdx, __ATOMIC_SEQ_CST);
+  if (c.site == kGate) {
+    if (*out != c.target) {
+      printf("FAILED\n  reserved base 0x%08X, expected 0x%08X\n", *out, c.target);
+      return 1;
+    }
+  } else if (done != c.target) {
+    printf("FAILED\n  returned with doneIdx=0x%08X: %d WQEs outstanding, and the drain\n", done,
+           static_cast<int32_t>(c.target - c.doneIdx));
+    printf("  called the queue quiet. Callers reuse those buffers next.\n");
+    return 1;
+  }
+
+  printf("PASSED\n");
+  return 0;
+}
+
+// HIP does not survive a fork, so the parent must stay clear of it -- including for
+// the "is there a GPU" question, which a child answers through its exit code.
+static int ProbeGpuCount() {
+  pid_t pid = fork();
+  if (pid == 0) {
+    int n = 0;
+    _exit(hipGetDeviceCount(&n) == hipSuccess ? n : 0);
+  }
+  int status = 0;
+  waitpid(pid, &status, 0);
+  return WIFEXITED(status) ? WEXITSTATUS(status) : 0;
+}
+
+// A spinning kernel cannot be cancelled, so each case gets a process of its own and
+// the parent kills it if the in-child release did not.
+static bool RunCaseInChild(const Case& c) {
+  pid_t pid = fork();
+  if (pid == 0) _exit(RunCase(c));
+
+  for (int waited = 0; waited < kChildDeadlineMs; waited += 20) {
+    int status = 0;
+    if (waitpid(pid, &status, WNOHANG) == pid) {
+      return WIFEXITED(status) && WEXITSTATUS(status) == 0;
+    }
+    usleep(20 * 1000);
+  }
+
+  printf("  killing the child: %d ms with a kernel that will not end\n", kChildDeadlineMs);
+  kill(pid, SIGKILL);
+  waitpid(pid, nullptr, 0);
+  return false;
+}
+
+static int RunUnitCases() {
+  const size_t numCases = sizeof(kCases) / sizeof(kCases[0]);
+  if (ProbeGpuCount() == 0) {
+    printf("=== SQ indices: SKIPPED, no GPU ===\n");
+    return 0;
+  }
+
+  printf("=== SQ indices (#626) -- %zu cases, no NIC ===\n", numCases);
+  int failed = 0;
+  for (const Case& c : kCases) {
+    if (!RunCaseInChild(c)) failed++;
+  }
+  if (failed) {
+    printf("=== %d/%zu FAILED ===\n\n", failed, numCases);
+    return 1;
+  }
+  printf("=== all %zu passed ===\n\n", numCases);
+  return 0;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════════ */
+/*  Part 2 — end-to-end: a real put with the counters seeded to the boundary       */
+/* ══════════════════════════════════════════════════════════════════════════════ */
+// 0xFFFFFFFF makes the very first reservation wrap for any numWqesNeeded >= 1, and no
+// smaller seed does when a put needs a single WQE.
+//
+// The seed leaves the QP unusable, deliberately: 0xFFFFFFFF % sqWqeNum is sqWqeNum-1,
+// not 0, so the counters no longer agree with the NIC's own SQ indices, still at
+// zero. While the bug is present that never matters -- the gate spins before any WQE
+// is written. Once fixed the kernel runs on and posts to a slot the NIC is not
+// expecting, so the QP is scrap by the time the kernel returns and the test exits
+// without unwinding it. Only the gate is under test here; delivery is covered
+// elsewhere.
+//
+// WARNING: this wedges a GPU. reserveWqeSlots has no iteration bound, so the only way
+// out is killing the process, which is what happens after the deadline. Check
+// `rocm-smi --showpids` before running on a shared box.
 
 static const size_t PER_RANK_VMM_SIZE = 256ULL * 1024 * 1024;
 static const size_t COUNT = 64;  // floats per rank-pair -- one WQE's worth
-
-// Any value with (postIdx + numWqesNeeded) >= 2^32 reproduces it; 0xFFFFFFFF does
-// so for every numWqesNeeded >= 1.
 static const uint32_t kSeed = 0xFFFFFFFFu;
-
-// How long to let the kernel run before calling it a deadlock.
-static const int kDeadlineMs = 3000;
+static const int kE2eDeadlineMs = 3000;
 
 // One put per peer. put() -> reserveWqeSlots() is where the spin happens; nothing
 // after it is reached.
@@ -91,35 +405,6 @@ __global__ void GdaPutKernel(mori::cco::ccoWindowDevice* sendWin,
             reinterpret_cast<ccoWindow_t>(sendWin), r * perPairBytes, perPairBytes,
             ccoGda_SignalInc{static_cast<ccoGdaSignal_t>(myRank)});
   }
-}
-
-// The gate from cco_scale_out.hpp:488-497 in both widths, so the printout shows
-// what the seeded QP makes the device compute before and after the fix. `admit` is
-// the gate's own `numFreeEntries > entriesUntilMine`.
-struct GateTerms {
-  uint64_t active, free, until;
-  bool admit;
-};
-
-// Pre-fix: uint64_t locals. curPostIdx + numWqesNeeded still wraps in uint32 while
-// dbTouched does not, so the subtraction underflows.
-static GateTerms gateTermsWide(uint32_t dbTouchIdx, uint32_t doneIdx, uint32_t curPostIdx,
-                               uint32_t numWqesNeeded, uint32_t sqWqeNum) {
-  uint64_t dbTouched = dbTouchIdx;
-  uint64_t dbDone = doneIdx;
-  uint64_t active = dbTouched - dbDone;
-  uint64_t free = sqWqeNum - active;
-  uint64_t until = curPostIdx + numWqesNeeded - dbTouched;
-  return {active, free, until, free > until};
-}
-
-// Post-fix: all uint32_t, so every term wraps in the same modulus.
-static GateTerms gateTermsNarrow(uint32_t dbTouchIdx, uint32_t doneIdx, uint32_t curPostIdx,
-                                 uint32_t numWqesNeeded, uint32_t sqWqeNum) {
-  uint32_t active = dbTouchIdx - doneIdx;
-  uint32_t free = sqWqeNum - active;
-  uint32_t until = curPostIdx + numWqesNeeded - dbTouchIdx;
-  return {active, free, until, free > until};
 }
 
 int run_test(int rank, int nranks, const mori::cco::ccoUniqueId& uid) {
@@ -192,29 +477,19 @@ int run_test(int rank, int nranks, const mori::cco::ccoUniqueId& uid) {
   HIP_CHECK(hipMemcpy(devComm.ibgda.endpoints, eps.data(),
                       numEps * sizeof(mori::core::RdmaEndpointDevice), hipMemcpyHostToDevice));
 
-  // What the seeded QP makes the gate compute. The queue is empty (active == 0) and
-  // has sqWqeNum slots free; the uint64_t gate refuses to admit one WQE anyway.
-  const GateTerms wide = gateTermsWide(kSeed, kSeed, kSeed, 1, sqWqeNum);
-  const GateTerms narrow = gateTermsNarrow(kSeed, kSeed, kSeed, 1, sqWqeNum);
-  printf("[rank %d] seeded postIdx=dbTouchIdx=doneIdx=0x%08X, sqWqeNum=%u\n", rank, kSeed,
-         sqWqeNum);
-  printf("[rank %d]   gate as uint64 (pre-fix):  active=%llu free=%llu until=%llu -> %s\n", rank,
-         (unsigned long long)wide.active, (unsigned long long)wide.free,
-         (unsigned long long)wide.until, wide.admit ? "admit" : "SPIN");
-  printf("[rank %d]   gate as uint32 (fixed):    active=%llu free=%llu until=%llu -> %s\n", rank,
-         (unsigned long long)narrow.active, (unsigned long long)narrow.free,
-         (unsigned long long)narrow.until, narrow.admit ? "admit" : "SPIN");
+  printf("[rank %d] seeded postIdx=dbTouchIdx=doneIdx=0x%08X on an empty SQ, sqWqeNum=%u\n", rank,
+         kSeed, sqWqeNum);
 
   ccoBarrierAll(comm);
 
-  // One block, one thread: a single wavefront on one CU, to keep the footprint on
-  // a shared device as small as the reproduction allows.
+  // One block, one thread: a single wavefront on one CU, to keep the footprint on a
+  // shared device as small as the reproduction allows.
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
   CCO_GDA_DISPATCH(GdaPutKernel<P, float><<<1, 1, 0, stream>>>(sendWin, recvWin, COUNT, devComm));
 
   bool finished = false;
-  for (int waited = 0; waited < kDeadlineMs; waited += 50) {
+  for (int waited = 0; waited < kE2eDeadlineMs; waited += 50) {
     if (hipStreamQuery(stream) == hipSuccess) {
       finished = true;
       break;
@@ -224,11 +499,8 @@ int run_test(int rank, int nranks, const mori::cco::ccoUniqueId& uid) {
 
   if (!finished) {
     printf("[rank %d] FAILED: kernel still running after %d ms -- reserveWqeSlots is spinning\n",
-           rank, kDeadlineMs);
-    printf("[rank %d]   on an empty SQ (%llu slots free) because entriesUntilMine underflowed to\n",
-           rank, (unsigned long long)wide.free);
-    printf("[rank %d]   %llu. See cco_scale_out.hpp:491. Killing the process to release the GPU.\n",
-           rank, (unsigned long long)wide.until);
+           rank, kE2eDeadlineMs);
+    printf("[rank %d]   on an empty SQ. Killing the process to release the GPU.\n", rank);
     fflush(stdout);
     _exit(1);  // the kernel cannot be cancelled; tear the context down
   }
@@ -236,15 +508,34 @@ int run_test(int rank, int nranks, const mori::cco::ccoUniqueId& uid) {
   printf("[rank %d] PASSED: kernel returned -- the gate survives the 2^32 wraparound\n", rank);
   fflush(stdout);
 
-  // The seed left the SQ counters out of step with the NIC's (see the header
-  // comment), so the kernel just posted to a slot the NIC is not expecting. Leave
-  // without unwinding the QP: deregistering and destroying a desynced endpoint can
-  // block on completions that will never arrive, which would turn a passing run
-  // into a hang. The process is exiting anyway and the driver reclaims everything.
+  // The seed left the SQ counters out of step with the NIC's, so the kernel just
+  // posted to a slot the NIC is not expecting. Leave without unwinding the QP:
+  // deregistering and destroying a desynced endpoint can block on completions that
+  // will never arrive, turning a passing run into a hang. The process is exiting
+  // anyway and the driver reclaims everything.
   HIP_CHECK(hipStreamDestroy(stream));
   _exit(0);  // noreturn
 }
 
 int main(int argc, char** argv) {
+  setvbuf(stdout, nullptr, _IONBF, 0);
+
+  // --case runs one unit case in-process (no fork, no deadline) so rocgdb can sit on
+  // the spin. Both flags are consumed here; anything else goes to the harness, whose
+  // own argv[1] is a rank count.
+  if (argc > 2 && !strcmp(argv[1], "--case")) {
+    for (const Case& c : kCases) {
+      if (!strcmp(c.name, argv[2])) return RunCase(c);
+    }
+    fprintf(stderr, "unknown case '%s'\n", argv[2]);
+    return 2;
+  }
+  bool unitOnly = argc > 1 && !strcmp(argv[1], "--unit-only");
+
+  // Part 2 wedges QPs and needs peers, so it is pointless to run when the arithmetic
+  // it depends on is already broken.
+  if (RunUnitCases() != 0) return 1;
+  if (unitOnly) return 0;
+
   return ccoTestMain(argc, argv, "CCO GDA wraparound", "/tmp/cco_gda_wraparound_uid", 19893);
 }

--- a/tests/cpp/cco/test_gda_wraparound.cpp
+++ b/tests/cpp/cco/test_gda_wraparound.cpp
@@ -1,0 +1,250 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// reserveWqeSlots deadlocks when the SQ counters cross 2^32 (ROCm/mori #626).
+//
+// wq.postIdx / dbTouchIdx / doneIdx are free-running uint32_t serial numbers. The
+// flow-control gate at cco_scale_out.hpp:464-473 loads them into uint64_t locals:
+//
+//     uint64_t dbTouched = ...dbTouchIdx;          // widened, does NOT wrap
+//     uint64_t entriesUntilMine = curPostIdx + numWqesNeeded - dbTouched;
+//                                 \_______ still uint32, DOES wrap _______/
+//
+// Once a reservation window ends at or past 2^32 the sum folds to a small value
+// while dbTouched stays near 4.29e9, the subtraction underflows to ~1.8e19, no
+// free-entry count can exceed it, and the loop spins forever -- on an empty queue.
+//
+// Reaching 2^32 by actually posting WQEs is not something a test can do, so this
+// seeds the counters to the boundary instead. Seeding to 0xFFFFFFFF makes the very
+// first reservation wrap for any numWqesNeeded >= 1, and no smaller seed does when
+// a put needs a single WQE -- the trigger is curPostIdx + numWqesNeeded >= 2^32.
+//
+// That seed leaves the QP unusable, and deliberately so: 0xFFFFFFFF % sqWqeNum is
+// sqWqeNum-1, not 0, so the counters no longer agree with the NIC's own SQ indices,
+// which are still at zero. While the bug is present that never matters -- the gate
+// spins before any WQE is written. Once it is fixed the kernel runs on through and
+// posts to a slot the NIC is not expecting, so the QP is scrap by the time the
+// kernel returns and the test exits without unwinding it (see the end of run_test).
+// Only the gate is under test here; delivery is covered elsewhere.
+//
+// WARNING: this wedges a GPU. reserveWqeSlots has no iteration bound, so the only
+// way out is killing the process, which is what the test does after the deadline.
+// Check `rocm-smi --showpids` before running on a shared box.
+//
+// Run:  ./test_gda_wraparound 2      (fork mode, 2 ranks / 2 GPUs)
+
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include "cco_test_harness.hpp"
+#include "mori/cco/cco_scale_out.hpp"
+#include "mori/core/transport/rdma/core_device_types.hpp"
+
+static const size_t PER_RANK_VMM_SIZE = 256ULL * 1024 * 1024;
+static const size_t COUNT = 64;  // floats per rank-pair -- one WQE's worth
+
+// Any value with (postIdx + numWqesNeeded) >= 2^32 reproduces it; 0xFFFFFFFF does
+// so for every numWqesNeeded >= 1.
+static const uint32_t kSeed = 0xFFFFFFFFu;
+
+// How long to let the kernel run before calling it a deadlock.
+static const int kDeadlineMs = 3000;
+
+// One put per peer. put() -> reserveWqeSlots() is where the spin happens; nothing
+// after it is reached.
+template <mori::core::ProviderType PrvdType, typename T>
+__global__ void GdaPutKernel(mori::cco::ccoWindowDevice* sendWin,
+                             mori::cco::ccoWindowDevice* recvWin, size_t count,
+                             mori::cco::ccoDevComm devComm) {
+  using namespace mori::cco;
+  ccoGda<PrvdType> gda{devComm, /*ginContext=*/0};
+
+  int myRank = devComm.rank;
+  size_t perPairBytes = count * sizeof(T);
+
+  for (int r = 0; r < devComm.worldSize; r++) {
+    if (r == myRank) continue;
+    gda.put(r, reinterpret_cast<ccoWindow_t>(recvWin), myRank * perPairBytes,
+            reinterpret_cast<ccoWindow_t>(sendWin), r * perPairBytes, perPairBytes,
+            ccoGda_SignalInc{static_cast<ccoGdaSignal_t>(myRank)});
+  }
+}
+
+// The gate from cco_scale_out.hpp:488-497 in both widths, so the printout shows
+// what the seeded QP makes the device compute before and after the fix. `admit` is
+// the gate's own `numFreeEntries > entriesUntilMine`.
+struct GateTerms {
+  uint64_t active, free, until;
+  bool admit;
+};
+
+// Pre-fix: uint64_t locals. curPostIdx + numWqesNeeded still wraps in uint32 while
+// dbTouched does not, so the subtraction underflows.
+static GateTerms gateTermsWide(uint32_t dbTouchIdx, uint32_t doneIdx, uint32_t curPostIdx,
+                               uint32_t numWqesNeeded, uint32_t sqWqeNum) {
+  uint64_t dbTouched = dbTouchIdx;
+  uint64_t dbDone = doneIdx;
+  uint64_t active = dbTouched - dbDone;
+  uint64_t free = sqWqeNum - active;
+  uint64_t until = curPostIdx + numWqesNeeded - dbTouched;
+  return {active, free, until, free > until};
+}
+
+// Post-fix: all uint32_t, so every term wraps in the same modulus.
+static GateTerms gateTermsNarrow(uint32_t dbTouchIdx, uint32_t doneIdx, uint32_t curPostIdx,
+                                 uint32_t numWqesNeeded, uint32_t sqWqeNum) {
+  uint32_t active = dbTouchIdx - doneIdx;
+  uint32_t free = sqWqeNum - active;
+  uint32_t until = curPostIdx + numWqesNeeded - dbTouchIdx;
+  return {active, free, until, free > until};
+}
+
+int run_test(int rank, int nranks, const mori::cco::ccoUniqueId& uid) {
+  using namespace mori::cco;
+  g_rank = rank;
+
+  // The harness leaves each rank via _exit(), which does not flush stdio. Under a
+  // pipe stdout is block-buffered, so everything below would be discarded.
+  setvbuf(stdout, nullptr, _IONBF, 0);
+
+  int numDevices = 0;
+  HIP_CHECK(hipGetDeviceCount(&numDevices));
+  HIP_CHECK(hipSetDevice(rank % numDevices));
+
+  ccoComm* comm = nullptr;
+  if (ccoCommCreate(uid, nranks, rank, PER_RANK_VMM_SIZE, &comm) != 0) {
+    fprintf(stderr, "[rank %d] CommCreate failed\n", rank);
+    return 1;
+  }
+
+  size_t bufSize = COUNT * nranks * sizeof(float);
+  void *sendBuf = nullptr, *recvBuf = nullptr;
+  if (ccoMemAlloc(comm, bufSize, &sendBuf) != 0 || ccoMemAlloc(comm, bufSize, &recvBuf) != 0) {
+    fprintf(stderr, "[rank %d] MemAlloc failed\n", rank);
+    return 1;
+  }
+  HIP_CHECK(hipMemset(sendBuf, 0, bufSize));
+  HIP_CHECK(hipMemset(recvBuf, 0, bufSize));
+
+  ccoWindow_t sendWin = nullptr, recvWin = nullptr;
+  if (ccoWindowRegister(comm, sendBuf, bufSize, &sendWin) != 0 ||
+      ccoWindowRegister(comm, recvBuf, bufSize, &recvWin) != 0) {
+    fprintf(stderr, "[rank %d] WindowRegister failed\n", rank);
+    return 1;
+  }
+
+  ccoDevCommRequirements reqs = CCO_DEV_COMM_REQUIREMENTS_INITIALIZER;
+  reqs.gdaConnectionType = CCO_GDA_CONNECTION_FULL;
+  reqs.gdaContextCount = 1;
+  reqs.gdaSignalCount = nranks;
+  reqs.gdaCounterCount = 0;
+  ccoDevComm devComm{};
+  if (ccoDevCommCreate(comm, &reqs, &devComm) != 0) {
+    fprintf(stderr, "[rank %d] DevCommCreate failed\n", rank);
+    return 1;
+  }
+  if (devComm.gdaConnType == CCO_GDA_CONNECTION_NONE) {
+    fprintf(stderr, "[rank %d] gdaConnType is NONE -- no RDMA peers, cannot test\n", rank);
+    return 1;
+  }
+
+  // ── seed every endpoint's SQ counters to the 2^32 boundary ──
+  const size_t numEps = static_cast<size_t>(devComm.worldSize) * devComm.ibgda.numQpPerPe;
+  std::vector<mori::core::RdmaEndpointDevice> eps(numEps);
+  HIP_CHECK(hipMemcpy(eps.data(), devComm.ibgda.endpoints,
+                      numEps * sizeof(mori::core::RdmaEndpointDevice), hipMemcpyDeviceToHost));
+
+  uint32_t sqWqeNum = 0;
+  for (size_t i = 0; i < numEps; i++) {
+    if (eps[i].GetProviderType() == mori::core::ProviderType::Unknown) continue;  // empty slot
+    if (sqWqeNum == 0) sqWqeNum = eps[i].wqHandle.sqWqeNum;
+    eps[i].wqHandle.postIdx = kSeed;
+    eps[i].wqHandle.dbTouchIdx = kSeed;
+    eps[i].wqHandle.doneIdx = kSeed;
+  }
+  if (sqWqeNum == 0) {
+    fprintf(stderr, "[rank %d] no connected endpoint\n", rank);
+    return 1;
+  }
+  HIP_CHECK(hipMemcpy(devComm.ibgda.endpoints, eps.data(),
+                      numEps * sizeof(mori::core::RdmaEndpointDevice), hipMemcpyHostToDevice));
+
+  // What the seeded QP makes the gate compute. The queue is empty (active == 0) and
+  // has sqWqeNum slots free; the uint64_t gate refuses to admit one WQE anyway.
+  const GateTerms wide = gateTermsWide(kSeed, kSeed, kSeed, 1, sqWqeNum);
+  const GateTerms narrow = gateTermsNarrow(kSeed, kSeed, kSeed, 1, sqWqeNum);
+  printf("[rank %d] seeded postIdx=dbTouchIdx=doneIdx=0x%08X, sqWqeNum=%u\n", rank, kSeed,
+         sqWqeNum);
+  printf("[rank %d]   gate as uint64 (pre-fix):  active=%llu free=%llu until=%llu -> %s\n", rank,
+         (unsigned long long)wide.active, (unsigned long long)wide.free,
+         (unsigned long long)wide.until, wide.admit ? "admit" : "SPIN");
+  printf("[rank %d]   gate as uint32 (fixed):    active=%llu free=%llu until=%llu -> %s\n", rank,
+         (unsigned long long)narrow.active, (unsigned long long)narrow.free,
+         (unsigned long long)narrow.until, narrow.admit ? "admit" : "SPIN");
+
+  ccoBarrierAll(comm);
+
+  // One block, one thread: a single wavefront on one CU, to keep the footprint on
+  // a shared device as small as the reproduction allows.
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+  CCO_GDA_DISPATCH(GdaPutKernel<P, float><<<1, 1, 0, stream>>>(sendWin, recvWin, COUNT, devComm));
+
+  bool finished = false;
+  for (int waited = 0; waited < kDeadlineMs; waited += 50) {
+    if (hipStreamQuery(stream) == hipSuccess) {
+      finished = true;
+      break;
+    }
+    usleep(50 * 1000);
+  }
+
+  if (!finished) {
+    printf("[rank %d] FAILED: kernel still running after %d ms -- reserveWqeSlots is spinning\n",
+           rank, kDeadlineMs);
+    printf("[rank %d]   on an empty SQ (%llu slots free) because entriesUntilMine underflowed to\n",
+           rank, (unsigned long long)wide.free);
+    printf("[rank %d]   %llu. See cco_scale_out.hpp:491. Killing the process to release the GPU.\n",
+           rank, (unsigned long long)wide.until);
+    fflush(stdout);
+    _exit(1);  // the kernel cannot be cancelled; tear the context down
+  }
+
+  printf("[rank %d] PASSED: kernel returned -- the gate survives the 2^32 wraparound\n", rank);
+  fflush(stdout);
+
+  // The seed left the SQ counters out of step with the NIC's (see the header
+  // comment), so the kernel just posted to a slot the NIC is not expecting. Leave
+  // without unwinding the QP: deregistering and destroying a desynced endpoint can
+  // block on completions that will never arrive, which would turn a passing run
+  // into a hang. The process is exiting anyway and the driver reclaims everything.
+  HIP_CHECK(hipStreamDestroy(stream));
+  _exit(0);  // noreturn
+}
+
+int main(int argc, char** argv) {
+  return ccoTestMain(argc, argv, "CCO GDA wraparound", "/tmp/cco_gda_wraparound_uid", 19893);
+}

--- a/tests/cpp/cco/test_gda_wraparound.cpp
+++ b/tests/cpp/cco/test_gda_wraparound.cpp
@@ -52,6 +52,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <vector>
 
@@ -530,12 +531,20 @@ int main(int argc, char** argv) {
     fprintf(stderr, "unknown case '%s'\n", argv[2]);
     return 2;
   }
-  bool unitOnly = argc > 1 && !strcmp(argv[1], "--unit-only");
+  // MORI_CCO_SKIP_GDA_FULL is set per-runner in CI for boxes without intranode
+  // cross-rail RDMA, where part 2's FULL connection cannot form. Part 1 needs no NIC,
+  // so honour the same signal here and run only that rather than being skipped whole.
+  const bool skipGdaFull = getenv("MORI_CCO_SKIP_GDA_FULL") != nullptr;
+  const bool unitOnly = argc > 1 && !strcmp(argv[1], "--unit-only");
 
   // Part 2 wedges QPs and needs peers, so it is pointless to run when the arithmetic
   // it depends on is already broken.
   if (RunUnitCases() != 0) return 1;
   if (unitOnly) return 0;
+  if (skipGdaFull) {
+    printf("=== end-to-end put: SKIPPED (MORI_CCO_SKIP_GDA_FULL) ===\n");
+    return 0;
+  }
 
   return ccoTestMain(argc, argv, "CCO GDA wraparound", "/tmp/cco_gda_wraparound_uid", 19893);
 }


### PR DESCRIPTION
postIdx / dbTouchIdx / doneIdx wrap at 2^32, so only their order matters. Flow
control mixed uint32 and uint64, underflowing into a forever-spin on an empty SQ;
fetch_max freezes the counter at the wrap; ionic's 24-bit MSN stored raw broke the
in-flight count past 2^24. Fixed all three, plus a boundary test.