### PR TITLE
Revert "perf(EPv2): skip the dispatch completion spin when the peer s…

### DIFF
--- a/src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp
+++ b/src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp
@@ -285,10 +285,6 @@ __device__ void EpDispatch1250xBody(EpArgs args) {
   const int aWarp = globalWarpId;
   const int aWarps = (int)gridDim.x * warpNum;
 
-  constexpr int kPresigCap = 512;
-  constexpr bool _presigOn = ((int)kCfg.maxTokPerRank <= kPresigCap) && (npes <= WS);
-  index_t _preSig = 1;
-
   const int _tpi = (topk > 0 && topk <= WS && (WS % topk) == 0) ? (WS / topk) : 1;
   const int _qTok = (aWarps > 0) ? (int)(((long long)args.numTokens + aWarps - 1) / aWarps) : _tpi;
   const int _etpi = (_tpi > 1 && _qTok >= 1 && _qTok < _tpi) ? _qTok : _tpi;
@@ -378,10 +374,6 @@ __device__ void EpDispatch1250xBody(EpArgs args) {
   const bool _blkMapNeeded = !((_bmPerTok > 0) && (((_bmTileB - 384) / _bmPerTok) > 0));
   for (int p = thdId; p < npes; p += blockDim.x) {
     index_t n = s_N[p];
-    if (_presigOn && globalWarpId == 0 && laneId < npes) {
-      _preSig = __hip_atomic_load(EpPeer<index_t>(win, laneId, args.offRecvNum) + myPe,
-                                  __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
-    }
     if (_blkMapNeeded) _cusplit_blkCount[(size_t)blockIdx.x * npes + p] = n;
     if (n > 0) {
       s_base[p] = __hip_atomic_fetch_add(EpPeer<index_t>(win, p, args.offTokOff), n,
@@ -682,8 +674,7 @@ __device__ void EpDispatch1250xBody(EpArgs args) {
 
     for (int destPe = laneId; destPe < npes; destPe += WS) {
       index_t* signal = EpPeer<index_t>(win, destPe, args.offRecvNum) + myPe;
-      if constexpr (_presigOn) asm volatile("" : "+v"(_preSig));
-      if (!_presigOn || _preSig != 0) EpWaitEq(signal, 0);
+      EpWaitEq(signal, 0);
       index_t numTokenSignal = __hip_atomic_load(args.destPeTokenCounter + destPe, __ATOMIC_RELAXED,
                                                  __HIP_MEMORY_SCOPE_AGENT) +
                                1;


### PR DESCRIPTION
…lot is already clear (#645)"

This reverts commit 26c7d868a35198e419112d7c6dcc5822ae4abb19.

The gain it was merged for is not there on the commit it was merged into. Three arms in one session, six alternating rounds each, one tree with only ep_intranode_1250x.hpp swapped, 4 ranks, graph mode, topk 6, WARMUP=5 ITERS=20, gfx1250. Dispatch, mean over 6 rounds:

  dtype  ct      ceb5677f   with #645
  bf16   512        59.45       58.22   (-1.23 us, slower in 1/6 rounds)
  bf16   4096      227.12      227.27   (+0.15 us, slower in 2/6)
  fp4    512        50.87       50.53   (-0.33 us, slower in 1/6)
  fp4    4096       74.27       74.23   (-0.03 us, slower in 3/6)

A single clean point on this machine has a run-to-run spread of 1.7 us, so all four sit in the noise. #645 measured -7.48 us at fp4 ct=512 against 0a9093b8, which was its base then.

One thing this run does not explain: fp4 ct=512 measures 50.87 us here, where #645 reported 38.92 us for its base. Both arms are about 12 us slower than that record, so what moved is the base and not this change. Why it moved is open and tracked separately -- it does not weaken the comparison above, which is same tree, same session, alternating order.

Without the gain, what stays behind is a compile-time gate, a live variable pinned by an empty volatile asm, and an atomic load of the peer slot whose result is only compared against zero.

