### PR TITLE
fix(allocator): link c10_hip in JIT path for getCurrentHIPStream

### DIFF
--- a/python/mori/allocator/__init__.py
+++ b/python/mori/allocator/__init__.py
@@ -164,6 +164,7 @@ def _jit_ext():
         extra_ldflags=[
             f"-L{rocm}/lib",
             "-lamdhip64",
+            "-lc10_hip",
             f"-L{pkg}",
             "-lmori_cco",
             f"-Wl,-rpath,{pkg}",


### PR DESCRIPTION
## Summary
- The JIT fallback (`_jit_ext()`) compiles `symm_backend.cpp` which calls `c10::hip::getCurrentHIPStream()`, but `extra_ldflags` only linked `amdhip64` and `mori_cco` — missing `libc10_hip.so` that provides the symbol (`c10::cuda::getCurrentCUDAStream` mangled name on ROCm).
- The `setup.py` prebuilt path already links `c10_hip`; this change matches it in the JIT path.

## Test plan
- [ ] `MORI_SYMM_FORCE_JIT=1` to force JIT compilation of `mori_torch_symm`, verify no undefined symbol error on ROCm

🤖 Generated with [Claude Code](https://claude.com/claude-code)