### PR TITLE
new collective development for JAX/XLA

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -109,6 +109,15 @@ add_executable(sdma_self_copy_test sdma/sdma_self_copy_test.cpp)
 target_link_libraries(sdma_self_copy_test mori_collective mori_shmem hip::host
                       hip::device)
 
+# Unified runtime-configurable benchmark for all XLA collectives (reduce_scatter,
+# all_reduce, all_gather, all_to_all, collective_permute). Links the CCO-backed
+# facade (no shmem dependency). Selects collective/dtype/op/mode/logS at runtime.
+add_executable(collectives_benchmark collective/xla/collectives_benchmark.cpp)
+target_link_libraries(collectives_benchmark mori_cco hip::host hip::device)
+# Print per-kernel resource usage (VGPRs / SGPRs / LDS / spills / occupancy) as
+# compiler remarks during the normal build of this TU.
+target_compile_options(collectives_benchmark PRIVATE -Rpass-analysis=kernel-resource-usage)
+
 # Find MPI package (required by intra-node examples)
 find_package(MPI REQUIRED)
 

--- a/examples/collective/timings_vs_RCCL.txt
+++ b/examples/collective/timings_vs_RCCL.txt
@@ -1,0 +1,122 @@
+
+RCCL reduce-scatter:
+I0000 00:00:1781190820.849456  195820 gpu_collectives_test.cc:798] bytes: 4194304 ms: 0.034509 alg_bw: 121.542 GB/s  bus_bw: 91.1567 GB/s
+I0000 00:00:1781190820.850156  195820 gpu_collectives_test.cc:798] bytes: 8388608 ms: 0.0528935 alg_bw: 158.594 GB/s  bus_bw: 118.946 GB/s
+I0000 00:00:1781190820.851236  195820 gpu_collectives_test.cc:798] bytes: 16777216 ms: 0.0879905 alg_bw: 190.671 GB/s  bus_bw: 143.003 GB/s
+I0000 00:00:1781190820.853203  195820 gpu_collectives_test.cc:798] bytes: 33554432 ms: 0.160136 alg_bw: 209.536 GB/s  bus_bw: 157.152 GB/s
+I0000 00:00:1781190820.856929  195820 gpu_collectives_test.cc:798] bytes: 67108864 ms: 0.307485 alg_bw: 218.251 GB/s  bus_bw: 163.688 GB/s
+I0000 00:00:1781190820.864209  195820 gpu_collectives_test.cc:798] bytes: 134217728 ms: 0.605257 alg_bw: 221.753 GB/s  bus_bw: 166.315 GB/s
+
+BUFFERED_LOAD/STORE float32
+
+reduce_scatter_test: 4 PEs, 1048576 bytes/shard (262144 elems), 4194304 bytes input/PE
+reduce_scatter_test: mode=PUSH slices=4 blocks=32 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 0.056 ms (74.995 GB/s) min 0.047 ms (89.469 GB/s) max 0.068 ms
+--------------------
+reduce_scatter_test: 4 PEs, 2097152 bytes/shard (524288 elems), 8388608 bytes input/PE
+reduce_scatter_test: mode=PUSH slices=4 blocks=64 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 0.072 ms (116.781 GB/s) min 0.070 ms (120.181 GB/s) max 0.074 ms
+--------------------
+reduce_scatter_test: 4 PEs, 4194304 bytes/shard (1048576 elems), 16777216 bytes input/PE
+reduce_scatter_test: mode=PUSH slices=4 blocks=128 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 0.103 ms (162.267 GB/s) min 0.090 ms (186.579 GB/s) max 0.109 ms
+--------------------
+reduce_scatter_test: 4 PEs, 8388608 bytes/shard (2097152 elems), 33554432 bytes input/PE
+reduce_scatter_test: mode=PUSH slices=4 blocks=256 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 0.176 ms (190.979 GB/s) min 0.161 ms (207.792 GB/s) max 0.189 ms
+--------------------
+reduce_scatter_test: 4 PEs, 16777216 bytes/shard (4194304 elems), 67108864 bytes input/PE
+reduce_scatter_test: mode=PUSH slices=4 blocks=256 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 0.346 ms (193.691 GB/s) min 0.340 ms (197.215 GB/s) max 0.353 ms
+--------------------
+reduce_scatter_test: 4 PEs, 33554432 bytes/shard (8388608 elems), 134217728 bytes input/PE
+reduce_scatter_test: mode=PUSH slices=4 blocks=256 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 0.624 ms (215.232 GB/s) min 0.618 ms (217.152 GB/s) max 0.626 ms
+--------------------
+reduce_scatter_test: 4 PEs, 67108864 bytes/shard (16777216 elems), 268435456 bytes input/PE
+reduce_scatter_test: mode=PUSH slices=4 blocks=256 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 1.214 ms (221.122 GB/s) min 1.207 ms (222.435 GB/s) max 1.220 ms
+--------------------
+reduce_scatter_test: 4 PEs, 134217728 bytes/shard (33554432 elems), 536870912 bytes input/PE
+reduce_scatter_test: mode=PUSH slices=4 blocks=256 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 2.391 ms (224.498 GB/s) min 2.389 ms (224.729 GB/s) max 2.393 ms
+
+------------------------------------------------------------------------------------------------
+GLOBAL LOAD/STORE float32
+
+reduce_scatter_test: 4 PEs, 1048576 bytes/shard (262144 elems), 4194304 bytes input/PE
+reduce_scatter_test: mode=PUSH slices=4 blocks=32 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 0.053 ms (79.197 GB/s) min 0.041 ms (101.508 GB/s) max 0.059 ms
+--------------------
+reduce_scatter_test: 4 PEs, 2097152 bytes/shard (524288 elems), 8388608 bytes input/PE
+reduce_scatter_test: mode=PUSH slices=4 blocks=64 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 0.069 ms (122.197 GB/s) min 0.067 ms (125.503 GB/s) max 0.072 ms
+--------------------
+reduce_scatter_test: 4 PEs, 4194304 bytes/shard (1048576 elems), 16777216 bytes input/PE
+reduce_scatter_test: mode=PUSH slices=4 blocks=128 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 0.106 ms (158.156 GB/s) min 0.102 ms (163.776 GB/s) max 0.108 ms
+--------------------
+reduce_scatter_test: 4 PEs, 8388608 bytes/shard (2097152 elems), 33554432 bytes input/PE
+reduce_scatter_test: mode=PUSH slices=4 blocks=256 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 0.179 ms (186.961 GB/s) min 0.176 ms (191.127 GB/s) max 0.183 ms
+--------------------
+reduce_scatter_test: 4 PEs, 16777216 bytes/shard (4194304 elems), 67108864 bytes input/PE
+reduce_scatter_test: mode=PUSH slices=4 blocks=256 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 0.325 ms (206.493 GB/s) min 0.321 ms (208.930 GB/s) max 0.328 ms
+--------------------
+reduce_scatter_test: 4 PEs, 33554432 bytes/shard (8388608 elems), 134217728 bytes input/PE
+reduce_scatter_test: mode=PUSH slices=4 blocks=256 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 0.619 ms (216.919 GB/s) min 0.610 ms (219.913 GB/s) max 0.624 ms
+--------------------
+reduce_scatter_test: 4 PEs, 67108864 bytes/shard (16777216 elems), 268435456 bytes input/PE
+reduce_scatter_test: mode=PUSH slices=4 blocks=256 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 1.207 ms (222.483 GB/s) min 1.203 ms (223.093 GB/s) max 1.212 ms
+--------------------
+reduce_scatter_test: 4 PEs, 134217728 bytes/shard (33554432 elems), 536870912 bytes input/PE
+reduce_scatter_test: mode=PUSH slices=4 blocks=256 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 2.377 ms (225.857 GB/s) min 2.364 ms (227.071 GB/s) max 2.383 ms
+
+===========================================================================================================
+
+all_reduce_test: 4 PEs, 1048576 bytes/shard (262144 elems), 4194304 bytes input/PE
+all_reduce_test: mode=PUSH slices=4 blocks=32 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 0.097 ms (43.094 GB/s) min 0.088 ms (47.640 GB/s) max 0.101 ms
+--------------------
+all_reduce_test: 4 PEs, 2097152 bytes/shard (524288 elems), 8388608 bytes input/PE
+all_reduce_test: mode=PUSH slices=4 blocks=64 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 0.118 ms (71.322 GB/s) min 0.116 ms (72.365 GB/s) max 0.120 ms
+--------------------
+all_reduce_test: 4 PEs, 4194304 bytes/shard (1048576 elems), 16777216 bytes input/PE
+all_reduce_test: mode=PUSH slices=4 blocks=128 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 0.191 ms (87.666 GB/s) min 0.187 ms (89.775 GB/s) max 0.196 ms
+--------------------
+all_reduce_test: 4 PEs, 8388608 bytes/shard (2097152 elems), 33554432 bytes input/PE
+all_reduce_test: mode=PUSH slices=4 blocks=256 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 0.340 ms (98.612 GB/s) min 0.338 ms (99.249 GB/s) max 0.344 ms
+--------------------
+all_reduce_test: 4 PEs, 16777216 bytes/shard (4194304 elems), 67108864 bytes input/PE
+all_reduce_test: mode=PUSH slices=4 blocks=256 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 0.631 ms (106.326 GB/s) min 0.625 ms (107.387 GB/s) max 0.636 ms
+--------------------
+all_reduce_test: 4 PEs, 33554432 bytes/shard (8388608 elems), 134217728 bytes input/PE
+all_reduce_test: mode=PUSH slices=4 blocks=256 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 1.207 ms (111.216 GB/s) min 1.202 ms (111.635 GB/s) max 1.209 ms
+--------------------
+all_reduce_test: 4 PEs, 67108864 bytes/shard (16777216 elems), 268435456 bytes input/PE
+all_reduce_test: mode=PUSH slices=4 blocks=256 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 2.367 ms (113.415 GB/s) min 2.365 ms (113.520 GB/s) max 2.373 ms
+--------------------
+all_reduce_test: 4 PEs, 134217728 bytes/shard (33554432 elems), 536870912 bytes input/PE
+all_reduce_test: mode=PUSH slices=4 blocks=256 (SMs=256)
+Rank 0: PASS | 2 warmup + 5 runs | avg 4.681 ms (114.680 GB/s) min 4.678 ms (114.760 GB/s) max 4.687 ms
+--------------------
+
+RCCL all-reduce
+I0000 00:00:1785496353.368317    5679 gpu_collectives_test.cc:801] bytes: 4194304 ms: 0.0582726 alg_bw: 71.9773 GB/s  bus_bw: 107.966 GB/s
+I0000 00:00:1785496353.369468    5679 gpu_collectives_test.cc:801] bytes: 8388608 ms: 0.0903609 alg_bw: 92.8345 GB/s  bus_bw: 139.252 GB/s
+I0000 00:00:1785496353.371351    5679 gpu_collectives_test.cc:801] bytes: 16777216 ms: 0.154869 alg_bw: 108.331 GB/s  bus_bw: 162.497 GB/s
+I0000 00:00:1785496353.374821    5679 gpu_collectives_test.cc:801] bytes: 33554432 ms: 0.286546 alg_bw: 117.1 GB/s  bus_bw: 175.649 GB/s
+I0000 00:00:1785496353.381540    5679 gpu_collectives_test.cc:801] bytes: 67108864 ms: 0.558368 alg_bw: 120.187 GB/s  bus_bw: 180.281 GB/s
+I0000 00:00:1785496353.394518    5679 gpu_collectives_test.cc:801] bytes: 134217728 ms: 1.0801 alg_bw: 124.264 GB/s  bus_bw: 186.395 GB/s
+I0000 00:00:1785496353.420343    5679 gpu_collectives_test.cc:801] bytes: 268435456 ms: 2.15134 alg_bw: 124.776 GB/s  bus_bw: 187.164 GB/s
+I0000 00:00:1785496353.471878    5679 gpu_collectives_test.cc:801] bytes: 536870912 ms: 4.29069 alg_bw: 125.125 GB/s  bus_bw: 187.687 GB/s

--- a/examples/collective/xla/collectives_benchmark.cpp
+++ b/examples/collective/xla/collectives_benchmark.cpp
@@ -1,0 +1,743 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Unified benchmark for the XLA push/pull collectives (single-process,
+// multi-threaded: one thread per GPU/PE, no MPI, no file-based bootstrap).
+// Consolidates the former reduce_scatter/all_reduce/all_gather/all_to_all/
+// collective_permute tests into one runtime-configurable executable so a
+// collective and all of its tuning knobs can be selected without recompiling.
+//
+// Usage:
+//   ./collectives_benchmark --coll <name> --npes <n> --size <num_elems> [opts]
+//
+//   --coll   reduce_scatter|all_reduce|all_gather|all_to_all|collective_permute
+//            (aliases: rs|ar|ag|a2a|cp)                                [required]
+//   --npes   number of GPUs/PEs to run in this process (1..8)          [required]
+//   --size   TOTAL element count. For the sharded collectives the per-rank shard
+//            is size/npes; for collective_permute size is the per-rank buffer.
+//                                                                      [required]
+//   --dtype  f32|bf16|f16|s32|s64   (reduction collectives)            [f32]
+//   --op     sum|prod|min|max       (reduction collectives)            [sum]
+//   --mode   push|pull              (reduce_scatter)                   [push]
+//   --logS   push slice count log2                                     [0]
+//   --warmup <n>                                                       [2]
+//   --iters  <n>                                                       [5]
+//
+// Note: dtype/op beyond f32/sum require a build with FACADE_REDUCE_USE_ALL_TYPES=1.
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+#include <type_traits>
+#include <vector>
+
+#include <hip/hip_bfloat16.h>
+#include <hip/hip_fp16.h>
+
+#define MORI_KERNELS_IMPL
+
+#include "mori/cco/cco.hpp"
+#include "mori/application/utils/check.hpp"
+#include "mori/core/transport/p2p/device_primitives.hpp"
+#include "mori/collective/collectives_facade.hpp"
+
+using namespace mori::cco;
+using namespace mori::collective;
+using RsMode = CollectivesFacade::RsMode;
+
+// Headroom added on top of the facade heap when sizing the CCO comm's per-rank
+// flat-VA slot: CCO carves its own internal windows (the DevComm resource
+// window) out of the same slot, so the heap must not consume all of it.
+static constexpr size_t kVmmSlack = 512ULL * 1024 * 1024;
+// The flat VA is reserved in 4 GiB units (stride4G = perRankSize >> 32).
+static constexpr size_t kVmmGrain = 4ULL * 1024 * 1024 * 1024;
+// Slack on top of the benchmark's own buffers, absorbing the facade's 256B
+// per-allocation alignment and its internal counters.
+static constexpr size_t kHeapSlack = 64ULL * 1024 * 1024;
+
+#define XPUT(fmt, ...) fprintf(stderr, fmt "\n", ##__VA_ARGS__)
+
+static size_t AlignUp(size_t v, size_t a) { return (v + a - 1) & ~(a - 1); }
+
+enum class Collective { kReduceScatter, kAllReduce, kAllGather, kAllToAll, kCollectivePermute };
+
+struct Config {
+  Collective coll{};
+  int npes{0};
+  size_t numElems{0};
+  DataType dt{DataType::F32};
+  ReduceOpKind op{ReduceOpKind::SUM};
+  RsMode mode{RsMode::kPush};
+  int logS{0};
+  int warmup{2};
+  int iters{5};
+  // Derived in main() by SizeHeap(): the facade's symmetric heap window, the
+  // push-path staging carved from it, and the comm's flat-VA slot.
+  size_t heapBytes{0};
+  size_t stagingBytes{0};
+  size_t perRankVmm{0};
+};
+
+// ---------------------------------------------------------------------------
+// Fill / verify kernels (templated on the element type)
+// ---------------------------------------------------------------------------
+// Common per-PE pattern: buf[i] = (myPe + 1) + (i % 8). Small integers, exact in
+// float/bf16 storage. Used by reduce-scatter/all-reduce (input), all-gather (my
+// shard) and collective-permute (send buffer).
+template <class ElemT>
+__global__ void FillCommonKernel(ElemT* buf, size_t numElements, int myPe) {
+  for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < numElements;
+       i += (size_t)gridDim.x * blockDim.x) {
+    buf[i] = static_cast<ElemT>(static_cast<float>((myPe + 1) + static_cast<int>(i % 8)));
+  }
+}
+
+// All-to-all send pattern: slot dest holds (sender=myPe, dest, j) encoded as
+// myPe*100 + dest*10 + j%8 (float-exact for myPe,dest < 10).
+template <class ElemT>
+__global__ void FillA2AKernel(ElemT* send, size_t chunkElems, int npes, int myPe) {
+  const size_t N = static_cast<size_t>(npes) * chunkElems;
+  for (size_t g = blockIdx.x * blockDim.x + threadIdx.x; g < N;
+       g += (size_t)gridDim.x * blockDim.x) {
+    const int dest = static_cast<int>(g / chunkElems);
+    const size_t j = g % chunkElems;
+    send[g] = static_cast<ElemT>(
+        static_cast<float>(myPe * 100 + dest * 10 + static_cast<int>(j % 8)));
+  }
+}
+
+// Reduce-scatter / all-reduce verify: expected[i] is the fold (seed PE 0, then
+// 1..npes-1) of ((p+1) + (globalIdx % 8)) at globalIdx = globalOffset + i, with a
+// round-trip through ElemT after each op (matches packed per-op rounding).
+template <class ElemT>
+__global__ void VerifyReduceKernel(const ElemT* output, size_t count, size_t globalOffset,
+                                   int npes, ReduceOpKind op, uint32_t* errorCount) {
+  for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < count;
+       i += (size_t)gridDim.x * blockDim.x) {
+    const size_t globalIdx = globalOffset + i;
+    float acc = static_cast<float>(1 + static_cast<int>(globalIdx % 8));  // PE 0 seed
+    for (int p = 1; p < npes; p++) {
+      float term = static_cast<float>((p + 1) + static_cast<int>(globalIdx % 8));
+      auto err = detail::DispatchReduceOp<ElemT>(op, [&acc, term](auto reduceOp) {
+        acc = reduceOp(acc, term);
+        return hipSuccess;
+      });
+      if (err != hipSuccess) { atomicAdd(errorCount, 1u); break; }
+      acc = static_cast<float>(static_cast<ElemT>(acc));
+    }
+    if (fabsf(static_cast<float>(output[i]) - acc) > 1e-3f) {
+      atomicAdd(errorCount, 1u);
+    }
+  }
+}
+
+// All-gather verify: output[p*chunk + j] == (p + 1) + (j % 8).
+template <class ElemT>
+__global__ void VerifyGatherKernel(const ElemT* output, size_t chunkElems, int npes,
+                                   uint32_t* errorCount) {
+  const size_t N = static_cast<size_t>(npes) * chunkElems;
+  for (size_t g = blockIdx.x * blockDim.x + threadIdx.x; g < N;
+       g += (size_t)gridDim.x * blockDim.x) {
+    const int p = static_cast<int>(g / chunkElems);
+    const size_t j = g % chunkElems;
+    float expected = static_cast<float>((p + 1) + static_cast<int>(j % 8));
+    if (fabsf(static_cast<float>(output[g]) - expected) > 1e-3f) {
+      atomicAdd(errorCount, 1u);
+    }
+  }
+}
+
+// All-to-all verify: recv[s*chunk + j] == s*100 + myPe*10 + j%8.
+template <class ElemT>
+__global__ void VerifyA2AKernel(const ElemT* recv, size_t chunkElems, int npes, int myPe,
+                                uint32_t* errorCount) {
+  const size_t N = static_cast<size_t>(npes) * chunkElems;
+  for (size_t g = blockIdx.x * blockDim.x + threadIdx.x; g < N;
+       g += (size_t)gridDim.x * blockDim.x) {
+    const int s = static_cast<int>(g / chunkElems);
+    const size_t j = g % chunkElems;
+    float expected = static_cast<float>(s * 100 + myPe * 10 + static_cast<int>(j % 8));
+    if (fabsf(static_cast<float>(recv[g]) - expected) > 1e-3f) {
+      atomicAdd(errorCount, 1u);
+    }
+  }
+}
+
+// Collective-permute (ring) verify: recv[i] == (srcPe + 1) + (i % 8).
+template <class ElemT>
+__global__ void VerifyPermuteKernel(const ElemT* recv, size_t numElements, int srcPe,
+                                    uint32_t* errorCount) {
+  for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < numElements;
+       i += (size_t)gridDim.x * blockDim.x) {
+    float expected = static_cast<float>((srcPe + 1) + static_cast<int>(i % 8));
+    if (fabsf(static_cast<float>(recv[i]) - expected) > 1e-3f) {
+      atomicAdd(errorCount, 1u);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-kernel launcher wrappers: the only place that needs the concrete element
+// type. Each wraps one templated kernel in detail::DispatchReduceType(dt) so the
+// benchmark body can stay type-agnostic and operate on raw void* buffers (the
+// facade Run* methods already dispatch dtype/op internally).
+// ---------------------------------------------------------------------------
+static void LaunchFillCommon(DataType dt, void* buf, size_t n, int myPe, int blocks, int threads,
+                             hipStream_t s) {
+  (void)detail::DispatchReduceType(dt, [&](auto tag) {
+    using ElemT = decltype(tag);
+    FillCommonKernel<ElemT><<<blocks, threads, 0, s>>>(static_cast<ElemT*>(buf), n, myPe);
+    return hipSuccess;
+  });
+}
+
+static void LaunchFillA2A(DataType dt, void* send, size_t chunkElems, int npes, int myPe,
+                          int blocks, int threads, hipStream_t s) {
+  (void)detail::DispatchReduceType(dt, [&](auto tag) {
+    using ElemT = decltype(tag);
+    FillA2AKernel<ElemT><<<blocks, threads, 0, s>>>(static_cast<ElemT*>(send), chunkElems, npes,
+                                                    myPe);
+    return hipSuccess;
+  });
+}
+
+static void LaunchVerifyReduce(DataType dt, const void* output, size_t count, size_t globalOffset,
+                               int npes, ReduceOpKind op, uint32_t* errorCount, int blocks,
+                               int threads, hipStream_t s) {
+  (void)detail::DispatchReduceType(dt, [&](auto tag) {
+    using ElemT = decltype(tag);
+    VerifyReduceKernel<ElemT><<<blocks, threads, 0, s>>>(static_cast<const ElemT*>(output), count,
+                                                         globalOffset, npes, op, errorCount);
+    return hipSuccess;
+  });
+}
+
+static void LaunchVerifyGather(DataType dt, const void* output, size_t chunkElems, int npes,
+                               uint32_t* errorCount, int blocks, int threads, hipStream_t s) {
+  (void)detail::DispatchReduceType(dt, [&](auto tag) {
+    using ElemT = decltype(tag);
+    VerifyGatherKernel<ElemT><<<blocks, threads, 0, s>>>(static_cast<const ElemT*>(output),
+                                                         chunkElems, npes, errorCount);
+    return hipSuccess;
+  });
+}
+
+static void LaunchVerifyA2A(DataType dt, const void* recv, size_t chunkElems, int npes, int myPe,
+                            uint32_t* errorCount, int blocks, int threads, hipStream_t s) {
+  (void)detail::DispatchReduceType(dt, [&](auto tag) {
+    using ElemT = decltype(tag);
+    VerifyA2AKernel<ElemT><<<blocks, threads, 0, s>>>(static_cast<const ElemT*>(recv), chunkElems,
+                                                      npes, myPe, errorCount);
+    return hipSuccess;
+  });
+}
+
+static void LaunchVerifyPermute(DataType dt, const void* recv, size_t numElements, int srcPe,
+                                uint32_t* errorCount, int blocks, int threads, hipStream_t s) {
+  (void)detail::DispatchReduceType(dt, [&](auto tag) {
+    using ElemT = decltype(tag);
+    VerifyPermuteKernel<ElemT><<<blocks, threads, 0, s>>>(static_cast<const ElemT*>(recv),
+                                                          numElements, srcPe, errorCount);
+    return hipSuccess;
+  });
+}
+
+struct ThreadInfo {
+  int rank{-1};
+  int worldSize{-1};
+  int deviceId{-1};
+  int ret_code{-1};
+};
+
+// ---------------------------------------------------------------------------
+// Shared benchmark + verify loop (identical across collectives).
+//   runOnce()      -> issues the collective on `stream`, returns hipError_t
+//   launchVerify(d)-> launches the verify kernel accumulating into d (uint32*)
+// ---------------------------------------------------------------------------
+template <class RunOnceFn, class LaunchVerifyFn>
+static int BenchAndVerify(const Config& cfg, ccoComm* comm, int myPe, hipStream_t stream,
+                          double rxBytes, const char* opLabel, RunOnceFn runOnce,
+                          LaunchVerifyFn launchVerify) {
+  const int nWarmup = cfg.warmup, nRuns = cfg.iters;
+  hipEvent_t tStart, tStop;
+  HIP_RUNTIME_CHECK(hipEventCreate(&tStart));
+  HIP_RUNTIME_CHECK(hipEventCreate(&tStop));
+
+  float totalMs = 0, minMs = 1e9f, maxMs = 0;
+  hipError_t launchErr = hipSuccess;
+  for (int iter = 0; iter < nWarmup + nRuns; iter++) {
+    ccoBarrierAll(comm);
+    HIP_RUNTIME_CHECK(hipEventRecord(tStart, stream));
+    launchErr = runOnce();
+    HIP_RUNTIME_CHECK(hipEventRecord(tStop, stream));
+    HIP_RUNTIME_CHECK(hipStreamSynchronize(stream));
+    if (launchErr != hipSuccess) break;
+
+    float iterMs = 0;
+    HIP_RUNTIME_CHECK(hipEventElapsedTime(&iterMs, tStart, tStop));
+    if (iter >= nWarmup) {
+      totalMs += iterMs;
+      minMs = std::min(minMs, iterMs);
+      maxMs = std::max(maxMs, iterMs);
+    }
+  }
+
+  // After every PE's last kernel has been stream-synced, each PE has observed all
+  // incoming completion signals -> every outgoing DMA has landed. This host
+  // barrier makes that global before teardown.
+  ccoBarrierAll(comm);
+
+  uint32_t hErrors = 0;
+  if (launchErr != hipSuccess) {
+    hErrors = 1;
+    if (myPe == 0) XPUT("Rank %d: FAIL launch=%s", myPe, hipGetErrorString(launchErr));
+  } else {
+    uint32_t* dErrors;
+    HIP_RUNTIME_CHECK(hipMalloc(&dErrors, sizeof(uint32_t)));
+    HIP_RUNTIME_CHECK(hipMemsetAsync(dErrors, 0, sizeof(uint32_t), stream));
+    launchVerify(dErrors);
+    HIP_RUNTIME_CHECK(
+        hipMemcpyAsync(&hErrors, dErrors, sizeof(uint32_t), hipMemcpyDeviceToHost, stream));
+    HIP_RUNTIME_CHECK(hipStreamSynchronize(stream));
+    HIP_RUNTIME_CHECK(hipFree(dErrors));
+
+    float avgMs = totalMs / nRuns;
+    double avgBw = (rxBytes / 1e9) / (avgMs / 1e3);
+    double maxBw = (rxBytes / 1e9) / (minMs / 1e3);
+    if (hErrors != 0 || myPe == 0) {
+      if (opLabel != nullptr) {
+        XPUT("Rank %d: %s op=%s | %d warmup + %d runs | avg %.3f ms (%.3f GB/s) "
+             "min %.3f ms (%.3f GB/s) max %.3f ms\n--------------------",
+             myPe, hErrors == 0 ? "PASS" : "FAIL", opLabel, nWarmup, nRuns, avgMs, avgBw, minMs,
+             maxBw, maxMs);
+      } else {
+        XPUT("Rank %d: %s | %d warmup + %d runs | avg %.3f ms (%.3f GB/s) "
+             "min %.3f ms (%.3f GB/s) max %.3f ms\n--------------------",
+             myPe, hErrors == 0 ? "PASS" : "FAIL", nWarmup, nRuns, avgMs, avgBw, minMs, maxBw,
+             maxMs);
+      }
+    }
+  }
+
+  HIP_RUNTIME_CHECK(hipEventDestroy(tStart));
+  HIP_RUNTIME_CHECK(hipEventDestroy(tStop));
+  return hErrors == 0 ? 0 : 1;
+}
+
+static size_t DtypeSize(DataType dt);  // defined below (CLI helpers)
+
+// ---------------------------------------------------------------------------
+// Per-collective body: allocate symmetric buffers, fill, benchmark + verify.
+// Type-agnostic: buffers are raw bytes (the facade Run* methods dispatch dtype/op
+// internally); only the local fill/verify launches need the element type, which
+// they resolve via the Launch* wrappers above.
+// ---------------------------------------------------------------------------
+static int RunCollective(const Config& cfg, CollectivesFacade* facade, ccoComm* comm, int myPe,
+                         int npes, hipStream_t stream) {
+  constexpr int kThreads = 256;
+  const size_t size = cfg.numElems;
+  const size_t elemSize = DtypeSize(cfg.dt);
+  const DataType dt = cfg.dt;
+  auto allocBytes = [&](size_t nElems) -> void* {
+    return CollectivesFacade::Allocate(nElems * elemSize);
+  };
+  auto blocksFor = [&](size_t n) {
+    return static_cast<int>(std::min<size_t>(1024, (n + kThreads - 1) / kThreads));
+  };
+
+  switch (cfg.coll) {
+    case Collective::kReduceScatter: {
+      const size_t chunk = size / npes, N = size;
+      void* in = allocBytes(N);
+      void* out = allocBytes(chunk);
+      if (in == nullptr || out == nullptr) { XPUT("ERROR: Allocate failed"); return 1; }
+      HIP_RUNTIME_CHECK(hipMemsetAsync(in, 0, N * elemSize, stream));
+      HIP_RUNTIME_CHECK(hipMemsetAsync(out, 0, chunk * elemSize, stream));
+      LaunchFillCommon(dt, in, N, myPe, blocksFor(N), kThreads, stream);
+      HIP_RUNTIME_CHECK(hipStreamSynchronize(stream));
+      ccoBarrierAll(comm);
+      return BenchAndVerify(
+          cfg, comm, myPe, stream, static_cast<double>(N) * elemSize,
+          detail::ReduceOpName(cfg.op),
+          [&] { return facade->RunReduceScatter(in, out, chunk, cfg.dt, cfg.op, stream); },
+          [&](uint32_t* e) {
+            LaunchVerifyReduce(dt, out, chunk, static_cast<size_t>(myPe) * chunk, npes, cfg.op, e,
+                               blocksFor(chunk), kThreads, stream);
+          });
+    }
+    case Collective::kAllReduce: {
+      const size_t N = size;
+      void* in = allocBytes(N);
+      void* out = allocBytes(N);
+      if (in == nullptr || out == nullptr) { XPUT("ERROR: Allocate failed"); return 1; }
+      HIP_RUNTIME_CHECK(hipMemsetAsync(in, 0, N * elemSize, stream));
+      HIP_RUNTIME_CHECK(hipMemsetAsync(out, 0, N * elemSize, stream));
+      LaunchFillCommon(dt, in, N, myPe, blocksFor(N), kThreads, stream);
+      HIP_RUNTIME_CHECK(hipStreamSynchronize(stream));
+      ccoBarrierAll(comm);
+      return BenchAndVerify(
+          cfg, comm, myPe, stream, static_cast<double>(N) * elemSize,
+          detail::ReduceOpName(cfg.op),
+          [&] { return facade->RunAllReduce(in, out, N, cfg.dt, cfg.op, stream); },
+          [&](uint32_t* e) {
+            LaunchVerifyReduce(dt, out, N, 0, npes, cfg.op, e, blocksFor(N), kThreads, stream);
+          });
+    }
+    case Collective::kAllGather: {
+      const size_t chunk = size / npes, N = size;
+      const size_t chunkBytes = chunk * elemSize;
+      void* in = allocBytes(chunk);
+      void* out = allocBytes(N);
+      if (in == nullptr || out == nullptr) { XPUT("ERROR: Allocate failed"); return 1; }
+      HIP_RUNTIME_CHECK(hipMemsetAsync(in, 0, chunkBytes, stream));
+      HIP_RUNTIME_CHECK(hipMemsetAsync(out, 0, N * elemSize, stream));
+      LaunchFillCommon(dt, in, chunk, myPe, blocksFor(chunk), kThreads, stream);
+      HIP_RUNTIME_CHECK(hipStreamSynchronize(stream));
+      ccoBarrierAll(comm);
+      return BenchAndVerify(
+          cfg, comm, myPe, stream, static_cast<double>(npes - 1) * chunkBytes, nullptr,
+          [&] { return facade->RunAllGather(in, out, chunkBytes, stream); },
+          [&](uint32_t* e) {
+            LaunchVerifyGather(dt, out, chunk, npes, e, blocksFor(N), kThreads, stream);
+          });
+    }
+    case Collective::kAllToAll: {
+      const size_t chunk = size / npes, N = size;
+      const size_t chunkBytes = chunk * elemSize;
+      void* send = allocBytes(N);
+      void* recv = allocBytes(N);
+      if (send == nullptr || recv == nullptr) { XPUT("ERROR: Allocate failed"); return 1; }
+      HIP_RUNTIME_CHECK(hipMemsetAsync(send, 0, N * elemSize, stream));
+      HIP_RUNTIME_CHECK(hipMemsetAsync(recv, 0, N * elemSize, stream));
+      LaunchFillA2A(dt, send, chunk, npes, myPe, blocksFor(N), kThreads, stream);
+      HIP_RUNTIME_CHECK(hipStreamSynchronize(stream));
+      ccoBarrierAll(comm);
+      auto* sendBytes = static_cast<uint8_t*>(send);
+      auto* recvBytes = static_cast<uint8_t*>(recv);
+      CollectivesFacade::AddressVector addrs(npes);
+      for (int p = 0; p < npes; p++) {
+        addrs[p] = {sendBytes + static_cast<size_t>(p) * chunkBytes,
+                    recvBytes + static_cast<size_t>(p) * chunkBytes};
+      }
+      return BenchAndVerify(
+          cfg, comm, myPe, stream, static_cast<double>(npes - 1) * chunkBytes, nullptr,
+          [&] { return facade->RunAllToAll(addrs, chunkBytes, stream); },
+          [&](uint32_t* e) {
+            LaunchVerifyA2A(dt, recv, chunk, npes, myPe, e, blocksFor(N), kThreads, stream);
+          });
+    }
+    case Collective::kCollectivePermute: {
+      // Ring: send whole per-rank buffer to (myPe+1)%npes, recv from (myPe-1).
+      const size_t n = size;  // per-rank element count
+      const size_t numBytes = n * elemSize;
+      const int dstPe = (myPe + 1) % npes;
+      const int srcPe = (myPe + npes - 1) % npes;
+      void* send = allocBytes(n);
+      void* recv = allocBytes(n);
+      if (send == nullptr || recv == nullptr) { XPUT("ERROR: Allocate failed"); return 1; }
+      HIP_RUNTIME_CHECK(hipMemsetAsync(send, 0, numBytes, stream));
+      HIP_RUNTIME_CHECK(hipMemsetAsync(recv, 0, numBytes, stream));
+      LaunchFillCommon(dt, send, n, myPe, blocksFor(n), kThreads, stream);
+      HIP_RUNTIME_CHECK(hipStreamSynchronize(stream));
+      ccoBarrierAll(comm);
+      return BenchAndVerify(
+          cfg, comm, myPe, stream, static_cast<double>(numBytes), nullptr,
+          [&] {
+            return facade->RunCollectivePermute(send, recv, numBytes, srcPe, {dstPe}, stream);
+          },
+          [&](uint32_t* e) {
+            LaunchVerifyPermute(dt, recv, n, srcPe, e, blocksFor(n), kThreads, stream);
+          });
+    }
+  }
+  return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Per-rank test body: one thread per GPU. Creates the comm, registers this
+// device's facade, applies the runtime tuning and runs the collective. Teardown
+// is deliberately left to main() -- see the note at the end of the function.
+// ---------------------------------------------------------------------------
+static void RunThreaded(const Config& cfg, const ccoUniqueId& uid, ThreadInfo& info) {
+  HIP_RUNTIME_CHECK(hipSetDevice(info.deviceId));
+
+  ccoComm* comm = nullptr;
+  int status = ccoCommCreate(uid, info.worldSize, info.rank, cfg.perRankVmm, &comm);
+  if (status != 0 || comm == nullptr) {
+    XPUT("ERROR: ccoCommCreate failed (ret=%d)", status);
+    info.ret_code = status != 0 ? status : -1;
+    return;
+  }
+
+  const int myPe = info.rank, npes = info.worldSize;
+  hipStream_t stream;
+  HIP_RUNTIME_CHECK(hipStreamCreate(&stream));
+
+  int rc = 1;
+  if (CollectivesFacade::Create(comm, myPe, npes, cfg.heapBytes, cfg.stagingBytes) != 0) {
+    XPUT("ERROR: Failed to create CollectivesFacade");
+  } else {
+    auto* facade = CollectivesFacade::Get();
+    if (facade == nullptr) {
+      XPUT("ERROR: No CollectivesFacade for device %d", info.deviceId);
+    } else if (facade->SetReduceMode(cfg.mode) && facade->SetPushLogSlices(cfg.logS)) {
+      rc = RunCollective(cfg, facade, comm, myPe, npes, stream);
+    }
+  }
+
+  HIP_RUNTIME_CHECK(hipStreamDestroy(stream));
+  // No ccoCommDestroy here: Create hands `comm` to the per-device facade registry
+  // (the facade dtor destroys it), and TearDown() clears every device at once, so
+  // tearing down from this thread would destroy the sibling threads' comms too.
+  // main() calls TearDown() once after joining.
+  info.ret_code = rc;
+}
+
+// ---------------------------------------------------------------------------
+// CLI parsing
+// ---------------------------------------------------------------------------
+static bool ParseColl(const char* s, Collective& c) {
+  if (!std::strcmp(s, "reduce_scatter") || !std::strcmp(s, "rs")) c = Collective::kReduceScatter;
+  else if (!std::strcmp(s, "all_reduce") || !std::strcmp(s, "ar")) c = Collective::kAllReduce;
+  else if (!std::strcmp(s, "all_gather") || !std::strcmp(s, "ag")) c = Collective::kAllGather;
+  else if (!std::strcmp(s, "all_to_all") || !std::strcmp(s, "a2a")) c = Collective::kAllToAll;
+  else if (!std::strcmp(s, "collective_permute") || !std::strcmp(s, "cp"))
+    c = Collective::kCollectivePermute;
+  else return false;
+  return true;
+}
+static const char* CollName(Collective c) {
+  switch (c) {
+    case Collective::kReduceScatter: return "reduce_scatter";
+    case Collective::kAllReduce: return "all_reduce";
+    case Collective::kAllGather: return "all_gather";
+    case Collective::kAllToAll: return "all_to_all";
+    case Collective::kCollectivePermute: return "collective_permute";
+  }
+  return "?";
+}
+static bool ParseDtype(const char* s, DataType& dt) {
+  if (!std::strcmp(s, "f32")) dt = DataType::F32;
+  else if (!std::strcmp(s, "bf16")) dt = DataType::BF16;
+  else if (!std::strcmp(s, "f16")) dt = DataType::F16;
+  else if (!std::strcmp(s, "s32")) dt = DataType::S32;
+  else if (!std::strcmp(s, "s64")) dt = DataType::S64;
+  else return false;
+  return true;
+}
+static size_t DtypeSize(DataType dt) {
+#define ITEM(name, type) case DataType::name: return sizeof(type);
+  switch (dt) {
+    COLLECTIVE_DATA_TYPE_LIST(ITEM)
+    default:
+      XPUT("ERROR: bad dtype %s", detail::DataTypeName(dt));
+      return 0;
+  }
+#undef ITEM
+}
+
+static bool ParseOp(const char* s, ReduceOpKind& op) {
+  if (!std::strcmp(s, "sum")) op = ReduceOpKind::SUM;
+  else if (!std::strcmp(s, "prod") || !std::strcmp(s, "product")) op = ReduceOpKind::PRODUCT;
+  else if (!std::strcmp(s, "min")) op = ReduceOpKind::MIN;
+  else if (!std::strcmp(s, "max")) op = ReduceOpKind::MAX;
+  else return false;
+  return true;
+}
+static bool ParseMode(const char* s, RsMode& m) {
+  if (!std::strcmp(s, "push")) m = RsMode::kPush;
+  else if (!std::strcmp(s, "pull")) m = RsMode::kPull;
+  else return false;
+  return true;
+}
+
+static void Usage(const char* prog) {
+  XPUT("Usage: %s --coll <name> --npes <n> --size <num_elems> "
+       "[--dtype f32|bf16|f16|s32|s64] [--op sum|prod|min|max] [--mode push|pull] "
+       "[--logS <n>] [--warmup <n>] [--iters <n>]\n"
+       "  coll: reduce_scatter|all_reduce|all_gather|all_to_all|collective_permute "
+       "(rs|ar|ag|a2a|cp)",
+       prog);
+}
+
+// ---------------------------------------------------------------------------
+// Heap / VA sizing. The facade heap is a bump allocator that never reclaims, so
+// it has to cover every buffer RunCollective allocates for the selected
+// collective plus the push path's staging region (which Create carves as the
+// first heap allocation). The comm's flat-VA slot must in turn hold the heap
+// plus CCO's own internal windows.
+// ---------------------------------------------------------------------------
+static void SizeHeap(Config& cfg) {
+  const size_t elemSize = DtypeSize(cfg.dt);
+  const size_t npes = static_cast<size_t>(cfg.npes);
+  const size_t N = cfg.numElems * elemSize;
+  // For collective_permute --size is already the per-rank count, so there is no
+  // sharding and the whole buffer is the unit that moves.
+  const bool isPermute = (cfg.coll == Collective::kCollectivePermute);
+  const size_t chunkBytes = isPermute ? N : N / npes;
+
+  size_t bufBytes = 0;
+  switch (cfg.coll) {
+    case Collective::kReduceScatter: bufBytes = N + chunkBytes; break;
+    case Collective::kAllGather: bufBytes = chunkBytes + N; break;
+    case Collective::kAllReduce:
+    case Collective::kAllToAll:
+    case Collective::kCollectivePermute: bufBytes = 2 * N; break;
+  }
+
+  // Only the reduce paths stage through peer-writable scratch. The others still
+  // get a token region: Create reads 0 as "use heapBytes / 4", so asking for
+  // nothing would silently burn a quarter of the heap.
+  const bool isReduce =
+      (cfg.coll == Collective::kReduceScatter || cfg.coll == Collective::kAllReduce);
+  const size_t staging = isReduce ? (npes - 1) * chunkBytes : 0;
+  cfg.stagingBytes = std::max<size_t>(staging, CollectivesFacade::kDefAlign);
+
+  cfg.heapBytes = AlignUp(bufBytes + cfg.stagingBytes + kHeapSlack, CollectivesFacade::kDefAlign);
+  cfg.perRankVmm = AlignUp(cfg.heapBytes + kVmmSlack, kVmmGrain);
+}
+
+int main(int argc, char* argv[]) {
+  int deviceCount = 0;
+  HIP_RUNTIME_CHECK(hipGetDeviceCount(&deviceCount));
+
+  Config cfg;
+  bool haveColl = false, haveNpes = false, haveSize = false;
+  for (int i = 1; i < argc; i++) {
+    auto need = [&](const char* name) -> const char* {
+      if (i + 1 >= argc) { XPUT("ERROR: %s needs a value", name); std::exit(1); }
+      return argv[++i];
+    };
+    if (!std::strcmp(argv[i], "--coll")) {
+      if (!ParseColl(need("--coll"), cfg.coll)) { XPUT("ERROR: bad --coll"); return 1; }
+      haveColl = true;
+    } else if (!std::strcmp(argv[i], "--npes")) {
+      cfg.npes = std::atoi(need("--npes"));
+      haveNpes = true;
+    } else if (!std::strcmp(argv[i], "--size")) {
+      cfg.numElems = static_cast<size_t>(std::atoll(need("--size")));
+      haveSize = true;
+    } else if (!std::strcmp(argv[i], "--dtype")) {
+      if (!ParseDtype(need("--dtype"), cfg.dt)) { XPUT("ERROR: bad --dtype"); return 1; }
+    } else if (!std::strcmp(argv[i], "--op")) {
+      if (!ParseOp(need("--op"), cfg.op)) { XPUT("ERROR: bad --op"); return 1; }
+    } else if (!std::strcmp(argv[i], "--mode")) {
+      if (!ParseMode(need("--mode"), cfg.mode)) { XPUT("ERROR: bad --mode"); return 1; }
+    } else if (!std::strcmp(argv[i], "--logS")) {
+      cfg.logS = std::atoi(need("--logS"));
+    } else if (!std::strcmp(argv[i], "--warmup")) {
+      cfg.warmup = std::atoi(need("--warmup"));
+    } else if (!std::strcmp(argv[i], "--iters")) {
+      cfg.iters = std::atoi(need("--iters"));
+    } else if (!std::strcmp(argv[i], "-h") || !std::strcmp(argv[i], "--help")) {
+      Usage(argv[0]);
+      return 0;
+    } else {
+      XPUT("ERROR: unknown arg '%s'", argv[i]);
+      Usage(argv[0]);
+      return 1;
+    }
+  }
+
+  if (!haveColl || !haveNpes || !haveSize) {
+    XPUT("ERROR: --coll, --npes and --size are required");
+    Usage(argv[0]);
+    return 1;
+  }
+  if (cfg.npes < 1 || cfg.npes > 8 || cfg.npes > deviceCount) {
+    XPUT("ERROR: --npes must be in 1..%d (SDMA fast path caps at 8)", deviceCount);
+    return 1;
+  }
+
+  // Buffer-size validation (per-collective element size from dtype).
+  const size_t elemSize = DtypeSize(cfg.dt);
+  if (cfg.coll == Collective::kCollectivePermute) {
+    const size_t nb = cfg.numElems * elemSize;
+    if (nb < 16 || (nb % 16) != 0) {
+      XPUT("ERROR: per-rank bytes (size * sizeof) must be a multiple of 16");
+      return 1;
+    }
+  } else {
+    if (cfg.numElems % static_cast<size_t>(cfg.npes) != 0) {
+      XPUT("ERROR: --size must be divisible by --npes");
+      return 1;
+    }
+    const size_t chunkBytes = (cfg.numElems / cfg.npes) * elemSize;
+    if (chunkBytes < 16 || (chunkBytes % 16) != 0) {
+      XPUT("ERROR: per-shard bytes (size/npes * sizeof) must be a multiple of 16");
+      return 1;
+    }
+  }
+
+  // The Launch* wrappers dispatch dtype internally and would silently no-op on a
+  // type this build does not instantiate, so probe once up front (rank-independent)
+  // and emit the actionable diagnostic instead of reporting a bogus verify failure.
+  if (detail::DispatchReduceType(cfg.dt, [](auto) { return hipSuccess; }) == hipErrorNotSupported) {
+    XPUT("ERROR: dtype %s not supported by this build "
+         "(rebuild with FACADE_REDUCE_USE_ALL_TYPES=1)",
+         detail::DataTypeName(cfg.dt));
+    return 1;
+  }
+
+  SizeHeap(cfg);
+
+  ccoUniqueId uid;
+  int ret = ccoGetUniqueId(&uid);
+  if (ret != 0) {
+    XPUT("ERROR: ccoGetUniqueId failed (ret=%d) -- set MORI_SOCKET_IFNAME=<iface>", ret);
+    return 1;
+  }
+
+  XPUT("collectives_benchmark: coll=%s npes=%d size=%zu dtype=%s op=%s mode=%s logS=%d",
+       CollName(cfg.coll), cfg.npes, cfg.numElems, detail::DataTypeName(cfg.dt),
+       detail::ReduceOpName(cfg.op), cfg.mode == RsMode::kPull ? "pull" : "push", cfg.logS);
+  XPUT("collectives_benchmark: heap=%zu staging=%zu perRankVmm=%zu", cfg.heapBytes,
+       cfg.stagingBytes, cfg.perRankVmm);
+
+  std::vector<std::thread> threads;
+  std::vector<ThreadInfo> infos(cfg.npes);
+  threads.reserve(cfg.npes);
+  for (int i = 0; i < cfg.npes; i++) {
+    infos[i].rank = i;
+    infos[i].worldSize = cfg.npes;
+    infos[i].deviceId = i;
+    threads.emplace_back(RunThreaded, std::cref(cfg), std::cref(uid), std::ref(infos[i]));
+  }
+  for (auto& t : threads) t.join();
+
+  // Registry-wide: destroys every device's heap window, SDMA DevComm and ccoComm.
+  // Must happen after the join, and exactly once.
+  CollectivesFacade::TearDown();
+
+  for (const auto& inf : infos) {
+    if (inf.ret_code != 0) {
+      XPUT("ERROR: Rank %d returned non-zero ret_code %d", inf.rank, inf.ret_code);
+      return 1;
+    }
+  }
+  return 0;
+}

--- a/include/mori/collective/collectives_facade.hpp
+++ b/include/mori/collective/collectives_facade.hpp
@@ -1,0 +1,647 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// ===========================================================================
+// collectives_facade.hpp
+//
+// Header-only central facade for the XLA push/pull collectives. It owns the
+// per-device staging buffer (symmetric heap) and the per-slice group counters,
+// and exposes Run* entry points that hoist all the host-side sizing/launch
+// logic (block count, slice count, push/pull mode) that used to be duplicated
+// in each test.
+//
+// CollectivesFacade is a per-device singleton, mirroring ShmemStatesSingleton
+// (one slot per GPU, indexed by hipGetDevice(); the SPMT contract is one thread
+// per GPU so each slot is accessed serially by its owning thread -- no lock).
+//
+// Fully header-only on purpose: all MORI device code (the templated __global__
+// kernels) is compiled only by the translation unit that includes this header,
+// so no MORI .cpp ever needs device compilation (keeps the Bazel/XLA wiring
+// simple -- headers are enough).
+// ===========================================================================
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <hip/hip_runtime.h>
+
+#include "mori/cco/cco.hpp"                  // ccoComm / ccoWindow_t
+#include "mori/application/utils/check.hpp"  // HIP_RUNTIME_CHECK
+#include "mori/core/utils/utils.hpp"         // MORI_UNLIKELY
+
+#include "mori/collective/xla/reduce_ops.hpp"
+#include "mori/collective/xla/collectives_common.hpp"
+
+// The device kernels and the reduction-op templates (SumOp/MaxOp/...) live in
+// these headers. They are needed only by the single TU that compiles the Run*
+// definitions -- the one that defines MORI_KERNELS_IMPL (the XLA device TU
+// mori_kernels.cu.cc, or each standalone MORI example binary). Host TUs see only
+// the declarations below and link against that TU's symbols.
+//
+// Device compilation is restricted to gfx942 / gfx950 / gfx1250. Other offload
+// arches skip the kernel headers (and get Run* stubs below) so fatbin builds
+// do not pull SDMA/b128 device code.
+#if defined(MORI_KERNELS_IMPL)
+#if !defined(__HIP_DEVICE_COMPILE__) || defined(__gfx942__) || defined(__gfx950__) || \
+    defined(__gfx1250__)
+#define MORI_FACADE_COLLECTIVES_ARCH 1
+#include <hip/hip_bfloat16.h>
+#include <hip/hip_fp16.h>
+#include "mori/collective/xla/all_gather_kernels.hpp"
+#include "mori/collective/xla/all_reduce_kernels.hpp"
+#include "mori/collective/xla/all_to_all_kernels.hpp"
+#include "mori/collective/xla/collective_permute_kernels.hpp"
+#include "mori/collective/xla/reduce_scatter_kernels.hpp"
+#endif
+#endif  // MORI_KERNELS_IMPL
+
+#define FACADE_PRINTF(fmt, ...) std::fprintf(stderr, fmt"\n", ##__VA_ARGS__)
+namespace mori {
+namespace collective {
+
+class CollectivesFacade {
+
+  CollectivesFacade() = default;
+ public:
+  // Reduce-scatter algorithm selection (default push). Set at runtime via
+  // SetReduceMode(); the push slice count via SetPushLogSlices().
+  enum class RsMode { kPush, kPull };
+
+  static constexpr size_t kDefAlign = 256;
+
+  // Per-peer all-to-all endpoints: addrs[p] = {chunk sent to peer p, recv slot
+  // for sender p}. The facade copies these into its pinned AddressPair buffer.
+  using AddressVector = std::vector<std::pair<const void*, void*>>;
+
+  CollectivesFacade(const CollectivesFacade&) = delete;
+  CollectivesFacade& operator=(const CollectivesFacade&) = delete;
+
+  static CollectivesFacade *Get() {
+    int dev = 0;
+    HIP_RUNTIME_CHECK(hipGetDevice(&dev));
+    std::lock_guard<std::mutex> lock(GetMutex());
+    if (MORI_UNLIKELY(GetInstances().size() <= static_cast<size_t>(dev))) {
+      return nullptr;
+    }
+    return GetInstances()[dev].get();
+  }
+
+  // CCO-backed factory. Records this device's rank identity (myPe, nPes) and the
+  // comm, and registers ONE big symmetric CCO "heap" window based on CCO comm
+  // size. Need to be called by every rank in parallel.
+  static int Create(mori::cco::ccoComm* comm, int myPe, int nPes, 
+                    size_t heapBytes, size_t maxStagingBytes = 0) {
+    if (comm == nullptr) {
+      FACADE_PRINTF("CollectivesFacade: null comm for CCO create");
+      return -1;
+    }
+    
+    if (maxStagingBytes == 0) {
+      maxStagingBytes = heapBytes / 4;
+    }
+    maxStagingBytes = (maxStagingBytes + kDefAlign - 1) & ~(kDefAlign - 1);
+    if (heapBytes == 0 || maxStagingBytes >= heapBytes) {
+      FACADE_PRINTF("CollectivesFacade: wrong heap size or maxStagingBytes");
+      return -1;
+    }
+
+    int dev = 0;
+    HIP_RUNTIME_CHECK(hipGetDevice(&dev));
+    auto& facade = CreateInternal(dev);
+    facade.myPe_ = myPe;
+    facade.nPes_ = nPes;
+    facade.ccoComm_ = comm;
+
+    {
+      int rc = mori::cco::ccoWindowRegister(comm, heapBytes, &facade.heapWin_,
+                                            reinterpret_cast<void**>(&facade.heapBase_));
+      if (rc != 0 || facade.heapBase_ == nullptr) {
+        FACADE_PRINTF("CollectivesFacade: failed to register heap window (%zu bytes, ret=%d)",
+                      heapBytes, rc);
+        return -1;
+      }
+      facade.heapSize_ = heapBytes;
+      facade.heapUsed_ = 0;
+    }
+
+    hipDeviceProp_t prop;
+    HIP_RUNTIME_CHECK(hipGetDeviceProperties(&prop, dev));
+    facade.MP_count_ = prop.multiProcessorCount;
+
+    // Tuning (reduce-scatter mode / push slice count) defaults to push, logS=0.
+    // Callers override at runtime via SetReduceMode() / SetPushLogSlices().
+    if (facade.nPes_ > kRSPushMaxPeers) {
+      FACADE_PRINTF("CollectivesFacade: npes too large (max %d)", kRSPushMaxPeers);
+      return -1;
+    }
+
+    // Staging is the push path's peer-writable scratch (SDMA scatter target). It
+    // lives in the shared heap window as the facade's FIRST internal allocation,
+    // so its heap offset is identical on every rank (symmetric) since every rank
+    // runs the same Create. User Allocate calls follow it. Pull needs none.
+    if (maxStagingBytes > 0) {
+      facade.staging_ = facade.Allocate(maxStagingBytes);
+      if (facade.staging_ == nullptr) {
+        FACADE_PRINTF("CollectivesFacade: failed to carve staging from heap (%zu bytes)",
+                      maxStagingBytes);
+        return -1;
+      }
+      facade.stagingBytes_ = maxStagingBytes;
+    }
+    HIP_RUNTIME_CHECK(hipMalloc(reinterpret_cast<void**>(&facade.groupCounters_),
+                                kRSPushMaxSlices * sizeof(uint32_t)));
+    HIP_RUNTIME_CHECK(hipMemset(facade.groupCounters_, 0, kRSPushMaxSlices * sizeof(uint32_t)));
+    // Preallocate the pinned (host-visible, device-readable) all-to-all pointer
+    // buffer once, so each RunAllToAll is a plain host fill + launch (no per-call
+    // device alloc/copy). Sized for the max supported peer count.
+    HIP_RUNTIME_CHECK(hipHostMalloc(reinterpret_cast<void**>(&facade.pinnedPairs_),
+                                    kRSPushMaxPeers * sizeof(AddressPair), 
+                                    hipHostMallocDefault));
+
+    // SDMA device comm for the push path (passed by value into the push kernel).
+    mori::cco::ccoDevCommRequirements reqs = CCO_DEV_COMM_REQUIREMENTS_INITIALIZER;
+    reqs.gdaConnectionType = mori::cco::CCO_GDA_CONNECTION_NONE;
+    reqs.gdaContextCount = 0;
+    reqs.gdaSignalCount = 0;
+    reqs.gdaCounterCount = 0;
+    reqs.sdmaQueueCount = 0; // Use the context's SDMA queue count
+    int ret = mori::cco::ccoDevCommCreate(comm, &reqs, &facade.devComm_);
+    if (ret != 0 || facade.devComm_.sdma.sdmaNumQueue == 0) {
+      FACADE_PRINTF("CollectivesFacade: ccoDevCommCreate failed or "
+                    "no SDMA queues allocated.");
+      return -1;
+    }
+    return 0;
+  }
+
+  // Release this device's heap window, counters, and SDMA comm. Staging is a
+  // sub-region of heapWin_, so it needs no separate deregistration.
+  ~CollectivesFacade() {
+    if (heapWin_ != nullptr) mori::cco::ccoWindowDeregister(ccoComm_, heapWin_);
+    if (ccoComm_ != nullptr) {
+      mori::cco::ccoDevCommDestroy(ccoComm_, &devComm_);
+      mori::cco::ccoCommDestroy(ccoComm_);
+    }
+    if (groupCounters_ != nullptr) HIP_RUNTIME_CHECK(hipFree(groupCounters_));
+    if (pinnedPairs_ != nullptr) HIP_RUNTIME_CHECK(hipHostFree(pinnedPairs_));
+  }
+
+  // Tear down all collectives instances (should be safe to be called from 
+  // a single thread).
+  static void TearDown() {
+    std::lock_guard<std::mutex> lock(GetMutex());
+    GetInstances().clear();
+  }
+
+  // Bump-allocate a peer-visible buffer from the static heap window. Returns a
+  // raw local pointer (heapBase_ + offset). Every rank MUST issue the same
+  // Allocate sequence (same sizes/order) so a given buffer sits at the same heap
+  // offset on all ranks (symmetric addressing). Returns nullptr if the heap is
+  // exhausted. `align` defaults to 256B (SDMA/b128 friendly).
+  static void* Allocate(size_t bytes) {
+    auto *facade = Get();
+    if (MORI_UNLIKELY(facade == nullptr)) {
+      FACADE_PRINTF("CollectivesFacade::Allocate: no instance");
+      return nullptr;
+    }
+    const size_t off = (facade->heapUsed_ + (kDefAlign - 1)) & ~(kDefAlign - 1);
+    if (MORI_UNLIKELY(off + bytes > facade->heapSize_)) {
+      FACADE_PRINTF("CollectivesFacade::Allocate: heap exhausted (need %zu at off %zu, size %zu)",
+                    bytes, off, facade->heapSize_);
+      return nullptr;
+    }
+    facade->heapUsed_ = off + bytes;
+    return facade->heapBase_ + off;
+  }
+
+  // Bump allocator: individual frees are a no-op. Use Reset() to reclaim the
+  // whole heap between phases (all outstanding buffers become invalid).
+  static int Deallocate(void* ptr) {
+    auto *facade = Get();
+    if (MORI_UNLIKELY(facade == nullptr)) {
+      FACADE_PRINTF("CollectivesFacade::Deallocate: no instance");
+      return -1;
+    }
+    return 0;
+  }
+
+  static void Reset() {
+    auto *facade = Get();
+    if (MORI_UNLIKELY(facade == nullptr)) {
+      FACADE_PRINTF("CollectivesFacade::Reset: no instance");
+      return;
+    }
+    facade->heapUsed_ = 0;
+  }
+
+  // Runtime tuning "backdoors" (replace the former RS_MODE / RS_LOG_PUSH_SLICES
+  // env vars). Call after Create, before the Run*. Both return false and leave
+  // the current value unchanged on an invalid request.
+  bool SetReduceMode(RsMode mode) {
+    if (mode == RsMode::kPull && nPes_ > 8) {
+      FACADE_PRINTF("CollectivesFacade: pull mode supports npes in [1,8]");
+      return false;
+    }
+    mode_ = mode;
+    return true;
+  }
+  bool SetPushLogSlices(int logS) {
+    if (logS < 0 || (1 << logS) > kRSPushMaxSlices) {
+      FACADE_PRINTF("CollectivesFacade: logS out of range (0..%d)",
+                    kRSPushMaxSlices > 0 ? 31 : 0);
+      return false;
+    }
+    logS_ = logS;
+    return true;
+  }
+  RsMode GetReduceMode() const { return mode_; }
+
+  // Reduce-scatter: input is the full N = npes*chunk vector (symmetric heap),
+  // output is this PE's reduced shard. `count` is the per-rank shard element
+  // count (chunk = count); the full input is npes*count. SetReduceMode() selects
+  // push|pull; SetPushLogSlices() tunes the push slice count. `dt` and `op`
+  // select the element type and reduction; F32/BF16/F16/S32/S64 support all four
+  // ops (SUM/PRODUCT/MIN/MAX).
+  hipError_t RunReduceScatter(const void* input, void* output, size_t count,
+                              DataType dt, ReduceOpKind op, hipStream_t stream);
+
+  // All-reduce: input is the full N = npes*chunk vector (symmetric heap), output
+  // is the full reduced N vector (symmetric heap). numElems is the TOTAL element
+  // count (chunk = numElems / npes). Push-only (npes in [1,8]). `dt`/`op` select
+  // the element type and reduction; F32/BF16/F16/S32/S64 support all four ops.
+  hipError_t RunAllReduce(const void* input, void* output, size_t numElems,
+                          DataType dt, ReduceOpKind op, hipStream_t stream);
+
+  // All-gather: input is this PE's single shard (symmetric heap), output is the
+  // gathered npes*chunk buffer (symmetric heap). Pure byte movement (element type
+  // irrelevant); `chunkBytes` is this PE's per-rank shard size in bytes (the
+  // gathered output is npes*chunkBytes).
+  hipError_t RunAllGather(const void* input, void* output, size_t chunkBytes, hipStream_t stream);
+
+  // All-to-all: addrs[p] = {chunk sent to peer p, recv slot for sender p}, one
+  // pair per peer (addrs.size() == npes). Pure byte movement, so chunkBytes is
+  // the per-peer chunk byte count.
+  hipError_t RunAllToAll(const AddressVector& addrs, size_t chunkBytes, hipStream_t stream);
+
+  // Device-wide barrier across all PEs on the given stream.
+  hipError_t RunBarrier(hipStream_t stream);
+
+  // Point-to-point send: push numBytes from sendBuf to PE `peer`. Dummy no-op.
+  hipError_t RunSend(const void* sendBuf, size_t numBytes, int peer, hipStream_t stream);
+
+  // Point-to-point recv: receive numBytes into recvBuf from PE `peer`. Dummy no-op.
+  hipError_t RunRecv(void* recvBuf, size_t numBytes, int peer, hipStream_t stream);
+
+  // Collective-permute: send my buffer to each target PE, recv from srcPe
+  // (srcPe < 0 means no source). v1: dstPes.size() == 1, SDMA push.
+  hipError_t RunCollectivePermute(const void* sendBuf, void* recvBuf, size_t numBytes,
+                                  int srcPe, const std::vector<int>& dstPes,
+                                  hipStream_t stream);
+
+  // Drain outstanding operations on `stream`. Dummy no-op.
+  hipError_t RunQuiet(hipStream_t stream);
+
+  // Memory fence across the device. Dummy no-op.
+  hipError_t RunFence();
+
+ private:
+
+  using FacadeMap = std::deque< std::unique_ptr<CollectivesFacade> >;
+  static std::mutex& GetMutex() {
+    static std::mutex mutex;
+    return mutex;
+  }
+
+  static FacadeMap& GetInstances() {
+    static FacadeMap instances(8);
+    return instances;
+  }
+
+  static CollectivesFacade& CreateInternal(uint32_t ordinal) {
+    std::lock_guard<std::mutex> lock(GetMutex());
+    if (ordinal >= GetInstances().size()) {
+      GetInstances().resize(ordinal + 1);
+    }
+    auto& inst = GetInstances()[ordinal];
+    if (inst == nullptr) {
+      inst = std::unique_ptr<CollectivesFacade>(new CollectivesFacade());
+    }
+    return *inst;
+  }
+
+ private:
+  // Real reduce implementations, keyed by element type T and reduction Op. Defined
+  // only in the MORI_KERNELS_IMPL TU; the enum Run* entry points dispatch to them.
+  template <class T, class Op>
+  hipError_t reduceScatterImpl(const void* input, void* output, size_t count, hipStream_t stream);
+  template <class T, class Op>
+  hipError_t allReduceImpl(const void* input, void* output, size_t numElems, hipStream_t stream);
+
+  void* staging_{nullptr};
+  size_t stagingBytes_{0};
+  uint32_t* groupCounters_{nullptr};
+  AddressPair* pinnedPairs_{nullptr};  // host-pinned, device-readable
+  mori::cco::ccoComm* ccoComm_{nullptr};
+  // Static heap: one symmetric window backing all user buffers (bump allocator).
+  mori::cco::ccoWindow_t heapWin_{nullptr};
+  uint8_t* heapBase_{nullptr};
+  size_t heapSize_{0};
+  size_t heapUsed_{0};
+  // CCO-backed push: staging_ (above) is a sub-region of heapWin_ (peer-writable
+  // SDMA target); devComm_ is the SDMA device comm.
+  mori::cco::ccoDevComm devComm_{};
+  int myPe_{0};
+  int nPes_{0};
+  int logS_{0};
+  int MP_count_{0};
+  RsMode mode_{RsMode::kPush};
+};
+
+// ---------------------------------------------------------------------------
+// Run* definitions. These contain kernel-launch syntax and pull in the
+// __global__ kernel headers, so they are compiled only by the single TU that
+// defines MORI_KERNELS_IMPL (a HIP compiler). Host TUs see only the declarations
+// above and link against that TU's non-template symbols.
+//
+// Host compile and gfx942/gfx950/gfx1250 device compile get the real launches.
+// Other device compiles of this TU never include the kernel headers and stub
+// every Run* to hipErrorNotSupported.
+// ---------------------------------------------------------------------------
+#if defined(MORI_KERNELS_IMPL) && defined(MORI_FACADE_COLLECTIVES_ARCH)
+
+namespace detail {
+// Device-wide barrier: dummy no-op. The old shmem device barrier
+// (ShmemBarrierAllThread) assumed shmem init, which is incompatible with the
+// CCO-backed facade. Callers currently barrier host-side via ccoBarrierAll; a
+// device-side CCO barrier can be wired here later if RunBarrier is needed.
+__global__ void BarrierKernel() {}
+
+}  // namespace detail
+
+template <class T, class Op>
+hipError_t CollectivesFacade::reduceScatterImpl(const void* input_v, void* output_v, size_t count,
+                                                hipStream_t stream) {
+  const T* input = static_cast<const T*>(input_v);
+  T* output = static_cast<T*>(output_v);
+  using ComputeT = typename detail::ReduceComputeType<T>::type;
+  using ReduceOp = Op;
+
+  const size_t chunkElems = count;
+  const size_t chunkBytes = chunkElems * sizeof(T);
+  // Staging is only needed by the push path; pull reads peers directly (no staging).
+  if (mode_ != RsMode::kPull && (nPes_ - 1) * chunkBytes > stagingBytes_) {
+    FACADE_PRINTF("ReduceScatter: staging too small; increase maxStagingBytes");
+    return hipErrorInvalidConfiguration;
+  }
+
+  // The reduce runs on a compute type derived from T (float reduces as float,
+  // bf16 reduces as a packed pair). Data buffers stay physically T; counts
+  // passed to the kernels are in packs (kPack = sizeof(ComputeT)/sizeof(T)).
+  constexpr size_t kPack = sizeof(ComputeT) / sizeof(T);
+  const size_t chunkElemsC = chunkElems / kPack;
+  constexpr int NumPushVecs = 8, NumPullVecs = 8;
+  constexpr int VecSize = VecBytes / sizeof(ComputeT);
+  constexpr int kThreads = 256;
+  size_t totalVecs = chunkElemsC / (VecSize * NumPushVecs);
+  int wantBlocks = static_cast<int>(std::max<size_t>(1, (totalVecs + kThreads - 1) / kThreads));
+  int blocks = std::min(wantBlocks, std::max(1, MP_count_));
+
+  int logS = logS_;
+  const size_t maxSlicesByData = std::max<size_t>(1, chunkElemsC / VecSize);
+  while (logS > 0 && (1ULL << logS) > maxSlicesByData) logS--;
+
+  if (mode_ == RsMode::kPull) {
+    // The kernel resolves peer pe's copy of `input` device-side by the same
+    // flat-VA rank delta the push path uses: input + (pe - myPe)*stride4G<<32,
+    // with stride4G read from heapWin_. NPES is a compile-time template arg;
+    // dispatch on the real npes.
+    auto launch = [&](auto NPES_c) {
+      ReduceScatterPullKernel<NumPullVecs, decltype(NPES_c)::value, ReduceOp>
+          <<<blocks, kThreads, 0, stream>>>(myPe_, heapWin_,
+                                  reinterpret_cast<const ComputeT*>(input),
+                                  reinterpret_cast<ComputeT*>(output), chunkElemsC);
+    };
+    switch (nPes_) {
+      case 2: launch(std::integral_constant<int, 2>{}); break;
+      case 4: launch(std::integral_constant<int, 4>{}); break;
+      default: launch(std::integral_constant<int, 8>{}); break;
+    }
+  } else {
+    // Every block loops over all S slices (no block-to-slice mapping), so the
+    // grid needs no rounding to a multiple of S.
+    ReduceScatterPushKernel<NumPushVecs, ReduceOp><<<blocks, kThreads, 0, stream>>>(
+        myPe_, nPes_, logS, reinterpret_cast<ComputeT*>(output),
+        groupCounters_, chunkElemsC, devComm_, heapWin_,
+        reinterpret_cast<const ComputeT*>(input),
+        reinterpret_cast<ComputeT*>(staging_));
+  }
+  return hipGetLastError();
+}
+
+// Enum entry point: dispatch (dt, op) to reduceScatterImpl for F32/BF16/F16/S32/S64
+// and all four reduction ops.
+hipError_t CollectivesFacade::RunReduceScatter(const void* input, void* output, size_t count,
+                                               DataType dt, ReduceOpKind op, hipStream_t stream) {
+  auto go = [=](auto typeTag) {
+    using T = decltype(typeTag);
+    return detail::DispatchReduceOp<T>(op, [=](auto reduceOp) {
+      using Op = decltype(reduceOp);
+      return this->reduceScatterImpl<T, Op>(input, output, count, stream);
+    });
+  };
+  return detail::DispatchReduceType(dt, go);
+}
+
+template <class T, class Op>
+hipError_t CollectivesFacade::allReduceImpl(const void* input_v, void* output_v, size_t numElems,
+                                            hipStream_t stream) {
+  const T* input = static_cast<const T*>(input_v);
+  T* output = static_cast<T*>(output_v);
+  using ComputeT = typename detail::ReduceComputeType<T>::type;
+  using ReduceOp = Op;
+
+  const size_t chunkElems = numElems / static_cast<size_t>(nPes_);
+  const size_t chunkBytes = chunkElems * sizeof(T);
+  if ((nPes_ - 1) * chunkBytes > stagingBytes_) {
+    FACADE_PRINTF("AllReduce: staging too small; increase maxStagingBytes");
+    return hipErrorInvalidConfiguration;
+  }
+
+  constexpr size_t kPack = sizeof(ComputeT) / sizeof(T);
+  const size_t chunkElemsC = chunkElems / kPack;
+  constexpr int NumPushVecs = 8;
+  constexpr int VecSize = VecBytes / sizeof(ComputeT);
+  constexpr int kThreads = 256;
+  size_t totalVecs = chunkElemsC / (VecSize * NumPushVecs);
+  int wantBlocks = static_cast<int>(std::max<size_t>(1, (totalVecs + kThreads - 1) / kThreads));
+  // Cap the grid to the SM count so all blocks are co-resident (required for the
+  // multi-producer broadcast submitPacket ordering).
+  int blocks = std::min(wantBlocks, std::max(1, MP_count_));
+
+  int logS = logS_;
+  const size_t maxSlicesByData = std::max<size_t>(1, chunkElemsC / VecSize);
+  while (logS > 0 && (1ULL << logS) > maxSlicesByData) logS--;
+
+  // Sliced push reduce-scatter + pipelined per-slice broadcast, all in one kernel.
+  // Every block loops over all S slices (no block-to-slice mapping), so the grid
+  // needs no rounding to a multiple of S.
+  // input/output/staging all live in the static heap (heapWin_); the kernel
+  // derives each intra-heap offset from the raw pointer via ccoGetLocalPtr.
+  AllReducePushKernel<NumPushVecs, ReduceOp><<<blocks, kThreads, 0, stream>>>(
+        myPe_, nPes_, logS, reinterpret_cast<const ComputeT*>(input),
+        reinterpret_cast<ComputeT*>(output), groupCounters_, chunkElemsC, devComm_,
+        reinterpret_cast<ComputeT*>(staging_), heapWin_);
+  return hipGetLastError();
+}
+
+// Enum entry point: dispatch (dt, op) to allReduceImpl for F32/BF16/F16/S32/S64
+// and all four reduction ops.
+hipError_t CollectivesFacade::RunAllReduce(const void* input, void* output, size_t numElems,
+                                           DataType dt, ReduceOpKind op, hipStream_t stream) {
+  auto go = [&](auto typeTag) {
+    using T = decltype(typeTag);
+    return detail::DispatchReduceOp<T>(op, [&](auto reduceOp) {
+      using Op = decltype(reduceOp);
+      return this->allReduceImpl<T, Op>(input, output, numElems, stream);
+    });
+  };
+  return detail::DispatchReduceType(dt, go);
+}
+
+hipError_t CollectivesFacade::RunAllGather(const void* input, void* output, size_t chunkBytes,
+                                           hipStream_t stream) {
+  constexpr int kThreads = 256;
+  // Single block: SDMA pushes my shard to every peer's output[myPe] slot (+ self).
+  AllGatherPushKernel<<<1, kThreads, 0, stream>>>(myPe_, nPes_, input, output, chunkBytes,
+                                                  devComm_, heapWin_);
+  return hipGetLastError();
+}
+
+hipError_t CollectivesFacade::RunAllToAll(const AddressVector& addrs, size_t chunkBytes,
+                                          hipStream_t stream) {
+  assert(static_cast<int>(addrs.size()) == nPes_ && "addrs size must equal npes");
+  // Fill the preallocated pinned (host-visible, device-readable) AddressPair
+  // buffer with a plain host write, then launch -- no per-call device copy.
+  for (int p = 0; p < nPes_; ++p) {
+    pinnedPairs_[p].source = addrs[p].first;
+    pinnedPairs_[p].dest = addrs[p].second;
+  }
+  constexpr int kThreads = 256;
+  // Single block: SDMA pushes each send slot p to peer p's recv slot (+ self).
+  AllToAllPushKernel<<<1, kThreads, 0, stream>>>(myPe_, nPes_, pinnedPairs_, chunkBytes, devComm_,
+                                                 heapWin_);
+  return hipGetLastError();
+}
+
+hipError_t CollectivesFacade::RunBarrier(hipStream_t stream) {
+  detail::BarrierKernel<<<1, 1, 0, stream>>>();
+  return hipGetLastError();
+}
+
+hipError_t CollectivesFacade::RunSend(const void* /*sendBuf*/, size_t /*numBytes*/,
+                                      int /*peer*/, hipStream_t /*stream*/) {
+  // TODO: dummy placeholder; real P2P send push kernel goes here.
+  return hipErrorNotSupported;
+}
+
+hipError_t CollectivesFacade::RunRecv(void* /*recvBuf*/, size_t /*numBytes*/,
+                                      int /*peer*/, hipStream_t /*stream*/) {
+  // TODO: dummy placeholder; real P2P recv kernel goes here.
+  return hipErrorNotSupported;
+}
+
+hipError_t CollectivesFacade::RunCollectivePermute(const void* sendBuf, void* recvBuf,
+                                                   size_t numBytes, int srcPe,
+                                                   const std::vector<int>& dstPes,
+                                                   hipStream_t stream) {
+  if (dstPes.size() != 1) {
+    FACADE_PRINTF("CollectivePermute: only dstPes.size()==1 is implemented");
+    return hipErrorNotSupported;
+  }
+  const int dstPe = dstPes[0];
+  if (dstPe < 0 || dstPe >= nPes_ || srcPe < -1 || srcPe >= nPes_) {
+    FACADE_PRINTF("CollectivePermute: dstPe=%d srcPe=%d out of range (nPes=%d)", dstPe, srcPe,
+                  nPes_);
+    return hipErrorInvalidValue;
+  }
+  constexpr int kThreads = 256;
+  CollectivePermutePushKernel<<<1, kThreads, 0, stream>>>(nPes_, dstPe, srcPe, sendBuf, recvBuf,
+                                                          numBytes, devComm_, heapWin_);
+  return hipGetLastError();
+}
+
+hipError_t CollectivesFacade::RunQuiet(hipStream_t /*stream*/) {
+  // TODO: dummy placeholder; real quiet/drain goes here.
+  return hipSuccess;
+}
+
+hipError_t CollectivesFacade::RunFence() {
+  // TODO: dummy placeholder; real device fence goes here.
+  return hipSuccess;
+}
+
+#elif defined(MORI_KERNELS_IMPL)
+hipError_t CollectivesFacade::RunReduceScatter(const void*, void*, size_t, DataType, ReduceOpKind,
+                                               hipStream_t) {
+  return hipErrorNotSupported;
+}
+hipError_t CollectivesFacade::RunAllReduce(const void*, void*, size_t, DataType, ReduceOpKind,
+                                           hipStream_t) {
+  return hipErrorNotSupported;
+}
+hipError_t CollectivesFacade::RunAllGather(const void*, void*, size_t, hipStream_t) {
+  return hipErrorNotSupported;
+}
+hipError_t CollectivesFacade::RunAllToAll(const AddressVector&, size_t, hipStream_t) {
+  return hipErrorNotSupported;
+}
+hipError_t CollectivesFacade::RunBarrier(hipStream_t) { return hipErrorNotSupported; }
+hipError_t CollectivesFacade::RunSend(const void*, size_t, int, hipStream_t) {
+  return hipErrorNotSupported;
+}
+hipError_t CollectivesFacade::RunRecv(void*, size_t, int, hipStream_t) {
+  return hipErrorNotSupported;
+}
+hipError_t CollectivesFacade::RunCollectivePermute(const void*, void*, size_t, int,
+                                                   const std::vector<int>&, hipStream_t) {
+  return hipErrorNotSupported;
+}
+hipError_t CollectivesFacade::RunQuiet(hipStream_t) { return hipErrorNotSupported; }
+hipError_t CollectivesFacade::RunFence() { return hipErrorNotSupported; }
+
+#endif  // MORI_KERNELS_IMPL
+
+}  // namespace collective
+}  // namespace mori
+
+#undef MORI_FACADE_COLLECTIVES_ARCH

--- a/include/mori/collective/xla/all_gather_kernels.hpp
+++ b/include/mori/collective/xla/all_gather_kernels.hpp
@@ -1,0 +1,104 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// ===========================================================================
+// all_gather_kernels.hpp
+//
+// SDMA-based "push" all-gather. All-gather is the mirror of reduce-scatter's
+// scatter step with NO reduction: each PE pushes its single local shard into
+// every peer's output[myPe] slot -- including itself (SDMA self-copy). Since
+// there is no GPU compute to overlap, this uses a single block and logS=0
+// (S=1, one slice, one completion flag), reusing the generalized fused SDMA
+// scatter (StartSdmaScatter, byte-based) from collectives_common.hpp.
+// ===========================================================================
+#pragma once
+
+#include <cstdint>
+#include "mori/collective/xla/collectives_common.hpp"
+
+namespace mori {
+namespace collective {
+
+// Single-block, compute-free all-gather.
+//   input  : raw symmetric-heap pointer, my shard of chunkBytes bytes
+//   output : raw symmetric-heap pointer, npes*chunkBytes bytes (all shards)
+//
+// Phase 1: SDMA scatters my shard into every peer's output[myPe] slot (self
+// included), each copy trailed by an ADD64 of 1 into the receiver's
+// signalPtrs[0] counter. Phase 2: thread 0 waits until the counter reaches npes
+// (self-copy included), then an acquire fence makes the peer SDMA writes to
+// output visible. No Phase 3 -- output is already fully written by SDMA. Finally
+// thread 0 resets the counter for the next launch.
+//
+// blockDim.x must be >= npes for block 0's fast-path packet build; launch with
+// npes <= 8 (SDMA fast path) and a comfortable blockDim (256).
+__global__ void AllGatherPushKernel(int myPe, int npes, const void* __restrict__ input,
+                                    void* __restrict__ output, size_t chunkBytes,
+                                    mori::cco::ccoDevComm devComm,
+                                    mori::cco::ccoWindow_t heapWin) {
+  // Single block: push my shard to every peer's output[myPe] slot (+ self). The
+  // destination slot is myPe for every peer, so the byte offset is constant; the
+  // source is our single shard (same for all peers). The output buffer's own
+  // offset within the heap window is added so the dst resolves correctly even
+  // when output is not at heap offset 0.
+  const size_t heapBase = reinterpret_cast<uintptr_t>(mori::cco::ccoGetLocalPtr(heapWin));
+  const size_t outOff = reinterpret_cast<uintptr_t>(output) - heapBase;
+  const size_t dstOff = outOff + static_cast<size_t>(myPe) * chunkBytes;
+  StartSdmaScatter(
+      devComm.sdma, npes, /*logS=*/0, chunkBytes,
+      [](int) { return true; },
+      [=](int) -> const uint8_t* { return reinterpret_cast<const uint8_t*>(input); },
+      [=](int peer) -> uint8_t* {
+        return reinterpret_cast<uint8_t*>(mori::cco::ccoGetLsaPeerPtr(heapWin, peer, dstOff));
+      });
+
+  uint64_t* __restrict__ signalBuf = devComm.sdma.signalBuf;
+
+  // === Phase 2: wait until the counter reaches all npes senders. ===============
+  if (threadIdx.x == 0) {
+    const uint32_t want = static_cast<uint32_t>(npes);  // self-copy included
+    // 32-bit ADD into the low dword -> poll 32 bits of the single counter.
+    auto* addr = Iglobal(reinterpret_cast<uint32_t*>(&signalBuf[0]));  // S=1
+    while (__hip_atomic_load(addr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT) < want) {
+    }
+  }
+  __syncthreads();
+  // System-scope ACQUIRE: output was written by peers' SDMA over XGMI, so
+  // invalidate against another device's writes before any reader trusts output.
+  __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "");
+
+  // No Phase 3: output already fully written by SDMA. Reset the counter for reuse.
+  // SYSTEM scope (sc0 sc1: write-through past L2) because peers ADD into this slot
+  // by SDMA straight into HBM -- a plain store would leave a dirty line that could
+  // evict on top of a later ADD and swallow it. That is also why no release fence
+  // follows: there is nothing left in L2 to write back.
+  //
+  // NOTE: this clears at kernel END, so it still relies on the caller barriering
+  // between launches (the benchmark does hipStreamSynchronize + ccoBarrierAll per
+  // iteration); without one, a peer's NEXT launch's ADD can arrive before this
+  // store and be overwritten by it, no matter the scope.
+  if (threadIdx.x == 0) {
+    StreamStore<ESystemScope, sizeof(uint64_t)>(&signalBuf[0], 0);
+  }
+}
+} // namespace collective
+} // namespace mori

--- a/include/mori/collective/xla/all_reduce_kernels.hpp
+++ b/include/mori/collective/xla/all_reduce_kernels.hpp
@@ -1,0 +1,203 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// ===========================================================================
+// all_reduce_kernels.hpp
+//
+// Fused "push" all-reduce built on top of the reduce-scatter push kernel. The
+// kernel runs the reduce-scatter phases (fused SDMA scatter into staging +
+// receiver-side completion wait + grid-strided vectorized reduce) to produce
+// THIS PE's reduced shard, sliced into S = 1<<logS slices. Each slice is
+// broadcast to every peer the moment the grid finishes reducing it -- a
+// pipelined per-slice broadcast that overlaps with the reduce of the later
+// slices (no device-wide barrier). After the collective every PE holds the full
+// reduced vector.
+//
+// This header reuses the reduce-scatter building blocks (ReduceVecGroup, the Op
+// functors, ReduceComputeType) and the shared StartSdmaScatter. Phase 1-3 (the
+// scatter + completion wait + acquire + grid-strided reduce) are exactly what
+// reduce-scatter does: every block loops all S slices itself and calls the shared
+// per-slice reduce, detail::WaitAndReduceSlice. This kernel appends Phase 4 to
+// each iteration of that loop, so the two collectives share the per-slice reduce
+// and neither constrains gridDim.x.
+// ===========================================================================
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+#include "mori/collective/xla/reduce_scatter_kernels.hpp"
+
+namespace mori {
+namespace collective {
+// ---------------------------------------------------------------------------
+// Fused all-reduce kernel ("push").
+//
+//   input         : raw symmetric-heap pointer, N = npes*chunkElems elements
+//   staging       : raw symmetric-heap pointer, (npes-1) slots of chunkElems
+//   output        : raw symmetric-heap pointer, N = npes*chunkElems elements
+//                   (the FULL reduced vector; on exit every slot p holds the
+//                    reduction over all PEs of shard p)
+//   groupCounters : plain device buffer (>= S uint32): per-slice arrival
+//                   counters. Zeroed once by the host; each slice's elected block
+//                   self-resets its slot. Used to detect the last block to finish
+//                   a slice, so exactly one block broadcasts that slice.
+//
+// Phase 1-3 are the reduce-scatter push algorithm: block 0 SDMA-scatters each
+// peer's source slice into that peer's staging slot, then every block loops the S
+// slices itself and calls the shared per-slice reduce
+// (detail::WaitAndReduceSlice), which waits on that slice's completion counter and
+// reduces it with the whole grid into output[myPe] (= myShard).
+//
+// Phase 4 (pipelined per-slice broadcast) is the rest of that same loop iteration.
+// As soon as a block finishes reducing slice s it does a system fence (publishing
+// its reduce stores) and bumps groupCounters[s]. The block that reads the full count
+// gridDim.x is the last one out of slice s -- it knows the slice is complete -- and
+// ISSUES a broadcast of JUST slice s into every peer's output[myPe] slice via a
+// multi-producer-safe SDMA scatter (CAS reserve, since several slices' elected
+// blocks may share a per-peer queue). Each copy trails an ADD32(1) into the
+// receiver's DEDICATED per-slice broadcast counter signalPtrs[kBcastSlot+s] --
+// distinct from the reduce-scatter slice counters [0..S-1] AND from other slices'
+// broadcast counters, so no ADD can be miscounted by any other wait.
+static constexpr int kBcastSlot = kRSPushMaxSlices;
+
+template <int NumVecs, class ReduceOp, class T = typename ReduceOp::Type>
+__global__ void __launch_bounds__(256, 1)
+AllReducePushKernel(int myPe, int npes, int logS, const T* __restrict__ input,
+                    T* __restrict__ output, uint32_t* __restrict__ groupCounters,
+                    size_t chunkElems, mori::cco::ccoDevComm devComm,
+                    T* __restrict__ staging, mori::cco::ccoWindow_t heapWin) {
+
+  // Phase 1: scatter the input to the staging buffer
+  if (blockIdx.x == 0) {
+    // reduce-scatter: per-peer source slice (stride=chunkElems), dst=staging,
+    // no self-copy (self is folded in by the Phase-3 reduce reading local input).
+    // Staging is packed densely (no self hole): slot = myPe<peer?myPe:myPe-1, a
+    // bijection over the npes-1 non-self peers. 
+    const size_t chunkBytes = chunkElems * sizeof(T);
+    StartSdmaScatter<sizeof(T)>(
+        devComm.sdma, npes, logS, chunkElems,
+        [=](int peer) { return peer != myPe; },
+        [=](int peer) -> const uint8_t* {
+          return reinterpret_cast<const uint8_t*>(input + peer * chunkElems);
+        },
+        [=](int peer) -> uint8_t* {
+          const int slot = (myPe < peer ? myPe : myPe - 1);   // my slot in peer's staging
+          int32_t diff = (peer - myPe)*static_cast<int32_t>(heapWin->stride4G);
+          return reinterpret_cast<uint8_t*>(staging + slot * chunkElems) + 
+             (static_cast<uint64_t>(diff)<<32);
+        });
+  }
+
+  // My reduced shard lives in output slot myPe.
+  T* __restrict__ myShard = output + myPe * chunkElems;
+  uint64_t* __restrict__ signalBuf = devComm.sdma.signalBuf;
+
+  // Slices this block broadcast, and therefore owes a completion wait. Deferring
+  // that wait to the tail below keeps the elected block reducing the remaining
+  // slices instead of stalling on XGMI in the middle of the loop.
+  uint32_t ownedMask = 0;
+  __shared__ bool isSliceLast;
+
+  constexpr int vecSize = VecBytes / sizeof(T);
+  const uint32_t S = 1u << logS;
+  // vecSize-aligned slice length; the last slice absorbs the remainder.
+  const size_t sliceLen = ((chunkElems >> logS) / vecSize) * vecSize;
+  const uint32_t lstride = FORCE_SGPR(gridDim.x * blockDim.x);  // loop-invariant
+
+  for (uint32_t s = 0; s < S; s++) {
+    // Slice s covers [sOfs, sOfs+sCnt) of my shard -- Phase 3 reduces that range
+    // and Phase 4 broadcasts exactly the same range.
+    const size_t sOfs = FORCE_SGPR(s * sliceLen);
+    const size_t sCnt = FORCE_SGPR((s == S - 1) ? (chunkElems - sOfs) : sliceLen);
+
+    // === Phase 2-3: shared per-slice front (completion wait + acquire +
+    // grid-strided reduce) into MY shard slot within the full output. ===
+    detail::WaitAndReduceSlice<NumVecs, ReduceOp>(signalBuf, s, myPe, npes, input, staging,
+                                                 myShard, sOfs, sCnt, chunkElems, lstride);
+
+    // === Phase 4: this slice is reduced -- elect one block to broadcast it =====
+    // Publish this block's reduce stores to slice s before announcing arrival, so
+    // once the counter hits gridDim.x every block's stores are globally visible to
+    // the elected block's DMA read of the slice.
+    __threadfence_system();
+    if (threadIdx.x == 0) {
+      isSliceLast = (atomicAdd(&groupCounters[s], 1u) + 1 == gridDim.x);
+    }
+    __syncthreads();
+
+    if (isSliceLast) {  // block-uniform: isSliceLast is shared
+      if (threadIdx.x == 0) {
+        StreamStore<ESystemScope, sizeof(uint64_t)>(&signalBuf[s], 0);
+        groupCounters[s] = 0;  // reset slice s's arrival counter
+      }
+      // That reset must have landed before any doorbell below rings: once a
+      // broadcast lands, its receiver can finish this collective and its NEXT
+      // launch's Phase-1 SDMA starts ADDing to my signalBuf[s]. __syncthreads()
+      // carries an s_waitcnt vmcnt(0) that drains thread 0's store, and it orders
+      // that store before the doorbells of ALL lanes, not just thread 0's.
+      __syncthreads();
+
+      // Destination slot is myPe on every peer, so the source (my reduced slice)
+      // and the symmetric destination address are the same for all peers. Self
+      // already holds it.
+      // Warp 0 issues slice s to all peers, each copy trailing an ADD32(1) into
+      // that peer's DEDICATED per-slice broadcast counter signalBuf[kBcastSlot+s].
+      // The CAS reserve keeps it correct even when two slices' elected blocks
+      // share a queue. No wait here -- see the tail.
+      if (threadIdx.x < warpSize) {
+        SdmaBroadcastSliceWarp(
+            devComm.sdma, myShard + sOfs,
+            [=](int peer) -> uint8_t* {
+              int32_t diff = (peer - myPe) * static_cast<int32_t>(heapWin->stride4G);
+              return reinterpret_cast<uint8_t*>(myShard + sOfs) +
+                     (static_cast<uint64_t>(diff) << 32);
+            },
+            sCnt * sizeof(T), myPe, npes, kBcastSlot + static_cast<int>(s), /*qId=*/0);
+      }
+      ownedMask |= (1u << s);
+    }
+  }
+
+  // === Tail: collect the broadcasts this block issued ==========================
+  // No fence closes the kernel. The broadcast-counter resets are system-scope
+  // stores, so they need no writeback, and nothing beyond the kernel boundary
+  // races them: unlike the Phase-2 counters, this slot is only touched again by a
+  // peer's Phase 4, which cannot run before my NEXT launch's scatter. Nor is an
+  // acquire needed -- no thread here reads the slices peers DMA'd into output, and
+  // whoever consumes them acquires at its own kernel boundary.
+  if (threadIdx.x == 0 && ownedMask != 0) {
+    const uint32_t want = static_cast<uint32_t>(npes - 1);  // no self-copy
+    for (uint32_t s = 0; s < S; s++) {
+      if ((ownedMask & (1u << s)) == 0) continue;
+      // Wait for every peer's copy of slice s to land in my output[myPe] slice.
+      // 32-bit ADD into the low dword -> poll 32 bits of this slice's counter.
+      auto* addr = Iglobal(reinterpret_cast<uint32_t*>(&signalBuf[kBcastSlot + s]));
+      while (__hip_atomic_load(addr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT) < want) {
+      }
+      // System scope again: peers ADD into this slot from their Phase 4.
+      StreamStore<ESystemScope, sizeof(uint64_t)>(&signalBuf[kBcastSlot + s], 0);
+    }
+  }
+}
+} // namespace collective
+} // namespace mori

--- a/include/mori/collective/xla/all_to_all_kernels.hpp
+++ b/include/mori/collective/xla/all_to_all_kernels.hpp
@@ -1,0 +1,108 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// ===========================================================================
+// all_to_all_kernels.hpp
+//
+// SDMA-based "push" all-to-all. Mirrors RCCL's per-rank send/recv loop: PE myPe
+// sends srcPtrs[p] to peer p, and peer p stores it in its recv slot for sender
+// myPe (dstPtrs[myPe]). Self (p==myPe) is included via an SDMA self-copy, like
+// all-gather. Compute-free: SDMA writes every peer's recv slot directly and the
+// kernel only waits for completion.
+//
+// Reuses the shared fused SDMA routine StartSdmaScatter (collectives_common.hpp)
+// via call-site lambdas: active=true (self included), per-peer source is an
+// arbitrary pointer srcPtrs[peer], and the destination offset is constant
+// (dstPtrs[myPe] - heapBase; every receiver stores our chunk at its own
+// dstPtrs[myPe]-equivalent symmetric-heap offset).
+// ===========================================================================
+#pragma once
+
+#include <cstdint>
+#include "mori/collective/xla/collectives_common.hpp"
+
+namespace mori {
+namespace collective {
+
+// Single-block, compute-free all-to-all.
+//   srcPtrs : npes local symmetric-heap pointers; srcPtrs[p] sent to peer p.
+//   dstPtrs : npes local symmetric-heap pointers; dstPtrs[p] receives peer p's chunk.
+//   chunkBytes : size in bytes of each per-peer chunk.
+//
+// Phase 1: SDMA scatters each chunk into every peer's recv slot (self included),
+// each copy trailed by an ADD64 of 1 into the receiver's signalPtrs[0] counter.
+// Phase 2: thread 0 waits until the counter reaches npes (self-copy included),
+// then an acquire fence makes the peer SDMA writes visible. No Phase 3. Finally
+// thread 0 resets the counter for the next launch.
+//
+// blockDim.x must be >= npes for the fast-path packet build; launch <<<1, 256>>>
+// with npes <= 8 (SDMA fast path).
+__global__ void AllToAllPushKernel(int myPe, int npes, const AddressPair* __restrict__ pairs,
+                                   size_t chunkBytes, mori::cco::ccoDevComm devComm,
+                                   mori::cco::ccoWindow_t heapWin) {
+  // Phase 1: push each send slot p to peer p's recv slot for sender myPe (self
+  // included). My recv slot has the SAME byte offset within the heap window on
+  // every peer (all ranks Allocate identically), so compute it once from the
+  // local window base and reuse it for every peer. The source is an arbitrary
+  // per-peer local pointer (SDMA reads local VA directly).
+  const size_t heapBase = reinterpret_cast<uintptr_t>(mori::cco::ccoGetLocalPtr(heapWin));
+  const size_t off = reinterpret_cast<uintptr_t>(pairs[myPe].dest) - heapBase;
+  StartSdmaScatter(
+      devComm.sdma, npes, /*logS=*/0, chunkBytes,
+      [](int) { return true; },
+      [=](int peer) -> const uint8_t* {
+        return reinterpret_cast<const uint8_t*>(pairs[peer].source);
+      },
+      [=](int peer) -> uint8_t* {
+        return reinterpret_cast<uint8_t*>(mori::cco::ccoGetLsaPeerPtr(heapWin, peer, off));
+      });
+
+  uint64_t* __restrict__ signalBuf = devComm.sdma.signalBuf;
+
+  // === Phase 2: wait until the counter reaches all npes senders. ===============
+  if (threadIdx.x == 0) {
+    const uint32_t want = static_cast<uint32_t>(npes);  // self-copy included
+    // 32-bit ADD into the low dword -> poll 32 bits of the single counter.
+    auto* addr = Iglobal(reinterpret_cast<uint32_t*>(&signalBuf[0]));  // S=1
+    while (__hip_atomic_load(addr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT) < want) {
+    }
+  }
+  __syncthreads();
+  // System-scope ACQUIRE: recv slots were written by peers' SDMA over XGMI.
+  __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "");
+
+  // No Phase 3: recv buffers already fully written by SDMA. Reset counter for reuse.
+  // SYSTEM scope (sc0 sc1: write-through past L2) because peers ADD into this slot
+  // by SDMA straight into HBM -- a plain store would leave a dirty line that could
+  // evict on top of a later ADD and swallow it. That is also why no release fence
+  // follows: there is nothing left in L2 to write back.
+  //
+  // NOTE: this clears at kernel END, so it still relies on the caller barriering
+  // between launches (the benchmark does hipStreamSynchronize + ccoBarrierAll per
+  // iteration); without one, a peer's NEXT launch's ADD can arrive before this
+  // store and be overwritten by it, no matter the scope.
+  if (threadIdx.x == 0) {
+    StreamStore<ESystemScope, sizeof(uint64_t)>(&signalBuf[0], 0);
+  }
+}
+} // namespace collective
+} // namespace mori

--- a/include/mori/collective/xla/collective_permute_kernels.hpp
+++ b/include/mori/collective/xla/collective_permute_kernels.hpp
@@ -1,0 +1,102 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// ===========================================================================
+// collective_permute_kernels.hpp
+//
+// SDMA-based "push" collective-permute for a single destination. PE myPe copies
+// sendBuf into peer dstPe's recvBuf (self-copy when dstPe == myPe) and waits for
+// srcPe's copy to land in our recvBuf (srcPe < 0 means no incoming).
+//
+// Compute-free: one block, logS=0, reusing StartSdmaScatter from
+// collectives_common.hpp. sendBuf and recvBuf must be symmetric-heap pointers
+// so the address-based SDMA put can translate local->peer (offset from
+// heapBaseAddr).
+// ===========================================================================
+#pragma once
+
+#include <cstdint>
+#include "mori/collective/xla/collectives_common.hpp"
+
+namespace mori {
+namespace collective {
+
+// Single-block, compute-free collective-permute (one destination).
+//   sendBuf  : raw symmetric-heap pointer, numBytes to send
+//   recvBuf  : raw symmetric-heap pointer, numBytes receive slot
+//   dstPe    : peer that receives our sendBuf (may be myPe)
+//   srcPe    : peer that sends into our recvBuf, or -1 if nobody does
+//
+// Phase 1: SDMA pushes sendBuf into dstPe's recvBuf (self included when
+// dstPe == myPe), trailed by an ADD32 of 1 into the receiver's signalPtrs[0].
+// Phase 2: if srcPe >= 0, thread 0 waits until the counter reaches 1, then an
+// acquire fence makes the peer SDMA write visible. Finally thread 0 resets the
+// counter for the next launch.
+//
+// Launch <<<1, 256>>> with npes <= 8 (SDMA fast path).
+__global__ void CollectivePermutePushKernel(int npes, int dstPe, int srcPe,
+                                            const void* __restrict__ sendBuf,
+                                            void* __restrict__ recvBuf, size_t numBytes,
+                                            mori::cco::ccoDevComm devComm,
+                                            mori::cco::ccoWindow_t heapWin) {
+  // recvBuf's byte offset within the heap window is identical on every rank
+  // (symmetric layout), so dstPe's recv slot resolves via the same offset.
+  const size_t heapBase = reinterpret_cast<uintptr_t>(mori::cco::ccoGetLocalPtr(heapWin));
+  const size_t dstOff = reinterpret_cast<uintptr_t>(recvBuf) - heapBase;
+  StartSdmaScatter(
+      devComm.sdma, npes, /*logS=*/0, numBytes,
+      [=](int peer) { return peer == dstPe; },
+      [=](int) -> const uint8_t* { return reinterpret_cast<const uint8_t*>(sendBuf); },
+      [=](int peer) -> uint8_t* {
+        return reinterpret_cast<uint8_t*>(mori::cco::ccoGetLsaPeerPtr(heapWin, peer, dstOff));
+      });
+
+  uint64_t* __restrict__ signalBuf = devComm.sdma.signalBuf;
+  const uint32_t want = (srcPe >= 0) ? 1u : 0u;
+
+  if (threadIdx.x == 0 && want) {
+    auto* addr = Iglobal(reinterpret_cast<uint32_t*>(&signalBuf[0]));  // S=1
+    while (__hip_atomic_load(addr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT) < want) {
+    }
+  }
+  __syncthreads();
+  if (want) {
+    // System-scope ACQUIRE: recvBuf was written by srcPe's SDMA over XGMI.
+    __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "");
+  }
+
+  // Reset the counter for reuse. SYSTEM scope (sc0 sc1: write-through past L2)
+  // because srcPe ADDs into this slot by SDMA straight into HBM -- a plain store
+  // would leave a dirty line that could evict on top of a later ADD and swallow
+  // it. That is also why no release fence follows: there is nothing left in L2 to
+  // write back.
+  //
+  // NOTE: this clears at kernel END, so it still relies on the caller barriering
+  // between launches (the benchmark does hipStreamSynchronize + ccoBarrierAll per
+  // iteration); without one, srcPe's NEXT launch's ADD can arrive before this
+  // store and be overwritten by it, no matter the scope.
+  if (threadIdx.x == 0) {
+    StreamStore<ESystemScope, sizeof(uint64_t)>(&signalBuf[0], 0);
+  }
+}
+} // namespace collective
+} // namespace mori

--- a/include/mori/collective/xla/collectives_common.hpp
+++ b/include/mori/collective/xla/collectives_common.hpp
@@ -1,0 +1,516 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+#if defined(__HIPCC__) || defined(__HIP__)
+#include "mori/cco/cco.hpp"
+#endif  // __HIPCC__ || __HIP__
+
+#include "mori/core/transport/sdma/sdma_pkt_struct.h"
+
+// ---------------------------------------------------------------------------
+// Shared building blocks for collective kernels: cache-bypassing vector
+// load/store (StreamLoad/StreamStore), a 128-bit SDMA ring-store helper, and the
+// warp-cooperative fused copy+atomic SDMA put used by the push collectives.
+// ---------------------------------------------------------------------------
+namespace mori {
+namespace collective {
+
+static constexpr size_t kSDMACopyAtomicPktSize = 64;
+static_assert(sizeof(SDMA_PKT_COPY_LINEAR) + sizeof(SDMA_PKT_ATOMIC) 
+                                  + sizeof(uint32_t) == kSDMACopyAtomicPktSize,
+              "Packet size mismatch: copy+atomic must be 64B");
+#if defined(__HIPCC__) || defined(__HIP__)
+static_assert(mori::cco::CCO_SDMA_QUEUE_SIZE % kSDMACopyAtomicPktSize == 0,
+              "SDMA ring must be a multiple of the 64B fused packet");
+#endif
+
+static constexpr int kRSPushMaxPeers = 16;
+static constexpr int kRSPushMaxSlices = 8;
+
+// Per-peer all-to-all endpoints: chunk sent from `source` to peer p / received// into `dest` from peer p. Host-fillable, device-readable (host-pinned buffer).
+struct AddressPair {
+  const void* source;
+  void* dest;
+};
+
+#if defined(__HIPCC__) || defined(__HIP__)
+
+#define USE_NONTEMPORAL_LOAD 0
+#define GLOBAL_SPACE __attribute__((address_space(1)))
+#define BREAK_ON_RETRIES 1
+
+// Streaming (cache-bypassing) 16-byte load/store.
+#if (defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__))
+#if __has_builtin(__builtin_amdgcn_global_load_b128) && \
+    __has_builtin(__builtin_amdgcn_global_store_b128)
+#elif defined(__HIP_DEVICE_COMPILE__)
+#error "Global b128 load/store not supported on this architecture"
+#endif
+#endif
+
+constexpr uint32_t VecBytes = 16;
+
+using V128 = __attribute__((__vector_size__(4 * sizeof(uint32_t)))) uint32_t;
+using V128_GLOBAL = GLOBAL_SPACE V128*;
+template <int TVecBytes>
+using TVecType = std::conditional_t<
+    TVecBytes == 1, uint8_t,
+        std::conditional_t<TVecBytes == 2, uint16_t,
+        std::conditional_t<TVecBytes == 4, uint32_t,
+        std::conditional_t<TVecBytes == 8, uint64_t,
+        std::conditional_t<TVecBytes == 16, V128, void>>>>>;
+
+template <typename T>
+__device__ __host__ inline static T* Iglobal(T* ptr) {
+  return (T*)(GLOBAL_SPACE T*)reinterpret_cast<uintptr_t>(ptr);
+}
+
+enum StreamScope {
+  ESystemScope = 0,
+  EAgentScope = 1,
+};
+
+template <StreamScope Scope, int Bytes = VecBytes>
+__device__ __forceinline__ TVecType<Bytes> StreamLoad(const void* p) {
+  static_assert(Bytes == 1 || Bytes == 2 || Bytes == 4 || Bytes == 8 || Bytes == 16,
+                "StreamLoad supports 1/2/4/8/16 byte accesses");
+  auto ptr = reinterpret_cast<const TVecType<Bytes>*>(p); 
+#if USE_NONTEMPORAL_LOAD
+  return __builtin_nontemporal_load(MemSpace(ptr));
+#else
+  if constexpr (Bytes == 16) {
+    if constexpr (Scope == ESystemScope) {
+      return __builtin_amdgcn_global_load_b128((V128_GLOBAL)p, "");
+    } else {
+      return __builtin_amdgcn_global_load_b128((V128_GLOBAL)p, "agent");
+    }
+  } else {
+    return __hip_atomic_load(ptr, __ATOMIC_RELAXED,
+              Scope == ESystemScope ? __HIP_MEMORY_SCOPE_SYSTEM 
+                                    : __HIP_MEMORY_SCOPE_AGENT);
+  }
+#endif
+}
+
+template <StreamScope Scope, int Bytes = VecBytes>
+__device__ __forceinline__ void StreamStore(void* p, TVecType<Bytes> v) {
+  static_assert(Bytes == 1 || Bytes == 2 || Bytes == 4 || Bytes == 8 || Bytes == 16,
+                "StreamStore supports 1/2/4/8/16 byte accesses");
+  auto ptr = reinterpret_cast<TVecType<Bytes>*>(p);
+#if USE_NONTEMPORAL_LOAD
+  __builtin_nontemporal_store(v, MemSpace(ptr));
+#else
+  if constexpr (Bytes == 16) {
+    if constexpr (Scope == ESystemScope) {
+      __builtin_amdgcn_global_store_b128((V128_GLOBAL)p, v, "");
+    } else {
+      __builtin_amdgcn_global_store_b128((V128_GLOBAL)p, v, "agent");
+    }
+  } else {
+    __hip_atomic_store(ptr, v, __ATOMIC_RELAXED,
+                       Scope == ESystemScope ? __HIP_MEMORY_SCOPE_SYSTEM 
+                                             : __HIP_MEMORY_SCOPE_AGENT);
+  }
+#endif
+}
+
+#define FORCE_SGPR(x) __builtin_amdgcn_readfirstlane(x)
+
+// ---------------------------------------------------------------------------
+// Range-checked raw-buffer 128-bit load/store.
+//
+// A buffer resource (V#) is built by hand as a uniform int32x4: word0..1 = 64-bit
+// base, word2 = num_records (valid byte extent, stride 0 => bytes), word3 = the
+// raw-buffer config. Building the descriptor explicitly (rather than via
+// __builtin_amdgcn_make_buffer_rsrc) keeps it a scalar/uniform value in SGPRs and
+// avoids the compiler emitting a per-lane "waterfall" around the buffer op.
+//
+// Out-of-range accesses are hardware range-checked: buffer_load/store_dwordx4
+// check PER 32-bit COMPONENT (CDNA4 ISA 9.1.5 note 4) -- OOB reads return 0, OOB
+// writes write nothing. That lets a reduce loop cover the final partial vector
+// with no scalar tail: the store's per-component check drops any OOB output dword
+// regardless of the reduction op.
+//
+// RS_BUF_AUX is the cache-policy immediate (the intrinsic's last operand),
+// separate from word3 and from memory scope; it carries the non-temporal /
+// streaming hint. Verified on gfx950: bit0 (0x1) -> `sc0`, bit1 (0x2) -> `nt`.
+// Default 0x2 = non-temporal streaming, CU-scope caching (no sc bits): correct
+// for the push reduce, whose local-HBM sources are already made visible by the
+// caller's system-scope acquire fence before Phase 3.
+// ---------------------------------------------------------------------------
+#ifndef RS_BUF_AUX
+#define RS_BUF_AUX 2
+#endif
+
+// word3 config for a plain (non-format) raw buffer on gfx9xx / CDNA. make_buffer_rsrc
+// packs its `flags` arg straight into word3 without auto-setting DATA_FORMAT, so on
+// gfx9 flags=0 => BUF_DATA_FORMAT_INVALID and buffer_load_dwordx4 returns garbage;
+// the descriptor MUST carry this (DATA_FORMAT=32) constant.
+#define RS_BUF_RSRC_WORD3 0x00020000
+using BufRsrc = int32_t __attribute__((ext_vector_type(4)));
+
+__device__ BufRsrc llvm_amdgcn_raw_buffer_load_v4i32(BufRsrc rsrc, int voffset, int soffset,
+                                                     int aux) __asm("llvm.amdgcn.raw.buffer.load.v4i32");
+__device__ void llvm_amdgcn_raw_buffer_store_v4i32(BufRsrc vdata, BufRsrc rsrc, int voffset,
+                                                   int soffset, int aux) __asm("llvm.amdgcn.raw.buffer.store.v4i32");
+
+__device__ __forceinline__ BufRsrc MakeRawRsrc(const void* base, uint32_t numBytes) {
+  const uint64_t b = reinterpret_cast<uintptr_t>(base);
+  BufRsrc r;
+  r.x = __builtin_amdgcn_readfirstlane(static_cast<int32_t>(b & 0xFFFFFFFFu));  // word0: base low 32b
+  r.y = __builtin_amdgcn_readfirstlane(static_cast<int32_t>(b >> 32));          // word1: base high (stride 0)
+  r.z = __builtin_amdgcn_readfirstlane(static_cast<int32_t>(numBytes));         // word2: num_records (bytes)
+  r.w = RS_BUF_RSRC_WORD3;                                                      // word3: raw-buffer config
+  return r;
+}
+
+__device__ __forceinline__ V128 BufferLoad128(BufRsrc r, uint32_t voff) {
+  BufRsrc v = llvm_amdgcn_raw_buffer_load_v4i32(r, static_cast<int>(voff), /*soffset=*/0, RS_BUF_AUX);
+  return __builtin_bit_cast(V128, v);
+}
+
+__device__ __forceinline__ void BufferStore128(BufRsrc r, V128 v, uint32_t voff) {
+  llvm_amdgcn_raw_buffer_store_v4i32(__builtin_bit_cast(BufRsrc, v), r, static_cast<int>(voff),
+                                     /*soffset=*/0, RS_BUF_AUX);
+}
+
+__device__ __forceinline__ void WriteFusedPacket(int lane, 
+     const void* srcBuf, const void* dstBuf, size_t packetSize, HSAuint64* signal,
+     uint32_t* outBasePtr) {
+  
+  uint32_t dw[4];
+  // if (lane == 0) {
+  //   decltype(SDMA_PKT_COPY_LINEAR::HEADER_UNION) hdr;
+  //   hdr.DW_0_DATA = 0;
+  //   hdr.op = SDMA_OP_COPY;
+  //   hdr.sub_op = SDMA_SUBOP_COPY_LINEAR;
+  //   dw[0] = 0;  // leading single-dword NOP (must be 0)
+  //   dw[1] = hdr.DW_0_DATA;
+  //   dw[2] = static_cast<uint32_t>(packetSize - 1);  // COUNT_UNION.count (reserved bits 0)
+  //   dw[3] = 0;                                      // PARAMETER_UNION (unused)
+  // } else if (lane == 2) {
+  //   decltype(SDMA_PKT_ATOMIC::HEADER_UNION) hdr;
+  //   hdr.DW_0_DATA = 0;
+  //   hdr.op = SDMA_OP_ATOMIC;
+  //   hdr.operation = SDMA_ATOMIC_ADD32;
+  //   dw[0] = hdr.DW_0_DATA;
+  //   dw[1] = (uint32_t)((uintptr_t)signal);
+  //   dw[2] = (uint32_t)((uintptr_t)signal >> 32);
+  //   dw[3] = 1;
+  if (lane % 2 == 0) {
+  // Header depends only on constants; a scalar-replaceable local keeps the
+  // bitfield layout authoritative and constant-folds (no address taken).
+    decltype(SDMA_PKT_COPY_LINEAR::HEADER_UNION) cp;
+    cp.DW_0_DATA = 0;
+    cp.op = SDMA_OP_COPY;
+    cp.sub_op = SDMA_SUBOP_COPY_LINEAR;
+    decltype(SDMA_PKT_ATOMIC::HEADER_UNION) inc;
+    inc.DW_0_DATA = 0;
+    inc.op = SDMA_OP_ATOMIC;
+    inc.operation = SDMA_ATOMIC_ADD32;
+
+    uint32_t flag = lane >> 1;
+    dw[0] = inc.DW_0_DATA & -flag;
+    dw[1] = flag == 0 ? cp.DW_0_DATA : (uint32_t)((uintptr_t)signal);
+    dw[2] = flag == 0 ? static_cast<uint32_t>(packetSize) - 1 : 
+                        (uint32_t)((uintptr_t)signal >> 32);
+    dw[3] = flag;
+  } else {
+    // lane 1 - real addresses, lane 3 - all zeros
+    uint32_t mask = lane == 1 ? ~0u : 0;
+    dw[0] = (uint32_t)(uintptr_t)srcBuf & mask;
+    dw[1] = (uint32_t)((uintptr_t)srcBuf >> 32) & mask;
+    dw[2] = (uint32_t)(uintptr_t)dstBuf & mask;
+    dw[3] = (uint32_t)((uintptr_t)dstBuf >> 32) & mask;
+  }
+  const V128 v = {dw[0], dw[1], dw[2], dw[3]};
+  StreamStore<EAgentScope, 16>(outBasePtr + lane * 4, v);
+} 
+
+// Broadcast `v` from `srcLane` of this wave. ds_bpermute is lane-addressed;
+// srcLane must be < warpSize (64 on gfx950, 32 on gfx1250).
+template <typename T>
+__device__ __forceinline__ T broadcast_warp(T v, int srcLane) {
+  static_assert(sizeof(T) % sizeof(uint32_t) == 0, 
+                        "T must be a multiple of uint32_t");
+  union {
+    T v;
+    uint32_t dw[sizeof(T) / sizeof(uint32_t)];
+  } S = {.v = v};
+#pragma unroll
+  for (int i = 0; i < sizeof(T) / sizeof(uint32_t); i++) {
+    S.dw[i] = __builtin_amdgcn_ds_bpermute(srcLane << 2, S.dw[i]);
+  }
+  return S.v;
+}
+
+// SDMA queue handle augmented with collective-specific ring writers. It adds no
+// data members (same layout as the base), so a base handle can be used through it
+// via a reinterpret_cast -- mirroring anvil::SdmaQueueSingleProducerDeviceHandle.
+struct SdmaCollectiveHandle : mori::cco::ccoSdmaQueueDeviceHandle {
+
+  static __device__ __forceinline__ uint64_t WrapIntoRing(uint64_t index) {
+    return index % mori::cco::CCO_SDMA_QUEUE_SIZE;
+  }
+
+  __device__ __forceinline__ bool CanWriteUpto(uint64_t uptoIndex) {
+    const uint64_t queue_size_in_bytes = mori::cco::CCO_SDMA_QUEUE_SIZE;
+    if ((uptoIndex - cachedHwReadIndex) < queue_size_in_bytes) {
+      return true;
+    }
+    // Only read hardware register if the queue is full based on cached index
+    cachedHwReadIndex = __hip_atomic_load(rptr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+    __atomic_signal_fence(__ATOMIC_SEQ_CST);
+    return (uptoIndex - cachedHwReadIndex) < queue_size_in_bytes;
+  }
+
+  // Multi-producer CAS reserve. Packets are always kSDMACopyAtomicPktSize and
+  // the ring is a multiple of that, so a reservation never straddles the wrap.
+  __device__ __forceinline__ uint64_t ReserveQueueSpace(const size_t size_in_bytes) {
+    uint64_t cur_index;
+    long long retries = 0;
+
+    while (true) {
+      cur_index = __hip_atomic_load(cachedWptr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      uint64_t new_index = cur_index + size_in_bytes;
+
+      if (CanWriteUpto(new_index)) {
+        if (__hip_atomic_compare_exchange_strong(cachedWptr, &cur_index, new_index,
+                                                 __ATOMIC_RELAXED, __ATOMIC_RELAXED,
+                                                 __HIP_MEMORY_SCOPE_AGENT)) {
+          break;
+        }
+      }
+      // Never return an unreserved index: fail loud rather than corrupt the queue.
+      if (++retries > mori::cco::CCO_SDMA_MAX_RETRIES) __builtin_trap();
+    }
+    return cur_index;
+  }
+
+  // Sole-producer reservation: no CAS. Valid only when this queue has exactly
+  // one producing thread for the lifetime of the reservation (e.g. one leader
+  // lane per distinct queue). Claim-then-wait like cco ReserveSlot: fetch_add
+  // first, then poll rptr if occupancy exceeds the ring.
+  //
+  // Packets are always kSDMACopyAtomicPktSize and the ring is a multiple of that,
+  // so a reservation never straddles the wrap.
+  //
+  // cachedHwReadIndex is by-value. The caller snapshots the handle once and
+  // reuses it across packets so a refreshed rptr stays in the local copy;
+  // write the hint back to `shared` once at the end if it moved. The hint only
+  // moves forward to a value rptr actually had, so a later writer is harmless.
+  __device__ __forceinline__ uint64_t ReserveSingleProducer(const size_t size_in_bytes) {
+    constexpr uint64_t q_size = mori::cco::CCO_SDMA_QUEUE_SIZE;
+    uint64_t base =
+        __hip_atomic_fetch_add(cachedWptr, size_in_bytes, __ATOMIC_RELAXED,
+                               __HIP_MEMORY_SCOPE_AGENT);
+    const uint64_t end = base + size_in_bytes;
+    if (end - cachedHwReadIndex > q_size) {
+      int64_t retries = 0;
+      do {
+        cachedHwReadIndex =
+            __hip_atomic_load(rptr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+        if constexpr (mori::cco::CCO_SDMA_BREAK_ON_RETRIES) {
+          if (retries++ == mori::cco::CCO_SDMA_MAX_RETRIES) __builtin_trap();
+        }
+      } while (end - cachedHwReadIndex > q_size);
+    }
+    return base;
+  }
+};
+
+static_assert(sizeof(SdmaCollectiveHandle) == sizeof(mori::cco::ccoSdmaQueueDeviceHandle));
+
+// One warp broadcasts a single slice to every peer's destination slice,
+// trailing an ADD32(1) into peer signalPtrs[signalSlot]. The per-peer
+// destination pointer is supplied by the caller via dstOf(peer) -> uint8_t*
+// (warp-uniform at peer granularity), mirroring StartSdmaScatter's dstOf. Four
+// consecutive lanes write one fused 64B packet via WriteFusedPacket.
+// Multi-producer-safe: other slice-groups' last blocks may hit the same
+// per-peer queue concurrently, so this uses the CAS-based ReserveQueueSpace +
+// ordered submitPacket (NOT the single-producer CAS-free fast path). The leader
+// copies the handle (VGPR pointer fields for submitPacket) and writes
+// cachedHwReadIndex back if CanWriteUpto refreshed it. sub==0 of each peer group
+// reserves/rings; the whole warp must execute the barriers.
+template <class DstFn>
+inline __device__ void SdmaBroadcastSliceWarp(
+  mori::cco::ccoSdmaContext sdma,
+  const void* src, DstFn dstOf, size_t sliceBytes,
+                                              int myPe, int npes, int signalSlot, int qId) {
+  const uint32_t numSdmaQ = sdma.sdmaNumQueue;
+  constexpr int W = warpSize;
+  const int lane = static_cast<int>(threadIdx.x) % W;
+  const int nWork = npes << 2;
+
+  for (int i = lane; i < nWork; i += W) {
+    const int peer = i >> 2, sub = i & 3, leader = lane & ~3;
+    const bool active = peer != myPe;
+
+    uint64_t base = 0;
+    SdmaCollectiveHandle handle;
+    uint32_t* queueBuf = nullptr;
+    if (active && sub == 0) {
+      auto* shared = static_cast<SdmaCollectiveHandle*>(
+          *(sdma.deviceHandles + peer * numSdmaQ + qId));
+      handle = *shared;
+      const uint64_t hint = handle.cachedHwReadIndex;
+      base = handle.ReserveQueueSpace(kSDMACopyAtomicPktSize);  // CAS: multi-producer safe
+      if (handle.cachedHwReadIndex != hint) {
+        __hip_atomic_store(&shared->cachedHwReadIndex, handle.cachedHwReadIndex,
+                           __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+      }
+      queueBuf = handle.queueBuf;
+    }
+    base = broadcast_warp(base, leader);
+    queueBuf = broadcast_warp(queueBuf, leader);
+
+    if (active) {
+      // Peer's destination slice, computed by the caller-supplied dstOf(peer).
+      uint8_t* dst = dstOf(peer);
+      auto* signal = sdma.peerSignalPtrs[peer] + signalSlot;
+      const uint64_t Xbase =
+          SdmaCollectiveHandle::WrapIntoRing(base) / sizeof(uint32_t);
+      WriteFusedPacket(sub, src, dst, sliceBytes, signal, queueBuf + Xbase);
+    }
+
+    mori::cco::ccoSdmaPublishStores();
+    __builtin_amdgcn_wave_barrier();
+
+    if (active && sub == 0) {
+      handle.submitPacket(base, base + kSDMACopyAtomicPktSize);
+    }
+  }
+  __syncwarp();
+}
+
+// ---------------------------------------------------------------------------
+// Fused SDMA "push" scatter shared by the push collectives (reduce-scatter and
+// all-gather). Four consecutive lanes write one fused 64B copy+atomic via
+// WriteFusedPacket (one b128 store each). nWork = npes*4; a peer never straddles
+// a warp (warpSize % 4 == 0). sub==0 snapshots the queue handle once, then for
+// each slice s: reserves 64B, the four lanes write, sub==0 rings that packet.
+// Same-lane sequential doorbells; distinct peers are distinct queues, so several
+// sub==0 lanes in one warp do not share a commit chain. No LDS / syncthreads.
+// Occupancy (rptr) stays; the local cachedHwReadIndex is reused across s and
+// written back once if it moved.
+//
+// Each shard is split into S = 1<<logS slices. Slice s is an SDMA copy from
+// srcOf(peer) into dstOf(peer), followed by an ADD32(1) into peer's per-slice
+// completion counter signalPtrs[s]. The atomic targets the *receiver's* counter,
+// so completion is observed on the receive side -- fire-and-forget, no local
+// quiet, no cross-PE barrier.
+//
+// The three peer-indexed quantities are supplied by the caller as device
+// callables (all warp-uniform at peer granularity):
+//   activeOf(peer) -> bool         : whether this peer's copy is issued
+//   srcOf(peer)    -> const uint8_t*: local source base for peer's chunk (pre-slice)
+//   dstOffOf(peer) -> size_t        : byte offset of the destination slot within
+//                                     the (symmetric) peer heap
+// Callers build these per collective, e.g.:
+//   reduce-scatter: active=peer!=myPe, src=input+peer*chunkElems, dst slot packs
+//                   staging densely (slot = myPe<peer?myPe:myPe-1). Self folded in
+//                   by the reduce.
+//   all-gather:     active=true, src=input (single shard to everyone incl. self),
+//                   dst slot = myPe (constant offset).
+//   all-to-all:     active=true, src=srcPtrs[peer], dst offset = dstPtrs[myPe] slot
+//                   (constant, symmetric-heap layout).
+//
+// srcOf(peer)/dstOffOf(peer) MUST reference the symmetric static heap (ShmemMalloc)
+// so the address-based SDMA put can translate local->peer (offset from
+// heapBaseAddr).
+// ---------------------------------------------------------------------------
+template <uint64_t ElemBytes = 1, class ActiveFn, class SrcFn, class DstFn>
+__device__ __forceinline__ void StartSdmaScatter(
+    mori::cco::ccoSdmaContext sdma, int npes, int logS, size_t chunkElems,
+    ActiveFn activeOf, SrcFn srcOf, DstFn dstOf) {
+
+  static_assert(ElemBytes > 0 && VecBytes % ElemBytes == 0,
+                "ElemBytes must divide VecBytes");
+  constexpr size_t vecSize = VecBytes / ElemBytes;
+  constexpr int W = warpSize;
+
+  const int S = 1 << logS, tid = static_cast<int>(threadIdx.x),
+            B = static_cast<int>(blockDim.x);
+
+  const uint32_t numSdmaQ = sdma.sdmaNumQueue;
+  const size_t sliceLen = ((chunkElems >> logS) / vecSize) * vecSize,
+          sliceBytes = sliceLen * ElemBytes,
+          lastBytes = (chunkElems - (sliceLen << logS) + sliceLen) * ElemBytes;
+
+  const int nWork = npes << 2, lane = tid % W;
+  for (int i = tid; i < nWork; i += B) {
+    const int peer = i >> 2, sub = i & 3, leader = lane & ~3;
+    const bool active = activeOf(peer);
+
+    SdmaCollectiveHandle handle;
+    SdmaCollectiveHandle* shared = nullptr;
+    uint32_t* queueBuf = nullptr;
+    uint64_t hint0 = 0;
+    if (active && sub == 0) {
+      shared = static_cast<SdmaCollectiveHandle*>(
+          *(sdma.deviceHandles + peer * numSdmaQ));
+      handle = *shared;
+      hint0 = handle.cachedHwReadIndex;
+      queueBuf = handle.queueBuf;
+    }
+    queueBuf = broadcast_warp(queueBuf, leader);
+
+    for (int s = 0; s < S; s++) {
+      uint64_t pktBase = 0;
+      if (active && sub == 0) {
+        pktBase = handle.ReserveSingleProducer(kSDMACopyAtomicPktSize);
+      }
+      pktBase = broadcast_warp(pktBase, leader);
+
+      if (active) {
+        auto* srcp = srcOf(peer) + s * sliceBytes;
+        auto* dstp = dstOf(peer) + s * sliceBytes;
+        const size_t sz = (s == S - 1) ? lastBytes : sliceBytes;
+        auto* signal = sdma.peerSignalPtrs[peer] + s;
+        const uint64_t ringDw =
+            SdmaCollectiveHandle::WrapIntoRing(pktBase) / sizeof(uint32_t);
+        WriteFusedPacket(sub, srcp, dstp, sz, signal, queueBuf + ringDw);
+      }
+
+      mori::cco::ccoSdmaPublishStores();
+      __builtin_amdgcn_wave_barrier();
+
+      if (active && sub == 0) {
+        handle.submitPacket(pktBase, pktBase + kSDMACopyAtomicPktSize);
+      }
+    }
+
+    if (active && sub == 0 && handle.cachedHwReadIndex != hint0) {
+      __hip_atomic_store(&shared->cachedHwReadIndex, handle.cachedHwReadIndex,
+                         __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    }
+  }
+}
+
+#endif  // __HIPCC__ || __HIP__
+
+}  // namespace collective
+}  // namespace mori

--- a/include/mori/collective/xla/reduce_ops.hpp
+++ b/include/mori/collective/xla/reduce_ops.hpp
@@ -1,0 +1,329 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// ===========================================================================
+// reduce_ops.hpp
+//
+// Reduction-op functors and the storage -> compute type map used by the
+// reduce-scatter / all-reduce kernels. The accumulator stays in the element
+// type T (so bf16 reduces in bf16-width registers -- half the VGPRs of a float
+// accumulator and no spilling for the 8x8 register tile). Numerical accuracy is
+// handled inside the Op functor: packed-bf16 ops promote each lane to float,
+// apply the op, and round back to bf16 (per-op rounding, not a float running
+// sum). Packed-f16 ops stay in native f16 (V_PK_ADD/MUL/MIN/MAX_F16).
+// ===========================================================================
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+
+#include <hip/hip_bfloat16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_fp8.h>
+
+#define FACADE_REDUCE_USE_ALL_TYPES 0
+
+#if defined(__HIPCC__) || defined(__HIP__)
+#include "mori/core/transport/p2p/device_primitives.hpp"  // Bf16BitsToF32
+#endif // __HIPCC__ || __HIP__
+
+namespace mori {
+namespace collective {
+
+#define COLLECTIVE_DATA_TYPE_LIST(V) \
+  V(F8E5M2, __hip_fp8_e5m2) \
+  V(F8E4M3FN, __hip_fp8_e4m3) \
+  V(F16, __half) \
+  V(BF16, hip_bfloat16) \
+  V(S8,  int8_t) \
+  V(U8,  uint8_t) \
+  V(S32, int32_t) \
+  V(U32, uint32_t) \
+  V(S64, int64_t) \
+  V(U64, uint64_t) \
+  V(F32, float) \
+  V(F64, double)
+
+// Numeric element type of the reduce collectives, expressed as a plain enum so
+// the facade public API stays non-templated. The type/op -> kernel dispatch
+// happens inside the (device) Run* definitions.
+enum class DataType {
+  #define DECLARE_ENUM(enum_name, ...) enum_name,
+    COLLECTIVE_DATA_TYPE_LIST(DECLARE_ENUM)
+  #undef DECLARE_ENUM
+};
+
+#define COLLECTIVE_REDUCE_OP_LIST(V) \
+  V(SUM) \
+  V(PRODUCT) \
+  V(MIN) \
+  V(MAX)
+
+// Reduction operation for the reduce collectives.
+enum class ReduceOpKind {
+  #define DECLARE_ENUM(enum_name) enum_name,
+    COLLECTIVE_REDUCE_OP_LIST(DECLARE_ENUM)
+  #undef DECLARE_ENUM
+};
+
+namespace detail {
+
+inline const char *DataTypeName(DataType dt) {
+#define ITEM(name, ...) case DataType::name: return #name;
+  switch (dt) {
+    COLLECTIVE_DATA_TYPE_LIST(ITEM)
+    default:
+      return "?";
+  }
+#undef ITEM
+}
+  
+inline const char* ReduceOpName(ReduceOpKind op) {
+#define ITEM(x) case ReduceOpKind::x: return #x;
+  switch (op) {
+    COLLECTIVE_REDUCE_OP_LIST(ITEM)
+    default:
+      return "?";
+  }
+#undef ITEM
+}
+
+template <DataType dt>
+struct ReduceTypeMap;  // primary left undefined: unmapped dt -> compile error
+#define ITEM(name, ctype) \
+  template <> struct ReduceTypeMap<DataType::name> { using type = ctype; };
+  COLLECTIVE_DATA_TYPE_LIST(ITEM)
+#undef ITEM
+
+template <DataType dt>
+using ReduceType = typename ReduceTypeMap<dt>::type;
+
+#if defined(__HIPCC__) || defined(__HIP__)
+
+#define COLL_HOST_DEVICE __host__ __device__
+template <typename T>
+struct SumOp {
+  using Type = T;
+  COLL_HOST_DEVICE T operator()(T a, T b) { return a + b; }
+};
+template <class T>
+struct MaxOp {
+  using Type = T;
+  COLL_HOST_DEVICE T operator()(T a, T b) { return std::max(a, b); }
+};
+template <class T>
+struct MinOp {
+  using Type = T;
+  COLL_HOST_DEVICE T operator()(T a, T b) { return std::min(a, b); }
+};
+template <class T>
+struct ProdOp {
+  using Type = T;
+  COLL_HOST_DEVICE T operator()(T a, T b) { return a * b; }
+};
+
+// Maps a storage element type to the type used to INSTANTIATE the reduce kernels.
+// float/s32 reduce as themselves; s64 is 8B so vecSize is 2; bf16/f16 reduce as a
+// packed pair so vecSize stays at fp32 parity and the 8x8 accumulator tile does
+// not spill. Data buffers stay physically ElemT; host code reinterpret_casts them
+// to ComputeT and passes counts in packs (kPack = sizeof(ComputeT)/sizeof(ElemT)).
+template <class T>
+struct ReduceComputeType {
+  using type = T;
+};
+
+template <class F>
+COLL_HOST_DEVICE hipError_t DispatchReduceType(DataType dt, F&& func) {
+  switch (dt) {
+    case DataType::F32:
+      return std::forward<F>(func)(float{});
+#if FACADE_REDUCE_USE_ALL_TYPES
+    case DataType::BF16:
+      return std::forward<F>(func)(hip_bfloat16{});
+    case DataType::F16:
+      return std::forward<F>(func)(__half{});
+    case DataType::S32:
+      return std::forward<F>(func)(int32_t{});
+    case DataType::S64:
+      return std::forward<F>(func)(int64_t{});
+#endif
+    default:
+      return hipErrorNotSupported;
+  }
+}
+
+template <class T, class F>
+COLL_HOST_DEVICE hipError_t DispatchReduceOp(ReduceOpKind op, F&& func) {
+  using C = typename ReduceComputeType<T>::type;
+  switch (op) {
+    case ReduceOpKind::SUM:
+      return std::forward<F>(func)(SumOp<C>{});
+#if FACADE_REDUCE_USE_ALL_TYPES
+    case ReduceOpKind::PRODUCT:
+      return std::forward<F>(func)(ProdOp<C>{});
+    case ReduceOpKind::MIN:
+      return std::forward<F>(func)(MinOp<C>{});
+    case ReduceOpKind::MAX:
+      return std::forward<F>(func)(MaxOp<C>{});
+#endif
+    default:
+      return hipErrorNotSupported;
+  }
+}
+
+template <class T>
+struct AccumulatorType {
+  using type = T;
+};
+
+// Generic up/down cast (identity for float; specialize for fp16/bf16 if needed).
+template <typename T>
+__device__ __forceinline__ typename AccumulatorType<T>::type UpcastF(T v) {
+  return static_cast<typename AccumulatorType<T>::type>(v);
+}
+
+template <typename T>
+__device__ __forceinline__ T DowncastF(typename AccumulatorType<T>::type v) {
+  return static_cast<T>(v);
+}
+
+struct alignas(4) BF16Pack {
+  hip_bfloat16 x, y;
+};
+static_assert(sizeof(BF16Pack) == 4 && alignof(BF16Pack) == 4);
+
+struct alignas(4) F16Pack {
+  __half x, y;
+};
+static_assert(sizeof(F16Pack) == 4 && alignof(F16Pack) == 4);
+template <>
+struct ReduceComputeType<hip_bfloat16> {
+  using type = BF16Pack;
+};
+template <>
+struct ReduceComputeType<__half> {
+  using type = F16Pack;
+};
+
+__device__ __forceinline__ float2 UnpackBf16Pack(BF16Pack a) {
+  const uint32_t u = __builtin_bit_cast(uint32_t, a);
+  return float2{mori::core::Bf16BitsToF32(static_cast<uint16_t>(u)),
+                mori::core::Bf16BitsToF32(static_cast<uint16_t>(u >> 16))};
+}
+
+__device__ __forceinline__ BF16Pack PackBf16Pack(float x, float y) {
+  const auto r = static_cast<__hip_bfloat162_raw>(__float22bfloat162_rn(float2{x, y}));
+  const auto packed = static_cast<uint32_t>(r.x) | (static_cast<uint32_t>(r.y) << 16);
+  return __builtin_bit_cast(BF16Pack, packed);
+}
+
+__device__ __forceinline__ __half2 ToHalf2(F16Pack a) { 
+  return __builtin_bit_cast(__half2, a); 
+}
+
+__device__ __forceinline__ F16Pack FromHalf2(__half2 v) { 
+  return __builtin_bit_cast(F16Pack, v); 
+}
+
+template <>
+struct SumOp<BF16Pack> {
+  using Type = BF16Pack;
+  __device__ Type operator()(Type a, Type b) {
+    const float2 xa = UnpackBf16Pack(a);
+    const float2 xb = UnpackBf16Pack(b);
+    return PackBf16Pack(xa.x + xb.x, xa.y + xb.y);
+  }
+};
+
+template <>
+struct ProdOp<BF16Pack> {
+  using Type = BF16Pack;
+  __device__ Type operator()(Type a, Type b) {
+    const float2 xa = UnpackBf16Pack(a);
+    const float2 xb = UnpackBf16Pack(b);
+    return PackBf16Pack(xa.x * xb.x, xa.y * xb.y);
+  }
+};
+
+template <>
+struct MinOp<BF16Pack> {
+  using Type = BF16Pack;
+  __device__ Type operator()(Type a, Type b) {
+    const float2 xa = UnpackBf16Pack(a);
+    const float2 xb = UnpackBf16Pack(b);
+    return PackBf16Pack(fminf(xa.x, xb.x), fminf(xa.y, xb.y));
+  }
+};
+
+template <>
+struct MaxOp<BF16Pack> {
+  using Type = BF16Pack;
+  __device__ Type operator()(Type a, Type b) {
+    const float2 xa = UnpackBf16Pack(a);
+    const float2 xb = UnpackBf16Pack(b);
+    return PackBf16Pack(fmaxf(xa.x, xb.x), fmaxf(xa.y, xb.y));
+  }
+};
+
+template <>
+struct SumOp<F16Pack> {
+  using Type = F16Pack;
+  __device__ Type operator()(Type a, Type b) {
+    return FromHalf2(__hadd2(ToHalf2(a), ToHalf2(b)));
+  }
+};
+
+template <>
+struct ProdOp<F16Pack> {
+  using Type = F16Pack;
+  __device__ Type operator()(Type a, Type b) {
+    return FromHalf2(__hmul2(ToHalf2(a), ToHalf2(b)));
+  }
+};
+
+template <>
+struct MinOp<F16Pack> {
+  using Type = F16Pack;
+  __device__ Type operator()(Type a, Type b) {
+    // HIP AMD has no __hmin2; per-lane __hmin (plan fallback).
+    const __half2 ha = ToHalf2(a);
+    const __half2 hb = ToHalf2(b);
+    return FromHalf2(__half2{__hmin(ha.x, hb.x), __hmin(ha.y, hb.y)});
+  }
+};
+
+template <>
+struct MaxOp<F16Pack> {
+  using Type = F16Pack;
+  __device__ Type operator()(Type a, Type b) {
+    // HIP AMD has no __hmax2; per-lane __hmax (plan fallback).
+    const __half2 ha = ToHalf2(a);
+    const __half2 hb = ToHalf2(b);
+    return FromHalf2(__half2{__hmax(ha.x, hb.x), __hmax(ha.y, hb.y)});
+  }
+};
+
+#endif // __HIPCC__ || __HIP__
+}  // namespace detail
+
+}  // namespace collective
+}  // namespace mori

--- a/include/mori/collective/xla/reduce_scatter_kernels.hpp
+++ b/include/mori/collective/xla/reduce_scatter_kernels.hpp
@@ -1,0 +1,518 @@
+// Copyright © Advanced Micro Devices, Inc. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// ===========================================================================
+// reduce_scatter_kernels.hpp
+//
+// Device/template kernels for the reduce-scatter example. Both modes share the
+// same streaming load/store, reduction op functors (see reduce_ops.hpp), and the
+// generic vectorized reduce core (ReduceVecGroup):
+//
+//   * ReduceScatterPushKernel  — fused SDMA "push" scatter + receiver-side
+//                                completion signal + grid-strided reduce.
+//   * ReduceScatterPullKernel  — direct P2P "pull": read each peer's shard over
+//                                XGMI and reduce in one pass (no staging/SDMA).
+//
+// All host-only test code (fill/verify, threading, main) stays in the .cpp.
+// ===========================================================================
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+#include "mori/collective/xla/collectives_common.hpp"
+#include "mori/collective/xla/reduce_ops.hpp"
+
+// Push Phase-3 reduce path: 1 = range-checked raw-buffer loads/stores (no scalar
+// tail), 0 = original global b128 load/store + partial-group + scalar tail.
+#ifndef RS_USE_BUFFER_REDUCE
+#define RS_USE_BUFFER_REDUCE 0
+#endif
+
+namespace mori {
+namespace collective {
+
+namespace detail {
+
+// Reduce one group of NV vectors (each NV-member at vector index g + i*gstride)
+// across all npes staging slots into the output. Callers guarantee every member
+// index is in-bounds, so there are NO per-lane guards here. Used with NV=NumVecs
+// for the full-group fast path and NV=1 for the single trailing partial group.
+// Generic core: srcBase(pe) returns the base pointer of peer pe's contribution
+// to THIS PE's shard. Peer 0 seeds the accumulators, peers 1..npes-1 reduce in.
+template <int NV, class ReduceOp, StreamScope Scope,
+          class T = typename ReduceOp::Type>
+__device__ __forceinline__ void ReduceVecGroup(const T* __restrict__ input, 
+                                               const T* __restrict__ staging, 
+                                  T* __restrict__ output, int npes, int myPe,
+                                  size_t v, size_t lstride, size_t chunkElems) {
+  constexpr int vecSize = VecBytes / sizeof(T);
+  using Vec = TVecType<VecBytes>;
+  using AccType = typename AccumulatorType<T>::type;
+  using Data = std::array<T, vecSize>;
+
+  AccType acc[NV][vecSize];
+  Vec vec[NV];
+  const T* p[NV];
+  // Seed accumulators from peer 0: load its NV vectors, then upcast lanes.
+  p[0] = input + myPe * chunkElems;
+#pragma unroll
+  for (int i = 0; i < NV; i++) {
+    const size_t idx = (v + i * lstride) * vecSize;
+    vec[i] = StreamLoad<Scope>(p[0] + idx);
+  }
+#pragma unroll
+  for (int i = 0; i < NV; i++) {
+    Data lanes = __builtin_bit_cast(Data, vec[i]);
+#pragma unroll
+    for (int j = 0; j < vecSize; j++) acc[i][j] = UpcastF<T>(lanes[j]);
+  }
+  
+  #pragma unroll
+  for (int i = 0; i < NV; i++) {
+    p[i] = staging + (v + i*lstride) * vecSize; // do manual hoisting
+  }
+  // Reduce peers 1..npes-1 in: load their NV vectors, then fold lanes into acc.
+  for (int pe = 1; pe < npes; pe++) {
+#pragma unroll
+    for (int i = 0; i < NV; i++) {
+      vec[i] = StreamLoad<Scope>(p[i]);
+      p[i] += chunkElems;
+    }
+#pragma unroll
+    for (int i = 0; i < NV; i++) {
+      Data lanes = __builtin_bit_cast(Data, vec[i]);
+#pragma unroll
+      for (int j = 0; j < vecSize; j++) {
+        acc[i][j] = ReduceOp()(acc[i][j], UpcastF<T>(lanes[j]));
+      }
+    }
+  }
+  // Downcast the accumulators back into NV vectors and store them.
+#pragma unroll
+  for (int i = 0; i < NV; i++) {
+    const size_t idx = v + i * lstride;
+    Data lanes;
+#pragma unroll
+    for (int j = 0; j < vecSize; j++) lanes[j] = DowncastF<T>(acc[i][j]);
+    StreamStore<Scope>(output + idx * vecSize, __builtin_bit_cast(Vec, lanes));
+  }
+}
+
+// Buffered variant of ReduceVecGroup for the push path: same NV-grouped reduce,
+// but every access goes through a range-checked RAW buffer resource (V#) instead
+// of a raw pointer. srcRsrc(pe) returns peer pe's slice descriptor and outR is the
+// output slice descriptor; each descriptor's num_records is the valid slice byte
+// extent, so the hardware per-component range check (CDNA4 ISA 9.1.5 note 4)
+// handles the final partial vector -- OOB reads return 0 and OOB stores are
+// dropped -- with NO per-lane guard and NO scalar tail, for ANY reduction op.
+// The byte offset of vector index k is k * VecBytes (uint32; slice < 4 GiB).
+// Cache policy / non-temporal hint rides RS_BUF_AUX inside BufferLoad/Store128.
+template <int NV, class ReduceOp, class SrcRsrcFn, class T = typename ReduceOp::Type>
+__device__ __forceinline__ void ReduceVecGroupBuffered(SrcRsrcFn srcRsrc, BufRsrc outR,
+                                                       int npes, uint32_t g, uint32_t gstride) {
+  static_assert(VecBytes == 16, "ReduceVecGroupBuffered uses b128 buffer ops");
+  constexpr int vecSize = VecBytes / sizeof(T);
+  using Vec = TVecType<VecBytes>;
+  using AccType = typename AccumulatorType<T>::type;
+  using Data = std::array<T, vecSize>;
+
+  AccType acc[NV][vecSize];
+  Vec vec[NV];
+
+  // Seed accumulators from peer 0.
+  BufRsrc r0 = srcRsrc(0);
+#pragma unroll
+  for (int i = 0; i < NV; i++) {
+    uint32_t voff = static_cast<uint32_t>((g + i * gstride) * VecBytes);
+    vec[i] = BufferLoad128(r0, voff);
+  }
+#pragma unroll
+  for (int i = 0; i < NV; i++) {
+    Data lanes = __builtin_bit_cast(Data, vec[i]);
+#pragma unroll
+    for (int j = 0; j < vecSize; j++) acc[i][j] = UpcastF<T>(lanes[j]);
+  }
+  for (int pe = 1; pe < npes; pe++) {
+    BufRsrc rp = srcRsrc(pe);
+#pragma unroll
+    for (int i = 0; i < NV; i++) {
+      uint32_t voff = static_cast<uint32_t>((g + i * gstride) * VecBytes);
+      vec[i] = BufferLoad128(rp, voff);
+    }
+#pragma unroll
+    for (int i = 0; i < NV; i++) {
+      Data lanes = __builtin_bit_cast(Data, vec[i]);
+#pragma unroll
+      for (int j = 0; j < vecSize; j++) {
+        acc[i][j] = ReduceOp()(acc[i][j], UpcastF<T>(lanes[j]));
+      }
+    }
+  }
+#pragma unroll
+  for (int i = 0; i < NV; i++) {
+    Data lanes;
+#pragma unroll
+    for (int j = 0; j < vecSize; j++) lanes[j] = DowncastF<T>(acc[i][j]);
+    vec[i] = __builtin_bit_cast(Vec, lanes);
+  }
+#pragma unroll
+  for (int i = 0; i < NV; i++) {
+    uint32_t voff = static_cast<uint32_t>((g + i * gstride) * VecBytes);
+    BufferStore128(outR, vec[i], voff);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fused reduce-scatter kernel ("push", sliced into S = 1<<logS slices)
+//
+//   input         : raw symmetric-heap pointer, N = npes*chunkElems elements
+//   staging       : raw symmetric-heap pointer, npes slots of chunkElems elements
+//   output        : raw symmetric-heap pointer, chunkElems elements
+//   groupCounters : plain device buffer (>= 1 uint32), local-only arrival counter
+//
+// Each shard is split into S slices. A sender issues S separate SDMA copies; copy
+// s bumps the receiver's per-slice completion counter signalPtrs[s] via an SDMA
+// ADD64 of 1 (one copy + one atomic per (sender,slice)). On the receive side EVERY
+// block loops the S slices itself and calls the shared per-slice reduce
+// (detail::WaitAndReduceSlice): for slice s it spins on slice s's counter until it
+// reaches npes-1 senders, then the WHOLE grid reduces slice s. Slice order matches
+// the senders' packet order, so the waits are satisfied in the order they are
+// performed and each slice's reduce overlaps the still-in-flight transfer of the
+// later slices (pipelining). The last block to finish the loop zeroes every slice
+// counter + the arrival counter for the next launch -- no monotonic generation
+// counter needed.
+//
+// There is no block-to-slice mapping, so gridDim.x is unconstrained. All-reduce
+// loops the same per-slice reduce and appends its pipelined per-slice broadcast to
+// each iteration (see all_reduce_kernels.hpp).
+//
+// Phase 1: block 0, four consecutive lanes per peer (nWork = npes*4). sub==0
+// snapshots that peer's queue handle, then for each slice s reserves 64B, the
+// four lanes write the fused copy+atomic, and sub==0 rings that packet. One
+// leader per queue (peers map to distinct queues) so the commit chain cannot
+// deadlock; occupancy (rptr) is still checked, with cachedHwReadIndex kept local
+// across s and written back once if it moved. Wrap/NOP pad is gone: packets are
+// 64B and the ring is a 64B multiple.
+//
+// input/staging/output MUST live in the symmetric static heap (ShmemMalloc) so
+// the address-based SDMA put can translate local->peer (offset from heapBaseAddr);
+// groupCounters is a plain hipMalloc'd buffer (never peer-written).
+// ---------------------------------------------------------------------------
+
+// Phases 2 + 3 for ONE slice: wait until slice `slice` has landed from every
+// sender, then reduce its element range [sOfs, sOfs+sCnt) of my shard with the
+// WHOLE grid. There is no block-to-slice mapping -- every block strides over all
+// of every slice -- so gridDim.x is unconstrained (need not be a multiple of S).
+//
+// The pointers are taken by value, so advancing them by the slice offset is
+// local to this call and the caller passes the same bases on every slice.
+template <int NumVecs, class ReduceOp, class T = typename ReduceOp::Type>
+__device__ __forceinline__ void WaitAndReduceSlice(
+    uint64_t* signalBuf, uint32_t slice, int myPe, int npes,
+    const T* __restrict__ input, const T* __restrict__ staging,
+    T* __restrict__ shardOut, size_t sOfs, size_t sCnt, size_t chunkElems,
+    uint32_t lstride) {
+
+  const uint32_t BlockDimX = blockDim.x;
+  constexpr int vecSize = VecBytes / sizeof(T);
+
+  // === Phase 2: wait until this slice's counter reaches all npes-1 senders =====
+  // Each slice's counter lives in my local HBM (bumped by remote SDMA ADD64s).
+  // One thread per block polls signalPtrs[slice]; every block does its own
+  // wait+acquire (read-only -> L2 hits). At npes==1 want==0, so no spin.
+  if (threadIdx.x == 0) {
+    // Self-copy is skipped, so exactly npes-1 senders bump this slice's counter.
+    const uint32_t want = static_cast<uint32_t>(npes - 1);
+    auto* addr = Iglobal(reinterpret_cast<uint32_t*>(&signalBuf[slice]));
+    while (__hip_atomic_load(addr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT) < want) {
+      __builtin_amdgcn_s_sleep(1);
+    }
+  }
+  __syncthreads();
+  // System-scope ACQUIRE (not the full seq_cst __threadfence_system): the staging
+  // was written by peers' SDMA over XGMI, so we must invalidate against another
+  // device's writes -- scope "" (system) is required -- but only the acquire half
+  // is needed here (we publish nothing at this point), so drop the release/waitcnt.
+  __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "");
+
+  // === Phase 3: grid-strided vectorized reduce over this slice =================
+  // Streaming reduction over the slice only, strided over the whole grid. Uses
+  // the nontemporal load<16>/store<16> primitives (single-use, bypass L2).
+  input += sOfs;
+  staging += sOfs;
+  shardOut += sOfs;
+
+#if RS_USE_BUFFER_REDUCE
+  // Range-checked raw-buffer path. Each descriptor's num_records is the valid
+  // slice byte extent (sCnt elements), so the hardware per-component range check
+  // covers the final partial vector: OOB reads return 0 and OOB stores are
+  // dropped. No partial-group loop, no scalar tail -- correct for any op. We only
+  // iterate to the vector ceiling; groups whose members run past the end are
+  // no-ops (bounded by NumVecs-1 extra chunks per thread).
+  const uint32_t sliceBytes32 = static_cast<uint32_t>(sCnt * sizeof(T));
+  auto srcRsrc = [input, staging, chunkElems, myPe, sliceBytes32](int pe) -> BufRsrc {
+    const T *ptr = pe == 0 ? input + myPe * chunkElems : 
+                             staging + (pe - 1) * chunkElems;
+    return MakeRawRsrc(ptr, sliceBytes32);
+  };
+  const BufRsrc outR = MakeRawRsrc(shardOut, sliceBytes32);
+  // Index in 32-bit: within a slice the vector index is bounded by the same
+  // < 4 GiB extent the buffer descriptor (num_records) already assumes, and the
+  // grid dims are small -- so 32-bit avoids 64-bit address math and VGPRs.
+  const uint32_t totalVecs = static_cast<uint32_t>(sCnt / vecSize);
+  const uint32_t totalVecsCeil = static_cast<uint32_t>((sCnt + vecSize - 1) / vecSize);
+  // Full NumVecs groups only while every member is in-bounds (no wasted OOB
+  // chunks), then NV=1 buffered groups to the ceiling so only the genuine final
+  // sub-vector element(s) hit the hardware range check.
+  uint32_t v = blockIdx.x * BlockDimX + threadIdx.x;
+  for (; v + (NumVecs - 1) * lstride < totalVecs; v += lstride * NumVecs) {
+    ReduceVecGroupBuffered<NumVecs, ReduceOp>(srcRsrc, outR, npes, v, lstride);
+  }
+  for (; v < totalVecsCeil; v += lstride) {
+    ReduceVecGroupBuffered<1, ReduceOp>(srcRsrc, outR, npes, v, lstride);
+  }
+#else
+  // Push path: every source (input + staging) is LOCAL HBM and the Phase-2
+  // __threadfence_system() already made the remote-DMA'd staging visible, so the
+  // per-access loads/stores use agent scope (scope=EAgentScope).
+  const size_t totalVecs = sCnt / vecSize;
+  // Grid-strided thread id / stride. The grid is capped by CU count
+  size_t v = blockIdx.x * BlockDimX + threadIdx.x;
+  for (; v + (NumVecs - 1) * lstride < totalVecs; v += lstride * NumVecs) {
+    ReduceVecGroup<NumVecs, ReduceOp, EAgentScope>(input, staging, shardOut, 
+                                        npes, myPe, v, lstride, chunkElems);
+  }
+  // Trailing partial group: the remaining in-bounds vectors for this thread.
+  for (; v < totalVecs; v += lstride) {
+    ReduceVecGroup<1, ReduceOp, EAgentScope>(input, staging, shardOut, 
+                                        npes, myPe, v, lstride, chunkElems);
+  }
+  // Scalar tail (only the last slice can be non-vecSize-aligned).
+  v = blockIdx.x * BlockDimX + threadIdx.x + totalVecs * vecSize;
+  for (; v < sCnt; v += lstride) {
+    using Vec = TVecType<sizeof(T)>;
+    using AccType = typename AccumulatorType<T>::type;
+    const T *ptr = input + myPe * chunkElems;
+    Vec V = StreamLoad<EAgentScope, sizeof(T)>(ptr + v);
+    AccType a = UpcastF<T>(__builtin_bit_cast(T, V));
+    ptr = staging + v;
+    for (int pe = 1; pe < npes; pe++, ptr += chunkElems) {
+      V = StreamLoad<EAgentScope, sizeof(T)>(ptr);
+      a = ReduceOp()(a, UpcastF<T>(__builtin_bit_cast(T, V)));
+    }
+    V = __builtin_bit_cast(Vec, DowncastF<T>(a));
+    StreamStore<EAgentScope, sizeof(T)>(shardOut + v, V);
+  }
+#endif // RS_USE_BUFFER_REDUCE
+}
+
+// Load M output positions x NPES peers ALL up front into distinct registers, then
+// reduce each position. Unlike ReduceVecGroup (which reuses one buffer per peer and
+// so serializes the remote loads peer-by-peer via a WAR dependency), every load
+// here is independent: with all indices compile-time the regs[][] array stays in
+// VGPRs and the M*NPES loads issue back-to-back, so the long remote-load latency is
+// paid once and the per-position reductions overlap with still-in-flight loads.
+// Callers guarantee every member index (g + m*gstride) is in-bounds.
+template <int M, int NPES, class ReduceOp, StreamScope Scope, class SrcBaseFn, 
+          class T = typename ReduceOp::Type>
+__device__ __forceinline__ void ReduceAllPeersGroup(SrcBaseFn srcBase, T* __restrict__ output,
+                                                    size_t g, size_t gstride) {
+  constexpr int vecSize = VecBytes / sizeof(T);
+  using Vec = TVecType<VecBytes>;
+  using AccType = typename AccumulatorType<T>::type;
+  using Data = std::array<T, vecSize>;
+  Vec regs[M][NPES];
+#pragma unroll
+  for (int m = 0; m < M; m++) {
+    size_t idx = g + static_cast<size_t>(m) * gstride;
+#pragma unroll
+    for (int pe = 0; pe < NPES; pe++)
+      regs[m][pe] = StreamLoad<Scope>(srcBase(pe) + idx * vecSize);
+  }
+#pragma unroll
+  for (int m = 0; m < M; m++) {
+    AccType acc[vecSize];
+    Data l0 = __builtin_bit_cast(Data, regs[m][0]);
+#pragma unroll
+    for (int j = 0; j < vecSize; j++) acc[j] = UpcastF<T>(l0[j]);
+#pragma unroll
+    for (int pe = 1; pe < NPES; pe++) {
+      Data l = __builtin_bit_cast(Data, regs[m][pe]);
+#pragma unroll
+      for (int j = 0; j < vecSize; j++) {
+        acc[j] = ReduceOp()(acc[j], UpcastF<T>(l[j]));
+      }
+    }
+    Data o;
+#pragma unroll
+    for (int j = 0; j < vecSize; j++) o[j] = DowncastF<T>(acc[j]);
+    StreamStore<Scope>(output + (g + static_cast<size_t>(m) * gstride) * vecSize,
+                       __builtin_bit_cast(Vec, o));
+  }
+}
+
+}  // namespace detail
+
+template <int NumVecs, class ReduceOp, class T = typename ReduceOp::Type>
+__global__ void __launch_bounds__(256, 1)
+ReduceScatterPushKernel(int myPe, int npes, int logS, T* __restrict__ output,
+                                    uint32_t* __restrict__ groupCounters, size_t chunkElems,
+                                    mori::cco::ccoDevComm devComm, mori::cco::ccoWindow_t heapWin,
+                                    const T* __restrict__ input, T* __restrict__ staging) {
+
+    // Phase 1: scatter the input to the staging buffer
+  if (blockIdx.x == 0) {
+    // reduce-scatter: per-peer source slice (stride=chunkElems), dst=staging,
+    // no self-copy (self is folded in by the Phase-3 reduce reading local input).
+    // Staging is packed densely (no self hole): slot = myPe<peer?myPe:myPe-1, a
+    // bijection over the npes-1 non-self peers.
+    StartSdmaScatter<sizeof(T)>(
+        devComm.sdma, npes, logS, chunkElems,
+        [=](int peer) { return peer != myPe; },
+        [=](int peer) -> const uint8_t* {
+          return reinterpret_cast<const uint8_t*>(input + peer * chunkElems);
+        },
+        [=](int peer) -> uint8_t* {
+          const int slot = (myPe < peer ? myPe : myPe - 1);   // my slot in peer's staging
+          int32_t diff = (peer - myPe)*static_cast<int32_t>(heapWin->stride4G);
+          return reinterpret_cast<uint8_t*>(staging + slot * chunkElems) + 
+             (static_cast<uint64_t>(diff)<<32);
+        });
+  }
+  
+  // Phase 2-3: walk all S slices in the order the senders queued them, reducing
+  // each into this PE's shard-sized output buffer. Nothing happens per slice --
+  // the counters are cleared once below, after every slice is done.
+  constexpr int vecSize = VecBytes / sizeof(T);
+  const uint32_t S = 1u << logS;
+  // vecSize-aligned slice length; the last slice absorbs the remainder.
+  const size_t sliceLen = ((chunkElems >> logS) / vecSize) * vecSize;
+  const uint32_t lstride = FORCE_SGPR(gridDim.x * blockDim.x);  // loop-invariant
+  for (uint32_t s = 0; s < S; s++) {
+    const size_t sOfs = FORCE_SGPR(s * sliceLen);
+    const size_t sCnt = FORCE_SGPR((s == S - 1) ? (chunkElems - sOfs) : sliceLen);
+    detail::WaitAndReduceSlice<NumVecs, ReduceOp>(devComm.sdma.signalBuf, s, myPe, npes,
+                                                 input, staging, output, sOfs, sCnt,
+                                                 chunkElems, lstride);
+  }
+
+  // === Reset: the last block of the grid zeroes every slice counter ============
+  // A block only reaches here after passing the Phase-2 wait on EVERY slice, so
+  // when the arrival counter hits gridDim.x all S slice counters are dead and
+  // clearing them cannot drop an unseen signal.
+  if (threadIdx.x == 0) {
+    uint32_t z = atomicAdd(&groupCounters[0], 1u);
+    if (z + 1 == gridDim.x) {
+      for (uint32_t s = 0; s < S; s++) {  // clear slice s's completion counter
+        StreamStore<ESystemScope, sizeof(uint64_t)>(&devComm.sdma.signalBuf[s], 0);
+      }
+      groupCounters[0] = 0;  // clear the grid-wide arrival counter
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Direct "pull" reduce-scatter kernel (no staging, no SDMA scatter) — CCO/LSA.
+//
+// Each PE reads its shard directly from every peer's input buffer over the P2P
+// fabric (XGMI) and reduces in one pass:
+//
+//   output[j] = REDUCE_p( input_p[ myPe*chunkElems + j ] )
+//
+// input_p's base is resolved device-side by the same flat-VA rank-delta math the
+// push path uses for its SDMA destinations: peer pe's copy of a local heap
+// pointer sits at that pointer + (pe - myPe)*stride4G<<32, so shifting my own
+// shard pointer (input + myPe*chunkElems) lands on peer pe's contribution to my
+// shard. peer==myPe resolves back to the local input. This is the direct
+// analogue of the old shmem peerPtrs[pe] lookup and assumes nothing about
+// `input`'s offset within the heap window. There is no staging buffer and no
+// cross-block flag handoff, so every block is independent (no co-residency cap)
+// and the kernel is a single fused grid-strided reduce.
+//
+// The fast path uses ReduceAllPeersGroup: each group reduces M = NumVecs/NPES
+// output positions and issues all M*NPES remote loads up front, for maximum
+// memory-level parallelism across peers (the long XGMI read latency is paid once
+// per group instead of once per peer). NPES is a compile-time template arg so the
+// per-position/per-peer register tile stays in VGPRs; the host dispatches on the
+// real npes.
+//
+// Correctness requires all PEs to have produced their input before launch; the
+// host issues a ccoBarrierAll() before timing.
+// ---------------------------------------------------------------------------
+template <int NumVecs, int NPES, class ReduceOp, class T = typename ReduceOp::Type>
+__global__ void ReduceScatterPullKernel(int myPe,
+                                        mori::cco::ccoWindow_t heapWin,
+                                        const T* __restrict__ input,
+                                        T* __restrict__ output, size_t chunkElems) {
+  constexpr int vecSize = VecBytes / sizeof(T);
+  constexpr int M = NumVecs / NPES;  // output positions per group (M >= 1 for NPES <= NumVecs)
+  const size_t gtid = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const size_t gstride = static_cast<size_t>(blockDim.x) * gridDim.x;
+  const size_t totalVecs = chunkElems / vecSize;
+
+  // Peer addressing, same signed-delta form the push path uses for its SDMA
+  // destinations (Phase 1 of ReduceScatterPushKernel): all rank slots in the LSA
+  // flat VA have identical size, so a local pointer maps to the same object in
+  // peer pe's slot by adding (pe - myPe)*stride4G<<32. That is the canonical
+  // ccoGetLsaPeerPtr(heapWin, pe, input - ccoGetLocalPtr(heapWin)) with winBase
+  // cancelled out, so it needs neither the window-base load nor the intra-heap
+  // offset round trip, and it keeps no "input at heap offset 0" assumption.
+  // Shifting my own shard pointer gives peer pe's contribution to my shard
+  // directly; pe == myPe yields diff 0, i.e. the local input.
+  const uint32_t stride4G = heapWin->stride4G;
+  const T* __restrict__ myShard = input + static_cast<size_t>(myPe) * chunkElems;
+  auto srcBase = [myShard, myPe, stride4G](int pe) -> const T* {
+    int32_t diff = (pe - myPe) * static_cast<int32_t>(stride4G);
+    return reinterpret_cast<const T*>(reinterpret_cast<const uint8_t*>(myShard) +
+                                      (static_cast<uint64_t>(diff) << 32));
+  };
+
+  // Fast path: M positions per group, all M*NPES loads issued up front.
+  size_t g = gtid;
+  for (; g + static_cast<size_t>(M - 1) * gstride < totalVecs; g += gstride * M) {
+    detail::ReduceAllPeersGroup<M, NPES, ReduceOp, ESystemScope>(srcBase, output, g, gstride);
+  }
+  // Trailing in-bounds vectors for this thread (fewer than M left). Reuse the
+  // all-peers primitive with M=1 (one position, NPES loads up front) so the pull
+  // kernel stays on a single reduction path and needs no runtime-npes helper.
+  for (size_t idx = g; idx < totalVecs; idx += gstride) {
+    detail::ReduceAllPeersGroup<1, NPES, ReduceOp, ESystemScope>(srcBase, output, idx, gstride);
+  }
+
+  // Scalar tail for elements not covered by the vectorized loop.
+  for (size_t i = totalVecs * vecSize + gtid; i < chunkElems; i += gstride) {
+    using Vec = TVecType<sizeof(T)>;
+    using AccType = typename detail::AccumulatorType<T>::type;
+    AccType a = detail::UpcastF<T>(__builtin_bit_cast(T, 
+                  StreamLoad<ESystemScope, sizeof(T)>(srcBase(0) + i)));
+    for (int pe = 1; pe < NPES; pe++) {
+      auto V = StreamLoad<ESystemScope, sizeof(T)>(srcBase(pe) + i);
+      a = ReduceOp()(a, detail::UpcastF<T>(__builtin_bit_cast(T, V)));
+    }
+    Vec V = __builtin_bit_cast(Vec, detail::DowncastF<T>(a));
+    StreamStore<ESystemScope, sizeof(T)>(output + i, V);
+  }
+}
+
+} // namespace collective
+} // namespace mori

--- a/include/mori/core/transport/sdma/anvil_device.hpp
+++ b/include/mori/core/transport/sdma/anvil_device.hpp
@@ -80,6 +80,7 @@ __device__ __forceinline__ SDMA_PKT_COPY_LINEAR CreateCopyPacket(void* srcBuf, v
   return copy_packet;
 }
 
+// Build an SDMA ADD64 atomic packet that increments the signal by 1.
 __device__ __forceinline__ SDMA_PKT_ATOMIC CreateAtomicIncPacket(HSAuint64* signal) {
   SDMA_PKT_ATOMIC packet = {};
 
@@ -89,8 +90,8 @@ __device__ __forceinline__ SDMA_PKT_ATOMIC CreateAtomicIncPacket(HSAuint64* sign
   packet.ADDR_LO_UNION.addr_31_0 = (uint32_t)((uintptr_t)signal);
   packet.ADDR_HI_UNION.addr_63_32 = (uint32_t)((uintptr_t)signal >> 32);
 
-  packet.SRC_DATA_LO_UNION.src_data_31_0 = 0x1;
-  packet.SRC_DATA_HI_UNION.src_data_63_32 = 0x0;
+  packet.SRC_DATA_LO_UNION.src_data_31_0 = 1;
+  packet.SRC_DATA_HI_UNION.src_data_63_32 = 0;
 
   return packet;
 }
@@ -117,12 +118,11 @@ __device__ __forceinline__ bool waitForSignal(HSAuint64* addr, uint64_t expected
   }
   return true;
 }
-
 #endif  // __HIPCC__ || __CUDACC__
 
 struct SdmaQueueDeviceHandle {
 #if defined(__HIPCC__) || defined(__CUDACC__)
-  __device__ __forceinline__ uint64_t WrapIntoRing(uint64_t index) {
+  static __device__ __forceinline__ uint64_t WrapIntoRing(uint64_t index) {
     const uint64_t queue_size_in_bytes = SDMA_QUEUE_SIZE;
     return index % queue_size_in_bytes;
   }

--- a/include/mori/core/transport/sdma/sdma_pkt_struct.h
+++ b/include/mori/core/transport/sdma/sdma_pkt_struct.h
@@ -42,7 +42,8 @@ const unsigned int SDMA_OP_CONST_FILL = 11;
 const unsigned int SDMA_SUBOP_COPY_LINEAR = 0;
 
 const unsigned int SDMA_SUBOP_WRITE_LINEAR = 0;
-const unsigned int SDMA_ATOMIC_ADD64 = 47;
+const unsigned int SDMA_ATOMIC_ADD64 = 47;  // TC_OP_ATOMIC_ADD_RTN_64 (0x2F)
+const unsigned int SDMA_ATOMIC_ADD32 = 15;  // TC_OP_ATOMIC_ADD_RTN_32 (0x0F)
 
 typedef struct SDMA_PKT_COPY_LINEAR_TAG {
   union {

--- a/run_multi_node.sh
+++ b/run_multi_node.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+
+# ---------------------------------------------------------------------------
+# Configuration — adjust these to match your setup
+# ---------------------------------------------------------------------------
+REMOTE_HOST="banff-ccs-aus-p20-14"
+LOCAL_CONTAINER="pemeliya-jax191"
+REMOTE_CONTAINER="${LOCAL_CONTAINER}"
+
+WORLD_SIZE=2
+LOCAL_RANK=0
+REMOTE_RANK=1
+NUM_GPUS_PER_PROCESS=2
+
+#$TEST $pid $NUM_PROCS $NUM_GPUS_PER_PROCESS
+
+# NFS-mounted path *inside* the container where the repo / build lives
+NFS_WORK_DIR="${NFS_WORK_DIR:-/data/mori}"
+PROGRAM="${PROGRAM:-build/examples/allgather_test}"
+CHUNK_BYTES="${CHUNK_BYTES:-1048576}"
+
+# ---------------------------------------------------------------------------
+# Environment variables forwarded into the containers
+# ---------------------------------------------------------------------------
+ENV_VARS=(
+  -e HSA_NO_SCRATCH_RECLAIM=1
+  -e HIP_FORCE_DEV_KERNARG=1
+  -e MORI_SHMEM_MODE=STATIC_HEAP
+  -e MORI_SHMEM_HEAP_SIZE=5G
+  -e MORI_KERNEL_DIR="${NFS_WORK_DIR}/build/lib/gfx942_mlx5"
+  -e MORI_APP_LOG_LEVEL=DEBUG
+  -e MORI_SHMEM_LOG_LEVEL=DEBUG
+  -e MORI_CORE_LOG_LEVEL=DEBUG
+  -e MORI_OPS_LOG_LEVEL=DEBUG
+  -e MORI_DISABLE_P2P=0
+  -e MORI_ENABLE_SDMA=0
+  -e LD_PRELOAD=/lib/x86_64-linux-gnu/libnuma.so.1
+)
+
+for v in ${EXTRA_ENV:-}; do
+  ENV_VARS+=(-e "$v")
+done
+
+rm -f ${NFS_WORK_DIR}/allgather_test_uid.bin
+# ---------------------------------------------------------------------------
+# Build the inner commands: <rank> <world_size> [chunk_bytes]
+# ---------------------------------------------------------------------------
+LOCAL_CMD="cd ${NFS_WORK_DIR} && ./${PROGRAM} ${LOCAL_RANK} ${WORLD_SIZE} ${NUM_GPUS_PER_PROCESS} ${CHUNK_BYTES}"
+REMOTE_CMD="cd ${NFS_WORK_DIR} && ./${PROGRAM} ${REMOTE_RANK} ${WORLD_SIZE} ${NUM_GPUS_PER_PROCESS} ${CHUNK_BYTES}"
+
+echo "============================================================"
+echo " Local host  : $(hostname)  container: ${LOCAL_CONTAINER}"
+echo " Remote host : ${REMOTE_HOST}  container: ${REMOTE_CONTAINER}"
+echo " Program     : ${PROGRAM}  world_size=${WORLD_SIZE}  chunk=${CHUNK_BYTES}"
+echo "============================================================"
+
+# ---------------------------------------------------------------------------
+# Launch rank 0 locally (background) — must start first to create uid file
+# ---------------------------------------------------------------------------
+echo "[rank ${LOCAL_RANK}]  Starting on local container ${LOCAL_CONTAINER} ..."
+docker exec "${ENV_VARS[@]}" "${LOCAL_CONTAINER}" \
+  bash -c "${LOCAL_CMD}" 2>&1 | sed "s/^/[rank ${LOCAL_RANK}] /" &
+LOCAL_PID=$!
+
+# Small delay to let rank 0 write the uid file before rank 1 starts polling
+sleep 1
+
+# ---------------------------------------------------------------------------
+# Launch rank 1 on remote host via SSH (background)
+# ---------------------------------------------------------------------------
+DOCKER_CMD="docker exec"
+for e in "${ENV_VARS[@]}"; do
+  DOCKER_CMD+=" $e"
+done
+DOCKER_CMD+=" ${REMOTE_CONTAINER} bash -c '${REMOTE_CMD}'"
+
+echo "[rank ${REMOTE_RANK}] Starting on ${REMOTE_HOST} container ${REMOTE_CONTAINER} ..."
+ssh -i ~/.ssh/id_rsa_scp "${REMOTE_HOST}" "${DOCKER_CMD}" 2>&1 \
+  | sed "s/^/[rank ${REMOTE_RANK}] /" &
+REMOTE_PID=$!
+
+# ---------------------------------------------------------------------------
+# Wait for both and report exit codes
+# ---------------------------------------------------------------------------
+LOCAL_RC=0;  wait "${LOCAL_PID}"  || LOCAL_RC=$?
+REMOTE_RC=0; wait "${REMOTE_PID}" || REMOTE_RC=$?
+
+echo "============================================================"
+echo " Rank ${LOCAL_RANK}  (local)  exit code: ${LOCAL_RC}"
+echo " Rank ${REMOTE_RANK} (remote) exit code: ${REMOTE_RC}"
+echo "============================================================"
+
+if [[ ${LOCAL_RC} -ne 0 || ${REMOTE_RC} -ne 0 ]]; then
+  exit 1
+fi

--- a/src/application/CMakeLists.txt
+++ b/src/application/CMakeLists.txt
@@ -8,6 +8,25 @@ if(WITH_MPI)
         "'-DBUILD_EXAMPLES=OFF' / 'BUILD_EXAMPLES=OFF pip install .'")
   endif()
 endif()
+# ROCm's hsakmt CMake package links an imported target `numa::numa`, but some
+# ROCm distributions ship hsakmtTargets.cmake without a Find module that
+# actually creates it. Define it here from the system libnuma if missing.
+if(NOT TARGET numa::numa)
+  find_library(NUMA_LIBRARY NAMES numa)
+  find_path(NUMA_INCLUDE_DIR NAMES numa.h)
+  if(NUMA_LIBRARY)
+    add_library(numa::numa UNKNOWN IMPORTED)
+    set_target_properties(
+      numa::numa PROPERTIES IMPORTED_LOCATION "${NUMA_LIBRARY}"
+                            INTERFACE_INCLUDE_DIRECTORIES "${NUMA_INCLUDE_DIR}")
+  else()
+    message(
+      FATAL_ERROR
+        "libnuma not found but required by hsakmt (numa::numa). Install it "
+        "(e.g. 'apt install libnuma-dev').")
+  endif()
+endif()
+
 find_package(hsa-runtime64 REQUIRED)
 
 # ROCm 7.14's hsakmtTargets.cmake leaks its build machine into

--- a/src/application/context/context.cpp
+++ b/src/application/context/context.cpp
@@ -489,7 +489,8 @@ void Context::EnsureSdmaTransport(int requestedChannels) {
     if (!peerCaps[i].canSDMA) continue;
     // Peer within-node device id: count of same-host peers before it.
     int peerDevId = SameHostPeersBefore(i);
-    if (i != LocalRank()) anvil::EnablePeerAccess(localDevId, peerDevId);
+    // NOTE NOTE this is not necessary for SDMA !!
+    //if (i != LocalRank()) anvil::EnablePeerAccess(localDevId, peerDevId);
     anvil::anvil.connect(localDevId, peerDevId, sdmaNumChannels);
   }
   sdmaChannels_ = sdmaNumChannels;

--- a/src/application/memory/symmetric_memory.cpp
+++ b/src/application/memory/symmetric_memory.cpp
@@ -298,7 +298,21 @@ SymmMemObjPtr SymmMemManager::RegisterSymmMemObj(void* localPtr, size_t size, bo
       }
     }
 
-    size_t signalArraySize = sizeof(HSAuint64) * numDevices * numOfQueuesPerDevice;
+    // Push collectives use the per-PE signal buffer for two disjoint counter
+    // ranges: the reduce-scatter per-slice completion counters [0..S-1] and the
+    // all-reduce broadcast counters [kBcastSlot .. kBcastSlot+S-1] (kBcastSlot ==
+    // kRSPushMaxSlices), so the max index reached is 2*kRSPushMaxSlices-1 with
+    // S <= kRSPushMaxSlices. Reserve a minimum even when npes*channels is small.
+    // RS_MIN_SIGNAL_SLOTS_PER_DEV overrides the floor with a per-device count
+    // (floor = numDevices * value) so tests can size the buffer explicitly.
+    size_t numSignalSlots = numDevices * numOfQueuesPerDevice;
+    size_t minSignalSlots = 16;  // default total floor (comfortable headroom)
+    if (const char* s = std::getenv("RS_MIN_SIGNAL_SLOTS_PER_DEV")) {
+      int perDev = std::atoi(s);
+      if (perDev > 0) minSignalSlots = numDevices * static_cast<size_t>(perDev);
+    }
+    if (numSignalSlots < minSignalSlots) numSignalSlots = minSignalSlots;
+    size_t signalArraySize = sizeof(HSAuint64) * numSignalSlots;
     HIP_RUNTIME_CHECK(hipMalloc(&gpuMemObj->signalPtrs, signalArraySize));
     HIP_RUNTIME_CHECK(hipMemset(gpuMemObj->signalPtrs, 0, signalArraySize));
     HIP_RUNTIME_CHECK(hipMalloc(&gpuMemObj->expectSignalsPtr, signalArraySize));


### PR DESCRIPTION
the initial work:  https://github.com/ROCm/mori/tree/pemeliya/collectives-develop

## Summary

Add a header-only, CCO-backed collective implementation intended for
XLA integration. The new path uses CCO symmetric windows and SDMA
copy-plus-completion packets for intra-node GPU communication without
depending on MORI's SHMEM collective path.

This PR provides the MORI-side facade and kernels; it does not yet add
JAX/XLA registration or Bazel integration.

## Changes

- Add `CollectivesFacade` for symmetric allocation, lifecycle management,
  kernel dispatch, and runtime tuning.
- Add SDMA push implementations for:
  - reduce-scatter
  - all-reduce
  - all-gather
  - all-to-all
  - collective-permute
- Add a direct-XGMI pull implementation for reduce-scatter.
- Add sliced/pipelined reduce-scatter and all-reduce execution.
- Add SDMA ADD32 completion packets and supporting runtime plumbing.
- Add a unified multi-GPU benchmark with device-side correctness checks
  and runtime selection of collective, size, algorithm, and slice count.

## Current scope

- Intra-node LSA/XGMI communication only.
- Real kernels are compiled for gfx942, gfx950, and gfx1250.
- Reduction dispatch defaults to `f32` with `sum`.
- Collective-permute currently supports one destination per rank.
- Back-to-back launches require stream completion and a host-side
  `ccoBarrierAll`.
- Send, receive, device barrier, quiet, and fence APIs are placeholders.

## Validation

The benchmark validates each rank's output after timing.

Before submission, record:

- GPU and ROCm versions:
- PE counts and message sizes:
- Collectives and modes tested:
- Build command:
- Benchmark commands and results:

## Performance

Any RCCL comparison should be rerun on the same hardware and software
configuration using the same bandwidth definition. No performance claim
is made from the preliminary checked-in timing log.