### PR TITLE
test(ep/v2): warm the internode bench with the timed loop's tensor lifetime

### DIFF
--- a/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
+++ b/tests/python/ops/dispatch_combine_v2/test_dispatch_combine_v2_internode.py
@@ -763,13 +763,28 @@ def _bench(op, cfg, dist_handle, device, args, comm):
     events = [torch.cuda.Event(enable_timing=True) for _ in range(3 * num_rounds + 1)]
 
     total_recv = 0
+    # Warm with the SAME tensor lifetime the timed loop uses. Passing the
+    # converted tensor inline makes it a temporary that dies at the end of the
+    # statement, so warmup only ever keeps one alive, while the timed loop keeps
+    # two: it binds the result to a name, and Python evaluates the right-hand
+    # side before rebinding, so the previous round's tensor is still referenced.
+    # Warming one block deep leaves the caching allocator holding one where two
+    # are needed, and the second timed round pays a fresh hipMalloc -- ~100us of
+    # HOST time. The timing events tile the timed region, so that host stall is
+    # charged to the combine window as GPU idle and reads as a first round twice
+    # as slow as every round after it.
+    warmup_combine_input = None
     for i in range(args.warmup):
         dispatch_out = op.dispatch(inp, wts, sc, idx, return_routing=True)
         if i == args.warmup - 1:
             # Read it here, not in the timed loop: .item() synchronises.
             torch.cuda.synchronize()
             total_recv = int(dispatch_out[4][0].item())
-        op.combine(convert(dispatch_out[0]), combine_weights, routing=dispatch_out[5])
+        warmup_combine_input = convert(dispatch_out[0])
+        op.combine(warmup_combine_input, combine_weights, routing=dispatch_out[5])
+    # Release before the timed loop: left bound, it keeps a THIRD tensor alive
+    # and just moves the allocation into the measured region.
+    del warmup_combine_input
     torch.cuda.synchronize()
 
     # One pre-loop barrier, gloo, matching what the v1 harness does at this same
@@ -993,9 +1008,16 @@ def _timed_pass(
     """One warmup+timed block. Returns (dispatch_us, combine_us) as grand means over
     rounds x ranks, plus (worst_dispatch, worst_combine) as the worst single round."""
     events = [torch.cuda.Event(enable_timing=True) for _ in range(3 * num_rounds + 1)]
+    # Same tensor lifetime as the timed loop; see the warmup in _bench for why
+    # the inline temporary costs the second timed round a hipMalloc. It matters
+    # more here: this function reports a worst-single-round that the tuner uses
+    # to break ties, against a default --tuning-margin-us of 1.5.
+    warmup_combine_input = None
     for _ in range(num_warmup):
         dispatch_out = op.dispatch(inp, wts, sc, idx, return_routing=True)
-        op.combine(convert(dispatch_out[0]), combine_weights, routing=dispatch_out[5])
+        warmup_combine_input = convert(dispatch_out[0])
+        op.combine(warmup_combine_input, combine_weights, routing=dispatch_out[5])
+    del warmup_combine_input
     torch.cuda.synchronize()
     events[0].record()
     for i in range(num_rounds):


### PR DESCRIPTION
## Summary

The internode bench reports a combine `Worst` about twice its `Average`. That is not the kernel or the fabric: it is a `hipMalloc` inside the measured region, caused by the warmup loops holding the converted combine input for a shorter lifetime than the timed loops do.

## What happens

`convert(t)` is `t.to(bf16)` and allocates. The two loops keep the result alive for different lengths of time:

```python
# warmup: an inline temporary, dead at the end of the statement -> ONE alive
op.combine(convert(dispatch_out[0]), combine_weights, routing=dispatch_out[5])

# timed loop: bound to a name, and Python evaluates the right-hand side before
# rebinding, so the previous round's tensor is still referenced -> TWO alive
combine_input = convert(dispatch_out[0])
```

So warmup only ever makes the caching allocator reserve one block of that size. On the **second timed round** the loop needs a second one, the cache has none, and torch allocates a new 12 MB segment. Because the timing events tile the timed region, the resulting host stall is charged to the combine window as GPU idle.

Measured host time inside `convert`, and `segment.all.current`, per round:

| | round 0, 1, 2, 3 | segments |
|---|---|---|
| before | 23, **109**, 17, 12 | 2 -> **3** |
| after | 23, **16**, 14, 13 | **3, constant** |

`num_alloc_retries` is 0 throughout, so this is a clean new segment rather than a retry after cache exhaustion.

## Effect on the reported numbers

16 tokens, fp8 dispatch / bf16 combine, hidden 6144, topk 8, EP16 over two nodes of 8x MI308X. Three interleaved runs per variant, same build, only this patch differing.

| | first kept round | steady state | Worst | Average |
|---|---:|---:|---:|---:|
| before | 92.0 | 49.8 | 100.4 | 51.3 |
| after | 59.8 | 49.9 | **69.3** | 50.4 |

The segment count is constant across all 29 rounds and all 16 ranks after the change.

The roughly 10 us that remains on the first kept round is a genuine post-barrier transient, which is what `--drop-rounds` already exists for. This patch does not try to remove it.

## Why `_timed_pass` matters more than `_bench`

`_timed_pass` backs `--cmd tuning` and returns a worst-single-round that the tuner uses to break ties, against a default `--tuning-margin-us` of 1.5. Tracing the allocation across a sweep:

```
passes 1-8:  host time in convert ~78us on round 1,  segments 2 -> 3
passes 9+:   host time in convert ~15us on round 1,  segments 3, constant
```

Each candidate rebuilds the op, which releases the segment, so the penalty recurs until the pool settles. Candidates measured early were therefore penalised systematically, by roughly 40x the tie-break margin. That is a plausible contributor to the note in `internode_tuning_configs.py` that sweep-only winners routinely fail the manual re-check, though this PR does not attempt to prove that link.

## What was ruled out first

- **Rank skew, and a device-side barrier.** Inserting 3, 10 and 30 un-timed dispatch+combine rounds after the gloo barrier -- a stronger alignment than any barrier, since every fan-in realigns the ranks -- leaves the first timed combine at 77-107 us with no trend. The slow part is the host, so aligning the GPUs does not help.
- **The post-warmup `torch.cuda.synchronize()`.** Removing it made things worse, not better.
- **Allocator retries** and **`num_qp`** (1 vs 2 is indistinguishable at this token count).

## Test plan

Two nodes x 8 MI308X, world 16, ROCm 7.14, on top of `main` at ceac6df6.

- [x] `--cmd bench`, three interleaved runs per variant, numbers above
- [x] `--cmd tuning` with `--tuning-limit 3 --tuning-reps 2`: completes and produces paired incumbent-versus-candidate comparisons
- [x] `--cmd test` at 128 tokens: 5 rounds, `0 of 16 ranks disagree`, zero failures
- [x] Allocator probe: `segment.all.current` constant over every round and rank after the change
- [x] `pre-commit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
