### PR TITLE
perf(umbp): remove three bottlenecks from the distributed ranged read path

### DIFF
--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -218,39 +218,28 @@ struct RangedPhases {
   double xfer_wait = 0.0;
   double lock = 0.0;
   double remote = 0.0;
-  // remote split four ways.  Once the arena stopped serializing, `remote` was
-  // ~88% of a cross-node call with nothing inside it to point at: the resolve
-  // RPC, the RDMA itself, and the arena->GPU scatter are three different fixes.
+  // remote, split: the resolve RPC, the RDMA, and the arena->GPU scatter are
+  // three different fixes and were one undifferentiated ~88%.
   double rmt_resolve = 0.0;  // BatchResolveKeys round trip to the owning peer
   double rmt_build = 0.0;    // describing the transfer + planning it + posting it
-  // ...and rmt_build split, once it became the largest item: describing the
-  // spans, bucketing them into plans, and posting the RDMA are three costs.
+  // ...and rmt_build: describing spans, bucketing them, posting the RDMA.
   double rmt_bld_items = 0.0;
   double rmt_bld_plan = 0.0;
   double rmt_bld_post = 0.0;
   double rmt_wait = 0.0;  // the RDMA read itself
-  // Peer bookkeeping before any RPC: GetOrConnectPeer takes peers_mutex_ and
-  // EnsurePeerServiceConnection takes the per-peer conn_mutex, both on EVERY
-  // remote submit.  Two process-wide locks on the hot path is the shape the
-  // scratch arena had (Sec 12.42), so it gets its own timer rather than
-  // sitting in the unaccounted remainder.
+  // Peer bookkeeping before any RPC: two locks taken on every remote submit.
   double rmt_peer = 0.0;
-  // Turning the resolve reply into per-key page vectors.  It is neither the
-  // RPC (`rslv`) nor the transfer build (`bld`), it scales with TOTAL PAGES
-  // rather than keys, and it was the largest thing still sitting in the
-  // unaccounted remainder.
+  // Resolve reply -> per-key page vectors.  Scales with total pages, not keys.
   double rmt_decode = 0.0;
-  // The three things left inside `remote` that nothing timed.  Together they
-  // were ~20% of a cross-node call and invisible.
+  // The rest of `remote`, ~20% of a cross-node call and previously untimed.
   double rmt_sub = 0.0;          // per-group sub_* vectors + PartitionBatchGetRangeTargets
   double rmt_items_build = 0.0;  // BuildContiguousToRangesItems for the scatter
   double rmt_final = 0.0;        // ApplyTransferFailures + FinalizeRemoteGetEntries
   double rmt_medium = 0.0;       // ServeWholeObjectUnitsFromMedium
   double rmt_install = 0.0;      // install-from-arena / background prefetch
   double rmt_scatter = 0.0;      // arena -> caller buffers
-  // ...and the scatter split the same three ways as `xfer`, because the device
-  // gather kernel's own timer says it moves those bytes in an eighth of what
-  // the phase costs -- so most of it is not the copy.
+  // ...and the scatter the same three ways: the gather kernel's own timer says
+  // the copy is an eighth of the phase.
   double scat_plan = 0.0;
   double scat_submit = 0.0;
   double scat_wait = 0.0;
@@ -263,12 +252,9 @@ struct RangedPhases {
   // coalesce shows up here long before it shows up as a percentage.
   size_t rmt_items = 0;  // TransferItems handed to the RDMA planner
   size_t rmt_plans = 0;  // plans it produced -- items/plans is the fan-in
-  // Of those plans, how many the engine staged through its bounce pool.  A
-  // staged plan is run INLINE and under a global mutex inside Submit, so even
-  // one of them turns a non-blocking post into a blocking round trip that
-  // every other shard then queues behind.  Counted because `po` costs 46% on
-  // the model and 7% on the probe, and this is the difference that would
-  // explain it.
+  // Plans the engine staged through its bounce pool.  A staged plan runs inline
+  // under a global mutex in Submit, turning a non-blocking post into a blocking
+  // round trip everything else queues behind.
   size_t rmt_bounce = 0;
   size_t scat_items = 0;  // no plan count: getting one costs a second Plan()
                           // pass, inside the very phase being measured
@@ -309,11 +295,9 @@ class PhaseTimer {
   std::chrono::steady_clock::time_point start_;
 };
 
-// Sinks for the three legs that live inside the remote phase.  They are taken
-// in SubmitRemoteBatchGet / WaitRemoteBatchGet, three calls below the ranged
-// entry point and shared with the non-ranged path, so publishing them here
-// beats threading a debug pointer through five signatures no other caller
-// wants.  Null whenever the ranged debug is off, which is the normal case.
+// Sinks for the legs inside the remote phase.  Published here rather than
+// threaded through five signatures no other caller wants; null when the ranged
+// debug is off.
 struct RemoteLegSinks {
   size_t* items = nullptr;
   size_t* plans = nullptr;
@@ -1837,14 +1821,9 @@ bool PoolClient::BuildContiguousToRangesItems(const TransferRef& src, uint64_t s
                                               const std::vector<ObjectRange>& ranges, size_t tag,
                                               std::vector<TransferItem>* items) {
   const size_t before = items->size();
-  // ONE shared lock for the whole range list, not one per range -- the same
-  // thing BuildLocalRangeTransfers says about itself.  Describing each range
-  // by its REGION base is what keeps the plan count down (a plan is one
-  // (src base, dst base) pair, so self-described ranges make thousands of
-  // single-segment plans), but doing that lookup through UserBufferRef meant
-  // re-taking registered_mem_mutex_ for every one of ~7k ranges a call, on a
-  // path eight TP ranks walk at once.  Hoisting the lock keeps the plan
-  // collapse and drops the lock traffic to one acquisition.
+  // ONE shared lock for the whole list, as BuildLocalRangeTransfers says of
+  // itself.  Going through UserBufferRef per range re-took
+  // registered_mem_mutex_ ~7k times a call, on a path every rank walks at once.
   std::shared_lock<std::shared_mutex> reg_lock(registered_mem_mutex_);
   for (const auto& range : ranges) {
     // All-or-nothing per object: a partially appended object would be
@@ -3244,6 +3223,8 @@ PoolClient::ScratchArena::Lease PoolClient::ScratchArena::Acquire() {
   if (bases_.empty()) return Lease{};
   size_t index = bases_.size();
   cv_.wait(lock, [&] {
+    // Defer to a queued AcquireAll, or it never sees every shard free.
+    if (all_waiting_ != 0) return false;
     for (size_t i = 0; i < busy_.size(); ++i) {
       if (busy_[i] == 0) {
         index = i;
@@ -3259,13 +3240,14 @@ PoolClient::ScratchArena::Lease PoolClient::ScratchArena::Acquire() {
 PoolClient::ScratchArena::Lease PoolClient::ScratchArena::AcquireAll() {
   std::unique_lock<std::mutex> lock(mutex_);
   if (bases_.empty()) return Lease{};
-  // No fairness against Acquire(): an all-shard waiter can be starved by a
-  // steady stream of single-shard ones.  Acceptable because it is the rare path
-  // — a span wider than a shard — and the alternative (a queue) would make the
-  // common path pay for it.
+  // Write-preferring: announce first, so Acquire() stops handing out shards and
+  // the in-flight ones can drain.  Exclusive calls are rare and always finish,
+  // so the shard side cannot starve in turn.
+  ++all_waiting_;
   cv_.wait(lock, [&] {
     return std::all_of(busy_.begin(), busy_.end(), [](uint8_t b) { return b == 0; });
   });
+  --all_waiting_;
   std::fill(busy_.begin(), busy_.end(), 1);
   return Lease{this, 0, busy_.size(), bases_[0]};
 }
@@ -3277,9 +3259,7 @@ void PoolClient::ScratchArena::Release(size_t index, size_t count) {
     const size_t end = std::min(busy_.size(), index + count);
     for (size_t i = index; i < end; ++i) busy_[i] = 0;
   }
-  // notify_all, not notify_one: an all-shard waiter needs to re-check even when
-  // a single-shard waiter is also queued, and waking one of them may wake the
-  // wrong one.
+  // notify_all: waking one waiter may wake the wrong kind.
   cv_.notify_all();
 }
 
@@ -3546,28 +3526,34 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
     return results;
   }
   // Sharding must not change WHAT a call can do, only how many calls overlap.
-  // Two things a smaller arena would break, so both fall back to the whole
-  // arena taken exclusively:
+  // A shard-sized arena breaks two things, so either sends the call down the
+  // exclusive whole-arena path:
   //   * a span wider than a shard is unservable, though it was servable before;
   //   * a key whose spans total more than a shard gets SPLIT across units, and a
-  //     split unit is never holds_whole_object -- which silently costs it the
+  //     split unit is never holds_whole_object -- silently losing the
   //     whole-object medium bypass and the locality install.
-  // Both are bounded by the full arena, so a key too big for that splits either
-  // way and gains nothing from exclusivity.
+  //
+  // Asked PER KEY and OR'd, never as a batch-wide maximum.  A key too big for
+  // even the full arena is no better off exclusive, so it must not answer for
+  // the others: taking the max let one such key veto exclusivity for a
+  // batch-mate that needed it and would have fitted.
   const size_t shard_bytes = ranged_get_scratch_.ShardBytes();
   const size_t full_bytes = config_.ranged_get_scratch_size;
-  size_t widest_span = 0;
-  size_t widest_key_total = 0;
+  bool exclusive_arena = false;
   for (size_t index : missed) {
     size_t key_total = 0;
+    size_t widest_span = 0;
     for (size_t span_bytes : sizes[index]) {
       widest_span = std::max(widest_span, span_bytes);
       key_total += span_bytes;
     }
-    widest_key_total = std::max(widest_key_total, key_total);
+    const bool span_needs_full = widest_span > shard_bytes && widest_span <= full_bytes;
+    const bool total_needs_full = key_total > shard_bytes && key_total <= full_bytes;
+    if (span_needs_full || total_needs_full) {
+      exclusive_arena = true;
+      break;
+    }
   }
-  const bool exclusive_arena = widest_span > shard_bytes ||
-                               (widest_key_total > shard_bytes && widest_key_total <= full_bytes);
   const size_t scratch_size = exclusive_arena ? full_bytes : shard_bytes;
 
   // Routing is a master RPC that never touches the arena, so it runs before a
@@ -3696,13 +3682,9 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
         exclusive_arena ? ranged_get_scratch_.AcquireAll() : ranged_get_scratch_.Acquire();
   }
   char* const scratch_base = scratch_lease.base();
-  // The arena described ONCE, by its registered base.  The scatter below keys
-  // its plans on (src base, dst base), so giving each unit its own slice ref
-  // made every unit x destination-region pair a separate plan -- ~8k plans of
-  // one segment each for a layer-wise load, all sorted, bucketed and submitted
-  // individually.  Anchored to the arena base instead, the src half is constant
-  // and the plan count collapses to the number of distinct caller buffers.
-  // Same argument as BuildLocalRangeTransfers makes for the destination half.
+  // The arena described ONCE, by its registered base.  Plans key on (src base,
+  // dst base), so a per-unit slice ref made every unit x destination pair its
+  // own single-segment plan (~8k of them for a layer-wise load).
   const auto [arena_ref, arena_base] = UserBufferRef(scratch_base, scratch_size);
 
   // Pack as many units into the arena as fit, fetch that group, then repeat.
@@ -3712,9 +3694,8 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
   PhaseTimer remote_timer(dbg ? &dbg->remote : nullptr);
   RemoteLegSinks leg;
   if (dbg != nullptr) {
-    // Designated, not positional.  A positional list that falls one element
-    // short leaves the TAIL null and every timer past that point silently
-    // reads 0.0% -- which looks exactly like "that phase is free".
+    // Designated, not positional: a short positional list leaves the tail null
+    // and those timers silently read 0.0%, which looks like "phase is free".
     leg = {.items = &dbg->rmt_items,
            .plans = &dbg->rmt_plans,
            .bounce = &dbg->rmt_bounce,
@@ -3786,9 +3767,8 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
     PhaseTimer items_build_timer(dbg ? &dbg->rmt_items_build : nullptr);
     std::vector<TransferItem> scatter_items;
     std::vector<size_t> scatter_tag_to_j;
-    // By RANGES, not by units.  A unit carries every caller range it packed --
-    // ~14 of them here -- so reserving `count` left the vector to grow itself
-    // from 500 to 7000 while copying TransferItems (two TransferRefs apiece).
+    // By RANGES, not units: a unit carries every range it packed, so reserving
+    // `count` left a ~7k-element vector to grow itself from ~500.
     size_t scatter_range_total = 0;
     for (size_t j = 0; j < count; ++j) scatter_range_total += units[pos + j].packed.size();
     scatter_items.reserve(scatter_range_total);
@@ -3987,15 +3967,22 @@ std::vector<bool> PoolClient::BatchPutRanges(const std::vector<std::string>& key
     MORI_UMBP_ERROR("[PoolClient] BatchPutRanges: ranged scratch is absent or not registered");
     return results;
   }
-  // A put stages the WHOLE object and never splits one, so the widest object is
-  // the only thing a shard can make unservable; same whole-arena fallback as the
-  // get path, and the same "too big for the full arena gains nothing" bound.
-  size_t widest_object = 0;
-  for (size_t r : remote) widest_object = std::max(widest_object, object_sizes[valid[r]]);
-  const bool exclusive_arena = widest_object > ranged_put_scratch_.ShardBytes() &&
-                               widest_object <= config_.ranged_put_scratch_size;
-  const size_t scratch_size =
-      exclusive_arena ? config_.ranged_put_scratch_size : ranged_put_scratch_.ShardBytes();
+  // A put stages the WHOLE object and never splits one, so object size is the
+  // only thing a shard can make unservable.  Per key and OR'd, for the reason
+  // the get path spells out: a batch-wide max lets an object too big for the
+  // whole arena veto exclusivity for one that needed it, and that one then gets
+  // rejected at shard size though it was servable before sharding existed.
+  const size_t put_shard_bytes = ranged_put_scratch_.ShardBytes();
+  const size_t put_full_bytes = config_.ranged_put_scratch_size;
+  bool exclusive_arena = false;
+  for (size_t r : remote) {
+    const size_t object_size = object_sizes[valid[r]];
+    if (object_size > put_shard_bytes && object_size <= put_full_bytes) {
+      exclusive_arena = true;
+      break;
+    }
+  }
+  const size_t scratch_size = exclusive_arena ? put_full_bytes : put_shard_bytes;
   ScratchArena::Lease scratch_lease;
   {
     PhaseTimer lock_timer(dbg ? &dbg->lock : nullptr);
@@ -4401,8 +4388,7 @@ std::unique_ptr<PoolClient::RemoteGetInFlight> PoolClient::SubmitRemoteBatchGet(
     return nullptr;
   }
 
-  // Build + filter + plan + post: everything between the resolve reply and the
-  // RDMA being in flight, which is CPU this thread spends before any wire time.
+  // Everything between the resolve reply and the RDMA being in flight.
   PhaseTimer build_timer(t_remote_leg ? t_remote_leg->build : nullptr);
   PhaseTimer items_timer(t_remote_leg ? t_remote_leg->build_items : nullptr);
   std::vector<TransferItem> transfer_items;

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -245,6 +245,13 @@ struct RangedPhases {
   // coalesce shows up here long before it shows up as a percentage.
   size_t rmt_items = 0;    // TransferItems handed to the RDMA planner
   size_t rmt_plans = 0;    // plans it produced -- items/plans is the fan-in
+  // Of those plans, how many the engine staged through its bounce pool.  A
+  // staged plan is run INLINE and under a global mutex inside Submit, so even
+  // one of them turns a non-blocking post into a blocking round trip that
+  // every other shard then queues behind.  Counted because `po` costs 46% on
+  // the model and 7% on the probe, and this is the difference that would
+  // explain it.
+  size_t rmt_bounce = 0;
   size_t scat_items = 0;   // no plan count: getting one costs a second Plan()
                            // pass, inside the very phase being measured
   size_t local_keys = 0;
@@ -292,6 +299,7 @@ class PhaseTimer {
 struct RemoteLegSinks {
   size_t* items = nullptr;
   size_t* plans = nullptr;
+  size_t* bounce = nullptr;
   double* resolve = nullptr;
   double* build = nullptr;
   double* build_items = nullptr;
@@ -346,6 +354,7 @@ class RangedStats {
     t.items += p.items;
     t.rmt_items += p.rmt_items;
     t.rmt_plans += p.rmt_plans;
+    t.rmt_bounce += p.rmt_bounce;
     t.scat_items += p.scat_items;
 
     // Per-component totals, keyed by object size (one call = one pool).  The
@@ -387,7 +396,7 @@ class RangedStats {
   struct Totals {
     uint64_t calls = 0;
     uint64_t items = 0;
-    uint64_t rmt_items = 0, rmt_plans = 0, scat_items = 0;
+    uint64_t rmt_items = 0, rmt_plans = 0, rmt_bounce = 0, scat_items = 0;
     double total = 0, resolve = 0, classify = 0, build = 0, validate = 0, commit = 0, route = 0,
            xfer = 0, xfer_plan = 0, xfer_submit = 0, xfer_wait = 0, lock = 0, remote = 0,
            rmt_resolve = 0, rmt_build = 0, rmt_bld_items = 0, rmt_bld_plan = 0,
@@ -407,7 +416,7 @@ class RangedStats {
     auto share = [&](double v) { return t.total > 0 ? 100.0 * v / t.total : 0.0; };
     MORI_UMBP_INFO(
         "[RangedCall][dbg] SUMMARY {} calls={} total={:.3f}s mean_call={:.1f}us bytes={:.2f}GiB "
-        "items_per_call={:.0f} rmt_items={:.0f}/{:.0f}pl scat_items={:.0f} | "
+        "items_per_call={:.0f} rmt_items={:.0f}/{:.0f}pl bounce={:.2f} scat_items={:.0f} | "
         "resolve={:.1f}% classify={:.1f}% build={:.1f}% validate={:.1f}% "
         "commit={:.1f}% route={:.1f}% xfer={:.1f}%(plan={:.1f}% submit={:.1f}% wait={:.1f}%) "
         "lock={:.1f}% remote={:.1f}%(rslv={:.1f}% bld={:.1f}%[it={:.1f}% pl={:.1f}% "
@@ -416,7 +425,8 @@ class RangedStats {
         "other={:.1f}% | xfer_only={:.2f}GiB/s end2end={:.2f}GiB/s",
         name, t.calls, t.total, 1e6 * t.total / t.calls, t.bytes / (1024.0 * 1024 * 1024),
         static_cast<double>(t.items) / t.calls, static_cast<double>(t.rmt_items) / t.calls,
-        static_cast<double>(t.rmt_plans) / t.calls, static_cast<double>(t.scat_items) / t.calls,
+        static_cast<double>(t.rmt_plans) / t.calls, static_cast<double>(t.rmt_bounce) / t.calls,
+        static_cast<double>(t.scat_items) / t.calls,
         share(t.resolve), share(t.classify), share(t.build),
         share(t.validate), share(t.commit), share(t.route), share(t.xfer), share(t.xfer_plan),
         share(t.xfer_submit), share(t.xfer_wait), share(t.lock), share(t.remote),
@@ -3640,9 +3650,9 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
   PhaseTimer remote_timer(dbg ? &dbg->remote : nullptr);
   RemoteLegSinks leg;
   if (dbg != nullptr) {
-    leg = {&dbg->rmt_items,     &dbg->rmt_plans,    &dbg->rmt_resolve,
-           &dbg->rmt_build,      &dbg->rmt_bld_items, &dbg->rmt_bld_plan,
-           &dbg->rmt_bld_post,   &dbg->rmt_wait};
+    leg = {&dbg->rmt_items,      &dbg->rmt_plans,     &dbg->rmt_bounce,
+           &dbg->rmt_resolve,    &dbg->rmt_build,     &dbg->rmt_bld_items,
+           &dbg->rmt_bld_plan,   &dbg->rmt_bld_post,  &dbg->rmt_wait};
   }
   ScopedRemoteLeg leg_scope(dbg ? &leg : nullptr);
   size_t pos = 0;
@@ -4336,6 +4346,11 @@ std::unique_ptr<PoolClient::RemoteGetInFlight> PoolClient::SubmitRemoteBatchGet(
   if (t_remote_leg != nullptr) {
     if (t_remote_leg->items != nullptr) *t_remote_leg->items += active.size();
     if (t_remote_leg->plans != nullptr) *t_remote_leg->plans += planned.plans.size();
+    if (t_remote_leg->bounce != nullptr) {
+      for (const auto& p : planned.plans) {
+        if (p.uses_bounce) *t_remote_leg->bounce += 1;
+      }
+    }
   }
   ApplyRejectedTags(inflight->entries, planned.rejected_tags, "RemoteGet");
   if (planned.plans.empty()) {

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -228,7 +228,7 @@ struct RangedPhases {
   double rmt_bld_items = 0.0;
   double rmt_bld_plan = 0.0;
   double rmt_bld_post = 0.0;
-  double rmt_wait = 0.0;     // the RDMA read itself
+  double rmt_wait = 0.0;  // the RDMA read itself
   // Peer bookkeeping before any RPC: GetOrConnectPeer takes peers_mutex_ and
   // EnsurePeerServiceConnection takes the per-peer conn_mutex, both on EVERY
   // remote submit.  Two process-wide locks on the hot path is the shape the
@@ -242,12 +242,12 @@ struct RangedPhases {
   double rmt_decode = 0.0;
   // The three things left inside `remote` that nothing timed.  Together they
   // were ~20% of a cross-node call and invisible.
-  double rmt_sub = 0.0;    // per-group sub_* vectors + PartitionBatchGetRangeTargets
+  double rmt_sub = 0.0;          // per-group sub_* vectors + PartitionBatchGetRangeTargets
   double rmt_items_build = 0.0;  // BuildContiguousToRangesItems for the scatter
-  double rmt_final = 0.0;  // ApplyTransferFailures + FinalizeRemoteGetEntries
-  double rmt_medium = 0.0;   // ServeWholeObjectUnitsFromMedium
-  double rmt_install = 0.0;  // install-from-arena / background prefetch
-  double rmt_scatter = 0.0;  // arena -> caller buffers
+  double rmt_final = 0.0;        // ApplyTransferFailures + FinalizeRemoteGetEntries
+  double rmt_medium = 0.0;       // ServeWholeObjectUnitsFromMedium
+  double rmt_install = 0.0;      // install-from-arena / background prefetch
+  double rmt_scatter = 0.0;      // arena -> caller buffers
   // ...and the scatter split the same three ways as `xfer`, because the device
   // gather kernel's own timer says it moves those bytes in an eighth of what
   // the phase costs -- so most of it is not the copy.
@@ -261,8 +261,8 @@ struct RangedPhases {
   // Remote-leg shape.  The phase timers say WHERE the time goes; these say
   // whether it is one cost repeated too often.  A segment that failed to
   // coalesce shows up here long before it shows up as a percentage.
-  size_t rmt_items = 0;    // TransferItems handed to the RDMA planner
-  size_t rmt_plans = 0;    // plans it produced -- items/plans is the fan-in
+  size_t rmt_items = 0;  // TransferItems handed to the RDMA planner
+  size_t rmt_plans = 0;  // plans it produced -- items/plans is the fan-in
   // Of those plans, how many the engine staged through its bounce pool.  A
   // staged plan is run INLINE and under a global mutex inside Submit, so even
   // one of them turns a non-blocking post into a blocking round trip that
@@ -270,8 +270,8 @@ struct RangedPhases {
   // the model and 7% on the probe, and this is the difference that would
   // explain it.
   size_t rmt_bounce = 0;
-  size_t scat_items = 0;   // no plan count: getting one costs a second Plan()
-                           // pass, inside the very phase being measured
+  size_t scat_items = 0;  // no plan count: getting one costs a second Plan()
+                          // pass, inside the very phase being measured
   size_t local_keys = 0;
   size_t remote_keys = 0;
   double bytes = 0.0;
@@ -427,8 +427,8 @@ class RangedStats {
     uint64_t rmt_items = 0, rmt_plans = 0, rmt_bounce = 0, scat_items = 0;
     double total = 0, resolve = 0, classify = 0, build = 0, validate = 0, commit = 0, route = 0,
            xfer = 0, xfer_plan = 0, xfer_submit = 0, xfer_wait = 0, lock = 0, remote = 0,
-           rmt_resolve = 0, rmt_build = 0, rmt_bld_items = 0, rmt_bld_plan = 0,
-           rmt_bld_post = 0, rmt_peer = 0, rmt_decode = 0, rmt_sub = 0, rmt_items_build = 0, rmt_final = 0,
+           rmt_resolve = 0, rmt_build = 0, rmt_bld_items = 0, rmt_bld_plan = 0, rmt_bld_post = 0,
+           rmt_peer = 0, rmt_decode = 0, rmt_sub = 0, rmt_items_build = 0, rmt_final = 0,
            rmt_medium = 0, rmt_install = 0, rmt_wait = 0, rmt_scatter = 0, scat_plan = 0,
            scat_submit = 0, scat_wait = 0, bytes = 0;
   };
@@ -449,21 +449,21 @@ class RangedStats {
         "resolve={:.1f}% classify={:.1f}% build={:.1f}% validate={:.1f}% "
         "commit={:.1f}% route={:.1f}% xfer={:.1f}%(plan={:.1f}% submit={:.1f}% wait={:.1f}%) "
         "lock={:.1f}% remote={:.1f}%(rslv={:.1f}% bld={:.1f}%[it={:.1f}% pl={:.1f}% "
-        "po={:.1f}%] peer={:.1f}% dec={:.1f}% sub={:.1f}% ib={:.1f}% fin={:.1f}% med={:.1f}% inst={:.1f}% rdma={:.1f}% "
+        "po={:.1f}%] peer={:.1f}% dec={:.1f}% sub={:.1f}% ib={:.1f}% fin={:.1f}% med={:.1f}% "
+        "inst={:.1f}% rdma={:.1f}% "
         "scat={:.1f}%[pl={:.1f}% sub={:.1f}% wt={:.1f}%]) "
         "other={:.1f}% | xfer_only={:.2f}GiB/s end2end={:.2f}GiB/s",
         name, t.calls, t.total, 1e6 * t.total / t.calls, t.bytes / (1024.0 * 1024 * 1024),
         static_cast<double>(t.items) / t.calls, static_cast<double>(t.rmt_items) / t.calls,
         static_cast<double>(t.rmt_plans) / t.calls, static_cast<double>(t.rmt_bounce) / t.calls,
-        static_cast<double>(t.scat_items) / t.calls,
-        share(t.resolve), share(t.classify), share(t.build),
-        share(t.validate), share(t.commit), share(t.route), share(t.xfer), share(t.xfer_plan),
-        share(t.xfer_submit), share(t.xfer_wait), share(t.lock), share(t.remote),
-        share(t.rmt_resolve), share(t.rmt_build), share(t.rmt_bld_items), share(t.rmt_bld_plan),
-        share(t.rmt_bld_post), share(t.rmt_peer), share(t.rmt_decode), share(t.rmt_sub),
-        share(t.rmt_items_build), share(t.rmt_final), share(t.rmt_medium), share(t.rmt_install),
-        share(t.rmt_wait), share(t.rmt_scatter),
-        share(t.scat_plan), share(t.scat_submit), share(t.scat_wait), share(other),
+        static_cast<double>(t.scat_items) / t.calls, share(t.resolve), share(t.classify),
+        share(t.build), share(t.validate), share(t.commit), share(t.route), share(t.xfer),
+        share(t.xfer_plan), share(t.xfer_submit), share(t.xfer_wait), share(t.lock),
+        share(t.remote), share(t.rmt_resolve), share(t.rmt_build), share(t.rmt_bld_items),
+        share(t.rmt_bld_plan), share(t.rmt_bld_post), share(t.rmt_peer), share(t.rmt_decode),
+        share(t.rmt_sub), share(t.rmt_items_build), share(t.rmt_final), share(t.rmt_medium),
+        share(t.rmt_install), share(t.rmt_wait), share(t.rmt_scatter), share(t.scat_plan),
+        share(t.scat_submit), share(t.scat_wait), share(other),
         t.xfer > 0 ? (t.bytes / t.xfer) / (1024.0 * 1024 * 1024) : 0.0,
         t.total > 0 ? (t.bytes / t.total) / (1024.0 * 1024 * 1024) : 0.0);
   }
@@ -3566,8 +3566,8 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
     }
     widest_key_total = std::max(widest_key_total, key_total);
   }
-  const bool exclusive_arena =
-      widest_span > shard_bytes || (widest_key_total > shard_bytes && widest_key_total <= full_bytes);
+  const bool exclusive_arena = widest_span > shard_bytes ||
+                               (widest_key_total > shard_bytes && widest_key_total <= full_bytes);
   const size_t scratch_size = exclusive_arena ? full_bytes : shard_bytes;
 
   // Routing is a master RPC that never touches the arena, so it runs before a

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -3221,11 +3221,23 @@ void PoolClient::ScratchArena::Reset(void* base, size_t bytes, size_t shards) {
 PoolClient::ScratchArena::Lease PoolClient::ScratchArena::Acquire() {
   std::unique_lock<std::mutex> lock(mutex_);
   if (bases_.empty()) return Lease{};
+  // Uncontended: nothing is queued, so nobody can be jumped.
+  if (waiters_.empty()) {
+    for (size_t i = 0; i < busy_.size(); ++i) {
+      if (busy_[i] == 0) {
+        busy_[i] = 1;
+        return Lease{this, i, 1, bases_[i]};
+      }
+    }
+  }
   size_t index = bases_.size();
   const uint64_t ticket = next_ticket_++;
+  waiters_.emplace_back(ticket, false);
   cv_.wait(lock, [&] {
-    // Yield only to exclusive waiters that were already queued when we arrived.
-    if (!exclusive_queue_.empty() && exclusive_queue_.front() < ticket) return false;
+    for (const auto& [t, exclusive] : waiters_) {
+      if (t >= ticket) break;
+      if (exclusive) return false;  // an exclusive waiter got here first
+    }
     for (size_t i = 0; i < busy_.size(); ++i) {
       if (busy_[i] == 0) {
         index = i;
@@ -3234,6 +3246,7 @@ PoolClient::ScratchArena::Lease PoolClient::ScratchArena::Acquire() {
     }
     return false;
   });
+  Forget(ticket);
   busy_[index] = 1;
   return Lease{this, index, 1, bases_[index]};
 }
@@ -3241,17 +3254,28 @@ PoolClient::ScratchArena::Lease PoolClient::ScratchArena::Acquire() {
 PoolClient::ScratchArena::Lease PoolClient::ScratchArena::AcquireAll() {
   std::unique_lock<std::mutex> lock(mutex_);
   if (bases_.empty()) return Lease{};
-  // Queue first, so Acquire() stops admitting arrivals behind us and the shards
-  // held by earlier arrivals can drain.
+  // Queue first, so later arrivals stop being admitted and the shards held by
+  // earlier ones can drain.  Waiting to be the OLDEST waiter -- not merely the
+  // oldest exclusive one -- is what stops a stream of exclusives from stepping
+  // over a shard waiter that was already queued.
   const uint64_t ticket = next_ticket_++;
-  exclusive_queue_.push_back(ticket);
+  waiters_.emplace_back(ticket, true);
   cv_.wait(lock, [&] {
-    return exclusive_queue_.front() == ticket &&
+    return waiters_.front().first == ticket &&
            std::all_of(busy_.begin(), busy_.end(), [](uint8_t b) { return b == 0; });
   });
-  exclusive_queue_.pop_front();
+  Forget(ticket);
   std::fill(busy_.begin(), busy_.end(), 1);
   return Lease{this, 0, busy_.size(), bases_[0]};
+}
+
+void PoolClient::ScratchArena::Forget(uint64_t ticket) {
+  for (auto it = waiters_.begin(); it != waiters_.end(); ++it) {
+    if (it->first == ticket) {
+      waiters_.erase(it);
+      return;
+    }
+  }
 }
 
 void PoolClient::ScratchArena::Release(size_t index, size_t count) {

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -3222,9 +3222,10 @@ PoolClient::ScratchArena::Lease PoolClient::ScratchArena::Acquire() {
   std::unique_lock<std::mutex> lock(mutex_);
   if (bases_.empty()) return Lease{};
   size_t index = bases_.size();
+  const uint64_t ticket = next_ticket_++;
   cv_.wait(lock, [&] {
-    // Defer to a queued AcquireAll, or it never sees every shard free.
-    if (all_waiting_ != 0) return false;
+    // Yield only to exclusive waiters that were already queued when we arrived.
+    if (!exclusive_queue_.empty() && exclusive_queue_.front() < ticket) return false;
     for (size_t i = 0; i < busy_.size(); ++i) {
       if (busy_[i] == 0) {
         index = i;
@@ -3240,14 +3241,15 @@ PoolClient::ScratchArena::Lease PoolClient::ScratchArena::Acquire() {
 PoolClient::ScratchArena::Lease PoolClient::ScratchArena::AcquireAll() {
   std::unique_lock<std::mutex> lock(mutex_);
   if (bases_.empty()) return Lease{};
-  // Write-preferring: announce first, so Acquire() stops handing out shards and
-  // the in-flight ones can drain.  Exclusive calls are rare and always finish,
-  // so the shard side cannot starve in turn.
-  ++all_waiting_;
+  // Queue first, so Acquire() stops admitting arrivals behind us and the shards
+  // held by earlier arrivals can drain.
+  const uint64_t ticket = next_ticket_++;
+  exclusive_queue_.push_back(ticket);
   cv_.wait(lock, [&] {
-    return std::all_of(busy_.begin(), busy_.end(), [](uint8_t b) { return b == 0; });
+    return exclusive_queue_.front() == ticket &&
+           std::all_of(busy_.begin(), busy_.end(), [](uint8_t b) { return b == 0; });
   });
-  --all_waiting_;
+  exclusive_queue_.pop_front();
   std::fill(busy_.begin(), busy_.end(), 1);
   return Lease{this, 0, busy_.size(), bases_[0]};
 }

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -595,6 +595,22 @@ bool RangesAreDisjointAndInBounds(size_t object_size, const std::vector<size_t>&
 // slices never share one.
 constexpr size_t kRangedScratchAlignment = 64;
 
+// How many shards each ranged scratch arena is cut into.  1 is the historical
+// single-arena behaviour; 8 is one shard per rank of a TP8 node, which is what
+// the single arena mutex was serializing.
+size_t RangedScratchShards() {
+  static const size_t n = [] {
+    size_t shards = 1;
+    if (const char* value = std::getenv("UMBP_DISTRIBUTED_RANGED_SCRATCH_SHARDS")) {
+      char* end = nullptr;
+      const unsigned long long parsed = std::strtoull(value, &end, 10);
+      if (end != value && *end == '\0' && parsed > 0) shards = static_cast<size_t>(parsed);
+    }
+    return std::min<size_t>(shards, 64);
+  }();
+  return n;
+}
+
 bool AlignUpChecked(size_t value, size_t alignment, size_t* out) {
   if (!out || alignment == 0) return false;
   const size_t remainder = value % alignment;
@@ -988,6 +1004,19 @@ bool PoolClient::Init() {
       hbm_engine_->AddHostGatherRegion(config_.ranged_put_scratch_buffer,
                                        config_.ranged_put_scratch_size);
     }
+  }
+
+  // Registration above covers the whole buffer; the shards below are slices of
+  // it, so cutting them needs no further registration.
+  const size_t scratch_shards = RangedScratchShards();
+  ranged_get_scratch_.Reset(config_.ranged_get_scratch_buffer, config_.ranged_get_scratch_size,
+                            scratch_shards);
+  ranged_put_scratch_.Reset(config_.ranged_put_scratch_buffer, config_.ranged_put_scratch_size,
+                            scratch_shards);
+  if (config_.ranged_get_scratch_size > 0) {
+    MORI_UMBP_INFO("[PoolClient] ranged scratch: shards={} get_shard={}B put_shard={}B",
+                   scratch_shards, ranged_get_scratch_.ShardBytes(),
+                   ranged_put_scratch_.ShardBytes());
   }
 
   if (master_client_) master_client_->SetBackendRegistry(&registry_);
@@ -3029,6 +3058,71 @@ std::vector<PoolClient::ObjectRange> MakeWriteRanges(const std::vector<const voi
 
 }  // namespace
 
+void PoolClient::ScratchArena::Reset(void* base, size_t bytes, size_t shards) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  bases_.clear();
+  busy_.clear();
+  shard_bytes_ = 0;
+  if (base == nullptr || bytes == 0 || shards == 0) return;
+
+  // Shards are cut on kRangedScratchAlignment so a slice never starts mid-cache
+  // line, and a count that would leave a shard smaller than one alignment unit
+  // collapses back to a single arena rather than producing unusable slivers.
+  size_t shard = (bytes / shards) & ~(kRangedScratchAlignment - 1);
+  if (shard == 0) {
+    shard = bytes;
+    shards = 1;
+  }
+  shard_bytes_ = shard;
+  bases_.reserve(shards);
+  busy_.assign(shards, 0);
+  for (size_t i = 0; i < shards; ++i) bases_.push_back(static_cast<char*>(base) + i * shard);
+}
+
+PoolClient::ScratchArena::Lease PoolClient::ScratchArena::Acquire() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  if (bases_.empty()) return Lease{};
+  size_t index = bases_.size();
+  cv_.wait(lock, [&] {
+    for (size_t i = 0; i < busy_.size(); ++i) {
+      if (busy_[i] == 0) {
+        index = i;
+        return true;
+      }
+    }
+    return false;
+  });
+  busy_[index] = 1;
+  return Lease{this, index, 1, bases_[index]};
+}
+
+PoolClient::ScratchArena::Lease PoolClient::ScratchArena::AcquireAll() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  if (bases_.empty()) return Lease{};
+  // No fairness against Acquire(): an all-shard waiter can be starved by a
+  // steady stream of single-shard ones.  Acceptable because it is the rare path
+  // — a span wider than a shard — and the alternative (a queue) would make the
+  // common path pay for it.
+  cv_.wait(lock, [&] {
+    return std::all_of(busy_.begin(), busy_.end(), [](uint8_t b) { return b == 0; });
+  });
+  std::fill(busy_.begin(), busy_.end(), 1);
+  return Lease{this, 0, busy_.size(), bases_[0]};
+}
+
+void PoolClient::ScratchArena::Release(size_t index, size_t count) {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (index >= busy_.size()) return;
+    const size_t end = std::min(busy_.size(), index + count);
+    for (size_t i = index; i < end; ++i) busy_[i] = 0;
+  }
+  // notify_all, not notify_one: an all-shard waiter needs to re-check even when
+  // a single-shard waiter is also queued, and waking one of them may wake the
+  // wrong one.
+  cv_.notify_all();
+}
+
 // The route-first arm of BatchGetRanges: one BatchRouteGet over EVERY key,
 // issued before anything is served.
 //
@@ -3282,18 +3376,42 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
   // overlap with anything.  Packing spans instead also multiplies how many keys
   // fit in one arena round by the same factor.
   //
-  // GET has its own arena and mutex, so it overlaps a concurrent remote PUT
-  // (which uses the separate PUT arena/mutex).
-  char* const scratch_base = static_cast<char*>(config_.ranged_get_scratch_buffer);
-  const size_t scratch_size = config_.ranged_get_scratch_size;
-  if (scratch_base == nullptr || scratch_size == 0 ||
-      !FindRegisteredMemory(scratch_base, scratch_size).has_value()) {
+  // GET has its own arena, so it overlaps a concurrent remote PUT (which uses
+  // the separate PUT arena).  Sizing below is against ONE SHARD, not the whole
+  // buffer: a unit that fits the buffer but not a shard would never get a slice.
+  char* const scratch_all = static_cast<char*>(config_.ranged_get_scratch_buffer);
+  if (scratch_all == nullptr || ranged_get_scratch_.ShardBytes() == 0 ||
+      !FindRegisteredMemory(scratch_all, config_.ranged_get_scratch_size).has_value()) {
     MORI_UMBP_ERROR("[PoolClient] BatchGetRanges: ranged scratch is absent or not registered");
     return results;
   }
+  // Sharding must not change WHAT a call can do, only how many calls overlap.
+  // Two things a smaller arena would break, so both fall back to the whole
+  // arena taken exclusively:
+  //   * a span wider than a shard is unservable, though it was servable before;
+  //   * a key whose spans total more than a shard gets SPLIT across units, and a
+  //     split unit is never holds_whole_object -- which silently costs it the
+  //     whole-object medium bypass and the locality install.
+  // Both are bounded by the full arena, so a key too big for that splits either
+  // way and gains nothing from exclusivity.
+  const size_t shard_bytes = ranged_get_scratch_.ShardBytes();
+  const size_t full_bytes = config_.ranged_get_scratch_size;
+  size_t widest_span = 0;
+  size_t widest_key_total = 0;
+  for (size_t index : missed) {
+    size_t key_total = 0;
+    for (size_t span_bytes : sizes[index]) {
+      widest_span = std::max(widest_span, span_bytes);
+      key_total += span_bytes;
+    }
+    widest_key_total = std::max(widest_key_total, key_total);
+  }
+  const bool exclusive_arena =
+      widest_span > shard_bytes || (widest_key_total > shard_bytes && widest_key_total <= full_bytes);
+  const size_t scratch_size = exclusive_arena ? full_bytes : shard_bytes;
 
-  // Routing is a master RPC that never touches the arena, so it runs before the
-  // lock is taken rather than holding every other arena user behind it.
+  // Routing is a master RPC that never touches the arena, so it runs before a
+  // shard is taken rather than holding every other arena user behind it.
   std::vector<std::string> route_keys;
   route_keys.reserve(missed.size());
   for (size_t index : missed) route_keys.push_back(keys[index]);
@@ -3406,13 +3524,15 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
     return results;
   }
 
-  // Only the arena users serialize; the local hits above were fully concurrent,
-  // and so were the routing RPC and the slot-served units.
-  std::unique_lock<std::mutex> scratch_lock(ranged_get_scratch_mutex_, std::defer_lock);
+  // Only arena users wait, and only for a free SHARD; the local hits above were
+  // fully concurrent, and so were the routing RPC and the slot-served units.
+  ScratchArena::Lease scratch_lease;
   {
     PhaseTimer lock_timer(dbg ? &dbg->lock : nullptr);
-    scratch_lock.lock();
+    scratch_lease =
+        exclusive_arena ? ranged_get_scratch_.AcquireAll() : ranged_get_scratch_.Acquire();
   }
+  char* const scratch_base = scratch_lease.base();
 
   // Pack as many units into the arena as fit, fetch that group, then repeat.
   // Units are 64 B apart so two concurrently-filled slices never share a cache
@@ -3653,21 +3773,31 @@ std::vector<bool> PoolClient::BatchPutRanges(const std::vector<std::string>& key
   if (remote.empty()) return results;
 
   // A key routed to another node has to be one contiguous object on the wire,
-  // so this is the one direction that needs the arena.  PUT has its own arena
-  // and mutex, so it overlaps a concurrent remote GET (which uses the separate
-  // GET arena/mutex).
-  char* const scratch_base = static_cast<char*>(config_.ranged_put_scratch_buffer);
-  const size_t scratch_size = config_.ranged_put_scratch_size;
-  if (scratch_base == nullptr || scratch_size == 0 ||
-      !FindRegisteredMemory(scratch_base, scratch_size).has_value()) {
+  // so this is the one direction that needs the arena.  PUT has its own arena,
+  // so it overlaps a concurrent remote GET (which uses the separate GET arena).
+  // Sizing is against ONE SHARD; see the GET path for why.
+  char* const scratch_all = static_cast<char*>(config_.ranged_put_scratch_buffer);
+  if (scratch_all == nullptr || ranged_put_scratch_.ShardBytes() == 0 ||
+      !FindRegisteredMemory(scratch_all, config_.ranged_put_scratch_size).has_value()) {
     MORI_UMBP_ERROR("[PoolClient] BatchPutRanges: ranged scratch is absent or not registered");
     return results;
   }
-  std::unique_lock<std::mutex> scratch_lock(ranged_put_scratch_mutex_, std::defer_lock);
+  // A put stages the WHOLE object and never splits one, so the widest object is
+  // the only thing a shard can make unservable; same whole-arena fallback as the
+  // get path, and the same "too big for the full arena gains nothing" bound.
+  size_t widest_object = 0;
+  for (size_t r : remote) widest_object = std::max(widest_object, object_sizes[valid[r]]);
+  const bool exclusive_arena = widest_object > ranged_put_scratch_.ShardBytes() &&
+                               widest_object <= config_.ranged_put_scratch_size;
+  const size_t scratch_size =
+      exclusive_arena ? config_.ranged_put_scratch_size : ranged_put_scratch_.ShardBytes();
+  ScratchArena::Lease scratch_lease;
   {
     PhaseTimer lock_timer(dbg ? &dbg->lock : nullptr);
-    scratch_lock.lock();
+    scratch_lease =
+        exclusive_arena ? ranged_put_scratch_.AcquireAll() : ranged_put_scratch_.Acquire();
   }
+  char* const scratch_base = scratch_lease.base();
 
   PhaseTimer remote_timer(dbg ? &dbg->remote : nullptr);
   size_t pos = 0;

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -218,10 +218,35 @@ struct RangedPhases {
   double xfer_wait = 0.0;
   double lock = 0.0;
   double remote = 0.0;
+  // remote split four ways.  Once the arena stopped serializing, `remote` was
+  // ~88% of a cross-node call with nothing inside it to point at: the resolve
+  // RPC, the RDMA itself, and the arena->GPU scatter are three different fixes.
+  double rmt_resolve = 0.0;  // BatchResolveKeys round trip to the owning peer
+  double rmt_build = 0.0;    // describing the transfer + planning it + posting it
+  // ...and rmt_build split, once it became the largest item: describing the
+  // spans, bucketing them into plans, and posting the RDMA are three costs.
+  double rmt_bld_items = 0.0;
+  double rmt_bld_plan = 0.0;
+  double rmt_bld_post = 0.0;
+  double rmt_wait = 0.0;     // the RDMA read itself
+  double rmt_scatter = 0.0;  // arena -> caller buffers
+  // ...and the scatter split the same three ways as `xfer`, because the device
+  // gather kernel's own timer says it moves those bytes in an eighth of what
+  // the phase costs -- so most of it is not the copy.
+  double scat_plan = 0.0;
+  double scat_submit = 0.0;
+  double scat_wait = 0.0;
   size_t keys = 0;
   // TransferItems handed to the engine.  Grows with ranges, not keys, and is
   // what makes the item-per-range cost visible next to the phase times.
   size_t items = 0;
+  // Remote-leg shape.  The phase timers say WHERE the time goes; these say
+  // whether it is one cost repeated too often.  A segment that failed to
+  // coalesce shows up here long before it shows up as a percentage.
+  size_t rmt_items = 0;    // TransferItems handed to the RDMA planner
+  size_t rmt_plans = 0;    // plans it produced -- items/plans is the fan-in
+  size_t scat_items = 0;   // no plan count: getting one costs a second Plan()
+                           // pass, inside the very phase being measured
   size_t local_keys = 0;
   size_t remote_keys = 0;
   double bytes = 0.0;
@@ -259,6 +284,34 @@ class PhaseTimer {
   std::chrono::steady_clock::time_point start_;
 };
 
+// Sinks for the three legs that live inside the remote phase.  They are taken
+// in SubmitRemoteBatchGet / WaitRemoteBatchGet, three calls below the ranged
+// entry point and shared with the non-ranged path, so publishing them here
+// beats threading a debug pointer through five signatures no other caller
+// wants.  Null whenever the ranged debug is off, which is the normal case.
+struct RemoteLegSinks {
+  size_t* items = nullptr;
+  size_t* plans = nullptr;
+  double* resolve = nullptr;
+  double* build = nullptr;
+  double* build_items = nullptr;
+  double* build_plan = nullptr;
+  double* build_post = nullptr;
+  double* wait = nullptr;
+};
+thread_local RemoteLegSinks* t_remote_leg = nullptr;
+
+class ScopedRemoteLeg {
+ public:
+  explicit ScopedRemoteLeg(RemoteLegSinks* sinks) : prev_(t_remote_leg) { t_remote_leg = sinks; }
+  ~ScopedRemoteLeg() { t_remote_leg = prev_; }
+  ScopedRemoteLeg(const ScopedRemoteLeg&) = delete;
+  ScopedRemoteLeg& operator=(const ScopedRemoteLeg&) = delete;
+
+ private:
+  RemoteLegSinks* prev_;
+};
+
 class RangedStats {
  public:
   void Record(const char* op, const RangedPhases& p, double total) {
@@ -279,8 +332,21 @@ class RangedStats {
     t.xfer_wait += p.xfer_wait;
     t.lock += p.lock;
     t.remote += p.remote;
+    t.rmt_resolve += p.rmt_resolve;
+    t.rmt_build += p.rmt_build;
+    t.rmt_bld_items += p.rmt_bld_items;
+    t.rmt_bld_plan += p.rmt_bld_plan;
+    t.rmt_bld_post += p.rmt_bld_post;
+    t.rmt_wait += p.rmt_wait;
+    t.rmt_scatter += p.rmt_scatter;
+    t.scat_plan += p.scat_plan;
+    t.scat_submit += p.scat_submit;
+    t.scat_wait += p.scat_wait;
     t.bytes += p.bytes;
     t.items += p.items;
+    t.rmt_items += p.rmt_items;
+    t.rmt_plans += p.rmt_plans;
+    t.scat_items += p.scat_items;
 
     // Per-component totals, keyed by object size (one call = one pool).  The
     // sample key is stored once per (op, size) so the log proves the
@@ -321,8 +387,12 @@ class RangedStats {
   struct Totals {
     uint64_t calls = 0;
     uint64_t items = 0;
+    uint64_t rmt_items = 0, rmt_plans = 0, scat_items = 0;
     double total = 0, resolve = 0, classify = 0, build = 0, validate = 0, commit = 0, route = 0,
-           xfer = 0, xfer_plan = 0, xfer_submit = 0, xfer_wait = 0, lock = 0, remote = 0, bytes = 0;
+           xfer = 0, xfer_plan = 0, xfer_submit = 0, xfer_wait = 0, lock = 0, remote = 0,
+           rmt_resolve = 0, rmt_build = 0, rmt_bld_items = 0, rmt_bld_plan = 0,
+           rmt_bld_post = 0, rmt_wait = 0, rmt_scatter = 0, scat_plan = 0,
+           scat_submit = 0, scat_wait = 0, bytes = 0;
   };
   struct Component {
     uint64_t calls = 0;
@@ -337,14 +407,22 @@ class RangedStats {
     auto share = [&](double v) { return t.total > 0 ? 100.0 * v / t.total : 0.0; };
     MORI_UMBP_INFO(
         "[RangedCall][dbg] SUMMARY {} calls={} total={:.3f}s mean_call={:.1f}us bytes={:.2f}GiB "
-        "items_per_call={:.0f} | resolve={:.1f}% classify={:.1f}% build={:.1f}% validate={:.1f}% "
+        "items_per_call={:.0f} rmt_items={:.0f}/{:.0f}pl scat_items={:.0f} | "
+        "resolve={:.1f}% classify={:.1f}% build={:.1f}% validate={:.1f}% "
         "commit={:.1f}% route={:.1f}% xfer={:.1f}%(plan={:.1f}% submit={:.1f}% wait={:.1f}%) "
-        "lock={:.1f}% remote={:.1f}% "
+        "lock={:.1f}% remote={:.1f}%(rslv={:.1f}% bld={:.1f}%[it={:.1f}% pl={:.1f}% "
+        "po={:.1f}%] rdma={:.1f}% "
+        "scat={:.1f}%[pl={:.1f}% sub={:.1f}% wt={:.1f}%]) "
         "other={:.1f}% | xfer_only={:.2f}GiB/s end2end={:.2f}GiB/s",
         name, t.calls, t.total, 1e6 * t.total / t.calls, t.bytes / (1024.0 * 1024 * 1024),
-        static_cast<double>(t.items) / t.calls, share(t.resolve), share(t.classify), share(t.build),
+        static_cast<double>(t.items) / t.calls, static_cast<double>(t.rmt_items) / t.calls,
+        static_cast<double>(t.rmt_plans) / t.calls, static_cast<double>(t.scat_items) / t.calls,
+        share(t.resolve), share(t.classify), share(t.build),
         share(t.validate), share(t.commit), share(t.route), share(t.xfer), share(t.xfer_plan),
-        share(t.xfer_submit), share(t.xfer_wait), share(t.lock), share(t.remote), share(other),
+        share(t.xfer_submit), share(t.xfer_wait), share(t.lock), share(t.remote),
+        share(t.rmt_resolve), share(t.rmt_build), share(t.rmt_bld_items), share(t.rmt_bld_plan),
+        share(t.rmt_bld_post), share(t.rmt_wait), share(t.rmt_scatter),
+        share(t.scat_plan), share(t.scat_submit), share(t.scat_wait), share(other),
         t.xfer > 0 ? (t.bytes / t.xfer) / (1024.0 * 1024 * 1024) : 0.0,
         t.total > 0 ? (t.bytes / t.total) / (1024.0 * 1024 * 1024) : 0.0);
   }
@@ -409,13 +487,15 @@ class ScopedRangedReport {
         "[RangedCall][dbg] op={} obj={} key0='{}' keys={} items={} local={} remote={} bytes={} "
         "total={:.1f}us resolve={:.1f}us classify={:.1f}us build={:.1f}us validate={:.1f}us "
         "commit={:.1f}us route={:.1f}us xfer={:.1f}us(plan={:.1f} submit={:.1f} wait={:.1f}) "
-        "lock={:.1f}us remote_phase={:.1f}us other={:.1f}us",
+        "lock={:.1f}us remote_phase={:.1f}us(rslv={:.1f} bld={:.1f} rdma={:.1f} scat={:.1f}) "
+        "other={:.1f}us",
         op_, phases_.object_size, phases_.key0 != nullptr ? *phases_.key0 : std::string("?"),
         phases_.keys, phases_.items, phases_.local_keys, phases_.remote_keys, phases_.bytes,
         total * 1e6, phases_.resolve * 1e6, phases_.classify * 1e6, phases_.build * 1e6,
         phases_.validate * 1e6, phases_.commit * 1e6, phases_.route * 1e6, phases_.xfer * 1e6,
         phases_.xfer_plan * 1e6, phases_.xfer_submit * 1e6, phases_.xfer_wait * 1e6,
-        phases_.lock * 1e6, phases_.remote * 1e6, other * 1e6);
+        phases_.lock * 1e6, phases_.remote * 1e6, phases_.rmt_resolve * 1e6,
+        phases_.rmt_build * 1e6, phases_.rmt_wait * 1e6, phases_.rmt_scatter * 1e6, other * 1e6);
   }
 
  private:
@@ -1721,8 +1801,15 @@ bool PoolClient::BuildContiguousToRangesItems(const TransferRef& src, uint64_t s
     item.tag = tag;
     item.src = src;
     item.src_offset = src_base + range.object_offset;
-    item.dst = ClassifiedUserBytes(range.user, range.size);
-    item.dst_offset = 0;
+    // By REGION base + offset, not by the range's own address.  A plan is one
+    // (src base, dst base) pair, so describing each range by itself makes every
+    // one of them its own plan -- 8192 plans for one layer-wise load, each
+    // sorted, bucketed and submitted separately.  Sharing the region base
+    // collapses them to one plan per destination buffer, inside which adjacent
+    // segments also coalesce.  This is the same effect standalone_server.cpp
+    // notes for the local path (plan 23.2% -> 1.4% once the region is
+    // declared); the region was declared, but this builder never looked it up.
+    std::tie(item.dst, item.dst_offset) = UserBufferRef(range.user, range.size);
     items->push_back(std::move(item));
   }
   return items->size() > before;
@@ -1739,10 +1826,10 @@ bool PoolClient::CopyContiguousToRanges(const TransferRef& src, uint64_t src_bas
   return transfer_engine_->Transfer(items, /*failed_tags=*/nullptr);
 }
 
-bool PoolClient::BuildRangesToContiguousItems(const std::vector<ObjectRange>& ranges, void* dst,
+bool PoolClient::BuildRangesToContiguousItems(const std::vector<ObjectRange>& ranges,
+                                              const TransferRef& dst, uint64_t dst_base,
                                               size_t object_size, size_t tag,
                                               std::vector<TransferItem>* items) {
-  const TransferRef object_ref = TransferRef::HostBytes(dst, object_size);
   const size_t before = items->size();
   for (const auto& range : ranges) {
     if (range.size == 0 || range.user == nullptr ||
@@ -1753,10 +1840,11 @@ bool PoolClient::BuildRangesToContiguousItems(const std::vector<ObjectRange>& ra
     TransferItem item;
     item.size = range.size;
     item.tag = tag;
-    item.src = ClassifiedUserBytes(range.user, range.size);
-    item.src_offset = 0;
-    item.dst = object_ref;
-    item.dst_offset = range.object_offset;
+    // Region base + offset, for the reason spelled out in
+    // BuildContiguousToRangesItems: this is the assemble side of the same shape.
+    std::tie(item.src, item.src_offset) = UserBufferRef(range.user, range.size);
+    item.dst = dst;
+    item.dst_offset = dst_base + range.object_offset;
     items->push_back(std::move(item));
   }
   return items->size() > before;
@@ -1766,7 +1854,10 @@ bool PoolClient::CopyRangesToContiguous(const std::vector<ObjectRange>& ranges, 
                                         size_t object_size) {
   std::vector<TransferItem> items;
   items.reserve(ranges.size());
-  if (!BuildRangesToContiguousItems(ranges, dst, object_size, /*tag=*/0, &items)) return false;
+  if (!BuildRangesToContiguousItems(ranges, TransferRef::HostBytes(dst, object_size),
+                                    /*dst_base=*/0, object_size, /*tag=*/0, &items)) {
+    return false;
+  }
   return transfer_engine_->Transfer(items, /*failed_tags=*/nullptr);
 }
 
@@ -3533,12 +3624,27 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
         exclusive_arena ? ranged_get_scratch_.AcquireAll() : ranged_get_scratch_.Acquire();
   }
   char* const scratch_base = scratch_lease.base();
+  // The arena described ONCE, by its registered base.  The scatter below keys
+  // its plans on (src base, dst base), so giving each unit its own slice ref
+  // made every unit x destination-region pair a separate plan -- ~8k plans of
+  // one segment each for a layer-wise load, all sorted, bucketed and submitted
+  // individually.  Anchored to the arena base instead, the src half is constant
+  // and the plan count collapses to the number of distinct caller buffers.
+  // Same argument as BuildLocalRangeTransfers makes for the destination half.
+  const auto [arena_ref, arena_base] = UserBufferRef(scratch_base, scratch_size);
 
   // Pack as many units into the arena as fit, fetch that group, then repeat.
   // Units are 64 B apart so two concurrently-filled slices never share a cache
   // line; spans WITHIN a unit are exactly packed, which is what lets a group of
   // adjacent layer ranges coalesce into a single wire segment.
   PhaseTimer remote_timer(dbg ? &dbg->remote : nullptr);
+  RemoteLegSinks leg;
+  if (dbg != nullptr) {
+    leg = {&dbg->rmt_items,     &dbg->rmt_plans,    &dbg->rmt_resolve,
+           &dbg->rmt_build,      &dbg->rmt_bld_items, &dbg->rmt_bld_plan,
+           &dbg->rmt_bld_post,   &dbg->rmt_wait};
+  }
+  ScopedRemoteLeg leg_scope(dbg ? &leg : nullptr);
   size_t pos = 0;
   while (pos < units.size()) {
     std::vector<size_t> scratch_offsets;
@@ -3599,17 +3705,22 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
       if (!fetched[j]) continue;
       const auto& unit = units[pos + j];
       const size_t tag = scatter_tag_to_j.size();
-      if (!BuildContiguousToRangesItems(TransferRef::HostBytes(sub_dsts[j], unit.bytes),
-                                        /*src_base=*/0, unit.bytes, unit.packed, tag,
-                                        &scatter_items)) {
+      if (!BuildContiguousToRangesItems(arena_ref, arena_base + scratch_offsets[j], unit.bytes,
+                                        unit.packed, tag, &scatter_items)) {
         continue;
       }
       scatter_tag_to_j.push_back(j);
     }
     std::unordered_set<size_t> scatter_failed;
     if (!scatter_items.empty()) {
+      PhaseTimer scatter_timer(dbg ? &dbg->rmt_scatter : nullptr);
       std::vector<size_t> failed_tags;
-      transfer_engine_->Transfer(scatter_items, &failed_tags);
+      TransferEngine::StepTiming steps;
+      if (dbg != nullptr) {
+        steps = {&dbg->scat_plan, &dbg->scat_submit, &dbg->scat_wait};
+        dbg->scat_items += scatter_items.size();
+      }
+      transfer_engine_->Transfer(scatter_items, &failed_tags, dbg != nullptr ? &steps : nullptr);
       for (size_t tag : failed_tags) {
         if (tag < scatter_tag_to_j.size()) scatter_failed.insert(scatter_tag_to_j[tag]);
       }
@@ -3798,6 +3909,9 @@ std::vector<bool> PoolClient::BatchPutRanges(const std::vector<std::string>& key
         exclusive_arena ? ranged_put_scratch_.AcquireAll() : ranged_put_scratch_.Acquire();
   }
   char* const scratch_base = scratch_lease.base();
+  // The arena named once, by its registered base -- the read side's reason
+  // (see BatchGetRanges) applies unchanged to the assemble side.
+  const auto [arena_ref, arena_base] = UserBufferRef(scratch_base, scratch_size);
 
   PhaseTimer remote_timer(dbg ? &dbg->remote : nullptr);
   size_t pos = 0;
@@ -3853,11 +3967,10 @@ std::vector<bool> PoolClient::BatchPutRanges(const std::vector<std::string>& key
     assembly_tag_to_j.reserve(count);
     for (size_t j = 0; j < count; ++j) {
       const size_t original = valid[remote[pos + j]];
-      void* slice = scratch_base + scratch_offsets[j];
       const size_t tag = assembly_tag_to_j.size();
       if (!BuildRangesToContiguousItems(
-              MakeWriteRanges(srcs[original], sizes[original], dst_offsets[original]), slice,
-              object_sizes[original], tag, &assembly_items)) {
+              MakeWriteRanges(srcs[original], sizes[original], dst_offsets[original]), arena_ref,
+              arena_base + scratch_offsets[j], object_sizes[original], tag, &assembly_items)) {
         MORI_UMBP_ERROR("[PoolClient] BatchPutRanges: assembly plan failed for key='{}'",
                         keys[original]);
         continue;
@@ -4191,6 +4304,10 @@ std::unique_ptr<PoolClient::RemoteGetInFlight> PoolClient::SubmitRemoteBatchGet(
     return nullptr;
   }
 
+  // Build + filter + plan + post: everything between the resolve reply and the
+  // RDMA being in flight, which is CPU this thread spends before any wire time.
+  PhaseTimer build_timer(t_remote_leg ? t_remote_leg->build : nullptr);
+  PhaseTimer items_timer(t_remote_leg ? t_remote_leg->build_items : nullptr);
   std::vector<TransferItem> transfer_items;
   if (!BuildRemoteGetTransfers(inflight->entries, first.route.node_id, &transfer_items)) {
     MORI_UMBP_WARN(
@@ -4213,7 +4330,13 @@ std::unique_ptr<PoolClient::RemoteGetInFlight> PoolClient::SubmitRemoteBatchGet(
     return nullptr;
   }
 
+  items_timer.Stop();
+  PhaseTimer plan_timer(t_remote_leg ? t_remote_leg->build_plan : nullptr);
   TransferPlanSet planned = transfer_engine_->Plan(active);
+  if (t_remote_leg != nullptr) {
+    if (t_remote_leg->items != nullptr) *t_remote_leg->items += active.size();
+    if (t_remote_leg->plans != nullptr) *t_remote_leg->plans += planned.plans.size();
+  }
   ApplyRejectedTags(inflight->entries, planned.rejected_tags, "RemoteGet");
   if (planned.plans.empty()) {
     for (auto& entry : inflight->entries) {
@@ -4223,6 +4346,8 @@ std::unique_ptr<PoolClient::RemoteGetInFlight> PoolClient::SubmitRemoteBatchGet(
   }
   // POST; do NOT wait.  Everything the post references is owned by the returned
   // handle, including any bytes staged through the engine's bounce pool.
+  plan_timer.Stop();
+  PhaseTimer post_timer(t_remote_leg ? t_remote_leg->build_post : nullptr);
   inflight->handle = transfer_engine_->Submit(std::move(planned.plans));
   if (inflight->handle == nullptr) {
     for (auto& entry : inflight->entries) (*results)[entry.result_index] = false;
@@ -4236,7 +4361,10 @@ void PoolClient::WaitRemoteBatchGet(RemoteGetInFlight& f, std::vector<bool>* res
   if (f.drained) return;
   f.drained = true;
   std::vector<TransferFailure> failures;
-  if (f.handle != nullptr) f.handle->Wait(&failures);
+  {
+    PhaseTimer wait_timer(t_remote_leg ? t_remote_leg->wait : nullptr);
+    if (f.handle != nullptr) f.handle->Wait(&failures);
+  }
   ApplyTransferFailures(f.entries, failures, "RemoteGet");
   // Nothing to copy out here even for a staged read: the engine owns its bounce
   // pool and lands the bytes in the user's dst before its Wait returns.
@@ -4276,7 +4404,11 @@ bool PoolClient::PrepareRemoteGetEntries(const std::vector<BatchGetItem>& items,
       return false;
     }
     resolve_ctx.set_deadline(std::chrono::system_clock::now() + remaining);
-    auto resolve_status = stub->BatchResolveKeys(&resolve_ctx, resolve_req, &resolve_resp);
+    grpc::Status resolve_status;
+    {
+      PhaseTimer resolve_timer(t_remote_leg ? t_remote_leg->resolve : nullptr);
+      resolve_status = stub->BatchResolveKeys(&resolve_ctx, resolve_req, &resolve_resp);
+    }
     if (!resolve_status.ok() ||
         BatchResolveKeyCount(resolve_resp) != static_cast<int>(items.size())) {
       MORI_UMBP_WARN("[PoolClient] BatchResolveKeys failed on {}: {}", items.front().route.node_id,

--- a/src/umbp/distributed/pool_client.cpp
+++ b/src/umbp/distributed/pool_client.cpp
@@ -229,6 +229,24 @@ struct RangedPhases {
   double rmt_bld_plan = 0.0;
   double rmt_bld_post = 0.0;
   double rmt_wait = 0.0;     // the RDMA read itself
+  // Peer bookkeeping before any RPC: GetOrConnectPeer takes peers_mutex_ and
+  // EnsurePeerServiceConnection takes the per-peer conn_mutex, both on EVERY
+  // remote submit.  Two process-wide locks on the hot path is the shape the
+  // scratch arena had (Sec 12.42), so it gets its own timer rather than
+  // sitting in the unaccounted remainder.
+  double rmt_peer = 0.0;
+  // Turning the resolve reply into per-key page vectors.  It is neither the
+  // RPC (`rslv`) nor the transfer build (`bld`), it scales with TOTAL PAGES
+  // rather than keys, and it was the largest thing still sitting in the
+  // unaccounted remainder.
+  double rmt_decode = 0.0;
+  // The three things left inside `remote` that nothing timed.  Together they
+  // were ~20% of a cross-node call and invisible.
+  double rmt_sub = 0.0;    // per-group sub_* vectors + PartitionBatchGetRangeTargets
+  double rmt_items_build = 0.0;  // BuildContiguousToRangesItems for the scatter
+  double rmt_final = 0.0;  // ApplyTransferFailures + FinalizeRemoteGetEntries
+  double rmt_medium = 0.0;   // ServeWholeObjectUnitsFromMedium
+  double rmt_install = 0.0;  // install-from-arena / background prefetch
   double rmt_scatter = 0.0;  // arena -> caller buffers
   // ...and the scatter split the same three ways as `xfer`, because the device
   // gather kernel's own timer says it moves those bytes in an eighth of what
@@ -305,6 +323,9 @@ struct RemoteLegSinks {
   double* build_items = nullptr;
   double* build_plan = nullptr;
   double* build_post = nullptr;
+  double* peer = nullptr;
+  double* decode = nullptr;
+  double* final_ = nullptr;
   double* wait = nullptr;
 };
 thread_local RemoteLegSinks* t_remote_leg = nullptr;
@@ -346,6 +367,13 @@ class RangedStats {
     t.rmt_bld_plan += p.rmt_bld_plan;
     t.rmt_bld_post += p.rmt_bld_post;
     t.rmt_wait += p.rmt_wait;
+    t.rmt_peer += p.rmt_peer;
+    t.rmt_decode += p.rmt_decode;
+    t.rmt_sub += p.rmt_sub;
+    t.rmt_items_build += p.rmt_items_build;
+    t.rmt_final += p.rmt_final;
+    t.rmt_medium += p.rmt_medium;
+    t.rmt_install += p.rmt_install;
     t.rmt_scatter += p.rmt_scatter;
     t.scat_plan += p.scat_plan;
     t.scat_submit += p.scat_submit;
@@ -400,7 +428,8 @@ class RangedStats {
     double total = 0, resolve = 0, classify = 0, build = 0, validate = 0, commit = 0, route = 0,
            xfer = 0, xfer_plan = 0, xfer_submit = 0, xfer_wait = 0, lock = 0, remote = 0,
            rmt_resolve = 0, rmt_build = 0, rmt_bld_items = 0, rmt_bld_plan = 0,
-           rmt_bld_post = 0, rmt_wait = 0, rmt_scatter = 0, scat_plan = 0,
+           rmt_bld_post = 0, rmt_peer = 0, rmt_decode = 0, rmt_sub = 0, rmt_items_build = 0, rmt_final = 0,
+           rmt_medium = 0, rmt_install = 0, rmt_wait = 0, rmt_scatter = 0, scat_plan = 0,
            scat_submit = 0, scat_wait = 0, bytes = 0;
   };
   struct Component {
@@ -420,7 +449,7 @@ class RangedStats {
         "resolve={:.1f}% classify={:.1f}% build={:.1f}% validate={:.1f}% "
         "commit={:.1f}% route={:.1f}% xfer={:.1f}%(plan={:.1f}% submit={:.1f}% wait={:.1f}%) "
         "lock={:.1f}% remote={:.1f}%(rslv={:.1f}% bld={:.1f}%[it={:.1f}% pl={:.1f}% "
-        "po={:.1f}%] rdma={:.1f}% "
+        "po={:.1f}%] peer={:.1f}% dec={:.1f}% sub={:.1f}% ib={:.1f}% fin={:.1f}% med={:.1f}% inst={:.1f}% rdma={:.1f}% "
         "scat={:.1f}%[pl={:.1f}% sub={:.1f}% wt={:.1f}%]) "
         "other={:.1f}% | xfer_only={:.2f}GiB/s end2end={:.2f}GiB/s",
         name, t.calls, t.total, 1e6 * t.total / t.calls, t.bytes / (1024.0 * 1024 * 1024),
@@ -431,7 +460,9 @@ class RangedStats {
         share(t.validate), share(t.commit), share(t.route), share(t.xfer), share(t.xfer_plan),
         share(t.xfer_submit), share(t.xfer_wait), share(t.lock), share(t.remote),
         share(t.rmt_resolve), share(t.rmt_build), share(t.rmt_bld_items), share(t.rmt_bld_plan),
-        share(t.rmt_bld_post), share(t.rmt_wait), share(t.rmt_scatter),
+        share(t.rmt_bld_post), share(t.rmt_peer), share(t.rmt_decode), share(t.rmt_sub),
+        share(t.rmt_items_build), share(t.rmt_final), share(t.rmt_medium), share(t.rmt_install),
+        share(t.rmt_wait), share(t.rmt_scatter),
         share(t.scat_plan), share(t.scat_submit), share(t.scat_wait), share(other),
         t.xfer > 0 ? (t.bytes / t.xfer) / (1024.0 * 1024 * 1024) : 0.0,
         t.total > 0 ? (t.bytes / t.total) / (1024.0 * 1024 * 1024) : 0.0);
@@ -1108,6 +1139,14 @@ bool PoolClient::Init() {
                    scratch_shards, ranged_get_scratch_.ShardBytes(),
                    ranged_put_scratch_.ShardBytes());
   }
+  // The switches that decide how much of a ranged call is even reachable, said
+  // once at startup so a run can assert which configuration it got.  An arm
+  // that silently ran a different one is the failure mode that still produces
+  // plausible numbers, and local_first in particular changes whether the master
+  // is consulted at all -- it is worth 30% of a fully-local call.
+  MORI_UMBP_INFO(
+      "[PoolClient] routing: local_first={} cache_remote_fetches={} ranged_locality_prefetch={}",
+      config_.local_first, config_.cache_remote_fetches, config_.ranged_locality_prefetch);
 
   if (master_client_) master_client_->SetBackendRegistry(&registry_);
 
@@ -1798,6 +1837,15 @@ bool PoolClient::BuildContiguousToRangesItems(const TransferRef& src, uint64_t s
                                               const std::vector<ObjectRange>& ranges, size_t tag,
                                               std::vector<TransferItem>* items) {
   const size_t before = items->size();
+  // ONE shared lock for the whole range list, not one per range -- the same
+  // thing BuildLocalRangeTransfers says about itself.  Describing each range
+  // by its REGION base is what keeps the plan count down (a plan is one
+  // (src base, dst base) pair, so self-described ranges make thousands of
+  // single-segment plans), but doing that lookup through UserBufferRef meant
+  // re-taking registered_mem_mutex_ for every one of ~7k ranges a call, on a
+  // path eight TP ranks walk at once.  Hoisting the lock keeps the plan
+  // collapse and drops the lock traffic to one acquisition.
+  std::shared_lock<std::shared_mutex> reg_lock(registered_mem_mutex_);
   for (const auto& range : ranges) {
     // All-or-nothing per object: a partially appended object would be
     // transferred as a torn read, so roll back to the batch's prior end.
@@ -1811,15 +1859,14 @@ bool PoolClient::BuildContiguousToRangesItems(const TransferRef& src, uint64_t s
     item.tag = tag;
     item.src = src;
     item.src_offset = src_base + range.object_offset;
-    // By REGION base + offset, not by the range's own address.  A plan is one
-    // (src base, dst base) pair, so describing each range by itself makes every
-    // one of them its own plan -- 8192 plans for one layer-wise load, each
-    // sorted, bucketed and submitted separately.  Sharing the region base
-    // collapses them to one plan per destination buffer, inside which adjacent
-    // segments also coalesce.  This is the same effect standalone_server.cpp
-    // notes for the local path (plan 23.2% -> 1.4% once the region is
-    // declared); the region was declared, but this builder never looked it up.
-    std::tie(item.dst, item.dst_offset) = UserBufferRef(range.user, range.size);
+    if (const RegisteredRegion* reg = FindRegisteredRegionLocked(range.user, range.size)) {
+      item.dst = reg->ref;
+      item.dst_offset = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(range.user) -
+                                              reinterpret_cast<uintptr_t>(reg->base));
+    } else {
+      item.dst = ClassifiedUserBytes(range.user, range.size);
+      item.dst_offset = 0;
+    }
     items->push_back(std::move(item));
   }
   return items->size() > before;
@@ -1841,6 +1888,8 @@ bool PoolClient::BuildRangesToContiguousItems(const std::vector<ObjectRange>& ra
                                               size_t object_size, size_t tag,
                                               std::vector<TransferItem>* items) {
   const size_t before = items->size();
+  // One shared lock for the whole list; see BuildContiguousToRangesItems.
+  std::shared_lock<std::shared_mutex> reg_lock(registered_mem_mutex_);
   for (const auto& range : ranges) {
     if (range.size == 0 || range.user == nullptr ||
         IsObjectRangeOverflow(range.object_offset, range.size, object_size)) {
@@ -1852,7 +1901,14 @@ bool PoolClient::BuildRangesToContiguousItems(const std::vector<ObjectRange>& ra
     item.tag = tag;
     // Region base + offset, for the reason spelled out in
     // BuildContiguousToRangesItems: this is the assemble side of the same shape.
-    std::tie(item.src, item.src_offset) = UserBufferRef(range.user, range.size);
+    if (const RegisteredRegion* reg = FindRegisteredRegionLocked(range.user, range.size)) {
+      item.src = reg->ref;
+      item.src_offset = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(range.user) -
+                                              reinterpret_cast<uintptr_t>(reg->base));
+    } else {
+      item.src = ClassifiedUserBytes(range.user, range.size);
+      item.src_offset = 0;
+    }
     item.dst = dst;
     item.dst_offset = dst_base + range.object_offset;
     items->push_back(std::move(item));
@@ -2568,8 +2624,11 @@ std::unique_ptr<PoolClient::RemotePutInFlight> PoolClient::SubmitRemoteBatchPut(
   }
 
   const auto& first = items.front();
+  PhaseTimer peer_timer(t_remote_leg ? t_remote_leg->peer : nullptr);
   auto& peer = GetOrConnectPeer(first.route.node_id, first.route.peer_address);
-  if (!EnsurePeerServiceConnection(peer)) {
+  const bool peer_ready = EnsurePeerServiceConnection(peer);
+  peer_timer.Stop();
+  if (!peer_ready) {
     MORI_UMBP_WARN(
         "[PoolClient] SubmitRemoteBatchPut: peer service connection unavailable, node='{}' "
         "addr='{}' items={}",
@@ -3619,7 +3678,10 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
 
   // Whole-object units skip the arena entirely when a slot can be had; what
   // comes back is everything that still needs one.
-  units = ServeWholeObjectUnitsFromMedium(keys, std::move(units), &unit_ok, &remote_bytes);
+  {
+    PhaseTimer medium_timer(dbg ? &dbg->rmt_medium : nullptr);
+    units = ServeWholeObjectUnitsFromMedium(keys, std::move(units), &unit_ok, &remote_bytes);
+  }
   if (units.empty()) {
     for (const auto& [original, ok] : unit_ok) results[original] = ok;
     return results;
@@ -3650,9 +3712,21 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
   PhaseTimer remote_timer(dbg ? &dbg->remote : nullptr);
   RemoteLegSinks leg;
   if (dbg != nullptr) {
-    leg = {&dbg->rmt_items,      &dbg->rmt_plans,     &dbg->rmt_bounce,
-           &dbg->rmt_resolve,    &dbg->rmt_build,     &dbg->rmt_bld_items,
-           &dbg->rmt_bld_plan,   &dbg->rmt_bld_post,  &dbg->rmt_wait};
+    // Designated, not positional.  A positional list that falls one element
+    // short leaves the TAIL null and every timer past that point silently
+    // reads 0.0% -- which looks exactly like "that phase is free".
+    leg = {.items = &dbg->rmt_items,
+           .plans = &dbg->rmt_plans,
+           .bounce = &dbg->rmt_bounce,
+           .resolve = &dbg->rmt_resolve,
+           .build = &dbg->rmt_build,
+           .build_items = &dbg->rmt_bld_items,
+           .build_plan = &dbg->rmt_bld_plan,
+           .build_post = &dbg->rmt_bld_post,
+           .peer = &dbg->rmt_peer,
+           .decode = &dbg->rmt_decode,
+           .final_ = &dbg->rmt_final,
+           .wait = &dbg->rmt_wait};
   }
   ScopedRemoteLeg leg_scope(dbg ? &leg : nullptr);
   size_t pos = 0;
@@ -3673,6 +3747,7 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
     // always fits and this loop always advances.
     const size_t count = end - pos;
 
+    PhaseTimer sub_timer(dbg ? &dbg->rmt_sub : nullptr);
     std::vector<std::string> sub_keys;
     std::vector<void*> sub_dsts;
     std::vector<size_t> sub_object_sizes;
@@ -3698,6 +3773,7 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
     std::vector<bool> fetched(count, false);
     BatchGetPlan plan = PartitionBatchGetRangeTargets(sub_keys, sub_dsts, sub_object_sizes,
                                                       sub_bytes, sub_spans, sub_routes);
+    sub_timer.Stop();
     // recache_remote=false: a ranged entry never holds the whole object, so
     // there is nothing the generic re-cache could legally install.  Locality is
     // restored by MaybePrefetchWholeObject below instead.
@@ -3707,9 +3783,15 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
     // same reason the put side assembles with one (see BatchPutRanges): a
     // per-unit CopyContiguousToRanges is a blocking Transfer each, and the
     // launch + synchronize dominates the copy at these object sizes.
+    PhaseTimer items_build_timer(dbg ? &dbg->rmt_items_build : nullptr);
     std::vector<TransferItem> scatter_items;
     std::vector<size_t> scatter_tag_to_j;
-    scatter_items.reserve(count);
+    // By RANGES, not by units.  A unit carries every caller range it packed --
+    // ~14 of them here -- so reserving `count` left the vector to grow itself
+    // from 500 to 7000 while copying TransferItems (two TransferRefs apiece).
+    size_t scatter_range_total = 0;
+    for (size_t j = 0; j < count; ++j) scatter_range_total += units[pos + j].packed.size();
+    scatter_items.reserve(scatter_range_total);
     scatter_tag_to_j.reserve(count);
     for (size_t j = 0; j < count; ++j) {
       if (!fetched[j]) continue;
@@ -3721,6 +3803,7 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
       }
       scatter_tag_to_j.push_back(j);
     }
+    items_build_timer.Stop();
     std::unordered_set<size_t> scatter_failed;
     if (!scatter_items.empty()) {
       PhaseTimer scatter_timer(dbg ? &dbg->rmt_scatter : nullptr);
@@ -3759,6 +3842,7 @@ std::vector<bool> PoolClient::BatchGetRanges(const std::vector<std::string>& key
       //   * it is not -> ask the background worker to pull the object.
       // Installing from the arena has to happen now, before the next sub-batch
       // reuses this slice.
+      PhaseTimer install_timer(dbg ? &dbg->rmt_install : nullptr);
       if (unit.holds_whole_object) {
         MaybeInstallCompleteArenaObject(sub_keys[j], sub_dsts[j], unit.object_size);
       } else {
@@ -4295,8 +4379,11 @@ std::unique_ptr<PoolClient::RemoteGetInFlight> PoolClient::SubmitRemoteBatchGet(
   }
 
   const auto& first = items.front();
+  PhaseTimer peer_timer(t_remote_leg ? t_remote_leg->peer : nullptr);
   auto& peer = GetOrConnectPeer(first.route.node_id, first.route.peer_address);
-  if (!EnsurePeerServiceConnection(peer)) {
+  const bool peer_ready = EnsurePeerServiceConnection(peer);
+  peer_timer.Stop();
+  if (!peer_ready) {
     MORI_UMBP_WARN(
         "[PoolClient] SubmitRemoteBatchGet: peer service connection unavailable, node='{}' "
         "addr='{}' items={}",
@@ -4380,6 +4467,7 @@ void PoolClient::WaitRemoteBatchGet(RemoteGetInFlight& f, std::vector<bool>* res
     PhaseTimer wait_timer(t_remote_leg ? t_remote_leg->wait : nullptr);
     if (f.handle != nullptr) f.handle->Wait(&failures);
   }
+  PhaseTimer final_timer(t_remote_leg ? t_remote_leg->final_ : nullptr);
   ApplyTransferFailures(f.entries, failures, "RemoteGet");
   // Nothing to copy out here even for a staged read: the engine owns its bounce
   // pool and lands the bytes in the user's dst before its Wait returns.
@@ -4432,7 +4520,10 @@ bool PoolClient::PrepareRemoteGetEntries(const std::vector<BatchGetItem>& items,
       return false;
     }
 
-    decoded = DecodeBatchResolveResponse(resolve_resp);
+    {
+      PhaseTimer decode_timer(t_remote_leg ? t_remote_leg->decode : nullptr);
+      decoded = DecodeBatchResolveResponse(resolve_resp);
+    }
     if (decoded.keys.size() != items.size()) {
       // Malformed (mismatched parallel arrays); fail the whole batch rather
       // than partially reading it.

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -467,8 +467,12 @@ class PoolClient {
   //
   // `tag` is the caller's key index; a failure comes back through
   // Transfer's failed_tags so one bad object does not fail the batch.
-  bool BuildRangesToContiguousItems(const std::vector<ObjectRange>& ranges, void* dst,
-                                    size_t object_size, size_t tag,
+  // `dst` is a REF plus a base offset rather than a raw pointer so the arena
+  // caller can name the whole registered arena once instead of one ref per
+  // slice; see BuildContiguousToRangesItems for what that costs when it does
+  // not happen.
+  bool BuildRangesToContiguousItems(const std::vector<ObjectRange>& ranges, const TransferRef& dst,
+                                    uint64_t dst_base, size_t object_size, size_t tag,
                                     std::vector<TransferItem>* items);
   bool BuildContiguousToRangesItems(const TransferRef& src, uint64_t src_base, size_t object_size,
                                     const std::vector<ObjectRange>& ranges, size_t tag,

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -674,10 +674,14 @@ class PoolClient {
 
     std::mutex mutex_;
     std::condition_variable cv_;
-    // Queued AcquireAll callers.  Acquire() defers to them, otherwise a steady
-    // stream of single-shard calls can hold at least one shard forever and the
-    // exclusive waiter never runs -- a hang, with no timeout above it.
-    size_t all_waiting_ = 0;
+    // Admission is by ARRIVAL ORDER, which is what makes both directions
+    // starvation-free.  Deferring unconditionally to queued AcquireAll callers
+    // fixes shard-stream-starves-exclusive but creates its mirror; "each
+    // exclusive call finishes" does not mean the exclusive queue ever empties.
+    // A waiter is blocked only by waiters that arrived BEFORE it, and those are
+    // finite in number, so everyone is eventually oldest.
+    uint64_t next_ticket_ = 0;
+    std::deque<uint64_t> exclusive_queue_;
     std::vector<char*> bases_;
     // Not vector<bool>: this is written under the mutex and read by index, and
     // the proxy-reference specialisation buys nothing at these sizes.

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -660,14 +660,13 @@ class PoolClient {
       char* base_ = nullptr;
     };
 
-    // Blocks until a shard is free.  Returns an empty lease if Reset was never
-    // called with a usable buffer, which the caller already rejects upstream.
+    // Blocks until a shard is free, and until no AcquireAll is queued.  Empty
+    // lease if Reset never got a usable buffer; the caller rejects that upstream.
     Lease Acquire();
 
-    // Blocks until EVERY shard is free and leases the whole buffer.  Sharding
-    // must not shrink what a call can serve: a span bigger than one shard was
-    // servable before and still has to be, so such a call takes the arena
-    // exclusively instead of failing.
+    // Blocks until EVERY shard is free, then leases the whole buffer.  Sharding
+    // must not shrink what a call can serve, so a call needing more than a shard
+    // takes the arena exclusively rather than failing.
     Lease AcquireAll();
 
    private:
@@ -675,6 +674,10 @@ class PoolClient {
 
     std::mutex mutex_;
     std::condition_variable cv_;
+    // Queued AcquireAll callers.  Acquire() defers to them, otherwise a steady
+    // stream of single-shard calls can hold at least one shard forever and the
+    // exclusive waiter never runs -- a hang, with no timeout above it.
+    size_t all_waiting_ = 0;
     std::vector<char*> bases_;
     // Not vector<bool>: this is written under the mutex and read by index, and
     // the proxy-reference specialisation buys nothing at these sizes.

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -671,17 +671,24 @@ class PoolClient {
 
    private:
     void Release(size_t index, size_t count);
+    // Drop an admitted waiter from the arrival queue.
+    void Forget(uint64_t ticket);
 
     std::mutex mutex_;
     std::condition_variable cv_;
-    // Admission is by ARRIVAL ORDER, which is what makes both directions
-    // starvation-free.  Deferring unconditionally to queued AcquireAll callers
-    // fixes shard-stream-starves-exclusive but creates its mirror; "each
-    // exclusive call finishes" does not mean the exclusive queue ever empties.
-    // A waiter is blocked only by waiters that arrived BEFORE it, and those are
-    // finite in number, so everyone is eventually oldest.
+    // One arrival-ordered queue of everything not yet admitted, which is what
+    // makes both directions starvation-free:
+    //   * a shard waiter enters once no EXCLUSIVE waiter arrived ahead of it
+    //     and a shard is free -- so consecutive shard waiters still run
+    //     concurrently, which is the whole point of sharding;
+    //   * an exclusive waiter enters once it is the oldest waiter of EITHER
+    //     kind and every shard is free.
+    // Each is then blocked only by arrivals older than itself, and those are
+    // finite, so neither side can be passed over indefinitely.  Recording only
+    // one of the two kinds gets this wrong in whichever direction is left
+    // invisible.  An uncontended Acquire never touches the queue.
     uint64_t next_ticket_ = 0;
-    std::deque<uint64_t> exclusive_queue_;
+    std::deque<std::pair<uint64_t, bool>> waiters_;  // (ticket, is_exclusive)
     std::vector<char*> bases_;
     // Not vector<bool>: this is written under the mutex and read by index, and
     // the proxy-reference specialisation buys nothing at these sizes.

--- a/src/umbp/include/umbp/distributed/pool_client.h
+++ b/src/umbp/include/umbp/distributed/pool_client.h
@@ -601,16 +601,85 @@ class PoolClient {
   // that misses locally would queue another pull of bytes already in flight.
   std::unordered_set<std::string> prefetch_inflight_;
 
-  // Serializes users of each caller-owned ranged scratch arena.  Only the remote
-  // half of a ranged operation takes one — keys served by this node's own medium
-  // never touch an arena and stay fully concurrent.
+  // One caller-owned ranged scratch buffer, split into equal shards that are
+  // leased independently.  Only the remote half of a ranged operation takes a
+  // shard — keys served by this node's own medium never touch an arena and stay
+  // fully concurrent.
   //
-  // Separate GET and PUT arenas each get their own mutex, so a remote ranged GET
-  // and a remote ranged PUT run concurrently instead of serializing on one lock
-  // — the load/offload overlap sglang's direct linker wants.  (Two same-kind ops
-  // still serialize on their arena's mutex.)
-  std::mutex ranged_get_scratch_mutex_;
-  std::mutex ranged_put_scratch_mutex_;
+  // Separate GET and PUT arenas, so a remote ranged GET and a remote ranged PUT
+  // run concurrently — the load/offload overlap sglang's direct linker wants.
+  //
+  // Why shards and not one lock: every rank on a node shares one standalone
+  // server process, hence one PoolClient and one arena.  With a single mutex TP8
+  // made 7 of 8 remote ranged GETs wait, measured at 84–87% of call time (`lock=`
+  // in the UMBP_RANGED_CALL_DEBUG summary).  Shards split the SAME allocation, so
+  // a larger count means smaller shards and more arena rounds per call — raise
+  // UMBP_DISTRIBUTED_RANGED_SCRATCH_BYTES alongside it.
+  class ScratchArena {
+   public:
+    // Non-owning: the buffer belongs to the caller (DistributedClient).  A shard
+    // count of 0 or 1 keeps the original single-arena behaviour.
+    void Reset(void* base, size_t bytes, size_t shards);
+    size_t ShardBytes() const { return shard_bytes_; }
+
+    // Holds a shard for its lifetime and gives it back on destruction, so every
+    // early exit out of an arena loop releases it.
+    class Lease {
+     public:
+      Lease() = default;
+      Lease(ScratchArena* owner, size_t index, size_t count, char* base)
+          : owner_(owner), index_(index), count_(count), base_(base) {}
+      Lease(const Lease&) = delete;
+      Lease& operator=(const Lease&) = delete;
+      Lease(Lease&& other) noexcept { *this = std::move(other); }
+      Lease& operator=(Lease&& other) noexcept {
+        if (this != &other) {
+          if (owner_ != nullptr) owner_->Release(index_, count_);
+          owner_ = other.owner_;
+          index_ = other.index_;
+          count_ = other.count_;
+          base_ = other.base_;
+          other.owner_ = nullptr;
+          other.base_ = nullptr;
+        }
+        return *this;
+      }
+      ~Lease() {
+        if (owner_ != nullptr) owner_->Release(index_, count_);
+      }
+      char* base() const { return base_; }
+
+     private:
+      ScratchArena* owner_ = nullptr;
+      size_t index_ = 0;
+      size_t count_ = 0;
+      char* base_ = nullptr;
+    };
+
+    // Blocks until a shard is free.  Returns an empty lease if Reset was never
+    // called with a usable buffer, which the caller already rejects upstream.
+    Lease Acquire();
+
+    // Blocks until EVERY shard is free and leases the whole buffer.  Sharding
+    // must not shrink what a call can serve: a span bigger than one shard was
+    // servable before and still has to be, so such a call takes the arena
+    // exclusively instead of failing.
+    Lease AcquireAll();
+
+   private:
+    void Release(size_t index, size_t count);
+
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    std::vector<char*> bases_;
+    // Not vector<bool>: this is written under the mutex and read by index, and
+    // the proxy-reference specialisation buys nothing at these sizes.
+    std::vector<uint8_t> busy_;
+    size_t shard_bytes_ = 0;
+  };
+
+  ScratchArena ranged_get_scratch_;
+  ScratchArena ranged_put_scratch_;
   std::condition_variable recache_cv_;
   std::thread recache_worker_;
   bool recache_stop_ = false;

--- a/tests/cpp/umbp/distributed/test_pool_client_ranges.cpp
+++ b/tests/cpp/umbp/distributed/test_pool_client_ranges.cpp
@@ -690,6 +690,47 @@ TEST_F(PoolClientRangesTest, SplitRemotePutThenGetRoundTrips) {
   }
 }
 
+// One object too big for the WHOLE arena must not decide arena sizing for its
+// batch-mates.  Sharding sizes a call against one shard and falls back to the
+// whole arena exclusively for anything that needs more; asking that question as
+// a batch-wide maximum let the oversized key answer it -- it fails the "fits the
+// full arena" half, exclusivity is switched off for everyone, and a batch-mate
+// that needed the full arena is then rejected at shard size although it was
+// servable before sharding existed.
+//
+// Only bites at shards > 1 (UMBP_DISTRIBUTED_RANGED_SCRATCH_SHARDS); at the
+// default of 1 the shard IS the arena and this passes either way.
+TEST_F(PoolClientRangesTest, OversizedObjectDoesNotVetoArenaFallbackForItsBatch) {
+  const size_t arena = caller_put_scratch_.size();
+  const std::string too_big = "veto-too-big";      // > the whole arena: fails either way
+  const std::string needs_all = "veto-needs-all";  // > one shard, <= the arena
+  std::vector<char> big(arena + kPageSize);
+  std::vector<char> fits(arena);
+  for (size_t i = 0; i < big.size(); ++i) big[i] = static_cast<char>((i * 31 + 7) & 0xff);
+  for (size_t i = 0; i < fits.size(); ++i) fits[i] = static_cast<char>((i * 17 + 3) & 0xff);
+
+  std::vector<std::string> keys = {too_big, needs_all};
+  std::vector<size_t> object_sizes = {big.size(), fits.size()};
+  std::vector<std::vector<const void*>> ptrs = {{big.data()}, {fits.data()}};
+  std::vector<std::vector<size_t>> sizes = {{big.size()}, {fits.size()}};
+  std::vector<std::vector<size_t>> offsets = {{0}, {0}};
+
+  auto put = caller_->BatchPutRanges(keys, object_sizes, ptrs, sizes, offsets);
+  EXPECT_FALSE(put[0]) << "an object larger than the whole arena cannot be staged";
+  ASSERT_TRUE(put[1]) << "batch-mate that fits the arena must still be served";
+
+  caller_->Master().FlushHeartbeat();
+  target_->Master().FlushHeartbeat();
+  ASSERT_TRUE(WaitForExists(caller_.get(), needs_all));
+
+  std::vector<char> out(fits.size(), 0);
+  std::vector<std::vector<void*>> get_ptrs = {{out.data()}};
+  std::vector<std::vector<size_t>> get_sizes = {{fits.size()}};
+  std::vector<std::vector<size_t>> get_offsets = {{0}};
+  ASSERT_TRUE(caller_->BatchGetRanges({needs_all}, get_ptrs, get_sizes, get_offsets).front());
+  EXPECT_EQ(std::memcmp(out.data(), fits.data(), fits.size()), 0);
+}
+
 // Concurrent remote gets (GET arena) and remote puts (PUT arena) on disjoint key
 // sets: every payload must survive byte-for-byte, proving the two arenas never
 // overwrite each other under real contention.


### PR DESCRIPTION
Two bottlenecks on `PoolClient`'s distributed **ranged** read path, plus the observability
that found them. Nothing changes outside `PoolClient`, and no change to what bytes move,
in what order, or where they land — only to how the work is serialized and described.

| | mechanism | effect |
|---|---|---|
| 1 `9b6fd04` | one arena mutex serialized every TP rank | `lock` **81.4% → 0.0%** of a call |
| 2 `0461acd` + `4a3b7ff` | scatter built one transfer plan per fragment | plan **21.0% → 1.7%**, 1.61× per call |
| 3 `e8269f9` | the remote leg was an undifferentiated ~88% | where 1 and 2 were found |

Both sit on the path a **first cross-node read** takes. Sharding ships **off**
(`shards = 1`, bit-identical), so merging changes nothing until an operator opts in.

---

## 1. The ranged scratch arena serialized every rank

One host arena for remote ranged GET and one for PUT, each behind a single mutex. In the
standalone-server deployment one process serves every TP rank, so all ranks' remote reads
queue on that mutex — `BatchResolveKeys`, the RDMA read and the scatter all run under it.
`lock=` was **81.4–86.8%** of a cross-node call across two runs, against 7/8 = 87.5% for
8-way serialization, and 0.0% on a local-only arm.

**Change.** The same buffer, cut into N independently-leased shards; a call takes one
shard. A span wider than one shard, or a key whose spans exceed one, falls back to taking
the arena exclusively — so sharding never changes *what* a call can serve.

**Knob.** `UMBP_DISTRIBUTED_RANGED_SCRATCH_SHARDS`, default **1** (bit-identical).

| | shards=1 | shards=8 |
|---|---:|---:|
| mean ranged call | 17,099 µs | **6,363 µs** |
| server end-to-end | 0.75 GiB/s | **2.02 GiB/s** |

`load` (= ttft − device-hit time, 100% hit): 64K 316.8 → **50.4** ms, 128K 605.2 →
**106.6**, 256K 1080.8 → **227.1**. Both arms did identical work (`calls=2593`,
`bytes=33.33GiB`).

## 2. The scatter exploded into one transfer plan per fragment

With the lock gone, the arena → caller scatter was 40–44% of a call — about 9× the RDMA
it was scattering. `UMBP_HBM_COPY_DEBUG=1` said why: `plans=7936 segs=7936`.
`HbmCopyEngine::Plan` coalesces adjacent segments within a `(src.host_ptr, dst.host_ptr)`
group, but **both** endpoints were described by their own address, so every fragment
formed its own group.

**Change (`0461acd`).** Describe both by their registered region base plus an offset —
what `BuildLocalRangeTransfers` already does on the local path. Same bytes, same order,
same destinations.

> ⚠️ Fixing one half alone does nothing (measured: 84.43 → 84.43 ms). The plan count is
> the *product* of the two.

| | before | after |
|---|---:|---:|
| scatter `Plan()` share | 21.0% | **1.7%** |
| cross-node, 8 clients | 90.9 ms/load | **56.6 ms/load** (1.61×) |
| **local-only control, same run** | 29.16 ms | **29.04 ms** (unchanged) |

Three interleaved A/B pairs: 1.61× / 1.54× / 1.61×. The local control is load-bearing —
this touches only the remote scatter, so a patch that also moves the local arm is
measuring something else.

**`4a3b7ff` is the other half of this, not a third item.** Reaching the region base goes
through `UserBufferRef`, which takes `registered_mem_mutex_` — one `shared_lock` for
**every one of ~7k ranges in a call**, on a path every rank walks concurrently.
`BuildLocalRangeTransfers` already takes one shared lock for the whole batch; both ranged
builders now do. Item-build 12.7% → **6.7%**, mean call 8,973 → **7,878 µs**.

> ⚠️ That 1.14× is a **probe** number: on the model the same phase is 3.8% of a call and
> per-call time did not move measurably. It is here because it removes lock traffic the
> first half introduced.

## 3. Observability (`e8269f9`, plus parts of the above)

`UMBP_RANGED_CALL_DEBUG=1`'s summary now splits the remote leg into `resolve` / `build` /
`peer` / `decode` / `sub-batch` / `item-build` / `finalize` / `rdma` / `scatter`, and
reports transfer-item, plan and staged-plan counts. Before this, `remote` was an
undifferentiated ~88%, which is where both of the above were hiding. Sinks are published
through a `thread_local` and are inert when the flag is off.

⚠️ **The summary is cumulative, not steady state.** ~7 s of lazy RDMA connection setup
lands on the first calls; quote the last line and `post` reads 46%, subtract an early
window and it is ~2%.

## Testing

* `test_umbp_pool_client_ranges`: **27/27**, at shards = 1, 2, 4, 8, 16, 64 for the
  sharding commit and at 1 and 8 for the rest.
* Page-level restore end to end on DeepSeek-V4-Flash TP8 across four prompt lengths —
  restored token counts equal both the device-path counts and the expected counts, cold
  control at 0. This is the check that matters for #2: a wrong region base is not a crash,
  it is bytes landing at the wrong offset.
* Achieved hit rate identical across arms in every cell (0.996 / 0.998 / 0.999).

## What these numbers are, and are not

Two standalone servers on **one host**, capacity asymmetry (8 GiB vs 256 GiB) routing
every PUT to the large peer so every GET has to cross, and the three fall-back-to-local
mechanisms (`local_first`, `cache_remote_fetches`, `ranged_locality_prefetch`) switched
off. 8-way TP, DeepSeek-V4-Flash, 100% prefix hit, median of 3.

⚠️ **At their defaults those mechanisms install a remotely-fetched object locally, so a
key crosses the wire once rather than on every load.** These are the cost of a **first
cross-node read**: the right numbers for sizing that path, the wrong ones for predicting a
whole-workload speedup. Re-running the same cells with the defaults on gives the same
absolute phase costs — they change how often a cross-node read happens, not what one costs:

| | `scat` | `rdma` | `rslv` | us/call |
|---|---:|---:|---:|---:|
| mechanisms off | 372 us | 250 us | 516 us | 2584 |
| shipped defaults | 285 us | 312 us | 400 us | 2836 |

(Steady state, differenced between two `SUMMARY` windows — the line is cumulative.)

⚠️ **NIC loopback, not two machines** — absolute figures are not cross-machine numbers.
Every result is a **ratio between two arms measured back to back in the same run**, same
binary wherever a runtime knob could express both arms. The end-to-end noise floor is
~10% run to run on `load`, which is why the in-process phase timers rather than wall clock
are the primary evidence throughout.

## Defaults

Sharding ships off, so this merges without changing behaviour. Happy to flip it if you
would rather have the win by default. The arena-base change has no knob and is always on,
since it only changes how a transfer is described.

